### PR TITLE
Use same notification for mined transactions and blocks.

### DIFF
--- a/dcrjson/chainsvrwscmds.go
+++ b/dcrjson/chainsvrwscmds.go
@@ -23,6 +23,32 @@ func NewAuthenticateCmd(username, passphrase string) *AuthenticateCmd {
 	}
 }
 
+// OutPoint describes a transaction outpoint that will be marshalled to and
+// from JSON.  Contains Decred addition.
+type OutPoint struct {
+	Hash  string `json:"hash"`
+	Tree  int8   `json:"tree"`
+	Index uint32 `json:"index"`
+}
+
+// LoadTxFilterCmd defines the loadtxfilter request parameters to load or
+// reload a transaction filter.
+type LoadTxFilterCmd struct {
+	Reload    bool
+	Addresses []string
+	OutPoints []OutPoint
+}
+
+// NewLoadTxFilterCmd returns a new instance which can be used to issue a
+// loadtxfilter JSON-RPC command.
+func NewLoadTxFilterCmd(reload bool, addresses []string, outPoints []OutPoint) *LoadTxFilterCmd {
+	return &LoadTxFilterCmd{
+		Reload:    reload,
+		Addresses: addresses,
+		OutPoints: outPoints,
+	}
+}
+
 // NotifyBlocksCmd defines the notifyblocks JSON-RPC command.
 type NotifyBlocksCmd struct{}
 
@@ -78,86 +104,17 @@ func NewStopNotifyNewTransactionsCmd() *StopNotifyNewTransactionsCmd {
 	return &StopNotifyNewTransactionsCmd{}
 }
 
-// NotifyReceivedCmd defines the notifyreceived JSON-RPC command.
-type NotifyReceivedCmd struct {
-	Addresses []string
-}
-
-// NewNotifyReceivedCmd returns a new instance which can be used to issue a
-// notifyreceived JSON-RPC command.
-func NewNotifyReceivedCmd(addresses []string) *NotifyReceivedCmd {
-	return &NotifyReceivedCmd{
-		Addresses: addresses,
-	}
-}
-
-// OutPoint describes a transaction outpoint that will be marshalled to and
-// from JSON.  Contains Decred addition.
-type OutPoint struct {
-	Hash  string `json:"hash"`
-	Tree  int8   `json:"tree"`
-	Index uint32 `json:"index"`
-}
-
-// NotifySpentCmd defines the notifyspent JSON-RPC command.
-type NotifySpentCmd struct {
-	OutPoints []OutPoint
-}
-
-// NewNotifySpentCmd returns a new instance which can be used to issue a
-// notifyspent JSON-RPC command.
-func NewNotifySpentCmd(outPoints []OutPoint) *NotifySpentCmd {
-	return &NotifySpentCmd{
-		OutPoints: outPoints,
-	}
-}
-
-// StopNotifyReceivedCmd defines the stopnotifyreceived JSON-RPC command.
-type StopNotifyReceivedCmd struct {
-	Addresses []string
-}
-
-// NewStopNotifyReceivedCmd returns a new instance which can be used to issue a
-// stopnotifyreceived JSON-RPC command.
-func NewStopNotifyReceivedCmd(addresses []string) *StopNotifyReceivedCmd {
-	return &StopNotifyReceivedCmd{
-		Addresses: addresses,
-	}
-}
-
-// StopNotifySpentCmd defines the stopnotifyspent JSON-RPC command.
-type StopNotifySpentCmd struct {
-	OutPoints []OutPoint
-}
-
-// NewStopNotifySpentCmd returns a new instance which can be used to issue a
-// stopnotifyspent JSON-RPC command.
-func NewStopNotifySpentCmd(outPoints []OutPoint) *StopNotifySpentCmd {
-	return &StopNotifySpentCmd{
-		OutPoints: outPoints,
-	}
-}
-
 // RescanCmd defines the rescan JSON-RPC command.
 type RescanCmd struct {
-	BeginBlock string
-	Addresses  []string
-	OutPoints  []OutPoint
-	EndBlock   *string
+	// Concatinated block hashes in non-byte-reversed hex encoding.  Must
+	// have length evenly divisible by 2*chainhash.HashSize.
+	BlockHashes string
 }
 
 // NewRescanCmd returns a new instance which can be used to issue a rescan
 // JSON-RPC command.
