### PR TITLE
mempool/peer: Sync upstream comment updates.

### DIFF
--- a/mempool.go
+++ b/mempool.go
@@ -1592,7 +1592,8 @@ func (mp *txMemPool) processOrphans(hash *chainhash.Hash) []*dcrutil.Tx {
 
 			// Potentially accept the transaction into the
 			// transaction pool.
-			missingParents, err := mp.maybeAcceptTransaction(tx, true, true, true)
+			missingParents, err := mp.maybeAcceptTransaction(tx,
+				true, true, true)
 			if err != nil {
 				// TODO: Remove orphans that depend on this
 				// failed transaction.
@@ -1733,8 +1734,9 @@ func (mp *txMemPool) ProcessTransaction(tx *dcrutil.Tx, allowOrphan,
 	// If len(missingParents) == 0 then we know the tx is NOT an orphan
 	if len(missingParents) == 0 {
 		// Accept any orphan transactions that depend on this
-		// transaction (they are no longer orphans) and repeat for those
-		// accepted transactions until there are no more.
+		// transaction (they are no longer orphans if all inputs are
+		// now available) and repeat for those accepted transactions
+		// until there are no more.
 		newTxs := mp.processOrphans(tx.Sha())
 		acceptedTxs := make([]*dcrutil.Tx, len(newTxs)+1)
 

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1525,11 +1525,6 @@ out:
 			}
 
 		case *wire.MsgAlert:
-			// Note: The reference client currently bans peers that
-			// send alerts not signed with its key.  We could verify
-			// against their key, but since the reference client is
-			// currently unwilling to support other implementions'
-			// alert messages, we will not relay theirs.
 			if p.cfg.Listeners.OnAlert != nil {
 				p.cfg.Listeners.OnAlert(p, msg)
 			}


### PR DESCRIPTION
Upstream commits
- 5016675d40c85e1db25fb54fe14c15d9681fd487
- d765c73a419087c637ba03ff79d8d2f21040d70a

The changes in d765c73a419087c637ba03ff79d8d2f21040d70a had previously been cherry-picked, so it's effectively a NOOP.