### PR TITLE
rpcserver: Correct verifymessage hash generation.

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -5531,8 +5531,12 @@ func handleVerifyMessage(s *rpcServer, cmd interface{}, closeChan <-chan struct{
 
 	// Validate the signature - this just shows that it was valid at all.
 	// we will compare it with the key next.
+	var buf bytes.Buffer
+	wire.WriteVarString(&buf, 0, "Decred Signed Message:\n")
+	wire.WriteVarString(&buf, 0, c.Message)
+	expectedMessageHash := chainhash.HashFuncB(buf.Bytes())
 	pk, wasCompressed, err := chainec.Secp256k1.RecoverCompact(sig,
-		chainhash.HashFuncB([]byte("Secp256k1 Signed Message:\n"+c.Message)))
+		expectedMessageHash)
 	if err != nil {
 		// Mirror Bitcoin Core behavior, which treats error in
 		// RecoverCompact as invalid signature.


### PR DESCRIPTION
Upstream commit 07406791c9b09beb2b9ca97260017ab1ebe04067

All other commits in the merge have already previously been cherry-picked and therefore are NOOPs.