### PR TITLE
rpcserver: Add filteraddrs param to srt API.

### DIFF
--- a/dcrjson/chainsvrcmds.go
+++ b/dcrjson/chainsvrcmds.go
@@ -587,12 +587,13 @@ func NewReconsiderBlockCmd(blockHash string) *ReconsiderBlockCmd {
 
 // SearchRawTransactionsCmd defines the searchrawtransactions JSON-RPC command.
 type SearchRawTransactionsCmd struct {
-	Address  string
-	Verbose  *int  `jsonrpcdefault:"1"`
-	Skip     *int  `jsonrpcdefault:"0"`
-	Count    *int  `jsonrpcdefault:"100"`
-	VinExtra *int  `jsonrpcdefault:"0"`
-	Reverse  *bool `jsonrpcdefault:"false"`
+	Address     string
+	Verbose     *int  `jsonrpcdefault:"1"`
+	Skip        *int  `jsonrpcdefault:"0"`
+	Count       *int  `jsonrpcdefault:"100"`
+	VinExtra    *int  `jsonrpcdefault:"0"`
+	Reverse     *bool `jsonrpcdefault:"false"`
+	FilterAddrs *[]string
 }
 
 // NewSearchRawTransactionsCmd returns a new instance which can be used to issue a
@@ -600,14 +601,15 @@ type SearchRawTransactionsCmd struct {
 //
 // The parameters which are pointers indicate they are optional.  Passing nil
 // for optional parameters will use the default value.
-func NewSearchRawTransactionsCmd(address string, verbose, skip, count *int, vinExtra *int, reverse *bool) *SearchRawTransactionsCmd {
+func NewSearchRawTransactionsCmd(address string, verbose, skip, count *int, vinExtra *int, reverse *bool, filterAddrs *[]string) *SearchRawTransactionsCmd {
 	return &SearchRawTransactionsCmd{
-		Address:  address,
-		Verbose:  verbose,
-		Skip:     skip,
-		Count:    count,
-		VinExtra: vinExtra,
-		Reverse:  reverse,
+		Address:     address,
+		Verbose:     verbose,
+		Skip:        skip,
+		Count:       count,
+		VinExtra:    vinExtra,
+		Reverse:     reverse,
+		FilterAddrs: filterAddrs,
 	}
 }
 

--- a/dcrjson/chainsvrcmds_test.go
+++ b/dcrjson/chainsvrcmds_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015 The Decred developers
+// Copyright (c) 2016 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -714,16 +714,17 @@ func TestChainSvrCmds(t *testing.T) {
 				return dcrjson.NewCmd("searchrawtransactions", "1Address")
 			},
 			staticCmd: func() interface{} {
-				return dcrjson.NewSearchRawTransactionsCmd("1Address", nil, nil, nil, nil, nil)
+				return dcrjson.NewSearchRawTransactionsCmd("1Address", nil, nil, nil, nil, nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address"],"id":1}`,
 			unmarshalled: &dcrjson.SearchRawTransactionsCmd{
-				Address:  "1Address",
-				Verbose:  dcrjson.Int(1),
-				Skip:     dcrjson.Int(0),
-				Count:    dcrjson.Int(100),
-				VinExtra: dcrjson.Int(0),
-				Reverse:  dcrjson.Bool(false),
+				Address:     "1Address",
+				Verbose:     dcrjson.Int(1),
+				Skip:        dcrjson.Int(0),
+				Count:       dcrjson.Int(100),
+				VinExtra:    dcrjson.Int(0),
+				Reverse:     dcrjson.Bool(false),
+				FilterAddrs: nil,
 			},
 		},
 		{
@@ -733,16 +734,17 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 			staticCmd: func() interface{} {
 				return dcrjson.NewSearchRawTransactionsCmd("1Address",
-					dcrjson.Int(0), nil, nil, nil, nil)
+					dcrjson.Int(0), nil, nil, nil, nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0],"id":1}`,
 			unmarshalled: &dcrjson.SearchRawTransactionsCmd{
-				Address:  "1Address",
-				Verbose:  dcrjson.Int(0),
-				Skip:     dcrjson.Int(0),
-				Count:    dcrjson.Int(100),
-				VinExtra: dcrjson.Int(0),
-				Reverse:  dcrjson.Bool(false),
+				Address:     "1Address",
+				Verbose:     dcrjson.Int(0),
+				Skip:        dcrjson.Int(0),
+				Count:       dcrjson.Int(100),
+				VinExtra:    dcrjson.Int(0),
+				Reverse:     dcrjson.Bool(false),
+				FilterAddrs: nil,
 			},
 		},
 		{
@@ -752,16 +754,17 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 			staticCmd: func() interface{} {
 				return dcrjson.NewSearchRawTransactionsCmd("1Address",
-					dcrjson.Int(0), dcrjson.Int(5), nil, nil, nil)
+					dcrjson.Int(0), dcrjson.Int(5), nil, nil, nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0,5],"id":1}`,
 			unmarshalled: &dcrjson.SearchRawTransactionsCmd{
-				Address:  "1Address",
-				Verbose:  dcrjson.Int(0),
-				Skip:     dcrjson.Int(5),
-				Count:    dcrjson.Int(100),
-				VinExtra: dcrjson.Int(0),
-				Reverse:  dcrjson.Bool(false),
+				Address:     "1Address",
+				Verbose:     dcrjson.Int(0),
+				Skip:        dcrjson.Int(5),
+				Count:       dcrjson.Int(100),
+				VinExtra:    dcrjson.Int(0),
+				Reverse:     dcrjson.Bool(false),
+				FilterAddrs: nil,
 			},
 		},
 		{
@@ -771,16 +774,17 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 			staticCmd: func() interface{} {
 				return dcrjson.NewSearchRawTransactionsCmd("1Address",
-					dcrjson.Int(0), dcrjson.Int(5), dcrjson.Int(10), nil, nil)
+					dcrjson.Int(0), dcrjson.Int(5), dcrjson.Int(10), nil, nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0,5,10],"id":1}`,
 			unmarshalled: &dcrjson.SearchRawTransactionsCmd{
-				Address:  "1Address",
-				Verbose:  dcrjson.Int(0),
-				Skip:     dcrjson.Int(5),
-				Count:    dcrjson.Int(10),
-				VinExtra: dcrjson.Int(0),
-				Reverse:  dcrjson.Bool(false),
+				Address:     "1Address",
+				Verbose:     dcrjson.Int(0),
+				Skip:        dcrjson.Int(5),
+				Count:       dcrjson.Int(10),
+				VinExtra:    dcrjson.Int(0),
+				Reverse:     dcrjson.Bool(false),
+				FilterAddrs: nil,
 			},
 		},
 		{
@@ -790,16 +794,17 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 			staticCmd: func() interface{} {
 				return dcrjson.NewSearchRawTransactionsCmd("1Address",
-					dcrjson.Int(0), dcrjson.Int(5), dcrjson.Int(10), dcrjson.Int(1), nil)
+					dcrjson.Int(0), dcrjson.Int(5), dcrjson.Int(10), dcrjson.Int(1), nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0,5,10,1],"id":1}`,
 			unmarshalled: &dcrjson.SearchRawTransactionsCmd{
-				Address:  "1Address",
-				Verbose:  dcrjson.Int(0),
-				Skip:     dcrjson.Int(5),
-				Count:    dcrjson.Int(10),
-				VinExtra: dcrjson.Int(1),
-				Reverse:  dcrjson.Bool(false),
+				Address:     "1Address",
+				Verbose:     dcrjson.Int(0),
+				Skip:        dcrjson.Int(5),
+				Count:       dcrjson.Int(10),
+				VinExtra:    dcrjson.Int(1),
+				Reverse:     dcrjson.Bool(false),
+				FilterAddrs: nil,
 			},
 		},
 		{
@@ -809,16 +814,39 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 			staticCmd: func() interface{} {
 				return dcrjson.NewSearchRawTransactionsCmd("1Address",
-					dcrjson.Int(0), dcrjson.Int(5), dcrjson.Int(10), dcrjson.Int(1), dcrjson.Bool(true))
+					dcrjson.Int(0), dcrjson.Int(5), dcrjson.Int(10),
+					dcrjson.Int(1), dcrjson.Bool(true), nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0,5,10,1,true],"id":1}`,
 			unmarshalled: &dcrjson.SearchRawTransactionsCmd{
-				Address:  "1Address",
-				Verbose:  dcrjson.Int(0),
-				Skip:     dcrjson.Int(5),
-				Count:    dcrjson.Int(10),
-				VinExtra: dcrjson.Int(1),
-				Reverse:  dcrjson.Bool(true),
+				Address:     "1Address",
+				Verbose:     dcrjson.Int(0),
+				Skip:        dcrjson.Int(5),
+				Count:       dcrjson.Int(10),
+				VinExtra:    dcrjson.Int(1),
+				Reverse:     dcrjson.Bool(true),
+				FilterAddrs: nil,
+			},
+		},
+		{
+			name: "searchrawtransactions",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("searchrawtransactions", "1Address", 0, 5, 10, 1, true, []string{"1Address"})
+			},
+			staticCmd: func() interface{} {
+				return dcrjson.NewSearchRawTransactionsCmd("1Address",
+					dcrjson.Int(0), dcrjson.Int(5), dcrjson.Int(10),
+					dcrjson.Int(1), dcrjson.Bool(true), &[]string{"1Address"})
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0,5,10,1,true,["1Address"]],"id":1}`,
+			unmarshalled: &dcrjson.SearchRawTransactionsCmd{
+				Address:     "1Address",
+				Verbose:     dcrjson.Int(0),
+				Skip:        dcrjson.Int(5),
+				Count:       dcrjson.Int(10),
+				VinExtra:    dcrjson.Int(1),
+				Reverse:     dcrjson.Bool(true),
+				FilterAddrs: &[]string{"1Address"},
 			},
 		},
 		{

--- a/dcrjson/chainsvrresults.go
+++ b/dcrjson/chainsvrresults.go
@@ -457,7 +457,7 @@ type TxRawResult struct {
 // SearchRawTransactionsResult models the data from the searchrawtransaction
 // command.
 type SearchRawTransactionsResult struct {
-	Hex           string       `json:"hex"`
+	Hex           string       `json:"hex,omitempty"`
 	Txid          string       `json:"txid"`
 	Version       int32        `json:"version"`
 	LockTime      uint32       `json:"locktime"`

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -592,6 +592,7 @@ var helpDescsEnUS = map[string]string{
 	"searchrawtransactions-count":       "The maximum number of transactions to return",
 	"searchrawtransactions-vinextra":    "Specify that extra data from previous output will be returned in vin",
 	"searchrawtransactions-reverse":     "Specifies that the transactions should be returned in reverse chronological order",
+	"searchrawtransactions-filteraddrs": "Address list.  Only inputs or outputs with matching address will be returned",
 	"searchrawtransactions--result0":    "Hex-encoded serialized transaction",
 
 	// SendRawTransactionCmd help.


### PR DESCRIPTION
**This PR codepends on decred/dcrrpcclient#25**

Contains the following upstream commits:
- 365b1bd156bdb9e4972d155ae8c7f939cf786e18
  - Previously cherry-picked so it is a NOOP
- b691a222d564e222801d2136489f8758b9154a16
  - Reverted because Decred uses a different signature algorithm
- c7eaee60208ba0d3acf5cd541996a3f8841e1187

In addition to the normal required changes for syncing, the following changes have been made in order to facilitate integration into Decred:

- Rework the code which extracts stake submission outputs a bit to be a little more efficient and to better fit with the code being merged
