### PR TITLE
blockchain: Remove impossible condition checks.

### DIFF
--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -409,21 +409,6 @@ func checkBlockSanity(block *dcrutil.Block, timeSource MedianTimeSource,
 			"any transactions")
 	}
 
-	// A block must not have more transactions than the max block payload.
-	if numTx > chainParams.MaximumBlockSize {
-		str := fmt.Sprintf("block contains too many transactions - "+
-			"got %d, max %d", numTx, chainParams.MaximumBlockSize)
-		return ruleError(ErrTooManyTransactions, str)
-	}
-
-	// A block must not have more stake transactions than the max block payload.
-	numStakeTx := len(msgBlock.STransactions)
-	if numStakeTx > chainParams.MaximumBlockSize {
-		str := fmt.Sprintf("block contains too many stake transactions - "+
-			"got %d, max %d", numStakeTx, chainParams.MaximumBlockSize)
-		return ruleError(ErrTooManyTransactions, str)
-	}
-
 	// A block must not exceed the maximum allowed block payload when
 	// serialized.
 	serializedSize := msgBlock.SerializeSize()


### PR DESCRIPTION
This removes a couple of checks that are completely impossible to hit.

These are impossible to hit because there is a maximum protocol limit of 1MiB and the absolute minimum possible transaction size that will successfully deserialize with no inputs and no outputs is 15 bytes
(which is itself an invalid transaction anyways), which means a maximum of 66,666 of these invalid transactions could fit into a 1MiB block. Since the check is comparing against 393,216 on mainnet and 1,000,000 on testnet and simnet, it can easily be seen it simply isn't possible to hit.

Technically, if it were possible to hit these conditions, changing them would be a hard fork, however, since they're impossible to hit, this is effectively a noop change in regards to consensus.