### PR TITLE
blockchain: Add string mapping for ErrBIP0030.

### DIFF
--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -496,6 +496,7 @@ var errorCodeStrings = map[ErrorCode]string{
 	ErrSSRtxPayees:            "ErrSSRtxPayees",
 	ErrTxSStxOutSpend:         "ErrTxSStxOutSpend",
 	ErrRegTxSpendStakeOut:     "ErrRegTxSpendStakeOut",
+	ErrBIP0030:                "ErrBIP0030",
 	ErrInvalidFinalState:      "ErrInvalidFinalState",
 	ErrPoolSize:               "ErrPoolSize",
 	ErrForceReorgWrongChain:   "ErrForceReorgWrongChain",


### PR DESCRIPTION
This ensures the error appears by its identifier instead of its value should it be printed.