### PR TITLE
server: Make consistent use of svr peer stringer.

### DIFF
--- a/peer/doc.go
+++ b/peer/doc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 The btcsuite developers
+// Copyright (c) 2015-2016 The btcsuite developers
 // Copyright (c) 2016 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
@@ -67,15 +67,12 @@ This provides high flexibility for things such as connecting via proxies, acting
 as a proxy, creating bridge peers, choosing whether to listen for inbound peers,
 etc.
 
-For outgoing peers, the NewOutboundPeer function must be used to specify the
-configuration followed by invoking Connect with the net.Conn instance.  This
- will start all async I/O goroutines and initiate the initial negotiation
-process.  Once that has been completed, the peer is fully functional.
-
-For inbound peers, the NewInboundPeer function must be used to specify the
-configuration and net.Conn instance followed by invoking Start.  This will start
-all async I/O goroutines and listen for the initial negotiation process.  Once
-that has been completed, the peer is fully functional.
+NewOutboundPeer and NewInboundPeer functions must be followed by calling Connect
+with a net.Conn instance to the peer.  This will start all async I/O goroutines
+and initiate the protocol negotiation process.  Once finished with the peer call
+Disconnect to disconnect from the peer and clean up all resources.
+WaitForDisconnect can be used to block until peer disconnection and resource
+cleanup has completed.
 
 Callbacks
 

--- a/peer/example_test.go
+++ b/peer/example_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 The btcsuite developers
+// Copyright (c) 2015-2016 The btcsuite developers
 // Copyright (c) 2016 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
@@ -39,9 +39,9 @@ func mockRemotePeer() error {
 		}
 
 		// Create and start the inbound peer.
-		p := peer.NewInboundPeer(peerCfg, conn)
-		if err := p.Start(); err != nil {
-			fmt.Printf("Start: error %v\n", err)
+		p := peer.NewInboundPeer(peerCfg)
+		if err := p.Connect(conn); err != nil {
+			fmt.Printf("Connect: error %v\n", err)
 			return
 		}
 	}()
@@ -106,8 +106,9 @@ func Example_newOutboundPeer() {
 		fmt.Printf("Example_peerConnection: verack timeout")
 	}
 
