### PR TITLE
peer: Rename variable for consistency.

### DIFF
--- a/cpuminer.go
+++ b/cpuminer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/decred/dcrd/blockchain"
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/mining"
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrutil"
 )
@@ -59,8 +60,8 @@ var (
 // system which is typically sufficient.
 type CPUMiner struct {
 	sync.Mutex
-	policy            *miningPolicy
-	txSource          TxSource
+	policy            *mining.Policy
+	txSource          mining.TxSource
 	server            *server
 	numWorkers        uint32
 	started           bool
@@ -649,7 +650,7 @@ func (m *CPUMiner) GenerateNBlocks(n uint32) ([]*chainhash.Hash, error) {
 // newCPUMiner returns a new instance of a CPU miner for the provided server.
 // Use Start to begin the mining process.  See the documentation for CPUMiner
 // type for more details.
-func newCPUMiner(policy *miningPolicy, s *server) *CPUMiner {
+func newCPUMiner(policy *mining.Policy, s *server) *CPUMiner {
 	return &CPUMiner{
 		policy:            policy,
 		txSource:          s.txMemPool,

--- a/mempool.go
+++ b/mempool.go
@@ -21,6 +21,7 @@ import (
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/database"
+	"github.com/decred/dcrd/mining"
 	"github.com/decred/dcrd/txscript"
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrutil"
@@ -85,7 +86,7 @@ type VoteTx struct {
 // mempoolTxDesc is a descriptor containing a transaction in the mempool along
 // with additional metadata.
 type mempoolTxDesc struct {
-	miningTxDesc
+	mining.TxDesc
 
 	// StartingPriority is the priority of the transaction when it was added
 	// to the pool.
@@ -399,7 +400,7 @@ func (mp *txMemPool) SortParentsByVotes(currentTopBlock chainhash.Hash,
 }
 
 // Ensure the txMemPool type implements the mining.TxSource interface.
-var _ TxSource = (*txMemPool)(nil)
+var _ mining.TxSource = (*txMemPool)(nil)
 
 // removeOrphan is the internal function which implements the public
 // RemoveOrphan.  See the comment for RemoveOrphan for more details.
@@ -708,7 +709,7 @@ func (mp *txMemPool) addTransaction(txStore blockchain.TxStore, tx *dcrutil.Tx,
 	// Add the transaction to the pool and mark the referenced outpoints
 	// as spent by the pool.
 	mp.pool[*tx.Sha()] = &mempoolTxDesc{
-		miningTxDesc: miningTxDesc{
+		TxDesc: mining.TxDesc{
 			Tx:     tx,
 			Type:   txType,
 			Added:  time.Now(),
@@ -1735,16 +1736,16 @@ func (mp *txMemPool) TxDescs() []*mempoolTxDesc {
 // MiningDescs returns a slice of mining descriptors for all the transactions
 // in the pool.
 //
-// This is part of the TxSource interface implementation and is safe for
+// This is part of the mining.TxSource interface implementation and is safe for
 // concurrent access as required by the interface contract.
-func (mp *txMemPool) MiningDescs() []*miningTxDesc {
+func (mp *txMemPool) MiningDescs() []*mining.TxDesc {
 	mp.RLock()
 	defer mp.RUnlock()
 
-	descs := make([]*miningTxDesc, len(mp.pool))
+	descs := make([]*mining.TxDesc, len(mp.pool))
 	i := 0
 	for _, desc := range mp.pool {
-		descs[i] = &desc.miningTxDesc
+		descs[i] = &desc.TxDesc
 		i++
 	}
 

--- a/mining.go
+++ b/mining.go
@@ -703,9 +703,7 @@ func medianAdjustedTime(chainState *chainState,
 // valid from the perspective of the mainchain (not necessarily
 // the mempool or block) before inserting into a tx tree.
 // If it fails the check, it returns false; otherwise true.
-func maybeInsertStakeTx(mp *txMemPool, stx *dcrutil.Tx, treeValid bool) bool {
-	bm := mp.server.blockManager
-
+func maybeInsertStakeTx(bm *blockManager, stx *dcrutil.Tx, treeValid bool) bool {
 	missingInput := false
 
 	txStore, err := bm.FetchTransactionStore(stx, treeValid)
@@ -1714,7 +1712,7 @@ mempoolLoop:
 
 		if isSSGen, _ := stake.IsSSGen(tx); isSSGen {
 			txCopy := dcrutil.NewTxDeepTxIns(tx.MsgTx())
-			if maybeInsertStakeTx(mempool, txCopy, treeValid) {
+			if maybeInsertStakeTx(blockManager, txCopy, treeValid) {
 				vb := stake.GetSSGenVoteBits(txCopy)
 				voteBitsVoters = append(voteBitsVoters, vb)
 				blockTxnsStake = append(blockTxnsStake, txCopy)
@@ -1820,7 +1818,7 @@ mempoolLoop:
 			// Quick check for difficulty here.
 			if tx.MsgTx().TxOut[0].Value >= requiredStakeDifficulty {
 				txCopy := dcrutil.NewTxDeepTxIns(tx.MsgTx())
-				if maybeInsertStakeTx(mempool, txCopy, treeValid) {
+				if maybeInsertStakeTx(blockManager, txCopy, treeValid) {
 					blockTxnsStake = append(blockTxnsStake, txCopy)
 					freshStake++
 				}
@@ -1843,7 +1841,7 @@ mempoolLoop:
 		isSSRtx, _ := stake.IsSSRtx(tx)
 		if tx.Tree() == dcrutil.TxTreeStake && isSSRtx {
 			txCopy := dcrutil.NewTxDeepTxIns(tx.MsgTx())
-			if maybeInsertStakeTx(mempool, txCopy, treeValid) {
+			if maybeInsertStakeTx(blockManager, txCopy, treeValid) {
 				blockTxnsStake = append(blockTxnsStake, txCopy)
 				revocations++
 			}

--- a/mining/README.md
+++ b/mining/README.md
@@ -1,0 +1,23 @@
+mining
+======
+
+[![Build Status](http://img.shields.io/travis/decred/dcrd.svg)]
+(https://travis-ci.org/decred/dcrd) [![ISC License]
+(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
+(http://godoc.org/github.com/decred/dcrd/mining)
+
+## Overview
+
+This package is currently a work in progress.
+
+## Installation and Updating
+
+```bash
+$ go get -u github.com/decred/dcrd/mining
+```
+
+## License
+
+Package mining is licensed under the [copyfree](http://copyfree.org) ISC
+License.

--- a/mining/mining.go
+++ b/mining/mining.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2014-2015 The btcsuite developers
+// Copyright (c) 2016 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package mining
+
+import (
+	"time"
+
+	"github.com/decred/dcrd/blockchain/stake"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrutil"
+)
+
+// TxDesc is a descriptor about a transaction in a transaction source along with
+// additional metadata.
+type TxDesc struct {
+	// Tx is the transaction associated with the entry.
+	Tx *dcrutil.Tx
+
+	// Type is the type of the transaction associated with the entry.
+	Type stake.TxType
+
+	// Added is the time when the entry was added to the source pool.
+	Added time.Time
+
+	// Height is the block height when the entry was added to the the source
+	// pool.
+	Height int64
+
+	// Fee is the total fee the transaction associated with the entry pays.
+	Fee int64
+}
+
+// TxSource represents a source of transactions to consider for inclusion in
+// new blocks.
+//
+// The interface contract requires that all of these methods are safe for
+// concurrent access with respect to the source.
+type TxSource interface {
+	// LastUpdated returns the last time a transaction was added to or
+	// removed from the source pool.
+	LastUpdated() time.Time
+
+	// MiningDescs returns a slice of mining descriptors for all the
+	// transactions in the source pool.
+	MiningDescs() []*TxDesc
+
+	// HaveTransaction returns whether or not the passed transaction hash
+	// exists in the source pool.
+	HaveTransaction(hash *chainhash.Hash) bool
+}

--- a/mining/policy.go
+++ b/mining/policy.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2014-2015 The btcsuite developers
+// Copyright (c) 2016 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package mining
+
+import "github.com/decred/dcrutil"
+
+// Policy houses the policy (configuration parameters) which is used to control
+// the generation of block templates.  See the documentation for
+// NewBlockTemplate for more details on each of these parameters are used.
+type Policy struct {
+	// BlockMinSize is the minimum block size in bytes to be used when
+	// generating a block template.
+	BlockMinSize uint32
+
+	// BlockMaxSize is the maximum block size in bytes to be used when
+	// generating a block template.
+	BlockMaxSize uint32
+
+	// BlockPrioritySize is the size in bytes for high-priority / low-fee
+	// transactions to be used when generating a block template.
+	BlockPrioritySize uint32
+
+	// TxMinFreeFee is the minimum fee in Atoms/1000 bytes that is
+	// required for a transaction to be treated as free for mining purposes
+	// (block template generation).
+	TxMinFreeFee dcrutil.Amount
+}

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -749,7 +749,7 @@ func (p *Peer) pushVersionMsg() error {
 		}
 	}
 
-	theirNa := p.na
+	theirNA := p.na
 
 	// If we are behind a proxy and the connection comes from the proxy then
 	// we return an unroutable address as their address. This is to prevent
@@ -758,7 +758,7 @@ func (p *Peer) pushVersionMsg() error {
 		proxyaddress, _, err := net.SplitHostPort(p.cfg.Proxy)
 		// invalid proxy means poorly configured, be on the safe side.
 		if err != nil || p.na.IP.String() == proxyaddress {
-			theirNa = &wire.NetAddress{
+			theirNA = &wire.NetAddress{
 				Timestamp: time.Now(),
 				IP:        net.IP([]byte{0, 0, 0, 0}),
 			}
@@ -783,7 +783,7 @@ func (p *Peer) pushVersionMsg() error {
 	sentNonces.Add(nonce)
 
 	// Version message.
-	msg := wire.NewMsgVersion(ourNA, theirNa, nonce, int32(blockNum))
+	msg := wire.NewMsgVersion(ourNA, theirNA, nonce, int32(blockNum))
 	msg.AddUserAgent(p.cfg.UserAgentName, p.cfg.UserAgentVersion)
 
 	// XXX: bitcoind appears to always enable the full node services flag

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -244,6 +244,10 @@ type Config struct {
 	// peer.MaxProtocolVersion will be used.
 	ProtocolVersion uint32
 
+	// DisableRelayTx specifies if the remote peer should be informed to
+	// not send inv messages for transactions.
+	DisableRelayTx bool
+
 	// Listeners houses callback functions to be invoked on receiving peer
 	// messages.
 	Listeners MessageListeners
@@ -805,6 +809,9 @@ func (p *Peer) pushVersionMsg() error {
 
 	// Advertise our max supported protocol version.
 	msg.ProtocolVersion = int32(p.ProtocolVersion())
+
+	// Advertise if inv messages for transactions are desired.
+	msg.DisableRelayTx = p.cfg.DisableRelayTx
 
 	p.QueueMessage(msg, nil)
 	return nil

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -41,6 +41,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/database"
 	"github.com/decred/dcrd/dcrjson"
+	"github.com/decred/dcrd/mining"
 	"github.com/decred/dcrd/txscript"
 	"github.com/decred/dcrd/wire"
 
@@ -5684,7 +5685,7 @@ func handleVerifyMessage(s *rpcServer, cmd interface{}, closeChan <-chan struct{
 type rpcServer struct {
 	started      int32
 	shutdown     int32
-	policy       *miningPolicy
+	policy       *mining.Policy
 	server       *server
 	authsha      [fastsha256.Size]byte
 	limitauthsha [fastsha256.Size]byte
@@ -6168,7 +6169,7 @@ func genCertPair(certFile, keyFile string) error {
 }
 
 // newRPCServer returns a new instance of the rpcServer struct.
-func newRPCServer(listenAddrs []string, policy *miningPolicy, s *server) (*rpcServer, error) {
+func newRPCServer(listenAddrs []string, policy *mining.Policy, s *server) (*rpcServer, error) {
 	rpc := rpcServer{
 		policy:       policy,
 		server:       s,

--- a/server.go
+++ b/server.go
@@ -2524,6 +2524,8 @@ func newServer(listenAddrs []string, database database.Db, tmdb *stake.TicketDB,
 	s.txMemPool = newTxMemPool(&txC)
 
 	// Create the mining policy based on the configuration options.
+	// NOTE: The CPU miner relies on the mempool, so the mempool has to be
+	// created before calling the function to create the CPU miner.
 	policy := mining.Policy{
 		BlockMinSize:      cfg.BlockMinSize,
 		BlockMaxSize:      cfg.BlockMaxSize,

--- a/server.go
+++ b/server.go
@@ -1541,6 +1541,7 @@ func newPeerConfig(sp *serverPeer) *peer.Config {
 		UserAgentVersion: userAgentVersion,
 		ChainParams:      sp.server.chainParams,
 		Services:         sp.server.services,
+		DisableRelayTx:   false,
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/database"
+	"github.com/decred/dcrd/mining"
 	"github.com/decred/dcrd/peer"
 	"github.com/decred/dcrd/txscript"
 	"github.com/decred/dcrd/wire"
@@ -2522,7 +2523,7 @@ func newServer(listenAddrs []string, database database.Db, tmdb *stake.TicketDB,
 	s.txMemPool = newTxMemPool(&txC)
 
 	// Create the mining policy based on the configuration options.
-	policy := miningPolicy{
+	policy := mining.Policy{
 		BlockMinSize:      cfg.BlockMinSize,
 		BlockMaxSize:      cfg.BlockMaxSize,
 		BlockPrioritySize: cfg.BlockPrioritySize,


### PR DESCRIPTION
Contains the following upstream commits:
- 2f6aeacfab95db5c6afee054f8a118aee5821c97
  - This commit has already been independently applied so it is mostly a NOOP except for a comment update
- 542844832e6eccbce6c0650ba5d244562c60e09b
  - This commit has already been cherry picked so it is mostly a NOOP
- 4d40a2110a044113e4f19a7fdeb2d2b0c8893269
