### PR TITLE
Correct the expected number of inputs for stake P2SH outputs

### DIFF
--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -606,7 +606,7 @@ func CalcScriptInfo(sigScript, pkScript []byte, bip16 bool) (*ScriptInfo, error)
 	si.NumInputs = len(sigPops)
 
 	// Count sigops taking into account pay-to-script-hash.
-	if si.PkScriptClass == ScriptHashTy && bip16 {
+	if (si.PkScriptClass == ScriptHashTy || subClass == ScriptHashTy) && bip16 {
 		// The pay-to-hash-script is the final data push of the
 		// signature script.
 		script := sigPops[len(sigPops)-1].data


### PR DESCRIPTION
The required number of inputs for a stake P2SH output were incorrectly
estimated by CalcScriptInfo. Now the sub class for any given output is
also checked for whether or not it is P2SH.