-	// Shutdown the peer.
-	p.Shutdown()
+	// Disconnect the peer.
+	p.Disconnect()
+	p.WaitForDisconnect()
 
 	// Output:
 	// outbound: received version

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -394,10 +394,14 @@ type HostToNetAddrFunc func(host string, port uint16,
 // of specific types that typically require common special handling are
 // provided as a convenience.
 type Peer struct {
-	started    int32
-	connected  int32
-	disconnect int32 // only to be used atomically
-	conn       net.Conn
+	// The following variables must only be used atomically
+	started       int32
+	connected     int32
+	disconnect    int32
+	bytesReceived uint64
+	bytesSent     uint64
+
+	conn net.Conn
 
 	// These fields are set at creation time and never modified, so they are
 	// safe to read from concurrently without a mutex.
@@ -430,8 +434,6 @@ type Peer struct {
 	timeConnected      time.Time
 	lastSend           time.Time
 	lastRecv           time.Time
-	bytesReceived      uint64
-	bytesSent          uint64
 	startingHeight     int32
 	lastBlock          int32
 	lastAnnouncedBlock *chainhash.Hash
@@ -512,8 +514,8 @@ func (p *Peer) StatsSnapshot() *StatsSnap {
 		Services:       services,
 		LastSend:       p.lastSend,
 		LastRecv:       p.lastRecv,
-		BytesSent:      p.bytesSent,
-		BytesRecv:      p.bytesReceived,
+		BytesSent:      atomic.LoadUint64(&p.bytesSent),
+		BytesRecv:      atomic.LoadUint64(&p.bytesReceived),
 		ConnTime:       p.timeConnected,
 		TimeOffset:     p.timeOffset,
 		Version:        protocolVersion,
@@ -688,20 +690,14 @@ func (p *Peer) LastRecv() time.Time {
 //
 // This function is safe for concurrent access.
 func (p *Peer) BytesSent() uint64 {
-	p.statsMtx.RLock()
-	defer p.statsMtx.RUnlock()
-
-	return p.bytesSent
+	return atomic.LoadUint64(&p.bytesSent)
 }
 
 // BytesReceived returns the total number of bytes received by the peer.
 //
 // This function is safe for concurrent access.
 func (p *Peer) BytesReceived() uint64 {
-	p.statsMtx.RLock()
-	defer p.statsMtx.RUnlock()
-
-	return p.bytesReceived
+	return atomic.LoadUint64(&p.bytesReceived)
 }
 
 // TimeConnected returns the time at which the peer connected.
@@ -1104,9 +1100,7 @@ func (p *Peer) handlePongMsg(msg *wire.MsgPong) {
 func (p *Peer) readMessage() (wire.Message, []byte, error) {
 	n, msg, buf, err := wire.ReadMessageN(p.conn, p.ProtocolVersion(),
 		p.cfg.ChainParams.Net)
-	p.statsMtx.Lock()
-	p.bytesReceived += uint64(n)
-	p.statsMtx.Unlock()
+	atomic.AddUint64(&p.bytesReceived, uint64(n))
 	if p.cfg.Listeners.OnRead != nil {
 		p.cfg.Listeners.OnRead(p, n, msg, err)
 	}
@@ -1181,9 +1175,7 @@ func (p *Peer) writeMessage(msg wire.Message) error {
 	// Write the message to the peer.
 	n, err := wire.WriteMessageN(p.conn, msg, p.ProtocolVersion(),
 		p.cfg.ChainParams.Net)
-	p.statsMtx.Lock()
-	p.bytesSent += uint64(n)
-	p.statsMtx.Unlock()
+	atomic.AddUint64(&p.bytesSent, uint64(n))
 	if p.cfg.Listeners.OnWrite != nil {
 		p.cfg.Listeners.OnWrite(p, n, msg, err)
 	}

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -394,8 +394,7 @@ type HostToNetAddrFunc func(host string, port uint16,
 // of specific types that typically require common special handling are
 // provided as a convenience.
 type Peer struct {
-	// The following variables must only be used atomically
-	started       int32
+	// The following variables must only be used atomically.
 	connected     int32
 	disconnect    int32
 	bytesReceived uint64
@@ -1909,11 +1908,14 @@ func (p *Peer) Connect(conn net.Conn) error {
 		return nil
 	}
 
+	if p.inbound {
+		p.addr = conn.RemoteAddr().String()
+	}
 	p.conn = conn
 	p.timeConnected = time.Now()
 
 	atomic.AddInt32(&p.connected, 1)
-	return p.Start()
+	return p.start()
 }
 
 // Connected returns whether or not the peer is currently connected.
@@ -1941,18 +1943,12 @@ func (p *Peer) Disconnect() {
 
 // Start begins processing input and output messages.  It also sends the initial
 // version message for outbound connections to start the negotiation process.
-func (p *Peer) Start() error {
-	// Already started?
-	if atomic.AddInt32(&p.started, 1) != 1 {
-		return nil
-	}
-
+func (p *Peer) start() error {
 	log.Tracef("Starting peer %s", p)
 
 	// Send an initial version message if this is an outbound connection.
 	if !p.inbound {
-		err := p.pushVersionMsg()
-		if err != nil {
+		if err := p.pushVersionMsg(); err != nil {
 			log.Errorf("Can't send outbound version message %v", err)
 			p.Disconnect()
 			return err
@@ -1968,16 +1964,11 @@ func (p *Peer) Start() error {
 	return nil
 }
 
-// Shutdown gracefully shuts down the peer by disconnecting it.
-func (p *Peer) Shutdown() {
-	log.Tracef("Shutdown peer %s", p)
-	p.Disconnect()
-}
-
-// WaitForShutdown waits until the peer has completely shutdown.  This will
-// happen if either the local or remote side has been disconnected or the peer
-// is forcibly shutdown via Shutdown.
-func (p *Peer) WaitForShutdown() {
+// WaitForDisconnect waits until the peer has completely disconnected and all
+// resources are cleaned up.  This will happen if either the local or remote
+// side has been disconnected or the peer is forcibly disconnected via
+// Disconnect.
+func (p *Peer) WaitForDisconnect() {
 	<-p.quit
 }
 
@@ -2018,13 +2009,8 @@ func newPeerBase(cfg *Config, inbound bool) *Peer {
 
 // NewInboundPeer returns a new inbound decred peer. Use Start to begin
 // processing incoming and outgoing messages.
-func NewInboundPeer(cfg *Config, conn net.Conn) *Peer {
-	p := newPeerBase(cfg, true)
-	p.conn = conn
-	p.addr = conn.RemoteAddr().String()
-	p.timeConnected = time.Now()
-	atomic.AddInt32(&p.connected, 1)
-	return p
+func NewInboundPeer(cfg *Config) *Peer {
+	return newPeerBase(cfg, true)
 }
 
 // NewOutboundPeer returns a new outbound decred peer.

--- a/policy_test.go
+++ b/policy_test.go
@@ -1,4 +1,5 @@
 // Copyright (c) 2013-2015 The btcsuite developers
+// Copyright (c) 2016 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/server.go
+++ b/server.go
@@ -1182,9 +1182,8 @@ func (s *server) handleAddPeerMsg(state *peerState, sp *serverPeer) bool {
 
 	// Ignore new peers if we're shutting down.
 	if atomic.LoadInt32(&s.shutdown) != 0 {
-		srvrLog.Infof("New peer %s ignored - server is shutting "+
-			"down", sp)
-		sp.Shutdown()
+		srvrLog.Infof("New peer %s ignored - server is shutting down", sp)
+		sp.Disconnect()
 		return false
 	}
 
@@ -1192,14 +1191,14 @@ func (s *server) handleAddPeerMsg(state *peerState, sp *serverPeer) bool {
 	host, _, err := net.SplitHostPort(sp.Addr())
 	if err != nil {
 		srvrLog.Debugf("can't split hostport %v", err)
-		sp.Shutdown()
+		sp.Disconnect()
 		return false
 	}
 	if banEnd, ok := state.banned[host]; ok {
 		if time.Now().Before(banEnd) {
-			srvrLog.Debugf("Peer %s is banned for another %v - "+
-				"disconnecting", host, banEnd.Sub(time.Now()))
-			sp.Shutdown()
+			srvrLog.Debugf("Peer %s is banned for another %v - disconnecting",
+				host, banEnd.Sub(time.Now()))
+			sp.Disconnect()
 			return false
 		}
 
@@ -1214,16 +1213,16 @@ func (s *server) handleAddPeerMsg(state *peerState, sp *serverPeer) bool {
 		if state.OutboundCount() >= state.maxOutboundPeers {
 			srvrLog.Infof("Max outbound peers reached [%d] - disconnecting "+
 				"peer %s", state.maxOutboundPeers, sp)
-			sp.Shutdown()
+			sp.Disconnect()
 			return false
 		}
 	}
 
 	// Limit max number of total peers.
 	if state.Count() >= cfg.MaxPeers {
-		srvrLog.Infof("Max peers reached [%d] - disconnecting "+
-			"peer %s", cfg.MaxPeers, sp)
-		sp.Shutdown()
+		srvrLog.Infof("Max peers reached [%d] - disconnecting peer %s",
+			cfg.MaxPeers, sp)
+		sp.Disconnect()
 		// TODO(oga) how to handle permanent peers here?
 		// they should be rescheduled.
 		return false
@@ -1555,15 +1554,19 @@ func (s *server) listenHandler(listener net.Listener) {
 		if err != nil {
 			// Only log the error if we're not forcibly shutting down.
 			if atomic.LoadInt32(&s.shutdown) == 0 {
-				srvrLog.Errorf("can't accept connection: %v",
-					err)
+				srvrLog.Errorf("Can't accept connection: %v", err)
 			}
 			continue
 		}
 		sp := newServerPeer(s, false)
-		sp.Peer = peer.NewInboundPeer(newPeerConfig(sp), conn)
-		sp.Start()
+		sp.Peer = peer.NewInboundPeer(newPeerConfig(sp))
 		go s.peerDoneHandler(sp)
+		if err := sp.Connect(conn); err != nil {
+			if atomic.LoadInt32(&s.shutdown) == 0 {
+				srvrLog.Errorf("Can't accept connection: %v", err)
+			}
+			continue
+		}
 	}
 	s.wg.Done()
 	srvrLog.Tracef("Listener handler done for %s", listener.Addr())
@@ -1642,7 +1645,7 @@ func (s *server) peerConnHandler(sp *serverPeer) {
 // peerDoneHandler handles peer disconnects by notifiying the server that it's
 // done.
 func (s *server) peerDoneHandler(sp *serverPeer) {
-	sp.WaitForShutdown()
+	sp.WaitForDisconnect()
 	s.donePeers <- sp
 
 	// Only tell block manager we are gone if we ever told it we existed.
@@ -1779,11 +1782,11 @@ out:
 		case qmsg := <-s.query:
 			s.handleQuery(state, qmsg)
 
-		// Shutdown the peer handler.
 		case <-s.quit:
-			// Shutdown peers.
+			// Disconnect all peers on server shutdown.
 			state.forAllPeers(func(sp *serverPeer) {
-				sp.Shutdown()
+				srvrLog.Tracef("Shutdown peer %s", sp.Peer)
+				sp.Disconnect()
 			})
 			break out
 		}
@@ -1800,7 +1803,8 @@ out:
 		if !state.NeedMoreOutbound() || len(cfg.ConnectPeers) > 0 ||
 			atomic.LoadInt32(&s.shutdown) != 0 {
 			state.forPendingPeers(func(sp *serverPeer) {
-				sp.Shutdown()
+				srvrLog.Tracef("Shutdown peer %s", sp.Peer)
+				sp.Disconnect()
 			})
 			continue
 		}

--- a/server.go
+++ b/server.go
@@ -1785,7 +1785,7 @@ out:
 		case <-s.quit:
 			// Disconnect all peers on server shutdown.
 			state.forAllPeers(func(sp *serverPeer) {
-				srvrLog.Tracef("Shutdown peer %s", sp.Peer)
+				srvrLog.Tracef("Shutdown peer %s", sp)
 				sp.Disconnect()
 			})
 			break out
@@ -1803,7 +1803,7 @@ out:
 		if !state.NeedMoreOutbound() || len(cfg.ConnectPeers) > 0 ||
 			atomic.LoadInt32(&s.shutdown) != 0 {
 			state.forPendingPeers(func(sp *serverPeer) {
-				srvrLog.Tracef("Shutdown peer %s", sp.Peer)
+				srvrLog.Tracef("Shutdown peer %s", sp)
 				sp.Disconnect()
 			})
 			continue

--- a/server.go
+++ b/server.go
@@ -169,14 +169,15 @@ func (ps *peerState) forAllPeers(closure func(sp *serverPeer)) {
 // server provides a decred server for handling communications to and from
 // decred peers.
 type server struct {
+	// The following variables must only be used atomically.
+	started       int32
+	shutdown      int32
+	shutdownSched int32
+	bytesReceived uint64 // Total bytes received from all peers since start.
+	bytesSent     uint64 // Total bytes sent by all peers since start.
+
 	listeners            []net.Listener
 	chainParams          *chaincfg.Params
-	started              int32      // atomic
-	shutdown             int32      // atomic
-	shutdownSched        int32      // atomic
-	bytesMutex           sync.Mutex // For the following two fields.
-	bytesReceived        uint64     // Total bytes received from all peers since start.
-	bytesSent            uint64     // Total bytes sent by all peers since start.
 	addrManager          *addrmgr.AddrManager
 	sigCache             *txscript.SigCache
 	rpcServer            *rpcServer
@@ -2010,28 +2011,20 @@ func (s *server) ConnectNode(addr string, permanent bool) error {
 // AddBytesSent adds the passed number of bytes to the total bytes sent counter
 // for the server.  It is safe for concurrent access.
 func (s *server) AddBytesSent(bytesSent uint64) {
-	s.bytesMutex.Lock()
-	defer s.bytesMutex.Unlock()
-
-	s.bytesSent += bytesSent
+	atomic.AddUint64(&s.bytesSent, bytesSent)
 }
 
 // AddBytesReceived adds the passed number of bytes to the total bytes received
 // counter for the server.  It is safe for concurrent access.
 func (s *server) AddBytesReceived(bytesReceived uint64) {
-	s.bytesMutex.Lock()
-	defer s.bytesMutex.Unlock()
-
-	s.bytesReceived += bytesReceived
+	atomic.AddUint64(&s.bytesReceived, bytesReceived)
 }
 
 // NetTotals returns the sum of all bytes received and sent across the network
 // for all peers.  It is safe for concurrent access.
 func (s *server) NetTotals() (uint64, uint64) {
-	s.bytesMutex.Lock()
-	defer s.bytesMutex.Unlock()
-
-	return s.bytesReceived, s.bytesSent
+	return atomic.LoadUint64(&s.bytesReceived),
+		atomic.LoadUint64(&s.bytesSent)
 }
 
 // UpdatePeerHeights updates the heights of all peers who have have announced

--- a/wire/doc.go
+++ b/wire/doc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2015 The btcsuite developers
+// Copyright (c) 2013-2016 The btcsuite developers
 // Copyright (c) 2015 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
@@ -156,5 +156,6 @@ This package includes spec changes outlined by the following BIPs:
 	BIP0035 (https://github.com/bitcoin/bips/blob/master/bip-0035.mediawiki)
 	BIP0037 (https://github.com/bitcoin/bips/blob/master/bip-0037.mediawiki)
 	BIP0111	(https://github.com/bitcoin/bips/blob/master/bip-0111.mediawiki)
+	BIP0130 (https://github.com/bitcoin/bips/blob/master/bip-0130.mediawiki)
 */
 package wire

--- a/wire/message.go
+++ b/wire/message.go
@@ -52,6 +52,7 @@ const (
 	CmdFilterLoad     = "filterload"
 	CmdMerkleBlock    = "merkleblock"
 	CmdReject         = "reject"
+	CmdSendHeaders    = "sendheaders"
 )
 
 // Message is an interface that describes a decred message.  A type that
@@ -138,6 +139,9 @@ func makeEmptyMessage(command string) (Message, error) {
 
 	case CmdReject:
 		msg = &MsgReject{}
+
+	case CmdSendHeaders:
+		msg = &MsgSendHeaders{}
 
 	default:
 		return nil, fmt.Errorf("unhandled command [%s]", command)

--- a/wire/msgsendheaders.go
+++ b/wire/msgsendheaders.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2016 The btcsuite developers
+// Copyright (c) 2016 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"fmt"
+	"io"
+)
+
+// MsgSendHeaders implements the Message interface and represents a bitcoin
+// sendheaders message.  It is used to request the peer send block headers
+// rather than inventory vectors.
+//
+// This message has no payload and was not added until protocol versions
+// starting with SendHeadersVersion.
+type MsgSendHeaders struct{}
+
+// BtcDecode decodes r using the bitcoin protocol encoding into the receiver.
+// This is part of the Message interface implementation.
+func (msg *MsgSendHeaders) BtcDecode(r io.Reader, pver uint32) error {
+	if pver < SendHeadersVersion {
+		str := fmt.Sprintf("sendheaders message invalid for protocol "+
+			"version %d", pver)
+		return messageError("MsgSendHeaders.BtcDecode", str)
+	}
+
+	return nil
+}
+
+// BtcEncode encodes the receiver to w using the bitcoin protocol encoding.
+// This is part of the Message interface implementation.
+func (msg *MsgSendHeaders) BtcEncode(w io.Writer, pver uint32) error {
+	if pver < SendHeadersVersion {
+		str := fmt.Sprintf("sendheaders message invalid for protocol "+
+			"version %d", pver)
+		return messageError("MsgSendHeaders.BtcEncode", str)
+	}
+
+	return nil
+}
+
+// Command returns the protocol command string for the message.  This is part
+// of the Message interface implementation.
+func (msg *MsgSendHeaders) Command() string {
+	return CmdSendHeaders
+}
+
+// MaxPayloadLength returns the maximum length the payload can be for the
+// receiver.  This is part of the Message interface implementation.
+func (msg *MsgSendHeaders) MaxPayloadLength(pver uint32) uint32 {
+	return 0
+}
+
+// NewMsgSendHeaders returns a new bitcoin sendheaders message that conforms to
+// the Message interface.  See MsgSendHeaders for details.
+func NewMsgSendHeaders() *MsgSendHeaders {
+	return &MsgSendHeaders{}
+}

--- a/wire/msgsendheaders_test.go
+++ b/wire/msgsendheaders_test.go
@@ -1,0 +1,192 @@
+// Copyright (c) 2016 The btcsuite developers
+// Copyright (c) 2016 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire_test
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/decred/dcrd/wire"
+)
+
+// TestSendHeaders tests the MsgSendHeaders API against the latest protocol
+// version.
+func TestSendHeaders(t *testing.T) {
+	pver := wire.ProtocolVersion
+
+	// Ensure the command is expected value.
+	wantCmd := "sendheaders"
+	msg := wire.NewMsgSendHeaders()
+	if cmd := msg.Command(); cmd != wantCmd {
+		t.Errorf("NewMsgSendHeaders: wrong command - got %v want %v",
+			cmd, wantCmd)
+	}
+
+	// Ensure max payload is expected value.
+	wantPayload := uint32(0)
+	maxPayload := msg.MaxPayloadLength(pver)
+	if maxPayload != wantPayload {
+		t.Errorf("MaxPayloadLength: wrong max payload length for "+
+			"protocol version %d - got %v, want %v", pver,
+			maxPayload, wantPayload)
+	}
+
+	// Test encode with latest protocol version.
+	var buf bytes.Buffer
+	err := msg.BtcEncode(&buf, pver)
+	if err != nil {
+		t.Errorf("encode of MsgSendHeaders failed %v err <%v>", msg,
+			err)
+	}
+
+	// Older protocol versions should fail encode since message didn't
+	// exist yet.
+	oldPver := wire.SendHeadersVersion - 1
+	err = msg.BtcEncode(&buf, oldPver)
+	if err == nil {
+		s := "encode of MsgSendHeaders passed for old protocol " +
+			"version %v err <%v>"
+		t.Errorf(s, msg, err)
+	}
+
+	// Test decode with latest protocol version.
+	readmsg := wire.NewMsgSendHeaders()
+	err = readmsg.BtcDecode(&buf, pver)
+	if err != nil {
+		t.Errorf("decode of MsgSendHeaders failed [%v] err <%v>", buf,
+			err)
+	}
+
+	// Older protocol versions should fail decode since message didn't
+	// exist yet.
+	err = readmsg.BtcDecode(&buf, oldPver)
+	if err == nil {
+		s := "decode of MsgSendHeaders passed for old protocol " +
+			"version %v err <%v>"
+		t.Errorf(s, msg, err)
+	}
+
+	return
+}
+
+// TestSendHeadersBIP0130 tests the MsgSendHeaders API against the protocol
+// prior to version SendHeadersVersion.
+func TestSendHeadersBIP0130(t *testing.T) {
+	// Use the protocol version just prior to SendHeadersVersion changes.
+	pver := wire.SendHeadersVersion - 1
+
+	msg := wire.NewMsgSendHeaders()
+
+	// Test encode with old protocol version.
+	var buf bytes.Buffer
+	err := msg.BtcEncode(&buf, pver)
+	if err == nil {
+		t.Errorf("encode of MsgSendHeaders succeeded when it should " +
+			"have failed")
+	}
+
+	// Test decode with old protocol version.
+	readmsg := wire.NewMsgSendHeaders()
+	err = readmsg.BtcDecode(&buf, pver)
+	if err == nil {
+		t.Errorf("decode of MsgSendHeaders succeeded when it should " +
+			"have failed")
+	}
+
+	return
+}
+
+// TestSendHeadersCrossProtocol tests the MsgSendHeaders API when encoding with
+// the latest protocol version and decoding with SendHeadersVersion.
+func TestSendHeadersCrossProtocol(t *testing.T) {
+	msg := wire.NewMsgSendHeaders()
+
+	// Encode with latest protocol version.
+	var buf bytes.Buffer
+	err := msg.BtcEncode(&buf, wire.ProtocolVersion)
+	if err != nil {
+		t.Errorf("encode of MsgSendHeaders failed %v err <%v>", msg,
+			err)
+	}
+
+	// Decode with old protocol version.
+	readmsg := wire.NewMsgSendHeaders()
+	err = readmsg.BtcDecode(&buf, wire.SendHeadersVersion)
+	if err != nil {
+		t.Errorf("decode of MsgSendHeaders failed [%v] err <%v>", buf,
+			err)
+	}
+}
+
+// TestSendHeadersWire tests the MsgSendHeaders wire encode and decode for
+// various protocol versions.
+func TestSendHeadersWire(t *testing.T) {
+	msgSendHeaders := wire.NewMsgSendHeaders()
+	msgSendHeadersEncoded := []byte{}
+
+	tests := []struct {
+		in   *wire.MsgSendHeaders // Message to encode
+		out  *wire.MsgSendHeaders // Expected decoded message
+		buf  []byte               // Wire encoding
+		pver uint32               // Protocol version for wire encoding
+	}{
+		// Latest protocol version.
+		{
+			msgSendHeaders,
+			msgSendHeaders,
+			msgSendHeadersEncoded,
+			wire.ProtocolVersion,
+		},
+
+		// Protocol version SendHeadersVersion+1
+		{
+			msgSendHeaders,
+			msgSendHeaders,
+			msgSendHeadersEncoded,
+			wire.SendHeadersVersion + 1,
+		},
+
+		// Protocol version SendHeadersVersion
+		{
+			msgSendHeaders,
+			msgSendHeaders,
+			msgSendHeadersEncoded,
+			wire.SendHeadersVersion,
+		},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		// Encode the message to wire format.
+		var buf bytes.Buffer
+		err := test.in.BtcEncode(&buf, test.pver)
+		if err != nil {
+			t.Errorf("BtcEncode #%d error %v", i, err)
+			continue
+		}
+		if !bytes.Equal(buf.Bytes(), test.buf) {
+			t.Errorf("BtcEncode #%d\n got: %s want: %s", i,
+				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
+			continue
+		}
+
+		// Decode the message from wire format.
+		var msg wire.MsgSendHeaders
+		rbuf := bytes.NewReader(test.buf)
+		err = msg.BtcDecode(rbuf, test.pver)
+		if err != nil {
+			t.Errorf("BtcDecode #%d error %v", i, err)
+			continue
+		}
+		if !reflect.DeepEqual(&msg, test.out) {
+			t.Errorf("BtcDecode #%d\n got: %s want: %s", i,
+				spew.Sdump(msg), spew.Sdump(test.out))
+			continue
+		}
+	}
+}

--- a/wire/msgversion.go
+++ b/wire/msgversion.go
@@ -19,7 +19,7 @@ import (
 const MaxUserAgentLen = 2000
 
 // DefaultUserAgent for wire in the stack
-const DefaultUserAgent = "/dcrwire:0.1.0/"
+const DefaultUserAgent = "/dcrwire:0.2.0/"
 
 // MsgVersion implements the Message interface and represents a decred version
 // message.  It is used for a peer to advertise itself as soon as an outbound

--- a/wire/protocol.go
+++ b/wire/protocol.go
@@ -1,5 +1,5 @@
-// Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015 The Decred developers
+// Copyright (c) 2013-2016 The btcsuite developers
+// Copyright (c) 2015-2016 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -17,11 +17,15 @@ const (
 	InitialProcotolVersion uint32 = 1
 
 	// ProtocolVersion is the latest protocol version this package supports.
-	ProtocolVersion uint32 = 2
+	ProtocolVersion uint32 = 3
 
 	// BIP0111Version is the protocol version which added the SFNodeBloom
 	// service flag.
 	BIP0111Version uint32 = 2
+
+	// SendHeadersVersion is the protocol version which added a new
+	// sendheaders message.
+	SendHeadersVersion uint32 = 3
 )
 
 // ServiceFlag identifies services supported by a decred peer.


### PR DESCRIPTION
Contains the following upstream commits:
- d127ad4083a2db4f334f4a47ea02337a6f8a0590
  - This commit has already been cherry picked and is a NOOP
- d759d1d3df441bb81972ba9238fc80053af5fa25
  - This commit was originally cherry picked from Decred and is a NOOP
- d127ad4083a2db4f334f4a47ea02337a6f8a0590
