### PR TITLE
Fix VinPrevOut fields for Decred

### DIFF
--- a/dcrjson/chainsvrresults.go
+++ b/dcrjson/chainsvrresults.go
@@ -321,12 +321,16 @@ type PrevOut struct {
 
 // VinPrevOut is like Vin except it includes PrevOut.  It is used by searchrawtransaction
 type VinPrevOut struct {
-	Coinbase  string     `json:"coinbase"`
-	Txid      string     `json:"txid"`
-	Vout      uint32     `json:"vout"`
-	ScriptSig *ScriptSig `json:"scriptSig"`
-	PrevOut   *PrevOut   `json:"prevOut"`
-	Sequence  uint32     `json:"sequence"`
+	Coinbase    string     `json:"coinbase"`
+	Txid        string     `json:"txid"`
+	Vout        uint32     `json:"vout"`
+	Tree        int8       `json:"tree"`
+	AmountIn    *float64   `json:"amountin,omitempty"`
+	BlockHeight *uint32    `json:"blockheight,omitempty"`
+	BlockIndex  *uint32    `json:"blockindex,omitempty"`
+	ScriptSig   *ScriptSig `json:"scriptSig"`
+	PrevOut     *PrevOut   `json:"prevOut"`
+	Sequence    uint32     `json:"sequence"`
 }
 
 // IsCoinBase returns a bool to show if a Vin is a Coinbase one or not.
@@ -348,17 +352,25 @@ func (v *VinPrevOut) MarshalJSON() ([]byte, error) {
 	}
 
 	txStruct := struct {
-		Txid      string     `json:"txid"`
-		Vout      uint32     `json:"vout"`
-		ScriptSig *ScriptSig `json:"scriptSig"`
-		PrevOut   *PrevOut   `json:"prevOut,omitempty"`
-		Sequence  uint32     `json:"sequence"`
+		Txid        string     `json:"txid"`
+		Vout        uint32     `json:"vout"`
+		Tree        int8       `json:"tree"`
+		AmountIn    *float64   `json:"amountin,omitempty"`
+		BlockHeight *uint32    `json:"blockheight,omitempty"`
+		BlockIndex  *uint32    `json:"blockindex,omitempty"`
+		ScriptSig   *ScriptSig `json:"scriptSig"`
+		PrevOut     *PrevOut   `json:"prevOut,omitempty"`
+		Sequence    uint32     `json:"sequence"`
 	}{
-		Txid:      v.Txid,
-		Vout:      v.Vout,
-		ScriptSig: v.ScriptSig,
-		PrevOut:   v.PrevOut,
-		Sequence:  v.Sequence,
+		Txid:        v.Txid,
+		Vout:        v.Vout,
+		Tree:        v.Tree,
+		AmountIn:    v.AmountIn,
+		BlockHeight: v.BlockHeight,
+		BlockIndex:  v.BlockIndex,
+		ScriptSig:   v.ScriptSig,
+		PrevOut:     v.PrevOut,
+		Sequence:    v.Sequence,
 	}
 	return json.Marshal(txStruct)
 }

--- a/dcrjson/chainsvrresults_test.go
+++ b/dcrjson/chainsvrresults_test.go
@@ -68,7 +68,7 @@ func TestChainSvrCustomResults(t *testing.T) {
 				},
 				Sequence: 4294967295,
 			},
-			expected: `{"txid":"123","vout":1,"scriptSig":{"asm":"0","hex":"00"},"prevOut":{"addresses":["addr1"],"value":0},"sequence":4294967295}`,
+			expected: `{"txid":"123","vout":1,"tree":0,"scriptSig":{"asm":"0","hex":"00"},"prevOut":{"addresses":["addr1"],"value":0},"sequence":4294967295}`,
 		},
 	}
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1364,6 +1364,18 @@ func createVinListPrevOut(s *rpcServer, mtx *wire.MsgTx, chainParams *chaincfg.P
 		vinEntry := &vinList[i]
 		vinEntry.Txid = txIn.PreviousOutPoint.Hash.String()
 		vinEntry.Vout = txIn.PreviousOutPoint.Index
+		vinEntry.Tree = txIn.PreviousOutPoint.Tree
+
+		// Use the null block index as a flag to indicate if
+		// it was found in the mempool. If so, do not set the
+		// Vin entries for BlockHeight and BlockIndex.
+		if txIn.BlockIndex != wire.NullBlockIndex {
+			amtCoin := dcrutil.Amount(txIn.ValueIn).ToCoin()
+			vinEntry.AmountIn = &amtCoin
+			vinEntry.BlockHeight = &txIn.BlockHeight
+			vinEntry.BlockIndex = &txIn.BlockIndex
+		}
+
 		vinEntry.Sequence = txIn.Sequence
 		vinEntry.ScriptSig = &dcrjson.ScriptSig{
 			Asm: disbuf,

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -101,12 +101,16 @@ var helpDescsEnUS = map[string]string{
 	"prevout-value":     "previous output value",
 
 	// VinPrevOut help.
-	"vinprevout-coinbase":  "The hex-encoded bytes of the signature script (coinbase txns only)",
-	"vinprevout-txid":      "The hash of the origin transaction (non-coinbase txns only)",
-	"vinprevout-vout":      "The index of the output being redeemed from the origin transaction (non-coinbase txns only)",
-	"vinprevout-scriptSig": "The signature script used to redeem the origin transaction as a JSON object (non-coinbase txns only)",
-	"vinprevout-prevOut":   "Data from the origin transaction output with index vout.",
-	"vinprevout-sequence":  "The script sequence number",
+	"vinprevout-coinbase":    "The hex-encoded bytes of the signature script (coinbase txns only)",
+	"vinprevout-txid":        "The hash of the origin transaction (non-coinbase txns only)",
+	"vinprevout-vout":        "The index of the output being redeemed from the origin transaction (non-coinbase txns only)",
+	"vinprevout-tree":        "The transaction tree of the origin transaction",
+	"vinprevout-amountin":    "The amount in for this transaction input, in coins",
+	"vinprevout-blockheight": "The height of the block that includes the origin transaction",
+	"vinprevout-blockindex":  "The merkle tree index of the origin transaction",
+	"vinprevout-scriptSig":   "The signature script used to redeem the origin transaction as a JSON object (non-coinbase txns only)",
+	"vinprevout-prevOut":     "Data from the origin transaction output with index vout.",
+	"vinprevout-sequence":    "The script sequence number",
 
 	// Vin help.
 	"vin-coinbase":    "The hex-encoded bytes of the signature script (coinbase txns only)",


### PR DESCRIPTION
The VinPrevOut fields in Decred did not correspond to the
contents of Decred TxIns. This was modified so that these
are included.

Fixes #173.