### PR TITLE
Add new mining sorting algorithm for heap

### DIFF
--- a/config.go
+++ b/config.go
@@ -795,22 +795,17 @@ func loadConfig() (*config, []string, error) {
 		return nil, nil, err
 	}
 
-	// MaxPrioTicketSize is the size above which tickets are considered
-	// by their fees per kilobyte rather than their absolute fee.  Large
-	// tickets are considered a burden to the network because of their
-	// relatively consumption of the amount of space in blocks and the
-	// large size of the votes they produce.  Smaller tickets are thus
-	// encouraged by setting this priority size.
-	//
 	// This value must also be smaller than the largest int on 32-bit
 	// systems.
 	if cfg.MaxPrioTicketSize > 0x7FFFFFFF {
 		str := "%s: maxprioticketsize set too large (must be less than " +
-			"2147483647"
+			"2147483647)"
 		err := fmt.Errorf(str, funcName)
 		fmt.Fprintln(os.Stderr, err)
 		fmt.Fprintln(os.Stderr, usageMessage)
 		return nil, nil, err
+	} else {
+		configSetTicketPrioSize = int(cfg.MaxPrioTicketSize)
 	}
 
 	// Check and set the mining sorting algorithm.

--- a/mining.go
+++ b/mining.go
@@ -46,6 +46,7 @@ const (
 type txPrioItem struct {
 	tx       *dcrutil.Tx
 	txType   stake.TxType
+	txSize   int
 	fee      int64
 	priority float64
 	feePerKB float64
@@ -250,6 +251,70 @@ func txPQByStakeAndFeeAndThenPriority(pq *txPriorityQueue, i, j int) bool {
 
 	return pq.items[i].priority > pq.items[j].priority
 }
+
+// txPQByStakeSizeAndFeeAndThenPriority sorts a txPriorityQueue by stake priority,
+// followed by fees per kilobyte, and then if the transaction type is regular
+// or a revocation it sorts it by priority.  It differs from the
+// txPQByStakeAndFeeAndThenPriority function in that when there are two similarly
+// sized tickets less than a certain size, it will pick the higher absolute
+// fee instead of relative fee.
+// There are consquences to such a policy.  Although it might pick the highest
+// absolute fees for the block, it also increases the block's chance of being
+// orphaned.  Proof of work miners will have to determine whether the risk is
+// acceptable or not based on the amount of extra subsidy they might obtain.
+func txPQByStakeSizeAndFeeAndThenPriority(pq *txPriorityQueue, i, j int) bool {
+	// Sort by stake priority, continue if they're the same stake priority.
+	cmp := compareStakePriority(pq.items[i], pq.items[j])
+	if cmp == 1 {
+		return true
+	}
+	if cmp == -1 {
+		return false
+	}
+
+	bothAreLowStakePriority :=
+		txStakePriority(pq.items[i].txType) == regOrRevocPriority &&
+			txStakePriority(pq.items[j].txType) == regOrRevocPriority
+
+	// Use fees to determine locations of high stake priority transactions.
+	if !bothAreLowStakePriority {
+		// If both of these are tickets below the small ticket size threshold,
+		// only compare based on the absolute fees.
+		bothAreTickets := txStakePriority(pq.items[i].txType) == ticketPriority &&
+			txStakePriority(pq.items[j].txType) == ticketPriority
+		bothAreSmall := pq.items[i].txSize < int(cfg.MaxPrioTicketSize) &&
+			pq.items[j].txSize < int(cfg.MaxPrioTicketSize)
+		if bothAreTickets && bothAreSmall {
+			return pq.items[i].fee > pq.items[j].fee
+		}
+
+		// If one or both is not small or one or both is not tickets, just
+		// base it on fees per kilobyte.
+		return pq.items[i].feePerKB > pq.items[j].feePerKB
+	}
+
+	// Both transactions are of low stake importance. Use > here so that
+	// pop gives the highest priority item as opposed to the lowest.
+	// Sort by priority first, then fee.
+	if pq.items[i].priority == pq.items[j].priority {
+		return pq.items[i].feePerKB > pq.items[j].feePerKB
+	}
+
+	return pq.items[i].priority > pq.items[j].priority
+}
+
+// configSortingFuncMap is a map of strings to sorting functions, so that they
+// may be user selected in the configuration.
+var configSortingFuncMap = map[string]func(pq *txPriorityQueue, i, j int) bool{
+	"stakethenfeethenpriority": txPQByStakeAndFeeAndThenPriority,
+	"stakethenpriority":        txPQByStakeAndPriority,
+	"stakethenfee":             txPQByStakeAndFee,
+	"smallticketpriority":      txPQByStakeSizeAndFeeAndThenPriority,
+}
+
+// configSetSortingFunc is the global sorting function as set by the
+// configuration from the user.
+var configSetSortingFunc func(pq *txPriorityQueue, i, j int) bool
 
 // newTxPriorityQueue returns a new transaction priority queue that reserves the
 // passed amount of space for the elements.  The new priority queue uses the
@@ -1247,7 +1312,7 @@ func NewBlockTemplate(policy *mining.Policy, server *server,
 	// or not there is an area allocated for high-priority transactions.
 	sourceTxns := txSource.MiningDescs()
 	sortedByFee := policy.BlockPrioritySize == 0
-	lessFunc := txPQByStakeAndFeeAndThenPriority
+	lessFunc := configSetSortingFunc
 	if sortedByFee {
 		lessFunc = txPQByStakeAndFee
 	}
@@ -1332,7 +1397,8 @@ mempoolLoop:
 		// Setup dependencies for any transactions which reference
 		// other transactions in the mempool so they can be properly
 		// ordered below.
-		prioItem := &txPrioItem{tx: txDesc.Tx, txType: txDesc.Type}
+		prioItem := &txPrioItem{tx: txDesc.Tx, txType: txDesc.Type,
+			txSize: txDesc.Tx.MsgTx().SerializeSize()}
 		for i, txIn := range tx.MsgTx().TxIn {
 			// Evaluate if this is a stakebase input or not. If it is, continue
 			// without evaluation of the input.

--- a/mining_test.go
+++ b/mining_test.go
@@ -157,17 +157,20 @@ func TestTxFeePrioHeap(t *testing.T) {
 // fee for small tickets, relative fee per ticket size, then lower
 // stake priority by relative fee per transaction size works as expected.
 func TestTxStakeSortingWithSizeHeap(t *testing.T) {
+	maxPriorityTicketSize := 2500
+	configSetTicketPrioSize = 2500
+
 	// Create some fake priority items that exercise the expected sort
 	// edge conditions.
 	testItems := []*txPrioItem{
 		{feePerKB: 5678, priority: 5, txType: stake.TxTypeSStx, txSize: 100},
-		{feePerKB: 2840, priority: 2, txType: stake.TxTypeSStx, txSize: 200}, // Higher absolute fees despite size
+		{feePerKB: 2840, priority: 2, txType: stake.TxTypeSStx, txSize: 200}, // Higher absolute fees despite relative fees
 		{feePerKB: 1234, priority: 3, txType: stake.TxTypeSStx, txSize: 3000},
 		{feePerKB: 1235, priority: 1, txType: stake.TxTypeSStx, txSize: 3000}, // Too big size, higher fee per KB
 		{feePerKB: 5678, priority: 1, txType: stake.TxTypeSSGen, txSize: 100}, // Votes go first
 		{feePerKB: 5678, priority: 1, txType: stake.TxTypeSSGen, txSize: 200},
-		{feePerKB: 1234, priority: 2, txType: stake.TxTypeSStx, txSize: 100},
-		{feePerKB: 1234, priority: 5, txType: stake.TxTypeSStx, txSize: 100},     // Higher priority ticket all else accounted for
+		{feePerKB: 1234, priority: 2, txType: stake.TxTypeRegular, txSize: 100},
+		{feePerKB: 1234, priority: 5, txType: stake.TxTypeRegular, txSize: 100},  // Higher priority ticket all else accounted for
 		{feePerKB: 10000, priority: 0, txType: stake.TxTypeRegular, txSize: 100}, // Higher fee, smaller prio
 		{feePerKB: 0, priority: 10000, txType: stake.TxTypeRegular, txSize: 100}, // Higher prio, lower fee
 	}

--- a/mining_test.go
+++ b/mining_test.go
@@ -152,6 +152,122 @@ func TestTxFeePrioHeap(t *testing.T) {
 	}
 }
 
+// TestTxStakeSortingWithSizeHeap ensures the priority queue for stake
+// transactions, sorting by stake priority, ticket relative absolute
+// fee for small tickets, relative fee per ticket size, then lower
+// stake priority by relative fee per transaction size works as expected.
+func TestTxStakeSortingWithSizeHeap(t *testing.T) {
+	// Create some fake priority items that exercise the expected sort
+	// edge conditions.
+	testItems := []*txPrioItem{
+		{feePerKB: 5678, priority: 5, txType: stake.TxTypeSStx, txSize: 100},
+		{feePerKB: 2840, priority: 2, txType: stake.TxTypeSStx, txSize: 200}, // Higher absolute fees despite size
+		{feePerKB: 1234, priority: 3, txType: stake.TxTypeSStx, txSize: 3000},
+		{feePerKB: 1235, priority: 1, txType: stake.TxTypeSStx, txSize: 3000}, // Too big size, higher fee per KB
+		{feePerKB: 5678, priority: 1, txType: stake.TxTypeSSGen, txSize: 100}, // Votes go first
+		{feePerKB: 5678, priority: 1, txType: stake.TxTypeSSGen, txSize: 200},
+		{feePerKB: 1234, priority: 2, txType: stake.TxTypeSStx, txSize: 100},
+		{feePerKB: 1234, priority: 5, txType: stake.TxTypeSStx, txSize: 100},     // Higher priority ticket all else accounted for
+		{feePerKB: 10000, priority: 0, txType: stake.TxTypeRegular, txSize: 100}, // Higher fee, smaller prio
+		{feePerKB: 0, priority: 10000, txType: stake.TxTypeRegular, txSize: 100}, // Higher prio, lower fee
+	}
+
+	// Add random data in addition to the edge conditions already manually
+	// specified.
+	randSeed := rand.Int63()
+	defer func() {
+		if t.Failed() {
+			t.Logf("Random numbers using seed: %v", randSeed)
+		}
+	}()
+	prng := rand.New(rand.NewSource(randSeed))
+	for i := 0; i < 1000; i++ {
+		testItems = append(testItems, &txPrioItem{
+			feePerKB: prng.Float64() * dcrutil.AtomsPerCoin,
+			priority: prng.Float64() * 100,
+			txSize:   prng.Intn(6000),
+		})
+	}
+	for i := range testItems {
+		// This should be scaled for kilobyte, but ignore that here for
+		// the tests.
+		testItems[i].fee = int64(testItems[i].feePerKB) *
+			int64(testItems[i].txSize)
+	}
+
+	// Make a queue and then pop items off it, checking to see if
+	// the highest item we get is also highest priority in a
+	// refactor of the actual code.
+	priorityQueue := newTxPriorityQueue(len(testItems),
+		txPQByStakeSizeAndFeeAndThenPriority)
+	for i := 0; i < len(testItems); i++ {
+		heap.Push(priorityQueue, testItems[i])
+	}
+
+	fatalError := func(where string, i, j *txPrioItem) {
+		t.Fatalf("priority sort at %s: item (fee per KB: %v, "+
+			"priority: %v, txType %v, txSize %v, fee %v) "+
+			"higher than than prev (fee per KB: %v, "+
+			"priority %v, txType %v, txSize %v, fee %v)",
+			where,
+			i.feePerKB, i.priority, i.txType,
+			i.txSize, i.fee,
+			j.feePerKB, j.priority, j.txType,
+			j.txSize, j.fee)
+	}
+
+	var highest *txPrioItem
+	for i := 0; i < len(testItems); i++ {
+		prioItem := heap.Pop(priorityQueue).(*txPrioItem)
+		if highest == nil {
+			highest = prioItem
+			continue
+		}
+
+		txTypeEqual := false
+		switch {
+		case compareStakePriority(prioItem, highest) == 1:
+			fatalError("compareStakePriority", prioItem, highest)
+		case compareStakePriority(prioItem, highest) == 0:
+			txTypeEqual = true
+		default:
+		}
+
+		txFeesEqual := false
+		if txTypeEqual {
+			bothAreLowStakePriority :=
+				txStakePriority(prioItem.txType) == regOrRevocPriority &&
+					txStakePriority(highest.txType) == regOrRevocPriority
+			bothAreTickets := txStakePriority(prioItem.txType) == ticketPriority &&
+				txStakePriority(highest.txType) == ticketPriority
+			bothAreSmall := prioItem.txSize < maxPriorityTicketSize &&
+				highest.txSize < maxPriorityTicketSize
+
+			switch {
+			case (!bothAreLowStakePriority && bothAreTickets && bothAreSmall):
+				if prioItem.fee > highest.fee {
+					fatalError("both small tickets", prioItem, highest)
+				}
+			case !bothAreLowStakePriority:
+				if prioItem.feePerKB > highest.feePerKB {
+					fatalError("not both small tickets", prioItem, highest)
+				}
+			case prioItem.feePerKB == highest.feePerKB:
+				txFeesEqual = true
+			default:
+			}
+		}
+
+		if txFeesEqual {
+			if prioItem.priority > highest.priority {
+				fatalError("priority", prioItem, highest)
+			}
+		}
+
+		highest = prioItem
+	}
+}
+
 // TestStakeTxFeePrioHeap tests the priority heaps including the stake types for
 // both transaction fees per KB and transaction priority. It ensures that the
 // primary sorting is first by stake type, and then by the latter chosen priority


### PR DESCRIPTION
The old sorting algorithm would discriminate based on fees per KB for
tickets, even when tickets were both very small.  Because of the
limitations for numbers of tickets that may be included in the block,
along with the limited size of the block, it would be wiser when the
tickets are small to simply sort based on the absolute fee.

The option was added in the configuration to allow users to set
their own mining algorithms as well as their own priority ticket size.
The new algorithm is disabled by default, and comments around caveats
for enabling it are given in the codebase.