### PR TITLE
wire: Use ordered Service Flags.

### DIFF
--- a/wire/protocol.go
+++ b/wire/protocol.go
@@ -54,9 +54,9 @@ func (f ServiceFlag) String() string {
 
 	// Add individual bit flags.
 	s := ""
-	for flag, name := range sfStrings {
+	for _, flag := range orderedSFStrings {
 		if f&flag == flag {
-			s += name + "|"
+			s += sfStrings[flag] + "|"
 			f -= flag
 		}
 	}


### PR DESCRIPTION
This modifies the `wire.ServiceFlag` stringer to use the ordered slice of flags to ensure that the human readable representation of the flags is always in a well defined order.  This is not only useful for humans, but it also allows the output to be deterministically tested.