### PR TITLE
mempool: Move checkTransactionStandard to policy.

### DIFF
--- a/mempool.go
+++ b/mempool.go
@@ -44,39 +44,8 @@ const (
 	// of the max signature operations for a block.
 	maxSigOpsPerTx = blockchain.MaxSigOpsPerBlock / 5
 
-	// maxStandardTxSize is the maximum size allowed for transactions that
-	// are considered standard and will therefore be relayed and considered
-	// for mining.
-	maxStandardTxSize = 100000
-
-	// maxStandardSigScriptSize is the maximum size allowed for a
-	// transaction input signature script to be considered standard.  This
-	// value allows for a 15-of-15 CHECKMULTISIG pay-to-script-hash with
-	// compressed keys.
-	//
-	// The form of the overall script is: OP_0 <15 signatures> OP_PUSHDATA2
-	// <2 bytes len> [OP_15 <15 pubkeys> OP_15 OP_CHECKMULTISIG]
-	//
-	// For the p2sh script portion, each of the 15 compressed pubkeys are
-	// 33 bytes (plus one for the OP_DATA_33 opcode), and the thus it totals
-	// to (15*34)+3 = 513 bytes.  Next, each of the 15 signatures is a max
-	// of 73 bytes (plus one for the OP_DATA_73 opcode).  Also, there is one
-	// extra byte for the initial extra OP_0 push and 3 bytes for the
-	// OP_PUSHDATA2 needed to specify the 513 bytes for the script push.
-	// That brings the total to 1+(15*74)+3+513 = 1627.  This value also
-	// adds a few extra bytes to provide a little buffer.
-	// (1 + 15*74 + 3) + (15*34 + 3) + 23 = 1650
-	maxStandardSigScriptSize = 1650
-
-	// defaultMinRelayTxFee is the minimum fee in atoms that is required
-	// for a transaction to be treated as free for relay and mining
-	// purposes.  It is also used to help determine if a transaction is
-	// considered dust and as a base for calculating minimum required fees
-	// for larger transactions.  This value is in Atoms/1000 bytes.
-	defaultMinRelayTxFee = dcrutil.Amount(1e6)
-
-	// minTicketFeeMainNet is the minimum fee per KB in atoms that is
-	// required for a ticket to enter the mempool on MainNet.
+	// minTicketFee is the minimum fee per KB in atoms that is required for
+	// a ticket to enter the mempool.
 	minTicketFee = 1e6
 
 	// maxRelayFeeMultiplier is the factor that we disallow fees / kb above
@@ -387,111 +356,6 @@ func (mp *txMemPool) SortParentsByVotes(currentTopBlock chainhash.Hash,
 	sortedBlocks, err := mp.sortParentsByVotes(currentTopBlock, blocks)
 
 	return sortedBlocks, err
-}
-
-// checkTransactionStandard performs a series of checks on a transaction to
-// ensure it is a "standard" transaction.  A standard transaction is one that
-// conforms to several additional limiting cases over what is considered a
-// "sane" transaction such as having a version in the supported range, being
-// finalized, conforming to more stringent size constraints, having scripts
-// of recognized forms, and not containing "dust" outputs (those that are
-// so small it costs more to process them than they are worth).
-func (mp *txMemPool) checkTransactionStandard(tx *dcrutil.Tx, txType stake.TxType,
-	height int64) error {
-	msgTx := tx.MsgTx()
-
-	// The transaction must be a currently supported version.
-	if !wire.IsSupportedMsgTxVersion(msgTx) {
-		str := fmt.Sprintf("transaction version %d is not in the "+
-			"valid range of %d-%d", msgTx.Version, 1,
-			wire.TxVersion)
-		return txRuleError(wire.RejectNonstandard, str)
-	}
-
-	// The transaction must be finalized to be standard and therefore
-	// considered for inclusion in a block.
-	adjustedTime := mp.server.timeSource.AdjustedTime()
-	if !blockchain.IsFinalizedTransaction(tx, height, adjustedTime) {
-		return txRuleError(wire.RejectNonstandard,
-			"transaction is not finalized")
-	}
-
-	// Since extremely large transactions with a lot of inputs can cost
-	// almost as much to process as the sender fees, limit the maximum
-	// size of a transaction.  This also helps mitigate CPU exhaustion
-	// attacks.
-	serializedLen := msgTx.SerializeSize()
-	if serializedLen > maxStandardTxSize {
-		str := fmt.Sprintf("transaction size of %v is larger than max "+
-			"allowed size of %v", serializedLen, maxStandardTxSize)
-		return txRuleError(wire.RejectNonstandard, str)
-	}
-
-	for i, txIn := range msgTx.TxIn {
-		// Each transaction input signature script must not exceed the
-		// maximum size allowed for a standard transaction.  See
-		// the comment on maxStandardSigScriptSize for more details.
-		sigScriptLen := len(txIn.SignatureScript)
-		if sigScriptLen > maxStandardSigScriptSize {
-			str := fmt.Sprintf("transaction input %d: signature "+
-				"script size of %d bytes is large than max "+
-				"allowed size of %d bytes", i, sigScriptLen,
-				maxStandardSigScriptSize)
-			return txRuleError(wire.RejectNonstandard, str)
-		}
-
-		// Each transaction input signature script must only contain
-		// opcodes which push data onto the stack.
-		if !txscript.IsPushOnlyScript(txIn.SignatureScript) {
-			str := fmt.Sprintf("transaction input %d: signature "+
-				"script is not push only", i)
-			return txRuleError(wire.RejectNonstandard, str)
-		}
-
-	}
-
-	// None of the output public key scripts can be a non-standard script or
-	// be "dust" (except when the script is a null data script).
-	numNullDataOutputs := 0
-	for i, txOut := range msgTx.TxOut {
-		scriptClass := txscript.GetScriptClass(txOut.Version, txOut.PkScript)
-		err := checkPkScriptStandard(txOut.Version, txOut.PkScript, scriptClass)
-		if err != nil {
-			// Attempt to extract a reject code from the error so
-			// it can be retained.  When not possible, fall back to
-			// a non standard error.
-			rejectCode, found := extractRejectCode(err)
-			if !found {
-				rejectCode = wire.RejectNonstandard
-			}
-			str := fmt.Sprintf("transaction output %d: %v", i, err)
-			return txRuleError(rejectCode, str)
-		}
-
-		// Accumulate the number of outputs which only carry data.  For
-		// all other script types, ensure the output value is not
-		// "dust".
-		if scriptClass == txscript.NullDataTy {
-			numNullDataOutputs++
-		} else if isDust(txOut, cfg.minRelayTxFee) &&
-			txType != stake.TxTypeSStx {
-			str := fmt.Sprintf("transaction output %d: payment "+
-				"of %d is dust", i, txOut.Value)
-			return txRuleError(wire.RejectDust, str)
-		}
-	}
-
-	// A standard transaction must not have more than one output script that
-	// only carries data. However, certain types of standard stake transactions
-	// are allowed to have multiple OP_RETURN outputs, so only throw an error here
-	// if the tx is TxTypeRegular.
-	if numNullDataOutputs > maxNullDataOutputs && txType == stake.TxTypeRegular {
-		str := "more than one transaction output in a nulldata script for a " +
-			"regular type tx"
-		return txRuleError(wire.RejectNonstandard, str)
-	}
-
-	return nil
 }
 
 // removeOrphan is the internal function which implements the public
@@ -1197,7 +1061,8 @@ func (mp *txMemPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew,
 	// Don't allow non-standard transactions if the network parameters
 	// forbid their relaying.
 	if !activeNetParams.RelayNonStdTxs {
-		err := mp.checkTransactionStandard(tx, txType, nextBlockHeight)
+		err := checkTransactionStandard(tx, txType, nextBlockHeight,
+			mp.server.timeSource, cfg.minRelayTxFee)
 		if err != nil {
 			// Attempt to extract a reject code from the error so
 			// it can be retained.  When not possible, fall back to

--- a/policy.go
+++ b/policy.go
@@ -15,6 +15,37 @@ import (
 )
 
 const (
+	// maxStandardTxSize is the maximum size allowed for transactions that
+	// are considered standard and will therefore be relayed and considered
+	// for mining.
+	maxStandardTxSize = 100000
+
+	// maxStandardSigScriptSize is the maximum size allowed for a
+	// transaction input signature script to be considered standard.  This
+	// value allows for a 15-of-15 CHECKMULTISIG pay-to-script-hash with
+	// compressed keys.
+	//
+	// The form of the overall script is: OP_0 <15 signatures> OP_PUSHDATA2
+	// <2 bytes len> [OP_15 <15 pubkeys> OP_15 OP_CHECKMULTISIG]
+	//
+	// For the p2sh script portion, each of the 15 compressed pubkeys are
+	// 33 bytes (plus one for the OP_DATA_33 opcode), and the thus it totals
+	// to (15*34)+3 = 513 bytes.  Next, each of the 15 signatures is a max
+	// of 73 bytes (plus one for the OP_DATA_73 opcode).  Also, there is one
+	// extra byte for the initial extra OP_0 push and 3 bytes for the
+	// OP_PUSHDATA2 needed to specify the 513 bytes for the script push.
+	// That brings the total to 1+(15*74)+3+513 = 1627.  This value also
+	// adds a few extra bytes to provide a little buffer.
+	// (1 + 15*74 + 3) + (15*34 + 3) + 23 = 1650
+	maxStandardSigScriptSize = 1650
+
+	// defaultMinRelayTxFee is the minimum fee in satoshi that is required
+	// for a transaction to be treated as free for relay and mining
+	// purposes.  It is also used to help determine if a transaction is
+	// considered dust and as a base for calculating minimum required fees
+	// for larger transactions.  This value is in Satoshi/1000 bytes.
+	defaultMinRelayTxFee = dcrutil.Amount(1e6)
+
 	// maxStandardMultiSigKeys is the maximum number of public keys allowed
 	// in a multi-signature transaction output script for it to be
 	// considered standard.
@@ -313,6 +344,112 @@ func isDust(txOut *wire.TxOut, minRelayTxFee dcrutil.Amount) bool {
 	// The following is equivalent to (value/totalSize) * (1/3) * 1000
 	// without needing to do floating point math.
 	return txOut.Value*1000/(3*int64(totalSize)) < int64(minRelayTxFee)
+}
+
+// checkTransactionStandard performs a series of checks on a transaction to
+// ensure it is a "standard" transaction.  A standard transaction is one that
+// conforms to several additional limiting cases over what is considered a
+// "sane" transaction such as having a version in the supported range, being
+// finalized, conforming to more stringent size constraints, having scripts
+// of recognized forms, and not containing "dust" outputs (those that are
+// so small it costs more to process them than they are worth).
+func checkTransactionStandard(tx *dcrutil.Tx, txType stake.TxType, height int64,
+	timeSource blockchain.MedianTimeSource,
+	minRelayTxFee dcrutil.Amount) error {
+
+	// The transaction must be a currently supported version.
+	msgTx := tx.MsgTx()
+	if !wire.IsSupportedMsgTxVersion(msgTx) {
+		str := fmt.Sprintf("transaction version %d is not in the "+
+			"valid range of %d-%d", msgTx.Version, 1,
+			wire.TxVersion)
+		return txRuleError(wire.RejectNonstandard, str)
+	}
+
+	// The transaction must be finalized to be standard and therefore
+	// considered for inclusion in a block.
+	adjustedTime := timeSource.AdjustedTime()
+	if !blockchain.IsFinalizedTransaction(tx, height, adjustedTime) {
+		return txRuleError(wire.RejectNonstandard,
+			"transaction is not finalized")
+	}
+
+	// Since extremely large transactions with a lot of inputs can cost
+	// almost as much to process as the sender fees, limit the maximum
+	// size of a transaction.  This also helps mitigate CPU exhaustion
+	// attacks.
+	serializedLen := msgTx.SerializeSize()
+	if serializedLen > maxStandardTxSize {
+		str := fmt.Sprintf("transaction size of %v is larger than max "+
+			"allowed size of %v", serializedLen, maxStandardTxSize)
+		return txRuleError(wire.RejectNonstandard, str)
+	}
+
+	for i, txIn := range msgTx.TxIn {
+		// Each transaction input signature script must not exceed the
+		// maximum size allowed for a standard transaction.  See
+		// the comment on maxStandardSigScriptSize for more details.
+		sigScriptLen := len(txIn.SignatureScript)
+		if sigScriptLen > maxStandardSigScriptSize {
+			str := fmt.Sprintf("transaction input %d: signature "+
+				"script size of %d bytes is large than max "+
+				"allowed size of %d bytes", i, sigScriptLen,
+				maxStandardSigScriptSize)
+			return txRuleError(wire.RejectNonstandard, str)
+		}
+
+		// Each transaction input signature script must only contain
+		// opcodes which push data onto the stack.
+		if !txscript.IsPushOnlyScript(txIn.SignatureScript) {
+			str := fmt.Sprintf("transaction input %d: signature "+
+				"script is not push only", i)
+			return txRuleError(wire.RejectNonstandard, str)
+		}
+
+	}
+
+	// None of the output public key scripts can be a non-standard script or
+	// be "dust" (except when the script is a null data script).
+	numNullDataOutputs := 0
+	for i, txOut := range msgTx.TxOut {
+		scriptClass := txscript.GetScriptClass(txOut.Version, txOut.PkScript)
+		err := checkPkScriptStandard(txOut.Version, txOut.PkScript, scriptClass)
+		if err != nil {
+			// Attempt to extract a reject code from the error so
+			// it can be retained.  When not possible, fall back to
+			// a non standard error.
+			rejectCode, found := extractRejectCode(err)
+			if !found {
+				rejectCode = wire.RejectNonstandard
+			}
+			str := fmt.Sprintf("transaction output %d: %v", i, err)
+			return txRuleError(rejectCode, str)
+		}
+
+		// Accumulate the number of outputs which only carry data.  For
+		// all other script types, ensure the output value is not
+		// "dust".
+		if scriptClass == txscript.NullDataTy {
+			numNullDataOutputs++
+		} else if isDust(txOut, minRelayTxFee) &&
+			txType != stake.TxTypeSStx {
+			str := fmt.Sprintf("transaction output %d: payment "+
+				"of %d is dust", i, txOut.Value)
+			return txRuleError(wire.RejectDust, str)
+		}
+	}
+
+	// A standard transaction must not have more than one output script that
+	// only carries data. However, certain types of standard stake transactions
+	// are allowed to have multiple OP_RETURN outputs, so only throw an error here
+	// if the tx is TxTypeRegular.
+	if numNullDataOutputs > maxNullDataOutputs && txType == stake.TxTypeRegular {
+		str := "more than one transaction output in a nulldata script for a " +
+			"regular type tx"
+		return txRuleError(wire.RejectNonstandard, str)
+	}
+
+	return nil
 }
 
 // minInt is a helper function to return the minimum of two ints.  This avoids


### PR DESCRIPTION
Upstream commit 58e2762158fbd25134f715171287116167e974d6.

In addition to the normal required changes for syncing, the following changes have been made in order to facilitate integration into Decred:

- Modify the tests to include the new wire fields rather than letting them by set by the default val so they are more explicit
- Update policy tests to check for > 4 nulldata outputs as nonstandard
