### PR TITLE
Fix dropaddrindex flag usage message

### DIFF
--- a/config.go
+++ b/config.go
@@ -133,7 +133,7 @@ type config struct {
 	BlockPrioritySize  uint32        `long:"blockprioritysize" description:"Size in bytes for high-priority/low-fee transactions when creating a block"`
 	GetWorkKeys        []string      `long:"getworkkey" description:"DEPRECATED -- Use the --miningaddr option instead"`
 	NoAddrIndex        bool          `long:"addrindex" description:"Disable building and maintaining a full address index. Currently only supported by leveldb. Will prevent wallet resyncing from seed."`
-	DropAddrIndex      bool          `long:"dropaddrindex" description:"Deletes the address-based transaction index from the database on start up, and the exits."`
+	DropAddrIndex      bool          `long:"dropaddrindex" description:"Deletes the address-based transaction index from the database on start up, and then exits."`
 	NonAggressive      bool          `long:"nonaggressive" description:"Disable mining off of the parent block of the blockchain if there aren't enough voters"`
 	NoMiningStateSync  bool          `long:"nominingstatesync" description:"Disable synchronizing the mining state with other nodes"`
 	AllowOldVotes      bool          `long:"allowoldvotes" description:"Enable the addition of very old votes to the mempool"`


### PR DESCRIPTION
Contains the following upstream commits:
- d0f0a2ac02596ff312987fa1fe75972e5bf9a227
  - This commit has already been cherry-picked so it is a NOOP
- 09874f1e9115b56573168cf2d310357356c9d80a
