### PR TITLE
fix sample config per issue 116

### DIFF
--- a/sample-dcrd.conf
+++ b/sample-dcrd.conf
@@ -161,8 +161,9 @@
 ; Specify the interfaces for the RPC server listen on.  One listen address per
 ; line.  NOTE: The default port is modified by some options such as 'testnet',
 ; so it is recommended to not specify a port and allow a proper default to be
-; chosen unless you have a specific reason to do otherwise.
-; All interfaces on default port (this is the default):
+; chosen unless you have a specific reason to do otherwise.  By default, the
+; RPC server will only listen on localhost for IPv4 and IPv6.
+; All interfaces on default port:
 ;   rpclisten=
 ; All ipv4 interfaces on default port:
 ;   rpclisten=0.0.0.0


### PR DESCRIPTION
closes #116

verified that the rcp server by default only listens on the localhost