### PR TITLE
Add vote tallying architecture

### DIFF
--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -22,7 +22,7 @@ import (
 func TestBlockchainFunctions(t *testing.T) {
 	// Create a new database and chain instance to run tests against.
 	chain, teardownFunc, err := chainSetup("validateunittests",
-		simNetParams)
+		blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("Failed to setup chain instance: %v", err)
 		return
@@ -30,7 +30,7 @@ func TestBlockchainFunctions(t *testing.T) {
 	defer teardownFunc()
 
 	// The genesis block should fail to connect since it's already inserted.
-	genesisBlock := simNetParams.GenesisBlock
+	genesisBlock := blockchain.TestSimNetParams.GenesisBlock
 	err = chain.CheckConnectBlock(dcrutil.NewBlock(genesisBlock))
 	if err == nil {
 		t.Errorf("CheckConnectBlock: Did not receive expected error")

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -27,7 +27,7 @@ const (
 
 	// currentDatabaseVersion indicates what the current database
 	// version is.
-	currentDatabaseVersion = 2
+	currentDatabaseVersion = 3
 )
 
 // errNotInMainChain signifies that a block hash or height that is not in the
@@ -1271,7 +1271,7 @@ func (b *BlockChain) createChainState() error {
 	genesisBlock := dcrutil.NewBlock(b.chainParams.GenesisBlock)
 	header := &genesisBlock.MsgBlock().Header
 	node := newBlockNode(header, genesisBlock.Sha(), 0, []chainhash.Hash{},
-		[]chainhash.Hash{})
+		[]chainhash.Hash{}, []uint16{})
 	node.inMainChain = true
 	b.bestNode = node
 
@@ -1349,7 +1349,23 @@ func (b *BlockChain) createChainState() error {
 
 		// Initialize the stake buckets in the database, along with
 		// the best state for the stake database.
-		b.bestNode.stakeNode, err = stake.InitDatabaseState(dbTx, b.chainParams)
+		b.bestNode.stakeNode, err = stake.InitTicketDatabaseState(dbTx,
+			b.chainParams)
+		if err != nil {
+			return err
+		}
+
+		// Initialize the voting tally buckets in the database, along with
+		// the best state for the voting tallies database.
+		b.bestNode.rollingTally, err = stake.InitVotingDatabaseState(dbTx,
+			b.chainParams)
+		if err != nil {
+			return err
+		}
+
+		// Load the rolling tally cache.
+		b.rollingTallyCache, err = stake.InitRollingTallyCache(dbTx,
+			b.chainParams)
 		if err != nil {
 			return err
 		}
@@ -1434,7 +1450,8 @@ func (b *BlockChain) initChainState() error {
 		header := &block.Header
 		node := newBlockNode(header, &state.hash, int64(state.height),
 			ticketsSpentInBlock(dcrutil.NewBlock(&block)),
-			ticketsRevokedInBlock(dcrutil.NewBlock(&block)))
+			ticketsRevokedInBlock(dcrutil.NewBlock(&block)),
+			voteBitsForVotersInBlock(dcrutil.NewBlock(&block)))
 		node.inMainChain = true
 		node.workSum = state.workSum
 
@@ -1449,6 +1466,24 @@ func (b *BlockChain) initChainState() error {
 			}
 			node.stakeUndoData = node.stakeNode.UndoData()
 			node.newTickets = node.stakeNode.NewTickets()
+		}
+
+		// Exception for <= version 2 blockchains: skip loading the voting
+		// tally, as the upgrade path handles ensuring this is correctly
+		// set.
+		if dbInfo.version >= 3 {
+			tally, err := stake.LoadVotingDatabaseState(dbTx)
+			if err != nil {
+				return err
+			}
+			node.rollingTally = tally
+
+			// Load the rolling tally cache.
+			b.rollingTallyCache, err = stake.InitRollingTallyCache(dbTx,
+				b.chainParams)
+			if err != nil {
+				return err
+			}
 		}
 
 		b.bestNode = node

--- a/blockchain/common.go
+++ b/blockchain/common.go
@@ -3,7 +3,11 @@ package blockchain
 import (
 	"bytes"
 	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
 	"sort"
+	"time"
 
 	"github.com/decred/dcrd/blockchain/stake"
 	"github.com/decred/dcrd/chaincfg"
@@ -13,6 +17,107 @@ import (
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrutil"
 )
+
+const (
+	// testDbType is the database backend type to use for the tests.
+	testDbType = "ffldb"
+
+	// testDbRoot is the root directory used to create all test databases.
+	testDbRoot = "testdbs_internalapi"
+
+	// blockDataNet is the expected network in the test block data.
+	blockDataNet = wire.SimNet
+)
+
+// filesExists returns whether or not the named file or directory exists.
+func fileExists(name string) bool {
+	if _, err := os.Stat(name); err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+	}
+	return true
+}
+
+// isSupportedDbType returns whether or not the passed database type is
+// currently supported.
+func isSupportedDbType(dbType string) bool {
+	supportedDrivers := database.SupportedDrivers()
+	for _, driver := range supportedDrivers {
+		if dbType == driver {
+			return true
+		}
+	}
+
+	return false
+}
+
+// chainSetup is used to create a new db and chain instance with the genesis
+// block already inserted.  In addition to the new chain instnce, it returns
+// a teardown function the caller should invoke when done testing to clean up.
+func chainSetup(dbName string, params *chaincfg.Params) (*BlockChain, func(), error) {
+	if !isSupportedDbType(testDbType) {
+		return nil, nil, fmt.Errorf("unsupported db type %v", testDbType)
+	}
+
+	// Handle memory database specially since it doesn't need the disk
+	// specific handling.
+	var db database.DB
+	var teardown func()
+	if testDbType == "memdb" {
+		ndb, err := database.Create(testDbType)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error creating db: %v", err)
+		}
+		db = ndb
+
+		// Setup a teardown function for cleaning up.  This function is
+		// returned to the caller to be invoked when it is done testing.
+		teardown = func() {
+			db.Close()
+		}
+	} else {
+		// Create the root directory for test databases.
+		if !fileExists(testDbRoot) {
+			if err := os.MkdirAll(testDbRoot, 0700); err != nil {
+				err := fmt.Errorf("unable to create test db "+
+					"root: %v", err)
+				return nil, nil, err
+			}
+		}
+
+		// Create a new database to store the accepted blocks into.
+		dbPath := filepath.Join(testDbRoot, dbName)
+		_ = os.RemoveAll(dbPath)
+		ndb, err := database.Create(testDbType, dbPath, blockDataNet)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error creating db: %v", err)
+		}
+		db = ndb
+
+		// Setup a teardown function for cleaning up.  This function is
+		// returned to the caller to be invoked when it is done testing.
+		teardown = func() {
+			db.Close()
+			os.RemoveAll(dbPath)
+			os.RemoveAll(testDbRoot)
+		}
+	}
+
+	// Create the main chain instance.
+	chain, err := New(&Config{
+		DB:          db,
+		ChainParams: params,
+	})
+
+	if err != nil {
+		teardown()
+		err := fmt.Errorf("failed to create chain instance: %v", err)
+		return nil, nil, err
+	}
+
+	return chain, teardown, nil
+}
 
 // DoStxoTest does a test on a simulated blockchain to ensure that the data
 // stored in the STXO buckets is not corrupt.
@@ -468,4 +573,263 @@ func DebugStxosData(stxs []spentTxOut) string {
 	buffer.WriteString(str)
 
 	return buffer.String()
+}
+
+// testSimNetPowLimit is the highest proof of work value a Decred block
+// can have for the simulation test network.  It is the value 2^255 - 1.
+var testSimNetPowLimit = new(big.Int).Sub(new(big.Int).Lsh(bigOne, 255), bigOne)
+
+// TestSimNetParams defines the network parameters for the simulation test Decred
+// network.  This network is similar to the normal test network except it is
+// intended for private use within a group of individuals doing simulation
+// testing.  The functionality is intended to differ in that the only nodes
+// which are specifically specified are used to create the network rather than
+// following normal discovery rules.  This is important as otherwise it would
+// just turn into another public testnet.
+var TestSimNetParams = &chaincfg.Params{
+	Name:        "simnet",
+	Net:         wire.SimNet,
+	DefaultPort: "18555",
+
+	// Chain parameters
+	GenesisBlock:             &testSimNetGenesisBlock,
+	GenesisHash:              &testSimNetGenesisHash,
+	CurrentBlockVersion:      0,
+	PowLimit:                 testSimNetPowLimit,
+	PowLimitBits:             0x207fffff,
+	ResetMinDifficulty:       false,
+	GenerateSupported:        true,
+	MaximumBlockSize:         1000000,
+	TimePerBlock:             time.Second * 1,
+	WorkDiffAlpha:            1,
+	WorkDiffWindowSize:       8,
+	WorkDiffWindows:          4,
+	TargetTimespan:           time.Second * 1 * 8, // TimePerBlock * WindowSize
+	RetargetAdjustmentFactor: 4,
+
+	// Subsidy parameters.
+	BaseSubsidy:           50000000000,
+	MulSubsidy:            100,
+	DivSubsidy:            101,
+	ReductionInterval:     128,
+	WorkRewardProportion:  6,
+	StakeRewardProportion: 3,
+	BlockTaxProportion:    1,
+
+	// Checkpoints ordered from oldest to newest.
+	Checkpoints: nil,
+
+	// Mempool parameters
+	RelayNonStdTxs: true,
+
+	// Address encoding magics
+	PubKeyAddrID:     [2]byte{0x27, 0x6f}, // starts with Sk
+	PubKeyHashAddrID: [2]byte{0x0e, 0x91}, // starts with Ss
+	PKHEdwardsAddrID: [2]byte{0x0e, 0x71}, // starts with Se
+	PKHSchnorrAddrID: [2]byte{0x0e, 0x53}, // starts with SS
+	ScriptHashAddrID: [2]byte{0x0e, 0x6c}, // starts with Sc
+	PrivateKeyID:     [2]byte{0x23, 0x07}, // starts with Ps
+
+	// BIP32 hierarchical deterministic extended key magics
+	HDPrivateKeyID: [4]byte{0x04, 0x20, 0xb9, 0x03}, // starts with sprv
+	HDPublicKeyID:  [4]byte{0x04, 0x20, 0xbd, 0x3d}, // starts with spub
+
+	// BIP44 coin type used in the hierarchical deterministic path for
+	// address generation.
+	HDCoinType: 115, // ASCII for s
+
+	// Decred PoS parameters
+	MinimumStakeDiff:      20000,
+	TicketPoolSize:        64,
+	TicketsPerBlock:       5,
+	TicketMaturity:        16,
+	TicketExpiry:          256, // 4*TicketPoolSize
+	CoinbaseMaturity:      16,
+	SStxChangeMaturity:    1,
+	TicketPoolSizeWeight:  4,
+	StakeDiffAlpha:        1,
+	StakeDiffWindowSize:   8,
+	StakeDiffWindows:      8,
+	MaxFreshStakePerBlock: 40,            // 8*TicketsPerBlock
+	StakeEnabledHeight:    16 + 16,       // CoinbaseMaturity + TicketMaturity
+	StakeValidationHeight: 16 + (64 * 2), // CoinbaseMaturity + TicketPoolSize*2
+	StakeBaseSigScript:    []byte{0xDE, 0xAD, 0xBE, 0xEF},
+
+	// Decred organization related parameters
+	//
+	// "Dev org" address is a 3-of-3 P2SH going to wallet:
+	// aardvark adroitness aardvark adroitness
+	// aardvark adroitness aardvark adroitness
+	// aardvark adroitness aardvark adroitness
+	// aardvark adroitness aardvark adroitness
+	// aardvark adroitness aardvark adroitness
+	// aardvark adroitness aardvark adroitness
+	// aardvark adroitness aardvark adroitness
+	// aardvark adroitness aardvark adroitness
+	// briefcase
+	// (seed 0x00000000000000000000000000000000000000000000000000000000000000)
+	//
+	// This same wallet owns the three ledger outputs for simnet.
+	//
+	// P2SH details for simnet dev org is below.
+	//
+	// address: Scc4ZC844nzuZCXsCFXUBXTLks2mD6psWom
+	// redeemScript: 532103e8c60c7336744c8dcc7b85c27789950fc52aa4e48f895ebbfb
+	// ac383ab893fc4c2103ff9afc246e0921e37d12e17d8296ca06a8f92a07fbe7857ed1d4
+	// f0f5d94e988f21033ed09c7fa8b83ed53e6f2c57c5fa99ed2230c0d38edf53c0340d0f
+	// c2e79c725a53ae
+	//   (3-of-3 multisig)
+	// Pubkeys used:
+	//   SkQmxbeuEFDByPoTj41TtXat8tWySVuYUQpd4fuNNyUx51tF1csSs
+	//   SkQn8ervNvAUEX5Ua3Lwjc6BAuTXRznDoDzsyxgjYqX58znY7w9e4
+	//   SkQkfkHZeBbMW8129tZ3KspEh1XBFC1btbkgzs6cjSyPbrgxzsKqk
+	//
+	OrganizationPkScript:        chaincfg.SimNetParams.OrganizationPkScript,
+	OrganizationPkScriptVersion: chaincfg.SimNetParams.OrganizationPkScriptVersion,
+	BlockOneLedger:              testBlockOneLedgerSimNet,
+}
+
+// testBlockOneLedgerSimNet is the block one output ledger for the simulation
+// network. See below under "Decred organization related parameters" for
+// information on how to spend these outputs.
+var testBlockOneLedgerSimNet = []*chaincfg.TokenPayout{
+	{Address: "Sshw6S86G2bV6W32cbc7EhtFy8f93rU6pae", Amount: 100000 * 1e8},
+	{Address: "SsjXRK6Xz6CFuBt6PugBvrkdAa4xGbcZ18w", Amount: 100000 * 1e8},
+	{Address: "SsfXiYkYkCoo31CuVQw428N6wWKus2ZEw5X", Amount: 100000 * 1e8},
+}
+
+// testSimNetGenesisHash is the hash of the first block in the block chain for the
+// simulation test network.
+var testSimNetGenesisHash = testSimNetGenesisBlock.BlockSha()
+
+// testSimNetGenesisMerkleRoot is the hash of the first transaction in the genesis
+// block for the simulation test network.  It is the same as the merkle root for
+// the main network.
+var testSimNetGenesisMerkleRoot = testGenesisMerkleRoot
+
+// testGenesisCoinbaseTxLegacy legacy is the coinbase transaction for the genesis
+// blocks for the regression test network and test network.
+var testGenesisCoinbaseTxLegacy = wire.MsgTx{
+	Version: 1,
+	TxIn: []*wire.TxIn{
+		{
+			PreviousOutPoint: wire.OutPoint{
+				Hash:  chainhash.Hash{},
+				Index: 0xffffffff,
+			},
+			SignatureScript: []byte{
+				0x04, 0xff, 0xff, 0x00, 0x1d, 0x01, 0x04, 0x45, /* |.......E| */
+				0x54, 0x68, 0x65, 0x20, 0x54, 0x69, 0x6d, 0x65, /* |The Time| */
+				0x73, 0x20, 0x30, 0x33, 0x2f, 0x4a, 0x61, 0x6e, /* |s 03/Jan| */
+				0x2f, 0x32, 0x30, 0x30, 0x39, 0x20, 0x43, 0x68, /* |/2009 Ch| */
+				0x61, 0x6e, 0x63, 0x65, 0x6c, 0x6c, 0x6f, 0x72, /* |ancellor| */
+				0x20, 0x6f, 0x6e, 0x20, 0x62, 0x72, 0x69, 0x6e, /* | on brin| */
+				0x6b, 0x20, 0x6f, 0x66, 0x20, 0x73, 0x65, 0x63, /* |k of sec|*/
+				0x6f, 0x6e, 0x64, 0x20, 0x62, 0x61, 0x69, 0x6c, /* |ond bail| */
+				0x6f, 0x75, 0x74, 0x20, 0x66, 0x6f, 0x72, 0x20, /* |out for |*/
+				0x62, 0x61, 0x6e, 0x6b, 0x73, /* |banks| */
+			},
+			Sequence: 0xffffffff,
+		},
+	},
+	TxOut: []*wire.TxOut{
+		{
+			Value: 0x00000000,
+			PkScript: []byte{
+				0x41, 0x04, 0x67, 0x8a, 0xfd, 0xb0, 0xfe, 0x55, /* |A.g....U| */
+				0x48, 0x27, 0x19, 0x67, 0xf1, 0xa6, 0x71, 0x30, /* |H'.g..q0| */
+				0xb7, 0x10, 0x5c, 0xd6, 0xa8, 0x28, 0xe0, 0x39, /* |..\..(.9| */
+				0x09, 0xa6, 0x79, 0x62, 0xe0, 0xea, 0x1f, 0x61, /* |..yb...a| */
+				0xde, 0xb6, 0x49, 0xf6, 0xbc, 0x3f, 0x4c, 0xef, /* |..I..?L.| */
+				0x38, 0xc4, 0xf3, 0x55, 0x04, 0xe5, 0x1e, 0xc1, /* |8..U....| */
+				0x12, 0xde, 0x5c, 0x38, 0x4d, 0xf7, 0xba, 0x0b, /* |..\8M...| */
+				0x8d, 0x57, 0x8a, 0x4c, 0x70, 0x2b, 0x6b, 0xf1, /* |.W.Lp+k.| */
+				0x1d, 0x5f, 0xac, /* |._.| */
+			},
+		},
+	},
+	LockTime: 0,
+	Expiry:   0,
+}
+
+// testGenesisMerkleRoot is the hash of the first transaction in the genesis block
+// for the main network.
+var testGenesisMerkleRoot = testGenesisCoinbaseTxLegacy.TxSha()
+
+var regTestGenesisCoinbaseTx = wire.MsgTx{
+	Version: 1,
+	TxIn: []*wire.TxIn{
+		{
+			PreviousOutPoint: wire.OutPoint{
+				Hash:  chainhash.Hash{},
+				Index: 0xffffffff,
+			},
+			SignatureScript: []byte{
+				0x04, 0xff, 0xff, 0x00, 0x1d, 0x01, 0x04, 0x45, /* |.......E| */
+				0x54, 0x68, 0x65, 0x20, 0x54, 0x69, 0x6d, 0x65, /* |The Time| */
+				0x73, 0x20, 0x30, 0x33, 0x2f, 0x4a, 0x61, 0x6e, /* |s 03/Jan| */
+				0x2f, 0x32, 0x30, 0x30, 0x39, 0x20, 0x43, 0x68, /* |/2009 Ch| */
+				0x61, 0x6e, 0x63, 0x65, 0x6c, 0x6c, 0x6f, 0x72, /* |ancellor| */
+				0x20, 0x6f, 0x6e, 0x20, 0x62, 0x72, 0x69, 0x6e, /* | on brin| */
+				0x6b, 0x20, 0x6f, 0x66, 0x20, 0x73, 0x65, 0x63, /* |k of sec|*/
+				0x6f, 0x6e, 0x64, 0x20, 0x62, 0x61, 0x69, 0x6c, /* |ond bail| */
+				0x6f, 0x75, 0x74, 0x20, 0x66, 0x6f, 0x72, 0x20, /* |out for |*/
+				0x62, 0x61, 0x6e, 0x6b, 0x73, /* |banks| */
+			},
+			Sequence: 0xffffffff,
+		},
+	},
+	TxOut: []*wire.TxOut{
+		{
+			Value:   0x00000000,
+			Version: 0x0000,
+			PkScript: []byte{
+				0x41, 0x04, 0x67, 0x8a, 0xfd, 0xb0, 0xfe, 0x55, /* |A.g....U| */
+				0x48, 0x27, 0x19, 0x67, 0xf1, 0xa6, 0x71, 0x30, /* |H'.g..q0| */
+				0xb7, 0x10, 0x5c, 0xd6, 0xa8, 0x28, 0xe0, 0x39, /* |..\..(.9| */
+				0x09, 0xa6, 0x79, 0x62, 0xe0, 0xea, 0x1f, 0x61, /* |..yb...a| */
+				0xde, 0xb6, 0x49, 0xf6, 0xbc, 0x3f, 0x4c, 0xef, /* |..I..?L.| */
+				0x38, 0xc4, 0xf3, 0x55, 0x04, 0xe5, 0x1e, 0xc1, /* |8..U....| */
+				0x12, 0xde, 0x5c, 0x38, 0x4d, 0xf7, 0xba, 0x0b, /* |..\8M...| */
+				0x8d, 0x57, 0x8a, 0x4c, 0x70, 0x2b, 0x6b, 0xf1, /* |.W.Lp+k.| */
+				0x1d, 0x5f, 0xac, /* |._.| */
+			},
+		},
+	},
+	LockTime: 0,
+	Expiry:   0,
+}
+
+// testSimNetGenesisBlock defines the genesis block of the block chain which serves
+// as the public transaction ledger for the simulation test network.
+var testSimNetGenesisBlock = wire.MsgBlock{
+	Header: wire.BlockHeader{
+		Version: 1,
+		PrevBlock: chainhash.Hash([chainhash.HashSize]byte{ // Make go vet happy.
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		}),
+		MerkleRoot: testSimNetGenesisMerkleRoot,
+		StakeRoot: chainhash.Hash([chainhash.HashSize]byte{ // Make go vet happy.
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		}),
+		VoteBits:    uint16(0x0000),
+		FinalState:  [6]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+		Voters:      uint16(0x0000),
+		FreshStake:  uint8(0x00),
+		Revocations: uint8(0x00),
+		Timestamp:   time.Unix(1401292357, 0), // 2009-01-08 20:54:25 -0600 CST
+		PoolSize:    uint32(0),
+		Bits:        0x207fffff, // 545259519
+		SBits:       int64(0x0000000000000000),
+		Nonce:       0x00000000,
+		Height:      uint32(0),
+	},
+	Transactions:  []*wire.MsgTx{&regTestGenesisCoinbaseTx},
+	STransactions: []*wire.MsgTx{},
 }

--- a/blockchain/common_test.go
+++ b/blockchain/common_test.go
@@ -30,7 +30,7 @@ const (
 	testDbRoot = "testdbs"
 
 	// blockDataNet is the expected network in the test block data.
-	blockDataNet = wire.MainNet
+	blockDataNet = wire.SimNet
 )
 
 // filesExists returns whether or not the named file or directory exists.

--- a/blockchain/internal/progresslog/blocklogger.go
+++ b/blockchain/internal/progresslog/blocklogger.go
@@ -46,10 +46,18 @@ func (b *BlockProgressLogger) LogBlockHeight(block, parent *dcrutil.Block) {
 	b.Lock()
 	defer b.Unlock()
 	b.receivedLogBlocks++
-	regularTxTreeValid := dcrutil.IsFlagSet16(block.MsgBlock().Header.VoteBits,
-		dcrutil.BlockValid)
-	if regularTxTreeValid {
-		b.receivedLogTx += int64(len(parent.MsgBlock().Transactions))
+
+	// When the process depends on both the parent and the current block
+	// and is staggered, provide transaction counts from the parent and
+	// the current block.  Otherwise, just use the current block.
+	if parent != nil {
+		regularTxTreeValid := dcrutil.IsFlagSet16(
+			block.MsgBlock().Header.VoteBits, dcrutil.BlockValid)
+		if regularTxTreeValid {
+			b.receivedLogTx += int64(len(parent.MsgBlock().Transactions))
+		}
+	} else {
+		b.receivedLogTx += int64(len(block.MsgBlock().Transactions))
 	}
 	b.receivedLogTx += int64(len(block.MsgBlock().STransactions))
 

--- a/blockchain/reorganization_test.go
+++ b/blockchain/reorganization_test.go
@@ -22,7 +22,7 @@ import (
 func reorgTestLong(t *testing.T) {
 	// Create a new database and chain instance to run tests against.
 	chain, teardownFunc, err := chainSetup("reorgunittest",
-		simNetParams)
+		blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("Failed to setup chain instance: %v", err)
 		return
@@ -31,7 +31,7 @@ func reorgTestLong(t *testing.T) {
 
 	// The genesis block should fail to connect since it's already
 	// inserted.
-	genesisBlock := simNetParams.GenesisBlock
+	genesisBlock := blockchain.TestSimNetParams.GenesisBlock
 	err = chain.CheckConnectBlock(dcrutil.NewBlock(genesisBlock))
 	if err == nil {
 		t.Errorf("CheckConnectBlock: Did not receive expected error")
@@ -134,7 +134,7 @@ func reorgTestLong(t *testing.T) {
 func reorgTestShort(t *testing.T) {
 	// Create a new database and chain instance to run tests against.
 	chain, teardownFunc, err := chainSetup("reorgunittest",
-		simNetParams)
+		blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("Failed to setup chain instance: %v", err)
 		return
@@ -143,7 +143,7 @@ func reorgTestShort(t *testing.T) {
 
 	// The genesis block should fail to connect since it's already
 	// inserted.
-	genesisBlock := simNetParams.GenesisBlock
+	genesisBlock := blockchain.TestSimNetParams.GenesisBlock
 	err = chain.CheckConnectBlock(dcrutil.NewBlock(genesisBlock))
 	if err == nil {
 		t.Errorf("CheckConnectBlock: Did not receive expected error")
@@ -252,7 +252,7 @@ func reorgTestShort(t *testing.T) {
 func reorgTestForced(t *testing.T) {
 	// Create a new database and chain instance to run tests against.
 	chain, teardownFunc, err := chainSetup("reorgunittest",
-		simNetParams)
+		blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("Failed to setup chain instance: %v", err)
 		return
@@ -261,7 +261,7 @@ func reorgTestForced(t *testing.T) {
 
 	// The genesis block should fail to connect since it's already
 	// inserted.
-	genesisBlock := simNetParams.GenesisBlock
+	genesisBlock := blockchain.TestSimNetParams.GenesisBlock
 	err = chain.CheckConnectBlock(dcrutil.NewBlock(genesisBlock))
 	if err == nil {
 		t.Errorf("CheckConnectBlock: Did not receive expected error")

--- a/blockchain/stake/benchmark_test.go
+++ b/blockchain/stake/benchmark_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2016 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package stake
+
+import (
+	"testing"
+
+	"github.com/decred/dcrd/chaincfg"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+)
+
+// BenchmarkHashPRNG benchmarks how long it takes to generate a random uint32
+// using the hash-based deterministic PRNG.
+func BenchmarkHashPRNG(b *testing.B) {
+	seed := chainhash.HashFuncB([]byte{0x01})
+	prng := NewHash256PRNG(seed)
+
+	for n := 0; n < b.N; n++ {
+		prng.Hash256Rand()
+	}
+}
+
+// BenchmarkFindingVerdicts benchmarks how long it takes to iterate an
+// a list of tallies and determine verdicts for the default mainnet
+// parameters.
+func BenchmarkFindingVerdicts(b *testing.B) {
+	// Set up the cache and genesis block rolling tally.
+	params := &chaincfg.MainNetParams
+	cache := make(RollingVotingPrefixTallyCache)
+	var bestTally RollingVotingPrefixTally
+	bestTally.LastIntervalBlock = BlockKey{*params.GenesisHash, 0}
+
+	// 347 intervals in blocks.
+	numBlocks := 49968
+	vbSlice := []uint16{}
+	for i := 1; i < numBlocks; i++ {
+		if int64(i) >= chaincfg.MainNetParams.StakeValidationHeight {
+			switch i % 5 {
+			case 0:
+				vbSlice = []uint16{0x6665, 0x2345, 0x9999, 0xa0a1, 0xc432}
+			case 1:
+				vbSlice = []uint16{0x6687, 0x6689, 0x66bb, 0x66bb, 0x66e1}
+			case 2:
+				vbSlice = []uint16{0x3465, 0x5565, 0x6165, 0x65b6, 0xaaaa}
+			case 3:
+				vbSlice = []uint16{0xffff, 0x0000, 0x2342, 0x6444, 0xa333}
+			case 4:
+				vbSlice = []uint16{0x231b, 0xa343, 0xff34, 0x90bb}
+			}
+		}
+
+		// Skip using the database.
+		var err error
+		bestTally, err = bestTally.ConnectBlockToTally(cache, nil,
+			chainhash.Hash{byte(i)}, chainhash.Hash{byte(i - 1)}, uint32(i),
+			vbSlice, &chaincfg.MainNetParams)
+		if err != nil {
+			b.Fatalf("failed")
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		bestTally.GenerateVotingResults(cache,
+			nil, chaincfg.MainNetParams.VotingIntervals,
+			&chaincfg.MainNetParams)
+	}
+
+}

--- a/blockchain/stake/error.go
+++ b/blockchain/stake/error.go
@@ -176,49 +176,69 @@ const (
 	// ErrUnknownTicketSpent indicates that an unknown ticket was spent by
 	// the block.
 	ErrUnknownTicketSpent
+
+	// ErrBadVotingConnectBlock indicates there was an issue with the
+	// block being connected to a rolling voting tally.
+	ErrBadVotingConnectBlock
+
+	// ErrBadVotingRemoveBlock indicates there was an issue with the
+	// block being removed from a rolling voting tally.
+	ErrBadVotingRemoveBlock
+
+	// ErrMissingTally indicates that a given voting tally for some
+	// interval period was missing from the cache or database.
+	ErrMissingTally
+
+	// ErrTallyingIntervals indicates that an invalid number of tallying
+	// intervals to sum was passed by the caller.
+	ErrTallyingIntervals
 )
 
 // Map of ErrorCode values back to their constant names for pretty printing.
 var errorCodeStrings = map[ErrorCode]string{
-	ErrSStxTooManyInputs:    "ErrSStxTooManyInputs",
-	ErrSStxTooManyOutputs:   "ErrSStxTooManyOutputs",
-	ErrSStxNoOutputs:        "ErrSStxNoOutputs",
-	ErrSStxInvalidInputs:    "ErrSStxInvalidInputs",
-	ErrSStxInvalidOutputs:   "ErrSStxInvalidOutputs",
-	ErrSStxInOutProportions: "ErrSStxInOutProportions",
-	ErrSStxBadCommitAmount:  "ErrSStxBadCommitAmount",
-	ErrSStxBadChangeAmts:    "ErrSStxBadChangeAmts",
-	ErrSStxVerifyCalcAmts:   "ErrSStxVerifyCalcAmts",
-	ErrSSGenWrongNumInputs:  "ErrSSGenWrongNumInputs",
-	ErrSSGenTooManyOutputs:  "ErrSSGenTooManyOutputs",
-	ErrSSGenNoOutputs:       "ErrSSGenNoOutputs",
-	ErrSSGenWrongIndex:      "ErrSSGenWrongIndex",
-	ErrSSGenWrongTxTree:     "ErrSSGenWrongTxTree",
-	ErrSSGenNoStakebase:     "ErrSSGenNoStakebase",
-	ErrSSGenNoReference:     "ErrSSGenNoReference",
-	ErrSSGenBadReference:    "ErrSSGenBadReference",
-	ErrSSGenNoVotePush:      "ErrSSGenNoVotePush",
-	ErrSSGenBadVotePush:     "ErrSSGenBadVotePush",
-	ErrSSGenBadGenOuts:      "ErrSSGenBadGenOuts",
-	ErrSSRtxWrongNumInputs:  "ErrSSRtxWrongNumInputs",
-	ErrSSRtxTooManyOutputs:  "ErrSSRtxTooManyOutputs",
-	ErrSSRtxNoOutputs:       "ErrSSRtxNoOutputs",
-	ErrSSRtxWrongTxTree:     "ErrSSRtxWrongTxTree",
-	ErrSSRtxBadOuts:         "ErrSSRtxBadOuts",
-	ErrVerSStxAmts:          "ErrVerSStxAmts",
-	ErrVerifyInput:          "ErrVerifyInput",
-	ErrVerifyOutType:        "ErrVerifyOutType",
-	ErrVerifyTooMuchFees:    "ErrVerifyTooMuchFees",
-	ErrVerifySpendTooMuch:   "ErrVerifySpendTooMuch",
-	ErrVerifyOutputAmt:      "ErrVerifyOutputAmt",
-	ErrVerifyOutPkhs:        "ErrVerifyOutPkhs",
-	ErrDatabaseCorrupt:      "ErrDatabaseCorrupt",
-	ErrMissingDatabaseTx:    "ErrMissingDatabaseTx",
-	ErrMemoryCorruption:     "ErrMemoryCorruption",
-	ErrFindTicketIdxs:       "ErrFindTicketIdxs",
-	ErrMissingTicket:        "ErrMissingTicket",
-	ErrDuplicateTicket:      "ErrDuplicateTicket",
-	ErrUnknownTicketSpent:   "ErrUnknownTicketSpent",
+	ErrSStxTooManyInputs:     "ErrSStxTooManyInputs",
+	ErrSStxTooManyOutputs:    "ErrSStxTooManyOutputs",
+	ErrSStxNoOutputs:         "ErrSStxNoOutputs",
+	ErrSStxInvalidInputs:     "ErrSStxInvalidInputs",
+	ErrSStxInvalidOutputs:    "ErrSStxInvalidOutputs",
+	ErrSStxInOutProportions:  "ErrSStxInOutProportions",
+	ErrSStxBadCommitAmount:   "ErrSStxBadCommitAmount",
+	ErrSStxBadChangeAmts:     "ErrSStxBadChangeAmts",
+	ErrSStxVerifyCalcAmts:    "ErrSStxVerifyCalcAmts",
+	ErrSSGenWrongNumInputs:   "ErrSSGenWrongNumInputs",
+	ErrSSGenTooManyOutputs:   "ErrSSGenTooManyOutputs",
+	ErrSSGenNoOutputs:        "ErrSSGenNoOutputs",
+	ErrSSGenWrongIndex:       "ErrSSGenWrongIndex",
+	ErrSSGenWrongTxTree:      "ErrSSGenWrongTxTree",
+	ErrSSGenNoStakebase:      "ErrSSGenNoStakebase",
+	ErrSSGenNoReference:      "ErrSSGenNoReference",
+	ErrSSGenBadReference:     "ErrSSGenBadReference",
+	ErrSSGenNoVotePush:       "ErrSSGenNoVotePush",
+	ErrSSGenBadVotePush:      "ErrSSGenBadVotePush",
+	ErrSSGenBadGenOuts:       "ErrSSGenBadGenOuts",
+	ErrSSRtxWrongNumInputs:   "ErrSSRtxWrongNumInputs",
+	ErrSSRtxTooManyOutputs:   "ErrSSRtxTooManyOutputs",
+	ErrSSRtxNoOutputs:        "ErrSSRtxNoOutputs",
+	ErrSSRtxWrongTxTree:      "ErrSSRtxWrongTxTree",
+	ErrSSRtxBadOuts:          "ErrSSRtxBadOuts",
+	ErrVerSStxAmts:           "ErrVerSStxAmts",
+	ErrVerifyInput:           "ErrVerifyInput",
+	ErrVerifyOutType:         "ErrVerifyOutType",
+	ErrVerifyTooMuchFees:     "ErrVerifyTooMuchFees",
+	ErrVerifySpendTooMuch:    "ErrVerifySpendTooMuch",
+	ErrVerifyOutputAmt:       "ErrVerifyOutputAmt",
+	ErrVerifyOutPkhs:         "ErrVerifyOutPkhs",
+	ErrDatabaseCorrupt:       "ErrDatabaseCorrupt",
+	ErrMissingDatabaseTx:     "ErrMissingDatabaseTx",
+	ErrMemoryCorruption:      "ErrMemoryCorruption",
+	ErrFindTicketIdxs:        "ErrFindTicketIdxs",
+	ErrMissingTicket:         "ErrMissingTicket",
+	ErrDuplicateTicket:       "ErrDuplicateTicket",
+	ErrUnknownTicketSpent:    "ErrUnknownTicketSpent",
+	ErrBadVotingConnectBlock: "ErrBadVotingConnectBlock",
+	ErrBadVotingRemoveBlock:  "ErrBadVotingRemoveBlock",
+	ErrMissingTally:          "ErrMissingTally",
+	ErrTallyingIntervals:     "ErrTallyingIntervals",
 }
 
 // String returns the ErrorCode as a human-readable name.

--- a/blockchain/stake/error_test.go
+++ b/blockchain/stake/error_test.go
@@ -56,6 +56,10 @@ func TestErrorCodeStringer(t *testing.T) {
 		{stake.ErrMissingTicket, "ErrMissingTicket"},
 		{stake.ErrDuplicateTicket, "ErrDuplicateTicket"},
 		{stake.ErrUnknownTicketSpent, "ErrUnknownTicketSpent"},
+		{stake.ErrBadVotingConnectBlock, "ErrBadVotingConnectBlock"},
+		{stake.ErrBadVotingRemoveBlock, "ErrBadVotingRemoveBlock"},
+		{stake.ErrMissingTally, "ErrMissingTally"},
+		{stake.ErrTallyingIntervals, "ErrTallyingIntervals"},
 		{0xffff, "Unknown ErrorCode (65535)"},
 	}
 

--- a/blockchain/stake/internal/dbnamespace/dbnamespace.go
+++ b/blockchain/stake/internal/dbnamespace/dbnamespace.go
@@ -12,13 +12,15 @@ var (
 	// fields for storage in the database.
 	ByteOrder = binary.LittleEndian
 
+	// Tickets
+
 	// StakeDbInfoBucketName is the name of the database bucket used to
 	// house a single k->v that stores global versioning and date information for
-	// the stake database.
+	// the stake ticket database.
 	StakeDbInfoBucketName = []byte("stakedbinfo")
 
 	// StakeChainStateKeyName is the name of the db key used to store the best
-	// chain state from the perspective of the stake database.
+	// chain state from the perspective of the stake ticket database.
 	StakeChainStateKeyName = []byte("stakechainstate")
 
 	// LiveTicketsBucketName is the name of the db bucket used to house the
@@ -43,4 +45,19 @@ var (
 	// list of tickets in a block added to the mainchain, so that it can be
 	// looked up later to insert new tickets into the live ticket database.
 	TicketsInBlockBucketName = []byte("ticketsinblock")
+
+	// Voting
+
+	// VotingDbInfoBucketName is the name of the database bucket used to
+	// house a single k->v that stores global versioning and date information for
+	// the stake voting database.
+	VotingDbInfoBucketName = []byte("votingdbinfo")
+
+	// VotingChainStateKeyName is the name of the db key used to store the best
+	// chain state from the perspective of the stake voting database.
+	VotingChainStateKeyName = []byte("votingstakechainstate")
+
+	// IntervalBlockTallyBucket is the name of the db bucket used to house the
+	// rolling vote tallies for interval blocks in the tallying system.
+	IntervalBlockTallyBucketName = []byte("intervalblktally")
 )

--- a/blockchain/stake/internal/ticketdb/chainio.go
+++ b/blockchain/stake/internal/ticketdb/chainio.go
@@ -174,7 +174,7 @@ func DbPutDatabaseInfo(dbTx database.Tx, dbi *DatabaseInfo) error {
 func deserializeDatabaseInfo(dbInfoBytes []byte) (*DatabaseInfo, error) {
 	if len(dbInfoBytes) < databaseInfoSize {
 		return nil, ticketDBError(ErrDatabaseInfoShortRead,
-			"short read when deserializing best chain state data")
+			"short read when deserializing ticket database info")
 	}
 
 	rawVersion := dbnamespace.ByteOrder.Uint32(dbInfoBytes[0:4])
@@ -202,7 +202,8 @@ func DbFetchDatabaseInfo(dbTx database.Tx) (*DatabaseInfo, error) {
 
 	dbInfoBytes := bucket.Get(dbnamespace.StakeDbInfoBucketName)
 	if dbInfoBytes == nil {
-		return nil, ticketDBError(ErrMissingKey, "missing key for database info")
+		return nil, ticketDBError(ErrMissingKey, "missing key for ticket "+
+			"database info")
 	}
 
 	return deserializeDatabaseInfo(dbInfoBytes)

--- a/blockchain/stake/internal/ticketdb/chainio_test.go
+++ b/blockchain/stake/internal/ticketdb/chainio_test.go
@@ -1,4 +1,7 @@
-// chainio_test.go
+// Copyright (c) 2016 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
 package ticketdb
 
 import (

--- a/blockchain/stake/internal/votingdb/chainio.go
+++ b/blockchain/stake/internal/votingdb/chainio.go
@@ -1,0 +1,286 @@
+// Copyright (c) 2016 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package votingdb
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/decred/dcrd/blockchain/stake/internal/dbnamespace"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/database"
+)
+
+const (
+	// upgradeStartedBit if the bit flag for whether or not a database
+	// upgrade is in progress. It is used to determine if the database
+	// is in an inconsistent state from the update.
+	upgradeStartedBit = 0x80000000
+
+	// currentDatabaseVersion indicates what the current database
+	// version is.
+	currentDatabaseVersion = 1
+)
+
+// databaseInfoSize is the serialized size of the best chain state in bytes.
+const databaseInfoSize = 8
+
+// DatabaseInfo is the structure for a database.
+type DatabaseInfo struct {
+	Version        uint32
+	Date           time.Time
+	UpgradeStarted bool
+}
+
+// serializeDatabaseInfo serializes a database information struct.
+func serializeDatabaseInfo(dbi *DatabaseInfo) []byte {
+	version := dbi.Version
+	if dbi.UpgradeStarted {
+		version |= upgradeStartedBit
+	}
+
+	val := make([]byte, databaseInfoSize)
+	versionBytes := make([]byte, 4)
+	dbnamespace.ByteOrder.PutUint32(versionBytes, version)
+	copy(val[0:4], versionBytes)
+	timestampBytes := make([]byte, 4)
+	dbnamespace.ByteOrder.PutUint32(timestampBytes, uint32(dbi.Date.Unix()))
+	copy(val[4:8], timestampBytes)
+
+	return val
+}
+
+// DbPutDatabaseInfo uses an existing database transaction to store the database
+// information.
+func DbPutDatabaseInfo(dbTx database.Tx, dbi *DatabaseInfo) error {
+	meta := dbTx.Metadata()
+	subsidyBucket := meta.Bucket(dbnamespace.VotingDbInfoBucketName)
+	val := serializeDatabaseInfo(dbi)
+
+	// Store the current database info into the database.
+	return subsidyBucket.Put(dbnamespace.VotingDbInfoBucketName, val[:])
+}
+
+// deserializeDatabaseInfo deserializes a database information struct.
+func deserializeDatabaseInfo(dbInfoBytes []byte) (*DatabaseInfo, error) {
+	if len(dbInfoBytes) < databaseInfoSize {
+		return nil, votingDBError(ErrDatabaseInfoShortRead,
+			"short read when deserializing voting database info")
+	}
+
+	rawVersion := dbnamespace.ByteOrder.Uint32(dbInfoBytes[0:4])
+	upgradeStarted := (upgradeStartedBit & rawVersion) > 0
+	version := rawVersion &^ upgradeStartedBit
+	ts := dbnamespace.ByteOrder.Uint32(dbInfoBytes[4:8])
+
+	return &DatabaseInfo{
+		Version:        version,
+		Date:           time.Unix(int64(ts), 0),
+		UpgradeStarted: upgradeStarted,
+	}, nil
+}
+
+// DbFetchDatabaseInfo uses an existing database transaction to
+// fetch the database versioning and creation information.
+func DbFetchDatabaseInfo(dbTx database.Tx) (*DatabaseInfo, error) {
+	meta := dbTx.Metadata()
+	bucket := meta.Bucket(dbnamespace.VotingDbInfoBucketName)
+
+	// Uninitialized state.
+	if bucket == nil {
+		return nil, nil
+	}
+
+	dbInfoBytes := bucket.Get(dbnamespace.VotingDbInfoBucketName)
+	if dbInfoBytes == nil {
+		return nil, votingDBError(ErrMissingKey, "missing key for voting "+
+			"database info")
+	}
+
+	return deserializeDatabaseInfo(dbInfoBytes)
+}
+
+// -----------------------------------------------------------------------------
+// The best chain state consists of the best block hash and height, the best
+// block tally, and the tally of the previous interval block.
+//
+// The serialized format is:
+//
+//   <block hash><block height><current tally><last interval tally>
+//
+//   Field                Type              Size
+//   block hash           chainhash.Hash    chainhash.HashSize
+//   block height         uint32            4 bytes
+//   current tally        []byte            100 bytes (preserialized)
+// -----------------------------------------------------------------------------
+
+// minimumBestChainStateSize is the minimum serialized size of the best chain
+// state in bytes.
+var minimumBestChainStateSize = chainhash.HashSize + 4 + 100
+
+// BestChainState represents the data to be stored the database for the current
+// best chain state.
+type BestChainState struct {
+	Hash         chainhash.Hash
+	Height       uint32
+	CurrentTally []byte
+}
+
+// serializeBestChainState returns the serialization of the passed block best
+// chain state.  This is data to be stored in the chain state bucket. This
+// function will panic if the number of tickets per block is less than the
+// size of next winners, which should never happen unless there is memory
+// corruption.
+func serializeBestChainState(state BestChainState) []byte {
+	// Serialize the chain state.
+	serializedData := make([]byte, minimumBestChainStateSize)
+
+	offset := 0
+	copy(serializedData[offset:offset+chainhash.HashSize], state.Hash[:])
+	offset += chainhash.HashSize
+	dbnamespace.ByteOrder.PutUint32(serializedData[offset:], state.Height)
+	offset += 4
+
+	// Serialize the tallies.
+	copy(serializedData[offset:], state.CurrentTally[:])
+	offset += 100
+
+	return serializedData[:]
+}
+
+// deserializeBestChainState deserializes the passed serialized best chain
+// state.  This is data stored in the chain state bucket and is updated after
+// every block is connected or disconnected form the main chain.
+// block.
+func deserializeBestChainState(serializedData []byte) (BestChainState, error) {
+	// Ensure the serialized data has enough bytes to properly deserialize
+	// the state.
+	if len(serializedData) < minimumBestChainStateSize {
+		return BestChainState{}, votingDBError(ErrChainStateShortRead,
+			"short read when deserializing best chain voting state data")
+	}
+
+	state := BestChainState{}
+	offset := 0
+	copy(state.Hash[:], serializedData[offset:offset+chainhash.HashSize])
+	offset += chainhash.HashSize
+	state.Height = dbnamespace.ByteOrder.Uint32(serializedData[offset : offset+4])
+	offset += 4
+	state.CurrentTally = make([]byte, 100)
+	copy(state.CurrentTally[:], serializedData[offset:])
+	offset += 100
+
+	return state, nil
+}
+
+// DbFetchBestState uses an existing database transaction to fetch the best chain
+// state.
+func DbFetchBestState(dbTx database.Tx) (BestChainState, error) {
+	meta := dbTx.Metadata()
+	v := meta.Get(dbnamespace.VotingChainStateKeyName)
+	if v == nil {
+		return BestChainState{}, votingDBError(ErrMissingKey,
+			"missing key for chain state data")
+	}
+
+	return deserializeBestChainState(v)
+}
+
+// DbPutBestState uses an existing database transaction to update the best chain
+// state with the given parameters.
+func DbPutBestState(dbTx database.Tx, bcs BestChainState) error {
+	// Serialize the current best chain state.
+	serializedData := serializeBestChainState(bcs)
+
+	// Store the current best chain state into the database.
+	return dbTx.Metadata().Put(dbnamespace.VotingChainStateKeyName,
+		serializedData)
+}
+
+// DbFetchBlockTally fetches an interval block's tally from the voting database.
+func DbFetchBlockTally(dbTx database.Tx, blockKey []byte) ([]byte, error) {
+	meta := dbTx.Metadata()
+	bucket := meta.Bucket(dbnamespace.IntervalBlockTallyBucketName)
+
+	v := bucket.Get(blockKey[:])
+	if v == nil {
+		return nil, votingDBError(ErrMissingKey,
+			fmt.Sprintf("missing key %x for db tally", blockKey))
+	}
+
+	if len(v) < 100 {
+		return nil, votingDBError(ErrTallyShortRead,
+			fmt.Sprintf("short read of db tally data (got %v, min %v)",
+				len(v), 100))
+	}
+	serialized := make([]byte, 100)
+	copy(serialized[:], v[:])
+
+	return serialized, nil
+}
+
+// DbPutBlockTally inserts an interval block's tally into the voting database.
+func DbPutBlockTally(dbTx database.Tx, key, serializedTally []byte) error {
+	meta := dbTx.Metadata()
+	bucket := meta.Bucket(dbnamespace.IntervalBlockTallyBucketName)
+	if len(key) < 36 {
+		return votingDBError(ErrBlockKeyShortRead, fmt.Sprintf("block key "+
+			"short read (got %v, min %v)", len(key), 36))
+	}
+	if len(serializedTally) < 100 {
+		return votingDBError(ErrTallyShortRead, fmt.Sprintf("tally "+
+			"short read (got %v, min %v)", len(serializedTally), 100))
+	}
+
+	return bucket.Put(key[:], serializedTally[:])
+}
+
+// DbDeleteBlockTally deletes an interval block's tally from the voting database.
+func DbDeleteBlockTally(dbTx database.Tx, key []byte) error {
+	meta := dbTx.Metadata()
+	bucket := meta.Bucket(dbnamespace.IntervalBlockTallyBucketName)
+	if len(key) < 36 {
+		return votingDBError(ErrBlockKeyShortRead, fmt.Sprintf("block key "+
+			"short read (got %v, min %v)", len(key), 36))
+	}
+	v := bucket.Get(key[:])
+	if v == nil {
+		return votingDBError(ErrMissingKey,
+			fmt.Sprintf("missing key %x for db tally", key))
+	}
+
+	return bucket.Delete(key[:])
+}
+
+// DbCreate initializes all the buckets required for the database and stores
+// the current database version information.
+func DbCreate(dbTx database.Tx) error {
+	meta := dbTx.Metadata()
+
+	// Create the bucket that houses information about the database's
+	// creation and version.
+	_, err := meta.CreateBucket(dbnamespace.VotingDbInfoBucketName)
+	if err != nil {
+		return err
+	}
+
+	dbInfo := &DatabaseInfo{
+		Version:        currentDatabaseVersion,
+		Date:           time.Now(),
+		UpgradeStarted: false,
+	}
+	err = DbPutDatabaseInfo(dbTx, dbInfo)
+	if err != nil {
+		return err
+	}
+
+	// Create the bucket that houses the live tickets of the best node.
+	_, err = meta.CreateBucket(dbnamespace.IntervalBlockTallyBucketName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/blockchain/stake/internal/votingdb/chainio_test.go
+++ b/blockchain/stake/internal/votingdb/chainio_test.go
@@ -1,0 +1,347 @@
+// Copyright (c) 2016 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package votingdb
+
+import (
+	"bytes"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/decred/dcrd/chaincfg"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/database"
+	_ "github.com/decred/dcrd/database/ffldb"
+)
+
+const (
+	// testDbType is the database backend type to use for the tests.
+	testDbType = "ffldb"
+
+	// testDbRoot is the root directory used to create all test databases.
+	testDbRoot = "testdbs"
+)
+
+// hexToBytes converts a hex string to bytes, without returning any errors.
+func hexToBytes(s string) []byte {
+	b, _ := hex.DecodeString(s)
+
+	return b
+}
+
+// newShaHashFromStr converts a 64 character hex string to a chainhash.Hash.
+func newShaHashFromStr(s string) *chainhash.Hash {
+	h, _ := chainhash.NewHashFromStr(s)
+
+	return h
+}
+
+// TestDatabaseInfoSerialization ensures serializing and deserializing the
+// database version information works as expected.
+func TestDatabaseInfoSerialization(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		info       DatabaseInfo
+		serialized []byte
+	}{
+		{
+			name: "not upgrade",
+			info: DatabaseInfo{
+				Version:        currentDatabaseVersion,
+				Date:           time.Unix(int64(0x57acca95), 0),
+				UpgradeStarted: false,
+			},
+			serialized: hexToBytes("0100000095caac57"),
+		},
+		{
+			name: "upgrade",
+			info: DatabaseInfo{
+				Version:        currentDatabaseVersion,
+				Date:           time.Unix(int64(0x57acca95), 0),
+				UpgradeStarted: true,
+			},
+			serialized: hexToBytes("0100008095caac57"),
+		},
+	}
+
+	for i, test := range tests {
+		// Ensure the state serializes to the expected value.
+		gotBytes := serializeDatabaseInfo(&test.info)
+		if !bytes.Equal(gotBytes, test.serialized) {
+			t.Errorf("serializeDatabaseInfo #%d (%s): mismatched "+
+				"bytes - got %x, want %x", i, test.name,
+				gotBytes, test.serialized)
+			continue
+		}
+
+		// Ensure the serialized bytes are decoded back to the expected
+		// state.
+		info, err := deserializeDatabaseInfo(test.serialized)
+		if err != nil {
+			t.Errorf("deserializeDatabaseInfo #%d (%s) "+
+				"unexpected error: %v", i, test.name, err)
+			continue
+		}
+		if !reflect.DeepEqual(info, &test.info) {
+			t.Errorf("deserializeDatabaseInfo #%d (%s) "+
+				"mismatched state - got %v, want %v", i,
+				test.name, info, test.info)
+			continue
+		}
+	}
+}
+
+// TestDbInfoDeserializeErrors performs negative tests against
+// deserializing the database information to ensure error paths
+// work as expected.
+func TestDbInfoDeserializeErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		serialized []byte
+		errCode    ErrorCode
+	}{
+		{
+			name:       "short read",
+			serialized: hexToBytes("0000"),
+			errCode:    ErrDatabaseInfoShortRead,
+		},
+	}
+
+	for _, test := range tests {
+		// Ensure the expected error type is returned.
+		_, err := deserializeDatabaseInfo(test.serialized)
+		ticketDBErr, ok := err.(DBError)
+		if !ok {
+			t.Errorf("couldn't convert deserializeDatabaseInfo error "+
+				"to ticket db error (err: %v)", err)
+			continue
+		}
+		if ticketDBErr.GetCode() != test.errCode {
+			t.Errorf("deserializeDatabaseInfo (%s): expected error type "+
+				"does not match - got %v, want %v", test.name,
+				ticketDBErr.ErrorCode, test.errCode)
+			continue
+		}
+	}
+}
+
+// TestBestChainStateSerialization ensures serializing and deserializing the
+// best chain state works as expected.
+func TestBestChainStateSerialization(t *testing.T) {
+	t.Parallel()
+
+	currentTally := make([]byte, 100)
+	currentTally[0] = 0xFF
+
+	tests := []struct {
+		name       string
+		state      BestChainState
+		serialized []byte
+	}{
+		{
+			name: "generic block",
+			state: BestChainState{
+				Hash:         *newShaHashFromStr("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
+				Height:       12323,
+				CurrentTally: currentTally,
+			},
+			serialized: hexToBytes("6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d619000000000023300000ff000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"),
+		},
+	}
+
+	for i, test := range tests {
+		// Ensure the state serializes to the expected value.
+		gotBytes := serializeBestChainState(test.state)
+		if !bytes.Equal(gotBytes, test.serialized) {
+			t.Errorf("serializeBestChainState #%d (%s): mismatched "+
+				"bytes - got %x, want %x", i, test.name,
+				gotBytes, test.serialized)
+			continue
+		}
+
+		// Ensure the serialized bytes are decoded back to the expected
+		// state.
+		state, err := deserializeBestChainState(test.serialized)
+		if err != nil {
+			t.Errorf("deserializeBestChainState #%d (%s) "+
+				"unexpected error: %v", i, test.name, err)
+			continue
+		}
+		if !reflect.DeepEqual(state, test.state) {
+			t.Errorf("deserializeBestChainState #%d (%s) "+
+				"mismatched state - got %v, want %v", i,
+				test.name, state, test.state)
+			continue
+
+		}
+	}
+}
+
+// TestBestChainStateDeserializeErrors performs negative tests against
+// deserializing the chain state to ensure error paths work as expected.
+func TestBestChainStateDeserializeErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		serialized []byte
+		errCode    ErrorCode
+	}{
+		{
+			name:       "short read",
+			serialized: hexToBytes("0000"),
+			errCode:    ErrChainStateShortRead,
+		},
+	}
+
+	for _, test := range tests {
+		// Ensure the expected error type is returned.
+		_, err := deserializeBestChainState(test.serialized)
+		ticketDBErr, ok := err.(DBError)
+		if !ok {
+			t.Errorf("couldn't convert deserializeBestChainState error "+
+				"to ticket db error (err: %v)", err)
+			continue
+		}
+		if ticketDBErr.GetCode() != test.errCode {
+			t.Errorf("deserializeBestChainState (%s): expected error type "+
+				"does not match - got %v, want %v", test.name,
+				ticketDBErr.ErrorCode, test.errCode)
+			continue
+		}
+	}
+}
+
+// TestLiveDatabase tests various functions that require a live database.
+func TestLiveDatabase(t *testing.T) {
+	// Create a new database to store the accepted stake node data into.
+	dbName := "ffldb_ticketdb_test"
+	dbPath := filepath.Join(testDbRoot, dbName)
+	_ = os.RemoveAll(dbPath)
+	testDb, err := database.Create(testDbType, dbPath, chaincfg.SimNetParams.Net)
+	if err != nil {
+		t.Fatalf("error creating db: %v", err)
+	}
+
+	// Setup a teardown.
+	defer os.RemoveAll(dbPath)
+	defer os.RemoveAll(testDbRoot)
+	defer testDb.Close()
+
+	// Initialize the database, then try to read the version.
+	err = testDb.Update(func(dbTx database.Tx) error {
+		return DbCreate(dbTx)
+	})
+	if err != nil {
+		t.Fatalf("%v", err.Error())
+	}
+
+	var dbi *DatabaseInfo
+	err = testDb.View(func(dbTx database.Tx) error {
+		dbi, err = DbFetchDatabaseInfo(dbTx)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("%v", err.Error())
+	}
+	if dbi.Version != currentDatabaseVersion {
+		t.Fatalf("bad version after reading from DB; want %v, got %v",
+			currentDatabaseVersion, dbi.Version)
+	}
+
+	// Test storing some tally data.
+	keys := make([][36]byte, 10)
+	tallies := make([][100]byte, 10)
+	for i := 0; i < 10; i++ {
+		keys[i][0] = byte(i + 10)
+		tallies[i][36] = byte(i + 20)
+	}
+
+	// Test put tallies.
+	err = testDb.Update(func(dbTx database.Tx) error {
+		for i := 0; i < 10; i++ {
+			err = DbPutBlockTally(dbTx, keys[i][:], tallies[i][:])
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("%v", err.Error())
+	}
+
+	// Test fetch tallies.
+	talliesRead := make([][100]byte, 10)
+	err = testDb.View(func(dbTx database.Tx) error {
+		for i := 0; i < 10; i++ {
+			tally, err := DbFetchBlockTally(dbTx, keys[i][0:36])
+			if err != nil {
+				return err
+			}
+
+			copy(talliesRead[i][:], tally[:])
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("%v", err.Error())
+	}
+
+	if !reflect.DeepEqual(tallies, talliesRead) {
+		t.Errorf("failed to read stored tallies from database: stored %v, "+
+			"read %v", tallies, talliesRead)
+	}
+
+	// Test put best state.
+	best := BestChainState{
+		Hash:         chainhash.Hash{0xff},
+		Height:       55555,
+		CurrentTally: tallies[0][:],
+	}
+	err = testDb.Update(func(dbTx database.Tx) error {
+		err = DbPutBestState(dbTx, best)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("%v", err.Error())
+	}
+
+	// Test read best state.
+	var bestRead BestChainState
+	err = testDb.View(func(dbTx database.Tx) error {
+		bestRead, err = DbFetchBestState(dbTx)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("%v", err.Error())
+	}
+
+	if !reflect.DeepEqual(best, bestRead) {
+		t.Errorf("failed to read stored best state from database: stored %v, "+
+			"read %v", best, bestRead)
+	}
+}

--- a/blockchain/stake/internal/votingdb/error.go
+++ b/blockchain/stake/internal/votingdb/error.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package ticketdb
+package votingdb
 
 import (
 	"fmt"
@@ -13,25 +13,9 @@ type ErrorCode int
 
 // These constants are used to identify a specific RuleError.
 const (
-	// ErrUndoDataShortRead indicates that the given undo serialized data
-	// was took small.
-	ErrUndoDataShortRead = iota
-
-	// ErrUndoDataNoEntries indicates that the data for undoing ticket data
-	// in a serialized entry was corrupt.
-	ErrUndoDataCorrupt
-
-	// ErrTicketHashesShortRead indicates that the given ticket hashes
-	// serialized data was took small.
-	ErrTicketHashesShortRead
-
-	// ErrTicketHashesCorrupt indicates that the data for ticket hashes
-	// in a serialized entry was corrupt.
-	ErrTicketHashesCorrupt
-
 	// ErrUninitializedBucket indicates that a database bucket was not
 	// initialized and therefore could not be written to or read from.
-	ErrUninitializedBucket
+	ErrUninitializedBucket = iota
 
 	// ErrMissingKey indicates that a key was not found in a bucket.
 	ErrMissingKey
@@ -44,22 +28,23 @@ const (
 	// was too small.
 	ErrDatabaseInfoShortRead
 
-	// ErrLoadAllTickets indicates that there was an error loading the tickets
-	// from the database, presumably at startup.
-	ErrLoadAllTickets
+	// ErrTallyShortRead indicates that the given voting tally information
+	// was too small.
+	ErrTallyShortRead
+
+	// ErrBlockKeyShortRead indicates that the given voting block key
+	// was too small.
+	ErrBlockKeyShortRead
 )
 
 // Map of ErrorCode values back to their constant names for pretty printing.
 var errorCodeStrings = map[ErrorCode]string{
-	ErrUndoDataShortRead:     "ErrUndoDataShortRead",
-	ErrUndoDataCorrupt:       "ErrUndoDataCorrupt",
-	ErrTicketHashesShortRead: "ErrTicketHashesShortRead",
-	ErrTicketHashesCorrupt:   "ErrTicketHashesCorrupt",
 	ErrUninitializedBucket:   "ErrUninitializedBucket",
 	ErrMissingKey:            "ErrMissingKey",
 	ErrChainStateShortRead:   "ErrChainStateShortRead",
 	ErrDatabaseInfoShortRead: "ErrDatabaseInfoShortRead",
-	ErrLoadAllTickets:        "ErrLoadAllTickets",
+	ErrTallyShortRead:        "ErrTallyShortRead",
+	ErrBlockKeyShortRead:     "ErrBlockKeyShortRead",
 }
 
 // String returns the ErrorCode as a human-readable name.
@@ -89,7 +74,7 @@ func (e DBError) GetCode() ErrorCode {
 	return e.ErrorCode
 }
 
-// ticketDBError creates a DBError given a set of arguments.
-func ticketDBError(c ErrorCode, desc string) DBError {
+// votingDBError creates a DBError given a set of arguments.
+func votingDBError(c ErrorCode, desc string) DBError {
 	return DBError{ErrorCode: c, Description: desc}
 }

--- a/blockchain/stake/internal/votingdb/error_test.go
+++ b/blockchain/stake/internal/votingdb/error_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2014 Conformal Systems LLC.
+// Copyright (c) 2015-2016 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package votingdb_test
+
+import (
+	"testing"
+
+	"github.com/decred/dcrd/blockchain/stake/internal/votingdb"
+)
+
+// TestErrorCodeStringer tests the stringized output for the ErrorCode type.
+func TestErrorCodeStringer(t *testing.T) {
+	tests := []struct {
+		in   votingdb.ErrorCode
+		want string
+	}{
+		{votingdb.ErrUninitializedBucket, "ErrUninitializedBucket"},
+		{votingdb.ErrMissingKey, "ErrMissingKey"},
+		{votingdb.ErrChainStateShortRead, "ErrChainStateShortRead"},
+		{votingdb.ErrDatabaseInfoShortRead, "ErrDatabaseInfoShortRead"},
+		{votingdb.ErrTallyShortRead, "ErrTallyShortRead"},
+		{votingdb.ErrBlockKeyShortRead, "ErrBlockKeyShortRead"},
+		{0xffff, "Unknown ErrorCode (65535)"},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		result := test.in.String()
+		if result != test.want {
+			t.Errorf("String #%d\n got: %s want: %s", i, result,
+				test.want)
+			continue
+		}
+	}
+}
+
+// TestRuleError tests the error output for the RuleError type.
+func TestRuleError(t *testing.T) {
+	tests := []struct {
+		in   votingdb.DBError
+		want string
+	}{
+		{votingdb.DBError{Description: "duplicate block"},
+			"duplicate block",
+		},
+		{votingdb.DBError{Description: "human-readable error"},
+			"human-readable error",
+		},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		result := test.in.Error()
+		if result != test.want {
+			t.Errorf("Error #%d\n got: %s want: %s", i, result,
+				test.want)
+			continue
+		}
+	}
+}

--- a/blockchain/stake/lottery_test.go
+++ b/blockchain/stake/lottery_test.go
@@ -235,12 +235,3 @@ func TestTicketSorting(t *testing.T) {
 		t.Errorf("bucket sort failed to sort to the same slice as global sort")
 	}
 }
-
-func BenchmarkHashPRNG(b *testing.B) {
-	seed := chainhash.HashFuncB([]byte{0x01})
-	prng := NewHash256PRNG(seed)
-
-	for n := 0; n < b.N; n++ {
-		prng.Hash256Rand()
-	}
-}

--- a/blockchain/stake/tickets_test.go
+++ b/blockchain/stake/tickets_test.go
@@ -615,7 +615,7 @@ func TestTicketDBGeneral(t *testing.T) {
 	var bestNode *Node
 	err = testDb.Update(func(dbTx database.Tx) error {
 		var errLocal error
-		bestNode, errLocal = InitDatabaseState(dbTx, simNetParams)
+		bestNode, errLocal = InitTicketDatabaseState(dbTx, simNetParams)
 		if errLocal != nil {
 			return errLocal
 		}

--- a/blockchain/stake/voting.go
+++ b/blockchain/stake/voting.go
@@ -1,0 +1,955 @@
+// Copyright (c) 2016 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package stake
+
+import (
+	"fmt"
+
+	"github.com/decred/dcrd/blockchain/stake/internal/dbnamespace"
+	"github.com/decred/dcrd/blockchain/stake/internal/votingdb"
+	"github.com/decred/dcrd/chaincfg"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/database"
+)
+
+// IssueVote is the state of a vote on a given issue as indicated in the vote's
+// vote bits.  The mandatory vote bits, a little endian uint16, are organized as
+// follows:
+//
+//   Bits     Description
+//      0     Previous block is valid (boolean)
+//      1     Undefined (boolean)
+//    2-3     First issue (IssueVote)
+//    4-5     Second issue (IssueVote)
+//    6-7     Third issue (IssueVote)
+//        ...
+//  14-15     Seventh issue
+//
+type IssueVote uint8
+
+const (
+	// IssueVoteUndefined is what the votebits for this IssueVote should
+	// be set to when the issue state is formally undefined.
+	IssueVoteUndefined = 0 // 00
+
+	// IssueVoteYes indicates a YES vote for this issue.
+	IssueVoteYes = 1 // 01
+
+	// IssueVoteNo indications a NO vote for this issue.
+	IssueVoteNo = 2 // 10
+
+	// IssueVoteAbstain indications abstaining from voting on this issue.
+	IssueVoteAbstain = 3 // 11
+
+	// issuesLen is the number of issues that can be represented by the
+	// 14 remaining bits of vote bits.
+	issuesLen = 7
+)
+
+// String satisfies the stringer interface for IssueVote.
+func (i IssueVote) String() string {
+	switch i {
+	case IssueVoteUndefined:
+		return "undefined"
+	case IssueVoteYes:
+		return "yes"
+	case IssueVoteNo:
+		return "no"
+	case IssueVoteAbstain:
+		return "abstain"
+	}
+
+	return "error (unknown issue vote type)"
+}
+
+// DecodedVoteBitsPrefix represents the structure of decoded vote bits for the
+// passed vote bits.
+type DecodedVoteBitsPrefix struct {
+	BlockValid bool
+	Unused     bool
+	Issues     [issuesLen]IssueVote
+}
+
+// rotateLeft performs to a bitwise rotation left on a passed uint16.
+func rotateLeft(value uint16, count uint16) uint16 {
+	return (value << count) | (value >> (16 - count))
+}
+
+// DecodeVoteBitsPrefix decodes the passed 16 vote bits into their decoded
+// big endian structure for subsequent use in tallying or examination.
+func EncodeVoteBitsPrefix(voteBits DecodedVoteBitsPrefix) uint16 {
+	var val uint16
+
+	// Issues.
+	for i := 6; i >= 0; i-- {
+		// Set the issue and bitshift it to the left.
+		val += uint16(voteBits.Issues[i])
+		val <<= 2
+	}
+
+	// First two bits.
+	if voteBits.BlockValid {
+		val |= 0x0001 // set 0000 ... 0001
+	}
+	if voteBits.Unused {
+		val |= 0x0002 // set 0000 ... 0010
+	}
+
+	return val
+}
+
+// DecodeVoteBitsPrefix decodes the passed 16 vote bits into their decoded
+// big endian structure for subsequent use in tallying or examination.
+func DecodeVoteBitsPrefix(voteBits uint16) DecodedVoteBitsPrefix {
+	var dvbs DecodedVoteBitsPrefix
+
+	// First two bits.
+	dvbs.BlockValid = voteBits&0x0001 != 0 // b & 0000 ... 0001
+	dvbs.Unused = voteBits&0x0002 != 0     // b & 0000 ... 0010
+
+	// Issues.
+	mask := uint16(0x0003) // 0000 ... 0011
+	for i := uint16(0); i < issuesLen; i++ {
+		// Move the mask to select the next issue.
+		mask = rotateLeft(mask, 2)
+
+		// Pop off the issue and shift downwards so that is corresponds
+		// to the type of vote it should be.
+		dvbs.Issues[i] = IssueVote((mask & voteBits) >> ((i * 2) + 2))
+	}
+
+	return dvbs
+}
+
+// VotingTally is a rolling tally of votes for some issue.  The index of the
+// tally corresponds to the number of each vote types seen on the issue for
+// this period.  For example, we might observe for some issue:
+//    Undefined: 0
+//    Yes:       100
+//    No:        200
+//    Abstain:   300
+//
+// This would be the VotingTally represented by {0,100,200,300}.
+type VotingTally [4]uint16
+
+// SerializeInto serializes the VotingTally into a passed byte slice, stored as
+// little endian uint16s.  It takes a passed offset to begin writing into.
+//
+// The function does not check for the length of the byte slice and will panic
+// if there is not enough space to write into.
+func (v *VotingTally) SerializeInto(sl *[]byte, offset int) {
+	slVal := *sl
+	for i := 0; i < 8; i += 2 {
+		dbnamespace.ByteOrder.PutUint16(slVal[offset+i:offset+i+2], v[i/2])
+	}
+}
+
+// Deserialize deserializes from a byte slice into the VotingTally it is called
+// on.  It takes a passed offset to begin reading from.
+//
+// The function does not check for the length of the byte slice and will panic
+// if there is not enough space to write into.
+func (v *VotingTally) Deserialize(sl *[]byte, offset int) {
+	slVal := *sl
+	for i := 0; i < 8; i += 2 {
+		v[i/2] = dbnamespace.ByteOrder.Uint16(slVal[offset+i : offset+i+2])
+	}
+}
+
+// BlockKey is the block key for a given block, that is used to map fully
+// tallied blocks (at each difficulty changing interval) to tally data in
+// the database.
+type BlockKey struct {
+	Hash   chainhash.Hash
+	Height uint32
+}
+
+// BlockKeySize is the size of a serialized block key.
+const BlockKeySize = 36
+
+// SerializeInto serializes the BlockKey into a passed byte slice, stored as
+// a flat chainhash and a little endian uint32.  It takes a passed offset to
+// begin writing into.
+//
+// The function does not check for the length of the byte slice and will panic
+// if there is not enough space to write into.
+func (b *BlockKey) SerializeInto(sl *[]byte, offset int) {
+	slVal := *sl
+	copy(slVal[offset:], b.Hash[:])
+	offset += chainhash.HashSize
+	dbnamespace.ByteOrder.PutUint32(slVal[offset:], b.Height)
+}
+
+// Deserialize deserializes from a byte slice into the BlockKey it is called
+// on.  It takes a passed offset to begin reading from.
+//
+// The function does not check for the length of the byte slice and will panic
+// if there is not enough space to write into.
+func (b *BlockKey) Deserialize(sl *[]byte, offset int) {
+	slVal := *sl
+	copy(b.Hash[:], slVal[offset:])
+	offset += chainhash.HashSize
+	b.Height = dbnamespace.ByteOrder.Uint32(slVal[offset:])
+}
+
+// RollingVotingPrefixTally is a rolling tally of the decoded vote bits from
+// a series  of votes.  The tallies of the issues are arranged in a two
+// dimensional array.  The tallies themselves are a unidirectional linked list,
+// with the LastIntervalBlock component of the struct pointing the the previous
+// item which may be looked up in the database or cache.  The cache holds tallies
+// for sidechains, while the mainchain tallies reside in the database.
+type RollingVotingPrefixTally struct {
+	LastIntervalBlock  BlockKey
+	CurrentBlockHeight uint32
+	BlockValid         uint16
+	Unused             uint16
+	Issues             [issuesLen]VotingTally
+}
+
+// RollingVotingPrefixTallySize is the size of a serialized
+// RollingVotingPrefixTally The size is calculated as
+//   1x BlockKey (36 bytes) + 1x uint32 (4 bytes) +
+//   2x uint16s (4 bytes) + 7x VotingTallies (56 bytes)
+const RollingVotingPrefixTallySize = 36 + 4 + 4 + 56
+
+// Serialize serializes a RollingVotingPrefixTally into a contiguous slice of
+// bytes.  Integer values are serialized in little endian.
+func (r *RollingVotingPrefixTally) Serialize() []byte {
+	val := make([]byte, RollingVotingPrefixTallySize)
+	offset := 0
+	r.LastIntervalBlock.SerializeInto(&val, offset)
+	offset += BlockKeySize
+
+	dbnamespace.ByteOrder.PutUint32(val[offset:offset+4], r.CurrentBlockHeight)
+	offset += 4
+	dbnamespace.ByteOrder.PutUint16(val[offset:offset+2], r.BlockValid)
+	offset += 2
+	dbnamespace.ByteOrder.PutUint16(val[offset:offset+2], r.Unused)
+	offset += 2
+
+	// Serialize the issues individually; the array size
+	// is 8 bytes each.
+	for i := 0; i < issuesLen; i++ {
+		r.Issues[i].SerializeInto(&val, offset)
+		offset += 8
+	}
+
+	return val
+}
+
+// Deserialize deserializes a contiguous slice of bytes into the
+// RollingVotingPrefixTally the function is called on.
+func (r *RollingVotingPrefixTally) Deserialize(val []byte) error {
+	if len(val) < RollingVotingPrefixTallySize {
+		str := fmt.Sprintf("short read of serialized RollingVotingPrefixTally "+
+			"when deserializing (got %v, want %v bytes)", len(val),
+			RollingVotingPrefixTallySize)
+		return stakeRuleError(ErrMemoryCorruption, str)
+	}
+
+	offset := 0
+	r.LastIntervalBlock.Deserialize(&val, offset)
+	offset += BlockKeySize
+
+	r.CurrentBlockHeight = dbnamespace.ByteOrder.Uint32(val[offset : offset+4])
+	offset += 4
+	r.BlockValid = dbnamespace.ByteOrder.Uint16(val[offset : offset+2])
+	offset += 2
+	r.Unused = dbnamespace.ByteOrder.Uint16(val[offset : offset+2])
+	offset += 2
+
+	// Serialize the issues individually.  The array size
+	// is 8 bytes each.
+	for i := 0; i < issuesLen; i++ {
+		r.Issues[i].Deserialize(&val, offset)
+		offset += 8
+	}
+
+	return nil
+}
+
+// RollingVotingPrefixTallyCache is a cache of voting tallies for interval
+// blocks containing intermediate tallies.  On connection of the last block
+// in the interval period, the final tally is written with a block key
+// pointing to the block to look up for the last interval period, connecting the
+// unidirectional linked list.
+type RollingVotingPrefixTallyCache map[BlockKey]*RollingVotingPrefixTally
+
+// initCacheSize is how many interval windows into the past the cache should
+// restore on startup from the database.  It is equivalent to 4 months on
+// mainnet.
+const initCacheSize = 240
+
+// zeroKey is a placeholder for the determining if we reach the special case
+// of the genesis block when iterating backwards.
+var zeroKey = BlockKey{chainhash.Hash{0x00}, 0}
+
+// InitRollingTallyCache initializes a rolling tally cache from the stored
+// tallies in the database.  It loads the best state, then restores the past
+// tallies by iterating backwards over the records.
+func InitRollingTallyCache(dbTx database.Tx, params *chaincfg.Params) (RollingVotingPrefixTallyCache, error) {
+	best, err := votingdb.DbFetchBestState(dbTx)
+	if err != nil {
+		return nil, err
+	}
+
+	var bestTally RollingVotingPrefixTally
+	err = bestTally.Deserialize(best.CurrentTally)
+	if err != nil {
+		return nil, err
+	}
+
+	// Nothing to load if this is the first time.
+	if best.Hash == *params.GenesisHash {
+		return make(RollingVotingPrefixTallyCache), nil
+	}
+
+	// Iterate backwards through the entries in the database, loading
+	// them into the cache.
+	cache := make(RollingVotingPrefixTallyCache)
+	currentKey := bestTally.LastIntervalBlock
+	var currentKeyB [36]byte
+	buf := currentKeyB[:]
+	for i := 0; i < initCacheSize; i++ {
+		// Break if we reach the genesis block.
+		if currentKey.Hash == *zeroHash ||
+			currentKey.Hash == *params.GenesisHash {
+			break
+		}
+
+		// The initially loaded block is at the very end of an interval.  Load
+		// this tally into the cache as the first element, then continue loading
+		// by going backwards in time through the linked list.
+		if (best.Height+1)%uint32(params.StakeDiffWindowSize) == 0 && i == 0 {
+			key := BlockKey{Hash: best.Hash, Height: best.Height}
+			cache[key] = &bestTally
+			continue
+		}
+
+		currentKey.SerializeInto(&buf, 0)
+		currentTallyB, err := votingdb.DbFetchBlockTally(dbTx, buf)
+		if err != nil {
+			return nil, err
+		}
+		var currentTally RollingVotingPrefixTally
+		err = currentTally.Deserialize(currentTallyB)
+		if err != nil {
+			return nil, err
+		}
+
+		cache[currentKey] = &currentTally
+		currentKey = currentTally.LastIntervalBlock
+	}
+
+	return cache, nil
+}
+
+// FetchIntervalTally fetches a finalized interval tally from the cache or
+// database.  It returns an error if it can not find the relevant tally, which
+// should exist even if the block is on a sidechain.
+func FetchIntervalTally(key *BlockKey, cache RollingVotingPrefixTallyCache, dbTx database.Tx, params *chaincfg.Params) (*RollingVotingPrefixTally, error) {
+	// Exception for the genesis block window.
+	if *key == zeroKey || key.Hash == *params.GenesisHash {
+		var tally RollingVotingPrefixTally
+		tally.LastIntervalBlock = BlockKey{*params.GenesisHash, 0}
+		return &tally, nil
+	}
+
+	if cache != nil {
+		tally, exists := cache[*key]
+		if exists {
+			return tally, nil
+		}
+	}
+
+	if dbTx != nil {
+		var keyB [36]byte
+		buf := keyB[:]
+		key.SerializeInto(&buf, 0)
+		tallyB, err := votingdb.DbFetchBlockTally(dbTx, buf)
+		if err != nil && err.(votingdb.DBError).ErrorCode !=
+			votingdb.ErrMissingKey {
+			return nil, err
+		}
+
+		if len(tallyB) > 0 {
+			var tally RollingVotingPrefixTally
+			err = tally.Deserialize(tallyB)
+			if err != nil {
+				return nil, err
+			}
+
+			return &tally, nil
+		}
+	}
+
+	return nil, stakeRuleError(ErrMissingTally, fmt.Sprintf("failed to "+
+		"find tally for key %v in the interval cache or interval bucket of the "+
+		"database", key))
+}
+
+// rollover resets the RollingVotingPrefixTally when reaching a new tallying
+// interval.  It checks to see if the new interval block height corresponds
+// to the expected next block height.  If the height is also at a key block
+// interval, it rolls over these values as well.  Finally, it increments the
+// block height.
+func (r *RollingVotingPrefixTally) rollover(blockHash, parentHash chainhash.Hash, blockHeight uint32, params *chaincfg.Params) error {
+	if blockHeight != r.CurrentBlockHeight+1 {
+		str := fmt.Sprintf("reset called, but next block height does not "+
+			"correspond to the expected next block height (got %v, expect %v)",
+			blockHeight, r.CurrentBlockHeight+1)
+		return stakeRuleError(ErrBadVotingConnectBlock, str)
+	}
+
+	// New vote tallying interval.  The fields are reset here rather
+	// than above, because this interval should always coincide with
+	// a key block interval as well.  Not that this value stays the
+	// same for params.VoteKeyBlockInterval /
+	// params.StakeDiffWindowSize many interval periods.
+	if blockHeight%uint32(params.StakeDiffWindowSize) == 0 {
+		r.LastIntervalBlock.Hash = parentHash
+		r.LastIntervalBlock.Height = blockHeight - 1
+
+		// Reset the voting fields of the struct.
+		r.BlockValid = 0
+		r.Unused = 0
+		for i := 0; i < issuesLen; i++ {
+			for j := 0; j < 4; j++ {
+				r.Issues[i][j] = 0
+			}
+		}
+	}
+
+	r.CurrentBlockHeight++
+
+	return nil
+}
+
+// AddVoteBitsSlice adds a slice of vote bits to a tally, extracting the relevant
+// bits from each vote bits and then incrementing the relevant portion of the
+// talley.
+func (r *RollingVotingPrefixTally) AddVoteBitsSlice(voteBitsSlice []uint16) {
+	for i := range voteBitsSlice {
+		decoded := DecodeVoteBitsPrefix(voteBitsSlice[i])
+
+		if decoded.BlockValid {
+			r.BlockValid++
+		}
+		if decoded.Unused {
+			r.Unused++
+		}
+
+		// Extract the setting of the issue and add it to the relevant
+		// portion of the array that stores how an issue was voted.
+		// This portion of code might not be clear.  decoded.Issues[j]
+		// refers to 0...3, which is the length of the array for the
+		// issues in the rolling tally.  By using it as an index, you
+		// only increment the voting selection that the user indicated
+		// in their vote bits.
+		for j := 0; j < issuesLen; j++ {
+			r.Issues[j][decoded.Issues[j]]++
+		}
+	}
+}
+
+// AddTally adds two tallies together, storing the result in the original
+// tally.
+func (r *RollingVotingPrefixTally) AddTally(tally RollingVotingPrefixTally) {
+	r.BlockValid += tally.BlockValid
+	r.Unused += tally.Unused
+	for i := 0; i < issuesLen; i++ {
+		for j := 0; j < 4; j++ {
+			r.Issues[i][j] += tally.Issues[i][j]
+		}
+	}
+}
+
+// ConnectBlockToTally connects a "block" to a tally.  The only components of
+// the block required are the hash, the height, the extracted 16-bit mandatory
+// vote bits, and the network parameters.
+//
+// The work flow is as below:
+//  1. rollover, which pushes the talley to the next height and resets/sets
+//         relevant fields about the blockchain states.
+//  2. addTally, which adds the tally of the voteBits slice.
+//
+// The resulting RollingVotingPrefixTally is an "immutable" object similar to
+//     the stake node of tickets.go.
+func (r *RollingVotingPrefixTally) ConnectBlockToTally(intervalCache RollingVotingPrefixTallyCache, dbTx database.Tx, blockHash, parentHash chainhash.Hash, blockHeight uint32, voteBitsSlice []uint16, params *chaincfg.Params) (RollingVotingPrefixTally, error) {
+	tally := *r
+
+	err := tally.rollover(blockHash, parentHash, blockHeight, params)
+	if err != nil {
+		return RollingVotingPrefixTally{}, err
+	}
+
+	// Quick sanity check.
+	if int64(blockHeight) < params.StakeValidationHeight {
+		if len(voteBitsSlice) > 0 {
+			return RollingVotingPrefixTally{},
+				stakeRuleError(ErrBadVotingConnectBlock, "got block with "+
+					"votebits before stake validation height when tallying")
+		}
+	}
+	if int64(blockHeight) >= params.StakeValidationHeight {
+		if len(voteBitsSlice) <= int(params.TicketsPerBlock)/2 {
+			str := fmt.Sprintf("bad number of voters attempted to be connected "+
+				"to rolling tally (got %v, min %v)", len(voteBitsSlice),
+				((params.TicketsPerBlock)/2)+1)
+			return RollingVotingPrefixTally{},
+				stakeRuleError(ErrBadVotingConnectBlock, str)
+		}
+	}
+
+	tally.AddVoteBitsSlice(voteBitsSlice)
+
+	// This is the final block in the interval window, so write it to the
+	// cache now.
+	if (tally.CurrentBlockHeight+1)%uint32(params.StakeDiffWindowSize) == 0 {
+		intervalCache[BlockKey{Hash: blockHash, Height: blockHeight}] = &tally
+	}
+
+	return tally, nil
+}
+
+// SubtractVoteBitsSlice subtracts a slice of vote bits to a tally,
+// extracting the relevant bits from each vote bits and then
+// incrementing the relevant portion of the talley.
+func (r *RollingVotingPrefixTally) SubtractVoteBitsSlice(voteBitsSlice []uint16) {
+	for i := range voteBitsSlice {
+		decoded := DecodeVoteBitsPrefix(voteBitsSlice[i])
+
+		if decoded.BlockValid {
+			r.BlockValid--
+		}
+		if decoded.Unused {
+			r.Unused--
+		}
+
+		// Extract the setting of the issue and subtract it from the
+		// relevant portion of the array that stores how an issue was
+		// voted.
+		for j := 0; j < issuesLen; j++ {
+			r.Issues[j][decoded.Issues[j]]--
+		}
+	}
+}
+
+// revert reverts a tally to its previous state after the disconnection of a
+// block.  Importantly, if the rollback is all the way to the last interval
+// update to the tally where it was previously reset, it loads the data from
+// the passed lastIntervalTally instead of further subtracting votes (which
+// would result in underflow).
+func (r *RollingVotingPrefixTally) revert(blockHeight uint32, voteBitsSlice []uint16, lastIntervalTally *RollingVotingPrefixTally, params *chaincfg.Params) error {
+	if blockHeight != r.CurrentBlockHeight {
+		str := fmt.Sprintf("revert called, but block height does not "+
+			"correspond to the expected prev block height (got %v, expect %v)",
+			blockHeight, r.CurrentBlockHeight)
+		return stakeRuleError(ErrBadVotingRemoveBlock, str)
+	}
+
+	// Old short voting interval.  This interval should always coincide with
+	// a key block interval as well, so we roll back to the old state of the
+	// voting tally.
+	if (blockHeight)%uint32(params.StakeDiffWindowSize) == 0 {
+		*r = *lastIntervalTally
+		r.CurrentBlockHeight = blockHeight - 1
+	} else {
+		r.SubtractVoteBitsSlice(voteBitsSlice)
+		r.CurrentBlockHeight--
+	}
+
+	return nil
+}
+
+// DisconnectBlockFromTally disconnects a "block" from a rolling tally.  In the
+// simplest case, it just subtracts the individual votes on issues and then
+// rolls back the height.  In cases of rolling back an interval block (where
+// values for the votes were reset), it needs the previous interval tally to
+// be restored.  This is passed as lastIntervalTally.  If this does not exist,
+// the passed cache and the database will be searched to see if this interval
+// tally can be found.
+func (r *RollingVotingPrefixTally) DisconnectBlockFromTally(intervalCache RollingVotingPrefixTallyCache, dbTx database.Tx, blockHash chainhash.Hash, blockHeight uint32, voteBitsSlice []uint16, lastIntervalTally *RollingVotingPrefixTally, params *chaincfg.Params) (RollingVotingPrefixTally, error) {
+	tally := *r
+
+	// Search the cache and the database.
+	if lastIntervalTally == nil &&
+		(r.CurrentBlockHeight%uint32(params.StakeDiffWindowSize)) == 0 {
+		var err error
+		lastIntervalTally, err = FetchIntervalTally(&r.LastIntervalBlock,
+			intervalCache, dbTx, params)
+		if err != nil {
+			return RollingVotingPrefixTally{}, err
+		}
+	}
+
+	err := tally.revert(blockHeight, voteBitsSlice, lastIntervalTally, params)
+	if err != nil {
+		return RollingVotingPrefixTally{}, err
+	}
+
+	return tally, nil
+}
+
+// InitVotingDatabaseState initializes the chain with the best state being the
+// genesis block.
+func InitVotingDatabaseState(dbTx database.Tx, params *chaincfg.Params) (*RollingVotingPrefixTally, error) {
+	// Create the database.
+	err := votingdb.DbCreate(dbTx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Write the new block undo and new tickets data to the
+	// database for the genesis block.
+	var best votingdb.BestChainState
+	var bestTally RollingVotingPrefixTally
+	best.Hash = *params.GenesisHash
+	best.Height = 0
+	bestTally.LastIntervalBlock = BlockKey{best.Hash, best.Height}
+	best.CurrentTally = bestTally.Serialize()
+
+	err = votingdb.DbPutBestState(dbTx, best)
+	if err != nil {
+		return nil, err
+	}
+
+	return &bestTally, nil
+}
+
+// LoadVotingDatabaseState loads the best chain state of the voting datatabase.
+func LoadVotingDatabaseState(dbTx database.Tx) (*RollingVotingPrefixTally, error) {
+	info, err := votingdb.DbFetchDatabaseInfo(dbTx)
+	if err != nil {
+		return nil, err
+	}
+
+	best, err := votingdb.DbFetchBestState(dbTx)
+	if err != nil {
+		return nil, err
+	}
+
+	var bestTally RollingVotingPrefixTally
+	err = bestTally.Deserialize(best.CurrentTally)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Infof("Voting tally database version %v loaded", info.Version)
+
+	return &bestTally, nil
+}
+
+// WriteConnectedBlockTally writes a block tally to the database if the block is
+// the last block in the block interval.  It also updates the current best block
+// tally in the best chain component of the database.
+func WriteConnectedBlockTally(dbTx database.Tx, blockHash chainhash.Hash, blockHeight uint32, tally *RollingVotingPrefixTally, params *chaincfg.Params) error {
+	var best votingdb.BestChainState
+	best.Hash = blockHash
+	best.Height = blockHeight
+	best.CurrentTally = tally.Serialize()
+	key := BlockKey{Hash: blockHash, Height: blockHeight}
+	keyB := make([]byte, BlockKeySize)
+	key.SerializeInto(&keyB, 0)
+
+	if (tally.CurrentBlockHeight+1)%uint32(params.StakeDiffWindowSize) == 0 {
+		err := votingdb.DbPutBlockTally(dbTx, keyB, best.CurrentTally)
+		if err != nil {
+			return err
+		}
+	}
+
+	return votingdb.DbPutBestState(dbTx, best)
+}
+
+// WriteDisconnectedBlockTally disconnects a block tally from the database,
+// subtracting the slice of vote bits or restoring it to the previous tally's
+// state if it falls into an interval block.  We don't need to call the cache
+// here, because we know that disconnects are only on the mainchain and that the
+// mainchain MUST have the previous interval block in it.
+func WriteDisconnectedBlockTally(dbTx database.Tx, blockHash, parentHash chainhash.Hash, blockHeight uint32, tally *RollingVotingPrefixTally, voteBitsSlice []uint16, params *chaincfg.Params) error {
+	disconnectedTally, err := tally.DisconnectBlockFromTally(nil, dbTx,
+		blockHash, blockHeight, voteBitsSlice, nil, params)
+	if err != nil {
+		return err
+	}
+
+	var best votingdb.BestChainState
+	best.Hash = blockHash
+	best.Height = blockHeight
+	best.CurrentTally = disconnectedTally.Serialize()
+
+	// Delete the previous best tally if we're disconnecting into a
+	// previous window.
+	if (blockHeight+1)%uint32(params.StakeDiffWindowSize) == 0 {
+		key := BlockKey{Hash: blockHash, Height: blockHeight}
+		keyB := make([]byte, BlockKeySize)
+		key.SerializeInto(&keyB, 0)
+
+		err = votingdb.DbDeleteBlockTally(dbTx, keyB)
+		if err != nil {
+			return err
+		}
+	}
+
+	return votingdb.DbPutBestState(dbTx, best)
+}
+
+// SummedVotingTally is a voting tally struct comparable to a voting tally but
+// with a wider unsigned integer to prevent issues with overflowing while summing
+// over large periods.
+type SummedVotingTally [4]uint64
+
+// RollingSummedTally is a tally of the decoded vote bits from a series of votes
+// over a large period of time than the stake difficulty windows.  Note that
+// uint64s are used instead of uint16s, because the latter may overflow.  The
+// tallies of the issues are arranged in a two dimensional array, compared to
+// the RollingVotingPrefixTally more generally used.
+type RollingSummedTally struct {
+	LastIntervalBlock  BlockKey
+	CurrentBlockHeight uint32
+	BlockValid         uint64
+	Unused             uint64
+	Issues             [issuesLen]SummedVotingTally
+}
+
+// AddTally adds two tallies together, storing the result in the original
+// tally.
+func (r *RollingSummedTally) AddTally(tally RollingVotingPrefixTally) {
+	r.BlockValid += uint64(tally.BlockValid)
+	r.Unused += uint64(tally.Unused)
+	for i := 0; i < issuesLen; i++ {
+		for j := 0; j < 4; j++ {
+			r.Issues[i][j] += uint64(tally.Issues[i][j])
+		}
+	}
+}
+
+// GenerateSummedTally generates a summation of all the values for issues and
+// their votes.  It uses uint64s to prevent overflows when summing across very
+// long intervals.  The intervals passed are equivalent to the stake difficulty
+// window sizes, that is, one interval is 144 blocks on mainnet.  The rolling
+// tally this is called on must be a completed tally, that is, it must be the
+// last block in the interval voting window.
+//
+// It is currently unused but could be used in the future for popular majority
+// votes.
+func (r *RollingVotingPrefixTally) GenerateSummedTally(intervalCache RollingVotingPrefixTallyCache, dbTx database.Tx, intervals int, params *chaincfg.Params) (*RollingSummedTally, error) {
+	// Summed tallies should only be generated from tallies that are the
+	// last block in the window period.  If this is not at the correct
+	// height, throw an error.
+	if ((r.CurrentBlockHeight + 1) % uint32(params.StakeDiffWindowSize)) != 0 {
+		str := fmt.Sprintf("tried to sum incomplete tally at height %v",
+			r.CurrentBlockHeight)
+		return nil, stakeRuleError(ErrTallyingIntervals, str)
+	}
+
+	// Must sum at least one interval, which is the current one.  You
+	// can not sum tallies from before the genesis block.
+	maxIntervals := (r.CurrentBlockHeight + 1) / uint32(params.StakeDiffWindowSize)
+	if intervals <= 0 || intervals > int(maxIntervals) {
+		str := fmt.Sprintf("invalid tally intervals: got %v, max %v",
+			intervals, maxIntervals)
+		return nil, stakeRuleError(ErrTallyingIntervals, str)
+	}
+
+	// The last tally is the first interval.
+	tallySum := new(RollingSummedTally)
+	tallySum.LastIntervalBlock = r.LastIntervalBlock
+	tallySum.CurrentBlockHeight = r.CurrentBlockHeight
+	tallySum.AddTally(*r)
+
+	// Loop through the remaining intervals, going backwards through the
+	// chain until you successfully add all of the tallies.
+	currentKey := &r.LastIntervalBlock
+	var tallyLocal *RollingVotingPrefixTally
+	var err error
+	for i := 0; i < intervals-1; i++ {
+		tallyLocal, err = FetchIntervalTally(currentKey, intervalCache, dbTx,
+			params)
+		if err != nil {
+			return nil, err
+		}
+
+		tallySum.AddTally(*tallyLocal)
+		currentKey = &tallyLocal.LastIntervalBlock
+		tallySum.LastIntervalBlock = tallyLocal.LastIntervalBlock
+	}
+
+	return tallySum, nil
+}
+
+// Verdict is a voting outcome for a single interval.  It indicates whether or
+// not the voters have come to a consensus in this interval, and what the
+// consensus is.
+type Verdict uint8
+
+// String satisfies the stringer interface for a Verdict.
+func (v Verdict) String() string {
+	switch v {
+	case VerdictUndecided:
+		return "undecided"
+	case VerdictYes:
+		return "yes"
+	case VerdictNo:
+		return "no"
+	}
+
+	return "error (unknown verdict type)"
+}
+
+const (
+	// VerdictUndecided indicates that the voters for this interval have
+	// not yet come to a consensus.
+	VerdictUndecided = iota
+
+	// VerdictYes indicates that the voters for this interval have come to
+	// the consensus 'yes'.
+	VerdictYes
+
+	// VerdictNo indicates that the voters for this interval have come to
+	// the consensus 'no'.
+	VerdictNo
+)
+
+// VotingResults
+type VotingResults struct {
+	FirstIntervalBlock BlockKey
+	LastIntervalBlock  BlockKey
+	Issues             [issuesLen][]Verdict
+	Verdicts           [issuesLen]Verdict
+}
+
+// determineIssueStatus determines whether or not an issue has been voted yes
+// or no for some interval.  Importantly, it has a numerator multiplier and
+// a denominator such that the number of votes required to give a yes vote is:
+//     (numeratorMul * total) / denominatorMul
+// For example, if we had a 75% threshold and a total of 720 yes votes and no
+// votes total, we would use 3 as the numerator multiplier and 4 as the
+// denominator to yield (3*720)/4 = 540 yes votes required to pass the issue.
+func (r *RollingVotingPrefixTally) determineIssueStatus(issue int, numeratorMul, denominator uint16) Verdict {
+	// Only yes or no votes count.
+	total := r.Issues[issue][IssueVoteYes] +
+		r.Issues[issue][IssueVoteNo]
+	if total == 0 {
+		return VerdictUndecided
+	}
+
+	needed := (numeratorMul * total) / denominator
+
+	// Edge case: if needed is somehow zero because nearly all
+	// the votes on the issue are abstain, make at least one
+	// vote required in order to give yes to the issue.
+	if needed == 0 {
+		needed++
+	}
+
+	if r.Issues[issue][IssueVoteYes] >= needed {
+		return VerdictYes
+	}
+	if r.Issues[issue][IssueVoteNo] >= needed {
+		return VerdictNo
+	}
+
+	return VerdictUndecided
+}
+
+// GenerateVotingResults generates voting results from the passed interval
+// window's tally forward through the number of intervals in the past that
+// are requested.  For each issue, it creates a slice of verdicts for each
+// interval, and sets the verdict to be yes if the issue meets the network
+// requirements for having been voted yes, no if the same is true for no.
+// If consensus has not yet been met on the issue, it returns an undecided
+// verdict. The rolling tally this is called on must be a completed tally,
+// that is, it must be the last block in the interval voting window.
+func (r *RollingVotingPrefixTally) GenerateVotingResults(intervalCache RollingVotingPrefixTallyCache, dbTx database.Tx, intervals int, params *chaincfg.Params) (*VotingResults, error) {
+	// Summed tallies should only be generated from tallies that are the
+	// last block in the window period.  If this is not at the correct
+	// height, throw an error.
+	if ((r.CurrentBlockHeight + 1) % uint32(params.StakeDiffWindowSize)) != 0 {
+		str := fmt.Sprintf("tried to sum incomplete tally at height %v",
+			r.CurrentBlockHeight)
+		return nil, stakeRuleError(ErrTallyingIntervals, str)
+	}
+
+	// Must sum at least one interval, which is the current one.  You
+	// can not sum tallies from before the genesis block.
+	maxIntervals := int(r.CurrentBlockHeight+1) / int(params.StakeDiffWindowSize)
+	if intervals == 0 || intervals > maxIntervals {
+		str := fmt.Sprintf("invalid tally intervals: got %v, max %v",
+			intervals, maxIntervals)
+		return nil, stakeRuleError(ErrTallyingIntervals, str)
+	}
+
+	votingResults := new(VotingResults)
+	for i := 0; i < issuesLen; i++ {
+		votingResults.Issues[i] = make([]Verdict, intervals, intervals)
+	}
+
+	// Preserve the first interval used in the verdict determination.
+	votingResults.FirstIntervalBlock = r.LastIntervalBlock
+
+	// Loop through the remaining intervals, going backwards through the
+	// chain until you successfully add all of the tallies.
+	currentKey := &r.LastIntervalBlock
+	tallyLocal := r
+	var err error
+	for i := intervals - 1; i >= 0; i-- {
+		for j := 0; j < issuesLen; j++ {
+			votingResults.Issues[j][i] = tallyLocal.determineIssueStatus(j,
+				params.VotingIssueMultiplier, params.VotingIssueDivisor)
+		}
+		currentKey = &tallyLocal.LastIntervalBlock
+		votingResults.LastIntervalBlock = tallyLocal.LastIntervalBlock
+
+		// Get the next tally in the linked list if we're not at
+		// the last entry.
+		if i > 0 {
+			tallyLocal, err = FetchIntervalTally(currentKey, intervalCache, dbTx,
+				params)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// Calculate the 'verdict' by checking to see if the it's
+	// entirely set to either 'yes' or 'no' for all of the
+	// intervals for the issue.
+	for j := 0; j < issuesLen; j++ {
+		votingResults.Verdicts[j] = VerdictUndecided
+		allYes := true
+		allNo := true
+		for i := intervals - 1; i >= 0; i-- {
+			switch votingResults.Issues[j][i] {
+			case VerdictNo:
+				allYes = false
+
+			case VerdictYes:
+				allNo = false
+
+			case VerdictUndecided:
+				allYes = false
+				allNo = false
+			}
+		}
+
+		// Both yes and no can not be set to true.  This is an error
+		// if it occurs.
+		if allYes == true && allYes == allNo {
+			return nil, stakeRuleError(ErrMemoryCorruption, "a verdict "+
+				"returned both yes and no, which should be impossible")
+		}
+
+		if allYes {
+			votingResults.Verdicts[j] = VerdictYes
+		}
+		if allNo {
+			votingResults.Verdicts[j] = VerdictNo
+		}
+	}
+
+	return votingResults, nil
+}

--- a/blockchain/stake/voting_test.go
+++ b/blockchain/stake/voting_test.go
@@ -1,0 +1,969 @@
+// Copyright (c) 2016 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package stake
+
+import (
+	"bytes"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/decred/dcrd/chaincfg"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/database"
+	_ "github.com/decred/dcrd/database/ffldb"
+)
+
+func bytesFromHex(s string) []byte {
+	b, _ := hex.DecodeString(s)
+	return b
+}
+
+func TestDecodingAndEncodingVoteBits(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   uint16
+		out  DecodedVoteBitsPrefix
+	}{
+		{
+			"no and all undefined",
+			0x0000,
+			DecodedVoteBitsPrefix{
+				BlockValid: false,
+				Unused:     false,
+				Issues: [7]IssueVote{
+					IssueVoteUndefined, IssueVoteUndefined,
+					IssueVoteUndefined, IssueVoteUndefined,
+					IssueVoteUndefined, IssueVoteUndefined,
+					IssueVoteUndefined,
+				},
+			},
+		},
+		{
+			"yes and all undefined",
+			0x0001,
+			DecodedVoteBitsPrefix{
+				BlockValid: true,
+				Unused:     false,
+				Issues: [7]IssueVote{
+					IssueVoteUndefined, IssueVoteUndefined,
+					IssueVoteUndefined, IssueVoteUndefined,
+					IssueVoteUndefined, IssueVoteUndefined,
+					IssueVoteUndefined,
+				},
+			},
+		},
+		{
+			"no (unused set) and all undefined",
+			0x0002,
+			DecodedVoteBitsPrefix{
+				BlockValid: false,
+				Unused:     true,
+				Issues: [7]IssueVote{
+					IssueVoteUndefined, IssueVoteUndefined,
+					IssueVoteUndefined, IssueVoteUndefined,
+					IssueVoteUndefined, IssueVoteUndefined,
+					IssueVoteUndefined,
+				},
+			},
+		},
+		{
+			"yes and odd issues yes, even issues no",
+			0x6665,
+			DecodedVoteBitsPrefix{
+				BlockValid: true,
+				Unused:     false,
+				Issues: [7]IssueVote{
+					IssueVoteYes, IssueVoteNo,
+					IssueVoteYes, IssueVoteNo,
+					IssueVoteYes, IssueVoteNo,
+					IssueVoteYes,
+				},
+			},
+		},
+		{
+			"yes and odd issues no, even issues abstain",
+			0xBBB9,
+			DecodedVoteBitsPrefix{
+				BlockValid: true,
+				Unused:     false,
+				Issues: [7]IssueVote{
+					IssueVoteNo, IssueVoteAbstain,
+					IssueVoteNo, IssueVoteAbstain,
+					IssueVoteNo, IssueVoteAbstain,
+					IssueVoteNo,
+				},
+			},
+		},
+		{
+			"no and issue 1 yes, rest unused",
+			0x0004,
+			DecodedVoteBitsPrefix{
+				BlockValid: false,
+				Unused:     false,
+				Issues: [7]IssueVote{
+					IssueVoteYes, IssueVoteUndefined,
+					IssueVoteUndefined, IssueVoteUndefined,
+					IssueVoteUndefined, IssueVoteUndefined,
+					IssueVoteUndefined,
+				},
+			},
+		},
+		{
+			"yes and issue 3 yes, issue 4 no",
+			0x0241,
+			DecodedVoteBitsPrefix{
+				BlockValid: true,
+				Unused:     false,
+				Issues: [7]IssueVote{
+					IssueVoteUndefined, IssueVoteUndefined,
+					IssueVoteYes, IssueVoteNo,
+					IssueVoteUndefined, IssueVoteUndefined,
+					IssueVoteUndefined,
+				},
+			},
+		},
+		{
+			"yes on blocks, all issues yes",
+			0x5555,
+			DecodedVoteBitsPrefix{
+				BlockValid: true,
+				Unused:     false,
+				Issues: [7]IssueVote{
+					IssueVoteYes, IssueVoteYes,
+					IssueVoteYes, IssueVoteYes,
+					IssueVoteYes, IssueVoteYes,
+					IssueVoteYes,
+				},
+			},
+		},
+		{
+			"yes on blocks, all issues no",
+			0xaaa9,
+			DecodedVoteBitsPrefix{
+				BlockValid: true,
+				Unused:     false,
+				Issues: [7]IssueVote{
+					IssueVoteNo, IssueVoteNo,
+					IssueVoteNo, IssueVoteNo,
+					IssueVoteNo, IssueVoteNo,
+					IssueVoteNo,
+				},
+			},
+		},
+	}
+
+	// Encoding.
+	for i := range tests {
+		test := tests[i]
+		in := EncodeVoteBitsPrefix(test.out)
+		if !reflect.DeepEqual(in, test.in) {
+			t.Errorf("bad result on EncodeVoteBitsPrefix test %v: got %04x, "+
+				"want %04x", test.name, in, test.in)
+		}
+	}
+
+	// Decoding.
+	for i := range tests {
+		test := tests[i]
+		out := DecodeVoteBitsPrefix(test.in)
+		if out != test.out {
+			t.Errorf("bad result on DecodeVoteBitsPrefix test %v: got %v, "+
+				"want %v", test.name, out, test.out)
+		}
+	}
+}
+
+// TestRollingVotingPrefixTallySerializing tests serializing and deserializing
+// for RollingVotingPrefixTally.
+func TestRollingVotingPrefixTallySerializing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   RollingVotingPrefixTally
+		out  []byte
+	}{
+		{
+			"no and all undefined",
+			RollingVotingPrefixTally{
+				LastIntervalBlock:  BlockKey{Hash: chainhash.Hash{byte(0x02)}, Height: 38859},
+				CurrentBlockHeight: 10200,
+				BlockValid:         213,
+				Unused:             492,
+				Issues: [7]VotingTally{
+					VotingTally{123, 321, 324, 2819},
+					VotingTally{523, 2355, 0, 0},
+					VotingTally{352, 2352, 2442, 44},
+					VotingTally{234, 0, 44, 344},
+					VotingTally{523, 223, 133, 3444},
+					VotingTally{0, 44, 3233, 432},
+					VotingTally{867, 1, 444, 33},
+				},
+			},
+			bytesFromHex("0200000000000000000000000000000000000000000000000000000000000000cb970000d8270000d500ec017b0041014401030b0b02330900000000600130098a092c00ea0000002c0058010b02df008500740d00002c00a10cb00163030100bc012100"),
+		},
+	}
+
+	// Serialize.
+	for i := range tests {
+		test := tests[i]
+		out := test.in.Serialize()
+		if !bytes.Equal(out, test.out) {
+			t.Errorf("bad result on test.in.Serialize(): got %x, want %x",
+				out, test.out)
+		}
+	}
+
+	// Deserialize.
+	for i := range tests {
+		test := tests[i]
+		var tally RollingVotingPrefixTally
+		err := tally.Deserialize(test.out)
+		if err != nil {
+			t.Errorf("unexpected error %v", err)
+		}
+		if !reflect.DeepEqual(tally, test.in) {
+			t.Errorf("bad result on tally.Deserialize() test %v: got %v, "+
+				"want %v", test.name, tally, test.in)
+		}
+	}
+
+	// Test short read error.
+	for i := range tests {
+		test := tests[i]
+		var tally RollingVotingPrefixTally
+		err := tally.Deserialize(test.out[:len(test.out)-1])
+		if err == nil ||
+			err.(RuleError).ErrorCode != ErrMemoryCorruption {
+			t.Errorf("expected ErrMemoryCorruption on test %v, got %v",
+				test.name, err)
+		}
+	}
+}
+
+// TestBitsSliceAddingAndSubstracting tests adding and then substracting some vote
+// bits to/from a tally.
+func TestBitsSliceAddingAndSubstracting(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		tally    RollingVotingPrefixTally
+		votebits []uint16
+		out      RollingVotingPrefixTally
+	}{
+		{
+			"simple addition of 5 votebits",
+			RollingVotingPrefixTally{
+				LastIntervalBlock:  BlockKey{Hash: chainhash.Hash{byte(0x02)}, Height: 38859},
+				CurrentBlockHeight: 10200,
+				BlockValid:         6,
+				Unused:             7,
+				Issues: [7]VotingTally{
+					VotingTally{5, 4, 3, 2},
+					VotingTally{5, 4, 3, 2},
+					VotingTally{5, 4, 3, 2},
+					VotingTally{5, 4, 3, 2},
+					VotingTally{5, 4, 3, 2},
+					VotingTally{5, 4, 3, 2},
+					VotingTally{5, 4, 3, 2},
+				},
+			},
+			// Add 3x "yes and odd issues yes, even issues no", 1x "yes and odd
+			// issues no, even issues abstain", 1x "yes and unused yes,
+			// rest undeclared"
+			// Total:
+			//   +5 BlockValid
+			//   +1 Unused
+			//   +3 Yes on all odd issues
+			//   +3 No on all even issues
+			//   +1 No on all odd issues
+			//   +1 Abstain on all even issues
+			[]uint16{0x6665, 0xBBB9, 0x0003, 0x6665, 0x6665},
+			RollingVotingPrefixTally{
+				LastIntervalBlock:  BlockKey{Hash: chainhash.Hash{byte(0x02)}, Height: 38859},
+				CurrentBlockHeight: 10200,
+				BlockValid:         6 + 5,
+				Unused:             7 + 1,
+				Issues: [7]VotingTally{
+					VotingTally{5 + 1, 4 + 3, 3 + 1, 2}, // #1
+					VotingTally{5 + 1, 4, 3 + 3, 2 + 1}, // #2
+					VotingTally{5 + 1, 4 + 3, 3 + 1, 2}, // #3
+					VotingTally{5 + 1, 4, 3 + 3, 2 + 1}, // #4
+					VotingTally{5 + 1, 4 + 3, 3 + 1, 2}, // #5
+					VotingTally{5 + 1, 4, 3 + 3, 2 + 1}, // #6
+					VotingTally{5 + 1, 4 + 3, 3 + 1, 2}, // #7
+				},
+			},
+		},
+	}
+
+	for i := range tests {
+		testTally := tests[i].tally
+		testTally.AddVoteBitsSlice(tests[i].votebits)
+		if !reflect.DeepEqual(testTally, tests[i].out) {
+			t.Errorf("bad result on AddVoteBitsSlice test %v: got %v, "+
+				"want %v", tests[i].name, testTally, tests[i].out)
+		}
+
+		testTally.SubtractVoteBitsSlice(tests[i].votebits)
+		if !reflect.DeepEqual(testTally, tests[i].tally) {
+			t.Errorf("bad result on SubtractVoteBitsSlice test %v: got %v, "+
+				"want %v", tests[i].name, testTally, tests[i].tally)
+		}
+	}
+}
+
+// TestAddingTallies tests adding and then substracting some vote
+// bits to/from a tally.
+func TestAddingTallies(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		tally1 RollingVotingPrefixTally
+		tally2 RollingVotingPrefixTally
+		out    RollingVotingPrefixTally
+	}{
+		{
+			"simple addition of 1 or 2 to every field",
+			RollingVotingPrefixTally{
+				LastIntervalBlock:  BlockKey{Hash: chainhash.Hash{byte(0x02)}, Height: 38859},
+				CurrentBlockHeight: 10200,
+				BlockValid:         6,
+				Unused:             7,
+				Issues: [7]VotingTally{
+					VotingTally{5, 4, 3, 2},
+					VotingTally{5, 4, 3, 2},
+					VotingTally{5, 4, 3, 2},
+					VotingTally{5, 4, 3, 2},
+					VotingTally{5, 4, 3, 2},
+					VotingTally{5, 4, 3, 2},
+					VotingTally{5, 4, 3, 2},
+				},
+			},
+			RollingVotingPrefixTally{
+				LastIntervalBlock:  BlockKey{Hash: chainhash.Hash{byte(0x02)}, Height: 38859},
+				CurrentBlockHeight: 10200,
+				BlockValid:         1,
+				Unused:             2,
+				Issues: [7]VotingTally{
+					VotingTally{1, 2, 1, 2},
+					VotingTally{2, 1, 2, 1},
+					VotingTally{1, 2, 1, 2},
+					VotingTally{2, 1, 2, 1},
+					VotingTally{1, 2, 1, 2},
+					VotingTally{2, 1, 2, 1},
+					VotingTally{1, 2, 1, 2},
+				},
+			},
+			RollingVotingPrefixTally{
+				LastIntervalBlock:  BlockKey{Hash: chainhash.Hash{byte(0x02)}, Height: 38859},
+				CurrentBlockHeight: 10200,
+				BlockValid:         6 + 1,
+				Unused:             7 + 2,
+				Issues: [7]VotingTally{
+					VotingTally{5 + 1, 4 + 2, 3 + 1, 2 + 2},
+					VotingTally{5 + 2, 4 + 1, 3 + 2, 2 + 1},
+					VotingTally{5 + 1, 4 + 2, 3 + 1, 2 + 2},
+					VotingTally{5 + 2, 4 + 1, 3 + 2, 2 + 1},
+					VotingTally{5 + 1, 4 + 2, 3 + 1, 2 + 2},
+					VotingTally{5 + 2, 4 + 1, 3 + 2, 2 + 1},
+					VotingTally{5 + 1, 4 + 2, 3 + 1, 2 + 2},
+				},
+			},
+		},
+	}
+
+	for i := range tests {
+		testTally := tests[i].tally1
+		testTally.AddTally(tests[i].tally2)
+		if !reflect.DeepEqual(testTally, tests[i].out) {
+			t.Errorf("bad result on addTally test %v: got %v, "+
+				"want %v", tests[i].name, testTally, tests[i].out)
+		}
+	}
+}
+
+// pruneTallyCache prunes old blocks from a cache that are more than initCacheSize
+// blocks ago.
+func pruneTallyCache(cache RollingVotingPrefixTallyCache, height int64, params *chaincfg.Params) {
+	toRemove := make([]BlockKey, 0)
+	cutoff := uint32(0)
+	if height-params.StakeDiffWindowSize*initCacheSize > 0 {
+		cutoff = uint32(height - params.StakeDiffWindowSize*initCacheSize)
+	}
+	for k, _ := range cache {
+		if k.Height <= cutoff {
+			toRemove = append(toRemove, k)
+		}
+	}
+
+	for _, k := range toRemove {
+		delete(cache, k)
+	}
+}
+
+// rollingTallyCacheSliceTest is a sortable rolling tally cache used for
+// debugging the rolling tally cache.
+type rollingTallyCacheSliceTest []RollingVotingPrefixTally
+
+// Len satisfies the sort interface.
+func (s rollingTallyCacheSliceTest) Len() int {
+	return len(s)
+}
+
+// Swap satisfies the sort interface.
+func (s rollingTallyCacheSliceTest) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// Less satisfies the sort interface.
+func (s rollingTallyCacheSliceTest) Less(i, j int) bool {
+	return s[i].CurrentBlockHeight < s[j].CurrentBlockHeight
+}
+
+// numBlocks is the number of "blocks" to add/remove below, including the
+// genesis block (added as 1 below) which is automatically skipped.  That is,
+// if you want to generate 8064 blocks on top of the genesis block, use
+// 8064 below.
+const numBlocks = 99934
+
+// sortIntervalCache takes a RollingVotingPrefixTallyCache and returns a sorted
+// slice of all the elements, sorting by height.
+func sortIntervalCache(cache RollingVotingPrefixTallyCache) []RollingVotingPrefixTally {
+	s := make(rollingTallyCacheSliceTest, len(cache))
+
+	i := 0
+	for _, v := range cache {
+		s[i] = *v
+		i++
+	}
+
+	sort.Sort(s)
+
+	return s
+}
+
+// TestVotingDbAndSpoofedChain tests block connection, disconnect, and
+// a spoofed blockchain.
+func TestVotingDbAndSpoofedChain(t *testing.T) {
+	// Setup the database.
+	params := &chaincfg.MainNetParams
+	dbName := "ffldb_votingtest"
+	dbPath := filepath.Join(testDbRoot, dbName)
+	_ = os.RemoveAll(dbPath)
+	testDb, err := database.Create(testDbType, dbPath, params.Net)
+	if err != nil {
+		t.Fatalf("error creating db: %v", err)
+	}
+
+	// Setup a teardown.
+	defer os.RemoveAll(dbPath)
+	defer os.RemoveAll(testDbRoot)
+	defer testDb.Close()
+
+	// Create the buckets and best state for the genesis
+	// block.
+	var tally *RollingVotingPrefixTally
+	err = testDb.Update(func(dbTx database.Tx) error {
+		tally, err = InitVotingDatabaseState(dbTx, params)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("error initializing voting db: %v", err)
+	}
+
+	// Load the cache.
+	var cache RollingVotingPrefixTallyCache
+	err = testDb.View(func(dbTx database.Tx) error {
+		cache, err = InitRollingTallyCache(dbTx, params)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("error initializing cache: %v", err)
+	}
+
+	// Start adding some "blocks".
+	bestTally := *tally
+	var talliesForward [numBlocks]RollingVotingPrefixTally
+	vbSlice := []uint16{}
+	err = testDb.Update(func(dbTx database.Tx) error {
+		for i := 1; i <= numBlocks; i++ {
+			if int64(i) >= chaincfg.MainNetParams.StakeValidationHeight {
+				switch i % 5 {
+				case 0:
+					vbSlice = []uint16{0x6665, 0x2345, 0x9999, 0xa0a1, 0xc432}
+				case 1:
+					vbSlice = []uint16{0x6687, 0x6689, 0x66bb, 0x66bb, 0x66e1}
+				case 2:
+					vbSlice = []uint16{0x3465, 0x5565, 0x6165, 0x65b6, 0xaaaa}
+				case 3:
+					vbSlice = []uint16{0xffff, 0x0000, 0x2342, 0x6444, 0xa333}
+				case 4:
+					vbSlice = []uint16{0x231b, 0xa343, 0xff34, 0x90bb}
+				}
+			}
+
+			bestTally, err = bestTally.ConnectBlockToTally(cache, dbTx,
+				chainhash.Hash{byte(i)}, chainhash.Hash{byte(i - 1)}, uint32(i),
+				vbSlice, params)
+			if err != nil {
+				return err
+			}
+
+			talliesForward[i-1] = bestTally
+
+			err = WriteConnectedBlockTally(dbTx, chainhash.Hash{byte(i)},
+				uint32(i), &bestTally, params)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error adding blocks: %v", err)
+	}
+
+	var summedTally *RollingSummedTally
+	err = testDb.View(func(dbTx database.Tx) error {
+		lastBestInterval, err :=
+			FetchIntervalTally(&bestTally.LastIntervalBlock, cache, dbTx,
+				params)
+		if err != nil {
+			return err
+		}
+
+		summedTally, err = lastBestInterval.GenerateSummedTally(cache,
+			dbTx, chaincfg.MainNetParams.VotingIntervals,
+			params)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected fetching summedTally: %v", err)
+	}
+
+	// Go backwards, seeing if the state can be reverted.
+	var talliesBackward [numBlocks]RollingVotingPrefixTally
+	for i := numBlocks; i >= 1; i-- {
+		if int64(i) < chaincfg.MainNetParams.StakeValidationHeight {
+			vbSlice = []uint16{}
+		}
+		if int64(i) >= chaincfg.MainNetParams.StakeValidationHeight {
+			switch i % 5 {
+			case 0:
+				vbSlice = []uint16{0x6665, 0x2345, 0x9999, 0xa0a1, 0xc432}
+			case 1:
+				vbSlice = []uint16{0x6687, 0x6689, 0x66bb, 0x66bb, 0x66e1}
+			case 2:
+				vbSlice = []uint16{0x3465, 0x5565, 0x6165, 0x65b6, 0xaaaa}
+			case 3:
+				vbSlice = []uint16{0xffff, 0x0000, 0x2342, 0x6444, 0xa333}
+			case 4:
+				vbSlice = []uint16{0x231b, 0xa343, 0xff34, 0x90bb}
+			}
+		}
+
+		talliesBackward[i-1] = bestTally
+
+		bestTally, err = bestTally.DisconnectBlockFromTally(cache, nil,
+			chainhash.Hash{byte(i)}, uint32(i), vbSlice, nil,
+			params)
+		if err != nil {
+			t.Fatalf("unexpected error removing blocks: %v", err)
+		}
+	}
+
+	for i := len(talliesForward) - 1; i >= 0; i-- {
+		if talliesForward[i] != talliesBackward[i] {
+			t.Fatalf("non-equivalent disconnection tallies at height %v:"+
+				" backward %v, forward %v", i, talliesBackward[i],
+				talliesForward[i])
+		}
+	}
+
+	// Do it again, loading from the database and going backwards this
+	// time.  Reload the cache and the best tally manually.  Prune the
+	// old cache according to height and make sure it's 1:1 with the
+	// previously generated cache.
+	pruneTallyCache(cache, numBlocks, params)
+	oldBestCache := cache
+	err = testDb.View(func(dbTx database.Tx) error {
+		cache, err = InitRollingTallyCache(dbTx, params)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("error initializing cache going backwards: %v", err)
+	}
+	if !reflect.DeepEqual(oldBestCache, cache) {
+		t.Fatalf("caches aren't same: got %v, want %v",
+			sortIntervalCache(oldBestCache), sortIntervalCache(cache))
+	}
+
+	err = testDb.View(func(dbTx database.Tx) error {
+		bestTallyPtr, err := LoadVotingDatabaseState(dbTx)
+		if err != nil {
+			return err
+		}
+		bestTally = *bestTallyPtr
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("error reloading the best state: %v", err)
+	}
+
+	err = testDb.Update(func(dbTx database.Tx) error {
+		for i := numBlocks; i >= 1; i-- {
+			if int64(i) < chaincfg.MainNetParams.StakeValidationHeight {
+				vbSlice = []uint16{}
+			}
+			if int64(i) >= chaincfg.MainNetParams.StakeValidationHeight {
+				switch i % 5 {
+				case 0:
+					vbSlice = []uint16{0x6665, 0x2345, 0x9999, 0xa0a1, 0xc432}
+				case 1:
+					vbSlice = []uint16{0x6687, 0x6689, 0x66bb, 0x66bb, 0x66e1}
+				case 2:
+					vbSlice = []uint16{0x3465, 0x5565, 0x6165, 0x65b6, 0xaaaa}
+				case 3:
+					vbSlice = []uint16{0xffff, 0x0000, 0x2342, 0x6444, 0xa333}
+				case 4:
+					vbSlice = []uint16{0x231b, 0xa343, 0xff34, 0x90bb}
+				}
+			}
+
+			bestTallyCopy := bestTally
+			talliesBackward[i-1] = bestTally
+
+			bestTally, err = bestTally.DisconnectBlockFromTally(cache, dbTx,
+				chainhash.Hash{byte(i)}, uint32(i), vbSlice, nil,
+				params)
+			if err != nil {
+				return err
+			}
+
+			err = WriteDisconnectedBlockTally(dbTx, chainhash.Hash{byte(i)},
+				chainhash.Hash{byte(i - 1)}, uint32(i), &bestTallyCopy, vbSlice,
+				params)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error removing blocks: %v", err)
+	}
+
+	for i := range talliesForward {
+		if talliesForward[i] != talliesBackward[i] {
+			t.Fatalf("non-equivalent disconnection tallies at height %v:"+
+				" backward %v, forward %v", i, talliesBackward[i],
+				talliesForward[i])
+		}
+	}
+}
+
+// TestTallyingAndVerdicts tests the tallying and verdict supplying functions
+// to ensure that the operate correctly, even in edge cases.
+func TestTallyingAndVerdicts(t *testing.T) {
+	t.Parallel()
+	params := &chaincfg.MainNetParams
+
+	tests := []struct {
+		name      string
+		numBlocks int64
+		intervals int
+		votebits  func(int64, int64) []uint16
+		verdict   [issuesLen]Verdict
+		err       error
+	}{
+		{
+			"issue #1 is no, issue #2 is no, issue #3 is yes, issue #4 is no",
+			49968, // 347 intervals
+			params.VotingIntervals,
+			func(i, numBlocks int64) []uint16 {
+				if i >= chaincfg.MainNetParams.StakeValidationHeight {
+					switch i % 5 {
+					case 0:
+						return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0xc432}
+					case 1:
+						return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0x66e1}
+					case 2:
+						return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0xaaaa}
+					case 3:
+						return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0x0901}
+					case 4:
+						return []uint16{0x0241, 0x0241, 0x0241, 0x90bb}
+					}
+				}
+
+				return []uint16{}
+			},
+			[issuesLen]Verdict{VerdictNo, VerdictNo,
+				VerdictYes, VerdictNo, VerdictUndecided,
+				VerdictUndecided, VerdictUndecided},
+			nil,
+		},
+		{
+			"issue #3 is yes, issue #4 is no by 1 vote",
+			49968, // 347 intervals
+			params.VotingIntervals,
+			func(i, numBlocks int64) []uint16 {
+				if i >= chaincfg.MainNetParams.StakeValidationHeight {
+					if i == numBlocks-1 {
+						return []uint16{0x0141, 0x0141, 0x0141, 0x0241, 0x0241}
+					}
+
+					switch i % 4 {
+					case 0:
+						return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0x0241}
+					case 1:
+						return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0x0241}
+					case 2:
+						return []uint16{0x0141, 0x0141, 0x0241, 0x0241, 0x0241}
+					case 3:
+						return []uint16{0x0141, 0x0141, 0x0141, 0x0241, 0x0241}
+					}
+				}
+
+				return []uint16{}
+			},
+			[issuesLen]Verdict{VerdictUndecided, VerdictUndecided,
+				VerdictYes, VerdictNo, VerdictUndecided,
+				VerdictUndecided, VerdictUndecided},
+			nil,
+		},
+		{
+			"issue #3 is yes, issue #4 is undecided by 1 vote",
+			49968, // 347 intervals
+			params.VotingIntervals,
+			func(i, numBlocks int64) []uint16 {
+				if i >= chaincfg.MainNetParams.StakeValidationHeight {
+					if i == numBlocks-1 {
+						return []uint16{0x0141, 0x0141, 0x0141, 0x0241, 0x0141}
+					}
+
+					switch i % 4 {
+					case 0:
+						return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0x0241}
+					case 1:
+						return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0x0241}
+					case 2:
+						return []uint16{0x0141, 0x0141, 0x0241, 0x0241, 0x0241}
+					case 3:
+						return []uint16{0x0141, 0x0141, 0x0141, 0x0241, 0x0241}
+					}
+				}
+
+				return []uint16{}
+			},
+			[issuesLen]Verdict{VerdictUndecided, VerdictUndecided,
+				VerdictYes, VerdictUndecided, VerdictUndecided,
+				VerdictUndecided, VerdictUndecided},
+			nil,
+		},
+		{
+			"issue #3 single yes vote, rest abstain leading to yes",
+			49968, // 347 intervals
+			params.VotingIntervals,
+			func(i, numBlocks int64) []uint16 {
+				if i >= chaincfg.MainNetParams.StakeValidationHeight {
+					switch i % 144 {
+					case 0:
+						return []uint16{0x0041, 0x00c1, 0x00c1, 0x00c1, 0x00c1}
+					default:
+						return []uint16{0x00c1, 0x00c1, 0x00c1, 0x00c1, 0x00c1}
+					}
+				}
+
+				return []uint16{}
+			},
+			[issuesLen]Verdict{VerdictUndecided, VerdictUndecided,
+				VerdictYes, VerdictUndecided, VerdictUndecided,
+				VerdictUndecided, VerdictUndecided},
+			nil,
+		},
+		{
+			"issue #3 single no vote, rest abstain leading to no",
+			49968, // 347 intervals
+			params.VotingIntervals,
+			func(i, numBlocks int64) []uint16 {
+				if i >= chaincfg.MainNetParams.StakeValidationHeight {
+					switch i % 144 {
+					case 0:
+						return []uint16{0x0081, 0x00c1, 0x00c1, 0x00c1, 0x00c1}
+					default:
+						return []uint16{0x00c1, 0x00c1, 0x00c1, 0x00c1, 0x00c1}
+					}
+				}
+
+				return []uint16{}
+			},
+			[issuesLen]Verdict{VerdictUndecided, VerdictUndecided,
+				VerdictNo, VerdictUndecided, VerdictUndecided,
+				VerdictUndecided, VerdictUndecided},
+			nil,
+		},
+		{
+			"all issues yes",
+			49968, // 347 intervals
+			params.VotingIntervals,
+			func(i, numBlocks int64) []uint16 {
+				if i >= chaincfg.MainNetParams.StakeValidationHeight {
+					return []uint16{0x5555, 0x5555, 0x5555, 0x5555, 0x5555}
+				}
+
+				return []uint16{}
+			},
+			[issuesLen]Verdict{VerdictYes, VerdictYes,
+				VerdictYes, VerdictYes, VerdictYes,
+				VerdictYes, VerdictYes},
+			nil,
+		},
+		{
+			"all issues no",
+			49968, // 347 intervals
+			params.VotingIntervals,
+			func(i, numBlocks int64) []uint16 {
+				if i >= chaincfg.MainNetParams.StakeValidationHeight {
+					return []uint16{0xaaa9, 0xaaa9, 0xaaa9, 0xaaa9, 0xaaa9}
+				}
+
+				return []uint16{}
+			},
+			[issuesLen]Verdict{VerdictNo, VerdictNo,
+				VerdictNo, VerdictNo, VerdictNo,
+				VerdictNo, VerdictNo},
+			nil,
+		},
+		{
+			"only 3 of 5 voters, issue #3 is yes, issue #4 is no",
+			49968, // 347 intervals
+			params.VotingIntervals,
+			func(i, numBlocks int64) []uint16 {
+				if i >= chaincfg.MainNetParams.StakeValidationHeight {
+					switch i % 4 {
+					case 0:
+						return []uint16{0x0241, 0x0241, 0x0241}
+					case 1:
+						return []uint16{0x0241, 0x0241, 0x0241}
+					case 2:
+						return []uint16{0x0141, 0x0241, 0x0241}
+					case 3:
+						return []uint16{0x0141, 0x0141, 0x0241}
+					}
+				}
+
+				return []uint16{}
+			},
+			[issuesLen]Verdict{VerdictUndecided, VerdictUndecided,
+				VerdictYes, VerdictNo, VerdictUndecided,
+				VerdictUndecided, VerdictUndecided},
+			nil,
+		},
+		{
+			"error wrong height",
+			49967, // short 1 block, not an interval block
+			params.VotingIntervals,
+			func(i, numBlocks int64) []uint16 {
+				if i >= chaincfg.MainNetParams.StakeValidationHeight {
+					return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0x0241}
+				}
+
+				return []uint16{}
+			},
+			[issuesLen]Verdict{VerdictUndecided, VerdictUndecided,
+				VerdictYes, VerdictNo, VerdictUndecided,
+				VerdictUndecided, VerdictUndecided},
+			stakeRuleError(ErrTallyingIntervals, ""),
+		},
+		{
+			"too many voting intervals",
+			49968, // short 1 block, not an interval block
+			348,
+			func(i, numBlocks int64) []uint16 {
+				if i >= chaincfg.MainNetParams.StakeValidationHeight {
+					return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0x0241}
+				}
+
+				return []uint16{}
+			},
+			[issuesLen]Verdict{VerdictUndecided, VerdictUndecided,
+				VerdictYes, VerdictNo, VerdictUndecided,
+				VerdictUndecided, VerdictUndecided},
+			stakeRuleError(ErrTallyingIntervals, ""),
+		},
+	}
+
+	for _, test := range tests {
+		// Set up the cache and genesis block rolling tally.
+		cache := make(RollingVotingPrefixTallyCache)
+		var bestTally RollingVotingPrefixTally
+		bestTally.LastIntervalBlock = BlockKey{*params.GenesisHash, 0}
+
+		for i := int64(1); i < test.numBlocks; i++ {
+			// Skip using the database.
+			var err error
+			bestTally, err = bestTally.ConnectBlockToTally(cache, nil,
+				chainhash.Hash{byte(i)}, chainhash.Hash{byte(i - 1)}, uint32(i),
+				test.votebits(i, test.numBlocks),
+				&chaincfg.MainNetParams)
+			if err != nil {
+				t.Fatalf("failed connecting tally %v", err)
+			}
+		}
+
+		verdicts, err := bestTally.GenerateVotingResults(cache,
+			nil, test.intervals, &chaincfg.MainNetParams)
+		if err != nil && test.err == nil {
+			t.Fatalf("failed generating verdicts %v", err)
+		}
+		if err != nil && test.err != nil {
+			if err.(RuleError).ErrorCode != test.err.(RuleError).ErrorCode {
+				t.Fatalf("got incorrect error for test %v; got %v, want %v",
+					test.name, err.(RuleError).ErrorCode,
+					test.err.(RuleError).ErrorCode)
+			}
+			continue
+		}
+		if err == nil && test.err != nil {
+			t.Fatalf("expecting err %v for test %v, got no error",
+				test.err.(RuleError).ErrorCode, test.name)
+			continue
+		}
+
+		if !reflect.DeepEqual(test.verdict, verdicts.Verdicts) {
+			t.Fatalf("unexpected verdicts on test '%v', got %v want %v",
+				test.name, verdicts.Verdicts, test.verdict)
+		}
+	}
+}

--- a/blockchain/stakenode_test.go
+++ b/blockchain/stakenode_test.go
@@ -1,0 +1,896 @@
+// stakenode_test.go
+package blockchain
+
+import (
+	"bytes"
+	"compress/bzip2"
+	"encoding/binary"
+	"encoding/gob"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/decred/dcrd/blockchain/stake"
+	"github.com/decred/dcrd/chaincfg"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/database"
+	"github.com/decred/dcrd/wire"
+	"github.com/decred/dcrutil"
+)
+
+// stakeNodesEqual does a cursory test to ensure that data returned from the API
+// for any given node is equivalent.
+func stakeNodesEqual(a *stake.Node, b *stake.Node) error {
+	if !reflect.DeepEqual(a.LiveTickets(), b.LiveTickets()) {
+		return fmt.Errorf("live tickets were not equal between nodes; "+
+			"a: %v, b: %v", len(a.LiveTickets()), len(b.LiveTickets()))
+	}
+	if !reflect.DeepEqual(a.MissedTickets(), b.MissedTickets()) {
+		return fmt.Errorf("missed tickets were not equal between nodes; "+
+			"a: %v, b: %v", len(a.MissedTickets()), len(b.MissedTickets()))
+	}
+	if !reflect.DeepEqual(a.RevokedTickets(), b.RevokedTickets()) {
+		return fmt.Errorf("revoked tickets were not equal between nodes; "+
+			"a: %v, b: %v", len(a.RevokedTickets()), len(b.RevokedTickets()))
+	}
+	if !reflect.DeepEqual(a.NewTickets(), b.NewTickets()) {
+		return fmt.Errorf("new tickets were not equal between nodes; "+
+			"a: %v, b: %v", len(a.NewTickets()), len(b.NewTickets()))
+	}
+	if !reflect.DeepEqual(a.UndoData(), b.UndoData()) {
+		return fmt.Errorf("undo data were not equal between nodes; "+
+			"a: %v, b: %v", len(a.UndoData()), len(b.UndoData()))
+	}
+	if !reflect.DeepEqual(a.Winners(), b.Winners()) {
+		return fmt.Errorf("winners were not equal between nodes; "+
+			"a: %v, b: %v", a.Winners(), b.Winners())
+	}
+	if a.FinalState() != b.FinalState() {
+		return fmt.Errorf("final state were not equal between nodes; "+
+			"a: %x, b: %x", a.FinalState(), b.FinalState())
+	}
+	if a.PoolSize() != b.PoolSize() {
+		return fmt.Errorf("pool size were not equal between nodes; "+
+			"a: %x, b: %x", a.PoolSize(), b.PoolSize())
+	}
+	if !reflect.DeepEqual(a.SpentByBlock(), b.SpentByBlock()) {
+		return fmt.Errorf("spentbyblock were not equal between nodes; "+
+			"a: %x, b: %x", a.SpentByBlock(), b.SpentByBlock())
+	}
+	if !reflect.DeepEqual(a.MissedByBlock(), b.MissedByBlock()) {
+		return fmt.Errorf("missedbyblock were not equal between nodes; "+
+			"a: %x, b: %x", a.MissedByBlock(), b.MissedByBlock())
+	}
+
+	return nil
+}
+
+// pruneChildrenRecursivelyTest prunes the stake data present in a child node,
+// then prunes the stake data from any children of that child recursively.
+func (b *BlockChain) pruneChildrenRecursivelyTest(child *blockNode) {
+	child.stakeNode = nil
+	child.rollingTally = nil
+
+	for _, anotherChild := range child.children {
+		b.pruneChildrenRecursivelyTest(anotherChild)
+	}
+}
+
+// pruneRecursivelyTest prunes the stake data from all nodes except the best
+// node.
+func (b *BlockChain) pruneRecursivelyTest() {
+	node := b.bestNode.parent
+
+	for {
+		if node.parent != nil {
+			node = node.parent
+		} else {
+			break
+		}
+
+		if len(node.children) > 0 {
+			for _, child := range node.children {
+				if !child.inMainChain {
+					b.pruneChildrenRecursivelyTest(child)
+				}
+			}
+		}
+
+		node.stakeNode = nil
+		node.rollingTally = nil
+	}
+}
+
+// fetchNodeChildrenFromNodeTest is a recursive function that searches for
+// a node in the children of the passed node.  If it finds the node, it writes
+// it to the passed map.
+func (b *BlockChain) fetchNodeChildrenFromNodeTest(child *blockNode, allNodes map[chainhash.Hash]*blockNode) {
+	allNodes[child.hash] = child
+	for _, anotherChild := range child.children {
+		b.fetchNodeChildrenFromNodeTest(anotherChild, allNodes)
+	}
+}
+
+// fetchNodeTest is an internal testing function that scours the blockchain
+// looking for a node that corresponds to the passed hash.  It returns an
+// error if it fails to find the node.  Because it stores a map each time,
+// it is extremely expensive and should only be used during testing.
+func (b *BlockChain) fetchNodeTest(hash chainhash.Hash) (*blockNode, error) {
+	allNodes := make(map[chainhash.Hash]*blockNode)
+	current := b.bestNode
+	for {
+		if current.hash == hash {
+			return current, nil
+		}
+
+		allNodes[current.hash] = current
+
+		if len(current.children) > 0 {
+			for _, child := range current.children {
+				b.fetchNodeChildrenFromNodeTest(child, allNodes)
+			}
+		}
+
+		if current.parent != nil {
+			current = current.parent
+		} else {
+			var err error
+			current, err = b.getPrevNodeFromNode(current)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		if current == nil {
+			break
+		}
+	}
+
+	node, ok := allNodes[hash]
+	if ok {
+		return node, nil
+	}
+
+	return nil, fmt.Errorf("can't find node %v", hash)
+}
+
+// testPrunedStakeData tests stake ticket and tallying data from the blockchain
+// and then ensures that fetches of this data still work correctly and return
+// the same data as was originally set in memory before the pruning.
+func (b *BlockChain) testPrunedStakeData(hashes []chainhash.Hash) error {
+	// The list of hashes should be in order.  Fetch the last node and
+	// go backwards, storing all the intermediate stake data to check
+	// for equivalence after.
+	nodeStakeData := make([]struct {
+		node         *blockNode
+		stakeNode    *stake.Node
+		rollingTally *stake.RollingVotingPrefixTally
+	}, len(hashes))
+
+	for i := len(hashes) - 1; i >= 0; i-- {
+		n, err := b.fetchNodeTest(hashes[i])
+		if err != nil {
+			return err
+		}
+
+		nodeStakeData[i].node = n
+		nodeStakeData[i].stakeNode = n.stakeNode
+		nodeStakeData[i].rollingTally = n.rollingTally
+	}
+
+	for i := len(hashes) - 1; i >= 0; i-- {
+		b.pruneRecursivelyTest()
+
+		stakeNode, err := b.fetchStakeNode(nodeStakeData[i].node)
+		if err != nil {
+			return err
+		}
+		if err = stakeNodesEqual(stakeNode,
+			nodeStakeData[i].stakeNode); err != nil {
+			return fmt.Errorf("got not equal stake nodes at block %v: %v, %v (%v)",
+				nodeStakeData[i].node.hash, stakeNode,
+				nodeStakeData[i].stakeNode, err)
+		}
+
+		tally, err := b.fetchRollingTally(nodeStakeData[i].node)
+		if err != nil {
+			return err
+		}
+		if *tally != *nodeStakeData[i].rollingTally {
+			return fmt.Errorf("got not equal tallying data at block %v: %v, %v",
+				nodeStakeData[i].node.hash, *tally,
+				*nodeStakeData[i].rollingTally)
+		}
+	}
+
+	return nil
+}
+
+// TestReorgTestLongForStakeDataEquivalence performs a long reorganization and
+// ensures the correct fetching of stake data for a mainchain and its sidechain
+// by calling testPrunedStakeData at various times when manipulating the
+// blockchain.
+func TestReorgTestLongForStakeDataEquivalence(t *testing.T) {
+	// Create a new database and chain instance to run tests against.
+	chain, teardownFunc, err := chainSetup("stakedataequivtests",
+		TestSimNetParams)
+	if err != nil {
+		t.Errorf("Failed to setup chain instance: %v", err)
+		return
+	}
+	defer teardownFunc()
+
+	// The genesis block should fail to connect since it's already
+	// inserted.
+	genesisBlock := TestSimNetParams.GenesisBlock
+	err = chain.CheckConnectBlock(dcrutil.NewBlock(genesisBlock))
+	if err == nil {
+		t.Errorf("CheckConnectBlock: Did not receive expected error")
+	}
+
+	// Load up the rest of the blocks up to HEAD.
+	filename := filepath.Join("testdata/", "reorgto179.bz2")
+	fi, err := os.Open(filename)
+	bcStream := bzip2.NewReader(fi)
+	defer fi.Close()
+
+	// Create a buffer of the read file
+	bcBuf := new(bytes.Buffer)
+	bcBuf.ReadFrom(bcStream)
+
+	// Create decoder from the buffer and a map to store the data
+	bcDecoder := gob.NewDecoder(bcBuf)
+	blockChain := make(map[int64][]byte)
+
+	// Decode the blockchain into the map
+	if err := bcDecoder.Decode(&blockChain); err != nil {
+		t.Errorf("error decoding test blockchain: %v", err.Error())
+	}
+
+	// Load up the short chain
+	timeSource := NewMedianTime()
+	finalIdx1 := 179
+	mainchainBlockHashes := make([]chainhash.Hash, finalIdx1)
+	for i := 1; i < finalIdx1+1; i++ {
+		bl, err := dcrutil.NewBlockFromBytes(blockChain[int64(i)])
+		if err != nil {
+			t.Fatalf("NewBlockFromBytes error: %v", err.Error())
+		}
+		bl.SetHeight(int64(i))
+
+		_, _, err = chain.ProcessBlock(bl, timeSource, BFNone)
+		if err != nil {
+			t.Fatalf("ProcessBlock error at height %v: %v", i, err.Error())
+		}
+
+		blSha := bl.Sha()
+		mainchainBlockHashes[i-1] = *blSha
+	}
+
+	// Prune the stake data and test for each block.
+	err = chain.testPrunedStakeData(mainchainBlockHashes)
+	if err != nil {
+		t.Fatalf("fatal error on stake node add test: %v", err)
+	}
+
+	// Load the long chain and begin loading blocks from that too,
+	// forcing a reorganization
+	// Load up the rest of the blocks up to HEAD.
+	filename = filepath.Join("testdata/", "reorgto180.bz2")
+	fi, err = os.Open(filename)
+	bcStream = bzip2.NewReader(fi)
+	defer fi.Close()
+
+	// Create a buffer of the read file
+	bcBuf = new(bytes.Buffer)
+	bcBuf.ReadFrom(bcStream)
+
+	// Create decoder from the buffer and a map to store the data
+	bcDecoder = gob.NewDecoder(bcBuf)
+	blockChain = make(map[int64][]byte)
+
+	// Decode the blockchain into the map
+	if err := bcDecoder.Decode(&blockChain); err != nil {
+		t.Errorf("error decoding test blockchain: %v", err.Error())
+	}
+
+	forkPoint := 131
+	finalIdx2 := 180
+	sidechainBlockHashes := make([]chainhash.Hash, 0)
+	for i := forkPoint; i < finalIdx2+1; i++ {
+		// Test pruned data for all the sidechain nodes before
+		// adding the final block and forcing the reorg.
+		if i == finalIdx2 {
+			err = chain.testPrunedStakeData(sidechainBlockHashes)
+			if err != nil {
+				t.Fatalf("error %v", err)
+			}
+		}
+
+		bl, err := dcrutil.NewBlockFromBytes(blockChain[int64(i)])
+		if err != nil {
+			t.Fatalf("NewBlockFromBytes error: %v", err.Error())
+		}
+		bl.SetHeight(int64(i))
+
+		_, _, err = chain.ProcessBlock(bl, timeSource, BFNone)
+		if err != nil {
+			t.Fatalf("ProcessBlock error: %v", err.Error())
+		}
+
+		blSha := bl.Sha()
+		sidechainBlockHashes = append(sidechainBlockHashes, *blSha)
+	}
+
+	// Ensure our blockchain is at the correct best tip
+	topBlock, _ := chain.GetTopBlock()
+	tipHash := topBlock.Sha()
+	expected, _ := chainhash.NewHashFromStr("5ab969d0afd8295b6cd1506f2a310d" +
+		"259322015c8bd5633f283a163ce0e50594")
+	if *tipHash != *expected {
+		t.Errorf("Failed to correctly reorg; expected tip %v, got tip %v",
+			expected, tipHash)
+	}
+	have, err := chain.HaveBlock(expected)
+	if !have {
+		t.Errorf("missing tip block after reorganization test")
+	}
+	if err != nil {
+		t.Errorf("unexpected error testing for presence of new tip block "+
+			"after reorg test: %v", err)
+	}
+
+	return
+}
+
+// rollingTallyCacheSliceTest is a sortable rolling tally cache used for
+// debugging the rolling tally cache.
+type rollingTallyCacheSliceTest []*stake.RollingVotingPrefixTally
+
+// Len satisfies the sort interface.
+func (s rollingTallyCacheSliceTest) Len() int {
+	return len(s)
+}
+
+// Swap satisfies the sort interface.
+func (s rollingTallyCacheSliceTest) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// Less satisfies the sort interface.
+func (s rollingTallyCacheSliceTest) Less(i, j int) bool {
+	return s[i].CurrentBlockHeight < s[j].CurrentBlockHeight
+}
+
+// sortIntervalCache takes a RollingVotingPrefixTallyCache and returns a sorted
+// slice of all the elements, sorting by height.
+func sortIntervalCache(cache stake.RollingVotingPrefixTallyCache) []*stake.RollingVotingPrefixTally {
+	s := make(rollingTallyCacheSliceTest, len(cache))
+
+	i := 0
+	for _, v := range cache {
+		s[i] = v
+		i++
+	}
+
+	sort.Sort(s)
+
+	return s
+}
+
+// chainSetupForTallying sets up a blockchain to use in testing the evaluation
+// of the tallying of votes for stake nodes.  Importantly, it loads the dummy
+// database driver that is used
+func chainSetupForTallying(params *chaincfg.Params) *BlockChain {
+	// Generate a checkpoint by height map from the provided checkpoints.
+	var checkpointsByHeight map[int64]*chaincfg.Checkpoint
+	if len(params.Checkpoints) > 0 {
+		checkpointsByHeight = make(map[int64]*chaincfg.Checkpoint)
+		for i := range params.Checkpoints {
+			checkpoint := &params.Checkpoints[i]
+			checkpointsByHeight[checkpoint.Height] = checkpoint
+		}
+	}
+
+	ndb, err := database.Create("dummydb")
+	if err != nil {
+		panic(fmt.Sprintf("%v", err))
+	}
+
+	b := BlockChain{
+		checkpointsByHeight:     checkpointsByHeight,
+		db:                      ndb,
+		chainParams:             params,
+		notifications:           nil,
+		sigCache:                nil,
+		indexManager:            nil,
+		bestNode:                nil,
+		index:                   make(map[chainhash.Hash]*blockNode),
+		depNodes:                make(map[chainhash.Hash][]*blockNode),
+		orphans:                 make(map[chainhash.Hash]*orphanBlock),
+		prevOrphans:             make(map[chainhash.Hash][]*orphanBlock),
+		blockCache:              make(map[chainhash.Hash]*dcrutil.Block),
+		mainchainBlockCache:     make(map[chainhash.Hash]*dcrutil.Block),
+		mainchainBlockCacheSize: mainchainBlockCacheSize,
+	}
+
+	// Create a new node from the genesis block and set it as the best node.
+	genesisBlock := dcrutil.NewBlock(b.chainParams.GenesisBlock)
+	header := &genesisBlock.MsgBlock().Header
+	node := newBlockNode(header, genesisBlock.Sha(), 0, []chainhash.Hash{},
+		[]chainhash.Hash{}, []uint16{})
+	node.inMainChain = true
+	b.bestNode = node
+
+	// Add the new node to the index which is used for faster lookups.
+	b.index[node.hash] = node
+
+	// Initialize the state related to the best block.
+	numTxns := uint64(len(genesisBlock.MsgBlock().Transactions))
+	blockSize := uint64(genesisBlock.MsgBlock().SerializeSize())
+	b.stateSnapshot = newBestState(b.bestNode, blockSize, numTxns, numTxns, 0)
+
+	// Need the first tally.
+	var tally stake.RollingVotingPrefixTally
+	tally.LastIntervalBlock = stake.BlockKey{Hash: *params.GenesisHash, Height: 0}
+	b.bestNode.rollingTally = &tally
+
+	return &b
+}
+
+// TestTallyingonSpoofedNodes is a test for the verdicts derived from tallies
+// using a tally cache and a spoofed blockchain.  The blockchain uses a dummy
+// database and nodes that are pruned of most elements except for the necessary
+// architectural ones, votebits, and the block tallies.  The tests generate
+// very long sidechains and ensure that the evaluations of the data for the
+// sidechains returns the correct verdicts even after pruning.
+func TestTallyingonSpoofedNodes(t *testing.T) {
+	params := &chaincfg.MainNetParams
+	tests := []struct {
+		name         string
+		intervals    int
+		numNodes     int64
+		forkHeight   int64
+		tweakHeight  int64
+		votebitsMain func(int64) []uint16
+		votebitsSide func(int64, int64) []uint16
+		verdictsMain [7]stake.Verdict
+		verdictsSide [7]stake.Verdict
+		err          error
+	}{
+		{
+			"main chain issue #3 is yes, issue #4 is no by 1 vote; " +
+				"sidechain same but issue #4 no by 1 vote in last interval",
+			params.VotingIntervals,
+			49968, // 347 intervals
+			48000,
+			49824 + 3*6,
+			func(i int64) []uint16 {
+				if i >= params.StakeValidationHeight {
+					switch i % 4 {
+					case 0:
+						return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0x0241}
+					case 1:
+						return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0x0241}
+					case 2:
+						return []uint16{0x0141, 0x0141, 0x0241, 0x0241, 0x0241}
+					case 3:
+						return []uint16{0x0141, 0x0141, 0x0141, 0x0241, 0x0241}
+					}
+				}
+
+				return []uint16{}
+			},
+			func(i, tweakHeight int64) []uint16 {
+				if i == tweakHeight {
+					return []uint16{0x0141, 0x0141, 0x0141, 0x0241, 0x0141}
+				}
+
+				switch i % 4 {
+				case 0:
+					return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0x0241}
+				case 1:
+					return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0x0241}
+				case 2:
+					return []uint16{0x0141, 0x0141, 0x0241, 0x0241, 0x0241}
+				case 3:
+					return []uint16{0x0141, 0x0141, 0x0141, 0x0241, 0x0241}
+				}
+
+				return []uint16{}
+			},
+			[7]stake.Verdict{
+				stake.VerdictUndecided,
+				stake.VerdictUndecided,
+				stake.VerdictYes,
+				stake.VerdictNo,
+				stake.VerdictUndecided,
+				stake.VerdictUndecided,
+				stake.VerdictUndecided,
+			},
+			[7]stake.Verdict{
+				stake.VerdictUndecided,
+				stake.VerdictUndecided,
+				stake.VerdictYes,
+				stake.VerdictUndecided,
+				stake.VerdictUndecided,
+				stake.VerdictUndecided,
+				stake.VerdictUndecided,
+			},
+			nil,
+		},
+		{
+			"main chain issue #3 is yes, issue #4 is no by 1 vote; sidechain " +
+				"same but issue #4 no by 1 vote in middle of intervals",
+			params.VotingIntervals,
+			49968, // 347 intervals
+			43056,
+			43056 + 3,
+			func(i int64) []uint16 {
+				if i >= params.StakeValidationHeight {
+					switch i % 4 {
+					case 0:
+						return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0x0241}
+					case 1:
+						return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0x0241}
+					case 2:
+						return []uint16{0x0141, 0x0141, 0x0241, 0x0241, 0x0241}
+					case 3:
+						return []uint16{0x0141, 0x0141, 0x0141, 0x0241, 0x0241}
+					}
+				}
+
+				return []uint16{}
+			},
+			func(i, tweakHeight int64) []uint16 {
+				if i == tweakHeight {
+					return []uint16{0x0141, 0x0141, 0x0141, 0x0241, 0x0141}
+				}
+
+				switch i % 4 {
+				case 0:
+					return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0x0241}
+				case 1:
+					return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0x0241}
+				case 2:
+					return []uint16{0x0141, 0x0141, 0x0241, 0x0241, 0x0241}
+				case 3:
+					return []uint16{0x0141, 0x0141, 0x0141, 0x0241, 0x0241}
+				}
+
+				return []uint16{}
+			},
+			[7]stake.Verdict{
+				stake.VerdictUndecided,
+				stake.VerdictUndecided,
+				stake.VerdictYes,
+				stake.VerdictNo,
+				stake.VerdictUndecided,
+				stake.VerdictUndecided,
+				stake.VerdictUndecided,
+			},
+			[7]stake.Verdict{
+				stake.VerdictUndecided,
+				stake.VerdictUndecided,
+				stake.VerdictYes,
+				stake.VerdictUndecided,
+				stake.VerdictUndecided,
+				stake.VerdictUndecided,
+				stake.VerdictUndecided,
+			},
+			nil,
+		},
+		{
+			"main chain issue #3 is yes, issue #4 is no by 1 vote; " +
+				"sidechain same but issue #4 undecided by 1 vote in " +
+				"first interval",
+			params.VotingIntervals,
+			49968, // 347 intervals
+			41903,
+			41904,
+			func(i int64) []uint16 {
+				if i >= params.StakeValidationHeight {
+					switch i % 4 {
+					case 0:
+						return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0x0241}
+					case 1:
+						return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0x0241}
+					case 2:
+						return []uint16{0x0141, 0x0141, 0x0241, 0x0241, 0x0241}
+					case 3:
+						return []uint16{0x0141, 0x0141, 0x0141, 0x0241, 0x0241}
+					}
+				}
+
+				return []uint16{}
+			},
+			func(i, tweakHeight int64) []uint16 {
+				if i == tweakHeight {
+					return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0x0141}
+				}
+
+				switch i % 4 {
+				case 0:
+					return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0x0241}
+				case 1:
+					return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0x0241}
+				case 2:
+					return []uint16{0x0141, 0x0141, 0x0241, 0x0241, 0x0241}
+				case 3:
+					return []uint16{0x0141, 0x0141, 0x0141, 0x0241, 0x0241}
+				}
+
+				return []uint16{}
+			},
+			[7]stake.Verdict{
+				stake.VerdictUndecided,
+				stake.VerdictUndecided,
+				stake.VerdictYes,
+				stake.VerdictNo,
+				stake.VerdictUndecided,
+				stake.VerdictUndecided,
+				stake.VerdictUndecided,
+			},
+			[7]stake.Verdict{
+				stake.VerdictUndecided,
+				stake.VerdictUndecided,
+				stake.VerdictYes,
+				stake.VerdictUndecided,
+				stake.VerdictUndecided,
+				stake.VerdictUndecided,
+				stake.VerdictUndecided,
+			},
+			nil,
+		},
+		{
+			"main chain issue #3 is yes, issue #4 is no by 1 vote; " +
+				"sidechain same because tweak affects block before last window",
+			params.VotingIntervals,
+			49968, // 347 intervals
+			41326,
+			41327,
+			func(i int64) []uint16 {
+				if i >= params.StakeValidationHeight {
+					switch i % 4 {
+					case 0:
+						return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0x0241}
+					case 1:
+						return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0x0241}
+					case 2:
+						return []uint16{0x0141, 0x0141, 0x0241, 0x0241, 0x0241}
+					case 3:
+						return []uint16{0x0141, 0x0141, 0x0141, 0x0241, 0x0241}
+					}
+				}
+
+				return []uint16{}
+			},
+			func(i, tweakHeight int64) []uint16 {
+				if i == tweakHeight {
+					return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0x0141}
+				}
+
+				switch i % 4 {
+				case 0:
+					return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0x0241}
+				case 1:
+					return []uint16{0x0241, 0x0241, 0x0241, 0x0241, 0x0241}
+				case 2:
+					return []uint16{0x0141, 0x0141, 0x0241, 0x0241, 0x0241}
+				case 3:
+					return []uint16{0x0141, 0x0141, 0x0141, 0x0241, 0x0241}
+				}
+
+				return []uint16{}
+			},
+			[7]stake.Verdict{
+				stake.VerdictUndecided,
+				stake.VerdictUndecided,
+				stake.VerdictYes,
+				stake.VerdictNo,
+				stake.VerdictUndecided,
+				stake.VerdictUndecided,
+				stake.VerdictUndecided,
+			},
+			[7]stake.Verdict{
+				stake.VerdictUndecided,
+				stake.VerdictUndecided,
+				stake.VerdictYes,
+				stake.VerdictNo,
+				stake.VerdictUndecided,
+				stake.VerdictUndecided,
+				stake.VerdictUndecided,
+			},
+			nil,
+		},
+		{
+			"main chain issues all yes, sidechain issues all no",
+			params.VotingIntervals,
+			49968, // 347 intervals
+			41327,
+			0, // No tweaks
+			func(i int64) []uint16 {
+				if i >= params.StakeValidationHeight {
+					return []uint16{0x5555, 0x5555, 0x5555, 0x5555}
+				}
+
+				return []uint16{}
+			},
+			func(i, tweakHeight int64) []uint16 {
+				return []uint16{0xaaa9, 0xaaa9, 0xaaa9}
+			},
+			[7]stake.Verdict{
+				stake.VerdictYes,
+				stake.VerdictYes,
+				stake.VerdictYes,
+				stake.VerdictYes,
+				stake.VerdictYes,
+				stake.VerdictYes,
+				stake.VerdictYes,
+			},
+			[7]stake.Verdict{
+				stake.VerdictNo,
+				stake.VerdictNo,
+				stake.VerdictNo,
+				stake.VerdictNo,
+				stake.VerdictNo,
+				stake.VerdictNo,
+				stake.VerdictNo,
+			},
+			nil,
+		},
+	}
+
+	hashForHeight := func(sidechain bool, height uint32) chainhash.Hash {
+		var h chainhash.Hash
+		binary.LittleEndian.PutUint32(h[0:4], height)
+
+		if sidechain {
+			h[4] = 0x01
+		}
+
+		return h
+	}
+
+	for _, test := range tests {
+		chain := chainSetupForTallying(params)
+
+		// Reset the cache each time.
+		chain.rollingTallyCache = make(stake.RollingVotingPrefixTallyCache)
+
+		// Spoof a large number of nodes with varying voteBits settings
+		// and run them forwards.
+		var mainchainBest, sidechainBest *blockNode
+		for i := int64(1); i < test.numNodes; i++ {
+			// Make up a header.
+			header := wire.BlockHeader{
+				Version:   1,
+				PrevBlock: chain.bestNode.hash,
+				Height:    uint32(i),
+				Nonce:     uint32(0),
+			}
+
+			// Make up a node hash.
+			headerHash := hashForHeight(false, uint32(i))
+
+			thisNode := new(blockNode)
+			thisNode.header = header
+			thisNode.hash = headerHash
+			thisNode.height = i
+			thisNode.parent = chain.bestNode
+			thisNode.inMainChain = true
+			thisNode.voteBitsSlice = test.votebitsMain(i)
+			chain.bestNode.children = append(chain.bestNode.children, thisNode)
+
+			var err error
+			thisNode.rollingTally, err = chain.fetchRollingTally(thisNode)
+			if err != nil {
+				t.Fatalf("test %v failure fetching mainchain tally for "+
+					"height %v: %v", test.name, i, err)
+			}
+
+			if thisNode.height == test.forkHeight {
+				sidechainBest = thisNode
+			}
+
+			chain.bestNode = thisNode
+			mainchainBest = thisNode
+		}
+
+		mainchainVerdicts, err :=
+			mainchainBest.rollingTally.GenerateVotingResults(
+				chain.rollingTallyCache, nil, params.VotingIntervals,
+				&chaincfg.MainNetParams)
+		if err != nil {
+			t.Fatalf("test %v: failed generating verdicts %v", test.name, err)
+		}
+
+		// Generate a side chain and attempt to get the correctly set
+		// voteBits from there.  Store the results, then drop all the
+		// block nodes.  After the block nodes are gone, recreate the
+		// sidechain and ensure that the results are the same.
+		for i := test.forkHeight + 1; i < test.numNodes; i++ {
+			// Make up a header.
+			header := wire.BlockHeader{
+				Version:   1,
+				PrevBlock: sidechainBest.hash,
+				Height:    uint32(i),
+				Nonce:     uint32(1),
+			}
+
+			// Make up a node hash.
+			headerHash := hashForHeight(true, uint32(i))
+
+			thisNode := new(blockNode)
+			thisNode.header = header
+			thisNode.hash = headerHash
+			thisNode.height = i
+			thisNode.parent = sidechainBest
+			thisNode.inMainChain = false
+			thisNode.voteBitsSlice = test.votebitsSide(i, test.tweakHeight)
+			sidechainBest.children = append(sidechainBest.children, thisNode)
+			thisNode.rollingTally, err = chain.fetchRollingTally(thisNode)
+			if err != nil {
+				t.Fatalf("test %v block %v: failure fetching mainchain tally %v",
+					test.name, i, err)
+			}
+
+			sidechainBest = thisNode
+		}
+
+		sidechainVerdicts, err :=
+			sidechainBest.rollingTally.GenerateVotingResults(
+				chain.rollingTallyCache, nil, params.VotingIntervals,
+				&chaincfg.MainNetParams)
+		if err != nil {
+			t.Fatalf("test %v: failed generating verdicts %v", test.name, err)
+		}
+
+		if !reflect.DeepEqual(mainchainVerdicts.Verdicts, test.verdictsMain) {
+			t.Errorf("test %v: mainchain verdicts: got %v want %v",
+				test.name, mainchainVerdicts.Verdicts, test.verdictsMain)
+		}
+		if !reflect.DeepEqual(sidechainVerdicts.Verdicts, test.verdictsSide) {
+			t.Errorf("test %v: sidechain verdicts: got %v want %v",
+				test.name, sidechainVerdicts.Verdicts, test.verdictsSide)
+		}
+
+		// Prune recursively and see if it can restore correctly.
+		chain.pruneRecursivelyTest()
+		mainchainBestTally, err := chain.fetchRollingTally(mainchainBest)
+		if err != nil {
+			t.Fatalf("test %v: failed fetching mainchain best tally %v",
+				test.name, err)
+		}
+		mainchainVerdicts, err =
+			mainchainBestTally.GenerateVotingResults(chain.rollingTallyCache,
+				nil, params.VotingIntervals, &chaincfg.MainNetParams)
+		if err != nil {
+			t.Fatalf("test %v: failed generating verdicts %v", test.name, err)
+		}
+		sidechainBestTally, err := chain.fetchRollingTally(sidechainBest)
+		if err != nil {
+			t.Fatalf("test %v: failed fetching sidechain best tally %v",
+				test.name, err)
+		}
+		sidechainVerdicts, err =
+			sidechainBestTally.GenerateVotingResults(chain.rollingTallyCache,
+				nil, params.VotingIntervals, &chaincfg.MainNetParams)
+		if err != nil {
+			t.Fatalf("test %v: failed generating verdicts after prune: %v",
+				test.name, err)
+		}
+
+		if !reflect.DeepEqual(mainchainVerdicts.Verdicts, test.verdictsMain) {
+			t.Errorf("test %v: mainchain verdicts after prune: got %v want %v",
+				test.name, mainchainVerdicts.Verdicts, test.verdictsMain)
+		}
+		if !reflect.DeepEqual(sidechainVerdicts.Verdicts, test.verdictsSide) {
+			t.Errorf("test %v: sidechain verdicts after prune: got %v want %v",
+				test.name, sidechainVerdicts.Verdicts, test.verdictsSide)
+		}
+	}
+}

--- a/blockchain/upgrade.go
+++ b/blockchain/upgrade.go
@@ -24,7 +24,8 @@ func (b *BlockChain) upgradeToVersion2() error {
 	// for the genesis block, and then begin connecting stake nodes
 	// incrementally.
 	err := b.db.Update(func(dbTx database.Tx) error {
-		bestStakeNode, errLocal := stake.InitDatabaseState(dbTx, b.chainParams)
+		bestStakeNode, errLocal := stake.InitTicketDatabaseState(dbTx,
+			b.chainParams)
 		if errLocal != nil {
 			return errLocal
 		}
@@ -98,7 +99,88 @@ func (b *BlockChain) upgradeToVersion2() error {
 		return err
 	}
 
-	log.Infof("Upgrade to new stake database was successful!")
+	log.Infof("Upgrade to new stake ticket database was successful!")
+
+	return nil
+}
+
+// upgradeToVersion3 upgrades a version 2 blockchain to version 3, allowing
+// use of the new on-disk vote tallying database.
+func (b *BlockChain) upgradeToVersion3() error {
+	log.Infof("Initializing upgrade to database version 3")
+	best := b.BestSnapshot()
+	progressLogger := progresslog.NewBlockProgressLogger("Upgraded", log)
+
+	// The upgrade is atomic, so there is no need to set the flag that
+	// the database is undergoing an upgrade here.  Get the stake node
+	// for the genesis block, and then begin connecting stake nodes
+	// incrementally.
+	err := b.db.Update(func(dbTx database.Tx) error {
+		bestTally, errLocal := stake.InitVotingDatabaseState(dbTx,
+			b.chainParams)
+		if errLocal != nil {
+			return errLocal
+		}
+
+		b.rollingTallyCache, errLocal = stake.InitRollingTallyCache(dbTx,
+			b.chainParams)
+		if errLocal != nil {
+			return errLocal
+		}
+
+		parent, errLocal := dbFetchBlockByHeight(dbTx, 0)
+		if errLocal != nil {
+			return errLocal
+		}
+
+		for i := int64(1); i <= best.Height; i++ {
+			block, errLocal := dbFetchBlockByHeight(dbTx, i)
+			if errLocal != nil {
+				return errLocal
+			}
+
+			// Iteratively connect the tallies in memory.
+			blockSha := block.Sha()
+			parentSha := parent.Sha()
+			var tally stake.RollingVotingPrefixTally
+			tally, errLocal = bestTally.ConnectBlockToTally(b.rollingTallyCache,
+				dbTx, *blockSha, *parentSha, uint32(block.Height()),
+				voteBitsForVotersInBlock(block), b.chainParams)
+			if errLocal != nil {
+				return errLocal
+			}
+			bestTally = &tally
+
+			// Write the top block stake node to the database.
+			errLocal = stake.WriteConnectedBlockTally(dbTx, *blockSha,
+				uint32(block.Height()), bestTally, b.chainParams)
+			if errLocal != nil {
+				return errLocal
+			}
+
+			// Write the best block node when we reach it.
+			if i == best.Height {
+				b.bestNode.rollingTally = bestTally
+			}
+
+			progressLogger.LogBlockHeight(block, parent)
+			parent = block
+		}
+
+		// Write the new database version.
+		b.dbInfo.version = 3
+		errLocal = dbPutDatabaseInfo(dbTx, b.dbInfo)
+		if errLocal != nil {
+			return errLocal
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Upgrade to new vote tallying database was successful!")
 
 	return nil
 }
@@ -108,6 +190,12 @@ func (b *BlockChain) upgradeToVersion2() error {
 func (b *BlockChain) upgrade() error {
 	if b.dbInfo.version == 1 {
 		err := b.upgradeToVersion2()
+		if err != nil {
+			return err
+		}
+	}
+	if b.dbInfo.version == 2 {
+		err := b.upgradeToVersion3()
 		if err != nil {
 			return err
 		}

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -2406,7 +2406,8 @@ func (b *BlockChain) CheckConnectBlock(block *dcrutil.Block) error {
 	}
 
 	newNode := newBlockNode(&block.MsgBlock().Header, block.Sha(),
-		block.Height(), ticketsSpentInBlock(block), ticketsRevokedInBlock(block))
+		block.Height(), ticketsSpentInBlock(block), ticketsRevokedInBlock(block),
+		voteBitsForVotersInBlock(block))
 	newNode.parent = prevNode
 	newNode.workSum.Add(prevNode.workSum, newNode.workSum)
 	if prevNode != nil {

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -9,14 +9,11 @@ import (
 	"compress/bzip2"
 	"encoding/gob"
 	"encoding/hex"
-	"math/big"
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/decred/dcrd/blockchain"
-	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/txscript"
 	"github.com/decred/dcrd/wire"
@@ -57,7 +54,7 @@ func recalculateMsgBlockMerkleRootsSize(msgBlock *wire.MsgBlock) {
 func TestBlockValidationRules(t *testing.T) {
 	// Create a new database and chain instance to run tests against.
 	chain, teardownFunc, err := chainSetup("validateunittests",
-		simNetParams)
+		blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("Failed to setup chain instance: %v", err)
 		return
@@ -65,7 +62,7 @@ func TestBlockValidationRules(t *testing.T) {
 	defer teardownFunc()
 
 	// The genesis block should fail to connect since it's already inserted.
-	genesisBlock := simNetParams.GenesisBlock
+	genesisBlock := blockchain.TestSimNetParams.GenesisBlock
 	err = chain.CheckConnectBlock(dcrutil.NewBlock(genesisBlock))
 	if err == nil {
 		t.Errorf("CheckConnectBlock: Did not receive expected error")
@@ -112,7 +109,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b1test := dcrutil.NewBlock(noCoinbaseOuts1)
 	b1test.SetHeight(int64(1))
 
-	err = blockchain.CheckWorklessBlockSanity(b1test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b1test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("Got unexpected error for ErrBlockOneOutputs test 2: %v", err)
 	}
@@ -135,7 +132,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b1test = dcrutil.NewBlock(noCoinbaseOuts1)
 	b1test.SetHeight(int64(1))
 
-	err = blockchain.CheckWorklessBlockSanity(b1test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b1test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("Got unexpected error for ErrBlockOneOutputs test 3: %v", err)
 	}
@@ -158,7 +155,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b1test = dcrutil.NewBlock(noCoinbaseOuts1)
 	b1test.SetHeight(int64(1))
 
-	err = blockchain.CheckWorklessBlockSanity(b1test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b1test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("Got unexpected error for ErrBlockOneOutputs test 4: %v", err)
 	}
@@ -211,7 +208,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b142test := dcrutil.NewBlock(earlySSGen142)
 	b142test.SetHeight(int64(stakeEarlyTest))
 
-	err = blockchain.CheckWorklessBlockSanity(b142test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b142test, timeSource, blockchain.TestSimNetParams)
 	if err == nil {
 		t.Errorf("got no error for ErrInvalidEarlyStakeTx test")
 	}
@@ -232,7 +229,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b142test = dcrutil.NewBlock(earlyBadVoteBits42)
 	b142test.SetHeight(int64(stakeEarlyTest))
 
-	err = blockchain.CheckWorklessBlockSanity(b142test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b142test, timeSource, blockchain.TestSimNetParams)
 	if err == nil || err.(blockchain.RuleError).GetCode() !=
 		blockchain.ErrInvalidEarlyVoteBits {
 		t.Errorf("Got unexpected no error or wrong error for "+
@@ -285,7 +282,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b153test := dcrutil.NewBlock(badMerkleRoot153)
 	b153test.SetHeight(int64(testsIdx1))
 
-	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, blockchain.TestSimNetParams)
 	if err == nil || err.(blockchain.RuleError).GetCode() !=
 		blockchain.ErrBadMerkleRoot {
 		t.Errorf("Failed to get error or correct error for ErrBadMerkleRoot 1"+
@@ -308,7 +305,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b153test = dcrutil.NewBlock(badMerkleRoot153)
 	b153test.SetHeight(int64(testsIdx1))
 
-	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, blockchain.TestSimNetParams)
 	if err == nil || err.(blockchain.RuleError).GetCode() !=
 		blockchain.ErrBadMerkleRoot {
 		t.Errorf("Failed to get error or correct error for ErrBadMerkleRoot 2"+
@@ -375,7 +372,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b153test = dcrutil.NewBlock(missingParent153)
 	b153test.SetHeight(int64(testsIdx1))
 
-	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("Got unexpected sanity error for ErrMissingParent test: %v",
 			err)
@@ -396,7 +393,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b153test = dcrutil.NewBlock(badSubsidy153)
 	b153test.SetHeight(int64(testsIdx1))
 
-	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("Got unexpected sanity error for ErrBadCoinbaseValue test: %v",
 			err)
@@ -419,7 +416,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b153test = dcrutil.NewBlock(badCBOutpoint153)
 	b153test.SetHeight(int64(testsIdx1))
 
-	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, blockchain.TestSimNetParams)
 	if err == nil || err.(blockchain.RuleError).GetCode() !=
 		blockchain.ErrFirstTxNotCoinbase {
 		t.Errorf("Got no or unexpected sanity error for "+
@@ -440,7 +437,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b153test = dcrutil.NewBlock(badCBFraudProof153)
 	b153test.SetHeight(int64(testsIdx1))
 
-	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, blockchain.TestSimNetParams)
 	if err == nil || err.(blockchain.RuleError).GetCode() !=
 		blockchain.ErrBadCoinbaseFraudProof {
 		t.Errorf("Got no or unexpected sanity error for "+
@@ -462,7 +459,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b153test = dcrutil.NewBlock(badCBAmountIn153)
 	b153test.SetHeight(int64(testsIdx1))
 
-	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("Got unexpected error for ErrBadCoinbaseFraudProof test: %v",
 			err)
@@ -484,7 +481,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b153test = dcrutil.NewBlock(badSBAmountIn153)
 	b153test.SetHeight(int64(testsIdx1))
 
-	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("Got unexpected error for ErrBadCoinbaseFraudProof test: %v",
 			err)
@@ -511,7 +508,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b153test = dcrutil.NewBlock(badStakebaseOutpoint153)
 	b153test.SetHeight(int64(testsIdx1))
 
-	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, blockchain.TestSimNetParams)
 	if err == nil || err.(blockchain.RuleError).GetCode() !=
 		blockchain.ErrRegTxInStakeTree {
 		t.Errorf("Failed to get error or correct error for ErrRegTxInStakeTree "+
@@ -537,7 +534,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b153test = dcrutil.NewBlock(ssgenInRegular153)
 	b153test.SetHeight(int64(testsIdx1))
 
-	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, blockchain.TestSimNetParams)
 	if err == nil || err.(blockchain.RuleError).GetCode() !=
 		blockchain.ErrStakeTxInRegularTree {
 		t.Errorf("Failed to get error or correct error for ErrRegTxInStakeTree "+
@@ -561,7 +558,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b153test = dcrutil.NewBlock(badStakebaseSS153)
 	b153test.SetHeight(int64(testsIdx1))
 
-	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, blockchain.TestSimNetParams)
 	if err == nil || err.(blockchain.RuleError).GetCode() !=
 		blockchain.ErrBadStakebaseScriptLen {
 		t.Errorf("Failed to get error or correct error for bad stakebase "+
@@ -584,7 +581,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b153test = dcrutil.NewBlock(badStakebaseScr153)
 	b153test.SetHeight(int64(testsIdx1))
 
-	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, blockchain.TestSimNetParams)
 	if err == nil || err.(blockchain.RuleError).GetCode() !=
 		blockchain.ErrBadStakevaseScrVal {
 		t.Errorf("Failed to get error or correct error for bad stakebase "+
@@ -607,7 +604,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b153test = dcrutil.NewBlock(badSSRtxNum153)
 	b153test.SetHeight(int64(testsIdx1))
 
-	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, blockchain.TestSimNetParams)
 	if err == nil || err.(blockchain.RuleError).GetCode() !=
 		blockchain.ErrRevocationsMismatch {
 		t.Errorf("got unexpected no error or other error for "+
@@ -634,7 +631,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b153test = dcrutil.NewBlock(ssrtxPayeesMismatch153)
 	b153test.SetHeight(int64(testsIdx1))
 
-	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrSSRtxPayeesMismatch sanity  "+
 			"check: %v", err)
@@ -659,7 +656,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b153test = dcrutil.NewBlock(badSSRtxPayee153)
 	b153test.SetHeight(int64(testsIdx1))
 
-	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrSSRtxPayees sanity  "+
 			"check 1: %v", err)
@@ -686,7 +683,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b153test = dcrutil.NewBlock(badSSRtxPayee153)
 	b153test.SetHeight(int64(testsIdx1))
 
-	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrSSRtxPayees sanity "+
 			"check 2: %v", err)
@@ -721,7 +718,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b153test = dcrutil.NewBlock(badSSRtx153)
 	b153test.SetHeight(int64(testsIdx1))
 
-	// err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, simNetParams)
+	// err = blockchain.CheckWorklessBlockSanity(b153test, timeSource, blockchain.TestSimNetParams)
 	// if err != nil {
 	//	t.Errorf("got unexpected error for ErrInvalidSSRtx sanity check: %v",
 	//		err)
@@ -752,7 +749,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test.SetHeight(int64(testsIdx2))
 
 	// The incoming block should pass fine.
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("Unexpected error for check block 154 sanity: %v", err.Error())
 	}
@@ -773,7 +770,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test.SetHeight(int64(testsIdx2))
 
 	// This fails both checks.
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err == nil || err.(blockchain.RuleError).GetCode() !=
 		blockchain.ErrNotEnoughStake {
 		t.Errorf("Failed to get error or correct error for low stake amt "+
@@ -796,7 +793,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test.SetHeight(int64(testsIdx2))
 
 	// Throws an error in stake consensus.
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err == nil || err.(blockchain.RuleError).GetCode() !=
 		blockchain.ErrFreshStakeMismatch {
 		t.Errorf("Unexpected no or wrong error for ErrFreshStakeMismatch "+
@@ -825,7 +822,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test.SetHeight(int64(testsIdx2))
 
 	// Fails and hits ErrNotEnoughVotes.
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err == nil || err.(blockchain.RuleError).GetCode() !=
 		blockchain.ErrNotEnoughVotes {
 		t.Errorf("Got no or unexpected block sanity err for "+
@@ -858,7 +855,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test.SetHeight(int64(testsIdx2))
 
 	// Fails and hits ErrTooManyVotes.
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err == nil {
 		t.Errorf("got unexpected no error for ErrTooManyVotes sanity check")
 	}
@@ -873,7 +870,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(nonChosenTicket154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrTicketUnavailable sanity check"+
 			": %v",
@@ -900,7 +897,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(wrongBlockVote154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrVotesOnWrongBlock sanity check: %v",
 			err)
@@ -927,7 +924,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test.SetHeight(int64(testsIdx2))
 
 	// Fails and hits ErrVotesMismatch.
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err == nil || err.(blockchain.RuleError).GetCode() !=
 		blockchain.ErrVotesMismatch {
 		t.Errorf("got unexpected no or wrong error for ErrVotesMismatch "+
@@ -943,7 +940,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(badVoteBit154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrIncongruentVotebit 2 sanity  "+
 			"check: %v", err)
@@ -973,7 +970,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(badVoteBit154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrIncongruentVotebit 2 sanity  "+
 			"check: %v", err)
@@ -1003,7 +1000,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(badVoteBit154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrIncongruentVotebit 3 sanity  "+
 			"check: %v", err)
@@ -1033,7 +1030,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(badVoteBit154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrIncongruentVotebit 4 sanity  "+
 			"check: %v", err)
@@ -1068,7 +1065,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(badVoteBit154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrIncongruentVotebit 5 sanity  "+
 			"check: %v", err)
@@ -1103,7 +1100,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(badVoteBit154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrIncongruentVotebit 6 sanity  "+
 			"check: %v", err)
@@ -1138,7 +1135,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(badVoteBit154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrIncongruentVotebit 7 sanity  "+
 			"check: %v", err)
@@ -1165,7 +1162,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(badSStxCommit154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrSStxCommitment sanity check: %v",
 			err)
@@ -1199,7 +1196,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(badSSGenPayee154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrSSGenPayeeOuts sanity  "+
 			"check: %v", err)
@@ -1224,7 +1221,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(badSSGenPayee154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrSSGenPayeeOuts sanity  "+
 			"check2 : %v", err)
@@ -1286,7 +1283,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(spendTaggedIn154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrTxSStxOutSpend sanity check: %v",
 			err)
@@ -1315,7 +1312,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(spendTaggedOut154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrRegTxSpendStakeOut sanity check: %v",
 			err)
@@ -1337,7 +1334,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(badFinalState154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrInvalidFinalState sanity check: %v",
 			err)
@@ -1359,7 +1356,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(badPoolSize154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrPoolSize sanity check: %v",
 			err)
@@ -1391,7 +1388,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(errTxTreeIn154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrDiscordantTxTree sanity check: %v",
 			err)
@@ -1438,7 +1435,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(taxMissing154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("Got unexpected error for ErrNoTax "+
 			"test 1: %v", err)
@@ -1461,7 +1458,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(taxMissing154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("Got unexpected error for ErrNoTax test 2: %v", err)
 	}
@@ -1483,7 +1480,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(taxMissing154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("Got unexpected error for ErrNoTax test 3: %v", err)
 	}
@@ -1508,7 +1505,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(expiredTx154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrExpiredTx sanity check: %v",
 			err)
@@ -1535,7 +1532,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(badValueIn154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrFraudAmountIn sanity check: %v",
 			err)
@@ -1562,7 +1559,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(badHeightProof154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrFraudBlockHeight sanity check: %v",
 			err)
@@ -1589,7 +1586,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(badIndexProof154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrFraudBlockIndex sanity check: %v",
 			err)
@@ -1616,7 +1613,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(badScrVal154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrScriptValidation sanity check: %v",
 			err)
@@ -1639,7 +1636,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(badScrValS154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrScriptValidation sanity check: %v",
 			err)
@@ -1669,7 +1666,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(invalMissingInsS154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for invalMissingInsS154 sanity check: %v",
 			err)
@@ -1696,7 +1693,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(malformedScr154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrScriptValidation sanity check: %v",
 			err)
@@ -1737,7 +1734,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b154test = dcrutil.NewBlock(spendZeroValueIn154)
 	b154test.SetHeight(int64(testsIdx2))
 
-	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b154test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrZeroValueOutputSpend sanity "+
 			"check: %v", err)
@@ -1804,7 +1801,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b166test := dcrutil.NewBlock(spendInvalid166)
 	b166test.SetHeight(int64(testsIdx3))
 
-	err = blockchain.CheckWorklessBlockSanity(b166test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b166test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrMissingTx test 1 sanity "+
 			"check: %v", err)
@@ -1839,7 +1836,7 @@ func TestBlockValidationRules(t *testing.T) {
 	sstxToUse166.AddTxIn(sstxCBIn)
 
 	orgAddr, _ := dcrutil.DecodeAddress("ScuQxvveKGfpG1ypt6u27F99Anf7EW3cqhq",
-		simNetParams)
+		blockchain.TestSimNetParams)
 	pkScript, _ := txscript.GenerateSStxAddrPush(orgAddr,
 		dcrutil.Amount(29702992297), 0x0000)
 	txOut := wire.NewTxOut(int64(0), pkScript)
@@ -1852,7 +1849,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b166test = dcrutil.NewBlock(sstxSpendInvalid166)
 	b166test.SetHeight(int64(testsIdx3))
 
-	err = blockchain.CheckWorklessBlockSanity(b166test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b166test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrMissingTx test 2 sanity "+
 			"check: %v", err)
@@ -1896,7 +1893,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b166test = dcrutil.NewBlock(sstxSpend2Invalid166)
 	b166test.SetHeight(int64(testsIdx3))
 
-	err = blockchain.CheckWorklessBlockSanity(b166test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b166test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for ErrImmatureSpend test sanity "+
 			"check: %v", err)
@@ -1927,7 +1924,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b166test = dcrutil.NewBlock(sstxSpend3Invalid166)
 	b166test.SetHeight(int64(testsIdx3))
 
-	err = blockchain.CheckWorklessBlockSanity(b166test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b166test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for double spend test 1 sanity "+
 			"check: %v", err)
@@ -1953,7 +1950,7 @@ func TestBlockValidationRules(t *testing.T) {
 	b166test = dcrutil.NewBlock(regTxSpendStakeIn166)
 	b166test.SetHeight(int64(testsIdx3))
 
-	err = blockchain.CheckWorklessBlockSanity(b166test, timeSource, simNetParams)
+	err = blockchain.CheckWorklessBlockSanity(b166test, timeSource, blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("got unexpected error for deouble spend test 2 sanity "+
 			"check: %v", err)
@@ -1973,7 +1970,7 @@ func TestBlockValidationRules(t *testing.T) {
 func TestBlockchainSpendJournal(t *testing.T) {
 	// Create a new database and chain instance to run tests against.
 	chain, teardownFunc, err := chainSetup("reorgunittest",
-		simNetParams)
+		blockchain.TestSimNetParams)
 	if err != nil {
 		t.Errorf("Failed to setup chain instance: %v", err)
 		return
@@ -1982,7 +1979,7 @@ func TestBlockchainSpendJournal(t *testing.T) {
 
 	// The genesis block should fail to connect since it's already
 	// inserted.
-	genesisBlock := simNetParams.GenesisBlock
+	genesisBlock := blockchain.TestSimNetParams.GenesisBlock
 	err = chain.CheckConnectBlock(dcrutil.NewBlock(genesisBlock))
 	if err == nil {
 		t.Errorf("CheckConnectBlock: Did not receive expected error")
@@ -2027,265 +2024,4 @@ func TestBlockchainSpendJournal(t *testing.T) {
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-}
-
-// simNetPowLimit is the highest proof of work value a Decred block
-// can have for the simulation test network.  It is the value 2^255 - 1.
-var simNetPowLimit = new(big.Int).Sub(new(big.Int).Lsh(bigOne, 255), bigOne)
-
-// SimNetParams defines the network parameters for the simulation test Decred
-// network.  This network is similar to the normal test network except it is
-// intended for private use within a group of individuals doing simulation
-// testing.  The functionality is intended to differ in that the only nodes
-// which are specifically specified are used to create the network rather than
-// following normal discovery rules.  This is important as otherwise it would
-// just turn into another public testnet.
-var simNetParams = &chaincfg.Params{
-	Name:        "simnet",
-	Net:         wire.SimNet,
-	DefaultPort: "18555",
-
-	// Chain parameters
-	GenesisBlock:             &simNetGenesisBlock,
-	GenesisHash:              &simNetGenesisHash,
-	CurrentBlockVersion:      0,
-	PowLimit:                 simNetPowLimit,
-	PowLimitBits:             0x207fffff,
-	ResetMinDifficulty:       false,
-	GenerateSupported:        true,
-	MaximumBlockSize:         1000000,
-	TimePerBlock:             time.Second * 1,
-	WorkDiffAlpha:            1,
-	WorkDiffWindowSize:       8,
-	WorkDiffWindows:          4,
-	TargetTimespan:           time.Second * 1 * 8, // TimePerBlock * WindowSize
-	RetargetAdjustmentFactor: 4,
-
-	// Subsidy parameters.
-	BaseSubsidy:           50000000000,
-	MulSubsidy:            100,
-	DivSubsidy:            101,
-	ReductionInterval:     128,
-	WorkRewardProportion:  6,
-	StakeRewardProportion: 3,
-	BlockTaxProportion:    1,
-
-	// Checkpoints ordered from oldest to newest.
-	Checkpoints: nil,
-
-	// Mempool parameters
-	RelayNonStdTxs: true,
-
-	// Address encoding magics
-	PubKeyAddrID:     [2]byte{0x27, 0x6f}, // starts with Sk
-	PubKeyHashAddrID: [2]byte{0x0e, 0x91}, // starts with Ss
-	PKHEdwardsAddrID: [2]byte{0x0e, 0x71}, // starts with Se
-	PKHSchnorrAddrID: [2]byte{0x0e, 0x53}, // starts with SS
-	ScriptHashAddrID: [2]byte{0x0e, 0x6c}, // starts with Sc
-	PrivateKeyID:     [2]byte{0x23, 0x07}, // starts with Ps
-
-	// BIP32 hierarchical deterministic extended key magics
-	HDPrivateKeyID: [4]byte{0x04, 0x20, 0xb9, 0x03}, // starts with sprv
-	HDPublicKeyID:  [4]byte{0x04, 0x20, 0xbd, 0x3d}, // starts with spub
-
-	// BIP44 coin type used in the hierarchical deterministic path for
-	// address generation.
-	HDCoinType: 115, // ASCII for s
-
-	// Decred PoS parameters
-	MinimumStakeDiff:      20000,
-	TicketPoolSize:        64,
-	TicketsPerBlock:       5,
-	TicketMaturity:        16,
-	TicketExpiry:          256, // 4*TicketPoolSize
-	CoinbaseMaturity:      16,
-	SStxChangeMaturity:    1,
-	TicketPoolSizeWeight:  4,
-	StakeDiffAlpha:        1,
-	StakeDiffWindowSize:   8,
-	StakeDiffWindows:      8,
-	MaxFreshStakePerBlock: 40,            // 8*TicketsPerBlock
-	StakeEnabledHeight:    16 + 16,       // CoinbaseMaturity + TicketMaturity
-	StakeValidationHeight: 16 + (64 * 2), // CoinbaseMaturity + TicketPoolSize*2
-	StakeBaseSigScript:    []byte{0xDE, 0xAD, 0xBE, 0xEF},
-
-	// Decred organization related parameters
-	//
-	// "Dev org" address is a 3-of-3 P2SH going to wallet:
-	// aardvark adroitness aardvark adroitness
-	// aardvark adroitness aardvark adroitness
-	// aardvark adroitness aardvark adroitness
-	// aardvark adroitness aardvark adroitness
-	// aardvark adroitness aardvark adroitness
-	// aardvark adroitness aardvark adroitness
-	// aardvark adroitness aardvark adroitness
-	// aardvark adroitness aardvark adroitness
-	// briefcase
-	// (seed 0x00000000000000000000000000000000000000000000000000000000000000)
-	//
-	// This same wallet owns the three ledger outputs for simnet.
-	//
-	// P2SH details for simnet dev org is below.
-	//
-	// address: Scc4ZC844nzuZCXsCFXUBXTLks2mD6psWom
-	// redeemScript: 532103e8c60c7336744c8dcc7b85c27789950fc52aa4e48f895ebbfb
-	// ac383ab893fc4c2103ff9afc246e0921e37d12e17d8296ca06a8f92a07fbe7857ed1d4
-	// f0f5d94e988f21033ed09c7fa8b83ed53e6f2c57c5fa99ed2230c0d38edf53c0340d0f
-	// c2e79c725a53ae
-	//   (3-of-3 multisig)
-	// Pubkeys used:
-	//   SkQmxbeuEFDByPoTj41TtXat8tWySVuYUQpd4fuNNyUx51tF1csSs
-	//   SkQn8ervNvAUEX5Ua3Lwjc6BAuTXRznDoDzsyxgjYqX58znY7w9e4
-	//   SkQkfkHZeBbMW8129tZ3KspEh1XBFC1btbkgzs6cjSyPbrgxzsKqk
-	//
-	OrganizationPkScript:        chaincfg.SimNetParams.OrganizationPkScript,
-	OrganizationPkScriptVersion: chaincfg.SimNetParams.OrganizationPkScriptVersion,
-	BlockOneLedger:              BlockOneLedgerSimNet,
-}
-
-// BlockOneLedgerSimNet is the block one output ledger for the simulation
-// network. See below under "Decred organization related parameters" for
-// information on how to spend these outputs.
-var BlockOneLedgerSimNet = []*chaincfg.TokenPayout{
-	{Address: "Sshw6S86G2bV6W32cbc7EhtFy8f93rU6pae", Amount: 100000 * 1e8},
-	{Address: "SsjXRK6Xz6CFuBt6PugBvrkdAa4xGbcZ18w", Amount: 100000 * 1e8},
-	{Address: "SsfXiYkYkCoo31CuVQw428N6wWKus2ZEw5X", Amount: 100000 * 1e8},
-}
-
-var bigOne = new(big.Int).SetInt64(1)
-
-// simNetGenesisHash is the hash of the first block in the block chain for the
-// simulation test network.
-var simNetGenesisHash = simNetGenesisBlock.BlockSha()
-
-// simNetGenesisMerkleRoot is the hash of the first transaction in the genesis
-// block for the simulation test network.  It is the same as the merkle root for
-// the main network.
-var simNetGenesisMerkleRoot = genesisMerkleRoot
-
-// genesisCoinbaseTx legacy is the coinbase transaction for the genesis blocks for
-// the regression test network and test network.
-var genesisCoinbaseTxLegacy = wire.MsgTx{
-	Version: 1,
-	TxIn: []*wire.TxIn{
-		{
-			PreviousOutPoint: wire.OutPoint{
-				Hash:  chainhash.Hash{},
-				Index: 0xffffffff,
-			},
-			SignatureScript: []byte{
-				0x04, 0xff, 0xff, 0x00, 0x1d, 0x01, 0x04, 0x45, /* |.......E| */
-				0x54, 0x68, 0x65, 0x20, 0x54, 0x69, 0x6d, 0x65, /* |The Time| */
-				0x73, 0x20, 0x30, 0x33, 0x2f, 0x4a, 0x61, 0x6e, /* |s 03/Jan| */
-				0x2f, 0x32, 0x30, 0x30, 0x39, 0x20, 0x43, 0x68, /* |/2009 Ch| */
-				0x61, 0x6e, 0x63, 0x65, 0x6c, 0x6c, 0x6f, 0x72, /* |ancellor| */
-				0x20, 0x6f, 0x6e, 0x20, 0x62, 0x72, 0x69, 0x6e, /* | on brin| */
-				0x6b, 0x20, 0x6f, 0x66, 0x20, 0x73, 0x65, 0x63, /* |k of sec|*/
-				0x6f, 0x6e, 0x64, 0x20, 0x62, 0x61, 0x69, 0x6c, /* |ond bail| */
-				0x6f, 0x75, 0x74, 0x20, 0x66, 0x6f, 0x72, 0x20, /* |out for |*/
-				0x62, 0x61, 0x6e, 0x6b, 0x73, /* |banks| */
-			},
-			Sequence: 0xffffffff,
-		},
-	},
-	TxOut: []*wire.TxOut{
-		{
-			Value: 0x00000000,
-			PkScript: []byte{
-				0x41, 0x04, 0x67, 0x8a, 0xfd, 0xb0, 0xfe, 0x55, /* |A.g....U| */
-				0x48, 0x27, 0x19, 0x67, 0xf1, 0xa6, 0x71, 0x30, /* |H'.g..q0| */
-				0xb7, 0x10, 0x5c, 0xd6, 0xa8, 0x28, 0xe0, 0x39, /* |..\..(.9| */
-				0x09, 0xa6, 0x79, 0x62, 0xe0, 0xea, 0x1f, 0x61, /* |..yb...a| */
-				0xde, 0xb6, 0x49, 0xf6, 0xbc, 0x3f, 0x4c, 0xef, /* |..I..?L.| */
-				0x38, 0xc4, 0xf3, 0x55, 0x04, 0xe5, 0x1e, 0xc1, /* |8..U....| */
-				0x12, 0xde, 0x5c, 0x38, 0x4d, 0xf7, 0xba, 0x0b, /* |..\8M...| */
-				0x8d, 0x57, 0x8a, 0x4c, 0x70, 0x2b, 0x6b, 0xf1, /* |.W.Lp+k.| */
-				0x1d, 0x5f, 0xac, /* |._.| */
-			},
-		},
-	},
-	LockTime: 0,
-	Expiry:   0,
-}
-
-// genesisMerkleRoot is the hash of the first transaction in the genesis block
-// for the main network.
-var genesisMerkleRoot = genesisCoinbaseTxLegacy.TxSha()
-
-var regTestGenesisCoinbaseTx = wire.MsgTx{
-	Version: 1,
-	TxIn: []*wire.TxIn{
-		{
-			PreviousOutPoint: wire.OutPoint{
-				Hash:  chainhash.Hash{},
-				Index: 0xffffffff,
-			},
-			SignatureScript: []byte{
-				0x04, 0xff, 0xff, 0x00, 0x1d, 0x01, 0x04, 0x45, /* |.......E| */
-				0x54, 0x68, 0x65, 0x20, 0x54, 0x69, 0x6d, 0x65, /* |The Time| */
-				0x73, 0x20, 0x30, 0x33, 0x2f, 0x4a, 0x61, 0x6e, /* |s 03/Jan| */
-				0x2f, 0x32, 0x30, 0x30, 0x39, 0x20, 0x43, 0x68, /* |/2009 Ch| */
-				0x61, 0x6e, 0x63, 0x65, 0x6c, 0x6c, 0x6f, 0x72, /* |ancellor| */
-				0x20, 0x6f, 0x6e, 0x20, 0x62, 0x72, 0x69, 0x6e, /* | on brin| */
-				0x6b, 0x20, 0x6f, 0x66, 0x20, 0x73, 0x65, 0x63, /* |k of sec|*/
-				0x6f, 0x6e, 0x64, 0x20, 0x62, 0x61, 0x69, 0x6c, /* |ond bail| */
-				0x6f, 0x75, 0x74, 0x20, 0x66, 0x6f, 0x72, 0x20, /* |out for |*/
-				0x62, 0x61, 0x6e, 0x6b, 0x73, /* |banks| */
-			},
-			Sequence: 0xffffffff,
-		},
-	},
-	TxOut: []*wire.TxOut{
-		{
-			Value:   0x00000000,
-			Version: 0x0000,
-			PkScript: []byte{
-				0x41, 0x04, 0x67, 0x8a, 0xfd, 0xb0, 0xfe, 0x55, /* |A.g....U| */
-				0x48, 0x27, 0x19, 0x67, 0xf1, 0xa6, 0x71, 0x30, /* |H'.g..q0| */
-				0xb7, 0x10, 0x5c, 0xd6, 0xa8, 0x28, 0xe0, 0x39, /* |..\..(.9| */
-				0x09, 0xa6, 0x79, 0x62, 0xe0, 0xea, 0x1f, 0x61, /* |..yb...a| */
-				0xde, 0xb6, 0x49, 0xf6, 0xbc, 0x3f, 0x4c, 0xef, /* |..I..?L.| */
-				0x38, 0xc4, 0xf3, 0x55, 0x04, 0xe5, 0x1e, 0xc1, /* |8..U....| */
-				0x12, 0xde, 0x5c, 0x38, 0x4d, 0xf7, 0xba, 0x0b, /* |..\8M...| */
-				0x8d, 0x57, 0x8a, 0x4c, 0x70, 0x2b, 0x6b, 0xf1, /* |.W.Lp+k.| */
-				0x1d, 0x5f, 0xac, /* |._.| */
-			},
-		},
-	},
-	LockTime: 0,
-	Expiry:   0,
-}
-
-// simNetGenesisBlock defines the genesis block of the block chain which serves
-// as the public transaction ledger for the simulation test network.
-var simNetGenesisBlock = wire.MsgBlock{
-	Header: wire.BlockHeader{
-		Version: 1,
-		PrevBlock: chainhash.Hash([chainhash.HashSize]byte{ // Make go vet happy.
-			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-		}),
-		MerkleRoot: simNetGenesisMerkleRoot,
-		StakeRoot: chainhash.Hash([chainhash.HashSize]byte{ // Make go vet happy.
-			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-		}),
-		VoteBits:    uint16(0x0000),
-		FinalState:  [6]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
-		Voters:      uint16(0x0000),
-		FreshStake:  uint8(0x00),
-		Revocations: uint8(0x00),
-		Timestamp:   time.Unix(1401292357, 0), // 2009-01-08 20:54:25 -0600 CST
-		PoolSize:    uint32(0),
-		Bits:        0x207fffff, // 545259519
-		SBits:       int64(0x0000000000000000),
-		Nonce:       0x00000000,
-		Height:      uint32(0),
-	},
-	Transactions:  []*wire.MsgTx{&regTestGenesisCoinbaseTx},
-	STransactions: []*wire.MsgTx{},
 }

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -264,6 +264,58 @@ type Params struct {
 	// it to be this value miners/daemons could freely change it.
 	StakeBaseSigScript []byte
 
+	// VotingIntervals is the number of stake difficulty windows to use
+	// when calculating the verdict for some voted on issue.
+	VotingIntervals int
+
+	// VotingIssueMultiplier and VotingIssueDivisor are the terms used for
+	// selecting if a voted on issue has met the standards of an arbitrarily
+	// defined "majority" or not.  For any given voting interval the width
+	// of StakeDiffWindowSize, votes are tallied for 'yes', 'no', or
+	// 'abstain'.  In order for the verdict to be 'yes' or 'no' for
+	// this interval, the number of 'yes' and 'no' votes are added to get
+	// a vote total, then multiplied by the multiplier and divided by the
+	// divisor to determine the amount required to determine a majority
+	// verdict one way or the other.
+	//
+	// Below is an example to clarify for an issue, using the constants
+	// defined by the mainnet parameters (144 blocks per window, 5
+	// voters per block).
+	//
+	// Yes: 350 votes, No: 250 votes, Abstain: 120 votes
+	// Total non-abstaining votes: 600
+	// VotingIssueMultiplier: 3, VotingIssueDivisor: 4
+	// Required for majority: (VotingIssueMultiplier * 600) / VotingIssueDivisor
+	//                        (3 * 600) / 4
+	//                        450
+	//
+	// The threshold of 450 is met by neither the yes nor the no voters,
+	// so the issue is considered to be undecided and may continue to be
+	// voted on until reaching consensus.  If the number of yes or the
+	// number of no votes becomes equal to or greater than 450 while the
+	// number of abstains stays the same, the outcome will be either
+	// 'yes' or 'no'.
+	//
+	// These individual interval verdicts are then summed in a boolean
+	// fashion to provide a verdict within VotingIntervals many interval
+	// periods.  For example, if VotingIntervals is 4 intervals, and all
+	// 4 intervals had the verdict 'yes', the issue is considered to be
+	// 'yes' and consensus logic may require some series of actions
+	// based on this outcome.  If 3 of the 4 intervals are 'yes' and the
+	// remaining interval is 'no', the issue is considered to be
+	// undecided.
+	//
+	// Note that the tallies are encoded as uint16s.  For mainnet
+	// parameter windows, this means that each 'field' in the tally
+	// corresponding to a vote type could possibly be a maximum of
+	// 144 blocks * 5 voters = 720 votes.  The multiplier must NOT
+	// overflow the 2 byte uint16 field, or the results will be
+	// invalid.  This is not an issue for small multipliers like
+	// 3, which could cause a maximum value of 2,160.  This is much
+	// less that the maximum uint16 value of 65,535.
+	VotingIssueMultiplier uint16
+	VotingIssueDivisor    uint16
+
 	// OrganizationPkScript is the output script for block taxes to be
 	// distributed to in every block's coinbase. It should ideally be a P2SH
 	// multisignature address.  OrganizationPkScriptVersion is the version
@@ -362,6 +414,9 @@ var MainNetParams = Params{
 	StakeEnabledHeight:    256 + 256, // CoinbaseMaturity + TicketMaturity
 	StakeValidationHeight: 4096,      // ~14 days
 	StakeBaseSigScript:    []byte{0x00, 0x00},
+	VotingIntervals:       56, // 144 blocks * 56 = 8064 blocks or ~28 days
+	VotingIssueMultiplier: 3,
+	VotingIssueDivisor:    4, // 3 / 4 = 0.75 or 75% for a majority
 
 	// Decred organization related parameters
 	// Organization address is Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx
@@ -457,6 +512,9 @@ var TestNetParams = Params{
 	StakeEnabledHeight:    16 + 16, // CoinbaseMaturity + TicketMaturity
 	StakeValidationHeight: 768,     // Arbitrary
 	StakeBaseSigScript:    []byte{0xDE, 0xAD, 0xBE, 0xEF},
+	VotingIntervals:       10, // 144 blocks * 10 = 1440 blocks or ~2 days
+	VotingIssueMultiplier: 3,
+	VotingIssueDivisor:    4, // 3 / 4 = 0.75 or 75% for a majority
 
 	// Decred organization related parameters.
 	// Organization address is TcemyEtyHSg9L7jww7uihv9BJfKL6YGiZYn
@@ -543,6 +601,9 @@ var SimNetParams = Params{
 	StakeEnabledHeight:    16 + 16,       // CoinbaseMaturity + TicketMaturity
 	StakeValidationHeight: 16 + (64 * 2), // CoinbaseMaturity + TicketPoolSize*2
 	StakeBaseSigScript:    []byte{0xDE, 0xAD, 0xBE, 0xEF},
+	VotingIntervals:       64, // 64 * 8 blocks = 512 blocks
+	VotingIssueMultiplier: 3,
+	VotingIssueDivisor:    4, // 3 / 4 = 0.75 or 75% for a majority
 
 	// Decred organization related parameters
 	//

--- a/database/dummydb/dummy.go
+++ b/database/dummydb/dummy.go
@@ -1,0 +1,343 @@
+// Copyright (c) 2016 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+// dummydb implements a dummy database satisfying all interfaces but not
+// actually performing any functions.  It should be used ONLY in testing
+// environments, such as blockchain tests relying on blockNodes that have
+// operations that call the database but are not dependent on their
+// responses.  It should NEVER be used in a production environment!
+package dummydb
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btclog"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/database"
+	"github.com/decred/dcrutil"
+)
+
+var log = btclog.Disabled
+
+const (
+	dbType = "dummydb"
+)
+
+// init initializes the dummy database.
+func init() {
+	create := func(...interface{}) (database.DB, error) { return &db{}, nil }
+	open := func(...interface{}) (database.DB, error) { return &db{}, nil }
+
+	// Register the driver.
+	driver := database.Driver{
+		DbType:    dbType,
+		Create:    create,
+		Open:      open,
+		UseLogger: nil,
+	}
+	if err := database.RegisterDriver(driver); err != nil {
+		panic(fmt.Sprintf("Failed to regiser database driver '%s': %v",
+			dbType, err))
+	}
+}
+
+// cursor is a dummy structrequired to satisfy the interface.
+type cursor struct {
+}
+
+// Enforce cursor implements the database.Cursor interface.
+var _ database.Cursor = (*cursor)(nil)
+
+// Bucket is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Cursor interface implementation.
+func (c *cursor) Bucket() database.Bucket {
+	return c.Bucket()
+}
+
+// Delete is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Cursor interface implementation.
+func (c *cursor) Delete() error {
+	return nil
+}
+
+// First is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Cursor interface implementation.
+func (c *cursor) First() bool {
+	return false
+}
+
+// Last is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Cursor interface implementation.
+func (c *cursor) Last() bool {
+	return false
+}
+
+// Next is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Cursor interface implementation.
+func (c *cursor) Next() bool {
+	return false
+}
+
+// Prev is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Cursor interface implementation.
+func (c *cursor) Prev() bool {
+	return false
+}
+
+// See is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Cursor interface implementation.
+func (c *cursor) Seek(seek []byte) bool {
+	return false
+}
+
+// Key is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Cursor interface implementation.
+func (c *cursor) Key() []byte {
+	return []byte{}
+}
+
+// Value is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Cursor interface implementation.
+func (c *cursor) Value() []byte {
+	return []byte{}
+}
+
+// bucket is a dummy struct required to satisfy the interface.
+type bucket struct {
+	tx *transaction
+}
+
+// Enforce bucket implements the database.Bucket interface.
+var _ database.Bucket = (*bucket)(nil)
+
+// Bucket is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Bucket interface implementation.
+func (b *bucket) Bucket(key []byte) database.Bucket {
+	return &bucket{}
+}
+
+// CreateBucket is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Bucket interface implementation.
+func (b *bucket) CreateBucket(key []byte) (database.Bucket, error) {
+	return &bucket{}, nil
+}
+
+// CreateBucketIfNotExists is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Bucket interface implementation.
+func (b *bucket) CreateBucketIfNotExists(key []byte) (database.Bucket, error) {
+	return b.CreateBucket(key)
+}
+
+// DeleteBucket is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Bucket interface implementation.
+func (b *bucket) DeleteBucket(key []byte) error {
+	return nil
+}
+
+// Cursor is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Bucket interface implementation.
+func (b *bucket) Cursor() database.Cursor {
+	return &cursor{}
+}
+
+// ForEach is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Bucket interface implementation.
+func (b *bucket) ForEach(fn func(k, v []byte) error) error {
+	return nil
+}
+
+// ForEachBucket is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Bucket interface implementation.
+func (b *bucket) ForEachBucket(fn func(k []byte) error) error {
+	return nil
+}
+
+// Writable is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Bucket interface implementation.
+func (b *bucket) Writable() bool {
+	return false
+}
+
+// Put is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Bucket interface implementation.
+func (b *bucket) Put(key, value []byte) error {
+	return nil
+}
+
+// Get is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Bucket interface implementation.
+func (b *bucket) Get(key []byte) []byte {
+	return nil
+}
+
+// Delete is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Bucket interface implementation.
+func (b *bucket) Delete(key []byte) error {
+	return nil
+}
+
+// transaction is a dummy struct required to satisfy the interface.
+type transaction struct {
+}
+
+// Enforce transaction implements the database.Tx interface.
+var _ database.Tx = (*transaction)(nil)
+
+// Metadata  is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Tx interface implementation.
+func (tx *transaction) Metadata() database.Bucket {
+	return &bucket{}
+}
+
+// StoreBlock is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Tx interface implementation.
+func (tx *transaction) StoreBlock(block *dcrutil.Block) error {
+	return nil
+}
+
+// HasBlock is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Tx interface implementation.
+func (tx *transaction) HasBlock(hash *chainhash.Hash) (bool, error) {
+	return false, nil
+}
+
+// HasBlocks is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Tx interface implementation.
+func (tx *transaction) HasBlocks(hashes []chainhash.Hash) ([]bool, error) {
+	return []bool{}, nil
+}
+
+// FetchBlockHeader is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Tx interface implementation.
+func (tx *transaction) FetchBlockHeader(hash *chainhash.Hash) ([]byte, error) {
+	return []byte{}, nil
+}
+
+// FetchBlockHeaders is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Tx interface implementation.
+func (tx *transaction) FetchBlockHeaders(hashes []chainhash.Hash) ([][]byte, error) {
+	return [][]byte{}, nil
+}
+
+// FetchBlock is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Tx interface implementation.
+func (tx *transaction) FetchBlock(hash *chainhash.Hash) ([]byte, error) {
+	return nil, nil
+}
+
+// FetchBlocks is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Tx interface implementation.
+func (tx *transaction) FetchBlocks(hashes []chainhash.Hash) ([][]byte, error) {
+	return nil, nil
+}
+
+// FetchBlockRegion is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Tx interface implementation.
+func (tx *transaction) FetchBlockRegion(region *database.BlockRegion) ([]byte, error) {
+	return nil, nil
+}
+
+// FetchBlockRegions is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Tx interface implementation.
+func (tx *transaction) FetchBlockRegions(regions []database.BlockRegion) ([][]byte, error) {
+	return nil, nil
+}
+
+// Commit is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Tx interface implementation.
+func (tx *transaction) Commit() error {
+	return nil
+}
+
+// Rollback is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.Tx interface implementation.
+func (tx *transaction) Rollback() error {
+	return nil
+}
+
+// db is a dummy struct required to satisfy the interface.
+type db struct {
+}
+
+// Enforce db implements the database.DB interface.
+var _ database.DB = (*db)(nil)
+
+// Type returns the database driver type the current database instance was
+// created with.
+//
+// This function is part of the database.DB interface implementation.
+func (db *db) Type() string {
+	return dbType
+}
+
+// begin is a dummy function required to satisfy the interface.
+//
+// This function is only separate because it returns the internal transaction
+// which is used by the managed transaction code while the database method
+// returns the interface.
+func (db *db) begin(writable bool) (*transaction, error) {
+	return &transaction{}, nil
+}
+
+// Begin is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.DB interface implementation.
+func (db *db) Begin(writable bool) (database.Tx, error) {
+	return db.begin(writable)
+}
+
+// View is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.DB interface implementation.
+func (db *db) View(fn func(database.Tx) error) error {
+	fn(nil)
+	return nil
+}
+
+// Update is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.DB interface implementation.
+func (db *db) Update(fn func(database.Tx) error) error {
+	fn(nil)
+	return nil
+}
+
+// Close is a dummy function required to satisfy the interface.
+//
+// This function is part of the database.DB interface implementation.
+func (db *db) Close() error {
+	return nil
+}


### PR DESCRIPTION
Another peripheral database to be used later in consensus has been
added.  This database tracks tallying and summation of votes from
stakeholder vote voteBits.  The intermediary tallies are cached and
the evaluation of tallies over long periods of time is highly
efficient.  Below is the benchmark for tallying the results of
voting over a 28-day period.

```
BenchmarkFindingVerdicts-8  200000  7955  ns/op  704 B/op  8 allocs/op
```

As with the new ticket stake nodes, the storage in the blockchain
block nodes is dynamic.  On startup, the cache of the tallies is
loaded along with the current tally for the best node.  Any
intermediary or sidechain tallies can be quickly generated by either
accessing the cache or the database.

A large degree of test infrastructure was introduced to best test
edge cases relating the the new vote tallying.  A dummy database was
added into dcrd/database so that very long sidechain evaluations of
tallies could be tested, better ensuring that long reorganizations
will not pose a risk in forking.  These tests use dynamic functions
to set voteBits and can easily be modified to further test the
infrastructure.

The new database buckets require an upgrade on startup.  Code for
this upgrade has been added, and the upgrade itself takes seconds on
mainnet and testnet.

Infrastructure for testing some of the blockchain API relating to
accessory stake data for block nodes was also added.  A few minor
bugs were discovered and patched.  A number of comments that were
inaccurate or mislabeled in the stake package were also fixed.
Benchmarks were moved to their own file, benchmark_test.go.
