### PR TITLE
Add JSON RPC handling for listscripts wallet command

### DIFF
--- a/dcrjson/dcrwalletextcmds.go
+++ b/dcrjson/dcrwalletextcmds.go
@@ -172,6 +172,17 @@ func NewImportScriptCmd(hex string) *ImportScriptCmd {
 	return &ImportScriptCmd{hex}
 }
 
+// ListScriptsCmd is a type for handling custom marshaling and
+// unmarshaling of listscripts JSON wallet extension commands.
+type ListScriptsCmd struct {
+}
+
+// NewListScriptsCmd returns a new instance which can be used to issue a
+// listscripts JSON-RPC command.
+func NewListScriptsCmd() *ListScriptsCmd {
+	return &ListScriptsCmd{}
+}
+
 // NotifyWinningTicketsCmd is a type handling custom marshaling and
 // unmarshaling of notifywinningtickets JSON websocket extension
 // commands.
@@ -433,6 +444,7 @@ func init() {
 	MustRegisterCmd("gettickets", (*GetTicketsCmd)(nil), flags)
 	MustRegisterCmd("getticketvotebits", (*GetTicketVoteBitsCmd)(nil), flags)
 	MustRegisterCmd("importscript", (*ImportScriptCmd)(nil), flags)
+	MustRegisterCmd("listscripts", (*ListScriptsCmd)(nil), flags)
 	MustRegisterCmd("notifynewtickets", (*NotifyNewTicketsCmd)(nil), flags)
 	MustRegisterCmd("notifyspentandmissedtickets",
 		(*NotifySpentAndMissedTicketsCmd)(nil), flags)

--- a/dcrjson/dcrwalletextresults.go
+++ b/dcrjson/dcrwalletextresults.go
@@ -52,6 +52,20 @@ type GetTicketVoteBitsResult struct {
 	VoteBitsExt string `json:"votebitsext"`
 }
 
+// ScriptInfo is the structure representing a redeem script, its hash,
+// and its address.
+type ScriptInfo struct {
+	Hash160      string `json:"hash160"`
+	Address      string `json:"address"`
+	RedeemScript string `json:"redeemscript"`
+}
+
+// ListScriptsResult models the data returned from the listscripts
+// command.
+type ListScriptsResult struct {
+	Scripts []ScriptInfo `json:"scripts"`
+}
+
 // RedeemMultiSigOutResult models the data returned from the redeemmultisigout
 // command.
 type RedeemMultiSigOutResult struct {


### PR DESCRIPTION
Framework handling the new listscripts JSON RPC command for wallet
has been added. This will allow wallet users to dump the complete list
of redeem scripts from their wallet.