### PR TITLE
Add get/setmempoolfree rpc commands

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -277,6 +277,7 @@ type processTransactionMsg struct {
 	allowOrphans  bool
 	rateLimit     bool
 	allowHighFees bool
+	skipsFeeLocal bool
 	reply         chan processTransactionResponse
 }
 
@@ -893,7 +894,7 @@ func (b *blockManager) handleTxMsg(tmsg *txMsg) {
 	// memory pool, orphan handling, etc.
 	allowOrphans := cfg.MaxOrphanTxs > 0
 	err := tmsg.peer.server.txMemPool.ProcessTransaction(tmsg.tx,
-		allowOrphans, true, true)
+		allowOrphans, true, true, false)
 
 	// Remove transaction from request maps. Either the mempool/chain
 	// already knows about it and as such we shouldn't have any more
@@ -2047,7 +2048,7 @@ out:
 
 			case processTransactionMsg:
 				err := b.server.txMemPool.ProcessTransaction(msg.tx,
-					msg.allowOrphans, msg.rateLimit, msg.allowHighFees)
+					msg.allowOrphans, msg.rateLimit, msg.allowHighFees, msg.skipsFeeLocal)
 				msg.reply <- processTransactionResponse{
 					err: err,
 				}
@@ -2712,7 +2713,7 @@ func (b *blockManager) ProcessBlock(block *dcrutil.Block,
 func (b *blockManager) ProcessTransaction(tx *dcrutil.Tx, allowOrphans bool,
 	rateLimit bool, allowHighFees bool, skipsFeeLocal bool) error {
 	reply := make(chan processTransactionResponse, 1)
-	b.msgChan <- processTransactionMsg{tx, allowOrphans, rateLimit, allowHighFees, reply}
+	b.msgChan <- processTransactionMsg{tx, allowOrphans, rateLimit, allowHighFees, skipsFeeLocal, reply}
 	response := <-reply
 	return response.err
 }

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -2710,7 +2710,7 @@ func (b *blockManager) ProcessBlock(block *dcrutil.Block,
 // a block chain.  It is funneled through the block manager since blockchain is
 // not safe for concurrent access.
 func (b *blockManager) ProcessTransaction(tx *dcrutil.Tx, allowOrphans bool,
-	rateLimit bool, allowHighFees bool) error {
+	rateLimit bool, allowHighFees bool, skipsFeeLocal bool) error {
 	reply := make(chan processTransactionResponse, 1)
 	b.msgChan <- processTransactionMsg{tx, allowOrphans, rateLimit, allowHighFees, reply}
 	response := <-reply

--- a/dcrjson/dcrdextcmds.go
+++ b/dcrjson/dcrdextcmds.go
@@ -158,7 +158,7 @@ type SetMempoolFeeCmd struct {
 
 // NewSetMempoolFeeCmd returns a new instance which can be used to issue a
 // JSON-RPC set mempool fee command
-func NewrSetMempoolFeeCmd(relayFee, minFee int64, skipFeeLocal bool) *SetMempoolFeeCmd {
+func NewSetMempoolFeeCmd(relayFee, minFee int64, skipFeeLocal bool) *SetMempoolFeeCmd {
 	return &SetMempoolFeeCmd{relayFee, minFee, skipFeeLocal}
 }
 

--- a/dcrjson/dcrdextcmds.go
+++ b/dcrjson/dcrdextcmds.go
@@ -81,6 +81,15 @@ func NewGetCoinSupplyCmd() *GetCoinSupplyCmd {
 	return &GetCoinSupplyCmd{}
 }
 
+// GetMempoolFeeCmd defines the getmempoolfee JSON-RPC command.
+type GetMempoolFeeCmd struct{}
+
+// NewGetMempoolFeeCmd returns a new instance which can be used to issue a
+// JSON-RPC get mempool fee command
+func NewGetMempoolFeeCmd() *GetMempoolFeeCmd {
+	return &GetMempoolFeeCmd{}
+}
+
 // GetStakeDifficultyCmd is a type handling custom marshaling and
 // unmarshaling of getstakedifficulty JSON RPC commands.
 type GetStakeDifficultyCmd struct{}
@@ -140,26 +149,6 @@ func NewRebroadcastWinnersCmd() *RebroadcastWinnersCmd {
 	return &RebroadcastWinnersCmd{}
 }
 
-// TicketsForAddressCmd defines the ticketsforbucket JSON-RPC command.
-type TicketsForAddressCmd struct {
-	Address string
-}
-
-// NewTicketsForAddressCmd returns a new instance which can be used to issue a
-// JSON-RPC tickets for bucket command.
-func NewTicketsForAddressCmd(addr string) *TicketsForAddressCmd {
-	return &TicketsForAddressCmd{addr}
-}
-
-// GetMempoolFeeCmd defines the getmempoolfee JSON-RPC command.
-type GetMempoolFeeCmd struct{}
-
-// NewGetMempoolFeeCmd returns a new instance which can be used to issue a
-// JSON-RPC get mempool fee command
-func NewGetMempoolFeeCmd() *GetMempoolFeeCmd {
-	return &GetMempoolFeeCmd{}
-}
-
 // SetMempoolFeeCmd defines the setmempoolfee JSON-RPC command.
 type SetMempoolFeeCmd struct {
 	RelayFee     int64
@@ -173,6 +162,17 @@ func NewrSetMempoolFeeCmd(relayFee, minFee int64, skipFeeLocal bool) *SetMempool
 	return &SetMempoolFeeCmd{relayFee, minFee, skipFeeLocal}
 }
 
+// TicketsForAddressCmd defines the ticketsforbucket JSON-RPC command.
+type TicketsForAddressCmd struct {
+	Address string
+}
+
+// NewTicketsForAddressCmd returns a new instance which can be used to issue a
+// JSON-RPC tickets for bucket command.
+func NewTicketsForAddressCmd(addr string) *TicketsForAddressCmd {
+	return &TicketsForAddressCmd{addr}
+}
+
 func init() {
 	// No special flags for commands in this file.
 	flags := UsageFlag(0)
@@ -183,13 +183,13 @@ func init() {
 	MustRegisterCmd("existslivetickets", (*ExistsLiveTicketsCmd)(nil), flags)
 	MustRegisterCmd("existsmempooltxs", (*ExistsMempoolTxsCmd)(nil), flags)
 	MustRegisterCmd("getcoinsupply", (*GetCoinSupplyCmd)(nil), flags)
+	MustRegisterCmd("getmempoolfee", (*GetMempoolFeeCmd)(nil), flags)
 	MustRegisterCmd("getstakedifficulty", (*GetStakeDifficultyCmd)(nil), flags)
 	MustRegisterCmd("getticketpoolvalue", (*GetTicketPoolValueCmd)(nil), flags)
 	MustRegisterCmd("livetickets", (*LiveTicketsCmd)(nil), flags)
 	MustRegisterCmd("missedtickets", (*MissedTicketsCmd)(nil), flags)
 	MustRegisterCmd("rebroadcastmissed", (*RebroadcastMissedCmd)(nil), flags)
 	MustRegisterCmd("rebroadcastwinners", (*RebroadcastWinnersCmd)(nil), flags)
-	MustRegisterCmd("ticketsforaddress", (*TicketsForAddressCmd)(nil), flags)
-	MustRegisterCmd("getmempoolfee", (*GetMempoolFeeCmd)(nil), flags)
 	MustRegisterCmd("setmempoolfee", (*SetMempoolFeeCmd)(nil), flags)
+	MustRegisterCmd("ticketsforaddress", (*TicketsForAddressCmd)(nil), flags)
 }

--- a/dcrjson/dcrdextcmds.go
+++ b/dcrjson/dcrdextcmds.go
@@ -151,6 +151,28 @@ func NewTicketsForAddressCmd(addr string) *TicketsForAddressCmd {
 	return &TicketsForAddressCmd{addr}
 }
 
+// GetMempoolFeeCmd defines the getmempoolfee JSON-RPC command.
+type GetMempoolFeeCmd struct{}
+
+// NewGetMempoolFeeCmd returns a new instance which can be used to issue a
+// JSON-RPC get mempool fee command
+func NewGetMempoolFeeCmd() *GetMempoolFeeCmd {
+	return &GetMempoolFeeCmd{}
+}
+
+// SetMempoolFeeCmd defines the setmempoolfee JSON-RPC command.
+type SetMempoolFeeCmd struct {
+	RelayFee     int64
+	MinFee       int64
+	SkipFeeLocal bool
+}
+
+// NewSetMempoolFeeCmd returns a new instance which can be used to issue a
+// JSON-RPC set mempool fee command
+func NewrSetMempoolFeeCmd(relayFee, minFee int64, skipFeeLocal bool) *SetMempoolFeeCmd {
+	return &SetMempoolFeeCmd{relayFee, minFee, skipFeeLocal}
+}
+
 func init() {
 	// No special flags for commands in this file.
 	flags := UsageFlag(0)
@@ -168,4 +190,6 @@ func init() {
 	MustRegisterCmd("rebroadcastmissed", (*RebroadcastMissedCmd)(nil), flags)
 	MustRegisterCmd("rebroadcastwinners", (*RebroadcastWinnersCmd)(nil), flags)
 	MustRegisterCmd("ticketsforaddress", (*TicketsForAddressCmd)(nil), flags)
+	MustRegisterCmd("getmempoolfee", (*GetMempoolFeeCmd)(nil), flags)
+	MustRegisterCmd("setmempoolfee", (*SetMempoolFeeCmd)(nil), flags)
 }

--- a/dcrjson/dcrdextresults.go
+++ b/dcrjson/dcrdextresults.go
@@ -28,3 +28,11 @@ type Ticket struct {
 type TicketsForAddressResult struct {
 	Tickets []string `json:"tickets"`
 }
+
+// GetMempoolFeeResult models the data returned from getmempoolfee
+// command
+type GetMempoolFeeResult struct {
+	RelayFee     int64 `json:"relayfee"`
+	MinFee       int64 `json:"minfee"`
+	SkipFeeLocal bool  `json:"skipfeelocal"`
+}

--- a/dcrjson/dcrdextresults.go
+++ b/dcrjson/dcrdextresults.go
@@ -11,6 +11,14 @@ type LiveTicketsResult struct {
 	Tickets []string `json:"tickets"`
 }
 
+// GetMempoolFeeResult models the data returned from getmempoolfee
+// command
+type GetMempoolFeeResult struct {
+	RelayFee     int64 `json:"relayfee"`
+	MinFee       int64 `json:"minfee"`
+	SkipFeeLocal bool  `json:"skipfeelocal"`
+}
+
 // MissedTicketsResult models the data returned from the missedtickets
 // command.
 type MissedTicketsResult struct {
@@ -27,12 +35,4 @@ type Ticket struct {
 // command.
 type TicketsForAddressResult struct {
 	Tickets []string `json:"tickets"`
-}
-
-// GetMempoolFeeResult models the data returned from getmempoolfee
-// command
-type GetMempoolFeeResult struct {
-	RelayFee     int64 `json:"relayfee"`
-	MinFee       int64 `json:"minfee"`
-	SkipFeeLocal bool  `json:"skipfeelocal"`
 }

--- a/mempool.go
+++ b/mempool.go
@@ -1727,7 +1727,7 @@ func (mp *txMemPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew,
 	serializedSize := int64(tx.MsgTx().SerializeSize())
 	minFee := calcMinRequiredTxRelayFee(serializedSize, int64(minRelayTxFee))
 	if txType == stake.TxTypeRegular { // Non-stake only
-		if serializedSize >= (defaultBlockPrioritySize-1000) && txFee < minFee {
+		if serializedSize >= (defaultBlockPrioritySize-1000) && (txFee < minFee && !mp.SkipFeeLocal()) {
 			str := fmt.Sprintf("transaction %v has %v fees which is under "+
 				"the required amount of %v", txHash, txFee,
 				minFee)

--- a/mempool.go
+++ b/mempool.go
@@ -1482,7 +1482,7 @@ func detectTxType(tx *dcrutil.Tx) stake.TxType {
 // This should probably be done at the bottom using "IsSStx" etc functions.
 // It should also set the dcrutil tree type for the tx as well.
 func (mp *txMemPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew,
-	rateLimit, allowHighFees bool) ([]*chainhash.Hash, error) {
+	rateLimit, allowHighFees, skipsFeeLocal bool) ([]*chainhash.Hash, error) {
 	txHash := tx.Sha()
 
 	// Don't accept the transaction if it already exists in the pool.  This
@@ -1874,7 +1874,7 @@ func (mp *txMemPool) MaybeAcceptTransaction(tx *dcrutil.Tx, isNew,
 	mp.Lock()
 	defer mp.Unlock()
 
-	return mp.maybeAcceptTransaction(tx, isNew, rateLimit, true)
+	return mp.maybeAcceptTransaction(tx, isNew, rateLimit, true, false)
 }
 
 // processOrphans is the internal function which implements the public
@@ -1923,7 +1923,7 @@ func (mp *txMemPool) processOrphans(hash *chainhash.Hash) {
 
 			// Potentially accept the transaction into the
 			// transaction pool.
-			missingParents, err := mp.maybeAcceptTransaction(tx, true, true, true)
+			missingParents, err := mp.maybeAcceptTransaction(tx, true, true, true, false)
 			if err != nil {
 				// TODO: Remove orphans that depend on this
 				// failed transaction.
@@ -2045,7 +2045,7 @@ func (mp *txMemPool) ProcessTransaction(tx *dcrutil.Tx, allowOrphan,
 	txmpLog.Tracef("Processing transaction %v", tx.Sha())
 
 	// Potentially accept the transaction to the memory pool.
-	missingParents, err := mp.maybeAcceptTransaction(tx, true, rateLimit, allowHighFees)
+	missingParents, err := mp.maybeAcceptTransaction(tx, true, rateLimit, allowHighFees, skipsFeeLocal)
 	if err != nil {
 		return err
 	}

--- a/mempool.go
+++ b/mempool.go
@@ -2037,7 +2037,7 @@ func (mp *txMemPool) ProcessOrphans(hash *chainhash.Hash) {
 //
 // This function is safe for concurrent access.
 func (mp *txMemPool) ProcessTransaction(tx *dcrutil.Tx, allowOrphan,
-	rateLimit, allowHighFees bool) error {
+	rateLimit, allowHighFees, skipsFeeLocal bool) error {
 	// Protect concurrent access.
 	mp.Lock()
 	defer mp.Unlock()

--- a/mempool.go
+++ b/mempool.go
@@ -153,6 +153,11 @@ type txMemPool struct {
 	lastUpdated   time.Time // last time pool was updated.
 	pennyTotal    float64   // exponentially decaying total for penny spends.
 	lastPennyUnix int64     // unix time of last ``penny spend''
+
+	// tx fee rules
+	relayFee     int64
+	minFee       int64
+	skipFeeLocal bool
 }
 
 // insertVote inserts a vote into the map of block votes.
@@ -2191,4 +2196,55 @@ func newTxMemPool(server *server) *txMemPool {
 		memPool.addrindex = make(map[string]map[chainhash.Hash]struct{})
 	}
 	return memPool
+}
+
+// RelayFee gets the currently set relay fee
+func (mp *txMemPool) RelayFee() int64 {
+	mp.RWMutex.Lock()
+	relayFee := mp.relayFee
+	mp.RWMutex.Unlock()
+
+	return relayFee
+}
+
+// SetRelayFee sets the mempool relay fee
+func (mp *txMemPool) SetRelayFee(relayFee int64) {
+	mp.RWMutex.Lock()
+	mp.relayFee = relayFee
+	mp.RWMutex.Unlock()
+}
+
+// MinFee gets the currently set min fee
+func (mp *txMemPool) MinFee() int64 {
+	mp.RWMutex.Lock()
+	minFee := mp.minFee
+	mp.RWMutex.Unlock()
+
+	return minFee
+}
+
+// SetMinFee sets the mempool min fee for tx
+func (mp *txMemPool) SetMinFee(minFee int64) int64 {
+	mp.RWMutex.Lock()
+	mp.minFee = minFee
+	mp.RWMutex.Unlock()
+
+	return minFee
+}
+
+// SkipFeeLocal gets the currently set skip fee local bool
+func (mp *txMemPool) SkipFeeLocal() bool {
+	mp.RWMutex.Lock()
+	skipFeeLocal := mp.skipFeeLocal
+	mp.RWMutex.Unlock()
+
+	return skipFeeLocal
+}
+
+//SetSkipFeeLocal sets the bool that decides whether to locally
+// allow local tx that have no fees (for PoW miners)
+func (mp *txMemPool) SetSkipFeeLocal(skipFeeLocal bool) {
+	mp.RWMutex.Lock()
+	mp.skipFeeLocal = skipFeeLocal
+	mp.RWMutex.Unlock()
 }

--- a/mining.go
+++ b/mining.go
@@ -1549,7 +1549,8 @@ mempoolLoop:
 		// minimum block size, except for stake transactions.
 		if sortedByFee && (prioItem.feePerKB < float64(minTxRelayFee)) &&
 			(tx.Tree() != dcrutil.TxTreeStake) &&
-			(blockPlusTxSize >= cfg.BlockMinSize) {
+			(blockPlusTxSize >= cfg.BlockMinSize) &&
+			!mempool.SkipFeeLocal() {
 
 			minrLog.Tracef("Skipping tx %s with feePerKB %.2f "+
 				"< minTxRelayFee %d and block size %d >= "+

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -178,6 +178,7 @@ var rpcHandlersBeforeInit = map[string]commandHandler{
 	"getgenerate":           handleGetGenerate,
 	"gethashespersec":       handleGetHashesPerSec,
 	"getinfo":               handleGetInfo,
+	"getmempoolfee":         handleGetMempoolFee,
 	"getmininginfo":         handleGetMiningInfo,
 	"getnettotals":          handleGetNetTotals,
 	"getnetworkhashps":      handleGetNetworkHashPS,
@@ -198,6 +199,7 @@ var rpcHandlersBeforeInit = map[string]commandHandler{
 	"searchrawtransactions": handleSearchRawTransactions,
 	"sendrawtransaction":    handleSendRawTransaction,
 	"setgenerate":           handleSetGenerate,
+	"setmempoolfee":         handleSetMempoolFee,
 	"stop":                  handleStop,
 	"submitblock":           handleSubmitBlock,
 	"ticketsforaddress":     handleTicketsForAddress,
@@ -3224,6 +3226,17 @@ func handleGetInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (in
 	return ret, nil
 }
 
+// handleGetMempoolFee implements the getmempoolfee command. We will return
+// RelayFee, MinFee and whether bool to skip fee locally is set (for miners)
+func handleGetMempoolFee(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
+	result := dcrjson.GetMempoolFeeResult{
+		RelayFee:     0,
+		MinFee:       0,
+		SkipFeeLocal: false,
+	}
+	return &result, nil
+}
+
 // handleGetMiningInfo implements the getmininginfo command. We only return the
 // fields that are not related to wallet functionality.
 func handleGetMiningInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
@@ -4504,6 +4517,14 @@ func handleSetGenerate(s *rpcServer, cmd interface{}, closeChan <-chan struct{})
 		s.server.cpuMiner.SetNumWorkers(int32(genProcLimit))
 		s.server.cpuMiner.Start()
 	}
+	return nil, nil
+}
+
+// handleGetMempoolFee implements the getmempoolfee command. We will return
+// RelayFee, MinFee and whether bool to skip fee locally is set (for miners)
+func handleSetMempoolFee(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
+	c := cmd.(*dcrjson.SetMempoolFeeCmd)
+	fmt.Println("set mempool fee", c.RelayFee, c.MinFee, c.SkipFeeLocal)
 	return nil, nil
 }
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4524,8 +4524,8 @@ func handleSetGenerate(s *rpcServer, cmd interface{}, closeChan <-chan struct{})
 	return nil, nil
 }
 
-// handleGetMempoolFee implements the getmempoolfee command. We will return
-// RelayFee, MinFee and whether bool to skip fee locally is set (for miners)
+// handleSetMempoolFee implements the setmempoolfee command. Allows users to change
+// mempool fee rules
 func handleSetMempoolFee(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
 	c := cmd.(*dcrjson.SetMempoolFeeCmd)
 
@@ -4547,7 +4547,8 @@ func handleSetMempoolFee(s *rpcServer, cmd interface{}, closeChan <-chan struct{
 
 	if skipFeeLocal != c.SkipFeeLocal {
 		s.server.txMemPool.SetSkipFeeLocal(c.SkipFeeLocal)
-		resultStr += fmt.Sprintf("Set SkipFeeLocal from: %v to: %v.", skipFeeLocal, c.SkipFeeLocal)
+		resultStr += fmt.Sprintf("Set SkipFeeLocal from: %v to: %v.",
+			skipFeeLocal, c.SkipFeeLocal)
 	}
 
 	if resultStr == "" {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4457,9 +4457,10 @@ func handleSendRawTransaction(s *rpcServer, cmd interface{}, closeChan <-chan st
 			Message: "TX decode failed: " + err.Error(),
 		}
 	}
+	skipFeeLocal := s.server.txMemPool.SkipFeeLocal()
 
 	tx := dcrutil.NewTx(msgtx)
-	err = s.server.blockManager.ProcessTransaction(tx, false, false, allowHighFees)
+	err = s.server.blockManager.ProcessTransaction(tx, false, false, allowHighFees, skipFeeLocal)
 	if err != nil {
 		// When the error is a rule error, it means the transaction was
 		// simply rejected as opposed to something actually going wrong,

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4534,30 +4534,19 @@ func handleSetMempoolFee(s *rpcServer, cmd interface{}, closeChan <-chan struct{
 	minFee := s.server.txMemPool.MinFee()
 	skipFeeLocal := s.server.txMemPool.SkipFeeLocal()
 
-	resultStr := ""
-
 	if relayFee != c.RelayFee {
 		s.server.txMemPool.SetRelayFee(c.RelayFee)
-		resultStr += fmt.Sprintf("Set RelayFee from: %v to: %v.", relayFee, c.RelayFee)
 	}
 
 	if minFee != c.MinFee {
 		s.server.txMemPool.SetMinFee(c.MinFee)
-		resultStr += fmt.Sprintf("Set MinFee from: %v to: %v.", minFee, c.MinFee)
 	}
 
 	if skipFeeLocal != c.SkipFeeLocal {
 		s.server.txMemPool.SetSkipFeeLocal(c.SkipFeeLocal)
-		resultStr += fmt.Sprintf("Set SkipFeeLocal from: %v to: %v.",
-			skipFeeLocal, c.SkipFeeLocal)
 	}
 
-	if resultStr == "" {
-		resultStr += "No changes made to MemPoolFees\n"
-	} else {
-		resultStr += "\n"
-	}
-	return resultStr, nil
+	return nil, nil
 }
 
 // handleStop implements the stop command.

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -671,6 +671,19 @@ var helpDescsEnUS = map[string]string{
 	// GetCoinSupply help
 	"getcoinsupply--synopsis": "Returns current total coin supply in atoms",
 	"getcoinsupply--result0":  "Current coin supply in atoms",
+
+	// GetMempoolFee help
+	"getmempoolfee--synopsis":          "Returns current mempool fee rules",
+	"getmempoolfeeresult-relayfee":     "Current RelayFee",
+	"getmempoolfeeresult-minfee":       "Current MinFee",
+	"getmempoolfeeresult-skipfeelocal": "Current bool for whether to check local tx for miners",
+
+	// SetMempoolFee help
+	"setmempoolfee--synopsis":    "Sets the current mempool fee rules",
+	"setmempoolfee-relayfee":     "Sets the relay fee to this value",
+	"setmempoolfee-minfee":       "Sets the minfee to this value",
+	"setmempoolfee-skipfeelocal": "Sets the skip fee local check for miners",
+	"setmempoolfee--result0":     "String to signify success/failure of new settings",
 }
 
 // rpcResultTypes specifies the result types that each RPC command can return.
@@ -706,6 +719,7 @@ var rpcResultTypes = map[string][]interface{}{
 	"getgenerate":           []interface{}{(*bool)(nil)},
 	"gethashespersec":       []interface{}{(*float64)(nil)},
 	"getinfo":               []interface{}{(*dcrjson.InfoChainResult)(nil)},
+	"getmempoolfee":         []interface{}{(*dcrjson.GetMempoolFeeResult)(nil)},
 	"getmininginfo":         []interface{}{(*dcrjson.GetMiningInfoResult)(nil)},
 	"getnettotals":          []interface{}{(*dcrjson.GetNetTotalsResult)(nil)},
 	"getnetworkhashps":      []interface{}{(*int64)(nil)},
@@ -726,6 +740,7 @@ var rpcResultTypes = map[string][]interface{}{
 	"searchrawtransactions": []interface{}{(*string)(nil), (*[]dcrjson.TxRawResult)(nil)},
 	"sendrawtransaction":    []interface{}{(*string)(nil)},
 	"setgenerate":           nil,
+	"setmempoolfee":         []interface{}{(*string)(nil)},
 	"stop":                  []interface{}{(*string)(nil)},
 	"submitblock":           []interface{}{nil, (*string)(nil)},
 	"ticketsforaddress":     []interface{}{(*dcrjson.TicketsForAddressResult)(nil)},


### PR DESCRIPTION
getmempoolfee RPC command returns currently set mempool fee variables. (RelayFee, MinFee and SkipFeeLocal bool)

setmempoolfee <relayfee> <minfee> <skipfeelocal> RPC allows the user to set their daemons mempool fee rules.