### PR TITLE
Add consolidate cmd and response framework to the JSON RPC

### DIFF
--- a/dcrjson/dcrwalletextcmds.go
+++ b/dcrjson/dcrwalletextcmds.go
@@ -7,6 +7,19 @@
 
 package dcrjson
 
+// ConsolidateCmd is a type handling custom marshaling and
+// unmarshaling of consolidate JSON wallet extension
+// commands.
+type ConsolidateCmd struct {
+	Inputs  int `json:"inputs"`
+	Account *string
+}
+
+// NewConsolidateCmd creates a new ConsolidateCmd.
+func NewConsolidateCmd(inputs int, acct *string) *ConsolidateCmd {
+	return &ConsolidateCmd{Inputs: inputs, Account: acct}
+}
+
 // SStxInput represents the inputs to an SStx transaction. Specifically a
 // transactionsha and output number pair, along with the output amounts.
 type SStxInput struct {
@@ -469,6 +482,7 @@ func init() {
 	// server.
 	flags := UFWalletOnly
 
+	MustRegisterCmd("consolidate", (*ConsolidateCmd)(nil), flags)
 	MustRegisterCmd("createrawsstx", (*CreateRawSStxCmd)(nil), flags)
 	MustRegisterCmd("createrawssgentx", (*CreateRawSSGenTxCmd)(nil), flags)
 	MustRegisterCmd("createrawssrtx", (*CreateRawSSRtxCmd)(nil), flags)


### PR DESCRIPTION
This adds the consolidate command to master, enabling a wallet to
consolidate small UTXOs into a large UTXO.