### PR TITLE
Plug in and enable mempool address indexing

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1469,6 +1469,13 @@ func handleExistsAddress(s *rpcServer, cmd interface{},
 	if err == nil && tlr != nil {
 		return true, nil
 	}
+
+	// Check the mempool as well.
+	txs := s.server.txMemPool.FindTxForAddr(addr)
+	if len(txs) > 0 {
+		return true, nil
+	}
+
 	return false, nil
 }
 


### PR DESCRIPTION
Although the address indexer for the memory pool was a part of its
struct, it was not enabled in the daemon. The framework to enable it
by default has been completed and the mempool should now correctly
index transactions by address.