### PR TITLE
Remove legacy Bitcoin addr encoding bug

### DIFF
--- a/wire/msgaddr.go
+++ b/wire/msgaddr.go
@@ -89,12 +89,6 @@ func (msg *MsgAddr) BtcEncode(w io.Writer, pver uint32) error {
 	// Protocol versions before MultipleAddressVersion only allowed 1 address
 	// per message.
 	count := len(msg.AddrList)
-	if pver < ProtocolVersion && count > 1 {
-		str := fmt.Sprintf("too many addresses for message of "+
-			"protocol version %v [count %v, max 1]", pver, count)
-		return messageError("MsgAddr.BtcEncode", str)
-
-	}
 	if count > MaxAddrPerMsg {
 		str := fmt.Sprintf("too many addresses for message "+
 			"[count %v, max %v]", count, MaxAddrPerMsg)
@@ -125,11 +119,6 @@ func (msg *MsgAddr) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgAddr) MaxPayloadLength(pver uint32) uint32 {
-	if pver < ProtocolVersion {
-		// Num addresses (varInt) + a single net addresses.
-		return MaxVarIntPayload + maxNetAddressPayload(pver)
-	}
-
 	// Num addresses (varInt) + max allowed addresses.
 	return MaxVarIntPayload + (MaxAddrPerMsg * maxNetAddressPayload(pver))
 }


### PR DESCRIPTION
Legacy msgaddr encoding for Bitcoin caused getaddr response
failure when message protocol version was >1. This fixes this
bug.