### PR TITLE
Add handling of modified getrawmempool RPC call and existslivetickets

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -232,6 +232,23 @@ func (b *BlockChain) CheckLiveTicket(hash *chainhash.Hash) (bool, error) {
 	return b.tmdb.CheckLiveTicket(*hash)
 }
 
+// CheckLiveTickets returns whether or not a slice of tickets exist in the live
+// ticket map of the stake database.
+//
+// This function is NOT safe for concurrent access.
+func (b *BlockChain) CheckLiveTickets(hashes []*chainhash.Hash) ([]bool, error) {
+	var err error
+	existsSlice := make([]bool, len(hashes))
+	for i, hash := range hashes {
+		existsSlice[i], err = b.tmdb.CheckLiveTicket(*hash)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return existsSlice, nil
+}
+
 // HaveBlock returns whether or not the chain instance has the block represented
 // by the passed hash.  This includes checking the various places a block can
 // be like part of the main chain, on a side chain, or in the orphan pool.

--- a/dcrjson/chainsvrcmds.go
+++ b/dcrjson/chainsvrcmds.go
@@ -392,9 +392,31 @@ func NewGetPeerInfoCmd() *GetPeerInfoCmd {
 	return &GetPeerInfoCmd{}
 }
 
+// GetRawMempoolTxTypeCmd defines the type used in the getrawmempool JSON-RPC
+// command for the TxType command field.
+type GetRawMempoolTxTypeCmd string
+
+const (
+	// GRMAll indicates any type of transaction should be returned.
+	GRMAll GetRawMempoolTxTypeCmd = "add"
+
+	// GRMRegular indicates only regular transactions should be returned.
+	GRMRegular GetRawMempoolTxTypeCmd = "regular"
+
+	// GRMTickets indicates that only tickets should be returned.
+	GRMTickets GetRawMempoolTxTypeCmd = "tickets"
+
+	// GRMVotes indicates that only votes should be returned.
+	GRMVotes GetRawMempoolTxTypeCmd = "votes"
+
+	// GRMRevocations indicates that only revocations should be returned.
+	GRMRevocations GetRawMempoolTxTypeCmd = "revocations"
+)
+
 // GetRawMempoolCmd defines the getmempool JSON-RPC command.
 type GetRawMempoolCmd struct {
 	Verbose *bool `jsonrpcdefault:"false"`
+	TxType  *string
 }
 
 // NewGetRawMempoolCmd returns a new instance which can be used to issue a
@@ -402,9 +424,10 @@ type GetRawMempoolCmd struct {
 //
 // The parameters which are pointers indicate they are optional.  Passing nil
 // for optional parameters will use the default value.
-func NewGetRawMempoolCmd(verbose *bool) *GetRawMempoolCmd {
+func NewGetRawMempoolCmd(verbose *bool, txType *string) *GetRawMempoolCmd {
 	return &GetRawMempoolCmd{
 		Verbose: verbose,
+		TxType:  txType,
 	}
 }
 

--- a/dcrjson/chainsvrcmds_test.go
+++ b/dcrjson/chainsvrcmds_test.go
@@ -452,7 +452,7 @@ func TestChainSvrCmds(t *testing.T) {
 				return dcrjson.NewCmd("getrawmempool")
 			},
 			staticCmd: func() interface{} {
-				return dcrjson.NewGetRawMempoolCmd(nil)
+				return dcrjson.NewGetRawMempoolCmd(nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getrawmempool","params":[],"id":1}`,
 			unmarshalled: &dcrjson.GetRawMempoolCmd{
@@ -465,11 +465,25 @@ func TestChainSvrCmds(t *testing.T) {
 				return dcrjson.NewCmd("getrawmempool", false)
 			},
 			staticCmd: func() interface{} {
-				return dcrjson.NewGetRawMempoolCmd(dcrjson.Bool(false))
+				return dcrjson.NewGetRawMempoolCmd(dcrjson.Bool(false), nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getrawmempool","params":[false],"id":1}`,
 			unmarshalled: &dcrjson.GetRawMempoolCmd{
 				Verbose: dcrjson.Bool(false),
+			},
+		},
+		{
+			name: "getrawmempool optional 2",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("getrawmempool", false, "all")
+			},
+			staticCmd: func() interface{} {
+				return dcrjson.NewGetRawMempoolCmd(dcrjson.Bool(false), dcrjson.String("all"))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getrawmempool","params":[false,"all"],"id":1}`,
+			unmarshalled: &dcrjson.GetRawMempoolCmd{
+				Verbose: dcrjson.Bool(false),
+				TxType:  dcrjson.String("all"),
 			},
 		},
 		{

--- a/dcrjson/dcrdextcmds.go
+++ b/dcrjson/dcrdextcmds.go
@@ -33,6 +33,19 @@ func NewExistsLiveTicketCmd(txHash string) *ExistsLiveTicketCmd {
 	}
 }
 
+// ExistsLiveTicketsCmd defines the existslivetickets JSON-RPC command.
+type ExistsLiveTicketsCmd struct {
+	TxHashBlob string
+}
+
+// NewExistsLiveTicketsCmd returns a new instance which can be used to issue an
+// existslivetickets JSON-RPC command.
+func NewExistsLiveTicketsCmd(txHashBlob string) *ExistsLiveTicketsCmd {
+	return &ExistsLiveTicketsCmd{
+		TxHashBlob: txHashBlob,
+	}
+}
+
 // GetCoinSupplyCmd defines the getcoinsupply JSON-RPC command.
 type GetCoinSupplyCmd struct{}
 
@@ -99,6 +112,7 @@ func init() {
 
 	MustRegisterCmd("existsaddress", (*ExistsAddressCmd)(nil), flags)
 	MustRegisterCmd("existsliveticket", (*ExistsLiveTicketCmd)(nil), flags)
+	MustRegisterCmd("existslivetickets", (*ExistsLiveTicketsCmd)(nil), flags)
 	MustRegisterCmd("getcoinsupply", (*GetCoinSupplyCmd)(nil), flags)
 	MustRegisterCmd("getstakedifficulty", (*GetStakeDifficultyCmd)(nil), flags)
 	MustRegisterCmd("missedtickets", (*MissedTicketsCmd)(nil), flags)


### PR DESCRIPTION
getrawmempool has been modified to allow for the selection of specific
transaction types from the mempool. A new RPC call, existslivetickets,
has been added. This call takes a blob of ticket hashes and returns
a blob of bit flags specifying whether or not the tickets exist. This
allows for much faster getstakeinfo calls in the wallet.