### PR TITLE
Bug fix for checkBlockForHiddenVotes corrupting block templates

### DIFF
--- a/mining.go
+++ b/mining.go
@@ -719,7 +719,8 @@ func handleTooFewVoters(nextHeight int64,
 				}
 
 				if err := bm.CheckConnectBlock(block); err != nil {
-					minrLog.Errorf("failed to check template: %v", err.Error())
+					minrLog.Errorf("failed to check template while "+
+						"duplicating a parent: %v", err.Error())
 					return nil, miningRuleError(ErrCheckConnectBlock,
 						err.Error())
 				}
@@ -840,15 +841,16 @@ func handleTooFewVoters(nextHeight int64,
 				if err := blockchain.CheckWorklessBlockSanity(btBlock,
 					bm.server.timeSource,
 					bm.server.chainParams); err != nil {
-					str := fmt.Sprintf("failed to check sanity of template: %v",
+					str := fmt.Sprintf("failed to check sanity of template "+
+						"while constructing a new parent: %v",
 						err.Error())
 					return nil, miningRuleError(ErrCheckConnectBlock,
 						str)
 				}
 
 				if err := bm.CheckConnectBlock(btBlock); err != nil {
-					str := fmt.Sprintf("failed to check template: %v",
-						err.Error())
+					str := fmt.Sprintf("failed to check template: %v while "+
+						"constructing a new parent", err.Error())
 					return nil, miningRuleError(ErrCheckConnectBlock,
 						str)
 				}


### PR DESCRIPTION
The checkBlockForHiddenVotes function would corrupt block templates
by incorrectly inserting votes from other blocks. The function has
been rewritten and now correctly regenerates the block template with
the correct number of voters.

Fixes #53.