### PR TITLE
Sync upstream through Sep 28, 2015.

### DIFF
--- a/config.go
+++ b/config.go
@@ -126,6 +126,7 @@ type config struct {
 	NonAggressive      bool          `long:"nonaggressive" description:"Disable mining off of the parent block of the blockchain if there aren't enough voters"`
 	NoMiningStateSync  bool          `long:"nominingstatesync" description:"Disable synchronizing the mining state with other nodes"`
 	AllowOldVotes      bool          `long:"allowoldvotes" description:"Enable the addition of very old votes to the mempool"`
+	NoPeerBloomFilters bool          `long:"nopeerbloomfilters" description:"Disable bloom filtering support."`
 	onionlookup        func(string) ([]net.IP, error)
 	lookup             func(string) ([]net.IP, error)
 	oniondial          func(string, string) (net.Conn, error)

--- a/doc.go
+++ b/doc.go
@@ -22,86 +22,90 @@ Usage:
   dcrd [OPTIONS]
 
 Application Options:
-  -V, --version            Display version information and exit
-  -C, --configfile=        Path to configuration file
-  -b, --datadir=           Directory to store data
-  -a, --addpeer=           Add a peer to connect with at startup
-      --connect=           Connect only to the specified peers at startup
-      --nolisten           Disable listening for incoming connections -- NOTE:
-                           Listening is automatically disabled if the --connect
-                           or --proxy options are used without also specifying
-                           listen interfaces via --listen
-      --listen=            Add an interface/port to listen for connections
-                           (default all interfaces port: 9108, testnet: 19108)
-      --maxpeers=          Max number of inbound and outbound peers (125)
-      --banduration=       How long to ban misbehaving peers.  Valid time units
-                           are {s, m, h}.  Minimum 1 second (24h0m0s)
-  -u, --rpcuser=           Username for RPC connections
-  -P, --rpcpass=           Password for RPC connections
-      --rpclimituser=      Username for limited RPC connections
-      --rpclimitpass=      Password for limited RPC connections
-      --rpclisten=         Add an interface/port to listen for RPC connections
-                           (default port: 9109, testnet: 19109)
-      --rpccert=           File containing the certificate file
-      --rpckey=            File containing the certificate key
-      --rpcmaxclients=     Max number of RPC clients for standard connections
-                           (10)
-      --rpcmaxwebsockets=  Max number of RPC clients for standard connections
-                           (25)
-      --norpc              Disable built-in RPC server -- NOTE: The RPC server
-                           is disabled by default if no rpcuser/rpcpass is
-                           specified
-      --notls              Disable TLS for the RPC server -- NOTE: This is only
-                           allowed if the RPC server is bound to localhost
-      --nodnsseed          Disable DNS seeding for peers
-      --externalip:        Add an ip to the list of local addresses we claim to
-                           listen on to peers
-      --proxy=             Connect via SOCKS5 proxy (eg. 127.0.0.1:9050)
-      --proxyuser=         Username for proxy server
-      --proxypass=         Password for proxy server
-      --onion=             Connect to tor hidden services via SOCKS5 proxy (eg.
-                           127.0.0.1:9050)
-      --onionuser=         Username for onion proxy server
-      --onionpass=         Password for onion proxy server
-      --noonion=           Disable connecting to tor hidden services
-      --torisolation       Enable Tor stream isolation by randomizing user
-                           credentials for each connection.
-      --testnet=           Use the test network
-      --regtest=           Use the regression test network
-      --nocheckpoints=     Disable built-in checkpoints.  Don't do this unless
-                           you know what you're doing.
-      --dbtype=            Database backend to use for the Block Chain (leveldb)
-      --profile=           Enable HTTP profiling on given port -- NOTE port must
-                           be between 1024 and 65536 (6060)
-      --cpuprofile=        Write CPU profile to the specified file
-  -d, --debuglevel:        Logging level for all subsystems {trace, debug, info,
-                           warn, error, critical} -- You may also specify
-                           <subsystem>=<level>,<subsystem2>=<level>,... to set
-                           the log level for individual subsystems -- Use show
-                           to list available subsystems (info)
-      --upnp               Use UPnP to map our listening port outside of NAT
-      --limitfreerelay=    Limit relay of transactions with no transaction fee
-                           to the given amount in thousands of bytes per minute
-                           (15)
-      --norelaypriority    Do not require free or low-fee transactions to have
-                           high priority for relaying
-      --maxorphantx=       Max number of orphan transactions to keep in memory
-                           (1000)
-      --generate=          Generate (mine) decreds using the CPU
-      --miningaddr=        Add the specified payment address to the list of
-                           addresses to use for generated blocks -- At least
-                           one address is required if the generate option is set
-      --blockminsize=      Mininum block size in bytes to be used when creating
-                           a block
-      --blockmaxsize=      Maximum block size in bytes to be used when creating
-                           a block (750000)
-      --blockprioritysize= Size in bytes for high-priority/low-fee transactions
-                           when creating a block (50000)
-      --getworkkey=        DEPRECATED -- Use the --miningaddr option instead
-      --addrindex=         Build and maintain a full address index. Currently
-                           only supported by leveldb.
-      --dropaddrindex=     Deletes the address-based transaction index from the
-                           database on start up, and the exits.
+  -V, --version             Display version information and exit
+  -C, --configfile=         Path to configuration file
+  -b, --datadir=            Directory to store data
+      --logdir=             Directory to log output.
+  -a, --addpeer=            Add a peer to connect with at startup
+      --connect=            Connect only to the specified peers at startup
+      --nolisten            Disable listening for incoming connections -- NOTE:
+                            Listening is automatically disabled if the --connect
+                            or --proxy options are used without also specifying
+                            listen interfaces via --listen
+      --listen=             Add an interface/port to listen for connections
+                            (default all interfaces port: 9108, testnet: 19108)
+      --maxpeers=           Max number of inbound and outbound peers (125)
+      --banduration=        How long to ban misbehaving peers.  Valid time units
+                            are {s, m, h}.  Minimum 1 second (24h0m0s)
+  -u, --rpcuser=            Username for RPC connections
+  -P, --rpcpass=            Password for RPC connections
+      --rpclimituser=       Username for limited RPC connections
+      --rpclimitpass=       Password for limited RPC connections
+      --rpclisten=          Add an interface/port to listen for RPC connections
+                            (default port: 9109, testnet: 19109)
+      --rpccert=            File containing the certificate file
+      --rpckey=             File containing the certificate key
+      --rpcmaxclients=      Max number of RPC clients for standard connections
+                            (10)
+      --rpcmaxwebsockets=   Max number of RPC websocket connections (25)
+      --norpc               Disable built-in RPC server -- NOTE: The RPC server
+                            is disabled by default if no rpcuser/rpcpass or
+                            rpclimituser/rpclimitpass is specified
+      --notls               Disable TLS for the RPC server -- NOTE: This is only
+                            allowed if the RPC server is bound to localhost
+      --nodnsseed           Disable DNS seeding for peers
+      --externalip=         Add an ip to the list of local addresses we claim to
+                            listen on to peers
+      --proxy=              Connect via SOCKS5 proxy (eg. 127.0.0.1:9050)
+      --proxyuser=          Username for proxy server
+      --proxypass=          Password for proxy server
+      --onion=              Connect to tor hidden services via SOCKS5 proxy
+                            (eg. 127.0.0.1:9050)
+      --onionuser=          Username for onion proxy server
+      --onionpass=          Password for onion proxy server
+      --noonion             Disable connecting to tor hidden services
+      --torisolation        Enable Tor stream isolation by randomizing user
+                            credentials for each connection.
+      --testnet             Use the test network
+      --simnet              Use the simulation test network
+      --nocheckpoints       Disable built-in checkpoints.  Don't do this unless
+                            you know what you're doing.
+      --dbtype=             Database backend to use for the Block Chain
+                            (leveldb)
+      --profile=            Enable HTTP profiling on given port -- NOTE port
+                            must be between 1024 and 65536
+      --cpuprofile=         Write CPU profile to the specified file
+  -d, --debuglevel=         Logging level for all subsystems {trace, debug,
+                            info, warn, error, critical} -- You may also specify
+                            <subsystem>=<level>,<subsystem2>=<level>,... to set
+                            the log level for individual subsystems -- Use show
+                            to list available subsystems (info)
+      --upnp                Use UPnP to map our listening port outside of NAT
+      --limitfreerelay=     Limit relay of transactions with no transaction fee
+                            to the given amount in thousands of bytes per
+                            minute (15)
+      --norelaypriority     Do not require free or low-fee transactions to have
+                            high priority for relaying
+      --maxorphantx=        Max number of orphan transactions to keep in memory
+                            (1000)
+      --generate            Generate (mine) bitcoins using the CPU
+      --miningaddr=         Add the specified payment address to the list of
+                            addresses to use for generated blocks -- At least
+                            one address is required if the generate option is
+                            set
+      --blockminsize=       Mininum block size in bytes to be used when creating
+                            a block
+      --blockmaxsize=       Maximum block size in bytes to be used when creating
+                            a block (750000)
+      --blockprioritysize=  Size in bytes for high-priority/low-fee transactions
+                            when creating a block (50000)
+      --getworkkey=         DEPRECATED -- Use the --miningaddr option instead
+      --addrindex           Build and maintain a full address index. Currently
+                            only supported by leveldb.
+      --dropaddrindex       Deletes the address-based transaction index from the
+                            database on start up, and the exits.
+      --nopeerbloomfilters  Disable bloom filtering support.
+
 Help Options:
   -h, --help           Show this help message
 

--- a/peer.go
+++ b/peer.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	// maxProtocolVersion is the max protocol version the peer supports.
-	maxProtocolVersion = 1
+	maxProtocolVersion = 2
 
 	// outputBufferSize is the number of elements the output channels use.
 	outputBufferSize = 5000
@@ -347,8 +347,8 @@ func (p *peer) pushVersionMsg() error {
 	//      by the remote peer in its version message
 	msg.AddrYou.Services = wire.SFNodeNetwork
 
-	// Advertise that we're a full node.
-	msg.Services = wire.SFNodeNetwork
+	// Advertise our supported services.
+	msg.Services = p.server.services
 
 	// Advertise our max supported protocol version.
 	msg.ProtocolVersion = maxProtocolVersion
@@ -1224,11 +1224,33 @@ func (p *peer) handleGetHeadersMsg(msg *wire.MsgGetHeaders) {
 	p.QueueMessage(headersMsg, nil)
 }
 
+// isValidBIP0111 is a helper function for the bloom filter commands to check
+// BIP0111 compliance.
+func (p *peer) isValidBIP0111(cmd string) bool {
+	if p.server.services&wire.SFNodeBloom != wire.SFNodeBloom {
+		if p.ProtocolVersion() >= wire.BIP0111Version {
+			peerLog.Debugf("%s sent an unsupported %s "+
+				"request -- disconnecting", p, cmd)
+			p.Disconnect()
+		} else {
+			peerLog.Debugf("Ignoring %s request from %s -- bloom "+
+				"support is disabled", cmd, p)
+		}
+		return false
+	}
+
+	return true
+}
+
 // handleFilterAddMsg is invoked when a peer receives a filteradd decred
 // message and is used by remote peers to add data to an already loaded bloom
 // filter.  The peer will be disconnected if a filter is not loaded when this
 // message is received.
 func (p *peer) handleFilterAddMsg(msg *wire.MsgFilterAdd) {
+	if !p.isValidBIP0111(msg.Command()) {
+		return
+	}
+
 	if !p.filter.IsLoaded() {
 		peerLog.Debugf("%s sent a filteradd request with no filter "+
 			"loaded -- disconnecting", p)
@@ -1244,12 +1266,17 @@ func (p *peer) handleFilterAddMsg(msg *wire.MsgFilterAdd) {
 // The peer will be disconnected if a filter is not loaded when this message is
 // received.
 func (p *peer) handleFilterClearMsg(msg *wire.MsgFilterClear) {
+	if !p.isValidBIP0111(msg.Command()) {
+		return
+	}
+
 	if !p.filter.IsLoaded() {
 		peerLog.Debugf("%s sent a filterclear request with no "+
 			"filter loaded -- disconnecting", p)
 		p.Disconnect()
 		return
 	}
+
 	p.filter.Unload()
 }
 
@@ -1257,6 +1284,10 @@ func (p *peer) handleFilterClearMsg(msg *wire.MsgFilterClear) {
 // message and it used to load a bloom filter that should be used for delivering
 // merkle blocks and associated transactions that match the filter.
 func (p *peer) handleFilterLoadMsg(msg *wire.MsgFilterLoad) {
+	if !p.isValidBIP0111(msg.Command()) {
+		return
+	}
+
 	// Transaction relay is no longer disabled once a filterload message is
 	// received regardless of its original state.
 	p.relayMtx.Lock()

--- a/sample-dcrd.conf
+++ b/sample-dcrd.conf
@@ -144,6 +144,8 @@
 ; Disable listening for incoming connections.  This will override all listeners.
 ; nolisten=1
 
+; Disable peer bloom filtering.  See BIP0111.
+; nopeerbloomfilters=1
 
 ; ------------------------------------------------------------------------------
 ; RPC server options - The following options control the built-in RPC server

--- a/txscript/script.go
+++ b/txscript/script.go
@@ -219,18 +219,19 @@ func unparseScript(pops []parsedOpcode) ([]byte, error) {
 // appended.  In addition, the reason the script failed to parse is returned
 // if the caller wants more information about the failure.
 func DisasmString(buf []byte) (string, error) {
-	disbuf := ""
+	var disbuf bytes.Buffer
 	opcodes, err := parseScript(buf)
 	for _, pop := range opcodes {
-		disbuf += pop.print(true) + " "
+		disbuf.WriteString(pop.print(true))
+		disbuf.WriteByte(' ')
 	}
-	if disbuf != "" {
-		disbuf = disbuf[:len(disbuf)-1]
+	if disbuf.Len() > 0 {
+		disbuf.Truncate(disbuf.Len() - 1)
 	}
 	if err != nil {
-		disbuf += "[error]"
+		disbuf.WriteString("[error]")
 	}
-	return disbuf, err
+	return disbuf.String(), err
 }
 
 // removeOpcode will remove any opcode matching ``opcode'' from the opcode

--- a/wire/doc.go
+++ b/wire/doc.go
@@ -151,9 +151,10 @@ Bitcoin Improvement Proposals
 
 This package includes spec changes outlined by the following BIPs:
 
-		BIP0014 (https://en.bitcoin.it/wiki/BIP_0014)
-		BIP0031 (https://en.bitcoin.it/wiki/BIP_0031)
-		BIP0035 (https://en.bitcoin.it/wiki/BIP_0035)
-		BIP0037 (https://en.bitcoin.it/wiki/BIP_0037)
+	BIP0014 (https://github.com/bitcoin/bips/blob/master/bip-0014.mediawiki)
+	BIP0031 (https://github.com/bitcoin/bips/blob/master/bip-0031.mediawiki)
+	BIP0035 (https://github.com/bitcoin/bips/blob/master/bip-0035.mediawiki)
+	BIP0037 (https://github.com/bitcoin/bips/blob/master/bip-0037.mediawiki)
+	BIP0111	(https://github.com/bitcoin/bips/blob/master/bip-0111.mediawiki)
 */
 package wire

--- a/wire/msgminingstate.go
+++ b/wire/msgminingstate.go
@@ -25,10 +25,10 @@ const MaxMSVotesAtHeadPerMsg = 40 // 8 * 5
 // the maximum number of blocks per message and the maximum number of votes per
 // message.
 type MsgMiningState struct {
-	ProtocolVersion uint32
-	Height          uint32
-	BlockHashes     []*chainhash.Hash
-	VoteHashes      []*chainhash.Hash
+	Version     uint32
+	Height      uint32
+	BlockHashes []*chainhash.Hash
+	VoteHashes  []*chainhash.Hash
 }
 
 // AddBlockHash adds a new block hash to the message.
@@ -58,7 +58,7 @@ func (msg *MsgMiningState) AddVoteHash(hash *chainhash.Hash) error {
 // BtcDecode decodes r using the protocol encoding into the receiver.
 // This is part of the Message interface implementation.
 func (msg *MsgMiningState) BtcDecode(r io.Reader, pver uint32) error {
-	err := readElement(r, &msg.ProtocolVersion)
+	err := readElement(r, &msg.Version)
 	if err != nil {
 		return err
 	}
@@ -116,7 +116,7 @@ func (msg *MsgMiningState) BtcDecode(r io.Reader, pver uint32) error {
 // BtcEncode encodes the receiver to w using the protocol encoding.
 // This is part of the Message interface implementation.
 func (msg *MsgMiningState) BtcEncode(w io.Writer, pver uint32) error {
-	err := writeElement(w, msg.ProtocolVersion)
+	err := writeElement(w, msg.Version)
 	if err != nil {
 		return err
 	}
@@ -189,9 +189,9 @@ func (msg *MsgMiningState) MaxPayloadLength(pver uint32) uint32 {
 // the Message interface using the defaults for the fields.
 func NewMsgMiningState() *MsgMiningState {
 	return &MsgMiningState{
-		ProtocolVersion: ProtocolVersion,
-		Height:          0,
-		BlockHashes:     make([]*chainhash.Hash, 0, MaxMSBlocksAtHeadPerMsg),
-		VoteHashes:      make([]*chainhash.Hash, 0, MaxMSVotesAtHeadPerMsg),
+		Version:     1,
+		Height:      0,
+		BlockHashes: make([]*chainhash.Hash, 0, MaxMSBlocksAtHeadPerMsg),
+		VoteHashes:  make([]*chainhash.Hash, 0, MaxMSVotesAtHeadPerMsg),
 	}
 }

--- a/wire/msgminingstate_test.go
+++ b/wire/msgminingstate_test.go
@@ -17,7 +17,7 @@ import (
 func TestMiningStateWire(t *testing.T) {
 	// Empty tx message.
 	sampleMSMsg := wire.NewMsgMiningState()
-	sampleMSMsg.ProtocolVersion = wire.ProtocolVersion
+	sampleMSMsg.Version = 1
 	sampleMSMsg.Height = 123456
 
 	fakeBlock, _ := chainhash.NewHashFromStr("4433221144332211443322114" +
@@ -75,7 +75,7 @@ func TestMiningStateWire(t *testing.T) {
 		buf  []byte               // Wire encoding
 		pver uint32               // Protocol version for wire encoding
 	}{
-		// Latest protocol version sample message.
+		// Version 1 sample message with the latest protocol version.
 		{
 			sampleMSMsg,
 			sampleMSMsg,

--- a/wire/msgversion.go
+++ b/wire/msgversion.go
@@ -19,7 +19,7 @@ import (
 const MaxUserAgentLen = 2000
 
 // DefaultUserAgent for wire in the stack
-const DefaultUserAgent = "/dcrwire:0.0.1/"
+const DefaultUserAgent = "/dcrwire:0.1.0/"
 
 // MsgVersion implements the Message interface and represents a decred version
 // message.  It is used for a peer to advertise itself as soon as an outbound

--- a/wire/protocol.go
+++ b/wire/protocol.go
@@ -13,7 +13,11 @@ import (
 
 const (
 	// ProtocolVersion is the latest protocol version this package supports.
-	ProtocolVersion uint32 = 1
+	ProtocolVersion uint32 = 2
+
+	// BIP0111Version is the protocol version which added the SFNodeBloom
+	// service flag.
+	BIP0111Version uint32 = 2
 )
 
 // ServiceFlag identifies services supported by a decred peer.
@@ -22,11 +26,23 @@ type ServiceFlag uint64
 const (
 	// SFNodeNetwork is a flag used to indicate a peer is a full node.
 	SFNodeNetwork ServiceFlag = 1 << iota
+
+	// SFNodeBloom is a flag used to indiciate a peer supports bloom
+	// filtering.
+	SFNodeBloom
 )
 
 // Map of service flags back to their constant names for pretty printing.
 var sfStrings = map[ServiceFlag]string{
 	SFNodeNetwork: "SFNodeNetwork",
+	SFNodeBloom:   "SFNodeBloom",
+}
+
+// orderedSFStrings is an ordered list of service flags from highest to
+// lowest.
+var orderedSFStrings = []ServiceFlag{
+	SFNodeNetwork,
+	SFNodeBloom,
 }
 
 // String returns the ServiceFlag in human-readable form.

--- a/wire/protocol_test.go
+++ b/wire/protocol_test.go
@@ -19,7 +19,8 @@ func TestServiceFlagStringer(t *testing.T) {
 	}{
 		{0, "0x0"},
 		{wire.SFNodeNetwork, "SFNodeNetwork"},
-		{0xffffffff, "SFNodeNetwork|0xfffffffe"},
+		{wire.SFNodeBloom, "SFNodeBloom"},
+		{0xffffffff, "SFNodeNetwork|SFNodeBloom|0xfffffffc"},
 	}
 
 	t.Logf("Running %d tests", len(tests))


### PR DESCRIPTION
This sync includes a new service flag named `SFNodeBloom` that a node is required to use to indicate that it supports bloom filtering.  This includes a protocol version bump to `2` and a wire version bump to
`0.1.0`.

dcrd:
The `SFNodeBloom` flag is set by default.  A new configuration option `--nopeerbloomfilters` has been added to to disable bloom filtering.

Also, it corrects an issue with the mining state message where it was using the network protocol version instead of having its own version.