### PR TITLE
Implement stake voter version interrogation command.

### DIFF
--- a/blockchain/difficulty.go
+++ b/blockchain/difficulty.go
@@ -439,7 +439,7 @@ func (b *BlockChain) calcNextRequiredDifficulty(curNode *blockNode,
 func (b *BlockChain) CalcNextRequiredDiffFromNode(hash *chainhash.Hash,
 	timestamp time.Time) (uint32, error) {
 	// Fetch the block to get the difficulty for.
-	node, err := b.findNode(hash)
+	node, err := b.findNode(hash, maxSearchDepth)
 	if err != nil {
 		return 0, err
 	}

--- a/blockchain/stakeext.go
+++ b/blockchain/stakeext.go
@@ -56,7 +56,7 @@ func (b *BlockChain) lotteryDataForBlock(hash *chainhash.Hash) ([]chainhash.Hash
 	if n, exists := b.index[*hash]; exists {
 		node = n
 	} else {
-		node, _ = b.findNode(hash)
+		node, _ = b.findNode(hash, maxSearchDepth)
 	}
 
 	if node == nil {

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -2401,7 +2401,7 @@ func (b *BlockChain) CheckConnectBlock(block *dcrutil.Block) error {
 	defer b.chainLock.Unlock()
 
 	parentHash := block.MsgBlock().Header.PrevBlock
-	prevNode, err := b.findNode(&parentHash)
+	prevNode, err := b.findNode(&parentHash, maxSearchDepth)
 	if err != nil {
 		return ruleError(ErrMissingParent, err.Error())
 	}

--- a/dcrjson/dcrdextcmds.go
+++ b/dcrjson/dcrdextcmds.go
@@ -116,6 +116,22 @@ func NewGetStakeDifficultyCmd() *GetStakeDifficultyCmd {
 	return &GetStakeDifficultyCmd{}
 }
 
+// GetStakeVersionsCmd returns stake version for a range of blocks.
+// Count indicates how many blocks are walked backwards.
+type GetStakeVersionsCmd struct {
+	Hash  string
+	Count int32
+}
+
+// NewGetStakeVersionsCmd returns a new instance which can be used to
+// issue a JSON-RPC getstakeversions command.
+func NewGetStakeVersionsCmd(hash string, count int32) *GetStakeVersionsCmd {
+	return &GetStakeVersionsCmd{
+		Hash:  hash,
+		Count: count,
+	}
+}
+
 // GetTicketPoolValueCmd defines the getticketpoolvalue JSON-RPC command.
 type GetTicketPoolValueCmd struct{}
 
@@ -243,6 +259,7 @@ func init() {
 	MustRegisterCmd("existsmempooltxs", (*ExistsMempoolTxsCmd)(nil), flags)
 	MustRegisterCmd("getcoinsupply", (*GetCoinSupplyCmd)(nil), flags)
 	MustRegisterCmd("getstakedifficulty", (*GetStakeDifficultyCmd)(nil), flags)
+	MustRegisterCmd("getstakeversions", (*GetStakeVersionsCmd)(nil), flags)
 	MustRegisterCmd("getticketpoolvalue", (*GetTicketPoolValueCmd)(nil), flags)
 	MustRegisterCmd("livetickets", (*LiveTicketsCmd)(nil), flags)
 	MustRegisterCmd("missedtickets", (*MissedTicketsCmd)(nil), flags)

--- a/dcrjson/dcrdextcmds_test.go
+++ b/dcrjson/dcrdextcmds_test.go
@@ -42,6 +42,20 @@ func TestDcrdExtCmds(t *testing.T) {
 				LevelSpec: "trace",
 			},
 		},
+		{
+			name: "getstakeversions",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("getstakeversions", "deadbeef", 1)
+			},
+			staticCmd: func() interface{} {
+				return dcrjson.NewGetStakeVersionsCmd("deadbeef", 1)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getstakeversions","params":["deadbeef",1],"id":1}`,
+			unmarshalled: &dcrjson.GetStakeVersionsCmd{
+				Hash:  "deadbeef",
+				Count: 1,
+			},
+		},
 	}
 
 	t.Logf("Running %d tests", len(tests))

--- a/dcrjson/dcrdextresults.go
+++ b/dcrjson/dcrdextresults.go
@@ -12,6 +12,20 @@ type GetStakeDifficultyResult struct {
 	NextStakeDifficulty    float64 `json:"next"`
 }
 
+// StakeVersions models the data for GetStakeVersionsResult.
+type StakeVersions struct {
+	Hash          string   `json:"hash"`
+	Height        int64    `json:"height"`
+	StakeVersion  uint32   `json:"stakeversion"`
+	VoterVersions []uint32 `json:"voterversions"`
+}
+
+// GetStakeVersionsResult models the data returned from the getstakeversions
+// command.
+type GetStakeVersionsResult struct {
+	StakeVersions []StakeVersions `json:"stakeversions"`
+}
+
 // EstimateStakeDiffResult models the data returned from the estimatestakediff
 // command.
 type EstimateStakeDiffResult struct {

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -408,6 +408,16 @@ var helpDescsEnUS = map[string]string{
 	"getstakedifficultyresult-current": "The current top block's stake difficulty",
 	"getstakedifficultyresult-next":    "The calculated stake difficulty of the next block",
 
+	// GetStakeDifficultyCmd help.
+	"getstakeversions--synopsis":           "Returns the stake versions statistics.",
+	"getstakeversions-hash":                "The start block hash.",
+	"getstakeversions-count":               "The number of blocks that will be returned.",
+	"getstakeversionsresult-stakeversions": "Array of stake versions per block.",
+	"stakeversions-hash":                   "Hash of the block.",
+	"stakeversions-height":                 "Height of the block.",
+	"stakeversions-stakeversion":           "The stake version of the block",
+	"stakeversions-voterversions":          "The version of each vote in the block",
+
 	// GetGenerateCmd help.
 	"getgenerate--synopsis": "Returns if the server is set to generate coins (mine) or not.",
 	"getgenerate--result0":  "True if mining, false if not",
@@ -843,6 +853,7 @@ var rpcResultTypes = map[string][]interface{}{
 	"getcurrentnet":         {(*uint32)(nil)},
 	"getdifficulty":         {(*float64)(nil)},
 	"getstakedifficulty":    {(*dcrjson.GetStakeDifficultyResult)(nil)},
+	"getstakeversions":      {(*dcrjson.GetStakeVersionsResult)(nil)},
 	"getgenerate":           {(*bool)(nil)},
 	"gethashespersec":       {(*float64)(nil)},
 	"getheaders":            {(*dcrjson.GetHeadersResult)(nil)},


### PR DESCRIPTION
Implement dcrctl getstakeversions command.  This PR also expands the findNode command to search arbitrary depths but maintains backwards compat by implementing the prior 2800 depth max constant.

Example: dcrctl getstakeversions $(dcrctl getbestblockhash) 10
returns the last 10 stake/voter versions stats. 

Fixes #521 