### PR TITLE
Fix coin supply counter to reduce work and tax subsidy based on voters

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2961,6 +2961,9 @@ func handleGetCoinSupply(s *rpcServer, cmd interface{}, closeChan <-chan struct{
 		if int64(i) < params.StakeValidationHeight {
 			supply += (work + tax)
 		} else {
+			// Make sure to reduce work and tax subsidy based on number of voters
+			work = work * voters / int64(params.TicketsPerBlock)
+			tax = tax * voters / int64(params.TicketsPerBlock)
 			supply += (work + stake + tax)
 		}
 	}


### PR DESCRIPTION
The first pass for the getCoinSupply command did not accurately reduce the work and tax subsidies based on the number of voters.  So the coinsupply was slightly high due to blocks that had less than 5 voters not being properly reduced to match the proper total block reward.  Looks like this reduces current coin supply count by roughly 1507 DCR