### PR TITLE
Implement softfork mechanism.

### DIFF
--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -44,6 +44,11 @@ const (
 	// to a newer version.
 	ErrBlockVersionTooOld
 
+	// ErrBadStakeVersionindicates the block version is too old and is no
+	// longer accepted since the majority of the network has upgraded to a
+	// newer version.
+	ErrBadStakeVersion
+
 	// ErrInvalidTime indicates the time in the passed block has a precision
 	// that is more than one second.  The chain consensus rules require
 	// timestamps to have a maximum precision of one second.
@@ -426,6 +431,7 @@ var errorCodeStrings = map[ErrorCode]string{
 	ErrBlockTooBig:            "ErrBlockTooBig",
 	ErrWrongBlockSize:         "ErrWrongBlockSize",
 	ErrBlockVersionTooOld:     "ErrBlockVersionTooOld",
+	ErrBadStakeVersion:        "ErrBlockStakeVersion",
 	ErrInvalidTime:            "ErrInvalidTime",
 	ErrTimeTooOld:             "ErrTimeTooOld",
 	ErrTimeTooNew:             "ErrTimeTooNew",

--- a/blockchain/stakeversion.go
+++ b/blockchain/stakeversion.go
@@ -1,0 +1,372 @@
+// Copyright (c) 2016 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package blockchain
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/decred/dcrd/chaincfg/chainhash"
+)
+
+var (
+	errVoterVersionMajorityNotFound = errors.New("voter version majority " +
+		"not found")
+	errStakeVersionMajorityNotFound = errors.New("stake version majority " +
+		"not found")
+)
+
+// calcWantHeight calculates the height of the final block of the previous
+// interval given a stake validation height, stake validation interval, and
+// block height.
+func calcWantHeight(stakeValidationHeight, interval, height int64) int64 {
+	intervalOffset := stakeValidationHeight % interval
+
+	// The adjusted height accounts for the fact the starting validation
+	// height does not necessarily start on an interval and thus the
+	// intervals might not be zero-based.
+	adjustedHeight := height - intervalOffset - 1
+
+	return (adjustedHeight - ((adjustedHeight + 1) % interval)) +
+		intervalOffset
+}
+
+// findStakeVersionPriorNode walks the chain backwards from prevNode until it
+// reaches the final block of the previous stake version interval and returns
+// that node.  The returned node will be nil when the provided prevNode is too
+// low such that there is no previous stake version interval due to falling
+// prior to the stake validation interval.
+//
+// This function MUST be called with the chain state lock held (for writes).
+func (b *BlockChain) findStakeVersionPriorNode(prevNode *blockNode) (*blockNode, error) {
+	// Check to see if the blockchain is high enough to begin accounting
+	// stake versions.
+	nextHeight := prevNode.height + 1
+	if nextHeight < b.chainParams.StakeValidationHeight+
+		b.chainParams.StakeVersionInterval {
+		return nil, nil
+	}
+
+	wantHeight := calcWantHeight(b.chainParams.StakeValidationHeight,
+		b.chainParams.StakeVersionInterval, nextHeight)
+
+	// Walk backwards until we find an interval block and make sure we
+	// don't blow through the minimum height.
+	iterNode := prevNode
+	for iterNode.height > wantHeight {
+		var err error
+		iterNode, err = b.getPrevNodeFromNode(iterNode)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return iterNode, nil
+}
+
+// isVoterMajorityVersion determines if minVer requirement is met based on
+// prevNode.  The function always uses the voter versions of the prior window.
+// For example, if StakeVersionInterval = 11 and StakeValidationHeight = 13 the
+// windows start at 13 + 11 -1 = 24 and are as follows: 24-34, 35-45, 46-56 ...
+// If height comes in at 35 we use the 24-34 window, up to height 45.
+// If height comes in at 46 we use the 35-45 window, up to height 56 etc.
+//
+// This function MUST be called with the chain state lock held (for writes).
+func (b *BlockChain) isVoterMajorityVersion(minVer uint32, prevNode *blockNode) bool {
+	// Walk blockchain backwards to calculate version.
+	node, err := b.findStakeVersionPriorNode(prevNode)
+	if err != nil {
+		return false
+	}
+	if node == nil {
+		return 0 >= minVer
+	}
+
+	// Tally both the total number of votes in the previous stake version validation
+	// interval and how many of those votes are at least the requested minimum
+	// version.
+	totalVotesFound := int32(0)
+	versionCount := int32(0)
+	iterNode := node
+	for i := int64(0); i < b.chainParams.StakeVersionInterval && iterNode != nil; i++ {
+		totalVotesFound += int32(len(iterNode.voterVersions))
+		for _, version := range iterNode.voterVersions {
+			if version >= minVer {
+				versionCount += 1
+			}
+		}
+
+		var err error
+		iterNode, err = b.getPrevNodeFromNode(iterNode)
+		if err != nil {
+			return false
+		}
+	}
+
+	// Determine the required amount of votes to reach supermajority.
+	numRequired := totalVotesFound * b.chainParams.StakeMajorityMultiplier /
+		b.chainParams.StakeMajorityDivisor
+
+	return versionCount >= numRequired
+}
+
+// isStakeMajorityVersion determines if minVer requirement is met based on
+// prevNode.  The function always uses the stake versions of the prior window.
+// For example, if StakeVersionInterval = 11 and StakeValidationHeight = 13 the
+// windows start at 13 + (11 * 2) 25 and are as follows: 24-34, 35-45, 46-56 ...
+// If height comes in at 35 we use the 24-34 window, up to height 45.
+// If height comes in at 46 we use the 35-45 window, up to height 56 etc.
+//
+// This function MUST be called with the chain state lock held (for writes).
+func (b *BlockChain) isStakeMajorityVersion(minVer uint32, prevNode *blockNode) bool {
+	// Walk blockchain backwards to calculate version.
+	node, err := b.findStakeVersionPriorNode(prevNode)
+	if err != nil {
+		return false
+	}
+	if node == nil {
+		return 0 >= minVer
+	}
+
+	// Tally how many of the block headers in the previous stake version validation
+	// interval have their stake version set to at least the requested minimum
+	// version.
+	versionCount := int32(0)
+	iterNode := node
+	for i := int64(0); i < b.chainParams.StakeVersionInterval && iterNode != nil; i++ {
+		if iterNode.header.StakeVersion >= minVer {
+			versionCount += 1
+		}
+
+		var err error
+		iterNode, err = b.getPrevNodeFromNode(iterNode)
+		if err != nil {
+			return false
+		}
+	}
+
+	// Determine the required amount of votes to reach supermajority.
+	numRequired := int32(b.chainParams.StakeVersionInterval) *
+		b.chainParams.StakeMajorityMultiplier /
+		b.chainParams.StakeMajorityDivisor
+
+	return versionCount >= numRequired
+}
+
+// calcPriorStakeVersion calculates the header stake version of the prior
+// interval.  The function walks the chain backwards by one interval and then
+// it performs a standard majority calculation.
+//
+// This function MUST be called with the chain state lock held (for writes).
+func (b *BlockChain) calcPriorStakeVersion(prevNode *blockNode) (uint32, error) {
+	// Walk blockchain backwards to calculate version.
+	node, err := b.findStakeVersionPriorNode(prevNode)
+	if err != nil {
+		return 0, err
+	}
+	if node == nil {
+		return 0, nil
+	}
+
+	// Tally how many of each stake version the block headers in the previous stake
+	// version validation interval have.
+	versions := make(map[uint32]int32) // [version][count]
+	iterNode := node
+	for i := int64(0); i < b.chainParams.StakeVersionInterval && iterNode != nil; i++ {
+		versions[iterNode.header.StakeVersion]++
+
+		var err error
+		iterNode, err = b.getPrevNodeFromNode(iterNode)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	// Determine the required amount of votes to reach supermajority.
+	numRequired := int32(b.chainParams.StakeVersionInterval) *
+		b.chainParams.StakeMajorityMultiplier /
+		b.chainParams.StakeMajorityDivisor
+
+	for version, count := range versions {
+		if count >= numRequired {
+			return version, nil
+		}
+	}
+
+	return 0, errStakeVersionMajorityNotFound
+}
+
+// calcVoterVersionInterval tallies all voter versions in an interval and
+// returns a version that has reached 75% majority.  This function assumes that
+// prevNode is at a valid StakeVersionInterval.  It does not test for this and
+// if prevNode is not sitting on a valid StakeVersionInterval it'll walk the
+// chain backwards and find the next valid interval.
+// This function is really meant to be called internally only from this file.
+//
+// This function MUST be called with the chain state lock held (for writes).
+func (b *BlockChain) calcVoterVersionInterval(prevNode *blockNode) (uint32, error) {
+	// Note that we are NOT checking if we are on interval!
+	var err error
+
+	// Tally both the total number of votes in the previous stake version validation
+	// interval and how many of each version those votes have.
+	versions := make(map[uint32]int32) // [version][count]
+	totalVotesFound := int32(0)
+	iterNode := prevNode
+	for i := int64(0); i < b.chainParams.StakeVersionInterval && iterNode != nil; i++ {
+		totalVotesFound += int32(len(iterNode.voterVersions))
+		for _, version := range iterNode.voterVersions {
+			versions[version]++
+		}
+
+		iterNode, err = b.getPrevNodeFromNode(iterNode)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	// Assert wthat we have enough votes in case this function is called at
+	// an invalid interval.
+	if int64(totalVotesFound) < b.chainParams.StakeVersionInterval*
+		(int64(b.chainParams.TicketsPerBlock/2)+1) {
+		return 0, AssertError(fmt.Sprintf("Not enough "+
+			"votes: %v expected: %v ", totalVotesFound,
+			b.chainParams.StakeVersionInterval*
+				(int64(b.chainParams.TicketsPerBlock/2)+1)))
+	}
+
+	// Determine the required amount of votes to reach supermajority.
+	numRequired := totalVotesFound * b.chainParams.StakeMajorityMultiplier /
+		b.chainParams.StakeMajorityDivisor
+
+	for version, count := range versions {
+		if count >= numRequired {
+			return version, nil
+		}
+	}
+
+	return 0, errVoterVersionMajorityNotFound
+}
+
+// calcVoterVersion calculates the last prior valid majority stake version.  If
+// the current interval does not have a majority stake version it'll go back to
+// the prior interval.  It'll keep going back up to the minimum height at which
+// point we know the version was 0.
+//
+// This function MUST be called with the chain state lock held (for writes).
+func (b *BlockChain) calcVoterVersion(prevNode *blockNode) (uint32, *blockNode) {
+	// Walk blockchain backwards to find interval.
+	node, err := b.findStakeVersionPriorNode(prevNode)
+	if err != nil {
+		return 0, nil
+	}
+
+	// Iterate over versions until we find a majority.
+	iterNode := node
+	for iterNode != nil {
+		version, err := b.calcVoterVersionInterval(iterNode)
+		if err == nil {
+			return version, iterNode
+		}
+		if err != errVoterVersionMajorityNotFound {
+			break
+		}
+
+		// findStakeVersionPriorNode increases the height so we need to
+		// compensate by loading the prior node.
+		iterNode, err = b.getPrevNodeFromNode(iterNode)
+		if err != nil {
+			break
+		}
+
+		// Walk blockchain back to prior interval.
+		iterNode, err = b.findStakeVersionPriorNode(iterNode)
+		if err != nil {
+			break
+		}
+	}
+
+	// We didn't find a marority version.
+	return 0, nil
+}
+
+// calcStakeVersion calculates the header stake version based on voter
+// versions.  If there is a majority of voter versions it uses the header stake
+// version to prevent reverting to a prior version.
+//
+// This function MUST be called with the chain state lock held (for writes).
+func (b *BlockChain) calcStakeVersion(prevNode *blockNode) uint32 {
+	version, node := b.calcVoterVersion(prevNode)
+	if version == 0 || node == nil {
+		// short circuit
+		return 0
+	}
+
+	// Walk chain backwards to start of node interval (start of current
+	// period) Note that calcWantHeight returns the LAST height of the
+	// prior interval; hence the + 1.
+	startIntervalHeight := calcWantHeight(b.chainParams.StakeValidationHeight,
+		b.chainParams.StakeVersionInterval, node.height) + 1
+	iterNode := node
+	for iterNode.height > startIntervalHeight {
+		var err error
+		iterNode, err = b.getPrevNodeFromNode(iterNode)
+		if err != nil || iterNode == nil {
+			return 0
+		}
+	}
+
+	// See if we are enforcing V3 blocks yet.  Just return V0 since it it
+	// wasn't enforced and therefore irrelevant.
+	if !b.isMajorityVersion(3, iterNode,
+		b.chainParams.BlockRejectNumRequired) {
+		return 0
+	}
+
+	if b.isStakeMajorityVersion(version, node) {
+		priorVersion, _ := b.calcPriorStakeVersion(node)
+		if version > priorVersion {
+			return version
+		} else {
+			return priorVersion
+		}
+	}
+
+	return version
+}
+
+// calcStakeVersionByHash calculates the last prior valid majority stake
+// version.  If the current interval does not have a majority stake version
+// it'll go back to the prior interval.  It'll keep going back up to the
+// minimum height at which point we know the version was 0.
+//
+// This function MUST be called with the chain state lock held (for writes).
+func (b *BlockChain) calcStakeVersionByHash(hash *chainhash.Hash) (uint32, error) {
+	prevNode, err := b.findNode(hash, 0)
+	if err != nil {
+		return 0, err
+	}
+
+	return b.calcStakeVersionByNode(prevNode)
+}
+
+// calcStakeVersionByNode is identical to calcStakeVersionByHash but takes a
+// *blockNode instead.
+//
+// This function MUST be called with the chain state lock held (for writes).
+func (b *BlockChain) calcStakeVersionByNode(prevNode *blockNode) (uint32, error) {
+	return b.calcStakeVersion(prevNode), nil
+}
+
+// CalcStakeVersionByHash calculates the expected stake version for the
+// provided block hash.
+//
+// This function is safe for concurrent access.
+func (b *BlockChain) CalcStakeVersionByHash(hash *chainhash.Hash) (uint32, error) {
+	b.chainLock.Lock()
+	defer b.chainLock.Unlock()
+
+	return b.calcStakeVersionByHash(hash)
+}

--- a/blockchain/stakeversion_test.go
+++ b/blockchain/stakeversion_test.go
@@ -1,0 +1,825 @@
+// Copyright (c) 2016 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package blockchain
+
+import (
+	"testing"
+
+	"github.com/decred/dcrd/chaincfg"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/wire"
+	"github.com/decred/dcrutil"
+)
+
+// genesisBlockNode creates a fake chain of blockNodes.  It is used for testing
+// the mechanical properties of the version code.
+func genesisBlockNode(params *chaincfg.Params) *blockNode {
+	// Create a new node from the genesis block.
+	genesisBlock := dcrutil.NewBlock(params.GenesisBlock)
+	header := &genesisBlock.MsgBlock().Header
+	node := newBlockNode(header, genesisBlock.Hash(), 0, []chainhash.Hash{},
+		[]chainhash.Hash{}, []uint32{})
+	node.inMainChain = true
+
+	return node
+}
+
+func TestCalcWantHeight(t *testing.T) {
+	// For example, if StakeVersionInterval = 11 and StakeValidationHeight = 13 the
+	// windows start at 13 + (11 * 2) 25 and are as follows: 24-34, 35-45, 46-56 ...
+	// If height comes in at 35 we use the 24-34 window, up to height 45.
+	// If height comes in at 46 we use the 35-45 window, up to height 56 etc.
+	tests := []struct {
+		name       string
+		skip       int64
+		interval   int64
+		multiplier int64
+		negative   int64
+	}{
+		{
+			name:       "13 11 10000",
+			skip:       13,
+			interval:   11,
+			multiplier: 10000,
+		},
+		{
+			name:       "27 33 10000",
+			skip:       27,
+			interval:   33,
+			multiplier: 10000,
+		},
+		{
+			name:       "mainnet params",
+			skip:       chaincfg.MainNetParams.StakeValidationHeight,
+			interval:   chaincfg.MainNetParams.StakeVersionInterval,
+			multiplier: 5000,
+		},
+		{
+			name:       "testnet params",
+			skip:       chaincfg.TestNetParams.StakeValidationHeight,
+			interval:   chaincfg.TestNetParams.StakeVersionInterval,
+			multiplier: 1000,
+		},
+		{
+			name:       "simnet params",
+			skip:       chaincfg.SimNetParams.StakeValidationHeight,
+			interval:   chaincfg.SimNetParams.StakeVersionInterval,
+			multiplier: 10000,
+		},
+		{
+			name:       "negative mainnet params",
+			skip:       chaincfg.MainNetParams.StakeValidationHeight,
+			interval:   chaincfg.MainNetParams.StakeVersionInterval,
+			multiplier: 1000,
+			negative:   1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Logf("running: %v skip: %v interval: %v",
+			test.name, test.skip, test.interval)
+
+		start := int64(test.skip + test.interval*2)
+		expectedHeight := start - 1 // zero based
+		x := int64(0) + test.negative
+		for i := start; i < test.multiplier*test.interval; i++ {
+			if x%test.interval == 0 && i != start {
+				expectedHeight += test.interval
+			}
+			wantHeight := calcWantHeight(test.skip, test.interval, i)
+
+			if wantHeight != expectedHeight {
+				if test.negative == 0 {
+					t.Fatalf("%v: i %v x %v -> wantHeight %v expectedHeight %v\n",
+						test.name, i, x, wantHeight, expectedHeight)
+				}
+			}
+
+			x++
+		}
+	}
+}
+
+func newFakeNode(blockVersion int32, height int64, currentNode *blockNode) *blockNode {
+	// Make up a header.
+	header := &wire.BlockHeader{
+		Version: blockVersion,
+		Height:  uint32(height),
+		Nonce:   0,
+	}
+	node := newBlockNode(header, &chainhash.Hash{}, 0,
+		[]chainhash.Hash{}, []chainhash.Hash{},
+		[]uint32{})
+	node.height = height
+	node.parent = currentNode
+
+	return node
+}
+
+func TestCalcStakeVersionCorners(t *testing.T) {
+	params := &chaincfg.SimNetParams
+	currentNode := genesisBlockNode(params)
+
+	bc := &BlockChain{
+		chainParams: params,
+	}
+
+	svh := params.StakeValidationHeight
+	interval := params.StakeVersionInterval
+
+	height := int64(0)
+	for i := int64(1); i <= svh; i++ {
+		node := newFakeNode(0, i, currentNode)
+
+		// Don't set stake versions.
+
+		currentNode = node
+		bc.bestNode = currentNode
+		height = i
+	}
+	if height != svh {
+		t.Fatalf("invalid height got %v expected %v", height,
+			params.StakeValidationHeight)
+	}
+
+	// Generate 3 intervals with v2 votes and calculate StakeVersion.
+	runCount := interval * 3
+	for i := int64(0); i < runCount; i++ {
+		node := newFakeNode(3, height+i, currentNode)
+
+		// Set stake versions.
+		for x := uint16(0); x < params.TicketsPerBlock; x++ {
+			node.voterVersions = append(node.voterVersions, 2)
+		}
+
+		sv, err := bc.calcStakeVersionByNode(currentNode)
+		if err != nil {
+			t.Fatalf("calcStakeVersionByNode: unexpected error: %v", err)
+		}
+		node.header.StakeVersion = sv
+
+		currentNode = node
+		bc.bestNode = currentNode
+
+	}
+	height += runCount
+
+	if !bc.isStakeMajorityVersion(0, currentNode) {
+		t.Fatalf("invalid StakeVersion expected 0 -> true")
+	}
+	if !bc.isStakeMajorityVersion(2, currentNode) {
+		t.Fatalf("invalid StakeVersion expected 2 -> true")
+	}
+	if bc.isStakeMajorityVersion(4, currentNode) {
+		t.Fatalf("invalid StakeVersion expected 4 -> false")
+	}
+
+	// Generate 3 intervals with v4 votes and calculate StakeVersion.
+	runCount = interval * 3
+	for i := int64(0); i < runCount; i++ {
+		node := newFakeNode(3, height+i, currentNode)
+
+		// Set stake versions.
+		for x := uint16(0); x < params.TicketsPerBlock; x++ {
+			node.voterVersions = append(node.voterVersions, 4)
+		}
+
+		sv, err := bc.calcStakeVersionByNode(currentNode)
+		if err != nil {
+			t.Fatalf("calcStakeVersionByNode: unexpected error: %v", err)
+		}
+		node.header.StakeVersion = sv
+
+		currentNode = node
+		bc.bestNode = currentNode
+	}
+	height += runCount
+
+	if !bc.isStakeMajorityVersion(0, currentNode) {
+		t.Fatalf("invalid StakeVersion expected 0 -> true")
+	}
+	if !bc.isStakeMajorityVersion(2, currentNode) {
+		t.Fatalf("invalid StakeVersion expected 2 -> true")
+	}
+	if !bc.isStakeMajorityVersion(4, currentNode) {
+		t.Fatalf("invalid StakeVersion expected 4 -> true")
+	}
+	if bc.isStakeMajorityVersion(5, currentNode) {
+		t.Fatalf("invalid StakeVersion expected 5 -> false")
+	}
+
+	// Generate 3 intervals with v2 votes and calculate StakeVersion.
+	runCount = interval * 3
+	for i := int64(0); i < runCount; i++ {
+		node := newFakeNode(3, height+i, currentNode)
+
+		// Set stake versions.
+		for x := uint16(0); x < params.TicketsPerBlock; x++ {
+			node.voterVersions = append(node.voterVersions, 2)
+		}
+
+		sv, err := bc.calcStakeVersionByNode(currentNode)
+		if err != nil {
+			t.Fatalf("calcStakeVersionByNode: unexpected error: %v", err)
+		}
+		node.header.StakeVersion = sv
+
+		currentNode = node
+		bc.bestNode = currentNode
+
+	}
+	height += runCount
+
+	if !bc.isStakeMajorityVersion(0, currentNode) {
+		t.Fatalf("invalid StakeVersion expected 0 -> true")
+	}
+	if !bc.isStakeMajorityVersion(2, currentNode) {
+		t.Fatalf("invalid StakeVersion expected 2 -> true")
+	}
+	if !bc.isStakeMajorityVersion(4, currentNode) {
+		t.Fatalf("invalid StakeVersion expected 4 -> true")
+	}
+	if bc.isStakeMajorityVersion(5, currentNode) {
+		t.Fatalf("invalid StakeVersion expected 5 -> false")
+	}
+
+	// Generate 2 interval with v5 votes
+	runCount = interval * 2
+	for i := int64(0); i < runCount; i++ {
+		node := newFakeNode(3, height+i, currentNode)
+
+		// Set stake versions.
+		for x := uint16(0); x < params.TicketsPerBlock; x++ {
+			node.voterVersions = append(node.voterVersions, 5)
+		}
+
+		sv, err := bc.calcStakeVersionByNode(currentNode)
+		if err != nil {
+			t.Fatalf("calcStakeVersionByNode: unexpected error: %v", err)
+		}
+		node.header.StakeVersion = sv
+
+		currentNode = node
+		bc.bestNode = currentNode
+
+	}
+	height += runCount
+
+	if !bc.isStakeMajorityVersion(0, currentNode) {
+		t.Fatalf("invalid StakeVersion expected 0 -> true")
+	}
+	if !bc.isStakeMajorityVersion(2, currentNode) {
+		t.Fatalf("invalid StakeVersion expected 2 -> true")
+	}
+	if !bc.isStakeMajorityVersion(4, currentNode) {
+		t.Fatalf("invalid StakeVersion expected 4 -> true")
+	}
+	if !bc.isStakeMajorityVersion(5, currentNode) {
+		t.Fatalf("invalid StakeVersion expected 5 -> true")
+	}
+	if bc.isStakeMajorityVersion(6, currentNode) {
+		t.Fatalf("invalid StakeVersion expected 6 -> false")
+	}
+
+	// Generate 1 interval with v4 votes, to test the edge condition
+	runCount = interval
+	for i := int64(0); i < runCount; i++ {
+		node := newFakeNode(3, height+i, currentNode)
+
+		// Set stake versions.
+		for x := uint16(0); x < params.TicketsPerBlock; x++ {
+			node.voterVersions = append(node.voterVersions, 4)
+		}
+
+		sv, err := bc.calcStakeVersionByNode(currentNode)
+		if err != nil {
+			t.Fatalf("calcStakeVersionByNode: unexpected error: %v", err)
+		}
+		node.header.StakeVersion = sv
+
+		currentNode = node
+		bc.bestNode = currentNode
+
+	}
+	height += runCount
+
+	if !bc.isStakeMajorityVersion(0, currentNode) {
+		t.Fatalf("invalid StakeVersion expected 0 -> true")
+	}
+	if !bc.isStakeMajorityVersion(2, currentNode) {
+		t.Fatalf("invalid StakeVersion expected 2 -> true")
+	}
+	if !bc.isStakeMajorityVersion(4, currentNode) {
+		t.Fatalf("invalid StakeVersion expected 4 -> true")
+	}
+	if !bc.isStakeMajorityVersion(5, currentNode) {
+		t.Fatalf("invalid StakeVersion expected 5 -> true")
+	}
+	if bc.isStakeMajorityVersion(6, currentNode) {
+		t.Fatalf("invalid StakeVersion expected 6 -> false")
+	}
+
+	// Generate 1 interval with v4 votes.
+	runCount = interval
+	for i := int64(0); i < runCount; i++ {
+		node := newFakeNode(3, height+i, currentNode)
+
+		// Set stake versions.
+		for x := uint16(0); x < params.TicketsPerBlock; x++ {
+			node.voterVersions = append(node.voterVersions, 4)
+		}
+
+		sv, err := bc.calcStakeVersionByNode(currentNode)
+		if err != nil {
+			t.Fatalf("calcStakeVersionByNode: unexpected error: %v", err)
+		}
+		node.header.StakeVersion = sv
+
+		currentNode = node
+		bc.bestNode = currentNode
+
+	}
+	height += runCount
+
+	if !bc.isStakeMajorityVersion(0, currentNode) {
+		t.Fatalf("invalid StakeVersion expected 0 -> true")
+	}
+	if !bc.isStakeMajorityVersion(2, currentNode) {
+		t.Fatalf("invalid StakeVersion expected 2 -> true")
+	}
+	if !bc.isStakeMajorityVersion(4, currentNode) {
+		t.Fatalf("invalid StakeVersion expected 4 -> true")
+	}
+	if !bc.isStakeMajorityVersion(5, currentNode) {
+		t.Fatalf("invalid StakeVersion expected 5 -> true")
+	}
+	if bc.isStakeMajorityVersion(6, currentNode) {
+		t.Fatalf("invalid StakeVersion expected 6 -> false")
+	}
+}
+
+func TestCalcStakeVersionByNode(t *testing.T) {
+	params := &chaincfg.SimNetParams
+
+	tests := []struct {
+		name          string
+		numNodes      int64
+		expectVersion uint32
+		set           func(*blockNode)
+	}{
+		{
+			name:          "headerStake 2 votes 3",
+			numNodes:      params.StakeValidationHeight + params.StakeVersionInterval*3,
+			expectVersion: 3,
+			set: func(b *blockNode) {
+				if int64(b.header.Height) > params.StakeValidationHeight {
+					// set voter versions
+					for x := 0; x < int(params.TicketsPerBlock); x++ {
+						b.voterVersions = append(b.voterVersions, 3)
+					}
+
+					// set header stake version
+					b.header.StakeVersion = 2
+					// set enforcement version
+					b.header.Version = 3
+				}
+			},
+		},
+		{
+			name:          "headerStake 3 votes 2",
+			numNodes:      params.StakeValidationHeight + params.StakeVersionInterval*3,
+			expectVersion: 3,
+			set: func(b *blockNode) {
+				if int64(b.header.Height) > params.StakeValidationHeight {
+					// set voter versions
+					for x := 0; x < int(params.TicketsPerBlock); x++ {
+						b.voterVersions = append(b.voterVersions, 2)
+					}
+
+					// set header stake version
+					b.header.StakeVersion = 3
+					// set enforcement version
+					b.header.Version = 3
+				}
+			},
+		},
+	}
+
+	bc := &BlockChain{
+		chainParams: params,
+	}
+	for _, test := range tests {
+		currentNode := genesisBlockNode(params)
+
+		t.Logf("running: \"%v\"\n", test.name)
+		for i := int64(1); i <= test.numNodes; i++ {
+			// Make up a header.
+			header := &wire.BlockHeader{
+				Version: 1,
+				Height:  uint32(i),
+				Nonce:   uint32(0),
+			}
+			node := newBlockNode(header, &chainhash.Hash{}, 0,
+				[]chainhash.Hash{}, []chainhash.Hash{},
+				[]uint32{})
+			node.height = i
+			node.parent = currentNode
+
+			test.set(node)
+
+			currentNode = node
+			bc.bestNode = currentNode
+		}
+
+		version, err := bc.calcStakeVersionByNode(bc.bestNode)
+		t.Logf("name \"%v\" version %v err %v", test.name, version, err)
+		if err != nil {
+			t.Fatalf("calcStakeVersionByNode: unexpected error: %v", err)
+		}
+		if version != test.expectVersion {
+			t.Fatalf("version mismatch: got %v expected %v",
+				version, test.expectVersion)
+		}
+	}
+}
+
+func TestIsStakeMajorityVersion(t *testing.T) {
+	params := &chaincfg.MainNetParams
+
+	// Calculate super majority for 5 and 3 ticket maxes.
+	maxTickets5 := int32(params.StakeVersionInterval) * int32(params.TicketsPerBlock)
+	sm5 := maxTickets5 * params.StakeMajorityMultiplier / params.StakeMajorityDivisor
+	maxTickets3 := int32(params.StakeVersionInterval) * int32(params.TicketsPerBlock-2)
+	sm3 := maxTickets3 * params.StakeMajorityMultiplier / params.StakeMajorityDivisor
+
+	// Keep track of ticketcount in set.  Must be reset every test.
+	ticketCount := int32(0)
+
+	tests := []struct {
+		name                 string
+		numNodes             int64
+		set                  func(*blockNode)
+		blockVersion         int32
+		startStakeVersion    uint32
+		expectedStakeVersion uint32
+		expectedCalcVersion  uint32
+		result               bool
+	}{
+		{
+			name:                 "too shallow",
+			numNodes:             params.StakeValidationHeight + params.StakeVersionInterval - 1,
+			startStakeVersion:    1,
+			expectedStakeVersion: 1,
+			expectedCalcVersion:  0,
+			result:               true,
+		},
+		{
+			name:                 "just enough",
+			numNodes:             params.StakeValidationHeight + params.StakeVersionInterval,
+			startStakeVersion:    1,
+			expectedStakeVersion: 1,
+			expectedCalcVersion:  0,
+			result:               true,
+		},
+		{
+			name:                 "odd",
+			numNodes:             params.StakeValidationHeight + params.StakeVersionInterval + 1,
+			startStakeVersion:    1,
+			expectedStakeVersion: 1,
+			expectedCalcVersion:  0,
+			result:               true,
+		},
+		{
+			name:     "100%",
+			numNodes: params.StakeValidationHeight + params.StakeVersionInterval,
+			set: func(b *blockNode) {
+				if int64(b.header.Height) > params.StakeValidationHeight {
+					for x := 0; x < int(params.TicketsPerBlock); x++ {
+						b.voterVersions = append(b.voterVersions, 2)
+					}
+				}
+			},
+			startStakeVersion:    1,
+			expectedStakeVersion: 2,
+			expectedCalcVersion:  0,
+			result:               true,
+		},
+		{
+			name:     "50%",
+			numNodes: params.StakeValidationHeight + (params.StakeVersionInterval * 2),
+			set: func(b *blockNode) {
+				if int64(b.header.Height) <= params.StakeValidationHeight {
+					return
+				}
+
+				if int64(b.header.Height) < params.StakeValidationHeight+params.StakeVersionInterval {
+					for x := 0; x < int(params.TicketsPerBlock); x++ {
+						b.voterVersions = append(b.voterVersions, uint32(1))
+					}
+					return
+				}
+
+				threshold := maxTickets5 / 2
+
+				v := uint32(1)
+				for x := 0; x < int(params.TicketsPerBlock); x++ {
+					if ticketCount >= threshold {
+						v = 2
+					}
+					b.voterVersions = append(b.voterVersions, v)
+					ticketCount++
+				}
+			},
+			startStakeVersion:    1,
+			expectedStakeVersion: 2,
+			expectedCalcVersion:  0,
+			result:               false,
+		},
+		{
+			name:     "75%-1",
+			numNodes: params.StakeValidationHeight + (params.StakeVersionInterval * 2),
+			set: func(b *blockNode) {
+				if int64(b.header.Height) < params.StakeValidationHeight {
+					return
+				}
+
+				if int64(b.header.Height) < params.StakeValidationHeight+params.StakeVersionInterval {
+					for x := 0; x < int(params.TicketsPerBlock); x++ {
+						b.voterVersions = append(b.voterVersions, uint32(1))
+					}
+					return
+				}
+
+				threshold := maxTickets5 - sm5 + 1
+
+				v := uint32(1)
+				for x := 0; x < int(params.TicketsPerBlock); x++ {
+					if ticketCount >= threshold {
+						v = 2
+					}
+					b.voterVersions = append(b.voterVersions, v)
+					ticketCount++
+				}
+			},
+			startStakeVersion:    1,
+			expectedStakeVersion: 2,
+			expectedCalcVersion:  0,
+			result:               false,
+		},
+		{
+			name:     "75%",
+			numNodes: params.StakeValidationHeight + (params.StakeVersionInterval * 2),
+			set: func(b *blockNode) {
+				if int64(b.header.Height) <= params.StakeValidationHeight {
+					return
+				}
+
+				if int64(b.header.Height) < params.StakeValidationHeight+params.StakeVersionInterval {
+					for x := 0; x < int(params.TicketsPerBlock); x++ {
+						b.voterVersions = append(b.voterVersions, uint32(1))
+					}
+					return
+				}
+
+				threshold := maxTickets5 - sm5
+
+				v := uint32(1)
+				for x := 0; x < int(params.TicketsPerBlock); x++ {
+					if ticketCount >= threshold {
+						v = 2
+					}
+					b.voterVersions = append(b.voterVersions, v)
+					ticketCount++
+				}
+			},
+			startStakeVersion:    1,
+			expectedStakeVersion: 2,
+			expectedCalcVersion:  0,
+			result:               true,
+		},
+		{
+			name:     "100% after several non majority intervals",
+			numNodes: params.StakeValidationHeight + (params.StakeVersionInterval * 222),
+			set: func(b *blockNode) {
+				if int64(b.header.Height) <= params.StakeValidationHeight {
+					return
+				}
+
+				if int64(b.header.Height) < params.StakeValidationHeight+params.StakeVersionInterval {
+					for x := 0; x < int(params.TicketsPerBlock); x++ {
+						b.voterVersions = append(b.voterVersions, uint32(1))
+					}
+					return
+				}
+
+				for x := 0; x < int(params.TicketsPerBlock); x++ {
+					b.voterVersions = append(b.voterVersions, uint32(x)%5)
+				}
+			},
+			startStakeVersion:    1,
+			expectedStakeVersion: 1,
+			expectedCalcVersion:  0,
+			result:               true,
+		},
+		{
+			name:     "no majority ever",
+			numNodes: params.StakeValidationHeight + (params.StakeVersionInterval * 8),
+			set: func(b *blockNode) {
+				if int64(b.header.Height) <= params.StakeValidationHeight {
+					return
+				}
+
+				for x := 0; x < int(params.TicketsPerBlock); x++ {
+					b.voterVersions = append(b.voterVersions, uint32(x)%5)
+				}
+			},
+			startStakeVersion:    1,
+			expectedStakeVersion: 1,
+			expectedCalcVersion:  0,
+			result:               true,
+		},
+		{
+			name:     "75%-1 with 3 votes",
+			numNodes: params.StakeValidationHeight + (params.StakeVersionInterval * 2),
+			set: func(b *blockNode) {
+				if int64(b.header.Height) < params.StakeValidationHeight {
+					return
+				}
+
+				if int64(b.header.Height) < params.StakeValidationHeight+params.StakeVersionInterval {
+					for x := 0; x < int(params.TicketsPerBlock-2); x++ {
+						b.voterVersions = append(b.voterVersions, uint32(1))
+					}
+					return
+				}
+
+				threshold := maxTickets3 - sm3 + 1
+
+				v := uint32(1)
+				for x := 0; x < int(params.TicketsPerBlock-2); x++ {
+					if ticketCount >= threshold {
+						v = 2
+					}
+					b.voterVersions = append(b.voterVersions, v)
+					ticketCount++
+				}
+			},
+			startStakeVersion:    1,
+			expectedStakeVersion: 2,
+			expectedCalcVersion:  0,
+			result:               false,
+		},
+		{
+			name:     "75% with 3 votes",
+			numNodes: params.StakeValidationHeight + (params.StakeVersionInterval * 2),
+			set: func(b *blockNode) {
+				if int64(b.header.Height) <= params.StakeValidationHeight {
+					return
+				}
+
+				if int64(b.header.Height) < params.StakeValidationHeight+params.StakeVersionInterval {
+					for x := 0; x < int(params.TicketsPerBlock-2); x++ {
+						b.voterVersions = append(b.voterVersions, uint32(1))
+					}
+					return
+				}
+
+				threshold := maxTickets3 - sm3
+
+				v := uint32(1)
+				for x := 0; x < int(params.TicketsPerBlock-2); x++ {
+					if ticketCount >= threshold {
+						v = 2
+					}
+					b.voterVersions = append(b.voterVersions, v)
+					ticketCount++
+				}
+			},
+			startStakeVersion:    1,
+			expectedStakeVersion: 2,
+			expectedCalcVersion:  0,
+			result:               true,
+		},
+		{
+			name:     "75% with 3 votes blockversion 3",
+			numNodes: params.StakeValidationHeight + (params.StakeVersionInterval * 2),
+			set: func(b *blockNode) {
+				if int64(b.header.Height) <= params.StakeValidationHeight {
+					return
+				}
+
+				if int64(b.header.Height) < params.StakeValidationHeight+params.StakeVersionInterval {
+					for x := 0; x < int(params.TicketsPerBlock-2); x++ {
+						b.voterVersions = append(b.voterVersions, uint32(1))
+					}
+					return
+				}
+
+				threshold := maxTickets3 - sm3
+
+				v := uint32(1)
+				for x := 0; x < int(params.TicketsPerBlock-2); x++ {
+					if ticketCount >= threshold {
+						v = 2
+					}
+					b.voterVersions = append(b.voterVersions, v)
+					ticketCount++
+				}
+			},
+			blockVersion:         3,
+			startStakeVersion:    1,
+			expectedStakeVersion: 2,
+			expectedCalcVersion:  2,
+			result:               true,
+		},
+		{
+			name:     "75%-1 with 3 votes blockversion 3",
+			numNodes: params.StakeValidationHeight + (params.StakeVersionInterval * 2),
+			set: func(b *blockNode) {
+				if int64(b.header.Height) < params.StakeValidationHeight {
+					return
+				}
+
+				if int64(b.header.Height) < params.StakeValidationHeight+params.StakeVersionInterval {
+					for x := 0; x < int(params.TicketsPerBlock-2); x++ {
+						b.voterVersions = append(b.voterVersions, uint32(1))
+					}
+					return
+				}
+
+				threshold := maxTickets3 - sm3 + 1
+
+				v := uint32(1)
+				for x := 0; x < int(params.TicketsPerBlock-2); x++ {
+					if ticketCount >= threshold {
+						v = 2
+					}
+					b.voterVersions = append(b.voterVersions, v)
+					ticketCount++
+				}
+			},
+			blockVersion:         3,
+			startStakeVersion:    1,
+			expectedStakeVersion: 2,
+			expectedCalcVersion:  1,
+			result:               false,
+		},
+	}
+
+	bc := &BlockChain{
+		chainParams: params,
+	}
+	for _, test := range tests {
+		ticketCount = 0
+
+		genesisNode := genesisBlockNode(params)
+		genesisNode.header.StakeVersion = test.startStakeVersion
+
+		t.Logf("running: %v\n", test.name)
+		var currentNode *blockNode
+		currentNode = genesisNode
+		for i := int64(1); i <= test.numNodes; i++ {
+			// Make up a header.
+			header := &wire.BlockHeader{
+				Version:      test.blockVersion,
+				Height:       uint32(i),
+				Nonce:        uint32(0),
+				StakeVersion: test.startStakeVersion,
+			}
+			node := newBlockNode(header, &chainhash.Hash{}, 0,
+				[]chainhash.Hash{}, []chainhash.Hash{},
+				[]uint32{})
+			node.height = i
+			node.parent = currentNode
+
+			// Override version.
+			if test.set != nil {
+				test.set(node)
+			} else {
+				for x := 0; x < int(params.TicketsPerBlock); x++ {
+					node.voterVersions = append(node.voterVersions, test.startStakeVersion)
+				}
+			}
+
+			currentNode = node
+			bc.bestNode = currentNode
+		}
+
+		res := bc.isVoterMajorityVersion(test.expectedStakeVersion, currentNode)
+		if res != test.result {
+			t.Fatalf("%v isVoterMajorityVersion", test.name)
+		}
+
+		// validate calcStakeVersion
+		version, err := bc.calcStakeVersionByNode(currentNode)
+		if err != nil {
+			t.Fatalf("calcStakeVersionByNode: unexpected error: %v", err)
+		}
+		if version != test.expectedCalcVersion {
+			t.Fatalf("%v calcStakeVersionByNode got %v expected %v",
+				test.name, version, test.expectedCalcVersion)
+		}
+	}
+}

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -267,6 +267,10 @@ type Params struct {
 	// of the exponentially weighted average.
 	StakeDiffWindows int64
 
+	// StakeVersionInterval determines the interval where the stake version
+	// is calculated.
+	StakeVersionInterval int64
+
 	// MaxFreshStakePerBlock is the maximum number of new tickets that may be
 	// submitted per block.
 	MaxFreshStakePerBlock uint8
@@ -285,9 +289,11 @@ type Params struct {
 	// it to be this value miners/daemons could freely change it.
 	StakeBaseSigScript []byte
 
-	// StakeVersion is the current stake version.  Miners should use this
-	// value when creating new blocks.
-	StakeVersion uint32
+	// StakeMajorityMultiplier and StakeMajorityDivisor are used
+	// to calculate the super majority of stake votes using integer math as
+	// such: X*StakeMajorityMultiplier/StakeMajorityDivisor
+	StakeMajorityMultiplier int32
+	StakeMajorityDivisor    int32
 
 	// OrganizationPkScript is the output script for block taxes to be
 	// distributed to in every block's coinbase. It should ideally be a P2SH
@@ -383,22 +389,24 @@ var MainNetParams = Params{
 	HDCoinType: 20,
 
 	// Decred PoS parameters
-	MinimumStakeDiff:      2 * 1e8, // 2 Coin
-	TicketPoolSize:        8192,
-	TicketsPerBlock:       5,
-	TicketMaturity:        256,
-	TicketExpiry:          40960, // 5*TicketPoolSize
-	CoinbaseMaturity:      256,
-	SStxChangeMaturity:    1,
-	TicketPoolSizeWeight:  4,
-	StakeDiffAlpha:        1, // Minimal
-	StakeDiffWindowSize:   144,
-	StakeDiffWindows:      20,
-	MaxFreshStakePerBlock: 20,        // 4*TicketsPerBlock
-	StakeEnabledHeight:    256 + 256, // CoinbaseMaturity + TicketMaturity
-	StakeValidationHeight: 4096,      // ~14 days
-	StakeBaseSigScript:    []byte{0x00, 0x00},
-	StakeVersion:          2,
+	MinimumStakeDiff:        2 * 1e8, // 2 Coin
+	TicketPoolSize:          8192,
+	TicketsPerBlock:         5,
+	TicketMaturity:          256,
+	TicketExpiry:            40960, // 5*TicketPoolSize
+	CoinbaseMaturity:        256,
+	SStxChangeMaturity:      1,
+	TicketPoolSizeWeight:    4,
+	StakeDiffAlpha:          1, // Minimal
+	StakeDiffWindowSize:     144,
+	StakeDiffWindows:        20,
+	StakeVersionInterval:    144 * 2 * 7, // ~1 week
+	MaxFreshStakePerBlock:   20,          // 4*TicketsPerBlock
+	StakeEnabledHeight:      256 + 256,   // CoinbaseMaturity + TicketMaturity
+	StakeValidationHeight:   4096,        // ~14 days
+	StakeBaseSigScript:      []byte{0x00, 0x00},
+	StakeMajorityMultiplier: 3,
+	StakeMajorityDivisor:    4,
 
 	// Decred organization related parameters
 	// Organization address is Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx
@@ -490,22 +498,24 @@ var TestNetParams = Params{
 	HDCoinType: 11,
 
 	// Decred PoS parameters
-	MinimumStakeDiff:      20000000, // 0.2 Coin
-	TicketPoolSize:        1024,
-	TicketsPerBlock:       5,
-	TicketMaturity:        16,
-	TicketExpiry:          6144, // 6*TicketPoolSize
-	CoinbaseMaturity:      16,
-	SStxChangeMaturity:    1,
-	TicketPoolSizeWeight:  4,
-	StakeDiffAlpha:        1,
-	StakeDiffWindowSize:   144,
-	StakeDiffWindows:      20,
-	MaxFreshStakePerBlock: 20,      // 4*TicketsPerBlock
-	StakeEnabledHeight:    16 + 16, // CoinbaseMaturity + TicketMaturity
-	StakeValidationHeight: 768,     // Arbitrary
-	StakeBaseSigScript:    []byte{0xDE, 0xAD, 0xBE, 0xEF},
-	StakeVersion:          2,
+	MinimumStakeDiff:        20000000, // 0.2 Coin
+	TicketPoolSize:          1024,
+	TicketsPerBlock:         5,
+	TicketMaturity:          16,
+	TicketExpiry:            6144, // 6*TicketPoolSize
+	CoinbaseMaturity:        16,
+	SStxChangeMaturity:      1,
+	TicketPoolSizeWeight:    4,
+	StakeDiffAlpha:          1,
+	StakeDiffWindowSize:     144,
+	StakeDiffWindows:        20,
+	StakeVersionInterval:    144 * 2 * 7, // ~1 week
+	MaxFreshStakePerBlock:   20,          // 4*TicketsPerBlock
+	StakeEnabledHeight:      16 + 16,     // CoinbaseMaturity + TicketMaturity
+	StakeValidationHeight:   768,         // Arbitrary
+	StakeBaseSigScript:      []byte{0xDE, 0xAD, 0xBE, 0xEF},
+	StakeMajorityMultiplier: 3,
+	StakeMajorityDivisor:    4,
 
 	// Decred organization related parameters.
 	// Organization address is TcemyEtyHSg9L7jww7uihv9BJfKL6YGiZYn
@@ -586,22 +596,24 @@ var SimNetParams = Params{
 	HDCoinType: 115, // ASCII for s
 
 	// Decred PoS parameters
-	MinimumStakeDiff:      20000,
-	TicketPoolSize:        64,
-	TicketsPerBlock:       5,
-	TicketMaturity:        16,
-	TicketExpiry:          384, // 6*TicketPoolSize
-	CoinbaseMaturity:      16,
-	SStxChangeMaturity:    1,
-	TicketPoolSizeWeight:  4,
-	StakeDiffAlpha:        1,
-	StakeDiffWindowSize:   8,
-	StakeDiffWindows:      8,
-	MaxFreshStakePerBlock: 20,            // 4*TicketsPerBlock
-	StakeEnabledHeight:    16 + 16,       // CoinbaseMaturity + TicketMaturity
-	StakeValidationHeight: 16 + (64 * 2), // CoinbaseMaturity + TicketPoolSize*2
-	StakeBaseSigScript:    []byte{0xDE, 0xAD, 0xBE, 0xEF},
-	StakeVersion:          2,
+	MinimumStakeDiff:        20000,
+	TicketPoolSize:          64,
+	TicketsPerBlock:         5,
+	TicketMaturity:          16,
+	TicketExpiry:            384, // 6*TicketPoolSize
+	CoinbaseMaturity:        16,
+	SStxChangeMaturity:      1,
+	TicketPoolSizeWeight:    4,
+	StakeDiffAlpha:          1,
+	StakeDiffWindowSize:     8,
+	StakeDiffWindows:        8,
+	StakeVersionInterval:    8 * 2 * 7,
+	MaxFreshStakePerBlock:   20,            // 4*TicketsPerBlock
+	StakeEnabledHeight:      16 + 16,       // CoinbaseMaturity + TicketMaturity
+	StakeValidationHeight:   16 + (64 * 2), // CoinbaseMaturity + TicketPoolSize*2
+	StakeBaseSigScript:      []byte{0xDE, 0xAD, 0xBE, 0xEF},
+	StakeMajorityMultiplier: 3,
+	StakeMajorityDivisor:    4,
 
 	// Decred organization related parameters
 	//

--- a/mining.go
+++ b/mining.go
@@ -36,7 +36,7 @@ const (
 	// will require changes to the generated block.  Using the wire constant
 	// for generated block version could allow creation of invalid blocks
 	// for the updated version.
-	generatedBlockVersion = 2
+	generatedBlockVersion = 3
 
 	// blockHeaderOverhead is the max number of bytes it takes to serialize
 	// a block header and max possible transaction count.
@@ -2105,6 +2105,12 @@ mempoolLoop:
 		}
 	}
 
+	// Figure out stake version.
+	generatedStakeVersion, err := blockManager.chain.CalcStakeVersionByHash(prevHash)
+	if err != nil {
+		return nil, err
+	}
+
 	// Create a new block ready to be solved.
 	merkles := blockchain.BuildMerkleTreeStore(blockTxnsRegular)
 	merklesStake := blockchain.BuildMerkleTreeStore(blockTxnsStake)
@@ -2124,7 +2130,7 @@ mempoolLoop:
 		Timestamp:    ts,
 		SBits:        reqStakeDifficulty,
 		Bits:         reqDifficulty,
-		StakeVersion: server.chainParams.StakeVersion,
+		StakeVersion: generatedStakeVersion,
 		Height:       uint32(nextBlockHeight),
 		// Size declared below
 	}


### PR DESCRIPTION
this PR implements the mechanism for stake voters to influence the future of the network.  It does that by looking at set intervals (SVI) past stake validation height (SVH).  The initial interval starts therefore at SVH+SVI.  At subsequent intervals (SVH+N*SVI) reevaluate the versions.

Once 75% of the votes cast in a SVI have a particular version the stake version is flipped to said version (on an interval).  Once Stake Version reaches particular version it means that the daemon understands the new rules as of that version.

Consensus rule changes are as follows:
1. Reject version 2 blocks once a majority of the network has upgraded.
2. Enforce the stake version in the header once a majority of the network has upgraded to version 3 blocks.

Voter and Stake majorities are defined as 75% using the StakeMajorityMultiplier and StakeMajorityDivisor constants.

**This PR requires #522**

Fixes #523 