### PR TITLE
Fix merge regression bugs relating to transaction notifications

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -2327,7 +2327,8 @@ func (b *blockManager) handleNotifyMsg(notification *blockchain.Notification) {
 			b.server.txMemPool.RemoveTransaction(stx, false)
 			b.server.txMemPool.RemoveDoubleSpends(stx)
 			b.server.txMemPool.RemoveOrphan(stx.Sha())
-			b.server.txMemPool.ProcessOrphans(stx.Sha())
+			acceptedTxs := b.server.txMemPool.ProcessOrphans(stx.Sha())
+			b.server.AnnounceNewTransactions(acceptedTxs)
 		}
 
 		if r := b.server.rpcServer; r != nil {


### PR DESCRIPTION
There were two major regression related bugs from merging in the new
database. The first was failure to properly notify transactions in the
stake tree. The second was that the wrong sentinel value was being
used to terminate the rescanning loop, which normally causes
registration for relevant outpoints and addresses. Both bugs are
patched.