### PR TITLE
Add getheaders JSON-RPC extension command.

### DIFF
--- a/dcrjson/chainsvrcmds.go
+++ b/dcrjson/chainsvrcmds.go
@@ -348,6 +348,21 @@ func NewGetInfoCmd() *GetInfoCmd {
 	return &GetInfoCmd{}
 }
 
+// GetHeadersCmd defines the getheaders JSON-RPC command.
+type GetHeadersCmd struct {
+	BlockLocators string `json:"blocklocators"`
+	HashStop      string `json:"hashstop"`
+}
+
+// NewGetHeadersCmd returns a new instance which can be used to issue a
+// getheaders JSON-RPC command.
+func NewGetHeadersCmd(blockLocators string, hashStop string) *GetHeadersCmd {
+	return &GetHeadersCmd{
+		BlockLocators: blockLocators,
+		HashStop:      hashStop,
+	}
+}
+
 // GetMempoolInfoCmd defines the getmempoolinfo JSON-RPC command.
 type GetMempoolInfoCmd struct{}
 
@@ -766,6 +781,7 @@ func init() {
 	MustRegisterCmd("getdifficulty", (*GetDifficultyCmd)(nil), flags)
 	MustRegisterCmd("getgenerate", (*GetGenerateCmd)(nil), flags)
 	MustRegisterCmd("gethashespersec", (*GetHashesPerSecCmd)(nil), flags)
+	MustRegisterCmd("getheaders", (*GetHeadersCmd)(nil), flags)
 	MustRegisterCmd("getinfo", (*GetInfoCmd)(nil), flags)
 	MustRegisterCmd("getmempoolinfo", (*GetMempoolInfoCmd)(nil), flags)
 	MustRegisterCmd("getmininginfo", (*GetMiningInfoCmd)(nil), flags)

--- a/dcrjson/chainsvrresults.go
+++ b/dcrjson/chainsvrresults.go
@@ -487,3 +487,9 @@ type ValidateAddressChainResult struct {
 	IsValid bool   `json:"isvalid"`
 	Address string `json:"address,omitempty"`
 }
+
+// GetHeadersResult models the data returned by the chain server getheaders
+// command.
+type GetHeadersResult struct {
+	Headers []string `json:"headers"`
+}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -51,9 +51,9 @@ import (
 
 // API version constants
 const (
-	jsonrpcSemverString = "1.0.0"
+	jsonrpcSemverString = "1.1.0"
 	jsonrpcSemverMajor  = 1
-	jsonrpcSemverMinor  = 0
+	jsonrpcSemverMinor  = 1
 	jsonrpcSemverPatch  = 0
 )
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3319,8 +3319,8 @@ func handleGetHeaders(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) 
 	}
 	// Until wire.MsgGetHeaders uses []Hash instead of the []*Hash, this
 	// conversion is necessary.  The wire protocol getheaders is (probably)
-	// called much more often than this RPC, so optimize for that and give
-	// this one the performance penality.
+	// called much more often than this RPC, so server.locateBlocks is
+	// optimized for that and this is given the performance penality.
 	pBlockLocators := make([]*chainhash.Hash, len(blockLocators))
 	for i := range blockLocators {
 		pBlockLocators[i] = &blockLocators[i]

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3351,6 +3351,7 @@ func handleGetHeaders(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) 
 				"Failed to serialize block header")
 		}
 		hexBlockHeaders[i] = hex.EncodeToString(buf.Bytes())
+		buf.Reset()
 	}
 	return &dcrjson.GetHeadersResult{Headers: hexBlockHeaders}, nil
 }

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3317,7 +3317,7 @@ func handleGetHeaders(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) 
 			}
 		}
 	}
