### PR TITLE
Fix a bug for forced reorganizations

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -854,10 +854,28 @@ func (b *BlockChain) pruneStakeNodes() error {
 	return nil
 }
 
-// GetCurrentBlockHeader returns the block header of the block at HEAD.
+// BestBlockHeader returns a copy of the block header of the block at HEAD.
+//
 // This function is NOT safe for concurrent access.
-func (b *BlockChain) GetCurrentBlockHeader() *wire.BlockHeader {
-	return &b.bestNode.header
+func (b *BlockChain) BestBlockHeader() *wire.BlockHeader {
+	return wire.NewBlockHeader(
+		b.bestNode.header.Version,
+		&b.bestNode.header.PrevBlock,
+		&b.bestNode.header.MerkleRoot,
+		&b.bestNode.header.StakeRoot,
+		b.bestNode.header.VoteBits,
+		b.bestNode.header.FinalState,
+		b.bestNode.header.Voters,
+		b.bestNode.header.FreshStake,
+		b.bestNode.header.Revocations,
+		b.bestNode.header.PoolSize,
+		b.bestNode.header.Bits,
+		b.bestNode.header.SBits,
+		b.bestNode.header.Height,
+		b.bestNode.header.Size,
+		b.bestNode.header.Nonce,
+		b.bestNode.header.ExtraData,
+	)
 }
 
 // isMajorityVersion determines if a previous number of blocks in the chain

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1257,7 +1257,7 @@ func (b *blockManager) handleBlockMsg(bmsg *blockMsg) {
 			}
 
 			// Retrieve the current block header.
-			curBlockHeader := b.chain.GetCurrentBlockHeader()
+			curBlockHeader := b.chain.BestBlockHeader()
 
 			nextStakeDiff, errSDiff :=
 				b.chain.CalcNextRequiredStakeDifficulty()
@@ -1864,7 +1864,10 @@ out:
 							": %v", err)
 					}
 
-					curBlockHeader := b.chain.GetCurrentBlockHeader()
+					// The blockchain should be updated, so fetch the
+					// latest snapshot.
+					best = b.chain.BestSnapshot()
+					curBlockHeader := b.chain.BestBlockHeader()
 
 					b.updateChainState(best.Hash,
 						best.Height,
@@ -1996,7 +1999,7 @@ out:
 						bmgrLog.Warnf("Failed to get missing tickets for "+
 							"incoming block %v: %v", best.Hash, err)
 					}
-					curBlockHeader := b.chain.GetCurrentBlockHeader()
+					curBlockHeader := b.chain.BestBlockHeader()
 
 					winningTickets, poolSize, finalState, err :=
 						b.chain.LotteryDataForBlock(msg.block.Sha())
@@ -2779,7 +2782,7 @@ func newBlockManager(s *server, indexManager blockchain.IndexManager) (*blockMan
 	}
 
 	// Retrieve the current block header and next stake difficulty.
-	curBlockHeader := bm.chain.GetCurrentBlockHeader()
+	curBlockHeader := bm.chain.BestBlockHeader()
 	nextStakeDiff, err := bm.chain.CalcNextRequiredStakeDifficulty()
 	if err != nil {
 		return nil, err

--- a/mining.go
+++ b/mining.go
@@ -1182,6 +1182,14 @@ func NewBlockTemplate(policy *mining.Policy, server *server,
 	}
 	chainState.Unlock()
 
+	chainBest := blockManager.chain.BestSnapshot()
+	if *prevHash != *chainBest.Hash ||
+		nextBlockHeight-1 != chainBest.Height {
+		return nil, fmt.Errorf("chain state is not syncronized to the "+
+			"blockchain (got %v:%v, want %v,%v",
+			prevHash, nextBlockHeight-1, chainBest.Hash, chainBest.Height)
+	}
+
 	// Calculate the stake enabled height.
 	stakeValidationHeight := server.chainParams.StakeValidationHeight
 


### PR DESCRIPTION
A bug when updating the chain state during forced reorganizations
was fixed. An assertion was added into the mining code so that it
now errors out if the blockchain and chainState of the block
manager are inconsistent.