### PR TITLE
mempool: Refactor mempool code to its own package.

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -21,6 +21,7 @@ import (
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/database"
+	"github.com/decred/dcrd/mempool"
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrutil"
 )
@@ -839,7 +840,7 @@ func (b *blockManager) handleTxMsg(tmsg *txMsg) {
 		// simply rejected as opposed to something actually going wrong,
 		// so log it as such.  Otherwise, something really did go wrong,
 		// so log it as an actual error.
-		if _, ok := err.(RuleError); ok {
+		if _, ok := err.(mempool.RuleError); ok {
 			bmgrLog.Debugf("Rejected transaction %v from %s: %v",
 				txHash, tmsg.peer, err)
 		} else {
@@ -849,7 +850,7 @@ func (b *blockManager) handleTxMsg(tmsg *txMsg) {
 
 		// Convert the error into an appropriate reject message and
 		// send it.
-		code, reason := errToRejectErr(err)
+		code, reason := mempool.ErrToRejectErr(err)
 		tmsg.peer.PushRejectMsg(wire.CmdTx, code, reason, txHash,
 			false)
 		return
@@ -1140,7 +1141,7 @@ func (b *blockManager) handleBlockMsg(bmsg *blockMsg) {
 
 		// Convert the error into an appropriate reject message and
 		// send it.
-		code, reason := errToRejectErr(err)
+		code, reason := mempool.ErrToRejectErr(err)
 		bmsg.peer.PushRejectMsg(wire.CmdBlock, code, reason,
 			blockHash, false)
 		return
@@ -1205,7 +1206,7 @@ func (b *blockManager) handleBlockMsg(bmsg *blockMsg) {
 				b.server.chainParams.StakeValidationHeight-1 {
 				bmgrLog.Errorf("Failed to get next winning tickets: %v", err)
 
-				code, reason := errToRejectErr(err)
+				code, reason := mempool.ErrToRejectErr(err)
 				bmsg.peer.PushRejectMsg(wire.CmdBlock, code, reason,
 					blockHash, false)
 				return

--- a/config.go
+++ b/config.go
@@ -25,6 +25,7 @@ import (
 	"github.com/btcsuite/go-socks/socks"
 	"github.com/decred/dcrd/database"
 	_ "github.com/decred/dcrd/database/ffldb"
+	"github.com/decred/dcrd/mempool"
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrutil"
 )
@@ -47,7 +48,6 @@ const (
 	defaultBlockMaxSize          = 375000
 	blockMaxSizeMin              = 1000
 	blockMaxSizeMax              = wire.MaxBlockPayload - 1000
-	defaultBlockPrioritySize     = 20000
 	defaultAddrIndex             = false
 	defaultGenerate              = false
 	defaultNonAggressive         = false
@@ -362,11 +362,11 @@ func loadConfig() (*config, []string, error) {
 		DbType:            defaultDbType,
 		RPCKey:            defaultRPCKeyFile,
 		RPCCert:           defaultRPCCertFile,
-		MinRelayTxFee:     defaultMinRelayTxFee.ToCoin(),
+		MinRelayTxFee:     mempool.DefaultMinRelayTxFee.ToCoin(),
 		FreeTxRelayLimit:  defaultFreeTxRelayLimit,
 		BlockMinSize:      defaultBlockMinSize,
 		BlockMaxSize:      defaultBlockMaxSize,
-		BlockPrioritySize: defaultBlockPrioritySize,
+		BlockPrioritySize: mempool.DefaultBlockPrioritySize,
 		MaxOrphanTxs:      defaultMaxOrphanTransactions,
 		SigCacheMaxSize:   defaultSigCacheMaxSize,
 		Generate:          defaultGenerate,

--- a/log.go
+++ b/log.go
@@ -17,6 +17,7 @@ import (
 	"github.com/decred/dcrd/blockchain/indexers"
 	"github.com/decred/dcrd/blockchain/stake"
 	"github.com/decred/dcrd/database"
+	"github.com/decred/dcrd/mempool"
 	"github.com/decred/dcrd/peer"
 	"github.com/decred/dcrd/txscript"
 )
@@ -145,6 +146,7 @@ func useLogger(subsystemID string, logger btclog.Logger) {
 
 	case "TXMP":
 		txmpLog = logger
+		mempool.UseLogger(logger)
 	}
 }
 

--- a/mempool/README.md
+++ b/mempool/README.md
@@ -1,0 +1,23 @@
+mempool
+=======
+
+[![Build Status](http://img.shields.io/travis/decred/dcrd.svg)]
+(https://travis-ci.org/decred/dcrd) [![ISC License]
+(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
+(http://godoc.org/github.com/decred/dcrd/mempool)
+
+## Overview
+
+This package is currently a work in progress.
+
+## Installation and Updating
+
+```bash
+$ go get -u github.com/decred/dcrd/mempool
+```
+
+## License
+
+Package mempool is licensed under the [copyfree](http://copyfree.org) ISC
+License.

--- a/mempool/error.go
+++ b/mempool/error.go
@@ -1,9 +1,9 @@
-// Copyright (c) 2014 The btcsuite developers
+// Copyright (c) 2014-2016 The btcsuite developers
 // Copyright (c) 2015-2016 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package main
+package mempool
 
 import (
 	"github.com/decred/dcrd/blockchain"
@@ -110,9 +110,9 @@ func extractRejectCode(err error) (wire.RejectCode, bool) {
 	return wire.RejectInvalid, false
 }
 
-// errToRejectErr examines the underlying type of the error and returns a reject
+// ErrToRejectErr examines the underlying type of the error and returns a reject
 // code and string appropriate to be sent in a wire.MsgReject message.
-func errToRejectErr(err error) (wire.RejectCode, string) {
+func ErrToRejectErr(err error) (wire.RejectCode, string) {
 	// Return the reject code along with the error text if it can be
 	// extracted from the error.
 	rejectCode, found := extractRejectCode(err)

--- a/mempool/log.go
+++ b/mempool/log.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2013-2016 The btcsuite developers
+// Copyright (c) 2016 The decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package mempool
+
+import (
+	"github.com/btcsuite/btclog"
+)
+
+// log is a logger that is initialized with no output filters.  This
+// means the package will not perform any logging by default until the caller
+// requests it.
+var log btclog.Logger
+
+// The default amount of logging is none.
+func init() {
+	DisableLog()
+}
+
+// DisableLog disables all library log output.  Logging output is disabled
+// by default until either UseLogger or SetLogWriter are called.
+func DisableLog() {
+	log = btclog.Disabled
+}
+
+// UseLogger uses a specified Logger to output package logging info.
+// This should be used in preference to SetLogWriter if the caller is also
+// using btclog.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/mempool/policy.go
+++ b/mempool/policy.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package main
+package mempool
 
 import (
 	"fmt"
@@ -39,12 +39,12 @@ const (
 	// (1 + 15*74 + 3) + (15*34 + 3) + 23 = 1650
 	maxStandardSigScriptSize = 1650
 
-	// defaultMinRelayTxFee is the minimum fee in satoshi that is required
-	// for a transaction to be treated as free for relay and mining
-	// purposes.  It is also used to help determine if a transaction is
-	// considered dust and as a base for calculating minimum required fees
-	// for larger transactions.  This value is in Satoshi/1000 bytes.
-	defaultMinRelayTxFee = dcrutil.Amount(1e6)
+	// DefaultMinRelayTxFee is the minimum fee in atoms that is required for
+	// a transaction to be treated as free for relay and mining purposes.
+	// It is also used to help determine if a transaction is considered dust
+	// and as a base for calculating minimum required fees for larger
+	// transactions.  This value is in Atoms/1000 bytes.
+	DefaultMinRelayTxFee = dcrutil.Amount(1e6)
 
 	// maxStandardMultiSigKeys is the maximum number of public keys allowed
 	// in a multi-signature transaction output script for it to be
@@ -76,11 +76,11 @@ func calcMinRequiredTxRelayFee(serializedSize int64, minRelayTxFee dcrutil.Amoun
 	return minFee
 }
 
-// calcPriority returns a transaction priority given a transaction and the sum
+// CalcPriority returns a transaction priority given a transaction and the sum
 // of each of its input values multiplied by their age (# of confirmations).
 // Thus, the final formula for the priority is:
 // sum(inputValue * inputAge) / adjustedTxSize
-func calcPriority(tx *wire.MsgTx, utxoView *blockchain.UtxoViewpoint, nextBlockHeight int64) float64 {
+func CalcPriority(tx *wire.MsgTx, utxoView *blockchain.UtxoViewpoint, nextBlockHeight int64) float64 {
 	// In order to encourage spending multiple old unspent transaction
 	// outputs thereby reducing the total set, don't count the constant
 	// overhead for each input as well as enough bytes of the signature

--- a/mempool/policy_test.go
+++ b/mempool/policy_test.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package main
+package mempool
 
 import (
 	"bytes"
@@ -39,17 +39,17 @@ func TestCalcMinRequiredTxRelayFee(t *testing.T) {
 		{
 			"1000 bytes with default minimum relay fee",
 			1000,
-			defaultMinRelayTxFee,
+			DefaultMinRelayTxFee,
 			1000000,
 		},
 		{
 			"max standard tx size with default minimum relay fee",
 			maxStandardTxSize,
-			defaultMinRelayTxFee,
+			DefaultMinRelayTxFee,
 			100000000,
 		},
 		{
-			"max standard tx size with max satoshi relay fee",
+			"max standard tx size with max relay fee",
 			maxStandardTxSize,
 			dcrutil.MaxAmount,
 			dcrutil.MaxAmount,
@@ -242,7 +242,7 @@ func TestDust(t *testing.T) {
 		},
 		{
 			// Maximum allowed value is never dust.
-			"max satoshi amount is never dust",
+			"max amount is never dust",
 			wire.TxOut{Value: dcrutil.MaxAmount, Version: 0, PkScript: pkScript},
 			dcrutil.MaxAmount,
 			false,
@@ -480,7 +480,7 @@ func TestCheckTransactionStandard(t *testing.T) {
 		// Ensure standardness is as expected.
 		tx := dcrutil.NewTx(&test.tx)
 		err := checkTransactionStandard(tx, stake.DetermineTxType(&test.tx),
-			test.height, timeSource, defaultMinRelayTxFee)
+			test.height, timeSource, DefaultMinRelayTxFee)
 		if err == nil && test.isStandard {
 			// Test passes since function returned standard for a
 			// transaction which is intended to be standard.


### PR DESCRIPTION
Upstream commit 7fac099bee3a9f48512a8cb389b7d53e0c392c1b.

Also, the merge commit contains the necessary decred-specific alterations, adds a new policy parameter for `AllowOldVotes` to keep with the spirit of the merged commit, modifies the `RawMempoolVerbose` to accept an optional filter type to retain that functionality, and various other cleanup intended to bring the code bases more in line with one another.

