### PR TITLE
Waste less memory if sighash optimizations are on

### DIFF
--- a/txscript/internal_test.go
+++ b/txscript/internal_test.go
@@ -12,7 +12,12 @@ interface.  The functions are only exported while the tests are being run.
 
 package txscript
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/wire"
+)
 
 // TstMaxScriptSize makes the internal maxScriptSize constant available to the
 // test package.
@@ -82,6 +87,12 @@ func TstRemoveOpcodeByData(pkscript []byte, data []byte) ([]byte, error) {
 func (vm *Engine) TstSetPC(script, off int) {
 	vm.scriptIdx = script
 	vm.scriptOff = off
+}
+
+// TstCalcSignatureHash is an exported version for testing.
+func TstCalcSignatureHash(script []parsedOpcode, hashType SigHashType,
+	tx *wire.MsgTx, idx int, cachedPrefix *chainhash.Hash) ([]byte, error) {
+	return calcSignatureHash(script, hashType, tx, idx, cachedPrefix)
 }
 
 // Internal tests for opcode parsing with bad data templates.

--- a/txscript/script_test.go
+++ b/txscript/script_test.go
@@ -532,13 +532,14 @@ func TestCalcSignatureHash(t *testing.T) {
 	pops, _ := txscript.TstParseScript([]byte{0x01, 0x01, 0x02, 0x03})
 
 	// Test prefix caching.
-	msg1, err := txscript.CalcSignatureHash(pops, txscript.SigHashAll, tx, 0, nil)
+	msg1, err := txscript.TstCalcSignatureHash(pops, txscript.SigHashAll, tx, 0,
+		nil)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err.Error())
 	}
 
 	prefixHash := tx.TxSha()
-	msg2, err := txscript.CalcSignatureHash(pops, txscript.SigHashAll, tx, 0,
+	msg2, err := txscript.TstCalcSignatureHash(pops, txscript.SigHashAll, tx, 0,
 		&prefixHash)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err.Error())
@@ -563,7 +564,7 @@ func TestCalcSignatureHash(t *testing.T) {
 
 	// Move the index and make sure that we get a whole new hash, despite
 	// using the same TxOuts.
-	msg3, err := txscript.CalcSignatureHash(pops, txscript.SigHashAll, tx, 1,
+	msg3, err := txscript.TstCalcSignatureHash(pops, txscript.SigHashAll, tx, 1,
 		&prefixHash)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err.Error())

--- a/wire/common.go
+++ b/wire/common.go
@@ -6,6 +6,7 @@
 package wire
 
 import (
+	"bytes"
 	"crypto/rand"
 	"encoding/binary"
 	"fmt"
@@ -434,6 +435,13 @@ func writeVarInt(w io.Writer, pver uint32, val uint64) error {
 	return err
 }
 
+// WriteVarInt is the exported form of writeVarBytes. It uses the latest
+// version of the wire protocol as stored in the package.
+func WriteVarInt(buf *bytes.Buffer, val uint64) error {
+	w := io.Writer(buf)
+	return writeVarInt(w, ProtocolVersion, val)
+}
+
 // VarIntSerializeSize returns the number of bytes it would take to serialize
 // val as a variable length integer.
 func VarIntSerializeSize(val uint64) int {
@@ -533,7 +541,7 @@ func readVarBytes(r io.Reader, pver uint32, maxAllowed uint32,
 	return b, nil
 }
 
-// writeVarInt serializes a variable length byte array to w as a varInt
+// writeVarBytes serializes a variable length byte array to w as a varInt
 // containing the number of bytes, followed by the bytes themselves.
 func writeVarBytes(w io.Writer, pver uint32, bytes []byte) error {
 	slen := uint64(len(bytes))
@@ -547,6 +555,13 @@ func writeVarBytes(w io.Writer, pver uint32, bytes []byte) error {
 		return err
 	}
 	return nil
+}
+
+// WriteVarBytes is the exported form of writeVarBytes. It uses the latest
+// version of the wire protocol as stored in the package.
+func WriteVarBytes(buf *bytes.Buffer, bytes []byte) error {
+	w := io.Writer(buf)
+	return writeVarBytes(w, ProtocolVersion, bytes)
 }
 
 // randomUint64 returns a cryptographically random uint64 value.  This


### PR DESCRIPTION
Legacy transaction deep copy code mandated by the Bitcoin protocol
caused large amounts of data to be copied needlessly. If the
optimization for SigHashAll is set in chaincfg/params.go, these
extra copies are avoided by directly writing the pkScript and
decorations to a buffer and then hashing to get a witness hash,
while using the cached hash for the prefix.

Fixes #126.