### PR TITLE
Prevent high memory usage when turning txindex on first time

### DIFF
--- a/blockchain/indexers/manager.go
+++ b/blockchain/indexers/manager.go
@@ -476,7 +476,7 @@ func indexNeedsInputs(index Indexer) bool {
 
 // dbFetchTx looks up the passed transaction hash in the transaction index and
 // loads it from the database.
-func dbFetchTx(dbTx database.Tx, hash *chainhash.Hash) (*wire.MsgTx, error) {
+func dbFetchTx(dbTx database.Tx, hash chainhash.Hash) (*wire.MsgTx, error) {
 	// Look up the location of the transaction.
 	blockRegion, err := dbFetchTxIndexEntry(dbTx, hash)
 	if err != nil {
@@ -530,7 +530,7 @@ func makeUtxoView(dbTx database.Tx, block, parent *dcrutil.Block) (*blockchain.U
 					continue
 				}
 
-				originTx, err := dbFetchTx(dbTx, &originOut.Hash)
+				originTx, err := dbFetchTx(dbTx, originOut.Hash)
 				if err != nil {
 					return nil, err
 				}
@@ -557,7 +557,7 @@ func makeUtxoView(dbTx database.Tx, block, parent *dcrutil.Block) (*blockchain.U
 				continue
 			}
 
-			originTx, err := dbFetchTx(dbTx, &originOut.Hash)
+			originTx, err := dbFetchTx(dbTx, originOut.Hash)
 			if err != nil {
 				return nil, err
 			}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3691,7 +3691,7 @@ func handleGetRawTransaction(s *rpcServer, cmd interface{}, closeChan <-chan str
 		}
 
 		// Look up the location of the transaction.
-		blockRegion, err := txIndex.TxBlockRegion(txHash)
+		blockRegion, err := txIndex.TxBlockRegion(*txHash)
 		if err != nil {
 			context := "Failed to retrieve transaction location"
 			return nil, internalRPCError(err.Error(), context)
@@ -4504,7 +4504,7 @@ func fetchInputTxos(s *rpcServer, tx *wire.MsgTx) (map[wire.OutPoint]wire.TxOut,
 		}
 
 		// Look up the location of the transaction.
-		blockRegion, err := s.server.txIndex.TxBlockRegion(&origin.Hash)
+		blockRegion, err := s.server.txIndex.TxBlockRegion(origin.Hash)
 		if err != nil {
 			context := "Failed to retrieve transaction location"
 			return nil, internalRPCError(err.Error(), context)


### PR DESCRIPTION
If the transaction index was run and never synced before, the first
time run will cause an OOM failure on machines with low RAM. This was
due to the GC never collecting blocks and freeing them after they were
used, because there were references to the block pointers or internal
pointers to the transaction hashes in the database updates. The
pointers to hashes have all been replaced with values to save memory
and allow the GC to free the blocks/transactions as the indexer runs.