### PR TITLE
Output of --help/-h should go to os.Stdout rather than os.Stderr

### DIFF
--- a/cmd/dcrctl/config.go
+++ b/cmd/dcrctl/config.go
@@ -186,13 +186,19 @@ func loadConfig() (*config, []string, error) {
 	preParser := flags.NewParser(&preCfg, flags.HelpFlag)
 	_, err := preParser.Parse()
 	if err != nil {
-		if e, ok := err.(*flags.Error); ok && e.Type == flags.ErrHelp {
+		if e, ok := err.(*flags.Error); ok && e.Type != flags.ErrHelp {
+			fmt.Fprintln(os.Stderr, err)
+			fmt.Fprintln(os.Stderr, "")
+			fmt.Fprintln(os.Stderr, "The special parameter `-` "+
+				"indicates that a parameter should be read "+
+				"from the\nnext unread line from standard input.")
+			os.Exit(1)
+		} else if ok && e.Type == flags.ErrHelp {
 			fmt.Fprintln(os.Stdout, err)
 			fmt.Fprintln(os.Stdout, "")
 			fmt.Fprintln(os.Stdout, "The special parameter `-` "+
 				"indicates that a parameter should be read "+
-				"from the\nnext unread line from standard "+
-				"input.")
+				"from the\nnext unread line from standard input.")
 			os.Exit(0)
 		}
 	}

--- a/cmd/dcrctl/config.go
+++ b/cmd/dcrctl/config.go
@@ -187,13 +187,13 @@ func loadConfig() (*config, []string, error) {
 	_, err := preParser.Parse()
 	if err != nil {
 		if e, ok := err.(*flags.Error); ok && e.Type == flags.ErrHelp {
-			fmt.Fprintln(os.Stderr, err)
-			fmt.Fprintln(os.Stderr, "")
-			fmt.Fprintln(os.Stderr, "The special parameter `-` "+
+			fmt.Fprintln(os.Stdout, err)
+			fmt.Fprintln(os.Stdout, "")
+			fmt.Fprintln(os.Stdout, "The special parameter `-` "+
 				"indicates that a parameter should be read "+
 				"from the\nnext unread line from standard "+
 				"input.")
-			return nil, nil, err
+			os.Exit(0)
 		}
 	}
 

--- a/config.go
+++ b/config.go
@@ -390,7 +390,7 @@ func loadConfig() (*config, []string, error) {
 	if err != nil {
 		if e, ok := err.(*flags.Error); ok && e.Type != flags.ErrHelp {
 			fmt.Fprintln(os.Stderr, err)
-			os.Exit(0)
+			os.Exit(1)
 		} else if ok && e.Type == flags.ErrHelp {
 			fmt.Fprintln(os.Stdout, err)
 			os.Exit(0)

--- a/config.go
+++ b/config.go
@@ -388,7 +388,10 @@ func loadConfig() (*config, []string, error) {
 	preParser := newConfigParser(&preCfg, &serviceOpts, flags.HelpFlag)
 	_, err := preParser.Parse()
 	if err != nil {
-		if e, ok := err.(*flags.Error); ok && e.Type == flags.ErrHelp {
+		if e, ok := err.(*flags.Error); ok && e.Type != flags.ErrHelp {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(0)
+		} else if ok && e.Type == flags.ErrHelp {
 			fmt.Fprintln(os.Stdout, err)
 			os.Exit(0)
 		}

--- a/config.go
+++ b/config.go
@@ -389,8 +389,8 @@ func loadConfig() (*config, []string, error) {
 	_, err := preParser.Parse()
 	if err != nil {
 		if e, ok := err.(*flags.Error); ok && e.Type == flags.ErrHelp {
-			fmt.Fprintln(os.Stderr, err)
-			return nil, nil, err
+			fmt.Fprintln(os.Stdout, err)
+			os.Exit(0)
 		}
 	}
 


### PR DESCRIPTION
As described in Issue https://github.com/decred/dcrd/issues/105#issuecomment-250304334, `flags.ErrHelp` means that **`err` from `Parse()` the contains auto-generated help message from btcsuite/go-flags**, so we can print it to stdout.

**Clarification:** Only print to stdout when help is explicitly requested, _not_ because of an error.  Exit with code 0 in this case since there is no error.

Just opinions, but... http://stackoverflow.com/q/2199624/2778484
