### PR TITLE
Add JSON RPC handlers for getstakeinfo and related functions

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -224,6 +224,14 @@ func (b *BlockChain) TicketsWithAddress(address dcrutil.Address) ([]chainhash.Ha
 	return b.tmdb.GetLiveTicketsForAddress(address)
 }
 
+// CheckLiveTicket returns whether or not a ticket exists in the live ticket
+// map of the stake database.
+//
+// This function is NOT safe for concurrent access.
+func (b *BlockChain) CheckLiveTicket(hash *chainhash.Hash) (bool, error) {
+	return b.tmdb.CheckLiveTicket(*hash)
+}
+
 // HaveBlock returns whether or not the chain instance has the block represented
 // by the passed hash.  This includes checking the various places a block can
 // be like part of the main chain, on a side chain, or in the orphan pool.

--- a/dcrjson/dcrdextcmds.go
+++ b/dcrjson/dcrdextcmds.go
@@ -14,12 +14,22 @@ type ExistsAddressCmd struct {
 
 // NewExistsAddressCmd returns a new instance which can be used to issue a
 // existsaddress JSON-RPC command.
-//
-// The parameters which are pointers indicate they are optional.  Passing nil
-// for optional parameters will use the default value.
 func NewExistsAddressCmd(address string) *ExistsAddressCmd {
 	return &ExistsAddressCmd{
 		Address: address,
+	}
+}
+
+// ExistsLiveTicketCmd defines the existsliveticket JSON-RPC command.
+type ExistsLiveTicketCmd struct {
+	TxHash string
+}
+
+// NewExistsLiveTicketCmd returns a new instance which can be used to issue an
+// existsliveticket JSON-RPC command.
+func NewExistsLiveTicketCmd(txHash string) *ExistsLiveTicketCmd {
+	return &ExistsLiveTicketCmd{
+		TxHash: txHash,
 	}
 }
 
@@ -88,6 +98,7 @@ func init() {
 	flags := UsageFlag(0)
 
 	MustRegisterCmd("existsaddress", (*ExistsAddressCmd)(nil), flags)
+	MustRegisterCmd("existsliveticket", (*ExistsLiveTicketCmd)(nil), flags)
 	MustRegisterCmd("getcoinsupply", (*GetCoinSupplyCmd)(nil), flags)
 	MustRegisterCmd("getstakedifficulty", (*GetStakeDifficultyCmd)(nil), flags)
 	MustRegisterCmd("missedtickets", (*MissedTicketsCmd)(nil), flags)

--- a/dcrjson/dcrwalletextcmds.go
+++ b/dcrjson/dcrwalletextcmds.go
@@ -106,6 +106,16 @@ func NewGetSeedCmd() *GetSeedCmd {
 	return &GetSeedCmd{}
 }
 
+// GetStakeInfoCmd is a type handling custom marshaling and
+// unmarshaling of getstakeinfo JSON wallet extension commands.
+type GetStakeInfoCmd struct {
+}
+
+// NewGetStakeInfoCmd creates a new GetStakeInfoCmd.
+func NewGetStakeInfoCmd() *GetStakeInfoCmd {
+	return &GetStakeInfoCmd{}
+}
+
 // GetTicketMaxPriceCmd is a type handling custom marshaling and
 // unmarshaling of getticketmaxprice JSON wallet extension
 // commands.
@@ -418,6 +428,7 @@ func init() {
 	MustRegisterCmd("getmultisigoutinfo", (*GetMultisigOutInfoCmd)(nil), flags)
 	MustRegisterCmd("getmasterpubkey", (*GetMasterPubkeyCmd)(nil), flags)
 	MustRegisterCmd("getseed", (*GetSeedCmd)(nil), flags)
+	MustRegisterCmd("getstakeinfo", (*GetStakeInfoCmd)(nil), flags)
 	MustRegisterCmd("getticketmaxprice", (*GetTicketMaxPriceCmd)(nil), flags)
 	MustRegisterCmd("gettickets", (*GetTicketsCmd)(nil), flags)
 	MustRegisterCmd("getticketvotebits", (*GetTicketVoteBitsCmd)(nil), flags)

--- a/dcrjson/dcrwalletextresults.go
+++ b/dcrjson/dcrwalletextresults.go
@@ -22,6 +22,23 @@ type GetMultisigOutInfoResult struct {
 	Amount       float64  `json:"amount"`
 }
 
+// GetStakeInfoResult models the data returned from the getstakeinfo
+// command.
+type GetStakeInfoResult struct {
+	PoolSize         uint32  `json:"poolsize"`
+	Difficulty       float64 `json:"difficulty"`
+	AllMempoolTix    uint32  `json:"allmempooltix"`
+	OwnMempoolTix    uint32  `json:"ownmempooltix"`
+	Immature         uint32  `json:"immature"`
+	Live             uint32  `json:"live"`
+	ProportionLive   float64 `json:"proportionlive"`
+	Voted            uint32  `json:"voted"`
+	TotalSubsidy     float64 `json:"totalsubsidy"`
+	Missed           uint32  `json:"missed"`
+	ProportionMissed float64 `json:"proportionmissed"`
+	Revoked          uint32  `json:"revoked"`
+}
+
 // GetTicketsResult models the data returned from the gettickets
 // command.
 type GetTicketsResult struct {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -149,6 +149,7 @@ var rpcHandlersBeforeInit = map[string]commandHandler{
 	"decodescript":          handleDecodeScript,
 	"estimatefee":           handleEstimateFee,
 	"existsaddress":         handleExistsAddress,
+	"existsliveticket":      handleExistsLiveTicket,
 	"generate":              handleGenerate,
 	"getaddednodeinfo":      handleGetAddedNodeInfo,
 	"getbestblock":          handleGetBestBlock,
@@ -1477,6 +1478,22 @@ func handleExistsAddress(s *rpcServer, cmd interface{},
 	}
 
 	return false, nil
+}
+
+// handleExistsLiveTicket implements the existsliveticket command.
+func handleExistsLiveTicket(s *rpcServer, cmd interface{},
+	closeChan <-chan struct{}) (interface{}, error) {
+	c := cmd.(*dcrjson.ExistsLiveTicketCmd)
+
+	hash, err := chainhash.NewHashFromStr(c.TxHash)
+	if err != nil {
+		return nil, &dcrjson.RPCError{
+			Code:    dcrjson.ErrRPCDecodeHexString,
+			Message: "bad transaction hash",
+		}
+	}
+
+	return s.server.blockManager.ExistsLiveTicket(hash)
 }
 
 // handleGenerate handles generate commands.

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -147,6 +147,11 @@ var helpDescsEnUS = map[string]string{
 	"existsaddress-address":   "The address to check",
 	"existsaddress--result0":  "Bool showing if address exists or not",
 
+	// ExistsLiveTicketCmd help.
+	"existsliveticket--synopsis": "Test for the existance of the provided address",
+	"existsliveticket-txhash":    "The ticket hash to check",
+	"existsliveticket--result0":  "Bool showing if address exists in the live ticket database or not",
+
 	// GenerateCmd help
 	"generate--synopsis": "Generates a set number of blocks (simnet or regtest only) and returns a JSON\n" +
 		" array of their hashes.",
@@ -657,6 +662,7 @@ var rpcResultTypes = map[string][]interface{}{
 	"decodescript":          []interface{}{(*dcrjson.DecodeScriptResult)(nil)},
 	"estimatefee":           []interface{}{(*float64)(nil)},
 	"existsaddress":         []interface{}{(*bool)(nil)},
+	"existsliveticket":      []interface{}{(*bool)(nil)},
 	"getaddednodeinfo":      []interface{}{(*[]string)(nil), (*[]dcrjson.GetAddedNodeInfoResult)(nil)},
 	"getbestblock":          []interface{}{(*dcrjson.GetBestBlockResult)(nil)},
 	"generate":              []interface{}{(*[]string)(nil)},


### PR DESCRIPTION
The JSON framework has been modified to enable two new RPC calls,
existsliveticket and getstakeinfo. existsliveticket handling has
been added to the daemon RPC. It checks for the existence of a ticket
in the live ticket stake database given a hash.