### PR TITLE
Fix a bug with invalidating blocks in new DB and add more sanity checks

### DIFF
--- a/blockchain/chainio_test.go
+++ b/blockchain/chainio_test.go
@@ -464,7 +464,7 @@ func TestSpendJournalSerialization(t *testing.T) {
 
 		// Deserialize to a spend journal entry.
 		gotEntry, err := deserializeSpendJournalEntry(test.serialized,
-			test.blockTxns, test.utxoView)
+			test.blockTxns)
 		if err != nil {
 			t.Errorf("deserializeSpendJournalEntry #%d (%s) "+
 				"unexpected error: %v", i, test.name, err)
@@ -492,7 +492,6 @@ func TestSpendJournalErrors(t *testing.T) {
 	tests := []struct {
 		name       string
 		blockTxns  []*wire.MsgTx
-		utxoView   *UtxoViewpoint
 		serialized []byte
 		errType    error
 	}{
@@ -511,7 +510,6 @@ func TestSpendJournalErrors(t *testing.T) {
 				}},
 				LockTime: 0,
 			}},
-			utxoView:   NewUtxoViewpoint(),
 			serialized: hexToBytes(""),
 			errType:    AssertError(""),
 		},
@@ -529,7 +527,6 @@ func TestSpendJournalErrors(t *testing.T) {
 				}},
 				LockTime: 0,
 			}},
-			utxoView:   NewUtxoViewpoint(),
 			serialized: hexToBytes("1301320511db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a"),
 			errType:    errDeserialize(""),
 		},
@@ -539,7 +536,7 @@ func TestSpendJournalErrors(t *testing.T) {
 		// Ensure the expected error type is returned and the returned
 		// slice is nil.
 		stxos, err := deserializeSpendJournalEntry(test.serialized,
-			test.blockTxns, test.utxoView)
+			test.blockTxns)
 		if reflect.TypeOf(err) != reflect.TypeOf(test.errType) {
 			t.Errorf("deserializeSpendJournalEntry (%s): expected "+
 				"error type does not match - got %T, want %T",

--- a/blockchain/utxoviewpoint.go
+++ b/blockchain/utxoviewpoint.go
@@ -496,8 +496,6 @@ func (b *BlockChain) disconnectTransactions(view *UtxoViewpoint,
 	// Loop backwards through all transactions so everything is unspent in
 	// reverse order.  This is necessary since transactions later in a block
 	// can spend from previous ones.
-	// debug TODO remove
-	//stxoIdxParent, stxoIdxCurrent := countSpentOutputsPerTree(block, parent)
 	regularTxTreeValid := dcrutil.IsFlagSet16(block.MsgBlock().Header.VoteBits,
 		dcrutil.BlockValid)
 	thisNodeStakeViewpoint := ViewpointPrevInvalidStake
@@ -904,27 +902,6 @@ func (view *UtxoViewpoint) fetchInputUtxos(db database.DB,
 	block, parent *dcrutil.Block) error {
 	viewpoint := view.StakeViewpoint()
 
-	// If we need the previous block, grab it.
-	/*
-		var parent *dcrutil.Block
-		if viewpoint == ViewpointPrevValidInitial ||
-			viewpoint == ViewpointPrevValidStake {
-			prevBlock := block.MsgBlock().Header.PrevBlock
-			err := db.View(func(dbTx database.Tx) error {
-				var err error
-				parent, err = dbFetchBlockByHash(dbTx, &prevBlock)
-				if err != nil {
-					return err
-				}
-
-				return nil
-			})
-			if err != nil {
-				return err
-			}
-		}
-	*/
-
 	// Build a map of in-flight transactions because some of the inputs in
 	// this block could be referencing other transactions earlier in this
 	// block which are not yet in the chain.
@@ -992,8 +969,8 @@ func (view *UtxoViewpoint) fetchInputUtxos(db database.DB,
 		// in-flight in relation to the regular tx tree or to other tx in
 		// the stake tx tree, so don't do any of those expensive checks and
 		// just append it to the tx slice.
-		stransactions := block.STransactions()
-		for _, tx := range stransactions {
+		sTransactions := block.STransactions()
+		for _, tx := range sTransactions {
 			isSSGen, _ := stake.IsSSGen(tx)
 
 			for i, txIn := range tx.MsgTx().TxIn {

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1220,7 +1220,6 @@ func (b *blockManager) handleBlockMsg(bmsg *blockMsg) {
 	// handling, etc.
 	onMainChain, isOrphan, err := b.chain.ProcessBlock(bmsg.block,
 		b.server.timeSource, behaviorFlags)
-
 	if err != nil {
 		// When the error is a rule error, it means the block was simply
 		// rejected as opposed to something actually going wrong, so log
@@ -1235,7 +1234,7 @@ func (b *blockManager) handleBlockMsg(bmsg *blockMsg) {
 		}
 		if dbErr, ok := err.(database.Error); ok && dbErr.ErrorCode ==
 			database.ErrCorruption {
-			panic(dbErr)
+			bmgrLog.Errorf("Critical failure: %v", dbErr.Error())
 		}
 
 		// Convert the error into an appropriate reject message and


### PR DESCRIPTION
A bug prevented STXO data from being written correctly in the event
that a block became invalidated. This could cause failures on testnet
when a block was invalidated. There was also some debug code and a panic
that were in master that have now been removed. A new test has been
added to ensure that STXO data is being properly written, and more
stringent checks for STXO data validity when added or removing blocks
has been added.