### PR TITLE
Optimize coinbase output tax check.

### DIFF
--- a/blockchain/stake/tickets_test.go
+++ b/blockchain/stake/tickets_test.go
@@ -1038,8 +1038,9 @@ var simNetParams = &chaincfg.Params{
 	//   SkQn8ervNvAUEX5Ua3Lwjc6BAuTXRznDoDzsyxgjYqX58znY7w9e4
 	//   SkQkfkHZeBbMW8129tZ3KspEh1XBFC1btbkgzs6cjSyPbrgxzsKqk
 	//
-	OrganizationAddress: "ScuQxvveKGfpG1ypt6u27F99Anf7EW3cqhq",
-	BlockOneLedger:      BlockOneLedgerSimNet,
+	OrganizationPkScript:        chaincfg.SimNetParams.OrganizationPkScript,
+	OrganizationPkScriptVersion: chaincfg.SimNetParams.OrganizationPkScriptVersion,
+	BlockOneLedger:              BlockOneLedgerSimNet,
 }
 
 // BlockOneLedgerSimNet is the block one output ledger for the simulation

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -1838,7 +1838,7 @@ func TestBlockValidationRules(t *testing.T) {
 	sstxCBIn.SignatureScript = []byte{0x51, 0x51}
 	sstxToUse166.AddTxIn(sstxCBIn)
 
-	orgAddr, _ := dcrutil.DecodeAddress(simNetParams.OrganizationAddress,
+	orgAddr, _ := dcrutil.DecodeAddress("ScuQxvveKGfpG1ypt6u27F99Anf7EW3cqhq",
 		simNetParams)
 	pkScript, _ := txscript.GenerateSStxAddrPush(orgAddr,
 		dcrutil.Amount(29702992297), 0x0000)
@@ -2138,8 +2138,9 @@ var simNetParams = &chaincfg.Params{
 	//   SkQn8ervNvAUEX5Ua3Lwjc6BAuTXRznDoDzsyxgjYqX58znY7w9e4
 	//   SkQkfkHZeBbMW8129tZ3KspEh1XBFC1btbkgzs6cjSyPbrgxzsKqk
 	//
-	OrganizationAddress: "ScuQxvveKGfpG1ypt6u27F99Anf7EW3cqhq",
-	BlockOneLedger:      BlockOneLedgerSimNet,
+	OrganizationPkScript:        chaincfg.SimNetParams.OrganizationPkScript,
+	OrganizationPkScriptVersion: chaincfg.SimNetParams.OrganizationPkScriptVersion,
+	BlockOneLedger:              BlockOneLedgerSimNet,
 }
 
 // BlockOneLedgerSimNet is the block one output ledger for the simulation

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -6,6 +6,7 @@
 package chaincfg
 
 import (
+	"encoding/hex"
 	"errors"
 	"math/big"
 	"time"
@@ -263,10 +264,13 @@ type Params struct {
 	// it to be this value miners/daemons could freely change it.
 	StakeBaseSigScript []byte
 
-	// OrganizationAddress is the static address for block taxes to be
-	// distributed to in every block's coinbase. It should ideally be
-	// a P2SH multisignature address.
-	OrganizationAddress string
+	// OrganizationPkScript is the output script for block taxes to be
+	// distributed to in every block's coinbase. It should ideally be a P2SH
+	// multisignature address.  OrganizationPkScriptVersion is the version
+	// of the output script.  Until PoS hardforking is implemented, this
+	// version must always match for a block to validate.
+	OrganizationPkScript        []byte
+	OrganizationPkScriptVersion uint16
 
 	// BlockOneLedger specifies the list of payouts in the coinbase of
 	// block height 1. If there are no payouts to be given, set this
@@ -360,8 +364,10 @@ var MainNetParams = Params{
 	StakeBaseSigScript:    []byte{0x00, 0x00},
 
 	// Decred organization related parameters
-	OrganizationAddress: "Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx",
-	BlockOneLedger:      BlockOneLedgerMainNet,
+	// Organization address is Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx
+	OrganizationPkScript:        hexDecode("a914f5916158e3e2c4551c1796708db8367207ed13bb87"),
+	OrganizationPkScriptVersion: 0,
+	BlockOneLedger:              BlockOneLedgerMainNet,
 }
 
 // TestNetParams defines the network parameters for the test currency network.
@@ -452,9 +458,11 @@ var TestNetParams = Params{
 	StakeValidationHeight: 768,     // Arbitrary
 	StakeBaseSigScript:    []byte{0xDE, 0xAD, 0xBE, 0xEF},
 
-	// Decred organization related parameters
-	OrganizationAddress: "TcemyEtyHSg9L7jww7uihv9BJfKL6YGiZYn",
-	BlockOneLedger:      BlockOneLedgerTestNet,
+	// Decred organization related parameters.
+	// Organization address is TcemyEtyHSg9L7jww7uihv9BJfKL6YGiZYn
+	OrganizationPkScript:        hexDecode("a9144fa6cbd0dbe5ec407fe4c8ad374e667771fa0d4487"),
+	OrganizationPkScriptVersion: 0,
+	BlockOneLedger:              BlockOneLedgerTestNet,
 }
 
 // SimNetParams defines the network parameters for the simulation test Decred
@@ -565,8 +573,10 @@ var SimNetParams = Params{
 	//   SkQn8ervNvAUEX5Ua3Lwjc6BAuTXRznDoDzsyxgjYqX58znY7w9e4
 	//   SkQkfkHZeBbMW8129tZ3KspEh1XBFC1btbkgzs6cjSyPbrgxzsKqk
 	//
-	OrganizationAddress: "ScuQxvveKGfpG1ypt6u27F99Anf7EW3cqhq",
-	BlockOneLedger:      BlockOneLedgerSimNet,
+	// Organization address is ScuQxvveKGfpG1ypt6u27F99Anf7EW3cqhq
+	OrganizationPkScript:        hexDecode("a914cbb08d6ca783b533b2c7d24a51fbca92d937bf9987"),
+	OrganizationPkScriptVersion: 0,
+	BlockOneLedger:              BlockOneLedgerSimNet,
 }
 
 var (
@@ -698,6 +708,14 @@ func newHashFromStr(hexStr string) *chainhash.Hash {
 		panic(err)
 	}
 	return sha
+}
+
+func hexDecode(hexStr string) []byte {
+	b, err := hex.DecodeString(hexStr)
+	if err != nil {
+		panic(err)
+	}
+	return b
 }
 
 // BlockOneSubsidy returns the total subsidy of block height 1 for the

--- a/mining.go
+++ b/mining.go
@@ -515,20 +515,12 @@ func createCoinbaseTx(subsidyCache *blockchain.SubsidyCache,
 		nextBlockHeight,
 		voters,
 		activeNetParams.Params)
-	addrOrg, err := dcrutil.DecodeAddress(params.OrganizationAddress, params)
-	if err != nil {
-		return nil, err
-	}
-	pksOrg, err := txscript.PayToAddrScript(addrOrg)
-	if err != nil {
-		return nil, err
-	}
 
 	// Tax output.
 	if params.BlockTaxProportion > 0 {
 		tx.AddTxOut(&wire.TxOut{
 			Value:    tax,
-			PkScript: pksOrg,
+			PkScript: params.OrganizationPkScript,
 		})
 	} else {
 		// Tax disabled.


### PR DESCRIPTION
Profiling indicated that significant time was being spent validating
coinbase outputs, ensuring that they paid to the development
organization's P2SH tax address.  This check was more inefficient than
necessary for a couple of reasons:

* The tax address was always decoded from a string to a dcrutil.Address.

* The actual script being validated was always parsed for addresses to
  check if they matched the tax address.

Neither of these are needed.  To optimize the algorithm, only the
equality of the output script and script version are checked.