### PR TITLE
Add JSON RPC handling of setexpirydelta command

### DIFF
--- a/dcrjson/dcrwalletextcmds.go
+++ b/dcrjson/dcrwalletextcmds.go
@@ -512,11 +512,25 @@ type SetBalanceToMaintainCmd struct {
 	Balance float64
 }
 
-// NewSetBalanceToMaintainCmd creates a new instance of the setticketfee
+// NewSetBalanceToMaintainCmd creates a new instance of the setbalancetomaintain
 // command.
 func NewSetBalanceToMaintainCmd(balance float64) *SetBalanceToMaintainCmd {
 	return &SetBalanceToMaintainCmd{
 		Balance: balance,
+	}
+}
+
+// SetExpiryDeltaCmd is a type handling custom marshaling and
+// unmarshaling of setexpirydelta JSON RPC commands.
+type SetExpiryDeltaCmd struct {
+	Delta uint32
+}
+
+// NewSetExpiryDeltaCmd creates a new instance of the setexpirydelta
+// command.
+func NewSetExpiryDeltaCmd(delta uint32) *SetExpiryDeltaCmd {
+	return &SetExpiryDeltaCmd{
+		Delta: delta,
 	}
 }
 
@@ -645,6 +659,7 @@ func init() {
 	MustRegisterCmd("sendtossgen", (*SendToSSGenCmd)(nil), flags)
 	MustRegisterCmd("sendtossrtx", (*SendToSSRtxCmd)(nil), flags)
 	MustRegisterCmd("setbalancetomaintain", (*SetBalanceToMaintainCmd)(nil), flags)
+	MustRegisterCmd("setexpirydelta", (*SetExpiryDeltaCmd)(nil), flags)
 	MustRegisterCmd("setticketfee", (*SetTicketFeeCmd)(nil), flags)
 	MustRegisterCmd("setticketmaxprice", (*SetTicketMaxPriceCmd)(nil), flags)
 	MustRegisterCmd("setticketvotebits", (*SetTicketVoteBitsCmd)(nil), flags)

--- a/dcrjson/dcrwalletextresults.go
+++ b/dcrjson/dcrwalletextresults.go
@@ -145,5 +145,6 @@ type WalletInfoResult struct {
 	TicketFee         float64 `json:"ticketfee"`
 	TicketMaxPrice    float64 `json:"ticketmaxprice"`
 	BalanceToMaintain float64 `json:"balancetomaintain"`
+	ExpiryDelta       uint32  `json:"expirydelta"`
 	StakeMining       bool    `json:"stakemining"`
 }


### PR DESCRIPTION
The JSON framework for setexpirydelta commands in wallet have
been added. A field specifying what the expirydelta in wallet
currently is was also added to the walletinfo result.