### PR TITLE
Add new JSON handling for RPC commands and livetickets command

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -203,6 +203,18 @@ func (b *BlockChain) DisableVerify(disable bool) {
 	b.noVerify = disable
 }
 
+// LiveTickets returns all currently live tickets from the stake database.
+//
+// This function is NOT safe for concurrent access.
+func (b *BlockChain) LiveTickets() ([]*chainhash.Hash, error) {
+	live, err := b.tmdb.DumpAllLiveTicketHashes()
+	if err != nil {
+		return nil, err
+	}
+
+	return live, nil
+}
+
 // MissedTickets returns all currently missed tickets from the stake database.
 //
 // This function is NOT safe for concurrent access.

--- a/dcrjson/dcrdextcmds.go
+++ b/dcrjson/dcrdextcmds.go
@@ -20,6 +20,19 @@ func NewExistsAddressCmd(address string) *ExistsAddressCmd {
 	}
 }
 
+// ExistsAddressesCmd defines the existsaddresses JSON-RPC command.
+type ExistsAddressesCmd struct {
+	Addresses []string
+}
+
+// NewExistsAddressesCmd returns a new instance which can be used to issue an
+// existsaddresses JSON-RPC command.
+func NewExistsAddressesCmd(addresses []string) *ExistsAddressesCmd {
+	return &ExistsAddressesCmd{
+		Addresses: addresses,
+	}
+}
+
 // ExistsLiveTicketCmd defines the existsliveticket JSON-RPC command.
 type ExistsLiveTicketCmd struct {
 	TxHash string
@@ -87,6 +100,16 @@ func NewGetTicketPoolValueCmd() *GetTicketPoolValueCmd {
 	return &GetTicketPoolValueCmd{}
 }
 
+// LiveTicketsCmd is a type handling custom marshaling and
+// unmarshaling of livetickets JSON RPC commands.
+type LiveTicketsCmd struct{}
+
+// NewLiveTicketsCmd returns a new instance which can be used to issue a JSON-RPC
+// livetickets command.
+func NewLiveTicketsCmd() *LiveTicketsCmd {
+	return &LiveTicketsCmd{}
+}
+
 // MissedTicketsCmd is a type handling custom marshaling and
 // unmarshaling of missedtickets JSON RPC commands.
 type MissedTicketsCmd struct{}
@@ -133,12 +156,14 @@ func init() {
 	flags := UsageFlag(0)
 
 	MustRegisterCmd("existsaddress", (*ExistsAddressCmd)(nil), flags)
+	MustRegisterCmd("existsaddresses", (*ExistsAddressesCmd)(nil), flags)
 	MustRegisterCmd("existsliveticket", (*ExistsLiveTicketCmd)(nil), flags)
 	MustRegisterCmd("existslivetickets", (*ExistsLiveTicketsCmd)(nil), flags)
 	MustRegisterCmd("existsmempooltxs", (*ExistsMempoolTxsCmd)(nil), flags)
 	MustRegisterCmd("getcoinsupply", (*GetCoinSupplyCmd)(nil), flags)
 	MustRegisterCmd("getstakedifficulty", (*GetStakeDifficultyCmd)(nil), flags)
 	MustRegisterCmd("getticketpoolvalue", (*GetTicketPoolValueCmd)(nil), flags)
+	MustRegisterCmd("livetickets", (*LiveTicketsCmd)(nil), flags)
 	MustRegisterCmd("missedtickets", (*MissedTicketsCmd)(nil), flags)
 	MustRegisterCmd("rebroadcastmissed", (*RebroadcastMissedCmd)(nil), flags)
 	MustRegisterCmd("rebroadcastwinners", (*RebroadcastWinnersCmd)(nil), flags)

--- a/dcrjson/dcrdextresults.go
+++ b/dcrjson/dcrdextresults.go
@@ -5,6 +5,12 @@
 
 package dcrjson
 
+// LiveTicketsResult models the data returned from the livetickets
+// command.
+type LiveTicketsResult struct {
+	Tickets []string `json:"tickets"`
+}
+
 // MissedTicketsResult models the data returned from the missedtickets
 // command.
 type MissedTicketsResult struct {

--- a/dcrjson/dcrwalletextcmds.go
+++ b/dcrjson/dcrwalletextcmds.go
@@ -7,6 +7,49 @@
 
 package dcrjson
 
+// AccountAddressIndexCmd is a type handling custom marshaling and
+// unmarshaling of accountaddressindex JSON wallet extension
+// commands.
+type AccountAddressIndexCmd struct {
+	Account string `json:"account"`
+	Branch  int    `json:"branch"`
+}
+
+// NewAccountAddressIndexCmd creates a new AccountAddressIndexCmd.
+func NewAccountAddressIndexCmd(acct string) *AccountAddressIndexCmd {
+	return &AccountAddressIndexCmd{Account: acct}
+}
+
+// AccountFetchAddressesCmd is a type handling custom marshaling and
+// unmarshaling of accountfetchaddresses JSON wallet extension
+// commands.
+type AccountFetchAddressesCmd struct {
+	Account string `json:"account"`
+	Branch  int    `json:"branch"`
+	Start   int    `json:"start"`
+	End     int    `json:"end"`
+}
+
+// NewAccountFetchAddressesCmd creates a new AccountFetchAddressesCmd.
+func NewAccountFetchAddressesCmd(acct string) *AccountAddressIndexCmd {
+	return &AccountAddressIndexCmd{Account: acct}
+}
+
+// AccountSyncAddressIndexCmd is a type handling custom marshaling and
+// unmarshaling of accountsyncaddressindex JSON wallet extension
+// commands.
+type AccountSyncAddressIndexCmd struct {
+	Account string `json:"account"`
+	Branch  int    `json:"branch"`
+	Index   int    `json:"index"`
+}
+
+// NewAccountSyncAddressIndexCmd creates a new AccountSyncAddressIndexCmd.
+func NewAccountSyncAddressIndexCmd(acct string,
+	idx int) *AccountSyncAddressIndexCmd {
+	return &AccountSyncAddressIndexCmd{Account: acct, Index: idx}
+}
+
 // ConsolidateCmd is a type handling custom marshaling and
 // unmarshaling of consolidate JSON wallet extension
 // commands.
@@ -112,11 +155,12 @@ func NewGetMultisigOutInfoCmd(hash string, index uint32) *GetMultisigOutInfoCmd 
 // GetMasterPubkeyCmd is a type handling custom marshaling and unmarshaling of
 // getmasterpubkey JSON wallet extension commands.
 type GetMasterPubkeyCmd struct {
+	Account *string
 }
 
 // NewGetMasterPubkeyCmd creates a new GetMasterPubkeyCmd.
-func NewGetMasterPubkeyCmd() *GetMasterPubkeyCmd {
-	return &GetMasterPubkeyCmd{}
+func NewGetMasterPubkeyCmd(acct *string) *GetMasterPubkeyCmd {
+	return &GetMasterPubkeyCmd{Account: acct}
 }
 
 // GetSeedCmd is a type handling custom marshaling and
@@ -502,11 +546,24 @@ func NewSignRawTransactionsCmd(hexEncodedTxs []string,
 	}
 }
 
+// WalletInfoCmd defines the walletinfo JSON-RPC command.
+type WalletInfoCmd struct {
+}
+
+// NewWalletInfoCmd returns a new instance which can be used to issue a
+// walletinfo JSON-RPC command.
+func NewWalletInfoCmd() *WalletInfoCmd {
+	return &WalletInfoCmd{}
+}
+
 func init() {
 	// The commands in this file are only usable with a wallet
 	// server.
 	flags := UFWalletOnly
 
+	MustRegisterCmd("accountaddressindex", (*AccountAddressIndexCmd)(nil), flags)
+	MustRegisterCmd("accountfetchaddresses", (*AccountFetchAddressesCmd)(nil), flags)
+	MustRegisterCmd("accountsyncaddressindex", (*AccountSyncAddressIndexCmd)(nil), flags)
 	MustRegisterCmd("consolidate", (*ConsolidateCmd)(nil), flags)
 	MustRegisterCmd("createrawsstx", (*CreateRawSStxCmd)(nil), flags)
 	MustRegisterCmd("createrawssgentx", (*CreateRawSSGenTxCmd)(nil), flags)
@@ -542,4 +599,5 @@ func init() {
 	MustRegisterCmd("setticketmaxprice", (*SetTicketMaxPriceCmd)(nil), flags)
 	MustRegisterCmd("setticketvotebits", (*SetTicketVoteBitsCmd)(nil), flags)
 	MustRegisterCmd("signrawtransactions", (*SignRawTransactionsCmd)(nil), flags)
+	MustRegisterCmd("walletinfo", (*WalletInfoCmd)(nil), flags)
 }

--- a/dcrjson/dcrwalletextresults.go
+++ b/dcrjson/dcrwalletextresults.go
@@ -5,6 +5,12 @@
 
 package dcrjson
 
+// AccountFetchAddressesResult models the data returned from the
+// accountfetchaddresses command.
+type AccountFetchAddressesResult struct {
+	Addresses []string `json:"addresses"`
+}
+
 // GetMultisigOutInfoResult models the data returned from the getmultisigoutinfo
 // command.
 type GetMultisigOutInfoResult struct {
@@ -111,4 +117,16 @@ type SignedTransaction struct {
 // command.
 type SignRawTransactionsResult struct {
 	Results []SignedTransaction `json:"results"`
+}
+
+// WalletInfoResult models the data returned from the walletinfo
+// command.
+type WalletInfoResult struct {
+	DaemonConnected   bool    `json:"daemonconnected"`
+	Unlocked          bool    `json:"unlocked"`
+	TxFee             float64 `json:"txfee"`
+	TicketFee         float64 `json:"ticketfee"`
+	TicketMaxPrice    float64 `json:"ticketmaxprice"`
+	BalanceToMaintain float64 `json:"balancetomaintain"`
+	StakeMining       bool    `json:"stakemining"`
 }

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -147,6 +147,11 @@ var helpDescsEnUS = map[string]string{
 	"existsaddress-address":   "The address to check",
 	"existsaddress--result0":  "Bool showing if address exists or not",
 
+	// ExistsAddressesCmd help.
+	"existsaddresses--synopsis": "Test for the existance of the provided addresses in the blockchain or memory pool",
+	"existsaddresses-addresses": "The addresses to check",
+	"existsaddresses--result0":  "Bitset of bools showing if addresses exist or not",
+
 	// ExistsLiveTicketCmd help.
 	"existsliveticket--synopsis": "Test for the existance of the provided ticket",
 	"existsliveticket-txhash":    "The ticket hash to check",
@@ -654,6 +659,10 @@ var helpDescsEnUS = map[string]string{
 	"ticket-owner":                   "Address owning the ticket.",
 	"ticket-hash":                    "Hash of the ticket.",
 
+	// LiveTickets help.
+	"livetickets--synopsis":     "Reguest tickets the live ticket hashes from the ticket database",
+	"liveticketsresult-tickets": "List of live tickets",
+
 	// MissedTickets help.
 	"missedtickets--synopsis":     "Reguest tickets the client missed",
 	"missedticketsresult-tickets": "List of missed tickets",
@@ -677,6 +686,7 @@ var rpcResultTypes = map[string][]interface{}{
 	"decodescript":          []interface{}{(*dcrjson.DecodeScriptResult)(nil)},
 	"estimatefee":           []interface{}{(*float64)(nil)},
 	"existsaddress":         []interface{}{(*bool)(nil)},
+	"existsaddresses":       []interface{}{(*string)(nil)},
 	"existsliveticket":      []interface{}{(*bool)(nil)},
 	"existslivetickets":     []interface{}{(*string)(nil)},
 	"existsmempooltxs":      []interface{}{(*string)(nil)},
@@ -705,9 +715,10 @@ var rpcResultTypes = map[string][]interface{}{
 	"gettxout":              []interface{}{(*dcrjson.GetTxOutResult)(nil)},
 	"getwork":               []interface{}{(*dcrjson.GetWorkResult)(nil), (*bool)(nil)},
 	"getcoinsupply":         []interface{}{(*int64)(nil)},
+	"help":                  []interface{}{(*string)(nil), (*string)(nil)},
+	"livetickets":           []interface{}{(*dcrjson.LiveTicketsResult)(nil)},
 	"missedtickets":         []interface{}{(*dcrjson.MissedTicketsResult)(nil)},
 	"node":                  nil,
-	"help":                  []interface{}{(*string)(nil), (*string)(nil)},
 	"ping":                  nil,
 	"rebroadcastmissed":     nil,
 	"rebroadcastwinners":    nil,


### PR DESCRIPTION
New JSON handling has been added for the following wallet commands:
  accountaddressindex
  accountfetchaddresses
  accountsyncaddressindex
  getwalletinfo

getmasterpubkey has been modified to take an account argument.

The new daemon command livetickets has been added. This command dumps
the hashes for all the live tickets in the live ticket stake database.