### PR TITLE
Reject too low stake difficulty transactions and cache difficulty

### DIFF
--- a/mempool.go
+++ b/mempool.go
@@ -1257,10 +1257,24 @@ func (mp *txMemPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew,
 		}
 	}
 
-	isSSGen, _ := stake.IsSSGen(tx)
-	isSSRtx, _ := stake.IsSSRtx(tx)
-	if isSSGen || isSSRtx {
-		if isSSGen {
+	// If the transaction is a ticket, ensure that it meets the next
+	// stake difficulty.
+	if txType == stake.TxTypeSStx {
+		mp.server.blockManager.chainState.Lock()
+		sDiff := mp.server.blockManager.chainState.nextStakeDifficulty
+		mp.server.blockManager.chainState.Unlock()
+
+		if tx.MsgTx().TxOut[0].Value < sDiff {
+			str := fmt.Sprintf("transaction %v has not enough funds "+
+				"to meet stake difficuly (ticket diff %v < next diff %v)",
+				txHash, tx.MsgTx().TxOut[0].Value, sDiff)
+			return nil, txRuleError(wire.RejectInsufficientFee, str)
+		}
+	}
+
+	// Handle stake transaction double spending exceptions.
+	if (txType == stake.TxTypeSSGen) || (txType == stake.TxTypeSSRtx) {
+		if txType == stake.TxTypeSSGen {
 			ssGenAlreadyFound := 0
 			for _, mpTx := range mp.pool {
 				if mpTx.GetType() == stake.TxTypeSSGen {
@@ -1279,7 +1293,7 @@ func (mp *txMemPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew,
 			}
 		}
 
-		if isSSRtx {
+		if txType == stake.TxTypeSSRtx {
 			for _, mpTx := range mp.pool {
 				if mpTx.GetType() == stake.TxTypeSSRtx {
 					if mpTx.Tx.MsgTx().TxIn[0].PreviousOutPoint ==
@@ -1385,7 +1399,8 @@ func (mp *txMemPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew,
 	// the coinbase address itself can contain signature operations, the
 	// maximum allowed signature operations per transaction is less than
 	// the maximum allowed signature operations per block.
-	numSigOps, err := blockchain.CountP2SHSigOps(tx, false, isSSGen, txStore)
+	numSigOps, err := blockchain.CountP2SHSigOps(tx, false,
+		(txType == stake.TxTypeSSGen), txStore)
 	if err != nil {
 		if cerr, ok := err.(blockchain.RuleError); ok {
 			return nil, chainRuleError(cerr)
@@ -1393,7 +1408,7 @@ func (mp *txMemPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew,
 		return nil, err
 	}
 
-	numSigOps += blockchain.CountSigOps(tx, false, isSSGen)
+	numSigOps += blockchain.CountSigOps(tx, false, (txType == stake.TxTypeSSGen))
 	if numSigOps > maxSigOpsPerTx {
 		str := fmt.Sprintf("transaction %v has too many sigops: %d > %d",
 			txHash, numSigOps, maxSigOpsPerTx)

--- a/mining.go
+++ b/mining.go
@@ -1138,6 +1138,7 @@ func NewBlockTemplate(mempool *txMemPool,
 	prevHash := chainState.newestHash
 	nextBlockHeight := chainState.newestHeight + 1
 	poolSize := chainState.nextPoolSize
+	requiredStakeDifficulty := chainState.nextStakeDifficulty
 	finalState := chainState.nextFinalState
 	winningTickets := make([]chainhash.Hash, len(chainState.winningTickets),
 		len(chainState.winningTickets))
@@ -1206,14 +1207,6 @@ func NewBlockTemplate(mempool *txMemPool,
 				}
 			}
 		}
-	}
-
-	// Get the next required stake difficulty so we can determine SStx
-	// eligibility.
-	requiredStakeDifficulty, err := blockManager.CalcNextRequiredStakeDifficulty()
-	if err != nil {
-		return nil, miningRuleError(ErrGetStakeDifficulty, "couldn't get "+
-			"stake difficulty")
 	}
 
 	// Get the current memory pool transactions and create a priority queue


### PR DESCRIPTION
The mempool would allow low stake difficulty tickets and then remove
them after the next block was added. This prevents too low difficulty
tickets from being added in the first place. It also refactors some of
the old code in mempool.go, blockmanager.go, and mining.go for
efficiency.

Fixes #153.