### PR TITLE
Fix createrawssrtx command and logic

### DIFF
--- a/dcrjson/dcrwalletextcmds.go
+++ b/dcrjson/dcrwalletextcmds.go
@@ -144,12 +144,14 @@ func NewCreateRawSSGenTxCmd(inputs []TransactionInput,
 // unmarshaling of createrawssrtx JSON RPC commands.
 type CreateRawSSRtxCmd struct {
 	Inputs []TransactionInput
+	Fee    *float64
 }
 
 // NewCreateRawSSRtxCmd creates a new CreateRawSSRtxCmd.
-func NewCreateRawSSRtxCmd(inputs []TransactionInput) *CreateRawSSRtxCmd {
+func NewCreateRawSSRtxCmd(inputs []TransactionInput, fee *float64) *CreateRawSSRtxCmd {
 	return &CreateRawSSRtxCmd{
 		Inputs: inputs,
+		Fee:    fee,
 	}
 }
 

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -79,6 +79,7 @@ var helpDescsEnUS = map[string]string{
 		"The signrawtransaction RPC command provided by wallet must be used to sign the resulting transaction.",
 	"createrawssrtx--result0": "Hex-encoded bytes of the serialized transaction",
 	"createrawssrtx-inputs":   "The inputs to the transaction of type sstxinput",
+	"createrawssrtx-fee":      "The fee to apply to the revocation in Coins",
 
 	// CreateRawTransactionCmd help.
 	"createrawtransaction--synopsis": "Returns a new transaction spending the provided inputs and sending to the provided addresses.\n" +


### PR DESCRIPTION
The createrawssrtx could not produce correctly formed revocations.
The code has been corrected to call the correct internal API. A
new 'fee' option was added to the JSON command to add a fee to the
revocation.