### PR TITLE
Attempt to fix the broken paths in config autogen

### DIFF
--- a/cmd/dcrctl/config.go
+++ b/cmd/dcrctl/config.go
@@ -216,7 +216,8 @@ func loadConfig() (*config, []string, error) {
 	if _, err := os.Stat(preCfg.ConfigFile); os.IsNotExist(err) {
 		err := createDefaultConfigFile(preCfg.ConfigFile)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error creating a default config file: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error creating a default config file: %v\n",
+				err)
 		}
 	}
 
@@ -279,10 +280,13 @@ func loadConfig() (*config, []string, error) {
 // For this it tries to read the dcrd config file at its default path, and extract
 // the RPC user and password from it.
 func createDefaultConfigFile(destinationPath string) error {
-	// Create the destination directory if it does not exists
-	os.MkdirAll(filepath.Dir(destinationPath), 0700)
+	// Create the destination directory if it does not exists.
+	err := os.MkdirAll(filepath.Dir(destinationPath), 0700)
+	if err != nil {
+		return err
+	}
 
-	// Read dcrd.conf from its default path
+	// Read dcrd.conf from its default path.
 	dcrdConfigPath := filepath.Join(dcrdHomeDir, "dcrd.conf")
 	dcrdConfigFile, err := os.Open(dcrdConfigPath)
 	if err != nil {
@@ -294,36 +298,38 @@ func createDefaultConfigFile(destinationPath string) error {
 		return err
 	}
 
-	// Extract the rpcuser
+	// Extract the rpcuser.
 	rpcUserRegexp, err := regexp.Compile(`(?m)^\s*rpcuser=([^\s]+)`)
 	if err != nil {
 		return err
 	}
 	userSubmatches := rpcUserRegexp.FindSubmatch(content)
 	if userSubmatches == nil {
-		// No user found, nothing to do
+		// No user found, nothing to do.
 		return nil
 	}
 
-	// Extract the rpcpass
+	// Extract the rpcpass.
 	rpcPassRegexp, err := regexp.Compile(`(?m)^\s*rpcpass=([^\s]+)`)
 	if err != nil {
 		return err
 	}
 	passSubmatches := rpcPassRegexp.FindSubmatch(content)
 	if passSubmatches == nil {
-		// No password found, nothing to do
+		// No password found, nothing to do.
 		return nil
 	}
 
-	// Create the destination file and write the rpcuser and rpcpass to it
-	dest, err := os.OpenFile(destinationPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0700)
+	// Create the destination file and write the rpcuser and rpcpass to it.
+	dest, err := os.OpenFile(destinationPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC,
+		0644)
 	if err != nil {
 		return err
 	}
 	defer dest.Close()
 
-	dest.WriteString(fmt.Sprintf("rpcuser=%s\nrpcpass=%s", string(userSubmatches[1]), string(passSubmatches[1])))
+	dest.WriteString(fmt.Sprintf("rpcuser=%s\nrpcpass=%s",
+		string(userSubmatches[1]), string(passSubmatches[1])))
 
 	return nil
 }


### PR DESCRIPTION
The configuration autogenerator currently does not work well
and tries to read the sample file based on where the compiled
source's data directory was. This has been fixed so that the
most common directories where the sample configuration file
might be stored are searched. The configuration file is also
now generated in the correct place in Windows.

Fixes #289.