### PR TITLE
Add getcoinsupply rpc command

### DIFF
--- a/dcrjson/dcrdextcmds.go
+++ b/dcrjson/dcrdextcmds.go
@@ -23,6 +23,15 @@ func NewExistsAddressCmd(address string) *ExistsAddressCmd {
 	}
 }
 
+// GetCoinSupplyCmd defines the getcoinsupply JSON-RPC command.
+type GetCoinSupplyCmd struct{}
+
+// NewGetCoinSupplyCmd returns a new instance which can be used to issue a
+// getcoinsupply JSON-RPC command.
+func NewGetCoinSupplyCmd() *GetCoinSupplyCmd {
+	return &GetCoinSupplyCmd{}
+}
+
 // GetStakeDifficultyCmd is a type handling custom marshaling and
 // unmarshaling of getstakedifficulty JSON RPC commands.
 type GetStakeDifficultyCmd struct{}
@@ -79,6 +88,7 @@ func init() {
 	flags := UsageFlag(0)
 
 	MustRegisterCmd("existsaddress", (*ExistsAddressCmd)(nil), flags)
+	MustRegisterCmd("getcoinsupply", (*GetCoinSupplyCmd)(nil), flags)
 	MustRegisterCmd("getstakedifficulty", (*GetStakeDifficultyCmd)(nil), flags)
 	MustRegisterCmd("missedtickets", (*MissedTicketsCmd)(nil), flags)
 	MustRegisterCmd("rebroadcastmissed", (*RebroadcastMissedCmd)(nil), flags)

--- a/dcrjson/dcrdextresults.go
+++ b/dcrjson/dcrdextresults.go
@@ -11,6 +11,12 @@ type ExistsAddressResult struct {
 	Exists bool `json:"exists"`
 }
 
+// GetCoinSupplyResult models the data returned from the getcoinsupply
+// command.
+type GetCoinSupplyResult struct {
+	CoinSupply int64 `json:"coinsupply"`
+}
+
 // GetStakeDifficultyResult models the data returned from the getstakedifficulty
 // command.
 type GetStakeDifficultyResult struct {

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -639,6 +639,10 @@ var helpDescsEnUS = map[string]string{
 	// MissedTickets help.
 	"missedtickets--synopsis":     "Reguest tickets the client missed",
 	"missedticketsresult-tickets": "List of missed tickets",
+
+	// GetCoinSupply help
+	"getcoinsupply--synopsis":        "Returns current total coin supply in atoms",
+	"getcoinsupplyresult-coinsupply": "Current coin supply in atoms",
 }
 
 // rpcResultTypes specifies the result types that each RPC command can return.
@@ -678,6 +682,7 @@ var rpcResultTypes = map[string][]interface{}{
 	"getrawtransaction":     []interface{}{(*string)(nil), (*dcrjson.TxRawResult)(nil)},
 	"gettxout":              []interface{}{(*dcrjson.GetTxOutResult)(nil)},
 	"getwork":               []interface{}{(*dcrjson.GetWorkResult)(nil), (*bool)(nil)},
+	"getcoinsupply":         []interface{}{(*dcrjson.GetCoinSupplyResult)(nil)},
 	"missedtickets":         []interface{}{(*dcrjson.MissedTicketsResult)(nil)},
 	"node":                  nil,
 	"help":                  []interface{}{(*string)(nil), (*string)(nil)},


### PR DESCRIPTION
This RPC command should be able to hold us over until new db has been added which will allow us to more quickly / less expensively track total coin supply.

This is the current implementation in pseudo code:
   1) Get tip block height
   2) Iterate over all blocks, get block hash then get block header from that hash.
   3) If block 1, add block 1 subsidy as defined in chaincfg/params.go
   4) If current block is a "reduction interval", then reduce base subsidy accordingly
   5) Calculate PoW, PoS and dev subsidy for current block
   6) Add subsidies to running total (only PoW and dev if < Stake Validation Height) 