-	// Until wire.MsgGetHeaders uses []*Hash rather than []Hash, this
+	// Until wire.MsgGetHeaders uses []Hash instead of the []*Hash, this
 	// conversion is necessary.  The wire protocol getheaders is (probably)
 	// called much more often than this RPC, so optimize for that and give
 	// this one the performance penality.

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -204,6 +204,7 @@ var rpcHandlersBeforeInit = map[string]commandHandler{
 	"getdifficulty":         handleGetDifficulty,
 	"getgenerate":           handleGetGenerate,
 	"gethashespersec":       handleGetHashesPerSec,
+	"getheaders":            handleGetHeaders,
 	"getinfo":               handleGetInfo,
 	"getmempoolinfo":        handleGetMempoolInfo,
 	"getmininginfo":         handleGetMiningInfo,
@@ -3296,6 +3297,62 @@ func handleGetGenerate(s *rpcServer, cmd interface{}, closeChan <-chan struct{})
 // handleGetHashesPerSec implements the gethashespersec command.
 func handleGetHashesPerSec(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
 	return int64(s.server.cpuMiner.HashesPerSecond()), nil
+}
+
+// handleGetHeaders implements the getheaders command.
+func handleGetHeaders(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
+	c := cmd.(*dcrjson.GetHeadersCmd)
+	blockLocators, err := dcrjson.DecodeConcatenatedHashes(c.BlockLocators)
+	if err != nil {
+		// Already a *dcrjson.RPCError
+		return nil, err
+	}
+	var hashStop chainhash.Hash
+	if c.HashStop != "" {
+		err := chainhash.Decode(&hashStop, c.HashStop)
+		if err != nil {
+			return nil, &dcrjson.RPCError{
+				Code:    dcrjson.ErrRPCInvalidParameter,
+				Message: "Failed to decode hashstop: " + err.Error(),
+			}
+		}
+	}
+	// Until wire.MsgGetHeaders uses []*Hash rather than []Hash, this
+	// conversion is necessary.  The wire protocol getheaders is (probably)
+	// called much more often than this RPC, so optimize for that and give
+	// this one the performance penality.
+	pBlockLocators := make([]*chainhash.Hash, len(blockLocators))
+	for i := range blockLocators {
+		pBlockLocators[i] = &blockLocators[i]
+	}
+	blockHashes, err := s.server.locateBlocks(pBlockLocators, &hashStop)
+	if err != nil {
+		return nil, &dcrjson.RPCError{
+			Code: dcrjson.ErrRPCDatabase,
+			Message: "Failed to fetch hashes of block " +
+				"headers: " + err.Error(),
+		}
+	}
+	blockHeaders, err := fetchHeaders(s.server.db, blockHashes)
+	if err != nil {
+		return nil, &dcrjson.RPCError{
+			Code: dcrjson.ErrRPCDatabase,
+			Message: "Failed to fetch headers of located blocks: " +
+				err.Error(),
+		}
+	}
+
+	hexBlockHeaders := make([]string, len(blockHeaders))
+	var buf bytes.Buffer
+	for _, h := range blockHeaders {
+		err := h.Serialize(&buf)
+		if err != nil {
+			return nil, internalRPCError(err.Error(),
+				"Failed to serialize block header")
+		}
+		hexBlockHeaders = append(hexBlockHeaders, hex.EncodeToString(buf.Bytes()))
+	}
+	return &dcrjson.GetHeadersResult{Headers: hexBlockHeaders}, nil
 }
 
 // handleGetInfo implements the getinfo command. We only return the fields

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3344,13 +3344,13 @@ func handleGetHeaders(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) 
 
 	hexBlockHeaders := make([]string, len(blockHeaders))
 	var buf bytes.Buffer
-	for _, h := range blockHeaders {
+	for i, h := range blockHeaders {
 		err := h.Serialize(&buf)
 		if err != nil {
 			return nil, internalRPCError(err.Error(),
 				"Failed to serialize block header")
 		}
-		hexBlockHeaders = append(hexBlockHeaders, hex.EncodeToString(buf.Bytes()))
+		hexBlockHeaders[i] = hex.EncodeToString(buf.Bytes())
 	}
 	return &dcrjson.GetHeadersResult{Headers: hexBlockHeaders}, nil
 }

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -443,7 +443,7 @@ var helpDescsEnUS = map[string]string{
 	"getheaders--synopsis":     "Returns block headers starting with the first known block hash from the request",
 	"getheaders-blocklocators": "Concatenated hashes of blocks.  Headers are returned starting from the first known hash in this list",
 	"getheaders-hashstop":      "Optional block hash to stop including block headers for",
-	"getheadersresult-headers": "Serialized block headers of all located blocks, limited to 2000 at a time",
+	"getheadersresult-headers": "Serialized block headers of all located blocks, limited to some arbitrary maximum number of hashes (currently 2000, which matches the wire protocol headers message, but this is not guaranteed)",
 
 	// GetInfoCmd help.
 	"getinfo--synopsis": "Returns a JSON object containing various state info.",

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -441,7 +441,7 @@ var helpDescsEnUS = map[string]string{
 
 	// GetHeadersCmd help.
 	"getheaders--synopsis":     "Returns block headers starting with the first known block hash from the request",
-	"getheaders-blocklocators": "Concatenated hashes of blocks.  Headers are returned starting from the first known hash in thsi list",
+	"getheaders-blocklocators": "Concatenated hashes of blocks.  Headers are returned starting from the first known hash in this list",
 	"getheaders-hashstop":      "Optional block hash to stop including block headers for",
 	"getheadersresult-headers": "Serialized block headers of all located blocks, limited to 2000 at a time",
 

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -439,6 +439,12 @@ var helpDescsEnUS = map[string]string{
 	"infowalletresult-relayfee":        "The minimum relay fee for non-free transactions in DCR/KB",
 	"infowalletresult-errors":          "Any current errors",
 
+	// GetHeadersCmd help.
+	"getheaders--synopsis":     "Returns block headers starting with the first known block hash from the request",
+	"getheaders-blocklocators": "Concatenated hashes of blocks.  Headers are returned starting from the first known hash in thsi list",
+	"getheaders-hashstop":      "Optional block hash to stop including block headers for",
+	"getheadersresult-headers": "Serialized block headers of all located blocks, limited to 2000 at a time",
+
 	// GetInfoCmd help.
 	"getinfo--synopsis": "Returns a JSON object containing various state info.",
 
@@ -848,6 +854,7 @@ var rpcResultTypes = map[string][]interface{}{
 	"getstakedifficulty":    {(*dcrjson.GetStakeDifficultyResult)(nil)},
 	"getgenerate":           {(*bool)(nil)},
 	"gethashespersec":       {(*float64)(nil)},
+	"getheaders":            {(*dcrjson.GetHeadersResult)(nil)},
 	"getinfo":               {(*dcrjson.InfoChainResult)(nil)},
 	"getmempoolinfo":        {(*dcrjson.GetMempoolInfoResult)(nil)},
 	"getmininginfo":         {(*dcrjson.GetMiningInfoResult)(nil)},

--- a/server.go
+++ b/server.go
@@ -808,57 +808,34 @@ func (sp *serverPeer) OnGetBlocks(p *peer.Peer, msg *wire.MsgGetBlocks) {
 	}
 }
 
-// OnGetHeaders is invoked when a peer receives a getheaders wire message.
-func (sp *serverPeer) OnGetHeaders(p *peer.Peer, msg *wire.MsgGetHeaders) {
-	// Ignore getheaders requests if not in sync.
-	if !sp.server.blockManager.IsCurrent() {
-		return
-	}
-
+// locateBlocks returns the hashes of the blocks after the first known block in
+// locators, until hashStop is reached, or up to a max of
+// wire.MaxBlockHeadersPerMsg block hashes.  This implements the search
+// algorithm used by getheaders.
+//
+// TODO: For efficiency this should take a []Hash, not []*Hash.  This requires
+// changing the representation of the wire.MsgGetHeaders to use a []Hash array
+// for the block locators.
+func (s *server) locateBlocks(locators []*chainhash.Hash, hashStop *chainhash.Hash) ([]chainhash.Hash, error) {
 	// Attempt to look up the height of the provided stop hash.
-	chain := sp.server.blockManager.chain
+	chain := s.blockManager.chain
 	endIdx := int64(math.MaxInt64)
-	height, err := chain.BlockHeightByHash(&msg.HashStop)
+	height, err := chain.BlockHeightByHash(hashStop)
 	if err == nil {
 		endIdx = height + 1
 	}
 
 	// There are no block locators so a specific header is being requested
 	// as identified by the stop hash.
-	if len(msg.BlockLocatorHashes) == 0 {
+	if len(locators) == 0 {
 		// No blocks with the stop hash were found so there is nothing
 		// to do.  Just return.  This behavior mirrors the reference
 		// implementation.
 		if endIdx == math.MaxInt64 {
-			return
+			return nil, nil
 		}
 
-		// Fetch the raw block header bytes from the database.
-		var headerBytes []byte
-		err := sp.server.db.View(func(dbTx database.Tx) error {
-			var err error
-			headerBytes, err = dbTx.FetchBlockHeader(&msg.HashStop)
-			return err
-		})
-		if err != nil {
-			peerLog.Warnf("Lookup of known block hash failed: %v",
-				err)
-			return
-		}
-
-		// Deserialize the block header.
-		var header wire.BlockHeader
-		err = header.Deserialize(bytes.NewReader(headerBytes))
-		if err != nil {
-			peerLog.Warnf("Block header deserialize failed: %v",
-				err)
-			return
-		}
-
-		headersMsg := wire.NewMsgHeaders()
-		headersMsg.AddBlockHeader(&header)
-		p.QueueMessage(headersMsg, nil)
-		return
+		return []chainhash.Hash{*hashStop}, nil
 	}
 
 	// Find the most recent known block based on the block locator.
@@ -867,8 +844,8 @@ func (sp *serverPeer) OnGetHeaders(p *peer.Peer, msg *wire.MsgGetHeaders) {
 	// over with the genesis block if unknown block locators are provided.
 	// This mirrors the behavior in the reference implementation.
 	startIdx := int64(1)
-	for _, hash := range msg.BlockLocatorHashes {
-		height, err := chain.BlockHeightByHash(hash)
+	for _, loc := range locators {
+		height, err := chain.BlockHeightByHash(loc)
 		if err == nil {
 			// Start with the next hash since we know this one.
 			startIdx = height + 1
@@ -876,43 +853,65 @@ func (sp *serverPeer) OnGetHeaders(p *peer.Peer, msg *wire.MsgGetHeaders) {
 		}
 	}
 
-	// Don't attempt to fetch more than we can put into a single message.
+	// Don't attempt to fetch more than we can put into a single wire
+	// message.
 	if endIdx-startIdx > wire.MaxBlockHeadersPerMsg {
 		endIdx = startIdx + wire.MaxBlockHeadersPerMsg
 	}
 
 	// Fetch the inventory from the block database.
-	hashList, err := chain.HeightRange(startIdx, endIdx)
-	if err != nil {
-		peerLog.Warnf("Header lookup failed: %v", err)
-		return
-	}
+	return chain.HeightRange(startIdx, endIdx)
+}
 
-	// Generate headers message and send it.
-	headersMsg := wire.NewMsgHeaders()
-	err = sp.server.db.View(func(dbTx database.Tx) error {
-		for i := range hashList {
-			headerBytes, err := dbTx.FetchBlockHeader(&hashList[i])
-			if err != nil {
-				return err
-			}
-
-			var header wire.BlockHeader
-			err = header.Deserialize(bytes.NewReader(headerBytes))
-			if err != nil {
-				return err
-			}
-			headersMsg.AddBlockHeader(&header)
+// fetchHeaders fetches and decodes headers from the db for each hash in
+// blockHashes.
+func fetchHeaders(db database.DB, blockHashes []chainhash.Hash) ([]*wire.BlockHeader, error) {
+	headers := make([]*wire.BlockHeader, 0, len(blockHashes))
+	err := db.View(func(dbTx database.Tx) error {
+		rawHeaders, err := dbTx.FetchBlockHeaders(blockHashes)
+		if err != nil {
+			return err
 		}
-
+		for _, headerBytes := range rawHeaders {
+			h := new(wire.BlockHeader)
+			err = h.Deserialize(bytes.NewReader(headerBytes))
+			if err != nil {
+				return err
+			}
+			headers = append(headers, h)
+		}
 		return nil
 	})
-	if err != nil {
-		peerLog.Warnf("Failed to build headers: %v", err)
+	return headers, err
+}
+
+// OnGetHeaders is invoked when a peer receives a getheaders wire message.
+func (sp *serverPeer) OnGetHeaders(p *peer.Peer, msg *wire.MsgGetHeaders) {
+	// Ignore getheaders requests if not in sync.
+	if !sp.server.blockManager.IsCurrent() {
 		return
 	}
 
-	p.QueueMessage(headersMsg, nil)
+	blockHashes, err := sp.server.locateBlocks(msg.BlockLocatorHashes,
+		&msg.HashStop)
+	if err != nil {
+		peerLog.Errorf("OnGetHeaders: failed to fetch hashes: %v", err)
+		return
+	}
+	blockHeaders, err := fetchHeaders(sp.server.db, blockHashes)
+	if err != nil {
+		peerLog.Errorf("OnGetHeaders: failed to fetch block headers: "+
+			"%v", err)
+	}
+
+	if len(blockHeaders) > wire.MaxBlockHeadersPerMsg {
+		peerLog.Warnf("OnGetHeaders: fetched more block headers than " +
+			"allowed per message")
+		// Can still recover from this error, just slice off the extra
+		// headers and continue queing the message.
+		blockHeaders = blockHeaders[:wire.MaxBlockHeaderPayload]
+	}
+	p.QueueMessage(&wire.MsgHeaders{Headers: blockHeaders}, nil)
 }
 
 // OnFilterAdd is invoked when a peer receives a filteradd wire message and is

--- a/server.go
+++ b/server.go
@@ -814,7 +814,7 @@ func (sp *serverPeer) OnGetBlocks(p *peer.Peer, msg *wire.MsgGetBlocks) {
 // algorithm used by getheaders.
 //
 // TODO: For efficiency this should take a []Hash, not []*Hash.  This requires
-// changing the representation of the wire.MsgGetHeaders to use a []Hash array
+// changing the representation of the wire.MsgGetHeaders to use a []Hash slice
 // for the block locators.
 func (s *server) locateBlocks(locators []*chainhash.Hash, hashStop *chainhash.Hash) ([]chainhash.Hash, error) {
 	// Attempt to look up the height of the provided stop hash.


### PR DESCRIPTION
This RPC is essentially a reimplementation of the wire protocol
getheaders and headers messages and is planned on being used by the
wallet to fetch block headers during startup sync.