### PR TITLE
dcrd: handle signal SIGTERM (#688)

### DIFF
--- a/signalsigterm.go
+++ b/signalsigterm.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2016 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+// +build darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+func init() {
+	signals = []os.Signal{os.Interrupt, syscall.SIGTERM}
+}


### PR DESCRIPTION
When an OS reboots or shuts down, it sends all processes SIGTERM before
sending SIGKILL.  This allows dcrd to do a proper shutdown which most
importantly closes the databases.