### PR TITLE
Reduce likelihood of vote spam

### DIFF
--- a/mempool.go
+++ b/mempool.go
@@ -95,7 +95,7 @@ const (
 
 	// maxSSGensDoubleSpends is the maximum number of SSGen double spends
 	// allowed in the pool.
-	maxSSGensDoubleSpends = 64
+	maxSSGensDoubleSpends = 5
 
 	// heightDiffToPruneTicket is the number of blocks to pass by in terms
 	// of height before old tickets are pruned.


### PR DESCRIPTION
It was easy to spam the mempool with vote transactions that could never be
included in blocks. The original parameter for the number of double spent tickets
in the mempool was lax for simulations, but should be decreased to protect
mainnet daemons.