### PR TITLE
Fix median of slice of Amounts for ticketfeeinfo.

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -20,10 +20,10 @@ import (
 	"math"
 	"math/big"
 	"math/rand"
-	"sort"
 	"net"
 	"net/http"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -5116,7 +5116,7 @@ func median(s []dcrutil.Amount) dcrutil.Amount {
 		return 0
 	}
 
-	sort.Sort(dcrutil.AmountSorter(s));
+	sort.Sort(dcrutil.AmountSorter(s))
 
 	middle := len(s) / 2
 
@@ -5124,9 +5124,8 @@ func median(s []dcrutil.Amount) dcrutil.Amount {
 		return 0
 	} else if (len(s) % 2) != 0 {
 		return s[middle]
-	} else {
-		return (s[middle] + s[middle - 1]) / 2
 	}
+	return (s[middle] + s[middle-1]) / 2
 }
 
 // stdDev gets the standard deviation amount from a slice of amounts.

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"math/big"
 	"math/rand"
+	"sort"
 	"net"
 	"net/http"
 	"os"
@@ -5115,8 +5116,17 @@ func median(s []dcrutil.Amount) dcrutil.Amount {
 		return 0
 	}
 
+	sort.Sort(dcrutil.AmountSorter(s));
+
 	middle := len(s) / 2
-	return s[middle]
+
+	if len(s) == 0 {
+		return 0
+	} else if (len(s) % 2) != 0 {
+		return s[middle]
+	} else {
+		return (s[middle] + s[middle - 1]) / 2
+	}
 }
 
 // stdDev gets the standard deviation amount from a slice of amounts.


### PR DESCRIPTION
The median function was not operating on a sorted array, so the result was a random transaction's fee. The modified function sorts the slice, so a copy may be needed, but the callers in ticketfeeinfo do not seem to require the array in the original order.

Note: For length 0 slice, it returns 0.  Is there a more appropriate Amount?

Requires dcrutil.AmountSorter PR https://github.com/decred/dcrutil/pull/12