### PR TITLE
Add block version to getstakeversions

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -262,6 +262,7 @@ type BlockChain struct {
 type StakeVersions struct {
 	Hash          chainhash.Hash
 	Height        int64
+	BlockVersion  int32
 	StakeVersion  uint32
 	StakeVersions []uint32
 }
@@ -283,6 +284,7 @@ func (b *BlockChain) GetStakeVersions(hash *chainhash.Hash, count int32) ([]Stak
 		sv := StakeVersions{
 			Hash:         prevNode.hash,
 			Height:       prevNode.height,
+			BlockVersion: prevNode.header.Version,
 			StakeVersion: prevNode.header.StakeVersion,
 			StakeVersions: make([]uint32, 0,
 				len(prevNode.voterVersions)),

--- a/dcrjson/dcrdextresults.go
+++ b/dcrjson/dcrdextresults.go
@@ -16,6 +16,7 @@ type GetStakeDifficultyResult struct {
 type StakeVersions struct {
 	Hash          string   `json:"hash"`
 	Height        int64    `json:"height"`
+	BlockVersion  int32    `json:"blockversion"`
 	StakeVersion  uint32   `json:"stakeversion"`
 	VoterVersions []uint32 `json:"voterversions"`
 }

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3857,6 +3857,7 @@ func handleGetStakeVersions(s *rpcServer, cmd interface{}, closeChan <-chan stru
 		nsv := dcrjson.StakeVersions{
 			Hash:          v.Hash.String(),
 			Height:        v.Height,
+			BlockVersion:  v.BlockVersion,
 			StakeVersion:  v.StakeVersion,
 			VoterVersions: make([]uint32, 0, len(v.StakeVersions)),
 		}

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -415,6 +415,7 @@ var helpDescsEnUS = map[string]string{
 	"getstakeversionsresult-stakeversions": "Array of stake versions per block.",
 	"stakeversions-hash":                   "Hash of the block.",
 	"stakeversions-height":                 "Height of the block.",
+	"stakeversions-blockversion":           "The block version",
 	"stakeversions-stakeversion":           "The stake version of the block",
 	"stakeversions-voterversions":          "The version of each vote in the block",
 


### PR DESCRIPTION
Add header.Version to the getstakeversions command.  Even though that information can be obtained separately it would require a bunch of RPC chatter which is suboptimal.

Fixes #555