### PR TITLE
Check to see if missingParents != nil which means isOrphan

### DIFF
--- a/mempool.go
+++ b/mempool.go
@@ -2040,42 +2040,43 @@ func (mp *txMemPool) ProcessTransaction(tx *dcrutil.Tx, allowOrphan,
 		// transaction (they are no longer orphans) and repeat for those
 		// accepted transactions until there are no more.
 		mp.processOrphans(tx.Sha())
-	} else {
-		// The transaction is an orphan (has inputs missing).  Reject
-		// it if the flag to allow orphans is not set.
-		if !allowOrphan {
-			// NOTE: RejectDuplicate is really not an accurate
-			// reject code here, but it matches the reference
-			// implementation and there isn't a better choice due
-			// to the limited number of reject codes.  Missing
-			// inputs is assumed to mean they are already spent
-			// which is not really always the case.
-			var buf bytes.Buffer
-			buf.WriteString("transaction spends unknown inputs; includes " +
-				"inputs: \n")
-			lenIn := len(tx.MsgTx().TxIn)
-			for i, txIn := range tx.MsgTx().TxIn {
-				str := fmt.Sprintf("[%v]: %v, %v, %v",
-					i,
-					txIn.PreviousOutPoint.Hash,
-					txIn.PreviousOutPoint.Index,
-					txIn.PreviousOutPoint.Tree)
-				buf.WriteString(str)
-				if i != lenIn-1 {
-					buf.WriteString("\n")
-				}
+		return nil
+	}
+
+	// The transaction is an orphan (has inputs missing).  Reject
+	// it if the flag to allow orphans is not set.
+	if !allowOrphan {
+		// NOTE: RejectDuplicate is really not an accurate
+		// reject code here, but it matches the reference
+		// implementation and there isn't a better choice due
+		// to the limited number of reject codes.  Missing
+		// inputs is assumed to mean they are already spent
+		// which is not really always the case.
+		var buf bytes.Buffer
+		buf.WriteString("transaction spends unknown inputs; includes " +
+			"inputs: \n")
+		lenIn := len(tx.MsgTx().TxIn)
+		for i, txIn := range tx.MsgTx().TxIn {
+			str := fmt.Sprintf("[%v]: %v, %v, %v",
+				i,
+				txIn.PreviousOutPoint.Hash,
+				txIn.PreviousOutPoint.Index,
+				txIn.PreviousOutPoint.Tree)
+			buf.WriteString(str)
+			if i != lenIn-1 {
+				buf.WriteString("\n")
 			}
-			txmpLog.Debugf("%v", buf.String())
-
-			return txRuleError(wire.RejectDuplicate,
-				"transaction spends unknown inputs")
 		}
+		txmpLog.Debugf("%v", buf.String())
 
-		// Potentially add the orphan transaction to the orphan pool.
-		err := mp.maybeAddOrphan(tx)
-		if err != nil {
-			return err
-		}
+		return txRuleError(wire.RejectDuplicate,
+			"transaction spends unknown inputs")
+	}
+
+	// Potentially add the orphan transaction to the orphan pool.
+	err = mp.maybeAddOrphan(tx)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/mempool.go
+++ b/mempool.go
@@ -2025,15 +2025,13 @@ func (mp *txMemPool) ProcessTransaction(tx *dcrutil.Tx, allowOrphan,
 	txmpLog.Tracef("Processing transaction %v", tx.Sha())
 
 	// Potentially accept the transaction to the memory pool.
-	var isOrphan bool
 	missingParents, err := mp.maybeAcceptTransaction(tx, true, rateLimit)
 	if err != nil {
 		return err
 	}
 
-	isOrphan = len(missingParents) != 0
-
-	if !isOrphan {
+	// If len(missingParents) == 0 then we know the tx is NOT an orphan
+	if len(missingParents) == 0 {
 		// Generate the inventory vector and relay it.
 		iv := wire.NewInvVect(wire.InvTypeTx, tx.Sha())
 		mp.server.RelayInventory(iv, tx)

--- a/mempool.go
+++ b/mempool.go
@@ -2026,9 +2026,13 @@ func (mp *txMemPool) ProcessTransaction(tx *dcrutil.Tx, allowOrphan,
 
 	// Potentially accept the transaction to the memory pool.
 	var isOrphan bool
-	_, err := mp.maybeAcceptTransaction(tx, true, rateLimit)
+	missingParents, err := mp.maybeAcceptTransaction(tx, true, rateLimit)
 	if err != nil {
 		return err
+	}
+
+	if missingParents != nil {
+		isOrphan = true
 	}
 
 	if !isOrphan {

--- a/mempool.go
+++ b/mempool.go
@@ -2031,9 +2031,7 @@ func (mp *txMemPool) ProcessTransaction(tx *dcrutil.Tx, allowOrphan,
 		return err
 	}
 
-	if missingParents != nil {
-		isOrphan = true
-	}
+	isOrphan = len(missingParents) != 0
 
 	if !isOrphan {
 		// Generate the inventory vector and relay it.


### PR DESCRIPTION
Before you could use dcrctl sendrawtransactions <rawbytes> with a transaction that has unknown inputs, but it would act like it sent sucessfully (no error and return txid).  But, in fact, the tx was reject due to it being an orphan (spending unknown inputs) and it should accurately err out and tell the user of this.