### PR TITLE
peer: Extract protocol negotiation from main read and write loops

### DIFF
--- a/peer/example_test.go
+++ b/peer/example_test.go
@@ -40,10 +40,7 @@ func mockRemotePeer() error {
 
 		// Create and start the inbound peer.
 		p := peer.NewInboundPeer(peerCfg)
-		if err := p.Connect(conn); err != nil {
-			fmt.Printf("Connect: error %v\n", err)
-			return
-		}
+		p.Connect(conn)
 	}()
 
 	return nil
@@ -94,10 +91,7 @@ func Example_newOutboundPeer() {
 		fmt.Printf("net.Dial: error %v\n", err)
 		return
 	}
-	if err := p.Connect(conn); err != nil {
-		fmt.Printf("Connect: error %v\n", err)
-		return
-	}
+	p.Connect(conn)
 
 	// Wait for the verack message or timeout in case of failure.
 	select {

--- a/server.go
+++ b/server.go
@@ -1667,12 +1667,7 @@ func (s *server) listenHandler(listener net.Listener) {
 		sp := newServerPeer(s, false)
 		sp.Peer = peer.NewInboundPeer(newPeerConfig(sp))
 		go s.peerDoneHandler(sp)
-		if err := sp.Connect(conn); err != nil {
-			if atomic.LoadInt32(&s.shutdown) == 0 {
-				srvrLog.Errorf("Can't accept connection: %v", err)
-			}
-			continue
-		}
+		sp.Connect(conn)
 	}
 	s.wg.Done()
 	srvrLog.Tracef("Listener handler done for %s", listener.Addr())
@@ -1768,10 +1763,7 @@ func (s *server) establishConn(sp *serverPeer) error {
 	if err != nil {
 		return err
 	}
-	if err := sp.Connect(conn); err != nil {
-		return err
-	}
-	srvrLog.Debugf("Connected to %s", sp.Addr())
+	sp.Connect(conn)
 	s.addrManager.Attempt(sp.NA())
 	return nil
 }


### PR DESCRIPTION
Contains the following upstream commits:
- 5cbd1f85bf217f59d3465ff8a471883600795ea0
- 777ccdade39c7b483410585d5e65e88db304f156
- f3d759d78307298c06b1cffaeb5af48a978f55af
- 1ffc3dc18d95b7b0aaf841dc46bd363f546ceb8d

Also the merge commit updates the code to use the correct Decred protocol versions and contains a few style-related changes.

