### PR TITLE
blocklogger: fix singular case for stake transactions

### DIFF
--- a/blocklogger.go
+++ b/blocklogger.go
@@ -64,7 +64,7 @@ func (b *blockProgressLogger) logBlockHeight(block *dcrutil.Block) {
 		txStr = "transaction"
 	}
 	stxStr := "stake transactions"
-	if b.receivedLogTx == 1 {
+	if b.receivedLogSTx == 1 {
 		stxStr = "stake transaction"
 	}
 	b.subsystemLogger.Infof("%s %d %s in the last %s (%d %s, %d %s, height "+


### PR DESCRIPTION
This is very trivial, not sure if I should even do a PR, but here it is.

I noticed this in the dcrd log:

    18:18:38 2017-01-14 [INF] BMGR: Processed 1 block in the last 15.21s (1 transaction, 6 stake transaction, height 98443, 2017-01-14 18:18:31 +0100 CET)

It turns out that whenever there is "1 transaction", the "stake transaction" part is also singular, because of comparison on the wrong variable.
