### PR TITLE
Fix the dumpblockchain function

### DIFF
--- a/cmd/addblock/addblock.go
+++ b/cmd/addblock/addblock.go
@@ -114,8 +114,9 @@ func realMain() error {
 	}
 
 	log.Infof("Processed a total of %d blocks (%d imported, %d already "+
-		"known)", results.blocksProcessed, results.blocksImported,
-		results.blocksProcessed-results.blocksImported)
+		"known) in %v", results.blocksProcessed, results.blocksImported,
+		results.blocksProcessed-results.blocksImported, results.duration)
+
 	return nil
 }
 

--- a/cmd/addblock/import.go
+++ b/cmd/addblock/import.go
@@ -26,6 +26,7 @@ var zeroHash = chainhash.Hash{}
 type importResults struct {
 	blocksProcessed int64
 	blocksImported  int64
+	duration        time.Duration
 	err             error
 }
 
@@ -48,6 +49,7 @@ type blockImporter struct {
 	lastHeight        int64
 	lastBlockTime     time.Time
 	lastLogTime       time.Time
+	startTime         time.Time
 }
 
 // readBlock reads the next block from the input file.
@@ -257,6 +259,7 @@ func (bi *blockImporter) statusHandler(resultsChan chan *importResults) {
 		resultsChan <- &importResults{
 			blocksProcessed: bi.blocksProcessed,
 			blocksImported:  bi.blocksImported,
+			duration:        time.Now().Sub(bi.startTime),
 			err:             err,
 		}
 		close(bi.quit)
@@ -266,6 +269,7 @@ func (bi *blockImporter) statusHandler(resultsChan chan *importResults) {
 		resultsChan <- &importResults{
 			blocksProcessed: bi.blocksProcessed,
 			blocksImported:  bi.blocksImported,
+			duration:        time.Now().Sub(bi.startTime),
 			err:             nil,
 		}
 	}
@@ -352,5 +356,6 @@ func newBlockImporter(db database.DB, r io.ReadSeeker) (*blockImporter, error) {
 		chain:        chain,
 		medianTime:   blockchain.NewMedianTime(),
 		lastLogTime:  time.Now(),
+		startTime:    time.Now(),
 	}, nil
 }

--- a/config.go
+++ b/config.go
@@ -129,7 +129,7 @@ type config struct {
 	Profile             string        `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536"`
 	CPUProfile          string        `long:"cpuprofile" description:"Write CPU profile to the specified file"`
 	MemProfile          string        `long:"memprofile" description:"Write mem profile to the specified file"`
-	DumpBlockchain      string        `long:"dumpblockchain" description:"Write blockchain as a gob-encoded map to the specified file"`
+	DumpBlockchain      string        `long:"dumpblockchain" description:"Write blockchain as a flat file of blocks for use with addblock, to the specified filename"`
 	MiningTimeOffset    int           `long:"miningtimeoffset" description:"Offset the mining timestamp of a block by this many seconds (positive values are in the past)"`
 	DebugLevel          string        `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
 	Upnp                bool          `long:"upnp" description:"Use UPnP to map our listening port outside of NAT"`

--- a/server.go
+++ b/server.go
@@ -2266,11 +2266,13 @@ func (s *server) Stop() error {
 		}
 	}
 
-	// Stop the CPU miner if needed
-	s.cpuMiner.Stop()
+	// Stop the CPU miner if needed.
+	if cfg.Generate && s.cpuMiner != nil {
+		s.cpuMiner.Stop()
+	}
 
 	// Shutdown the RPC server if it's not disabled.
-	if !cfg.DisableRPC {
+	if !cfg.DisableRPC && s.rpcServer != nil {
 		s.rpcServer.Stop()
 	}
 


### PR DESCRIPTION
The dumpblockchain function used to serialize a map of block
into gob serialized format, which was used for testing but which
was incompatible with the addblock tool.  The function now dumps
a flat file the the same format required by the addblock tool.

A couple shutdown assertions were added as well, to prevent
potential panics if pointers were nil.  The duration of time
it took to sync the blockchain with addblock is now
reported.