### PR TITLE
Change maxShift from var to const

### DIFF
--- a/blockchain/difficulty.go
+++ b/blockchain/difficulty.go
@@ -26,11 +26,11 @@ var (
 	// oneLsh256 is 1 shifted left 256 bits.  It is defined here to avoid
 	// the overhead of creating it multiple times.
 	oneLsh256 = new(big.Int).Lsh(bigOne, 256)
-
-	// maxShift is the maximum shift for a difficulty that resets (e.g.
-	// testnet difficulty).
-	maxShift = uint(256)
 )
+
+// maxShift is the maximum shift for a difficulty that resets (e.g.
+// testnet difficulty).
+const maxShift = uint(256)
 
 // HashToBig converts a chainhash.Hash into a big.Int that can be used to
 // perform math comparisons.


### PR DESCRIPTION
This variable should never be changed and the code will run faster and avoid errors as a const.
It makes it read a little ugly because it's not in with the rest of them, but I don't think it's a problem.