### PR TITLE
Fix forced reorganizations

### DIFF
--- a/blockchain/reorganization_test.go
+++ b/blockchain/reorganization_test.go
@@ -248,6 +248,125 @@ func reorgTestShort(t *testing.T) {
 	return
 }
 
+// reorgTestsForced tests a forced reorganization of a single block at HEAD.
+func reorgTestForced(t *testing.T) {
+	// Create a new database and chain instance to run tests against.
+	chain, teardownFunc, err := chainSetup("reorgunittest",
+		simNetParams)
+	if err != nil {
+		t.Errorf("Failed to setup chain instance: %v", err)
+		return
+	}
+	defer teardownFunc()
+
+	// The genesis block should fail to connect since it's already
+	// inserted.
+	genesisBlock := simNetParams.GenesisBlock
+	err = chain.CheckConnectBlock(dcrutil.NewBlock(genesisBlock))
+	if err == nil {
+		t.Errorf("CheckConnectBlock: Did not receive expected error")
+	}
+
+	// Load up the rest of the blocks up to HEAD.
+	filename := filepath.Join("testdata/", "reorgto179.bz2")
+	fi, err := os.Open(filename)
+	bcStream := bzip2.NewReader(fi)
+	defer fi.Close()
+
+	// Create a buffer of the read file
+	bcBuf := new(bytes.Buffer)
+	bcBuf.ReadFrom(bcStream)
+
+	// Create decoder from the buffer and a map to store the data
+	bcDecoder := gob.NewDecoder(bcBuf)
+	blockChain := make(map[int64][]byte)
+
+	// Decode the blockchain into the map
+	if err := bcDecoder.Decode(&blockChain); err != nil {
+		t.Errorf("error decoding test blockchain: %v", err.Error())
+	}
+
+	// Load up the short chain
+	timeSource := blockchain.NewMedianTime()
+	finalIdx1 := 131
+	var oldBestHash *chainhash.Hash
+	for i := 1; i < finalIdx1+1; i++ {
+		bl, err := dcrutil.NewBlockFromBytes(blockChain[int64(i)])
+		if err != nil {
+			t.Fatalf("NewBlockFromBytes error: %v", err.Error())
+		}
+		bl.SetHeight(int64(i))
+		if i == finalIdx1 {
+			oldBestHash = bl.Sha()
+		}
+
+		_, _, err = chain.ProcessBlock(bl, timeSource, blockchain.BFNone)
+		if err != nil {
+			t.Fatalf("ProcessBlock error at height %v: %v", i, err.Error())
+		}
+	}
+
+	// Load the long chain and begin loading blocks from that too,
+	// forcing a reorganization
+	// Load up the rest of the blocks up to HEAD.
+	filename = filepath.Join("testdata/", "reorgto180.bz2")
+	fi, err = os.Open(filename)
+	bcStream = bzip2.NewReader(fi)
+	defer fi.Close()
+
+	// Create a buffer of the read file
+	bcBuf = new(bytes.Buffer)
+	bcBuf.ReadFrom(bcStream)
+
+	// Create decoder from the buffer and a map to store the data
+	bcDecoder = gob.NewDecoder(bcBuf)
+	blockChain = make(map[int64][]byte)
+
+	// Decode the blockchain into the map
+	if err := bcDecoder.Decode(&blockChain); err != nil {
+		t.Errorf("error decoding test blockchain: %v", err.Error())
+	}
+
+	forkPoint := int64(131)
+	forkBl, err := dcrutil.NewBlockFromBytes(blockChain[forkPoint])
+	if err != nil {
+		t.Fatalf("NewBlockFromBytes error: %v", err.Error())
+	}
+	forkBl.SetHeight(forkPoint)
+
+	_, _, err = chain.ProcessBlock(forkBl, timeSource, blockchain.BFNone)
+	if err != nil {
+		t.Fatalf("ProcessBlock error: %v", err.Error())
+	}
+	newBestHash := forkBl.Sha()
+
+	err = chain.ForceHeadReorganization(*oldBestHash, *newBestHash, timeSource)
+	if err != nil {
+		t.Fatalf("failed forced reorganization: %v", err.Error())
+	}
+
+	// Ensure our blockchain is at the correct best tip for our forced
+	// reorganization
+	topBlock, _ := chain.GetTopBlock()
+	tipHash := topBlock.Sha()
+	expected, _ := chainhash.NewHashFromStr("0df603f434be1dca22d706c7c47be16a8" +
+		"edcef2f151bcf08b51138aa1cda26e2")
+	if *tipHash != *expected {
+		t.Errorf("Failed to correctly reorg; expected tip %v, got tip %v",
+			expected, tipHash)
+	}
+	have, err := chain.HaveBlock(expected)
+	if !have {
+		t.Errorf("missing tip block after reorganization test")
+	}
+	if err != nil {
+		t.Errorf("unexpected error testing for presence of new tip block "+
+			"after reorg test: %v", err)
+	}
+
+	return
+}
+
 // TestReorganization loads a set of test blocks which force a chain
 // reorganization to test the block chain handling code.
 func TestReorganization(t *testing.T) {
@@ -255,4 +374,6 @@ func TestReorganization(t *testing.T) {
 
 	// This can take a while, do not enable it by default.
 	// reorgTestShort(t)
+
+	reorgTestForced(t)
 }


### PR DESCRIPTION
A bug in evaluating the correctness of a side chain block caused
forced reorganizations to fail post new database code. This was
corrected and children of the same parent at HEAD should now be
correctly evaluated and able to reorganize to one another without
issue. A test was also added for forced reorganizations.

Fixes #327.