### PR TITLE
Bring version in sync with dcrd.

### DIFF
--- a/cmd/dcrctl/version.go
+++ b/cmd/dcrctl/version.go
@@ -18,7 +18,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 // versioning 2.0.0 spec (http://semver.org/).
 const (
 	appMajor uint = 0
-	appMinor uint = 11
+	appMinor uint = 0
 	appPatch uint = 1
 
 	// appPreRelease MUST only contain characters from semanticAlphabet


### PR DESCRIPTION
Looks like it was overlooked in the btcsuite to decred transition.