### PR TITLE
blockchain: remove redundant check

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -22,11 +22,6 @@ import (
 // that the coinbase contains the height encoding to make coinbase hash collisions
 // impossible.
 func checkCoinbaseUniqueHeight(blockHeight int64, block *dcrutil.Block) error {
-	if !(len(block.MsgBlock().Transactions) > 0) {
-		str := fmt.Sprintf("block %v has no coinbase", block.Sha())
-		return ruleError(ErrNoTransactions, str)
-	}
-
 	// Coinbase TxOut[0] is always tax, TxOut[1] is always
 	// height + extranonce, so at least two outputs must
 	// exist.


### PR DESCRIPTION
checkCoinbaseUniqueHeight had a check to ensure the block had
transactions.  This check is already done beforehand by
checkBlockSanity.