### PR TITLE
mempool: Synchronize btcd commits fixing orphan hang

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4542,7 +4542,8 @@ func handleSendRawTransaction(s *rpcServer, cmd interface{}, closeChan <-chan st
 	}
 
 	tx := dcrutil.NewTx(msgtx)
-	err = s.server.blockManager.ProcessTransaction(tx, false, false, allowHighFees)
+	acceptedTxs, err := s.server.blockManager.ProcessTransaction(tx, false,
+		false, allowHighFees)
 	if err != nil {
 		// When the error is a rule error, it means the transaction was
 		// simply rejected as opposed to something actually going wrong,
@@ -4562,6 +4563,8 @@ func handleSendRawTransaction(s *rpcServer, cmd interface{}, closeChan <-chan st
 			Message: "TX rejected: " + err.Error(),
 		}
 	}
+
+	s.server.AnnounceNewTransactions(acceptedTxs)
 
 	// Keep track of all the sendrawtransaction request txns so that they
 	// can be rebroadcast if they don't make their way into a block.


### PR DESCRIPTION
The mempool would hang when processing orphans occasionally because 
some orphans would be added continuously to the orphan pool. This was 
fixed in btcd previously by changing a list to a map.