### PR TITLE
peer: Remove extraneous hasTimestamp check.

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -365,10 +365,8 @@ func (p *peer) updateAddresses(msg *wire.MsgVersion) {
 		}
 
 		// Request known addresses if the server address manager needs
-		// more and the peer has a protocol version new enough to
-		// include a timestamp with addresses.
-		hasTimestamp := true
-		if p.server.addrManager.NeedMoreAddresses() && hasTimestamp {
+		// more.
+		if p.server.addrManager.NeedMoreAddresses() {
 			p.QueueMessage(wire.NewMsgGetAddr(), nil)
 		}
 


### PR DESCRIPTION
The upstream project didn't have timestamps in address messages until a certain protocol version, however that doesn't apply to Decred.  As a result, it looks like the check for it was updated to just hard code it to true.  This was accurate, but there is no point in setting something to
true and then turn around and check if it's true one line later.

Consequently, this just removes the check altogether.