### PR TITLE
peer/server: various fixes from upstream

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1236,10 +1236,6 @@ func (p *Peer) maybeAddDeadline(pendingResponses map[string]time.Time, msgCmd st
 		// Expects a verack message.
 		pendingResponses[wire.CmdVerAck] = deadline
 
-	case wire.CmdGetAddr:
-		// Expects an addr message.
-		pendingResponses[wire.CmdAddr] = deadline
-
 	case wire.CmdMemPool:
 		// Expects an inv message.
 		pendingResponses[wire.CmdInv] = deadline

--- a/server.go
+++ b/server.go
@@ -51,7 +51,7 @@ const (
 	// connectionRetryInterval is the base amount of time to wait in between
 	// retries when connecting to persistent peers.  It is adjusted by the
 	// number of retries such that there is a retry backoff.
-	connectionRetryInterval = time.Second * 10
+	connectionRetryInterval = time.Second * 5
 
 	// maxConnectionRetryInterval is the max amount of time retrying of a
 	// persistent peer is allowed to grow to.  This is necessary since the
@@ -1264,7 +1264,7 @@ func (s *server) handleDonePeerMsg(state *peerState, sp *serverPeer) {
 			// Retry peer
 			sp = s.newOutboundPeer(sp.Addr(), sp.persistent)
 			if sp != nil {
-				go s.retryConn(sp, connectionRetryInterval/2)
+				go s.retryConn(sp, false)
 			}
 			list[sp.ID()] = sp
 			return
@@ -1616,7 +1616,7 @@ func (s *server) newOutboundPeer(addr string, persistent bool) *serverPeer {
 	sp := newServerPeer(s, persistent)
 	p, err := peer.NewOutboundPeer(newPeerConfig(sp), addr)
 	if err != nil {
-		srvrLog.Errorf("Cannot create outbound peer: %v", err)
+		srvrLog.Errorf("Cannot create outbound peer %s: %v", addr, err)
 		return nil
 	}
 	sp.Peer = p
@@ -1661,22 +1661,36 @@ func (s *server) establishConn(sp *serverPeer) error {
 	return nil
 }
 
-// retryConn retries connection to the peer after the given duration.
-func (s *server) retryConn(sp *serverPeer, retryDuration time.Duration) {
-	srvrLog.Debugf("Retrying connection to %s in %s", sp.Addr(), retryDuration)
-	select {
-	case <-time.After(retryDuration):
-		err := s.establishConn(sp)
-		if err != nil {
-			retryDuration += connectionRetryInterval / 2
-			if retryDuration > maxConnectionRetryInterval {
-				retryDuration = maxConnectionRetryInterval
+// retryConn retries connection to the peer after the given duration.  It must
+// be run as a goroutine.
+func (s *server) retryConn(sp *serverPeer, initialAttempt bool) {
+	retryDuration := connectionRetryInterval
+	for {
+		if initialAttempt {
+			retryDuration = 0
+			initialAttempt = false
+		} else {
+			srvrLog.Debugf("Retrying connection to %s in %s", sp.Addr(),
+				retryDuration)
+		}
+		select {
+		case <-time.After(retryDuration):
+			err := s.establishConn(sp)
+			if err != nil {
+				retryDuration += connectionRetryInterval
+				if retryDuration > maxConnectionRetryInterval {
+					retryDuration = maxConnectionRetryInterval
+				}
+				continue
 			}
-			go s.retryConn(sp, retryDuration)
+			return
+
+		case <-sp.quit:
+			return
+
+		case <-s.quit:
 			return
 		}
-	case <-sp.quit:
-	case <-s.quit:
 	}
 }
 
@@ -1717,7 +1731,7 @@ func (s *server) peerHandler() {
 	for _, addr := range permanentPeers {
 		sp := s.newOutboundPeer(addr, true)
 		if sp != nil {
-			go s.peerConnHandler(sp)
+			go s.retryConn(sp, true)
 		}
 	}
 

--- a/server.go
+++ b/server.go
@@ -1257,27 +1257,26 @@ func (s *server) handleDonePeerMsg(state *peerState, sp *serverPeer) {
 	} else {
 		list = state.outboundPeers
 	}
-	for id, e := range list {
-		if e == sp {
-			// Issue an asynchronous reconnect if the peer was a
-			// persistent outbound connection.
-			if !sp.Inbound() && sp.persistent && atomic.LoadInt32(&s.shutdown) == 0 {
-				// Retry peer
-				sp = s.newOutboundPeer(sp.Addr(), sp.persistent)
-				if sp != nil {
-					go s.retryConn(sp, connectionRetryInterval/2)
-				}
-				list[id] = sp
-				return
+	if _, ok := list[sp.ID()]; ok {
+		// Issue an asynchronous reconnect if the peer was a
+		// persistent outbound connection.
+		if !sp.Inbound() && sp.persistent && atomic.LoadInt32(&s.shutdown) == 0 {
+			// Retry peer
+			sp = s.newOutboundPeer(sp.Addr(), sp.persistent)
+			if sp != nil {
+				go s.retryConn(sp, connectionRetryInterval/2)
 			}
-			if !sp.Inbound() && sp.VersionKnown() {
-				state.outboundGroups[addrmgr.GroupKey(sp.NA())]--
-			}
-			delete(list, id)
-			srvrLog.Debugf("Removed peer %s", sp)
+			list[sp.ID()] = sp
 			return
 		}
+		if !sp.Inbound() && sp.VersionKnown() {
+			state.outboundGroups[addrmgr.GroupKey(sp.NA())]--
+		}
+		delete(list, sp.ID())
+		srvrLog.Debugf("Removed peer %s", sp)
+		return
 	}
+
 	// Update the address' last seen time if the peer has acknowledged
 	// our version and has sent us its version as well.
 	if sp.VerAckReceived() && sp.VersionKnown() && sp.NA() != nil {

--- a/server.go
+++ b/server.go
@@ -1262,12 +1262,10 @@ func (s *server) handleDonePeerMsg(state *peerState, sp *serverPeer) {
 		// persistent outbound connection.
 		if !sp.Inbound() && sp.persistent && atomic.LoadInt32(&s.shutdown) == 0 {
 			// Retry peer
-			sp = s.newOutboundPeer(sp.Addr(), sp.persistent)
-			if sp != nil {
-				go s.retryConn(sp, false)
+			sp2 := s.newOutboundPeer(sp.Addr(), sp.persistent)
+			if sp2 != nil {
+				go s.retryConn(sp2, false)
 			}
-			list[sp.ID()] = sp
-			return
 		}
 		if !sp.Inbound() && sp.VersionKnown() {
 			state.outboundGroups[addrmgr.GroupKey(sp.NA())]--


### PR DESCRIPTION
Cherry-picked various upstream commits that help with issues in the new peer package.  Mainly, a panic (most likely due to out-of-memory) from endless peerDoneHandlers being spawned.

After checking profile routines on master (400+ peerDoneHandler) with this PR (13-16 peerDoneHandler) it appears that the issue should be fixed.

Btcd upstream commits:
-7996eb1f9deee90a070e2d6455c71bd5738192f5
-89af747603fad09130129fa4688eaab53c0abdba
-d0f0a2ac02596ff312987fa1fe75972e5bf9a227
-f41ff545be905bd658084772a5826f4d091f1e2d
-d0cdd53720276ee3499ff56ab1ce7d22601d8d9a