### PR TITLE
multi: Restore correct upstream majority version code.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -902,12 +902,11 @@ func (b *BlockChain) BestBlockHeader() *wire.BlockHeader {
 // starting with startNode are at least the minimum passed version.
 //
 // This function MUST be called with the chain state lock held (for writes).
-func (b *BlockChain) isMajorityVersion(minVer int32, startNode *blockNode,
-	numRequired int32) bool {
-	numFound := int32(0)
+func (b *BlockChain) isMajorityVersion(minVer int32, startNode *blockNode, numRequired uint64) bool {
+	numFound := uint64(0)
 	iterNode := startNode
-	for i := int32(0); i < b.chainParams.CurrentBlockVersion &&
-		numFound < int32(numRequired) && iterNode != nil; i++ {
+	for i := uint64(0); i < b.chainParams.BlockUpgradeNumToCheck &&
+		numFound < numRequired && iterNode != nil; i++ {
 		// This node has a version that is at least the minimum version.
 		if iterNode.header.Version >= minVer {
 			numFound++

--- a/blockchain/fullblocktests/params.go
+++ b/blockchain/fullblocktests/params.go
@@ -111,7 +111,6 @@ var simNetParams = &chaincfg.Params{
 	// Chain parameters
 	GenesisBlock:             &simNetGenesisBlock,
 	GenesisHash:              newHashFromStr("5bec7567af40504e0994db3b573c186fffcc4edefe096ff2e58d00523bd7e8a6"),
-	CurrentBlockVersion:      0,
 	PowLimit:                 simNetPowLimit,
 	PowLimitBits:             0x207fffff,
 	ReduceMinDifficulty:      false,
@@ -135,6 +134,16 @@ var simNetParams = &chaincfg.Params{
 
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints: nil,
+
+	// Enforce current block version once majority of the network has
+	// upgraded.
+	// 51% (51 / 100)
+	// Reject previous block versions once a majority of the network has
+	// upgraded.
+	// 75% (75 / 100)
+	BlockEnforceNumRequired: 51,
+	BlockRejectNumRequired:  75,
+	BlockUpgradeNumToCheck:  100,
 
 	// Mempool parameters
 	RelayNonStdTxs: true,

--- a/blockchain/stake/tickets_test.go
+++ b/blockchain/stake/tickets_test.go
@@ -948,7 +948,6 @@ var simNetParams = &chaincfg.Params{
 	// Chain parameters
 	GenesisBlock:             &simNetGenesisBlock,
 	GenesisHash:              &simNetGenesisHash,
-	CurrentBlockVersion:      0,
 	PowLimit:                 simNetPowLimit,
 	PowLimitBits:             0x207fffff,
 	ReduceMinDifficulty:      false,
@@ -972,6 +971,16 @@ var simNetParams = &chaincfg.Params{
 
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints: nil,
+
+	// Enforce current block version once majority of the network has
+	// upgraded.
+	// 51% (51 / 100)
+	// Reject previous block versions once a majority of the network has
+	// upgraded.
+	// 75% (75 / 100)
+	BlockEnforceNumRequired: 51,
+	BlockRejectNumRequired:  75,
+	BlockUpgradeNumToCheck:  100,
 
 	// Mempool parameters
 	RelayNonStdTxs: true,

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -698,13 +698,11 @@ func (b *BlockChain) checkBlockHeaderContext(header *wire.BlockHeader, prevNode 
 	}
 
 	if !fastAdd {
-		// Reject old version blocks once a majority of the network has
+		// Reject version 1 blocks once a majority of the network has
 		// upgraded.
-		mv := b.chainParams.CurrentBlockVersion
-		if header.Version < mv &&
-			b.isMajorityVersion(mv,
-				prevNode,
-				b.chainParams.CurrentBlockVersion) {
+		if header.Version < 2 && b.isMajorityVersion(2, prevNode,
+			b.chainParams.BlockRejectNumRequired) {
+
 			str := "new blocks with version %d are no longer valid"
 			str = fmt.Sprintf(str, header.Version)
 			return ruleError(ErrBlockVersionTooOld, str)

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -2047,7 +2047,6 @@ var simNetParams = &chaincfg.Params{
 	// Chain parameters
 	GenesisBlock:             &simNetGenesisBlock,
 	GenesisHash:              &simNetGenesisHash,
-	CurrentBlockVersion:      0,
 	PowLimit:                 simNetPowLimit,
 	PowLimitBits:             0x207fffff,
 	ReduceMinDifficulty:      false,
@@ -2071,6 +2070,16 @@ var simNetParams = &chaincfg.Params{
 
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints: nil,
+
+	// Enforce current block version once majority of the network has
+	// upgraded.
+	// 51% (51 / 100)
+	// Reject previous block versions once a majority of the network has
+	// upgraded.
+	// 75% (75 / 100)
+	BlockEnforceNumRequired: 51,
+	BlockRejectNumRequired:  75,
+	BlockUpgradeNumToCheck:  100,
 
 	// Mempool parameters
 	RelayNonStdTxs: true,

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -99,10 +99,6 @@ type Params struct {
 	// GenesisHash is the starting block hash.
 	GenesisHash *chainhash.Hash
 
-	// CurrentBlockVersion is the version of the block that the majority of
-	// the network is currently on.
-	CurrentBlockVersion int32
-
 	// PowLimit defines the highest allowed proof of work value for a block
 	// as a uint256.
 	PowLimit *big.Int
@@ -195,6 +191,15 @@ type Params struct {
 
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints []Checkpoint
+
+	// Enforce current block version once network has upgraded.
+	BlockEnforceNumRequired uint64
+
+	// Reject previous block versions once network has upgraded.
+	BlockRejectNumRequired uint64
+
+	// The number of nodes to check.
+	BlockUpgradeNumToCheck uint64
 
 	// Mempool parameters
 	RelayNonStdTxs bool
@@ -313,7 +318,6 @@ var MainNetParams = Params{
 	// Chain parameters
 	GenesisBlock:             &genesisBlock,
 	GenesisHash:              &genesisHash,
-	CurrentBlockVersion:      2,
 	PowLimit:                 mainPowLimit,
 	PowLimitBits:             0x1d00ffff,
 	ReduceMinDifficulty:      false,
@@ -346,6 +350,16 @@ var MainNetParams = Params{
 		{65270, newHashFromStr("0000000000000021f107601962789b201f0a0cbb98ac5f8c12b93d94e795b441")},
 		{75380, newHashFromStr("0000000000000e7d13cfc85806aa720fe3670980f5b7d33253e4f41985558372")},
 	},
+
+	// Enforce current block version once majority of the network has
+	// upgraded.
+	// 75% (750 / 1000)
+	// Reject previous block versions once a majority of the network has
+	// upgraded.
+	// 95% (950 / 1000)
+	BlockEnforceNumRequired: 750,
+	BlockRejectNumRequired:  950,
+	BlockUpgradeNumToCheck:  1000,
 
 	// Mempool parameters
 	RelayNonStdTxs: false,
@@ -408,7 +422,6 @@ var TestNetParams = Params{
 	// Chain parameters
 	GenesisBlock:             &testNetGenesisBlock,
 	GenesisHash:              &testNetGenesisHash,
-	CurrentBlockVersion:      2,
 	PowLimit:                 testNetPowLimit,
 	PowLimitBits:             0x1e00ffff,
 	ReduceMinDifficulty:      false,
@@ -443,6 +456,16 @@ var TestNetParams = Params{
 		{173750, newHashFromStr("0000000000fe0a2f55589d8b75502f8adc26be95971a16d12d7ea65da5a0a507")},
 		{197920, newHashFromStr("000000000174a97eed678549df66b4025a8ff4b5034e7b0fdc63d1112d4716ab")},
 	},
+
+	// Enforce current block version once majority of the network has
+	// upgraded.
+	// 51% (51 / 100)
+	// Reject previous block versions once a majority of the network has
+	// upgraded.
+	// 75% (75 / 100)
+	BlockEnforceNumRequired: 51,
+	BlockRejectNumRequired:  75,
+	BlockUpgradeNumToCheck:  100,
 
 	// Mempool parameters
 	RelayNonStdTxs: true,
@@ -505,7 +528,6 @@ var SimNetParams = Params{
 	// Chain parameters
 	GenesisBlock:             &simNetGenesisBlock,
 	GenesisHash:              &simNetGenesisHash,
-	CurrentBlockVersion:      2,
 	PowLimit:                 simNetPowLimit,
 	PowLimitBits:             0x207fffff,
 	ReduceMinDifficulty:      false,
@@ -530,6 +552,16 @@ var SimNetParams = Params{
 
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints: nil,
+
+	// Enforce current block version once majority of the network has
+	// upgraded.
+	// 51% (51 / 100)
+	// Reject previous block versions once a majority of the network has
+	// upgraded.
+	// 75% (75 / 100)
+	BlockEnforceNumRequired: 51,
+	BlockRejectNumRequired:  75,
+	BlockUpgradeNumToCheck:  100,
 
 	// Mempool parameters
 	RelayNonStdTxs: true,

--- a/mining.go
+++ b/mining.go
@@ -29,6 +29,14 @@ const (
 	// transaction to be considered high priority.
 	minHighPriority = dcrutil.AtomsPerCoin * 144.0 / 250
 
+	// generatedBlockVersion is the version of the block being generated.
+	// It is defined as a constant here rather than using the
+	// wire.BlockVersion constant since a change in the block version
+	// will require changes to the generated block.  Using the wire constant
+	// for generated block version could allow creation of invalid blocks
+	// for the updated version.
+	generatedBlockVersion = 2
+
 	// blockHeaderOverhead is the max number of bytes it takes to serialize
 	// a block header and max possible transaction count.
 	blockHeaderOverhead = wire.MaxBlockHeaderPayload + wire.MaxVarIntPayload
@@ -2101,7 +2109,7 @@ mempoolLoop:
 
 	var msgBlock wire.MsgBlock
 	msgBlock.Header = wire.BlockHeader{
-		Version:      server.chainParams.CurrentBlockVersion,
+		Version:      generatedBlockVersion,
 		PrevBlock:    *prevHash,
 		MerkleRoot:   *merkles[len(merkles)-1],
 		StakeRoot:    *merklesStake[len(merklesStake)-1],


### PR DESCRIPTION
This reverts to the correct upstream majority version code which properly detects when certain thresholds of the network have been updated in order to determine when to start rejecting old version blocks and enforcing the rules in the new version block.

Fixes #489.