### PR TITLE
Corrected internal verion to release verion

### DIFF
--- a/version.go
+++ b/version.go
@@ -19,7 +19,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	appMajor uint = 0
 	appMinor uint = 0
-	appPatch uint = 1
+	appPatch uint = 4
 
 	// appPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
The internal version was still the 0.0.1-beta release. This makes recognizing updates by an external program almost impossible.