### PR TITLE
Add and implement the getticketpoolvalue JSON RPC command

### DIFF
--- a/dcrjson/dcrdextcmds.go
+++ b/dcrjson/dcrdextcmds.go
@@ -78,6 +78,15 @@ func NewGetStakeDifficultyCmd() *GetStakeDifficultyCmd {
 	return &GetStakeDifficultyCmd{}
 }
 
+// GetTicketPoolValueCmd defines the getticketpoolvalue JSON-RPC command.
+type GetTicketPoolValueCmd struct{}
+
+// NewGetTicketPoolValueCmd returns a new instance which can be used to issue a
+// getticketpoolvalue JSON-RPC command.
+func NewGetTicketPoolValueCmd() *GetTicketPoolValueCmd {
+	return &GetTicketPoolValueCmd{}
+}
+
 // MissedTicketsCmd is a type handling custom marshaling and
 // unmarshaling of missedtickets JSON RPC commands.
 type MissedTicketsCmd struct{}
@@ -129,6 +138,7 @@ func init() {
 	MustRegisterCmd("existsmempooltxs", (*ExistsMempoolTxsCmd)(nil), flags)
 	MustRegisterCmd("getcoinsupply", (*GetCoinSupplyCmd)(nil), flags)
 	MustRegisterCmd("getstakedifficulty", (*GetStakeDifficultyCmd)(nil), flags)
+	MustRegisterCmd("getticketpoolvalue", (*GetTicketPoolValueCmd)(nil), flags)
 	MustRegisterCmd("missedtickets", (*MissedTicketsCmd)(nil), flags)
 	MustRegisterCmd("rebroadcastmissed", (*RebroadcastMissedCmd)(nil), flags)
 	MustRegisterCmd("rebroadcastwinners", (*RebroadcastWinnersCmd)(nil), flags)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -180,6 +180,7 @@ var rpcHandlersBeforeInit = map[string]commandHandler{
 	"getrawmempool":         handleGetRawMempool,
 	"getrawtransaction":     handleGetRawTransaction,
 	"getstakedifficulty":    handleGetStakeDifficulty,
+	"getticketpoolvalue":    handleGetTicketPoolValue,
 	"gettxout":              handleGetTxOut,
 	"getwork":               handleGetWork,
 	"help":                  handleHelp,
@@ -3534,6 +3535,16 @@ func handleGetStakeDifficulty(s *rpcServer, cmd interface{}, closeChan <-chan st
 	sDiff := dcrutil.Amount(blockHeader.SBits)
 
 	return sDiff.ToCoin(), nil
+}
+
+// handleGetTicketPoolValue implements the getticketpoolvalue command.
+func handleGetTicketPoolValue(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
+	amt, err := s.server.blockManager.TicketPoolValue()
+	if err != nil {
+		return nil, err
+	}
+
+	return amt.ToCoin(), nil
 }
 
 // bigToLEUint256 returns the passed big integer as an unsigned 256-bit integer


### PR DESCRIPTION
The RPC command getticketpoolvalue has been added. Calling the
command will return the current value of all the locked stake from
tickets in the ticket pool.