### PR TITLE
deps: Update to latest commits.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 26b232a0701585082422dc9f718ad82932d29309789896663ce3c4a5925cb84b
-updated: 2016-08-24T12:05:43.171730574-04:00
+hash: f31381b9d7836c3acfccda809b8b279691b38d97517933b4f10e97f8ec468d2b
+updated: 2016-09-22T14:08:46.2606872-05:00
 imports:
 - name: github.com/btcsuite/btclog
   version: 73889fb79bd687870312b6e40effcecffbd57d30
@@ -29,7 +29,7 @@ imports:
   - leveldb/table
   - leveldb/util
 - name: github.com/btcsuite/seelog
-  version: ae8891d029dd3c269dcfd6f261ad23e761acd99f
+  version: 313961b101eb55f65ae0f03ddd4e322731763b6c
 - name: github.com/btcsuite/snappy-go
   version: 0bdef8d067237991ddaa1bb6072a740bc40601ba
 - name: github.com/btcsuite/websocket
@@ -53,7 +53,7 @@ imports:
 - name: github.com/decred/dcrrpcclient
   version: 103ed11be3a7035554d3925fbfaa67742641510f
 - name: github.com/decred/dcrutil
-  version: 4fc91a08eea88e74539d42d6301fd298b9bd8230
+  version: 0484582bf5503574d824f110e836a8c48aa60c8c
   subpackages:
   - base58
   - bloom
@@ -62,12 +62,12 @@ imports:
   subpackages:
   - edwards25519
 - name: golang.org/x/crypto
-  version: 986d3313588aa5c68f1df95eac956f79cf3b2c01
+  version: 8e06e8ddd9629eb88639aba897641bff8031f1d3
   subpackages:
   - ssh/terminal
 testImports:
 - name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/stretchr/testify

--- a/glide.yaml
+++ b/glide.yaml
@@ -18,7 +18,6 @@ import:
   - leveldb/opt
   - leveldb/util
 - package: github.com/btcsuite/seelog
-  version: v2.1
 - package: github.com/btcsuite/websocket
 - package: github.com/btcsuite/winsvc
   subpackages:
@@ -40,3 +39,7 @@ import:
 - package: golang.org/x/crypto
   subpackages:
   - ssh/terminal
+testImport:
+- package: github.com/stretchr/testify
+  subpackages:
+  - assert


### PR DESCRIPTION
This updates the `glide.yaml` to remove the incorrect `seelog` version so it can make use of the latest commit and adds the test import for `testify` used by the `dcrec` package.  Finally it uses `glide update` to update the `glide.lock` file accordingly.

All commits in between the old and newest commits in the lock file have been reviewed.