### PR TITLE
wire: Export (read|write)(VarInt|VarBytes).

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,6 +34,7 @@ const (
 	defaultLogFilename       = "dcrd.log"
 	defaultMaxPeers          = 125
 	defaultBanDuration       = time.Hour * 24
+	defaultBanThreshold      = 100
 	defaultMaxRPCClients     = 10
 	defaultMaxRPCWebsockets  = 25
 	defaultVerifyEnabled     = false
@@ -89,7 +90,9 @@ type config struct {
 	DisableListen      bool          `long:"nolisten" description:"Disable listening for incoming connections -- NOTE: Listening is automatically disabled if the --connect or --proxy options are used without also specifying listen interfaces via --listen"`
 	Listeners          []string      `long:"listen" description:"Add an interface/port to listen for connections (default all interfaces port: 9108, testnet: 19108)"`
 	MaxPeers           int           `long:"maxpeers" description:"Max number of inbound and outbound peers"`
+	DisableBanning     bool          `long:"nobanning" description:"Disable banning of misbehaving peers"`
 	BanDuration        time.Duration `long:"banduration" description:"How long to ban misbehaving peers.  Valid time units are {s, m, h}.  Minimum 1 second"`
+	BanThreshold       uint32        `long:"banthreshold" description:"Maximum allowed ban score before disconnecting and banning misbehaving peers."`
 	RPCUser            string        `short:"u" long:"rpcuser" description:"Username for RPC connections"`
 	RPCPass            string        `short:"P" long:"rpcpass" default-mask:"-" description:"Password for RPC connections"`
 	RPCLimitUser       string        `long:"rpclimituser" description:"Username for limited RPC connections"`
@@ -335,6 +338,7 @@ func loadConfig() (*config, []string, error) {
 		DebugLevel:        defaultLogLevel,
 		MaxPeers:          defaultMaxPeers,
 		BanDuration:       defaultBanDuration,
+		BanThreshold:      defaultBanThreshold,
 		RPCMaxClients:     defaultMaxRPCClients,
 		RPCMaxWebsockets:  defaultMaxRPCWebsockets,
 		DataDir:           defaultDataDir,

--- a/doc.go
+++ b/doc.go
@@ -35,6 +35,9 @@ Application Options:
       --listen=             Add an interface/port to listen for connections
                             (default all interfaces port: 9108, testnet: 19108)
       --maxpeers=           Max number of inbound and outbound peers (125)
+      --nobanning           Disable banning of misbehaving peers
+      --banthreshold=       Maximum allowed ban score before disconnecting and
+                            banning misbehaving peers.
       --banduration=        How long to ban misbehaving peers.  Valid time units
                             are {s, m, h}.  Minimum 1 second (24h0m0s)
   -u, --rpcuser=            Username for RPC connections

--- a/dynamicbanscore.go
+++ b/dynamicbanscore.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2016 The btcsuite developers
+// Copyright (c) 2016 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"math"
+	"sync"
+	"time"
+)
+
+const (
+	// Halflife defines the time (in seconds) by which the transient part
+	// of the ban score decays to one half of it's original value.
+	Halflife = 60
+
+	// lambda is the decaying constant.
+	lambda = math.Ln2 / Halflife
+
+	// Lifetime defines the maximum age of the transient part of the ban
+	// score to be considered a non-zero score (in seconds).
+	Lifetime = 1800
+
+	// precomputedLen defines the amount of decay factors (one per second) that
+	// should be precomputed at initialization.
+	precomputedLen = 64
+)
+
+// precomputedFactor stores precomputed exponential decay factors for the first
+// 'precomputedLen' seconds starting from t == 0.
+var precomputedFactor [precomputedLen]float64
+
+// init precomputes decay factors.
+func init() {
+	for i := range precomputedFactor {
+		precomputedFactor[i] = math.Exp(-1.0 * float64(i) * lambda)
+	}
+}
+
+// decayFactor returns the decay factor at t seconds, using precalculated values
+// if available, or calculating the factor if needed.
+func decayFactor(t int64) float64 {
+	if t < precomputedLen {
+		return precomputedFactor[t]
+	}
+	return math.Exp(-1.0 * float64(t) * lambda)
+}
+
+// dynamicBanScore provides dynamic ban scores consisting of a persistent and a
+// decaying component. The persistent score could be utilized to create simple
+// additive banning policies similar to those found in other bitcoin node
+// implementations.
+//
+// The decaying score enables the creation of evasive logic which handles
+// misbehaving peers (especially application layer DoS attacks) gracefully
+// by disconnecting and banning peers attempting various kinds of flooding.
+// dynamicBanScore allows these two approaches to be used in tandem.
+//
+// Zero value: Values of type dynamicBanScore are immediately ready for use upon
+// declaration.
+type dynamicBanScore struct {
+	lastUnix   int64
+	transient  float64
+	persistent uint32
+	sync.Mutex
+}
+
+// String returns the ban score as a human-readable string.
+func (s *dynamicBanScore) String() string {
+	s.Lock()
+	r := fmt.Sprintf("persistent %v + transient %v at %v = %v as of now",
+		s.persistent, s.transient, s.lastUnix, s.Int())
+	s.Unlock()
+	return r
+}
+
+// Int returns the current ban score, the sum of the persistent and decaying
+// scores.
+//
+// This function is safe for concurrent access.
+func (s *dynamicBanScore) Int() uint32 {
+	s.Lock()
+	r := s.int(time.Now())
+	s.Unlock()
+	return r
+}
+
+// Increase increases both the persistent and decaying scores by the values
+// passed as parameters. The resulting score is returned.
+//
+// This function is safe for concurrent access.
+func (s *dynamicBanScore) Increase(persistent, transient uint32) uint32 {
+	s.Lock()
+	r := s.increase(persistent, transient, time.Now())
+	s.Unlock()
+	return r
+}
+
+// Reset set both persistent and decaying scores to zero.
+//
+// This function is safe for concurrent access.
+func (s *dynamicBanScore) Reset() {
+	s.Lock()
+	s.persistent = 0
+	s.transient = 0
+	s.lastUnix = 0
+	s.Unlock()
+}
+
+// int returns the ban score, the sum of the persistent and decaying scores at a
+// given point in time.
+//
+// This function is not safe for concurrent access. It is intended to be used
+// internally and during testing.
+func (s *dynamicBanScore) int(t time.Time) uint32 {
+	dt := t.Unix() - s.lastUnix
+	if s.transient < 1 || dt < 0 || Lifetime < dt {
+		return s.persistent
+	}
+	return s.persistent + uint32(s.transient*decayFactor(dt))
+}
+
+// increase increases the persistent, the decaying or both scores by the values
+// passed as parameters. The resulting score is calculated as if the action was
+// carried out at the point time represented by the third paramter. The
+// resulting score is returned.
+//
+// This function is not safe for concurrent access.
+func (s *dynamicBanScore) increase(persistent, transient uint32, t time.Time) uint32 {
+	s.persistent += persistent
+	tu := t.Unix()
+	dt := tu - s.lastUnix
+
+	if transient > 0 {
+		if Lifetime < dt {
+			s.transient = 0
+		} else if s.transient > 1 && dt > 0 {
+			s.transient *= decayFactor(dt)
+		}
+		s.transient += float64(transient)
+		s.lastUnix = tu
+	}
+	return s.persistent + uint32(s.transient)
+}

--- a/dynamicbanscore_test.go
+++ b/dynamicbanscore_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016 The btcsuite developers
+// Copyright (c) 2016 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// TestDynamicBanScoreDecay tests the exponential decay implemented in
+// dynamicBanScore.
+func TestDynamicBanScoreDecay(t *testing.T) {
+	var bs dynamicBanScore
+	base := time.Now()
+
+	r := bs.increase(100, 50, base)
+	if r != 150 {
+		t.Errorf("Unexpected result %d after ban score increase.", r)
+	}
+
+	r = bs.int(base.Add(time.Minute))
+	if r != 125 {
+		t.Errorf("Halflife check failed - %d instead of 125", r)
+	}
+
+	r = bs.int(base.Add(7 * time.Minute))
+	if r != 100 {
+		t.Errorf("Decay after 7m - %d instead of 100", r)
+	}
+}
+
+// TestDynamicBanScoreLifetime tests that dynamicBanScore properly yields zero
+// once the maximum age is reached.
+func TestDynamicBanScoreLifetime(t *testing.T) {
+	var bs dynamicBanScore
+	base := time.Now()
+
+	r := bs.increase(0, math.MaxUint32, base)
+	r = bs.int(base.Add(Lifetime * time.Second))
+	if r != 3 { // 3, not 4 due to precision loss and truncating 3.999...
+		t.Errorf("Pre max age check with MaxUint32 failed - %d", r)
+	}
+	r = bs.int(base.Add((Lifetime + 1) * time.Second))
+	if r != 0 {
+		t.Errorf("Zero after max age check failed - %d instead of 0", r)
+	}
+}
+
+// TestDynamicBanScore tests exported functions of dynamicBanScore. Exponential
+// decay or other time based behavior is tested by other functions.
+func TestDynamicBanScoreReset(t *testing.T) {
+	var bs dynamicBanScore
+	if bs.Int() != 0 {
+		t.Errorf("Initial state is not zero.")
+	}
+	bs.Increase(100, 0)
+	r := bs.Int()
+	if r != 100 {
+		t.Errorf("Unexpected result %d after ban score increase.", r)
+	}
+	bs.Reset()
+	if bs.Int() != 0 {
+		t.Errorf("Failed to reset ban score.")
+	}
+}

--- a/mempool.go
+++ b/mempool.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2014 The btcsuite developers
+// Copyright (c) 2013-2016 The btcsuite developers
 // Copyright (c) 2015-2016 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.

--- a/peer/doc.go
+++ b/peer/doc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 The btcsuite developers
+// Copyright (c) 2015-2016 The btcsuite developers
 // Copyright (c) 2016 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
@@ -67,15 +67,12 @@ This provides high flexibility for things such as connecting via proxies, acting
 as a proxy, creating bridge peers, choosing whether to listen for inbound peers,
 etc.
 
-For outgoing peers, the NewOutboundPeer function must be used to specify the
-configuration followed by invoking Connect with the net.Conn instance.  This
- will start all async I/O goroutines and initiate the initial negotiation
-process.  Once that has been completed, the peer is fully functional.
-
-For inbound peers, the NewInboundPeer function must be used to specify the
-configuration and net.Conn instance followed by invoking Start.  This will start
-all async I/O goroutines and listen for the initial negotiation process.  Once
-that has been completed, the peer is fully functional.
+NewOutboundPeer and NewInboundPeer functions must be followed by calling Connect
+with a net.Conn instance to the peer.  This will start all async I/O goroutines
+and initiate the protocol negotiation process.  Once finished with the peer call
+Disconnect to disconnect from the peer and clean up all resources.
+WaitForDisconnect can be used to block until peer disconnection and resource
+cleanup has completed.
 
 Callbacks
 

--- a/peer/example_test.go
+++ b/peer/example_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 The btcsuite developers
+// Copyright (c) 2015-2016 The btcsuite developers
 // Copyright (c) 2016 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
@@ -39,9 +39,9 @@ func mockRemotePeer() error {
 		}
 
 		// Create and start the inbound peer.
-		p := peer.NewInboundPeer(peerCfg, conn)
-		if err := p.Start(); err != nil {
-			fmt.Printf("Start: error %v\n", err)
+		p := peer.NewInboundPeer(peerCfg)
+		if err := p.Connect(conn); err != nil {
+			fmt.Printf("Connect: error %v\n", err)
 			return
 		}
 	}()
@@ -106,8 +106,9 @@ func Example_newOutboundPeer() {
 		fmt.Printf("Example_peerConnection: verack timeout")
 	}
 
-	// Shutdown the peer.
-	p.Shutdown()
+	// Disconnect the peer.
+	p.Disconnect()
+	p.WaitForDisconnect()
 
 	// Output:
 	// outbound: received version

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -394,10 +394,14 @@ type HostToNetAddrFunc func(host string, port uint16,
 // of specific types that typically require common special handling are
 // provided as a convenience.
 type Peer struct {
-	started    int32
-	connected  int32
-	disconnect int32 // only to be used atomically
-	conn       net.Conn
+	// The following variables must only be used atomically
+	started       int32
+	connected     int32
+	disconnect    int32
+	bytesReceived uint64
+	bytesSent     uint64
+
+	conn net.Conn
 
 	// These fields are set at creation time and never modified, so they are
 	// safe to read from concurrently without a mutex.
@@ -430,8 +434,6 @@ type Peer struct {
 	timeConnected      time.Time
 	lastSend           time.Time
 	lastRecv           time.Time
-	bytesReceived      uint64
-	bytesSent          uint64
 	startingHeight     int32
 	lastBlock          int32
 	lastAnnouncedBlock *chainhash.Hash
@@ -512,8 +514,8 @@ func (p *Peer) StatsSnapshot() *StatsSnap {
 		Services:       services,
 		LastSend:       p.lastSend,
 		LastRecv:       p.lastRecv,
-		BytesSent:      p.bytesSent,
-		BytesRecv:      p.bytesReceived,
+		BytesSent:      atomic.LoadUint64(&p.bytesSent),
+		BytesRecv:      atomic.LoadUint64(&p.bytesReceived),
 		ConnTime:       p.timeConnected,
 		TimeOffset:     p.timeOffset,
 		Version:        protocolVersion,
@@ -688,20 +690,14 @@ func (p *Peer) LastRecv() time.Time {
 //
 // This function is safe for concurrent access.
 func (p *Peer) BytesSent() uint64 {
-	p.statsMtx.RLock()
-	defer p.statsMtx.RUnlock()
-
-	return p.bytesSent
+	return atomic.LoadUint64(&p.bytesSent)
 }
 
 // BytesReceived returns the total number of bytes received by the peer.
 //
 // This function is safe for concurrent access.
 func (p *Peer) BytesReceived() uint64 {
-	p.statsMtx.RLock()
-	defer p.statsMtx.RUnlock()
-
-	return p.bytesReceived
+	return atomic.LoadUint64(&p.bytesReceived)
 }
 
 // TimeConnected returns the time at which the peer connected.
@@ -1104,9 +1100,7 @@ func (p *Peer) handlePongMsg(msg *wire.MsgPong) {
 func (p *Peer) readMessage() (wire.Message, []byte, error) {
 	n, msg, buf, err := wire.ReadMessageN(p.conn, p.ProtocolVersion(),
 		p.cfg.ChainParams.Net)
-	p.statsMtx.Lock()
-	p.bytesReceived += uint64(n)
-	p.statsMtx.Unlock()
+	atomic.AddUint64(&p.bytesReceived, uint64(n))
 	if p.cfg.Listeners.OnRead != nil {
 		p.cfg.Listeners.OnRead(p, n, msg, err)
 	}
@@ -1181,9 +1175,7 @@ func (p *Peer) writeMessage(msg wire.Message) error {
 	// Write the message to the peer.
 	n, err := wire.WriteMessageN(p.conn, msg, p.ProtocolVersion(),
 		p.cfg.ChainParams.Net)
-	p.statsMtx.Lock()
-	p.bytesSent += uint64(n)
-	p.statsMtx.Unlock()
+	atomic.AddUint64(&p.bytesSent, uint64(n))
 	if p.cfg.Listeners.OnWrite != nil {
 		p.cfg.Listeners.OnWrite(p, n, msg, err)
 	}

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -394,8 +394,7 @@ type HostToNetAddrFunc func(host string, port uint16,
 // of specific types that typically require common special handling are
 // provided as a convenience.
 type Peer struct {
-	// The following variables must only be used atomically
-	started       int32
+	// The following variables must only be used atomically.
 	connected     int32
 	disconnect    int32
 	bytesReceived uint64
@@ -1909,11 +1908,14 @@ func (p *Peer) Connect(conn net.Conn) error {
 		return nil
 	}
 
+	if p.inbound {
+		p.addr = conn.RemoteAddr().String()
+	}
 	p.conn = conn
 	p.timeConnected = time.Now()
 
 	atomic.AddInt32(&p.connected, 1)
-	return p.Start()
+	return p.start()
 }
 
 // Connected returns whether or not the peer is currently connected.
@@ -1941,18 +1943,12 @@ func (p *Peer) Disconnect() {
 
 // Start begins processing input and output messages.  It also sends the initial
 // version message for outbound connections to start the negotiation process.
-func (p *Peer) Start() error {
-	// Already started?
-	if atomic.AddInt32(&p.started, 1) != 1 {
-		return nil
-	}
-
+func (p *Peer) start() error {
 	log.Tracef("Starting peer %s", p)
 
 	// Send an initial version message if this is an outbound connection.
 	if !p.inbound {
-		err := p.pushVersionMsg()
-		if err != nil {
+		if err := p.pushVersionMsg(); err != nil {
 			log.Errorf("Can't send outbound version message %v", err)
 			p.Disconnect()
 			return err
@@ -1968,16 +1964,11 @@ func (p *Peer) Start() error {
 	return nil
 }
 
-// Shutdown gracefully shuts down the peer by disconnecting it.
-func (p *Peer) Shutdown() {
-	log.Tracef("Shutdown peer %s", p)
-	p.Disconnect()
-}
-
-// WaitForShutdown waits until the peer has completely shutdown.  This will
-// happen if either the local or remote side has been disconnected or the peer
-// is forcibly shutdown via Shutdown.
-func (p *Peer) WaitForShutdown() {
+// WaitForDisconnect waits until the peer has completely disconnected and all
+// resources are cleaned up.  This will happen if either the local or remote
+// side has been disconnected or the peer is forcibly disconnected via
+// Disconnect.
+func (p *Peer) WaitForDisconnect() {
 	<-p.quit
 }
 
@@ -2018,13 +2009,8 @@ func newPeerBase(cfg *Config, inbound bool) *Peer {
 
 // NewInboundPeer returns a new inbound decred peer. Use Start to begin
 // processing incoming and outgoing messages.
-func NewInboundPeer(cfg *Config, conn net.Conn) *Peer {
-	p := newPeerBase(cfg, true)
-	p.conn = conn
-	p.addr = conn.RemoteAddr().String()
-	p.timeConnected = time.Now()
-	atomic.AddInt32(&p.connected, 1)
-	return p
+func NewInboundPeer(cfg *Config) *Peer {
+	return newPeerBase(cfg, true)
 }
 
 // NewOutboundPeer returns a new outbound decred peer.

--- a/policy_test.go
+++ b/policy_test.go
@@ -1,4 +1,5 @@
 // Copyright (c) 2013-2015 The btcsuite developers
+// Copyright (c) 2016 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3819,7 +3819,7 @@ func handleGetPeerInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{})
 			Inbound:        statsSnap.Inbound,
 			StartingHeight: statsSnap.StartingHeight,
 			CurrentHeight:  statsSnap.LastBlock,
-			BanScore:       0,
+			BanScore:       int32(p.banScore.Int()),
 			SyncNode:       p == syncPeer,
 		}
 		if p.LastPingNonce() != 0 {

--- a/sample-dcrd.conf
+++ b/sample-dcrd.conf
@@ -103,6 +103,12 @@
 ; Maximum number of inbound and outbound peers.
 ; maxpeers=8
 
+; Disable banning of misbehaving peers.
+; nobanning=1
+
+; Maximum allowed ban score before disconnecting and banning misbehaving peers.`
+; banthreshold=100
+
 ; How long to ban misbehaving peers. Valid time units are {s, m, h}.
 ; Minimum 1s.
 ; banduration=24h

--- a/server.go
+++ b/server.go
@@ -1182,9 +1182,8 @@ func (s *server) handleAddPeerMsg(state *peerState, sp *serverPeer) bool {
 
 	// Ignore new peers if we're shutting down.
 	if atomic.LoadInt32(&s.shutdown) != 0 {
-		srvrLog.Infof("New peer %s ignored - server is shutting "+
-			"down", sp)
-		sp.Shutdown()
+		srvrLog.Infof("New peer %s ignored - server is shutting down", sp)
+		sp.Disconnect()
 		return false
 	}
 
@@ -1192,14 +1191,14 @@ func (s *server) handleAddPeerMsg(state *peerState, sp *serverPeer) bool {
 	host, _, err := net.SplitHostPort(sp.Addr())
 	if err != nil {
 		srvrLog.Debugf("can't split hostport %v", err)
-		sp.Shutdown()
+		sp.Disconnect()
 		return false
 	}
 	if banEnd, ok := state.banned[host]; ok {
 		if time.Now().Before(banEnd) {
-			srvrLog.Debugf("Peer %s is banned for another %v - "+
-				"disconnecting", host, banEnd.Sub(time.Now()))
-			sp.Shutdown()
+			srvrLog.Debugf("Peer %s is banned for another %v - disconnecting",
+				host, banEnd.Sub(time.Now()))
+			sp.Disconnect()
 			return false
 		}
 
@@ -1214,16 +1213,16 @@ func (s *server) handleAddPeerMsg(state *peerState, sp *serverPeer) bool {
 		if state.OutboundCount() >= state.maxOutboundPeers {
 			srvrLog.Infof("Max outbound peers reached [%d] - disconnecting "+
 				"peer %s", state.maxOutboundPeers, sp)
-			sp.Shutdown()
+			sp.Disconnect()
 			return false
 		}
 	}
 
 	// Limit max number of total peers.
 	if state.Count() >= cfg.MaxPeers {
-		srvrLog.Infof("Max peers reached [%d] - disconnecting "+
-			"peer %s", cfg.MaxPeers, sp)
-		sp.Shutdown()
+		srvrLog.Infof("Max peers reached [%d] - disconnecting peer %s",
+			cfg.MaxPeers, sp)
+		sp.Disconnect()
 		// TODO(oga) how to handle permanent peers here?
 		// they should be rescheduled.
 		return false
@@ -1555,15 +1554,19 @@ func (s *server) listenHandler(listener net.Listener) {
 		if err != nil {
 			// Only log the error if we're not forcibly shutting down.
 			if atomic.LoadInt32(&s.shutdown) == 0 {
-				srvrLog.Errorf("can't accept connection: %v",
-					err)
+				srvrLog.Errorf("Can't accept connection: %v", err)
 			}
 			continue
 		}
 		sp := newServerPeer(s, false)
-		sp.Peer = peer.NewInboundPeer(newPeerConfig(sp), conn)
-		sp.Start()
+		sp.Peer = peer.NewInboundPeer(newPeerConfig(sp))
 		go s.peerDoneHandler(sp)
+		if err := sp.Connect(conn); err != nil {
+			if atomic.LoadInt32(&s.shutdown) == 0 {
+				srvrLog.Errorf("Can't accept connection: %v", err)
+			}
+			continue
+		}
 	}
 	s.wg.Done()
 	srvrLog.Tracef("Listener handler done for %s", listener.Addr())
@@ -1642,7 +1645,7 @@ func (s *server) peerConnHandler(sp *serverPeer) {
 // peerDoneHandler handles peer disconnects by notifiying the server that it's
 // done.
 func (s *server) peerDoneHandler(sp *serverPeer) {
-	sp.WaitForShutdown()
+	sp.WaitForDisconnect()
 	s.donePeers <- sp
 
 	// Only tell block manager we are gone if we ever told it we existed.
@@ -1779,11 +1782,11 @@ out:
 		case qmsg := <-s.query:
 			s.handleQuery(state, qmsg)
 
-		// Shutdown the peer handler.
 		case <-s.quit:
-			// Shutdown peers.
+			// Disconnect all peers on server shutdown.
 			state.forAllPeers(func(sp *serverPeer) {
-				sp.Shutdown()
+				srvrLog.Tracef("Shutdown peer %s", sp.Peer)
+				sp.Disconnect()
 			})
 			break out
 		}
@@ -1800,7 +1803,8 @@ out:
 		if !state.NeedMoreOutbound() || len(cfg.ConnectPeers) > 0 ||
 			atomic.LoadInt32(&s.shutdown) != 0 {
 			state.forPendingPeers(func(sp *serverPeer) {
-				sp.Shutdown()
+				srvrLog.Tracef("Shutdown peer %s", sp.Peer)
+				sp.Disconnect()
 			})
 			continue
 		}

--- a/server.go
+++ b/server.go
@@ -220,6 +220,7 @@ type serverPeer struct {
 	requestedBlocks map[chainhash.Hash]struct{}
 	filter          *bloom.Filter
 	knownAddresses  map[string]struct{}
+	banScore        dynamicBanScore
 	quit            chan struct{}
 
 	// The following chans are used to sync blockmanager and server.
@@ -294,6 +295,40 @@ func (sp *serverPeer) pushAddrMsg(addresses []*wire.NetAddress) {
 	sp.addKnownAddresses(known)
 }
 
+// addBanScore increases the persistent and decaying ban score fields by the
+// values passed as parameters. If the resulting score exceeds half of the ban
+// threshold, a warning is logged including the reason provided. Further, if
+// the score is above the ban threshold, the peer will be banned and
+// disconnected.
+func (sp *serverPeer) addBanScore(persistent, transient uint32, reason string) {
+	// No warning is logged and no score is calculated if banning is disabled.
+	if cfg.DisableBanning {
+		return
+	}
+	warnThreshold := cfg.BanThreshold >> 1
+	if transient == 0 && persistent == 0 {
+		// The score is not being increased, but a warning message is still
+		// logged if the score is above the warn threshold.
+		score := sp.banScore.Int()
+		if score > warnThreshold {
+			peerLog.Warnf("Misbehaving peer %s: %s -- ban score is %d, "+
+				"it was not increased this time", sp, reason, score)
+		}
+		return
+	}
+	score := sp.banScore.Increase(persistent, transient)
+	if score > warnThreshold {
+		peerLog.Warnf("Misbehaving peer %s: %s -- ban score increased to %d",
+			sp, reason, score)
+		if score > cfg.BanThreshold {
+			peerLog.Warnf("Misbehaving peer %s -- banning and disconnecting",
+				sp)
+			sp.server.BanPeer(sp)
+			sp.Disconnect()
+		}
+	}
+}
+
 // OnVersion is invoked when a peer receives a version wire message and is used
 // to negotiate the protocol version details as well as kick start the
 // communications.
@@ -359,9 +394,15 @@ func (sp *serverPeer) OnVersion(p *peer.Peer, msg *wire.MsgVersion) {
 // maximum inventory allowed per message.  When the peer has a bloom filter
 // loaded, the contents are filtered accordingly.
 func (sp *serverPeer) OnMemPool(p *peer.Peer, msg *wire.MsgMemPool) {
+	// A decaying ban score increase is applied to prevent flooding.
+	// The ban score accumulates and passes the ban threshold if a burst of
+	// mempool messages comes from a peer. The score decays each minute to
+	// half of its value.
+	sp.addBanScore(0, 33, "mempool")
+
 	// Generate inventory message with the available transactions in the
 	// transaction memory pool.  Limit it to the max allowed inventory
-	// per message.  The the NewMsgInvSizeHint function automatically limits
+	// per message.  The NewMsgInvSizeHint function automatically limits
 	// the passed hint to the maximum allowed, so it's safe to pass it
 	// without double checking it here.
 	txMemPool := sp.server.txMemPool
@@ -588,6 +629,16 @@ func (sp *serverPeer) OnGetData(p *peer.Peer, msg *wire.MsgGetData) {
 	numAdded := 0
 	notFound := wire.NewMsgNotFound()
 
+	length := len(msg.InvList)
+	// A decaying ban score increase is applied to prevent exhausting resources
+	// with unusually large inventory queries.
+	// Requesting more than the maximum inventory vector length within a short
+	// period of time yields a score above the default ban threshold. Sustained
+	// bursts of small requests are not penalized as that would potentially ban
+	// peers performing IBD.
+	// This incremental score decays each minute to half of its value.
+	sp.addBanScore(0, uint32(length)*99/wire.MaxInvPerMsg, "getdata")
+
 	// We wait on this wait channel periodically to prevent queueing
 	// far more data than we can send in a reasonable time, wasting memory.
 	// The waiting occurs after the database fetch for the next one to
@@ -598,7 +649,7 @@ func (sp *serverPeer) OnGetData(p *peer.Peer, msg *wire.MsgGetData) {
 	for i, iv := range msg.InvList {
 		var c chan struct{}
 		// If this will be the last message we send.
-		if i == len(msg.InvList)-1 && len(notFound.InvList) == 0 {
+		if i == length-1 && len(notFound.InvList) == 0 {
 			c = doneChan
 		} else if (i+1)%3 == 0 {
 			// Buffered so as to not make the send goroutine block.

--- a/server.go
+++ b/server.go
@@ -1785,7 +1785,7 @@ out:
 		case <-s.quit:
 			// Disconnect all peers on server shutdown.
 			state.forAllPeers(func(sp *serverPeer) {
-				srvrLog.Tracef("Shutdown peer %s", sp.Peer)
+				srvrLog.Tracef("Shutdown peer %s", sp)
 				sp.Disconnect()
 			})
 			break out
@@ -1803,7 +1803,7 @@ out:
 		if !state.NeedMoreOutbound() || len(cfg.ConnectPeers) > 0 ||
 			atomic.LoadInt32(&s.shutdown) != 0 {
 			state.forPendingPeers(func(sp *serverPeer) {
-				srvrLog.Tracef("Shutdown peer %s", sp.Peer)
+				srvrLog.Tracef("Shutdown peer %s", sp)
 				sp.Disconnect()
 			})
 			continue

--- a/server.go
+++ b/server.go
@@ -169,14 +169,15 @@ func (ps *peerState) forAllPeers(closure func(sp *serverPeer)) {
 // server provides a decred server for handling communications to and from
 // decred peers.
 type server struct {
+	// The following variables must only be used atomically.
+	started       int32
+	shutdown      int32
+	shutdownSched int32
+	bytesReceived uint64 // Total bytes received from all peers since start.
+	bytesSent     uint64 // Total bytes sent by all peers since start.
+
 	listeners            []net.Listener
 	chainParams          *chaincfg.Params
-	started              int32      // atomic
-	shutdown             int32      // atomic
-	shutdownSched        int32      // atomic
-	bytesMutex           sync.Mutex // For the following two fields.
-	bytesReceived        uint64     // Total bytes received from all peers since start.
-	bytesSent            uint64     // Total bytes sent by all peers since start.
 	addrManager          *addrmgr.AddrManager
 	sigCache             *txscript.SigCache
 	rpcServer            *rpcServer
@@ -2010,28 +2011,20 @@ func (s *server) ConnectNode(addr string, permanent bool) error {
 // AddBytesSent adds the passed number of bytes to the total bytes sent counter
 // for the server.  It is safe for concurrent access.
 func (s *server) AddBytesSent(bytesSent uint64) {
-	s.bytesMutex.Lock()
-	defer s.bytesMutex.Unlock()
-
-	s.bytesSent += bytesSent
+	atomic.AddUint64(&s.bytesSent, bytesSent)
 }
 
 // AddBytesReceived adds the passed number of bytes to the total bytes received
 // counter for the server.  It is safe for concurrent access.
 func (s *server) AddBytesReceived(bytesReceived uint64) {
-	s.bytesMutex.Lock()
-	defer s.bytesMutex.Unlock()
-
-	s.bytesReceived += bytesReceived
+	atomic.AddUint64(&s.bytesReceived, bytesReceived)
 }
 
 // NetTotals returns the sum of all bytes received and sent across the network
 // for all peers.  It is safe for concurrent access.
 func (s *server) NetTotals() (uint64, uint64) {
-	s.bytesMutex.Lock()
-	defer s.bytesMutex.Unlock()
-
-	return s.bytesReceived, s.bytesSent
+	return atomic.LoadUint64(&s.bytesReceived),
+		atomic.LoadUint64(&s.bytesSent)
 }
 
 // UpdatePeerHeights updates the heights of all peers who have have announced

--- a/txscript/opcode.go
+++ b/txscript/opcode.go
@@ -23,8 +23,8 @@ import (
 
 var optimizeSigVerification = chaincfg.SigHashOptimization
 
-// An opcode defines the information related to a txscript opcode.  opfunc if
-// present is the function to call to perform the opcode on the script.  The
+// An opcode defines the information related to a txscript opcode.  opfunc, if
+// present, is the function to call to perform the opcode on the script.  The
 // current script is passed in as a slice with the first member being the opcode
 // itself.
 type opcode struct {
@@ -1120,7 +1120,7 @@ func opcodeToAltStack(op *parsedOpcode, vm *Engine) error {
 // opcodeFromAltStack removes the top item from the alternate data stack and
 // pushes it onto the main data stack.
 //
-// Main data stack transformation: [... x1 x2 x3] -> [... x1 x2 x3 y1]
+// Main data stack transformation: [... x1 x2 x3] -> [... x1 x2 x3 y3]
 // Alt data stack transformation:  [... y1 y2 y3] -> [... y1 y2]
 func opcodeFromAltStack(op *parsedOpcode, vm *Engine) error {
 	so, err := vm.astack.PopByteArray()
@@ -1177,8 +1177,8 @@ func opcode2Swap(op *parsedOpcode, vm *Engine) error {
 
 // opcodeIfDup duplicates the top item of the stack if it is not zero.
 //
-// Stack transformation (x1==0): [... x1] -> [...]
-// Stack transformation (x1!=0): [... x1] -> [... x1]
+// Stack transformation (x1==0): [... x1] -> [... x1]
+// Stack transformation (x1!=0): [... x1] -> [... x1 x1]
 func opcodeIfDup(op *parsedOpcode, vm *Engine) error {
 	so, err := vm.dstack.PeekByteArray(0)
 	if err != nil {
@@ -2442,7 +2442,7 @@ func opcodeCheckSigVerify(op *parsedOpcode, vm *Engine) error {
 
 // parsedSigInfo houses a raw signature along with its parsed form and a flag
 // for whether or not it has already been parsed.  It is used to prevent parsing
-// the same signature multiple times when verify a multisig.
+// the same signature multiple times when verifying a multisig.
 type parsedSigInfo struct {
 	signature       []byte
 	parsedSignature chainec.Signature

--- a/wire/bench_test.go
+++ b/wire/bench_test.go
@@ -121,7 +121,7 @@ var blockOne = MsgBlock{
 // a single byte variable length integer.
 func BenchmarkWriteVarInt1(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		writeVarInt(ioutil.Discard, 0, 1)
+		WriteVarInt(ioutil.Discard, 0, 1)
 	}
 }
 
@@ -129,7 +129,7 @@ func BenchmarkWriteVarInt1(b *testing.B) {
 // a three byte variable length integer.
 func BenchmarkWriteVarInt3(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		writeVarInt(ioutil.Discard, 0, 65535)
+		WriteVarInt(ioutil.Discard, 0, 65535)
 	}
 }
 
@@ -137,7 +137,7 @@ func BenchmarkWriteVarInt3(b *testing.B) {
 // a five byte variable length integer.
 func BenchmarkWriteVarInt5(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		writeVarInt(ioutil.Discard, 0, 4294967295)
+		WriteVarInt(ioutil.Discard, 0, 4294967295)
 	}
 }
 
@@ -145,7 +145,7 @@ func BenchmarkWriteVarInt5(b *testing.B) {
 // a nine byte variable length integer.
 func BenchmarkWriteVarInt9(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		writeVarInt(ioutil.Discard, 0, 18446744073709551615)
+		WriteVarInt(ioutil.Discard, 0, 18446744073709551615)
 	}
 }
 
@@ -154,7 +154,7 @@ func BenchmarkWriteVarInt9(b *testing.B) {
 func BenchmarkReadVarInt1(b *testing.B) {
 	buf := []byte{0x01}
 	for i := 0; i < b.N; i++ {
-		readVarInt(bytes.NewReader(buf), 0)
+		ReadVarInt(bytes.NewReader(buf), 0)
 	}
 }
 
@@ -163,7 +163,7 @@ func BenchmarkReadVarInt1(b *testing.B) {
 func BenchmarkReadVarInt3(b *testing.B) {
 	buf := []byte{0x0fd, 0xff, 0xff}
 	for i := 0; i < b.N; i++ {
-		readVarInt(bytes.NewReader(buf), 0)
+		ReadVarInt(bytes.NewReader(buf), 0)
 	}
 }
 
@@ -172,7 +172,7 @@ func BenchmarkReadVarInt3(b *testing.B) {
 func BenchmarkReadVarInt5(b *testing.B) {
 	buf := []byte{0xfe, 0xff, 0xff, 0xff, 0xff}
 	for i := 0; i < b.N; i++ {
-		readVarInt(bytes.NewReader(buf), 0)
+		ReadVarInt(bytes.NewReader(buf), 0)
 	}
 }
 
@@ -181,7 +181,7 @@ func BenchmarkReadVarInt5(b *testing.B) {
 func BenchmarkReadVarInt9(b *testing.B) {
 	buf := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
 	for i := 0; i < b.N; i++ {
-		readVarInt(bytes.NewReader(buf), 0)
+		ReadVarInt(bytes.NewReader(buf), 0)
 	}
 }
 

--- a/wire/common.go
+++ b/wire/common.go
@@ -340,8 +340,8 @@ func writeElements(w io.Writer, elements ...interface{}) error {
 	return nil
 }
 
-// readVarInt reads a variable length integer from r and returns it as a uint64.
-func readVarInt(r io.Reader, pver uint32) (uint64, error) {
+// ReadVarInt reads a variable length integer from r and returns it as a uint64.
+func ReadVarInt(r io.Reader, pver uint32) (uint64, error) {
 	var b [8]byte
 	_, err := io.ReadFull(r, b[0:1])
 	if err != nil {
@@ -362,7 +362,7 @@ func readVarInt(r io.Reader, pver uint32) (uint64, error) {
 		// encoded using fewer bytes.
 		min := uint64(0x100000000)
 		if rv < min {
-			return 0, messageError("readVarInt", fmt.Sprintf(
+			return 0, messageError("ReadVarInt", fmt.Sprintf(
 				errNonCanonicalVarInt, rv, discriminant, min))
 		}
 
@@ -377,7 +377,7 @@ func readVarInt(r io.Reader, pver uint32) (uint64, error) {
 		// encoded using fewer bytes.
 		min := uint64(0x10000)
 		if rv < min {
-			return 0, messageError("readVarInt", fmt.Sprintf(
+			return 0, messageError("ReadVarInt", fmt.Sprintf(
 				errNonCanonicalVarInt, rv, discriminant, min))
 		}
 
@@ -392,7 +392,7 @@ func readVarInt(r io.Reader, pver uint32) (uint64, error) {
 		// encoded using fewer bytes.
 		min := uint64(0xfd)
 		if rv < min {
-			return 0, messageError("readVarInt", fmt.Sprintf(
+			return 0, messageError("ReadVarInt", fmt.Sprintf(
 				errNonCanonicalVarInt, rv, discriminant, min))
 		}
 
@@ -403,9 +403,9 @@ func readVarInt(r io.Reader, pver uint32) (uint64, error) {
 	return rv, nil
 }
 
-// writeVarInt serializes val to w using a variable number of bytes depending
+// WriteVarInt serializes val to w using a variable number of bytes depending
 // on its value.
-func writeVarInt(w io.Writer, pver uint32, val uint64) error {
+func WriteVarInt(w io.Writer, pver uint32, val uint64) error {
 	if val < 0xfd {
 		_, err := w.Write([]byte{uint8(val)})
 		return err
@@ -464,7 +464,7 @@ func VarIntSerializeSize(val uint64) int {
 // maximum block payload size since it helps protect against memory exhaustion
 // attacks and forced panics through malformed messages.
 func ReadVarString(r io.Reader, pver uint32) (string, error) {
-	count, err := readVarInt(r, pver)
+	count, err := ReadVarInt(r, pver)
 	if err != nil {
 		return "", err
 	}
@@ -490,7 +490,7 @@ func ReadVarString(r io.Reader, pver uint32) (string, error) {
 // the length of the string followed by the bytes that represent the string
 // itself.
 func WriteVarString(w io.Writer, pver uint32, str string) error {
-	err := writeVarInt(w, pver, uint64(len(str)))
+	err := WriteVarInt(w, pver, uint64(len(str)))
 	if err != nil {
 		return err
 	}
@@ -501,17 +501,17 @@ func WriteVarString(w io.Writer, pver uint32, str string) error {
 	return nil
 }
 
-// readVarBytes reads a variable length byte array.  A byte array is encoded
+// ReadVarBytes reads a variable length byte array.  A byte array is encoded
 // as a varInt containing the length of the array followed by the bytes
 // themselves.  An error is returned if the length is greater than the
 // passed maxAllowed parameter which helps protect against memory exhuastion
 // attacks and forced panics thorugh malformed messages.  The fieldName
 // parameter is only used for the error message so it provides more context in
 // the error.
-func readVarBytes(r io.Reader, pver uint32, maxAllowed uint32,
+func ReadVarBytes(r io.Reader, pver uint32, maxAllowed uint32,
 	fieldName string) ([]byte, error) {
 
-	count, err := readVarInt(r, pver)
+	count, err := ReadVarInt(r, pver)
 	if err != nil {
 		return nil, err
 	}
@@ -522,7 +522,7 @@ func readVarBytes(r io.Reader, pver uint32, maxAllowed uint32,
 	if count > uint64(maxAllowed) {
 		str := fmt.Sprintf("%s is larger than the max allowed size "+
 			"[count %d, max %d]", fieldName, count, maxAllowed)
-		return nil, messageError("readVarBytes", str)
+		return nil, messageError("ReadVarBytes", str)
 	}
 
 	b := make([]byte, count)
@@ -533,11 +533,11 @@ func readVarBytes(r io.Reader, pver uint32, maxAllowed uint32,
 	return b, nil
 }
 
-// writeVarInt serializes a variable length byte array to w as a varInt
+// WriteVarBytes serializes a variable length byte array to w as a varInt
 // containing the number of bytes, followed by the bytes themselves.
-func writeVarBytes(w io.Writer, pver uint32, bytes []byte) error {
+func WriteVarBytes(w io.Writer, pver uint32, bytes []byte) error {
 	slen := uint64(len(bytes))
-	err := writeVarInt(w, pver, slen)
+	err := WriteVarInt(w, pver, slen)
 	if err != nil {
 		return err
 	}

--- a/wire/common_test.go
+++ b/wire/common_test.go
@@ -288,11 +288,11 @@ func TestVarIntWire(t *testing.T) {
 		var buf bytes.Buffer
 		err := wire.TstWriteVarInt(&buf, test.pver, test.in)
 		if err != nil {
-			t.Errorf("writeVarInt #%d error %v", i, err)
+			t.Errorf("WriteVarInt #%d error %v", i, err)
 			continue
 		}
 		if !bytes.Equal(buf.Bytes(), test.buf) {
-			t.Errorf("writeVarInt #%d\n got: %s want: %s", i,
+			t.Errorf("WriteVarInt #%d\n got: %s want: %s", i,
 				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
 			continue
 		}
@@ -301,11 +301,11 @@ func TestVarIntWire(t *testing.T) {
 		rbuf := bytes.NewReader(test.buf)
 		val, err := wire.TstReadVarInt(rbuf, test.pver)
 		if err != nil {
-			t.Errorf("readVarInt #%d error %v", i, err)
+			t.Errorf("ReadVarInt #%d error %v", i, err)
 			continue
 		}
 		if val != test.out {
-			t.Errorf("readVarInt #%d\n got: %d want: %d", i,
+			t.Errorf("ReadVarInt #%d\n got: %d want: %d", i,
 				val, test.out)
 			continue
 		}
@@ -341,7 +341,7 @@ func TestVarIntWireErrors(t *testing.T) {
 		w := newFixedWriter(test.max)
 		err := wire.TstWriteVarInt(w, test.pver, test.in)
 		if err != test.writeErr {
-			t.Errorf("writeVarInt #%d wrong error got: %v, want: %v",
+			t.Errorf("WriteVarInt #%d wrong error got: %v, want: %v",
 				i, err, test.writeErr)
 			continue
 		}
@@ -350,7 +350,7 @@ func TestVarIntWireErrors(t *testing.T) {
 		r := newFixedReader(test.max, test.buf)
 		_, err = wire.TstReadVarInt(r, test.pver)
 		if err != test.readErr {
-			t.Errorf("readVarInt #%d wrong error got: %v, want: %v",
+			t.Errorf("ReadVarInt #%d wrong error got: %v, want: %v",
 				i, err, test.readErr)
 			continue
 		}
@@ -401,12 +401,12 @@ func TestVarIntNonCanonical(t *testing.T) {
 		rbuf := bytes.NewReader(test.in)
 		val, err := wire.TstReadVarInt(rbuf, test.pver)
 		if _, ok := err.(*wire.MessageError); !ok {
-			t.Errorf("readVarInt #%d (%s) unexpected error %v", i,
+			t.Errorf("ReadVarInt #%d (%s) unexpected error %v", i,
 				test.name, err)
 			continue
 		}
 		if val != 0 {
-			t.Errorf("readVarInt #%d (%s)\n got: %d want: 0", i,
+			t.Errorf("ReadVarInt #%d (%s)\n got: %d want: 0", i,
 				test.name, val)
 			continue
 		}
@@ -606,11 +606,11 @@ func TestVarBytesWire(t *testing.T) {
 		var buf bytes.Buffer
 		err := wire.TstWriteVarBytes(&buf, test.pver, test.in)
 		if err != nil {
-			t.Errorf("writeVarBytes #%d error %v", i, err)
+			t.Errorf("WriteVarBytes #%d error %v", i, err)
 			continue
 		}
 		if !bytes.Equal(buf.Bytes(), test.buf) {
-			t.Errorf("writeVarBytes #%d\n got: %s want: %s", i,
+			t.Errorf("WriteVarBytes #%d\n got: %s want: %s", i,
 				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
 			continue
 		}
@@ -620,11 +620,11 @@ func TestVarBytesWire(t *testing.T) {
 		val, err := wire.TstReadVarBytes(rbuf, test.pver,
 			wire.MaxMessagePayload, "test payload")
 		if err != nil {
-			t.Errorf("readVarBytes #%d error %v", i, err)
+			t.Errorf("ReadVarBytes #%d error %v", i, err)
 			continue
 		}
 		if !bytes.Equal(buf.Bytes(), test.buf) {
-			t.Errorf("readVarBytes #%d\n got: %s want: %s", i,
+			t.Errorf("ReadVarBytes #%d\n got: %s want: %s", i,
 				val, test.buf)
 			continue
 		}
@@ -662,7 +662,7 @@ func TestVarBytesWireErrors(t *testing.T) {
 		w := newFixedWriter(test.max)
 		err := wire.TstWriteVarBytes(w, test.pver, test.in)
 		if err != test.writeErr {
-			t.Errorf("writeVarBytes #%d wrong error got: %v, want: %v",
+			t.Errorf("WriteVarBytes #%d wrong error got: %v, want: %v",
 				i, err, test.writeErr)
 			continue
 		}
@@ -672,7 +672,7 @@ func TestVarBytesWireErrors(t *testing.T) {
 		_, err = wire.TstReadVarBytes(r, test.pver,
 			wire.MaxMessagePayload, "test payload")
 		if err != test.readErr {
-			t.Errorf("readVarBytes #%d wrong error got: %v, want: %v",
+			t.Errorf("ReadVarBytes #%d wrong error got: %v, want: %v",
 				i, err, test.readErr)
 			continue
 		}
@@ -704,7 +704,7 @@ func TestVarBytesOverflowErrors(t *testing.T) {
 		_, err := wire.TstReadVarBytes(rbuf, test.pver,
 			wire.MaxMessagePayload, "test payload")
 		if reflect.TypeOf(err) != reflect.TypeOf(test.err) {
-			t.Errorf("readVarBytes #%d wrong error got: %v, "+
+			t.Errorf("ReadVarBytes #%d wrong error got: %v, "+
 				"want: %v", i, err, reflect.TypeOf(test.err))
 			continue
 		}

--- a/wire/doc.go
+++ b/wire/doc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2015 The btcsuite developers
+// Copyright (c) 2013-2016 The btcsuite developers
 // Copyright (c) 2015 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
@@ -156,5 +156,6 @@ This package includes spec changes outlined by the following BIPs:
 	BIP0035 (https://github.com/bitcoin/bips/blob/master/bip-0035.mediawiki)
 	BIP0037 (https://github.com/bitcoin/bips/blob/master/bip-0037.mediawiki)
 	BIP0111	(https://github.com/bitcoin/bips/blob/master/bip-0111.mediawiki)
+	BIP0130 (https://github.com/bitcoin/bips/blob/master/bip-0130.mediawiki)
 */
 package wire

--- a/wire/internal_test.go
+++ b/wire/internal_test.go
@@ -52,28 +52,28 @@ func TstWriteElement(w io.Writer, element interface{}) error {
 	return writeElement(w, element)
 }
 
-// TstReadVarInt makes the internal readVarInt function available to the
+// TstReadVarInt makes the internal ReadVarInt function available to the
 // test package.
 func TstReadVarInt(r io.Reader, pver uint32) (uint64, error) {
-	return readVarInt(r, pver)
+	return ReadVarInt(r, pver)
 }
 
-// TstWriteVarInt makes the internal writeVarInt function available to the
+// TstWriteVarInt makes the internal WriteVarInt function available to the
 // test package.
 func TstWriteVarInt(w io.Writer, pver uint32, val uint64) error {
-	return writeVarInt(w, pver, val)
+	return WriteVarInt(w, pver, val)
 }
 
-// TstReadVarBytes makes the internal readVarBytes function available to the
+// TstReadVarBytes makes the internal ReadVarBytes function available to the
 // test package.
 func TstReadVarBytes(r io.Reader, pver uint32, maxAllowed uint32, fieldName string) ([]byte, error) {
-	return readVarBytes(r, pver, maxAllowed, fieldName)
+	return ReadVarBytes(r, pver, maxAllowed, fieldName)
 }
 
-// TstWriteVarBytes makes the internal writeVarBytes function available to the
+// TstWriteVarBytes makes the internal WriteVarBytes function available to the
 // test package.
 func TstWriteVarBytes(w io.Writer, pver uint32, bytes []byte) error {
-	return writeVarBytes(w, pver, bytes)
+	return WriteVarBytes(w, pver, bytes)
 }
 
 // TstReadNetAddress makes the internal readNetAddress function available to

--- a/wire/message.go
+++ b/wire/message.go
@@ -52,6 +52,7 @@ const (
 	CmdFilterLoad     = "filterload"
 	CmdMerkleBlock    = "merkleblock"
 	CmdReject         = "reject"
+	CmdSendHeaders    = "sendheaders"
 )
 
 // Message is an interface that describes a decred message.  A type that
@@ -138,6 +139,9 @@ func makeEmptyMessage(command string) (Message, error) {
 
 	case CmdReject:
 		msg = &MsgReject{}
+
+	case CmdSendHeaders:
+		msg = &MsgSendHeaders{}
 
 	default:
 		return nil, fmt.Errorf("unhandled command [%s]", command)

--- a/wire/msgaddr.go
+++ b/wire/msgaddr.go
@@ -59,7 +59,7 @@ func (msg *MsgAddr) ClearAddresses() {
 // BtcDecode decodes r using the bitcoin protocol encoding into the receiver.
 // This is part of the Message interface implementation.
 func (msg *MsgAddr) BtcDecode(r io.Reader, pver uint32) error {
-	count, err := readVarInt(r, pver)
+	count, err := ReadVarInt(r, pver)
 	if err != nil {
 		return err
 	}
@@ -95,7 +95,7 @@ func (msg *MsgAddr) BtcEncode(w io.Writer, pver uint32) error {
 		return messageError("MsgAddr.BtcEncode", str)
 	}
 
-	err := writeVarInt(w, pver, uint64(count))
+	err := WriteVarInt(w, pver, uint64(count))
 	if err != nil {
 		return err
 	}

--- a/wire/msgalert.go
+++ b/wire/msgalert.go
@@ -162,7 +162,7 @@ func (alert *Alert) Serialize(w io.Writer, pver uint32) error {
 			"[count %v, max %v]", count, maxCountSetCancel)
 		return messageError("Alert.Serialize", str)
 	}
-	err = writeVarInt(w, pver, uint64(count))
+	err = WriteVarInt(w, pver, uint64(count))
 	if err != nil {
 		return err
 	}
@@ -184,7 +184,7 @@ func (alert *Alert) Serialize(w io.Writer, pver uint32) error {
 			"[count %v, max %v]", count, maxCountSetSubVer)
 		return messageError("Alert.Serialize", str)
 	}
-	err = writeVarInt(w, pver, uint64(count))
+	err = WriteVarInt(w, pver, uint64(count))
 	if err != nil {
 		return err
 	}
@@ -226,7 +226,7 @@ func (alert *Alert) Deserialize(r io.Reader, pver uint32) error {
 	// SetCancel: first read a VarInt that contains
 	// count - the number of Cancel IDs, then
 	// iterate count times and read them
-	count, err := readVarInt(r, pver)
+	count, err := ReadVarInt(r, pver)
 	if err != nil {
 		return err
 	}
@@ -250,7 +250,7 @@ func (alert *Alert) Deserialize(r io.Reader, pver uint32) error {
 
 	// SetSubVer: similar to SetCancel
 	// but read count number of sub-version strings
-	count, err = readVarInt(r, pver)
+	count, err = ReadVarInt(r, pver)
 	if err != nil {
 		return err
 	}
@@ -344,7 +344,7 @@ type MsgAlert struct {
 func (msg *MsgAlert) BtcDecode(r io.Reader, pver uint32) error {
 	var err error
 
-	msg.SerializedPayload, err = readVarBytes(r, pver, MaxMessagePayload,
+	msg.SerializedPayload, err = ReadVarBytes(r, pver, MaxMessagePayload,
 		"alert serialized payload")
 	if err != nil {
 		return err
@@ -355,7 +355,7 @@ func (msg *MsgAlert) BtcDecode(r io.Reader, pver uint32) error {
 		msg.Payload = nil
 	}
 
-	msg.Signature, err = readVarBytes(r, pver, MaxMessagePayload,
+	msg.Signature, err = ReadVarBytes(r, pver, MaxMessagePayload,
 		"alert signature")
 	if err != nil {
 		return err
@@ -387,11 +387,11 @@ func (msg *MsgAlert) BtcEncode(w io.Writer, pver uint32) error {
 	if slen == 0 {
 		return messageError("MsgAlert.BtcEncode", "empty serialized payload")
 	}
-	err = writeVarBytes(w, pver, serializedpayload)
+	err = WriteVarBytes(w, pver, serializedpayload)
 	if err != nil {
 		return err
 	}
-	err = writeVarBytes(w, pver, msg.Signature)
+	err = WriteVarBytes(w, pver, msg.Signature)
 	if err != nil {
 		return err
 	}

--- a/wire/msgblock.go
+++ b/wire/msgblock.go
@@ -79,7 +79,7 @@ func (msg *MsgBlock) BtcDecode(r io.Reader, pver uint32) error {
 		return err
 	}
 
-	txCount, err := readVarInt(r, pver)
+	txCount, err := ReadVarInt(r, pver)
 	if err != nil {
 		return err
 	}
@@ -108,7 +108,7 @@ func (msg *MsgBlock) BtcDecode(r io.Reader, pver uint32) error {
 	// tx tree.
 	// It would be possible to cause memory exhaustion and panics without
 	// a sane upper bound on this count.
-	stakeTxCount, err := readVarInt(r, pver)
+	stakeTxCount, err := ReadVarInt(r, pver)
 	if err != nil {
 		return err
 	}
@@ -168,7 +168,7 @@ func (msg *MsgBlock) DeserializeTxLoc(r *bytes.Buffer) ([]TxLoc, []TxLoc, error)
 		return nil, nil, err
 	}
 
-	txCount, err := readVarInt(r, 0)
+	txCount, err := ReadVarInt(r, 0)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -197,7 +197,7 @@ func (msg *MsgBlock) DeserializeTxLoc(r *bytes.Buffer) ([]TxLoc, []TxLoc, error)
 		txLocs[i].TxLen = (fullLen - r.Len()) - txLocs[i].TxStart
 	}
 
-	stakeTxCount, err := readVarInt(r, 0)
+	stakeTxCount, err := ReadVarInt(r, 0)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -240,7 +240,7 @@ func (msg *MsgBlock) BtcEncode(w io.Writer, pver uint32) error {
 		return err
 	}
 
-	err = writeVarInt(w, pver, uint64(len(msg.Transactions)))
+	err = WriteVarInt(w, pver, uint64(len(msg.Transactions)))
 	if err != nil {
 		return err
 	}
@@ -252,7 +252,7 @@ func (msg *MsgBlock) BtcEncode(w io.Writer, pver uint32) error {
 		}
 	}
 
-	err = writeVarInt(w, pver, uint64(len(msg.STransactions)))
+	err = WriteVarInt(w, pver, uint64(len(msg.STransactions)))
 	if err != nil {
 		return err
 	}

--- a/wire/msgfilteradd.go
+++ b/wire/msgfilteradd.go
@@ -30,7 +30,7 @@ type MsgFilterAdd struct {
 // This is part of the Message interface implementation.
 func (msg *MsgFilterAdd) BtcDecode(r io.Reader, pver uint32) error {
 	var err error
-	msg.Data, err = readVarBytes(r, pver, MaxFilterAddDataSize,
+	msg.Data, err = ReadVarBytes(r, pver, MaxFilterAddDataSize,
 		"filteradd data")
 	if err != nil {
 		return err
@@ -49,7 +49,7 @@ func (msg *MsgFilterAdd) BtcEncode(w io.Writer, pver uint32) error {
 		return messageError("MsgFilterAdd.BtcEncode", str)
 	}
 
-	err := writeVarBytes(w, pver, msg.Data)
+	err := WriteVarBytes(w, pver, msg.Data)
 	if err != nil {
 		return err
 	}

--- a/wire/msgfilterload.go
+++ b/wire/msgfilterload.go
@@ -54,7 +54,7 @@ type MsgFilterLoad struct {
 // This is part of the Message interface implementation.
 func (msg *MsgFilterLoad) BtcDecode(r io.Reader, pver uint32) error {
 	var err error
-	msg.Filter, err = readVarBytes(r, pver, MaxFilterLoadFilterSize,
+	msg.Filter, err = ReadVarBytes(r, pver, MaxFilterLoadFilterSize,
 		"filterload filter size")
 	if err != nil {
 		return err
@@ -90,7 +90,7 @@ func (msg *MsgFilterLoad) BtcEncode(w io.Writer, pver uint32) error {
 		return messageError("MsgFilterLoad.BtcEncode", str)
 	}
 
-	err := writeVarBytes(w, pver, msg.Filter)
+	err := WriteVarBytes(w, pver, msg.Filter)
 	if err != nil {
 		return err
 	}

--- a/wire/msggetblocks.go
+++ b/wire/msggetblocks.go
@@ -58,7 +58,7 @@ func (msg *MsgGetBlocks) BtcDecode(r io.Reader, pver uint32) error {
 	}
 
 	// Read num block locator hashes and limit to max.
-	count, err := readVarInt(r, pver)
+	count, err := ReadVarInt(r, pver)
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func (msg *MsgGetBlocks) BtcEncode(w io.Writer, pver uint32) error {
 		return err
 	}
 
-	err = writeVarInt(w, pver, uint64(count))
+	err = WriteVarInt(w, pver, uint64(count))
 	if err != nil {
 		return err
 	}

--- a/wire/msggetdata.go
+++ b/wire/msggetdata.go
@@ -39,7 +39,7 @@ func (msg *MsgGetData) AddInvVect(iv *InvVect) error {
 // BtcDecode decodes r using the decred protocol encoding into the receiver.
 // This is part of the Message interface implementation.
 func (msg *MsgGetData) BtcDecode(r io.Reader, pver uint32) error {
-	count, err := readVarInt(r, pver)
+	count, err := ReadVarInt(r, pver)
 	if err != nil {
 		return err
 	}
@@ -73,7 +73,7 @@ func (msg *MsgGetData) BtcEncode(w io.Writer, pver uint32) error {
 		return messageError("MsgGetData.BtcEncode", str)
 	}
 
-	err := writeVarInt(w, pver, uint64(count))
+	err := WriteVarInt(w, pver, uint64(count))
 	if err != nil {
 		return err
 	}

--- a/wire/msggetheaders.go
+++ b/wire/msggetheaders.go
@@ -55,7 +55,7 @@ func (msg *MsgGetHeaders) BtcDecode(r io.Reader, pver uint32) error {
 	}
 
 	// Read num block locator hashes and limit to max.
-	count, err := readVarInt(r, pver)
+	count, err := ReadVarInt(r, pver)
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,7 @@ func (msg *MsgGetHeaders) BtcEncode(w io.Writer, pver uint32) error {
 		return err
 	}
 
-	err = writeVarInt(w, pver, uint64(count))
+	err = WriteVarInt(w, pver, uint64(count))
 	if err != nil {
 		return err
 	}

--- a/wire/msgheaders.go
+++ b/wire/msgheaders.go
@@ -38,7 +38,7 @@ func (msg *MsgHeaders) AddBlockHeader(bh *BlockHeader) error {
 // BtcDecode decodes r using the decred protocol encoding into the receiver.
 // This is part of the Message interface implementation.
 func (msg *MsgHeaders) BtcDecode(r io.Reader, pver uint32) error {
-	count, err := readVarInt(r, pver)
+	count, err := ReadVarInt(r, pver)
 	if err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func (msg *MsgHeaders) BtcDecode(r io.Reader, pver uint32) error {
 			return err
 		}
 
-		txCount, err := readVarInt(r, pver)
+		txCount, err := ReadVarInt(r, pver)
 		if err != nil {
 			return err
 		}
@@ -86,7 +86,7 @@ func (msg *MsgHeaders) BtcEncode(w io.Writer, pver uint32) error {
 		return messageError("MsgHeaders.BtcEncode", str)
 	}
 
-	err := writeVarInt(w, pver, uint64(count))
+	err := WriteVarInt(w, pver, uint64(count))
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func (msg *MsgHeaders) BtcEncode(w io.Writer, pver uint32) error {
 		// of transactions on header messages.  This is really just an
 		// artifact of the way the original implementation serializes
 		// block headers, but it is required.
-		err = writeVarInt(w, pver, 0)
+		err = WriteVarInt(w, pver, 0)
 		if err != nil {
 			return err
 		}

--- a/wire/msginv.go
+++ b/wire/msginv.go
@@ -47,7 +47,7 @@ func (msg *MsgInv) AddInvVect(iv *InvVect) error {
 // BtcDecode decodes r using the decred protocol encoding into the receiver.
 // This is part of the Message interface implementation.
 func (msg *MsgInv) BtcDecode(r io.Reader, pver uint32) error {
-	count, err := readVarInt(r, pver)
+	count, err := ReadVarInt(r, pver)
 	if err != nil {
 		return err
 	}
@@ -81,7 +81,7 @@ func (msg *MsgInv) BtcEncode(w io.Writer, pver uint32) error {
 		return messageError("MsgInv.BtcEncode", str)
 	}
 
-	err := writeVarInt(w, pver, uint64(count))
+	err := WriteVarInt(w, pver, uint64(count))
 	if err != nil {
 		return err
 	}

--- a/wire/msgmerkleblock.go
+++ b/wire/msgmerkleblock.go
@@ -69,7 +69,7 @@ func (msg *MsgMerkleBlock) BtcDecode(r io.Reader, pver uint32) error {
 	}
 
 	// Read num block locator hashes and limit to max.
-	count, err := readVarInt(r, pver)
+	count, err := ReadVarInt(r, pver)
 	if err != nil {
 		return err
 	}
@@ -95,7 +95,7 @@ func (msg *MsgMerkleBlock) BtcDecode(r io.Reader, pver uint32) error {
 	}
 
 	// Read num block locator hashes for stake and limit to max.
-	scount, err := readVarInt(r, pver)
+	scount, err := ReadVarInt(r, pver)
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,7 @@ func (msg *MsgMerkleBlock) BtcDecode(r io.Reader, pver uint32) error {
 		msg.AddSTxHash(&sha)
 	}
 
-	msg.Flags, err = readVarBytes(r, pver, maxFlagsPerMerkleBlock,
+	msg.Flags, err = ReadVarBytes(r, pver, maxFlagsPerMerkleBlock,
 		"merkle block flags size")
 	if err != nil {
 		return err
@@ -159,7 +159,7 @@ func (msg *MsgMerkleBlock) BtcEncode(w io.Writer, pver uint32) error {
 		return err
 	}
 
-	err = writeVarInt(w, pver, uint64(numHashes))
+	err = WriteVarInt(w, pver, uint64(numHashes))
 	if err != nil {
 		return err
 	}
@@ -175,7 +175,7 @@ func (msg *MsgMerkleBlock) BtcEncode(w io.Writer, pver uint32) error {
 		return err
 	}
 
-	err = writeVarInt(w, pver, uint64(numSHashes))
+	err = WriteVarInt(w, pver, uint64(numSHashes))
 	if err != nil {
 		return err
 	}
@@ -186,7 +186,7 @@ func (msg *MsgMerkleBlock) BtcEncode(w io.Writer, pver uint32) error {
 		}
 	}
 
-	err = writeVarBytes(w, pver, msg.Flags)
+	err = WriteVarBytes(w, pver, msg.Flags)
 	if err != nil {
 		return err
 	}

--- a/wire/msgminingstate.go
+++ b/wire/msgminingstate.go
@@ -69,7 +69,7 @@ func (msg *MsgMiningState) BtcDecode(r io.Reader, pver uint32) error {
 	}
 
 	// Read num block hashes and limit to max.
-	count, err := readVarInt(r, pver)
+	count, err := ReadVarInt(r, pver)
 	if err != nil {
 		return err
 	}
@@ -90,7 +90,7 @@ func (msg *MsgMiningState) BtcDecode(r io.Reader, pver uint32) error {
 	}
 
 	// Read num vote hashes and limit to max.
-	count, err = readVarInt(r, pver)
+	count, err = ReadVarInt(r, pver)
 	if err != nil {
 		return err
 	}
@@ -134,7 +134,7 @@ func (msg *MsgMiningState) BtcEncode(w io.Writer, pver uint32) error {
 		return messageError("MsgMiningState.BtcEncode", str)
 	}
 
-	err = writeVarInt(w, pver, uint64(count))
+	err = WriteVarInt(w, pver, uint64(count))
 	if err != nil {
 		return err
 	}
@@ -154,7 +154,7 @@ func (msg *MsgMiningState) BtcEncode(w io.Writer, pver uint32) error {
 		return messageError("MsgMiningState.BtcEncode", str)
 	}
 
-	err = writeVarInt(w, pver, uint64(count))
+	err = WriteVarInt(w, pver, uint64(count))
 	if err != nil {
 		return err
 	}

--- a/wire/msgnotfound.go
+++ b/wire/msgnotfound.go
@@ -36,7 +36,7 @@ func (msg *MsgNotFound) AddInvVect(iv *InvVect) error {
 // BtcDecode decodes r using the decred protocol encoding into the receiver.
 // This is part of the Message interface implementation.
 func (msg *MsgNotFound) BtcDecode(r io.Reader, pver uint32) error {
-	count, err := readVarInt(r, pver)
+	count, err := ReadVarInt(r, pver)
 	if err != nil {
 		return err
 	}
@@ -70,7 +70,7 @@ func (msg *MsgNotFound) BtcEncode(w io.Writer, pver uint32) error {
 		return messageError("MsgNotFound.BtcEncode", str)
 	}
 
-	err := writeVarInt(w, pver, uint64(count))
+	err := WriteVarInt(w, pver, uint64(count))
 	if err != nil {
 		return err
 	}

--- a/wire/msgsendheaders.go
+++ b/wire/msgsendheaders.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2016 The btcsuite developers
+// Copyright (c) 2016 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"fmt"
+	"io"
+)
+
+// MsgSendHeaders implements the Message interface and represents a bitcoin
+// sendheaders message.  It is used to request the peer send block headers
+// rather than inventory vectors.
+//
+// This message has no payload and was not added until protocol versions
+// starting with SendHeadersVersion.
+type MsgSendHeaders struct{}
+
+// BtcDecode decodes r using the bitcoin protocol encoding into the receiver.
+// This is part of the Message interface implementation.
+func (msg *MsgSendHeaders) BtcDecode(r io.Reader, pver uint32) error {
+	if pver < SendHeadersVersion {
+		str := fmt.Sprintf("sendheaders message invalid for protocol "+
+			"version %d", pver)
+		return messageError("MsgSendHeaders.BtcDecode", str)
+	}
+
+	return nil
+}
+
+// BtcEncode encodes the receiver to w using the bitcoin protocol encoding.
+// This is part of the Message interface implementation.
+func (msg *MsgSendHeaders) BtcEncode(w io.Writer, pver uint32) error {
+	if pver < SendHeadersVersion {
+		str := fmt.Sprintf("sendheaders message invalid for protocol "+
+			"version %d", pver)
+		return messageError("MsgSendHeaders.BtcEncode", str)
+	}
+
+	return nil
+}
+
+// Command returns the protocol command string for the message.  This is part
+// of the Message interface implementation.
+func (msg *MsgSendHeaders) Command() string {
+	return CmdSendHeaders
+}
+
+// MaxPayloadLength returns the maximum length the payload can be for the
+// receiver.  This is part of the Message interface implementation.
+func (msg *MsgSendHeaders) MaxPayloadLength(pver uint32) uint32 {
+	return 0
+}
+
+// NewMsgSendHeaders returns a new bitcoin sendheaders message that conforms to
+// the Message interface.  See MsgSendHeaders for details.
+func NewMsgSendHeaders() *MsgSendHeaders {
+	return &MsgSendHeaders{}
+}

--- a/wire/msgsendheaders_test.go
+++ b/wire/msgsendheaders_test.go
@@ -1,0 +1,192 @@
+// Copyright (c) 2016 The btcsuite developers
+// Copyright (c) 2016 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire_test
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/decred/dcrd/wire"
+)
+
+// TestSendHeaders tests the MsgSendHeaders API against the latest protocol
+// version.
+func TestSendHeaders(t *testing.T) {
+	pver := wire.ProtocolVersion
+
+	// Ensure the command is expected value.
+	wantCmd := "sendheaders"
+	msg := wire.NewMsgSendHeaders()
+	if cmd := msg.Command(); cmd != wantCmd {
+		t.Errorf("NewMsgSendHeaders: wrong command - got %v want %v",
+			cmd, wantCmd)
+	}
+
+	// Ensure max payload is expected value.
+	wantPayload := uint32(0)
+	maxPayload := msg.MaxPayloadLength(pver)
+	if maxPayload != wantPayload {
+		t.Errorf("MaxPayloadLength: wrong max payload length for "+
+			"protocol version %d - got %v, want %v", pver,
+			maxPayload, wantPayload)
+	}
+
+	// Test encode with latest protocol version.
+	var buf bytes.Buffer
+	err := msg.BtcEncode(&buf, pver)
+	if err != nil {
+		t.Errorf("encode of MsgSendHeaders failed %v err <%v>", msg,
+			err)
+	}
+
+	// Older protocol versions should fail encode since message didn't
+	// exist yet.
+	oldPver := wire.SendHeadersVersion - 1
+	err = msg.BtcEncode(&buf, oldPver)
+	if err == nil {
+		s := "encode of MsgSendHeaders passed for old protocol " +
+			"version %v err <%v>"
+		t.Errorf(s, msg, err)
+	}
+
+	// Test decode with latest protocol version.
+	readmsg := wire.NewMsgSendHeaders()
+	err = readmsg.BtcDecode(&buf, pver)
+	if err != nil {
+		t.Errorf("decode of MsgSendHeaders failed [%v] err <%v>", buf,
+			err)
+	}
+
+	// Older protocol versions should fail decode since message didn't
+	// exist yet.
+	err = readmsg.BtcDecode(&buf, oldPver)
+	if err == nil {
+		s := "decode of MsgSendHeaders passed for old protocol " +
+			"version %v err <%v>"
+		t.Errorf(s, msg, err)
+	}
+
+	return
+}
+
+// TestSendHeadersBIP0130 tests the MsgSendHeaders API against the protocol
+// prior to version SendHeadersVersion.
+func TestSendHeadersBIP0130(t *testing.T) {
+	// Use the protocol version just prior to SendHeadersVersion changes.
+	pver := wire.SendHeadersVersion - 1
+
+	msg := wire.NewMsgSendHeaders()
+
+	// Test encode with old protocol version.
+	var buf bytes.Buffer
+	err := msg.BtcEncode(&buf, pver)
+	if err == nil {
+		t.Errorf("encode of MsgSendHeaders succeeded when it should " +
+			"have failed")
+	}
+
+	// Test decode with old protocol version.
+	readmsg := wire.NewMsgSendHeaders()
+	err = readmsg.BtcDecode(&buf, pver)
+	if err == nil {
+		t.Errorf("decode of MsgSendHeaders succeeded when it should " +
+			"have failed")
+	}
+
+	return
+}
+
+// TestSendHeadersCrossProtocol tests the MsgSendHeaders API when encoding with
+// the latest protocol version and decoding with SendHeadersVersion.
+func TestSendHeadersCrossProtocol(t *testing.T) {
+	msg := wire.NewMsgSendHeaders()
+
+	// Encode with latest protocol version.
+	var buf bytes.Buffer
+	err := msg.BtcEncode(&buf, wire.ProtocolVersion)
+	if err != nil {
+		t.Errorf("encode of MsgSendHeaders failed %v err <%v>", msg,
+			err)
+	}
+
+	// Decode with old protocol version.
+	readmsg := wire.NewMsgSendHeaders()
+	err = readmsg.BtcDecode(&buf, wire.SendHeadersVersion)
+	if err != nil {
+		t.Errorf("decode of MsgSendHeaders failed [%v] err <%v>", buf,
+			err)
+	}
+}
+
+// TestSendHeadersWire tests the MsgSendHeaders wire encode and decode for
+// various protocol versions.
+func TestSendHeadersWire(t *testing.T) {
+	msgSendHeaders := wire.NewMsgSendHeaders()
+	msgSendHeadersEncoded := []byte{}
+
+	tests := []struct {
+		in   *wire.MsgSendHeaders // Message to encode
+		out  *wire.MsgSendHeaders // Expected decoded message
+		buf  []byte               // Wire encoding
+		pver uint32               // Protocol version for wire encoding
+	}{
+		// Latest protocol version.
+		{
+			msgSendHeaders,
+			msgSendHeaders,
+			msgSendHeadersEncoded,
+			wire.ProtocolVersion,
+		},
+
+		// Protocol version SendHeadersVersion+1
+		{
+			msgSendHeaders,
+			msgSendHeaders,
+			msgSendHeadersEncoded,
+			wire.SendHeadersVersion + 1,
+		},
+
+		// Protocol version SendHeadersVersion
+		{
+			msgSendHeaders,
+			msgSendHeaders,
+			msgSendHeadersEncoded,
+			wire.SendHeadersVersion,
+		},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		// Encode the message to wire format.
+		var buf bytes.Buffer
+		err := test.in.BtcEncode(&buf, test.pver)
+		if err != nil {
+			t.Errorf("BtcEncode #%d error %v", i, err)
+			continue
+		}
+		if !bytes.Equal(buf.Bytes(), test.buf) {
+			t.Errorf("BtcEncode #%d\n got: %s want: %s", i,
+				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
+			continue
+		}
+
+		// Decode the message from wire format.
+		var msg wire.MsgSendHeaders
+		rbuf := bytes.NewReader(test.buf)
+		err = msg.BtcDecode(rbuf, test.pver)
+		if err != nil {
+			t.Errorf("BtcDecode #%d error %v", i, err)
+			continue
+		}
+		if !reflect.DeepEqual(&msg, test.out) {
+			t.Errorf("BtcDecode #%d\n got: %s want: %s", i,
+				spew.Sdump(msg), spew.Sdump(test.out))
+			continue
+		}
+	}
+}

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -541,7 +541,7 @@ func (msg *MsgTx) Copy() *MsgTx {
 // decodePrefix decodes a transaction prefix and stores the contents
 // in the embedded msgTx.
 func (msg *MsgTx) decodePrefix(r io.Reader, pver uint32) error {
-	count, err := readVarInt(r, pver)
+	count, err := ReadVarInt(r, pver)
 	if err != nil {
 		return err
 	}
@@ -567,7 +567,7 @@ func (msg *MsgTx) decodePrefix(r io.Reader, pver uint32) error {
 		msg.TxIn[i] = &ti
 	}
 
-	count, err = readVarInt(r, pver)
+	count, err = ReadVarInt(r, pver)
 	if err != nil {
 		return err
 	}
@@ -613,7 +613,7 @@ func (msg *MsgTx) decodeWitness(r io.Reader, pver uint32, isFull bool) error {
 	// Witness only; generate the TxIn list and fill out only the
 	// sigScripts.
 	if !isFull {
-		count, err := readVarInt(r, pver)
+		count, err := ReadVarInt(r, pver)
 		if err != nil {
 			return err
 		}
@@ -643,7 +643,7 @@ func (msg *MsgTx) decodeWitness(r io.Reader, pver uint32, isFull bool) error {
 		// the number of signature scripts, check to make sure it's the
 		// same as the number of TxIns we currently have, then fill in
 		// the signature scripts.
-		count, err := readVarInt(r, pver)
+		count, err := ReadVarInt(r, pver)
 		if err != nil {
 			return err
 		}
@@ -690,7 +690,7 @@ func (msg *MsgTx) decodeWitness(r io.Reader, pver uint32, isFull bool) error {
 func (msg *MsgTx) decodeWitnessSigning(r io.Reader, pver uint32) error {
 	// Witness only for signing; generate the TxIn list and fill out only the
 	// sigScripts.
-	count, err := readVarInt(r, pver)
+	count, err := ReadVarInt(r, pver)
 	if err != nil {
 		return err
 	}
@@ -723,7 +723,7 @@ func (msg *MsgTx) decodeWitnessSigning(r io.Reader, pver uint32) error {
 func (msg *MsgTx) decodeWitnessValueSigning(r io.Reader, pver uint32) error {
 	// Witness only for signing; generate the TxIn list and fill out only the
 	// sigScripts.
-	count, err := readVarInt(r, pver)
+	count, err := ReadVarInt(r, pver)
 	if err != nil {
 		return err
 	}
@@ -816,7 +816,7 @@ func (msg *MsgTx) LegacyBtcDecode(r io.Reader, pver uint32) error {
 	}
 	msg.Version = int32(binary.LittleEndian.Uint32(buf[:]))
 
-	count, err := readVarInt(r, pver)
+	count, err := ReadVarInt(r, pver)
 	if err != nil {
 		return err
 	}
@@ -841,7 +841,7 @@ func (msg *MsgTx) LegacyBtcDecode(r io.Reader, pver uint32) error {
 		msg.TxIn[i] = &ti
 	}
 
-	count, err = readVarInt(r, pver)
+	count, err = ReadVarInt(r, pver)
 	if err != nil {
 		return err
 	}
@@ -911,7 +911,7 @@ func (msg *MsgTx) FromBytes(b []byte) error {
 func (msg *MsgTx) encodePrefix(w io.Writer, pver uint32) error {
 	var buf [4]byte
 	count := uint64(len(msg.TxIn))
-	err := writeVarInt(w, pver, count)
+	err := WriteVarInt(w, pver, count)
 	if err != nil {
 		return err
 	}
@@ -924,7 +924,7 @@ func (msg *MsgTx) encodePrefix(w io.Writer, pver uint32) error {
 	}
 
 	count = uint64(len(msg.TxOut))
-	err = writeVarInt(w, pver, count)
+	err = WriteVarInt(w, pver, count)
 	if err != nil {
 		return err
 	}
@@ -954,7 +954,7 @@ func (msg *MsgTx) encodePrefix(w io.Writer, pver uint32) error {
 // encodeWitness encodes a transaction witness into a writer.
 func (msg *MsgTx) encodeWitness(w io.Writer, pver uint32) error {
 	count := uint64(len(msg.TxIn))
-	err := writeVarInt(w, pver, count)
+	err := WriteVarInt(w, pver, count)
 	if err != nil {
 		return err
 	}
@@ -972,7 +972,7 @@ func (msg *MsgTx) encodeWitness(w io.Writer, pver uint32) error {
 // encodeWitnessSigning encodes a transaction witness into a writer for signing.
 func (msg *MsgTx) encodeWitnessSigning(w io.Writer, pver uint32) error {
 	count := uint64(len(msg.TxIn))
-	err := writeVarInt(w, pver, count)
+	err := WriteVarInt(w, pver, count)
 	if err != nil {
 		return err
 	}
@@ -991,7 +991,7 @@ func (msg *MsgTx) encodeWitnessSigning(w io.Writer, pver uint32) error {
 // signing, with the value included.
 func (msg *MsgTx) encodeWitnessValueSigning(w io.Writer, pver uint32) error {
 	count := uint64(len(msg.TxIn))
-	err := writeVarInt(w, pver, count)
+	err := WriteVarInt(w, pver, count)
 	if err != nil {
 		return err
 	}
@@ -1073,7 +1073,7 @@ func (msg *MsgTx) LegacyBtcEncode(w io.Writer, pver uint32) error {
 	}
 
 	count := uint64(len(msg.TxIn))
-	err = writeVarInt(w, pver, count)
+	err = WriteVarInt(w, pver, count)
 	if err != nil {
 		return err
 	}
@@ -1086,7 +1086,7 @@ func (msg *MsgTx) LegacyBtcEncode(w io.Writer, pver uint32) error {
 	}
 
 	count = uint64(len(msg.TxOut))
-	err = writeVarInt(w, pver, count)
+	err = WriteVarInt(w, pver, count)
 	if err != nil {
 		return err
 	}
@@ -1510,7 +1510,7 @@ func readTxInWitness(r io.Reader, pver uint32, version int32, ti *TxIn) error {
 	ti.BlockIndex = binary.LittleEndian.Uint32(buf4[:])
 
 	// Signature script.
-	ti.SignatureScript, err = readVarBytes(r, pver, MaxMessagePayload,
+	ti.SignatureScript, err = ReadVarBytes(r, pver, MaxMessagePayload,
 		"transaction input signature script")
 	if err != nil {
 		return err
@@ -1525,7 +1525,7 @@ func readTxInWitnessSigning(r io.Reader, pver uint32, version int32,
 	var err error
 
 	// Signature script.
-	ti.SignatureScript, err = readVarBytes(r, pver, MaxMessagePayload,
+	ti.SignatureScript, err = ReadVarBytes(r, pver, MaxMessagePayload,
 		"transaction input signature script")
 	if err != nil {
 		return err
@@ -1549,7 +1549,7 @@ func readTxInWitnessValueSigning(r io.Reader, pver uint32, version int32,
 	ti.ValueIn = int64(binary.LittleEndian.Uint64(buf8[:]))
 
 	// Signature script.
-	ti.SignatureScript, err = readVarBytes(r, pver, MaxMessagePayload,
+	ti.SignatureScript, err = ReadVarBytes(r, pver, MaxMessagePayload,
 		"transaction input signature script")
 	if err != nil {
 		return err
@@ -1568,7 +1568,7 @@ func legacyReadTxIn(r io.Reader, pver uint32, version int32, ti *TxIn) error {
 	}
 	ti.PreviousOutPoint = op
 
-	ti.SignatureScript, err = readVarBytes(r, pver, MaxMessagePayload,
+	ti.SignatureScript, err = ReadVarBytes(r, pver, MaxMessagePayload,
 		"transaction input signature script")
 	if err != nil {
 		return err
@@ -1592,7 +1592,7 @@ func legacyWriteTxIn(w io.Writer, pver uint32, version int32, ti *TxIn) error {
 		return err
 	}
 
-	err = writeVarBytes(w, pver, ti.SignatureScript)
+	err = WriteVarBytes(w, pver, ti.SignatureScript)
 	if err != nil {
 		return err
 	}
@@ -1652,7 +1652,7 @@ func writeTxInWitness(w io.Writer, pver uint32, version int32, ti *TxIn) error {
 	}
 
 	// Write the signature script.
-	err = writeVarBytes(w, pver, ti.SignatureScript)
+	err = WriteVarBytes(w, pver, ti.SignatureScript)
 	if err != nil {
 		return err
 	}
@@ -1667,7 +1667,7 @@ func writeTxInWitnessSigning(w io.Writer, pver uint32, version int32,
 	var err error
 
 	// Only write the signature script.
-	err = writeVarBytes(w, pver, ti.SignatureScript)
+	err = WriteVarBytes(w, pver, ti.SignatureScript)
 	if err != nil {
 		return err
 	}
@@ -1690,7 +1690,7 @@ func writeTxInWitnessValueSigning(w io.Writer, pver uint32, version int32,
 	}
 
 	// Signature script.
-	err = writeVarBytes(w, pver, ti.SignatureScript)
+	err = WriteVarBytes(w, pver, ti.SignatureScript)
 	if err != nil {
 		return err
 	}
@@ -1715,7 +1715,7 @@ func readTxOut(r io.Reader, pver uint32, version int32, to *TxOut) error {
 	}
 	to.Version = binary.LittleEndian.Uint16(buf2[:])
 
-	to.PkScript, err = readVarBytes(r, pver, MaxMessagePayload,
+	to.PkScript, err = ReadVarBytes(r, pver, MaxMessagePayload,
 		"transaction output public key script")
 	if err != nil {
 		return err
@@ -1741,7 +1741,7 @@ func writeTxOut(w io.Writer, pver uint32, version int32, to *TxOut) error {
 		return err
 	}
 
-	err = writeVarBytes(w, pver, to.PkScript)
+	err = WriteVarBytes(w, pver, to.PkScript)
 	if err != nil {
 		return err
 	}
@@ -1758,7 +1758,7 @@ func legacyReadTxOut(r io.Reader, pver uint32, version int32, to *TxOut) error {
 	}
 	to.Value = int64(binary.LittleEndian.Uint64(buf[:]))
 
-	to.PkScript, err = readVarBytes(r, pver, MaxMessagePayload,
+	to.PkScript, err = ReadVarBytes(r, pver, MaxMessagePayload,
 		"transaction output public key script")
 	if err != nil {
 		return err
@@ -1777,7 +1777,7 @@ func legacyWriteTxOut(w io.Writer, pver uint32, version int32, to *TxOut) error 
 		return err
 	}
 
-	err = writeVarBytes(w, pver, to.PkScript)
+	err = WriteVarBytes(w, pver, to.PkScript)
 	if err != nil {
 		return err
 	}

--- a/wire/msgversion.go
+++ b/wire/msgversion.go
@@ -19,7 +19,7 @@ import (
 const MaxUserAgentLen = 2000
 
 // DefaultUserAgent for wire in the stack
-const DefaultUserAgent = "/dcrwire:0.1.0/"
+const DefaultUserAgent = "/dcrwire:0.2.0/"
 
 // MsgVersion implements the Message interface and represents a decred version
 // message.  It is used for a peer to advertise itself as soon as an outbound

--- a/wire/msgversion_test.go
+++ b/wire/msgversion_test.go
@@ -260,7 +260,7 @@ func TestVersionWireErrors(t *testing.T) {
 	var newUAVarIntBuf bytes.Buffer
 	err := wire.TstWriteVarInt(&newUAVarIntBuf, pver, uint64(len(newUA)))
 	if err != nil {
-		t.Errorf("writeVarInt: error %v", err)
+		t.Errorf("WriteVarInt: error %v", err)
 	}
 
 	// Make a new buffer big enough to hold the base version plus the new

--- a/wire/protocol.go
+++ b/wire/protocol.go
@@ -1,5 +1,5 @@
-// Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015 The Decred developers
+// Copyright (c) 2013-2016 The btcsuite developers
+// Copyright (c) 2015-2016 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -17,11 +17,15 @@ const (
 	InitialProcotolVersion uint32 = 1
 
 	// ProtocolVersion is the latest protocol version this package supports.
-	ProtocolVersion uint32 = 2
+	ProtocolVersion uint32 = 3
 
 	// BIP0111Version is the protocol version which added the SFNodeBloom
 	// service flag.
 	BIP0111Version uint32 = 2
+
+	// SendHeadersVersion is the protocol version which added a new
+	// sendheaders message.
+	SendHeadersVersion uint32 = 3
 )
 
 // ServiceFlag identifies services supported by a decred peer.


### PR DESCRIPTION
Contains the following upstream commits:
- f45db028dbe816b6d032a01c9e0abc2e38a55f77
  - This commit was already cherry picked and is a NOOP
- f4d551c08dba560d1477c71b23acc560cc9c6cd3
  - This commit was already cherry picked and is a NOOP
- c17ff820610d9efce9ffc763f29ef64e94c7369b
