### PR TITLE
mempool: Rename GetVoteHashesForBlock & remove err.

### DIFF
--- a/mining.go
+++ b/mining.go
@@ -1187,9 +1187,10 @@ func NewBlockTemplate(policy *mining.Policy, server *server,
 
 				// Check to make sure we actually have the transactions
 				// (votes) we need in the mempool.
-				voteHashes, err := mempool.GetVoteHashesForBlock(newHead)
-				if err != nil {
-					return nil, err
+				voteHashes := mempool.VoteHashesForBlock(newHead)
+				if len(voteHashes) == 0 {
+					return nil, fmt.Errorf("no vote metadata for block %v",
+						newHead)
 				}
 
 				if exist := mempool.CheckIfTxsExist(voteHashes); !exist {

--- a/server.go
+++ b/server.go
@@ -493,6 +493,8 @@ func (sp *serverPeer) OnGetMiningState(p *peer.Peer, msg *wire.MsgGetMiningState
 		return
 	}
 
+	// Obtain the entire generation of blocks stemming from the parent of
+	// the current tip.
 	children, err := bm.GetGeneration(*newest)
 	if err != nil {
 		peerLog.Warnf("failed to access block manager to get the generation "+
@@ -526,11 +528,11 @@ func (sp *serverPeer) OnGetMiningState(p *peer.Peer, msg *wire.MsgGetMiningState
 	voteHashes := make([]chainhash.Hash, 0, wire.MaxMSVotesAtHeadPerMsg)
 	for _, bh := range blockHashes {
 		// Fetch the vote hashes themselves and append them.
-		vhsForBlock, err := mp.GetVoteHashesForBlock(bh)
-		if err != nil {
+		vhsForBlock := mp.VoteHashesForBlock(bh)
+		if len(vhsForBlock) == 0 {
 			peerLog.Warnf("unexpected error while fetching vote hashes "+
-				"for block %v for a mining state request: %v",
-				bh, err.Error())
+				"for block %v for a mining state request: no vote "+
+				"metadata for block", bh)
 			return
 		}
 		for _, vh := range vhsForBlock {


### PR DESCRIPTION
This renames the `GetVoteHashesForBlock` on the `mempool` type to `VoteHashesForBlock` so it is named according to Effective Go guidelines as required by the project's code contribution guidelines and removes
the error return and paths from the function.

The error has been removed since the function should not be assuming how the caller wishes to use the data.  Consequently, now when there are no votes for a given block hash, the function simply returns a nil slice to reflect that.  The caller can then decide if the lack of vote hashes for a block is an error or not.

Also, the error path regarding an unset vote hash in the metadata is an impossible condition because the `mempool` has full control over the vote insertion and thus will never insert vote metadata without it.

Fixes #481.