### PR TITLE
TravisCI: Remove external go vet reference. (#655)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,9 @@ go:
 sudo: false
 before_install:
   - gotools=golang.org/x/tools
-  - if [ "$TRAVIS_GO_VERSION" = "release" ]; then gotools=code.google.com/p/go.tools; fi
 install:
   - go get -d -t -v ./...
   - go get -v $gotools/cmd/cover
-  - go get -v $gotools/cmd/vet
   - go get -v github.com/bradfitz/goimports
   - go get -v github.com/golang/lint/golint
 script:


### PR DESCRIPTION
The vet tool moved into the Go source tree as of Go 1.5.  Its previous
location in the x/tools repo was deprecated at that time and has now
been removed.

This commit updates the .travis.yml configuration to avoid fetching vet
from the old location and to simply use the version now available as
part of the standard Go install.

Also, while here, remove the check for changing the tool path since it
is no longer needed.