### PR TITLE
Modify the purchaseticket RPC command

### DIFF
--- a/dcrjson/dcrwalletextcmds.go
+++ b/dcrjson/dcrwalletextcmds.go
@@ -337,17 +337,26 @@ type PurchaseTicketCmd struct {
 	SpendLimit    float64 // In Coins
 	MinConf       *int    `jsonrpcdefault:"1"`
 	TicketAddress *string
+	NumTickets    *int
+	PoolAddress   *string
+	PoolFees      *float64
+	Expiry        *int
 	Comment       *string
 }
 
 // NewPurchaseTicketCmd creates a new PurchaseTicketCmd.
 func NewPurchaseTicketCmd(fromAccount string, spendLimit float64, minConf *int,
-	ticketAddress *string, comment *string) *PurchaseTicketCmd {
+	ticketAddress *string, numTickets *int, poolAddress *string, poolFees *float64,
+	expiry *int, comment *string) *PurchaseTicketCmd {
 	return &PurchaseTicketCmd{
 		FromAccount:   fromAccount,
 		SpendLimit:    spendLimit,
 		MinConf:       minConf,
 		TicketAddress: ticketAddress,
+		NumTickets:    numTickets,
+		PoolAddress:   poolAddress,
+		PoolFees:      poolFees,
+		Expiry:        expiry,
 		Comment:       comment,
 	}
 }


### PR DESCRIPTION
The purchaseticket RPC command has been modified to add the new fields
now used by wallet.