### PR TITLE
Merge in btcd commit f893558d782396f10c2fe49a8bc73deff4a36d14

### DIFF
--- a/dcrec/secp256k1/ciphering.go
+++ b/dcrec/secp256k1/ciphering.go
@@ -42,7 +42,7 @@ var (
 )
 
 // GenerateSharedSecret generates a shared secret based on a private key and a
-// private key using Diffie-Hellman key exchange (ECDH) (RFC 4753).
+// public key using Diffie-Hellman key exchange (ECDH) (RFC 4753).
 // RFC5903 Section 9 states we should only return x.
 func GenerateSharedSecret(privkey *PrivateKey, pubkey *PublicKey) []byte {
 	x, _ := pubkey.Curve.ScalarMult(pubkey.X, pubkey.Y, privkey.D.Bytes())


### PR DESCRIPTION
Merges up to commit f893558d782396f10c2fe49a8bc73deff4a36d14 from btcd.

1a0e7452f3e7367b30d3d62cab23dcd4e0bb6d8c, 128366734f0307d55bdaca0ed6955054cd3114e1, and 2554caee5919958c0d4b41db8035f0e12ce6f624 are NOOPs because they have already been cherry-picked in.