### PR TITLE
wire: Export transaction tree constants.

### DIFF
--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -156,7 +156,7 @@ func makeSpendableOutForTx(tx *wire.MsgTx, blockHeight, txIndex, txOutIndex uint
 		prevOut: wire.OutPoint{
 			Hash:  tx.TxSha(),
 			Index: txOutIndex,
-			Tree:  dcrutil.TxTreeRegular,
+			Tree:  wire.TxTreeRegular,
 		},
 		blockHeight: blockHeight,
 		blockIndex:  txIndex,

--- a/blockchain/stake/staketx.go
+++ b/blockchain/stake/staketx.go
@@ -192,7 +192,7 @@ type VoteBits struct {
 func isNullOutpoint(tx *wire.MsgTx) bool {
 	nullInOP := tx.TxIn[0].PreviousOutPoint
 	if nullInOP.Index == math.MaxUint32 && nullInOP.Hash.IsEqual(zeroHash) &&
-		nullInOP.Tree == dcrutil.TxTreeRegular {
+		nullInOP.Tree == wire.TxTreeRegular {
 		return true
 	}
 	return false
@@ -950,7 +950,7 @@ func IsSSGen(tx *wire.MsgTx) (bool, error) {
 			return false, stakeRuleError(ErrSSGenWrongIndex, errStr)
 		}
 
-		if txin.PreviousOutPoint.Tree != dcrutil.TxTreeStake {
+		if txin.PreviousOutPoint.Tree != wire.TxTreeStake {
 			return false, stakeRuleError(ErrSSGenWrongTxTree, "SSGen used "+
 				"a non-stake input")
 		}
@@ -1109,7 +1109,7 @@ func IsSSRtx(tx *wire.MsgTx) (bool, error) {
 
 	// Check to make sure that the output used as input came from TxTreeStake.
 	for _, txin := range tx.TxIn {
-		if txin.PreviousOutPoint.Tree != dcrutil.TxTreeStake {
+		if txin.PreviousOutPoint.Tree != wire.TxTreeStake {
 			return false, stakeRuleError(ErrSSRtxWrongTxTree, "SSRtx used "+
 				"a non-stake input")
 		}
@@ -1170,9 +1170,9 @@ func DetermineTxType(tx *wire.MsgTx) TxType {
 func SetTxTree(tx *dcrutil.Tx) {
 	txType := DetermineTxType(tx.MsgTx())
 
-	indicatedTree := dcrutil.TxTreeRegular
+	indicatedTree := wire.TxTreeRegular
 	if txType != TxTypeRegular {
-		indicatedTree = dcrutil.TxTreeStake
+		indicatedTree = wire.TxTreeStake
 	}
 
 	tx.SetTree(indicatedTree)

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -57,7 +57,7 @@ var (
 // is set.
 func isNullOutpoint(outpoint *wire.OutPoint) bool {
 	if outpoint.Index == math.MaxUint32 && outpoint.Hash.IsEqual(zeroHash) &&
-		outpoint.Tree == dcrutil.TxTreeRegular {
+		outpoint.Tree == wire.TxTreeRegular {
 		return true
 	}
 	return false
@@ -1604,9 +1604,9 @@ func CheckTransactionInputs(subsidyCache *SubsidyCache, tx *dcrutil.Tx,
 		// Ensure that the outpoint's tx tree makes sense.
 		originTxOPTree := txIn.PreviousOutPoint.Tree
 		originTxType := utxoEntry.TransactionType()
-		indicatedTree := dcrutil.TxTreeRegular
+		indicatedTree := wire.TxTreeRegular
 		if originTxType != stake.TxTypeRegular {
-			indicatedTree = dcrutil.TxTreeStake
+			indicatedTree = wire.TxTreeStake
 		}
 		if indicatedTree != originTxOPTree {
 			errStr := fmt.Sprintf("tx %v attempted to spend from a %v "+

--- a/mempool.go
+++ b/mempool.go
@@ -655,9 +655,9 @@ func (mp *txMemPool) removeTransaction(tx *dcrutil.Tx, removeRedeemers bool) {
 	if removeRedeemers {
 		// Remove any transactions which rely on this one.
 		txType = stake.DetermineTxType(msgTx)
-		tree := dcrutil.TxTreeRegular
+		tree := wire.TxTreeRegular
 		if txType != stake.TxTypeRegular {
-			tree = dcrutil.TxTreeStake
+			tree = wire.TxTreeStake
 		}
 		for i := uint32(0); i < uint32(len(msgTx.TxOut)); i++ {
 			outpoint := wire.NewOutPoint(txHash, i, tree)
@@ -952,9 +952,9 @@ func (mp *txMemPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew,
 	// it to the network with TxTreeUnknown.
 	txType := stake.DetermineTxType(msgTx)
 	if txType == stake.TxTypeRegular {
-		tx.SetTree(dcrutil.TxTreeRegular)
+		tx.SetTree(wire.TxTreeRegular)
 	} else {
-		tx.SetTree(dcrutil.TxTreeStake)
+		tx.SetTree(wire.TxTreeStake)
 	}
 
 	// Don't allow non-standard transactions if the network parameters

--- a/mining.go
+++ b/mining.go
@@ -468,7 +468,7 @@ func createCoinbaseTx(subsidyCache *blockchain.SubsidyCache,
 		// Coinbase transactions have no inputs, so previous outpoint is
 		// zero hash and max index.
 		PreviousOutPoint: *wire.NewOutPoint(&chainhash.Hash{},
-			wire.MaxPrevOutIndex, dcrutil.TxTreeRegular),
+			wire.MaxPrevOutIndex, wire.TxTreeRegular),
 		Sequence:        wire.MaxTxInSequenceNum,
 		BlockHeight:     wire.NullBlockHeight,
 		BlockIndex:      wire.NullBlockIndex,
@@ -1502,7 +1502,7 @@ mempoolLoop:
 		// minimum block size, except for stake transactions.
 		if sortedByFee &&
 			(prioItem.feePerKB < float64(policy.TxMinFreeFee)) &&
-			(tx.Tree() != dcrutil.TxTreeStake) &&
+			(tx.Tree() != wire.TxTreeStake) &&
 			(blockPlusTxSize >= policy.BlockMinSize) {
 
 			minrLog.Tracef("Skipping tx %s with feePerKB %.2f "+
@@ -1699,7 +1699,7 @@ mempoolLoop:
 
 			tempBlockTxns := make([]*dcrutil.Tx, 0, len(sourceTxns))
 			for _, tx := range blockTxns {
-				if tx.Tree() == dcrutil.TxTreeRegular {
+				if tx.Tree() == wire.TxTreeRegular {
 					// Go through all the inputs and check to see if this mempool
 					// tx uses outputs from the parent block. This loop is
 					// probably very expensive.
@@ -1733,7 +1733,7 @@ mempoolLoop:
 	for _, tx := range blockTxns {
 		msgTx := tx.MsgTx()
 		isSStx, _ := stake.IsSStx(msgTx)
-		if tx.Tree() == dcrutil.TxTreeStake && isSStx {
+		if tx.Tree() == wire.TxTreeStake && isSStx {
 			// A ticket can not spend an input from TxTreeRegular, since it
 			// has not yet been validated.
 			if containsTxIns(blockTxns, tx) {
@@ -1765,7 +1765,7 @@ mempoolLoop:
 
 		msgTx := tx.MsgTx()
 		isSSRtx, _ := stake.IsSSRtx(msgTx)
-		if tx.Tree() == dcrutil.TxTreeStake && isSSRtx {
+		if tx.Tree() == wire.TxTreeStake && isSSRtx {
 			txCopy := dcrutil.NewTxDeepTxIns(msgTx)
 			if maybeInsertStakeTx(blockManager, txCopy, treeValid) {
 				blockTxnsStake = append(blockTxnsStake, txCopy)
@@ -1815,7 +1815,7 @@ mempoolLoop:
 		return nil, err
 	}
 
-	coinbaseTx.SetTree(dcrutil.TxTreeRegular) // Coinbase only in regular tx tree
+	coinbaseTx.SetTree(wire.TxTreeRegular) // Coinbase only in regular tx tree
 	if err != nil {
 		return nil, err
 	}
@@ -1833,9 +1833,9 @@ mempoolLoop:
 
 	// Assemble the two transaction trees.
 	for _, tx := range blockTxns {
-		if tx.Tree() == dcrutil.TxTreeRegular {
+		if tx.Tree() == wire.TxTreeRegular {
 			blockTxnsRegular = append(blockTxnsRegular, tx)
-		} else if tx.Tree() == dcrutil.TxTreeStake {
+		} else if tx.Tree() == wire.TxTreeStake {
 			continue
 		} else {
 			minrLog.Tracef("Error adding tx %s to block; invalid tree", tx.Sha())

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -614,8 +614,8 @@ func handleCreateRawTransaction(s *rpcServer, cmd interface{}, closeChan <-chan 
 			return nil, rpcDecodeHexError(input.Txid)
 		}
 
-		if !(int8(input.Tree) == dcrutil.TxTreeRegular ||
-			int8(input.Tree) == dcrutil.TxTreeStake) {
+		if !(int8(input.Tree) == wire.TxTreeRegular ||
+			int8(input.Tree) == wire.TxTreeStake) {
 			return nil, dcrjson.RPCError{
 				Code:    dcrjson.ErrRPCInvalidParams.Code,
 				Message: "Invalid parameter, tx tree must be regular or stake",
@@ -744,8 +744,8 @@ func handleCreateRawSStx(s *rpcServer,
 			}
 		}
 
-		if !(int8(input.Tree) == dcrutil.TxTreeRegular ||
-			int8(input.Tree) == dcrutil.TxTreeStake) {
+		if !(int8(input.Tree) == wire.TxTreeRegular ||
+			int8(input.Tree) == wire.TxTreeStake) {
 			return nil, dcrjson.RPCError{
 				Code:    dcrjson.ErrRPCInvalidParameter,
 				Message: "Invalid parameter, tx tree must be regular or stake",
@@ -1049,7 +1049,7 @@ func handleCreateRawSSGenTx(s *rpcServer,
 			}
 		}
 
-		if !(int8(input.Tree) == dcrutil.TxTreeStake) {
+		if !(int8(input.Tree) == wire.TxTreeStake) {
 			return nil, dcrjson.RPCError{
 				Code:    dcrjson.ErrRPCInvalidParameter,
 				Message: "Invalid parameter, tx tree of sstx input must be stake",
@@ -1229,7 +1229,7 @@ func handleCreateRawSSRtx(s *rpcServer,
 			}
 		}
 
-		if !(int8(input.Tree) == dcrutil.TxTreeStake) {
+		if !(int8(input.Tree) == wire.TxTreeStake) {
 			return nil, dcrjson.RPCError{
 				Code:    dcrjson.ErrRPCInvalidParameter,
 				Message: "Invalid parameter, tx tree of sstx input must be stake",

--- a/rpcwebsocket.go
+++ b/rpcwebsocket.go
@@ -1990,7 +1990,7 @@ func rescanBlock(filter *wsClientFilter, block *dcrutil.Block) []string {
 		added := false
 
 		inputs := tx.TxIn
-		if tree == dcrutil.TxTreeRegular {
+		if tree == wire.TxTreeRegular {
 			// Skip previous output checks for coinbase inputs.  These do
 			// not reference a previous output.
 			if blockchain.IsCoinBaseTx(tx) {
@@ -2044,10 +2044,10 @@ func rescanBlock(filter *wsClientFilter, block *dcrutil.Block) []string {
 	msgBlock := block.MsgBlock()
 	filter.mu.Lock()
 	for _, tx := range msgBlock.STransactions {
-		checkTransaction(tx, dcrutil.TxTreeStake)
+		checkTransaction(tx, wire.TxTreeStake)
 	}
 	for _, tx := range msgBlock.Transactions {
-		checkTransaction(tx, dcrutil.TxTreeRegular)
+		checkTransaction(tx, wire.TxTreeRegular)
 	}
 	filter.mu.Unlock()
 

--- a/wire/msgblock_test.go
+++ b/wire/msgblock_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/wire"
-	"github.com/decred/dcrutil"
 )
 
 // TestBlock tests the MsgBlock API.
@@ -599,7 +598,7 @@ var testBlock = wire.MsgBlock{
 					PreviousOutPoint: wire.OutPoint{
 						Hash:  chainhash.Hash{},
 						Index: 0xffffffff,
-						Tree:  dcrutil.TxTreeRegular,
+						Tree:  wire.TxTreeRegular,
 					},
 					Sequence:    0xffffffff,
 					ValueIn:     0x1616161616161616,
@@ -641,7 +640,7 @@ var testBlock = wire.MsgBlock{
 					PreviousOutPoint: wire.OutPoint{
 						Hash:  chainhash.Hash{},
 						Index: 0xffffffff,
-						Tree:  dcrutil.TxTreeStake,
+						Tree:  wire.TxTreeStake,
 					},
 					Sequence:    0xffffffff,
 					ValueIn:     0x1313131313131313,

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -45,6 +45,19 @@ const (
 	// DefaultPkScriptVersion is the default pkScript version, referring to
 	// extended Decred script.
 	DefaultPkScriptVersion uint16 = 0x0000
+
+	// TxTreeUnknown is the value returned for a transaction tree that is
+	// unknown.  This is typically because the transaction has not been
+	// inserted into a block yet.
+	TxTreeUnknown int8 = -1
+
+	// TxTreeRegular is the value for a normal transcation tree for a
+	// transaction's location in a block.
+	TxTreeRegular int8 = 0
+
+	// TxTreeStake is the value for a stake transcation tree for a
+	// transaction's location in a block.
+	TxTreeStake int8 = 1
 )
 
 const (

--- a/wire/msgtx_test.go
+++ b/wire/msgtx_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/wire"
-	"github.com/decred/dcrutil"
 )
 
 // TestTx tests the MsgTx API.
@@ -52,7 +51,7 @@ func TestTx(t *testing.T) {
 	// NOTE: This is a block hash and made up index, but we're only
 	// testing package functionality.
 	prevOutIndex := uint32(1)
-	prevOut := wire.NewOutPoint(hash, prevOutIndex, dcrutil.TxTreeRegular)
+	prevOut := wire.NewOutPoint(hash, prevOutIndex, wire.TxTreeRegular)
 	if !prevOut.Hash.IsEqual(hash) {
 		t.Errorf("NewOutPoint: wrong hash - got %v, want %v",
 			spew.Sprint(&prevOut.Hash), spew.Sprint(hash))
@@ -147,7 +146,7 @@ func TestTxSha(t *testing.T) {
 		PreviousOutPoint: wire.OutPoint{
 			Hash:  chainhash.Hash{},
 			Index: 0xffffffff,
-			Tree:  dcrutil.TxTreeRegular,
+			Tree:  wire.TxTreeRegular,
 		},
 		Sequence:        0xffffffff,
 		ValueIn:         5000000000,


### PR DESCRIPTION
This exports the transaction tree constants from the `wire` package instead of from `dcrutil`.  The tree is a fundamental part of a transaction and therefore its definitions belong in `wire` alongside the other constants that are also related to fundamental transaction fields.

Further, the `wire` package most definitely should not depend on `dcrutil` since that would create a cyclic import cycle.