### PR TITLE
peer: Fix failing test case due to wrong TimeOffset

### DIFF
--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -153,8 +153,11 @@ func testPeer(t *testing.T, p *peer.Peer, s peerStats) {
 		return
 	}
 
-	if p.TimeOffset() != s.wantTimeOffset {
-		t.Errorf("testPeer: wrong TimeOffset - got %v, want %v", p.TimeOffset(), s.wantTimeOffset)
+	// Allow for a deviation of 1s, as the second may tick when the message is
+	// in transit and the protocol doesn't support any further precision.
+	if p.TimeOffset() != s.wantTimeOffset && p.TimeOffset() != s.wantTimeOffset-1 {
+		t.Errorf("testPeer: wrong TimeOffset - got %v, want %v or %v", p.TimeOffset(),
+			s.wantTimeOffset, s.wantTimeOffset-1)
 		return
 	}
 


### PR DESCRIPTION
Upstream commit 21d11e280987c93a1ad376ebecf0789c8c78783a
