### PR TITLE
Use AllowHighFees in SendRawTransaction cmd to actually check tx fees

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4422,6 +4422,8 @@ func handleSearchRawTransactions(s *rpcServer, cmd interface{},
 func handleSendRawTransaction(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
 	c := cmd.(*dcrjson.SendRawTransactionCmd)
 	// Deserialize and send off to tx relay
+
+	allowHighFees := *c.AllowHighFees
 	hexStr := c.HexTx
 	if len(hexStr)%2 != 0 {
 		hexStr = "0" + hexStr
@@ -4440,7 +4442,7 @@ func handleSendRawTransaction(s *rpcServer, cmd interface{}, closeChan <-chan st
 	}
 
 	tx := dcrutil.NewTx(msgtx)
-	err = s.server.blockManager.ProcessTransaction(tx, false, false)
+	err = s.server.blockManager.ProcessTransaction(tx, false, false, allowHighFees)
 	if err != nil {
 		// When the error is a rule error, it means the transaction was
 		// simply rejected as opposed to something actually going wrong,


### PR DESCRIPTION
If the tx fee/kb are 100x above the minimum (1e6 atoms) and AllowHighFees is false (default), then error and don't allow the tx to be broadcast.

This will not effect any other incoming tx to this node, it is only being checked for sendrawtransaction coming out of that node.

Fixes issue 187 in dcrwallet