### PR TITLE
Add a block pruner that only prunes occassionally

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -239,12 +239,7 @@ func (b *BlockChain) maybeAcceptBlock(block *dcrutil.Block,
 	// Prune stake nodes and block nodes which are no longer needed before
 	// creating a new node.
 	if !dryRun {
-		err = b.pruneStakeNodes()
-		if err != nil {
-			return false, err
-		}
-
-		err = b.pruneBlockNodes()
+		err := b.pruner.pruneChainIfNeeded()
 		if err != nil {
 			return false, err
 		}

--- a/blockchain/prune.go
+++ b/blockchain/prune.go
@@ -1,0 +1,40 @@
+package blockchain
+
+import (
+	"time"
+)
+
+// pruningIntervalInMinutes is the interval in which to prune the blockchain's
+// nodes and restore memory to the garbage collector.
+const pruningIntervalInMinutes = 5
+
+// chainPruner is used to occasionally prune the blockchain of old nodes that
+// can be freed to the garbage collector.
+type chainPruner struct {
+	chain              *BlockChain
+	lastNodeInsertTime time.Time
+}
+
+// newChainPruner returns a new chain pruner.
+func newChainPruner(chain *BlockChain) *chainPruner {
+	return &chainPruner{
+		chain:              chain,
+		lastNodeInsertTime: time.Now(),
+	}
+}
+
+// pruneChainIfNeeded checks the current time versus the time of the last pruning.
+// If the blockchain hasn't been pruned in this time, it initiates a new pruning.
+//
+// pruneChainIfNeeded must be called with the chainLock held for writes.
+func (c *chainPruner) pruneChainIfNeeded() error {
+	now := time.Now()
+	duration := now.Sub(c.lastNodeInsertTime)
+	if duration < time.Minute*pruningIntervalInMinutes {
+		return nil
+	}
+
+	c.lastNodeInsertTime = now
+
+	return c.chain.pruneNodes()
+}


### PR DESCRIPTION
The blockchain pruning functions would run at every newly inserted
block node, causing performance degradation. Now the blockchain will
only prune nodes to return the memory to the garbage collector at
prespecified (5 minute) intervals, resulting in much less overhead
when syncing the blockchain.