### PR TITLE
config: Add --whitelist option

### DIFF
--- a/config.go
+++ b/config.go
@@ -102,6 +102,7 @@ type config struct {
 	DisableBanning       bool          `long:"nobanning" description:"Disable banning of misbehaving peers"`
 	BanDuration          time.Duration `long:"banduration" description:"How long to ban misbehaving peers.  Valid time units are {s, m, h}.  Minimum 1 second"`
 	BanThreshold         uint32        `long:"banthreshold" description:"Maximum allowed ban score before disconnecting and banning misbehaving peers."`
+	Whitelists           []string      `long:"whitelist" description:"Add an IP network or IP that will not be banned. (eg. 192.168.1.0/24 or ::1)"`
 	RPCUser              string        `short:"u" long:"rpcuser" description:"Username for RPC connections"`
 	RPCPass              string        `short:"P" long:"rpcpass" default-mask:"-" description:"Password for RPC connections"`
 	RPCLimitUser         string        `long:"rpclimituser" description:"Username for limited RPC connections"`
@@ -168,6 +169,7 @@ type config struct {
 	dial                 func(string, string) (net.Conn, error)
 	miningAddrs          []dcrutil.Address
 	minRelayTxFee        dcrutil.Amount
+	whitelists           []*net.IPNet
 }
 
 // serviceOptions defines the configuration options for the daemon as a service on
@@ -606,6 +608,38 @@ func loadConfig() (*config, []string, error) {
 		fmt.Fprintln(os.Stderr, err)
 		fmt.Fprintln(os.Stderr, usageMessage)
 		return nil, nil, err
+	}
+
+	// Validate any given whitelisted IP addresses and networks.
+	if len(cfg.Whitelists) > 0 {
+		var ip net.IP
+		cfg.whitelists = make([]*net.IPNet, 0, len(cfg.Whitelists))
+
+		for _, addr := range cfg.Whitelists {
+			_, ipnet, err := net.ParseCIDR(addr)
+			if err != nil {
+				ip = net.ParseIP(addr)
+				if ip == nil {
+					str := "%s: The whitelist value of '%s' is invalid"
+					err = fmt.Errorf(str, funcName, addr)
+					fmt.Fprintln(os.Stderr, err)
+					fmt.Fprintln(os.Stderr, usageMessage)
+					return nil, nil, err
+				}
+				var bits int
+				if ip.To4() == nil {
+					// IPv6
+					bits = 128
+				} else {
+					bits = 32
+				}
+				ipnet = &net.IPNet{
+					IP:   ip,
+					Mask: net.CIDRMask(bits, bits),
+				}
+			}
+			cfg.whitelists = append(cfg.whitelists, ipnet)
+		}
 	}
 
 	// --addPeer and --connect do not mix.

--- a/doc.go
+++ b/doc.go
@@ -36,10 +36,12 @@ Application Options:
                             (default all interfaces port: 9108, testnet: 19108)
       --maxpeers=           Max number of inbound and outbound peers (125)
       --nobanning           Disable banning of misbehaving peers
-      --banthreshold=       Maximum allowed ban score before disconnecting and
-                            banning misbehaving peers.
       --banduration=        How long to ban misbehaving peers.  Valid time units
                             are {s, m, h}.  Minimum 1 second (24h0m0s)
+      --banthreshold=       Maximum allowed ban score before disconnecting and
+                            banning misbehaving peers.
+      --whitelist=          Add an IP network or IP that will not be banned.
+                            (eg. 192.168.1.0/24 or ::1)
   -u, --rpcuser=            Username for RPC connections
   -P, --rpcpass=            Password for RPC connections
       --rpclimituser=       Username for limited RPC connections

--- a/sample-dcrd.conf
+++ b/sample-dcrd.conf
@@ -117,6 +117,13 @@
 ; banduration=24h
 ; banduration=11h30m15s
 
+; Add whitelisted IP networks and IPs. Connected peers whose IP matches a
+; whitelist will not have their ban score increased.
+; whitelist=127.0.0.1
+; whitelist=::1
+; whitelist=192.168.0.0/24
+; whitelist=fd00::/16
+
 ; Disable DNS seeding for peers.  By default, when dcrd starts, it will use
 ; DNS to query for available peers to connect with.
 ; nodnsseed=1


### PR DESCRIPTION
The whitelist option is used to specify networks that will not be
banned.

Fixes #351 
