### PR TITLE
Merge in btcd 7f07fb1093dd80105d36d61c8fb8a16f6e9d9b29

### DIFF
--- a/txscript/sigcache.go
+++ b/txscript/sigcache.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 The btcsuite developers
+// Copyright (c) 2015-2016 The btcsuite developers
 // Copyright (c) 2016 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
@@ -89,7 +89,7 @@ func (s *SigCache) Add(sigHash chainhash.Hash, sig chainec.Signature, pubKey cha
 	// If adding this new entry will put us over the max number of allowed
 	// entries, then evict an entry.
 	if uint(len(s.validSigs)+1) > s.maxEntries {
-		// Remove a random entry from the map relaying on the random
+		// Remove a random entry from the map. Relying on the random
 		// starting point of Go's map iteration. It's worth noting that
 		// the random iteration starting point is not 100% guaranteed
 		// by the spec, however most Go compilers support it.


### PR DESCRIPTION
Merge in btcd commit 7f07fb1093dd80105d36d61c8fb8a16f6e9d9b29, also merging in e8e2167a1af6c20f1f32abb76bd387ee87763bc9.

24e41c843bf5cc363387871b9d8df0598395974c is already cherry-picked and skipped as a NOOP.