-//
-// The parameters which are pointers indicate they are optional.  Passing nil
-// for optional parameters will use the default value.
-func NewRescanCmd(beginBlock string, addresses []string, outPoints []OutPoint, endBlock *string) *RescanCmd {
-	return &RescanCmd{
-		BeginBlock: beginBlock,
-		Addresses:  addresses,
-		OutPoints:  outPoints,
-		EndBlock:   endBlock,
-	}
+func NewRescanCmd(blockHashes string) *RescanCmd {
+	return &RescanCmd{BlockHashes: blockHashes}
 }
 
 func init() {
@@ -165,14 +122,11 @@ func init() {
 	flags := UFWebsocketOnly
 
 	MustRegisterCmd("authenticate", (*AuthenticateCmd)(nil), flags)
+	MustRegisterCmd("loadtxfilter", (*LoadTxFilterCmd)(nil), flags)
 	MustRegisterCmd("notifyblocks", (*NotifyBlocksCmd)(nil), flags)
 	MustRegisterCmd("notifynewtransactions", (*NotifyNewTransactionsCmd)(nil), flags)
-	MustRegisterCmd("notifyreceived", (*NotifyReceivedCmd)(nil), flags)
-	MustRegisterCmd("notifyspent", (*NotifySpentCmd)(nil), flags)
 	MustRegisterCmd("session", (*SessionCmd)(nil), flags)
 	MustRegisterCmd("stopnotifyblocks", (*StopNotifyBlocksCmd)(nil), flags)
 	MustRegisterCmd("stopnotifynewtransactions", (*StopNotifyNewTransactionsCmd)(nil), flags)
-	MustRegisterCmd("stopnotifyspent", (*StopNotifySpentCmd)(nil), flags)
-	MustRegisterCmd("stopnotifyreceived", (*StopNotifyReceivedCmd)(nil), flags)
 	MustRegisterCmd("rescan", (*RescanCmd)(nil), flags)
 }

--- a/dcrjson/chainsvrwscmds_test.go
+++ b/dcrjson/chainsvrwscmds_test.go
@@ -101,96 +101,16 @@ func TestChainSvrWsCmds(t *testing.T) {
 			unmarshalled: &dcrjson.StopNotifyNewTransactionsCmd{},
 		},
 		{
-			name: "notifyreceived",
-			newCmd: func() (interface{}, error) {
-				return dcrjson.NewCmd("notifyreceived", []string{"1Address"})
-			},
-			staticCmd: func() interface{} {
-				return dcrjson.NewNotifyReceivedCmd([]string{"1Address"})
-			},
-			marshalled: `{"jsonrpc":"1.0","method":"notifyreceived","params":[["1Address"]],"id":1}`,
-			unmarshalled: &dcrjson.NotifyReceivedCmd{
-				Addresses: []string{"1Address"},
-			},
-		},
-		{
-			name: "stopnotifyreceived",
-			newCmd: func() (interface{}, error) {
-				return dcrjson.NewCmd("stopnotifyreceived", []string{"1Address"})
-			},
-			staticCmd: func() interface{} {
-				return dcrjson.NewStopNotifyReceivedCmd([]string{"1Address"})
-			},
-			marshalled: `{"jsonrpc":"1.0","method":"stopnotifyreceived","params":[["1Address"]],"id":1}`,
-			unmarshalled: &dcrjson.StopNotifyReceivedCmd{
-				Addresses: []string{"1Address"},
-			},
-		},
-		{
-			name: "notifyspent",
-			newCmd: func() (interface{}, error) {
-				return dcrjson.NewCmd("notifyspent", `[{"hash":"123","index":0}]`)
-			},
-			staticCmd: func() interface{} {
-				ops := []dcrjson.OutPoint{{Hash: "123", Index: 0}}
-				return dcrjson.NewNotifySpentCmd(ops)
-			},
-			marshalled: `{"jsonrpc":"1.0","method":"notifyspent","params":[[{"hash":"123","tree":0,"index":0}]],"id":1}`,
-			unmarshalled: &dcrjson.NotifySpentCmd{
-				OutPoints: []dcrjson.OutPoint{{Hash: "123", Index: 0}},
-			},
-		},
-		{
-			name: "stopnotifyspent",
-			newCmd: func() (interface{}, error) {
-				return dcrjson.NewCmd("stopnotifyspent", `[{"hash":"123","index":0}]`)
-			},
-			staticCmd: func() interface{} {
-				ops := []dcrjson.OutPoint{{Hash: "123", Index: 0}}
-				return dcrjson.NewStopNotifySpentCmd(ops)
-			},
-			marshalled: `{"jsonrpc":"1.0","method":"stopnotifyspent","params":[[{"hash":"123","tree":0,"index":0}]],"id":1}`,
-			unmarshalled: &dcrjson.StopNotifySpentCmd{
-				OutPoints: []dcrjson.OutPoint{{Hash: "123", Index: 0}},
-			},
-		},
-		{
 			name: "rescan",
 			newCmd: func() (interface{}, error) {
-				return dcrjson.NewCmd("rescan", "123", `["1Address"]`, `[{"hash":"0000000000000000000000000000000000000000000000000000000000000123","tree":0,"index":0}]`)
+				return dcrjson.NewCmd("rescan", "0000000000000000000000000000000000000000000000000000000000000123")
 			},
 			staticCmd: func() interface{} {
-				addrs := []string{"1Address"}
-				ops := []dcrjson.OutPoint{{
-					Hash:  "0000000000000000000000000000000000000000000000000000000000000123",
-					Index: 0,
-				}}
-				return dcrjson.NewRescanCmd("123", addrs, ops, nil)
+				return dcrjson.NewRescanCmd("0000000000000000000000000000000000000000000000000000000000000123")
 			},
-			marshalled: `{"jsonrpc":"1.0","method":"rescan","params":["123",["1Address"],[{"hash":"0000000000000000000000000000000000000000000000000000000000000123","tree":0,"index":0}]],"id":1}`,
+			marshalled: `{"jsonrpc":"1.0","method":"rescan","params":["0000000000000000000000000000000000000000000000000000000000000123"],"id":1}`,
 			unmarshalled: &dcrjson.RescanCmd{
-				BeginBlock: "123",
-				Addresses:  []string{"1Address"},
-				OutPoints:  []dcrjson.OutPoint{{Hash: "0000000000000000000000000000000000000000000000000000000000000123", Index: 0}},
-				EndBlock:   nil,
-			},
-		},
-		{
-			name: "rescan optional",
-			newCmd: func() (interface{}, error) {
-				return dcrjson.NewCmd("rescan", "123", `["1Address"]`, `[{"hash":"123","tree":0,"index":0}]`, "456")
-			},
-			staticCmd: func() interface{} {
-				addrs := []string{"1Address"}
-				ops := []dcrjson.OutPoint{{Hash: "123", Index: 0}}
-				return dcrjson.NewRescanCmd("123", addrs, ops, dcrjson.String("456"))
-			},
-			marshalled: `{"jsonrpc":"1.0","method":"rescan","params":["123",["1Address"],[{"hash":"123","tree":0,"index":0}],"456"],"id":1}`,
-			unmarshalled: &dcrjson.RescanCmd{
-				BeginBlock: "123",
-				Addresses:  []string{"1Address"},
-				OutPoints:  []dcrjson.OutPoint{{Hash: "123", Index: 0}},
-				EndBlock:   dcrjson.String("456"),
+				BlockHashes: "0000000000000000000000000000000000000000000000000000000000000123",
 			},
 		},
 	}

--- a/dcrjson/chainsvrwsntfns.go
+++ b/dcrjson/chainsvrwsntfns.go
@@ -21,25 +21,6 @@ const (
 	// block chain is in the process of a reorganization.
 	ReorganizationNtfnMethod = "reorganization"
 
-	// RecvTxNtfnMethod is the method used for notifications from the chain
-	// server that a transaction which pays to a registered address has been
-	// processed.
-	RecvTxNtfnMethod = "recvtx"
-
-	// RedeemingTxNtfnMethod is the method used for notifications from the
-	// chain server that a transaction which spends a registered outpoint
-	// has been processed.
-	RedeemingTxNtfnMethod = "redeemingtx"
-
-	// RescanFinishedNtfnMethod is the method used for notifications from
-	// the chain server that a rescan operation has finished.
-	RescanFinishedNtfnMethod = "rescanfinished"
-
-	// RescanProgressNtfnMethod is the method used for notifications from
-	// the chain server that a rescan operation this is underway has made
-	// progress.
-	RescanProgressNtfnMethod = "rescanprogress"
-
 	// TxAcceptedNtfnMethod is the method used for notifications from the
 	// chain server that a transaction has been accepted into the mempool.
 	TxAcceptedNtfnMethod = "txaccepted"
@@ -49,52 +30,47 @@ const (
 	// mempool.  This differs from TxAcceptedNtfnMethod in that it provides
 	// more details in the notification.
 	TxAcceptedVerboseNtfnMethod = "txacceptedverbose"
+
+	// RelevantTxAcceptedNtfnMethod is the method used for notifications
+	// from the chain server that inform a client that a relevant
+	// transaction was accepted by the mempool.
+	RelevantTxAcceptedNtfnMethod = "relevanttxaccepted"
 )
 
 // BlockConnectedNtfn defines the blockconnected JSON-RPC notification.
 type BlockConnectedNtfn struct {
-	Hash     string
-	Height   int32
-	Time     int64
-	VoteBits uint16
+	Header        string   `json:"header"`
+	SubscribedTxs []string `json:"subscribedtxs"`
 }
 
 // NewBlockConnectedNtfn returns a new instance which can be used to issue a
 // blockconnected JSON-RPC notification.
-func NewBlockConnectedNtfn(hash string, height int32, time int64, voteBits uint16) *BlockConnectedNtfn {
+func NewBlockConnectedNtfn(header string, subscribedTxs []string) *BlockConnectedNtfn {
 	return &BlockConnectedNtfn{
-		Hash:     hash,
-		Height:   height,
-		Time:     time,
-		VoteBits: voteBits,
+		Header:        header,
+		SubscribedTxs: subscribedTxs,
 	}
 }
 
 // BlockDisconnectedNtfn defines the blockdisconnected JSON-RPC notification.
 type BlockDisconnectedNtfn struct {
-	Hash     string
-	Height   int32
-	Time     int64
-	VoteBits uint16
+	Header string `json:"header"`
 }
 
 // NewBlockDisconnectedNtfn returns a new instance which can be used to issue a
 // blockdisconnected JSON-RPC notification.
-func NewBlockDisconnectedNtfn(hash string, height int32, time int64, voteBits uint16) *BlockDisconnectedNtfn {
+func NewBlockDisconnectedNtfn(header string) *BlockDisconnectedNtfn {
 	return &BlockDisconnectedNtfn{
-		Hash:     hash,
-		Height:   height,
-		Time:     time,
-		VoteBits: voteBits,
+		Header: header,
 	}
 }
 
 // ReorganizationNtfn defines the reorganization JSON-RPC notification.
 type ReorganizationNtfn struct {
-	OldHash   string
-	OldHeight int32
-	NewHash   string
-	NewHeight int32
+	OldHash   string `json:"oldhash"`
+	OldHeight int32  `json:"oldheight"`
+	NewHash   string `json:"newhash"`
+	NewHeight int32  `json:"newheight"`
 }
 
 // NewReorganizationNtfn returns a new instance which can be used to issue a
@@ -109,84 +85,10 @@ func NewReorganizationNtfn(oldHash string, oldHeight int32, newHash string,
 	}
 }
 
-// BlockDetails describes details of a tx in a block.
-type BlockDetails struct {
-	Height   int32  `json:"height"`
-	Tree     int8   `json:"tree"`
-	Hash     string `json:"hash"`
-	Index    int    `json:"index"`
-	Time     int64  `json:"time"`
-	VoteBits uint16 `json:"votebits"`
-}
-
-// RecvTxNtfn defines the recvtx JSON-RPC notification.
-type RecvTxNtfn struct {
-	HexTx string
-	Block *BlockDetails
-}
-
-// NewRecvTxNtfn returns a new instance which can be used to issue a recvtx
-// JSON-RPC notification.
-func NewRecvTxNtfn(hexTx string, block *BlockDetails) *RecvTxNtfn {
-	return &RecvTxNtfn{
-		HexTx: hexTx,
-		Block: block,
-	}
-}
-
-// RedeemingTxNtfn defines the redeemingtx JSON-RPC notification.
-type RedeemingTxNtfn struct {
-	HexTx string
-	Block *BlockDetails
-}
-
-// NewRedeemingTxNtfn returns a new instance which can be used to issue a
-// redeemingtx JSON-RPC notification.
-func NewRedeemingTxNtfn(hexTx string, block *BlockDetails) *RedeemingTxNtfn {
-	return &RedeemingTxNtfn{
-		HexTx: hexTx,
-		Block: block,
-	}
-}
-
-// RescanFinishedNtfn defines the rescanfinished JSON-RPC notification.
-type RescanFinishedNtfn struct {
-	Hash   string
-	Height int64
-	Time   int64
-}
-
-// NewRescanFinishedNtfn returns a new instance which can be used to issue a
-// rescanfinished JSON-RPC notification.
-func NewRescanFinishedNtfn(hash string, height int64, time int64) *RescanFinishedNtfn {
-	return &RescanFinishedNtfn{
-		Hash:   hash,
-		Height: height,
-		Time:   time,
-	}
-}
-
-// RescanProgressNtfn defines the rescanprogress JSON-RPC notification.
-type RescanProgressNtfn struct {
-	Hash   string
-	Height int32
-	Time   int64
-}
-
-// NewRescanProgressNtfn returns a new instance which can be used to issue a
-// rescanprogress JSON-RPC notification.
-func NewRescanProgressNtfn(hash string, height int32, time int64) *RescanProgressNtfn {
-	return &RescanProgressNtfn{
-		Hash:   hash,
-		Height: height,
-		Time:   time,
-	}
-}
-
 // TxAcceptedNtfn defines the txaccepted JSON-RPC notification.
 type TxAcceptedNtfn struct {
-	TxID   string
-	Amount float64
+	TxID   string  `json:"txid"`
+	Amount float64 `json:"amount"`
 }
 
 // NewTxAcceptedNtfn returns a new instance which can be used to issue a
@@ -200,7 +102,7 @@ func NewTxAcceptedNtfn(txHash string, amount float64) *TxAcceptedNtfn {
 
 // TxAcceptedVerboseNtfn defines the txacceptedverbose JSON-RPC notification.
 type TxAcceptedVerboseNtfn struct {
-	RawTx TxRawResult
+	RawTx TxRawResult `json:"rawtx"`
 }
 
 // NewTxAcceptedVerboseNtfn returns a new instance which can be used to issue a
@@ -211,6 +113,18 @@ func NewTxAcceptedVerboseNtfn(rawTx TxRawResult) *TxAcceptedVerboseNtfn {
 	}
 }
 
+// RelevantTxAcceptedNtfn defines the parameters to the relevanttxaccepted
+// JSON-RPC notification.
+type RelevantTxAcceptedNtfn struct {
+	Transaction string `json:"transaction"`
+}
+
+// NewRelevantTxAcceptedNtfn returns a new instance which can be used to issue a
+// relevantxaccepted JSON-RPC notification.
+func NewRelevantTxAcceptedNtfn(txHex string) *RelevantTxAcceptedNtfn {
+	return &RelevantTxAcceptedNtfn{Transaction: txHex}
+}
+
 func init() {
 	// The commands in this file are only usable by websockets and are
 	// notifications.
@@ -219,10 +133,7 @@ func init() {
 	MustRegisterCmd(BlockConnectedNtfnMethod, (*BlockConnectedNtfn)(nil), flags)
 	MustRegisterCmd(BlockDisconnectedNtfnMethod, (*BlockDisconnectedNtfn)(nil), flags)
 	MustRegisterCmd(ReorganizationNtfnMethod, (*ReorganizationNtfn)(nil), flags)
-	MustRegisterCmd(RecvTxNtfnMethod, (*RecvTxNtfn)(nil), flags)
-	MustRegisterCmd(RedeemingTxNtfnMethod, (*RedeemingTxNtfn)(nil), flags)
-	MustRegisterCmd(RescanFinishedNtfnMethod, (*RescanFinishedNtfn)(nil), flags)
-	MustRegisterCmd(RescanProgressNtfnMethod, (*RescanProgressNtfn)(nil), flags)
 	MustRegisterCmd(TxAcceptedNtfnMethod, (*TxAcceptedNtfn)(nil), flags)
 	MustRegisterCmd(TxAcceptedVerboseNtfnMethod, (*TxAcceptedVerboseNtfn)(nil), flags)
+	MustRegisterCmd(RelevantTxAcceptedNtfnMethod, (*RelevantTxAcceptedNtfn)(nil), flags)
 }

--- a/dcrjson/chainsvrwsntfns_test.go
+++ b/dcrjson/chainsvrwsntfns_test.go
@@ -32,119 +32,41 @@ func TestChainSvrWsNtfns(t *testing.T) {
 		{
 			name: "blockconnected",
 			newNtfn: func() (interface{}, error) {
-				return dcrjson.NewCmd("blockconnected", "123", 100000, 123456789, 0)
+				return dcrjson.NewCmd("blockconnected", "header", []string{"tx0", "tx1"})
 			},
 			staticNtfn: func() interface{} {
-				return dcrjson.NewBlockConnectedNtfn("123", 100000, 123456789, 0)
+				return dcrjson.NewBlockConnectedNtfn("header", []string{"tx0", "tx1"})
 			},
-			marshalled: `{"jsonrpc":"1.0","method":"blockconnected","params":["123",100000,123456789,0],"id":null}`,
+			marshalled: `{"jsonrpc":"1.0","method":"blockconnected","params":["header",["tx0","tx1"]],"id":null}`,
 			unmarshalled: &dcrjson.BlockConnectedNtfn{
-				Hash:     "123",
-				Height:   100000,
-				Time:     123456789,
-				VoteBits: 0,
+				Header:        "header",
+				SubscribedTxs: []string{"tx0", "tx1"},
 			},
 		},
 		{
 			name: "blockdisconnected",
 			newNtfn: func() (interface{}, error) {
-				return dcrjson.NewCmd("blockdisconnected", "123", 100000, 123456789, 0)
+				return dcrjson.NewCmd("blockdisconnected", "header")
 			},
 			staticNtfn: func() interface{} {
-				return dcrjson.NewBlockDisconnectedNtfn("123", 100000, 123456789, 0)
+				return dcrjson.NewBlockDisconnectedNtfn("header")
 			},
-			marshalled: `{"jsonrpc":"1.0","method":"blockdisconnected","params":["123",100000,123456789,0],"id":null}`,
+			marshalled: `{"jsonrpc":"1.0","method":"blockdisconnected","params":["header"],"id":null}`,
 			unmarshalled: &dcrjson.BlockDisconnectedNtfn{
-				Hash:     "123",
-				Height:   100000,
-				Time:     123456789,
-				VoteBits: 0,
+				Header: "header",
 			},
 		},
 		{
-			name: "recvtx",
+			name: "relevanttxaccepted",
 			newNtfn: func() (interface{}, error) {
-				return dcrjson.NewCmd("recvtx", "001122", `{"height":100000,"tree":0,"hash":"123","index":0,"time":12345678,"votebits":0}`)
+				return dcrjson.NewCmd("relevanttxaccepted", "001122")
 			},
 			staticNtfn: func() interface{} {
-				blockDetails := dcrjson.BlockDetails{
-					Height:   100000,
-					Tree:     0,
-					Hash:     "123",
-					Index:    0,
-					Time:     12345678,
-					VoteBits: 0,
-				}
-				return dcrjson.NewRecvTxNtfn("001122", &blockDetails)
+				return dcrjson.NewRelevantTxAcceptedNtfn("001122")
 			},
-			marshalled: `{"jsonrpc":"1.0","method":"recvtx","params":["001122",{"height":100000,"tree":0,"hash":"123","index":0,"time":12345678,"votebits":0}],"id":null}`,
-			unmarshalled: &dcrjson.RecvTxNtfn{
-				HexTx: "001122",
-				Block: &dcrjson.BlockDetails{
-					Height:   100000,
-					Tree:     0,
-					Hash:     "123",
-					Index:    0,
-					Time:     12345678,
-					VoteBits: 0,
-				},
-			},
-		},
-		{
-			name: "redeemingtx",
-			newNtfn: func() (interface{}, error) {
-				return dcrjson.NewCmd("redeemingtx", "001122", `{"height":100000,"tree":0,"hash":"123","index":0,"time":12345678,"votebits":0}`)
-			},
-			staticNtfn: func() interface{} {
-				blockDetails := dcrjson.BlockDetails{
-					Height:   100000,
-					Hash:     "123",
-					Index:    0,
-					Time:     12345678,
-					VoteBits: 0,
-				}
-				return dcrjson.NewRedeemingTxNtfn("001122", &blockDetails)
-			},
-			marshalled: `{"jsonrpc":"1.0","method":"redeemingtx","params":["001122",{"height":100000,"tree":0,"hash":"123","index":0,"time":12345678,"votebits":0}],"id":null}`,
-			unmarshalled: &dcrjson.RedeemingTxNtfn{
-				HexTx: "001122",
-				Block: &dcrjson.BlockDetails{
-					Height:   100000,
-					Hash:     "123",
-					Index:    0,
-					Time:     12345678,
-					VoteBits: 0,
-				},
-			},
-		},
-		{
-			name: "rescanfinished",
-			newNtfn: func() (interface{}, error) {
-				return dcrjson.NewCmd("rescanfinished", "123", 100000, 12345678)
-			},
-			staticNtfn: func() interface{} {
-				return dcrjson.NewRescanFinishedNtfn("123", 100000, 12345678)
-			},
-			marshalled: `{"jsonrpc":"1.0","method":"rescanfinished","params":["123",100000,12345678],"id":null}`,
-			unmarshalled: &dcrjson.RescanFinishedNtfn{
-				Hash:   "123",
-				Height: 100000,
-				Time:   12345678,
-			},
-		},
-		{
-			name: "rescanprogress",
-			newNtfn: func() (interface{}, error) {
-				return dcrjson.NewCmd("rescanprogress", "123", 100000, 12345678)
-			},
-			staticNtfn: func() interface{} {
-				return dcrjson.NewRescanProgressNtfn("123", 100000, 12345678)
-			},
-			marshalled: `{"jsonrpc":"1.0","method":"rescanprogress","params":["123",100000,12345678],"id":null}`,
-			unmarshalled: &dcrjson.RescanProgressNtfn{
-				Hash:   "123",
-				Height: 100000,
-				Time:   12345678,
+			marshalled: `{"jsonrpc":"1.0","method":"relevanttxaccepted","params":["001122"],"id":null}`,
+			unmarshalled: &dcrjson.RelevantTxAcceptedNtfn{
+				Transaction: "001122",
 			},
 		},
 		{

--- a/dcrjson/chainsvrwsresults.go
+++ b/dcrjson/chainsvrwsresults.go
@@ -9,3 +9,15 @@ package dcrjson
 type SessionResult struct {
 	SessionID uint64 `json:"sessionid"`
 }
+
+// RescanResult models the result object returned by the rescan RPC.
+type RescanResult struct {
+	DiscoveredData []RescannedBlock `json:"discovereddata"`
+}
+
+// RescannedBlock contains the hash and all discovered transactions of a single
+// rescanned block.
+type RescannedBlock struct {
+	Hash         string   `json:"hash"`
+	Transactions []string `json:"transactions"`
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: f31381b9d7836c3acfccda809b8b279691b38d97517933b4f10e97f8ec468d2b
-updated: 2016-11-03T11:14:54.38201947-05:00
+updated: 2016-11-08T16:16:20.70957-05:00
 imports:
 - name: github.com/btcsuite/btclog
   version: 73889fb79bd687870312b6e40effcecffbd57d30
@@ -39,11 +39,11 @@ imports:
   subpackages:
   - eventlog
   - mgr
-  - svc
   - registry
+  - svc
   - winapi
 - name: github.com/davecgh/go-spew
-  version: 346938d642f2ec3594ed81d874461961cd0faa76
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
 - name: github.com/decred/bitset
@@ -55,8 +55,8 @@ imports:
 - name: github.com/decred/dcrutil
   version: 0484582bf5503574d824f110e836a8c48aa60c8c
   subpackages:
-  - bloom
   - base58
+  - bloom
 - name: github.com/decred/ed25519
   version: b0909d3f798b97a03c9e77023f97a5301a2a7900
   subpackages:
@@ -66,7 +66,7 @@ imports:
   subpackages:
   - ssh/terminal
 - name: golang.org/x/sys
-  version: c200b10b5d5e122be351b67af224adc6128af5bf
+  version: 9a2e24c3733eddc63871eda99f253e2db29bd3b9
   subpackages:
   - unix
 testImports:

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -51,9 +51,9 @@ import (
 
 // API version constants
 const (
-	jsonrpcSemverString = "1.2.0"
-	jsonrpcSemverMajor  = 1
-	jsonrpcSemverMinor  = 2
+	jsonrpcSemverString = "2.0.0"
+	jsonrpcSemverMajor  = 2
+	jsonrpcSemverMinor  = 0
 	jsonrpcSemverPatch  = 0
 )
 

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -690,37 +690,20 @@ var helpDescsEnUS = map[string]string{
 	// StopNotifyNewTransactionsCmd help.
 	"stopnotifynewtransactions--synopsis": "Stop sending either a txaccepted or a txacceptedverbose notification when a new transaction is accepted into the mempool.",
 
-	// NotifyReceivedCmd help.
-	"notifyreceived--synopsis": "Send a recvtx notification when a transaction added to mempool or appears in a newly-attached block contains a txout pkScript sending to any of the passed addresses.\n" +
-		"Matching outpoints are automatically registered for redeemingtx notifications.",
-	"notifyreceived-addresses": "List of address to receive notifications about",
-
-	// StopNotifyReceivedCmd help.
-	"stopnotifyreceived--synopsis": "Cancel registered receive notifications for each passed address.",
-	"stopnotifyreceived-addresses": "List of address to cancel receive notifications for",
-
 	// OutPoint help.
 	"outpoint-hash":  "The hex-encoded bytes of the outpoint hash",
 	"outpoint-index": "The index of the outpoint",
 	"outpoint-tree":  "The tree of the outpoint",
 
-	// NotifySpentCmd help.
-	"notifyspent--synopsis": "Send a redeemingtx notification when a transaction spending an outpoint appears in mempool (if relayed to this dcrd instance) and when such a transaction first appears in a newly-attached block.",
-	"notifyspent-outpoints": "List of transaction outpoints to monitor.",
-
-	// StopNotifySpentCmd help.
-	"stopnotifyspent--synopsis": "Cancel registered spending notifications for each passed outpoint.",
-	"stopnotifyspent-outpoints": "List of transaction outpoints to stop monitoring.",
+	// LoadTxFilterCmd help.
+	"loadtxfilter--synopsis": "Load, add to, or reload a websocket client's transaction filter for mempool transactions, new blocks and rescans.",
+	"loadtxfilter-reload":    "Load a new filter instead of adding data to an existing one",
+	"loadtxfilter-addresses": "Array of addresses to add to the transaction filter",
+	"loadtxfilter-outpoints": "Array of outpoints to add to the transaction filter",
 
 	// Rescan help.
-	"rescan--synopsis": "Rescan block chain for transactions to addresses.\n" +
-		"When the endblock parameter is omitted, the rescan continues through the best block in the main chain.\n" +
-		"Rescan results are sent as recvtx and redeemingtx notifications.\n" +
-		"This call returns once the rescan completes.",
-	"rescan-beginblock": "Hash of the first block to begin rescanning",
-	"rescan-addresses":  "List of addresses to include in the rescan",
-	"rescan-outpoints":  "List of transaction outpoints to include in the rescan",
-	"rescan-endblock":   "Hash of final block to rescan",
+	"rescan--synopsis":   "Rescan blocks for transactions matching the loaded transaction filter.",
+	"rescan-blockhashes": "Concatenated block hashes to rescan.  Each next block must be a child of the previous.",
 
 	// -------- Decred-specific help --------
 
@@ -897,6 +880,7 @@ var rpcResultTypes = map[string][]interface{}{
 	"version":               {(*map[string]dcrjson.VersionResult)(nil)},
 
 	// Websocket commands.
+	"loadtxfilter":                nil,
 	"session":                     {(*dcrjson.SessionResult)(nil)},
 	"notifywinningtickets":        nil,
 	"notifyspentandmissedtickets": nil,


### PR DESCRIPTION
Change the block connected and disconnected notifications to include
the entire block header.

Do not notify the previous block's regular tree transactions if the
newly attached block voted to approve them.  Instead, notify the
regular transactions from the newly attached block.  It is up to the
client to check the vote bits in the header to decide how to handle
the previous block's regular transactions.

Every websocket client now has an associated transaction filter that
is used to determine whether or not a processed transaction is (or
might be) relevant to the client.  A new RPC, loadtxfilter, has been
added to load, reload, or add to this filter.

Redo the entire rescan RPC to scan over previously-processed blocks
using the same transaction filter (rather than specifying which
addresses and outpoints to watch for in the rescan request).

Fixes #433.