### PR TITLE
multi: Implement block size hard fork demo voting.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -2171,6 +2171,46 @@ func (b *BlockChain) BestSnapshot() *BestState {
 	snapshot := b.stateSnapshot
 	b.stateLock.RUnlock()
 	return snapshot
+}
+
+// MaximumBlockSize returns the maximum permitted block size for the block
+// AFTER the given node.
+//
+// This function MUST be called with the chain state lock held (for reads).
+func (b *BlockChain) maxBlockSize(prevNode *blockNode) (int64, error) {
+	// Hard fork voting on block size is not enabled on mainnet.
+	if b.chainParams.Net == wire.MainNet {
+		return int64(b.chainParams.MaximumBlockSizes[0]), nil
+	}
+
+	// Return the larger block size if the version 4 stake vote for the max
+	// block size increase agenda is active.
+	//
+	// NOTE: The choice field of the return threshold state is not examined
+	// here because there is only one possible choice that can be active
+	// for the agenda, which is yes, so there is no need to check it.
+	maxSize := int64(b.chainParams.MaximumBlockSizes[0])
+	state, err := b.deploymentState(prevNode, 4, chaincfg.VoteIDMaxBlockSize)
+	if err != nil {
+		return maxSize, err
+	}
+	if state.State == ThresholdActive {
+		return int64(b.chainParams.MaximumBlockSizes[1]), nil
+	}
+
+	// The max block size is not changed in any other cases.
+	return maxSize, nil
+}
+
+// MaximumBlockSize returns the maximum permitted block size for the block AFTER
+// the end of the current best chain.
+//
+// This function is safe for concurrent access.
+func (b *BlockChain) MaxBlockSize() (int64, error) {
+	b.chainLock.Lock()
+	maxSize, err := b.maxBlockSize(b.bestNode)
+	b.chainLock.Unlock()
+	return maxSize, err
 }
 
 // IndexManager provides a generic interface that the is called when blocks are

--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 The Decred developers
+// Copyright (c) 2016-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -349,7 +349,7 @@ func Generate() (tests [][]TestInstance, err error) {
 	coinbaseMaturity := g.Params().CoinbaseMaturity
 	stakeEnabledHeight := g.Params().StakeEnabledHeight
 	stakeValidationHeight := g.Params().StakeValidationHeight
-	maxBlockSize := g.Params().MaximumBlockSize
+	maxBlockSize := g.Params().MaximumBlockSizes[0]
 	ticketsPerBlock := g.Params().TicketsPerBlock
 
 	// ---------------------------------------------------------------------

--- a/blockchain/fullblocktests/params.go
+++ b/blockchain/fullblocktests/params.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 The Decred developers
+// Copyright (c) 2016-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -6,6 +6,7 @@ package fullblocktests
 
 import (
 	"encoding/hex"
+	"math"
 	"math/big"
 	"time"
 
@@ -117,7 +118,8 @@ var simNetParams = &chaincfg.Params{
 	ReduceMinDifficulty:      false,
 	MinDiffReductionTime:     0, // Does not apply since ReduceMinDifficulty false
 	GenerateSupported:        true,
-	MaximumBlockSize:         1000000,
+	MaximumBlockSizes:        []int{1000000, 1310720},
+	MaxTxSize:                1000000,
 	TargetTimePerBlock:       time.Second,
 	WorkDiffAlpha:            1,
 	WorkDiffWindowSize:       8,
@@ -145,6 +147,36 @@ var simNetParams = &chaincfg.Params{
 	RuleChangeActivationMultiplier: 3,   // 75%
 	RuleChangeActivationDivisor:    4,
 	RuleChangeActivationInterval:   320, // 320 seconds
+	Deployments: map[uint32][]chaincfg.ConsensusDeployment{
+		4: {{
+			Vote: chaincfg.Vote{
+				Id:          chaincfg.VoteIDMaxBlockSize,
+				Description: "Change maximum allowed block size from 1MiB to 1.25MB",
+				Mask:        0x0006, // Bits 1 and 2
+				Choices: []chaincfg.Choice{{
+					Id:          "abstain",
+					Description: "abstain voting for change",
+					Bits:        0x0000,
+					IsIgnore:    true,
+					IsNo:        false,
+				}, {
+					Id:          "no",
+					Description: "reject changing max allowed block size",
+					Bits:        0x0002, // Bit 1
+					IsIgnore:    false,
+					IsNo:        true,
+				}, {
+					Id:          "yes",
+					Description: "accept changing max allowed block size",
+					Bits:        0x0004, // Bit 2
+					IsIgnore:    false,
+					IsNo:        false,
+				}},
+			},
+			StartTime:  0,             // Always available for vote
+			ExpireTime: math.MaxInt64, // Never expires
+		}},
+	},
 
 	// Enforce current block version once majority of the network has
 	// upgraded.

--- a/blockchain/stake/tickets_test.go
+++ b/blockchain/stake/tickets_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -9,6 +9,7 @@ import (
 	"compress/bzip2"
 	"encoding/gob"
 	"fmt"
+	"math"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -954,7 +955,8 @@ var simNetParams = &chaincfg.Params{
 	ReduceMinDifficulty:      false,
 	MinDiffReductionTime:     0, // Does not apply since ReduceMinDifficulty false
 	GenerateSupported:        true,
-	MaximumBlockSize:         1000000,
+	MaximumBlockSizes:        []int{1000000, 1310720},
+	MaxTxSize:                1000000,
 	TargetTimePerBlock:       time.Second,
 	WorkDiffAlpha:            1,
 	WorkDiffWindowSize:       8,
@@ -982,6 +984,36 @@ var simNetParams = &chaincfg.Params{
 	RuleChangeActivationMultiplier: 3,   // 75%
 	RuleChangeActivationDivisor:    4,
 	RuleChangeActivationInterval:   320, // 320 seconds
+	Deployments: map[uint32][]chaincfg.ConsensusDeployment{
+		4: {{
+			Vote: chaincfg.Vote{
+				Id:          chaincfg.VoteIDMaxBlockSize,
+				Description: "Change maximum allowed block size from 1MiB to 1.25MB",
+				Mask:        0x0006, // Bits 1 and 2
+				Choices: []chaincfg.Choice{{
+					Id:          "abstain",
+					Description: "abstain voting for change",
+					Bits:        0x0000,
+					IsIgnore:    true,
+					IsNo:        false,
+				}, {
+					Id:          "no",
+					Description: "reject changing max allowed block size",
+					Bits:        0x0002, // Bit 1
+					IsIgnore:    false,
+					IsNo:        true,
+				}, {
+					Id:          "yes",
+					Description: "accept changing max allowed block size",
+					Bits:        0x0004, // Bit 2
+					IsIgnore:    false,
+					IsNo:        false,
+				}},
+			},
+			StartTime:  0,             // Always available for vote
+			ExpireTime: math.MaxInt64, // Never expires
+		}},
+	},
 
 	// Enforce current block version once majority of the network has
 	// upgraded.

--- a/blockchain/thresholdstate_test.go
+++ b/blockchain/thresholdstate_test.go
@@ -1,0 +1,569 @@
+// Copyright (c) 2017 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package blockchain_test
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/decred/dcrd/blockchain"
+	"github.com/decred/dcrd/blockchain/chaingen"
+	"github.com/decred/dcrd/chaincfg"
+	"github.com/decred/dcrutil"
+)
+
+const (
+	// vbPrevBlockValid defines the vote bit necessary to vote yes to the
+	// previous block being valid.
+	vbPrevBlockValid = 0x01
+
+	// invalidChoice is the value returns by thresholdState when not in a
+	// state where the choice can be valid.
+	invalidChoice = 0xffffffff
+
+	// testDummy1ID is the human-readable ID for the first test dummy voting
+	// agenda.
+	testDummy1ID = "testdummy1"
+
+	// testDummy1YesIndex is the offset in the choices slice of the first
+	// test dummy agenda for the yes choice.
+	testDummy1YesIndex = 2
+
+	// testDummy2NoIndex is the offset in the choices slice of the second
+	// test dummy agenda for the no choice.
+	testDummy2NoIndex = 1
+
+	// vbTestDummy1No defines the vote bits necessary to vote no on the first
+	// test dummy agenda as well as yes to the previous block being valid.
+	vbTestDummy1No = 0x02
+
+	// vbTestDummy1Yes defines the vote bits necessary to vote yes on the
+	// first test dummy agenda as well as yes to the previous block being
+	// valid.
+	vbTestDummy1Yes = 0x04
+
+	// testDummy2ID is the human-readable ID for the second test dummy
+	// voting agenda.
+	testDummy2ID = "testdummy2"
+
+	// vbTestDummy2No defines the vote bits necessary to vote no on the
+	// second test dummy agenda as well as yes to the previous block being
+	// valid.
+	vbTestDummy2No = 0x08
+
+	// vbTestDummy2Yes defines the vote bits necessary to vote yes on the
+	// second test dummy agenda as well as yes to the previous block being
+	// valid.
+	vbTestDummy2Yes = 0x10
+)
+
+var (
+	// testDummy1 is a voting agenda used throughout these tests.
+	testDummy1 = chaincfg.Vote{
+		Id:          testDummy1ID,
+		Description: "",
+		Mask:        0x6, // 0b0110
+		Choices: []chaincfg.Choice{{
+			Id:          "abstain",
+			Description: "abstain voting for change",
+			Bits:        0x0000,
+			IsIgnore:    true,
+			IsNo:        false,
+		}, {
+			Id:          "no",
+			Description: "vote no",
+			Bits:        0x0002, // Bit 1
+			IsIgnore:    false,
+			IsNo:        true,
+		}, {
+			Id:          "yes",
+			Description: "vote yes",
+			Bits:        0x0004, // Bit 2
+			IsIgnore:    false,
+			IsNo:        false,
+		}},
+	}
+
+	// testDummy2 is a voting agenda used throughout these tests.
+	testDummy2 = chaincfg.Vote{
+		Id:          testDummy2ID,
+		Description: "",
+		Mask:        0x18, // 0b11000
+		Choices: []chaincfg.Choice{{
+			Id:          "abstain",
+			Description: "abstain voting for change",
+			Bits:        0x0000,
+			IsIgnore:    true,
+			IsNo:        false,
+		}, {
+			Id:          "no",
+			Description: "vote no",
+			Bits:        0x0008, // Bit 3
+			IsIgnore:    false,
+			IsNo:        true,
+		}, {
+			Id:          "yes",
+			Description: "vote yes",
+			Bits:        0x0010, // Bit 4
+			IsIgnore:    false,
+			IsNo:        false,
+		}},
+	}
+)
+
+// TestTresholdState ensures that the threshold state function progresses
+// through the states correctly.
+func TestTresholdState(t *testing.T) {
+	// Skip tests when running with -short
+	if testing.Short() {
+		t.Skip("Skipping full block threshold state tests in short mode")
+	}
+
+	// Create chain params based on simnet params, but add a specific test
+	// dummy deployment and set the proof-of-work difficulty readjustment
+	// size to a really large number so that the test chain can be generated
+	// more quickly.
+	posVersion := uint32(4)
+	params := chaincfg.SimNetParams
+	params.WorkDiffWindowSize = 200000
+	params.WorkDiffWindows = 1
+	params.TargetTimespan = params.TargetTimePerBlock *
+		time.Duration(params.WorkDiffWindowSize)
+	if params.Deployments == nil {
+		params.Deployments = make(map[uint32][]chaincfg.ConsensusDeployment)
+	}
+	params.Deployments[posVersion] = append(params.Deployments[posVersion],
+		chaincfg.ConsensusDeployment{
+			Vote:       testDummy1,
+			StartTime:  0,
+			ExpireTime: math.MaxUint64,
+		})
+	params.Deployments[posVersion] = append(params.Deployments[posVersion],
+		chaincfg.ConsensusDeployment{
+			Vote:       testDummy2,
+			StartTime:  0,
+			ExpireTime: math.MaxUint64,
+		})
+
+	// Create a test generator instance initialized with the genesis block
+	// as the tip.
+	g, err := chaingen.MakeGenerator(&params)
+	if err != nil {
+		t.Fatalf("Failed to create generator: %v", err)
+	}
+
+	// Create a new database and chain instance to run tests against.
+	chain, teardownFunc, err := chainSetup("thresholdstatetest", &params)
+	if err != nil {
+		t.Fatalf("Failed to setup chain instance: %v", err)
+	}
+	defer teardownFunc()
+
+	// accepted processes the current tip block associated with the
+	// generator and expects it to be accepted to the main chain.
+	accepted := func() {
+		msgBlock := g.Tip()
+		blockHeight := msgBlock.Header.Height
+		block := dcrutil.NewBlock(msgBlock)
+		t.Logf("Testing block %s (hash %s, height %d)",
+			g.TipName(), block.Hash(), blockHeight)
+
+		isMainChain, isOrphan, err := chain.ProcessBlock(block,
+			blockchain.BFNone)
+		if err != nil {
+			t.Fatalf("block %q (hash %s, height %d) should "+
+				"have been accepted: %v", g.TipName(),
+				block.Hash(), blockHeight, err)
+		}
+
+		// Ensure the main chain and orphan flags match the values
+		// specified in the test.
+		if !isMainChain {
+			t.Fatalf("block %q (hash %s, height %d) unexpected main "+
+				"chain flag -- got %v, want true", g.TipName(),
+				block.Hash(), blockHeight, isMainChain)
+		}
+		if isOrphan {
+			t.Fatalf("block %q (hash %s, height %d) unexpected "+
+				"orphan flag -- got %v, want false", g.TipName(),
+				block.Hash(), blockHeight, isOrphan)
+		}
+	}
+
+	// testThresholdState queries the threshold state from the current
+	// tip block associated with the generator and expects the returned
+	// state and choice to match the provided values.
+	testThresholdState := func(id string, state blockchain.ThresholdState, choice uint32) {
+		tipHash := g.Tip().BlockHash()
+		s, err := chain.ThresholdState(&tipHash, posVersion, id)
+		if err != nil {
+			t.Fatalf("block %q (hash %s, height %d) unexpected "+
+				"error when retrieving threshold state: %v",
+				g.TipName(), tipHash, g.Tip().Header.Height,
+				err)
+		}
+
+		if s.State != state {
+			t.Fatalf("block %q (hash %s, height %d) unexpected "+
+				"threshold state for %s -- got %v, want %v",
+				g.TipName(), tipHash, g.Tip().Header.Height,
+				id, s.State, state)
+		}
+		if s.Choice != choice {
+			t.Fatalf("block %q (hash %s, height %d) unexpected "+
+				"choice for %s -- got %v, want %v",
+				g.TipName(), tipHash, g.Tip().Header.Height,
+				id, s.Choice, choice)
+		}
+	}
+
+	// Shorter versions of useful params for convenience.
+	ticketsPerBlock := params.TicketsPerBlock
+	coinbaseMaturity := params.CoinbaseMaturity
+	stakeEnabledHeight := params.StakeEnabledHeight
+	stakeValidationHeight := params.StakeValidationHeight
+	stakeVerInterval := params.StakeVersionInterval
+	ruleChangeInterval := int64(params.RuleChangeActivationInterval)
+	powNumToCheck := int64(params.BlockUpgradeNumToCheck)
+
+	// ---------------------------------------------------------------------
+	// Premine.
+	// ---------------------------------------------------------------------
+
+	// Add the required premine block.
+	//
+	//   genesis -> bp
+	g.CreatePremineBlock("bp", 0)
+	g.AssertTipHeight(1)
+	accepted()
+	testThresholdState(testDummy1ID, blockchain.ThresholdDefined, invalidChoice)
+	testThresholdState(testDummy2ID, blockchain.ThresholdDefined, invalidChoice)
+
+	// ---------------------------------------------------------------------
+	// Generate enough blocks to have mature coinbase outputs to work with.
+	//
+	//   genesis -> bp -> bm0 -> bm1 -> ... -> bm#
+	// ---------------------------------------------------------------------
+
+	for i := uint16(0); i < coinbaseMaturity; i++ {
+		blockName := fmt.Sprintf("bm%d", i)
+		g.NextBlock(blockName, nil, nil)
+		g.SaveTipCoinbaseOuts()
+		accepted()
+	}
+	g.AssertTipHeight(uint32(coinbaseMaturity) + 1)
+	testThresholdState(testDummy1ID, blockchain.ThresholdDefined, invalidChoice)
+	testThresholdState(testDummy2ID, blockchain.ThresholdDefined, invalidChoice)
+
+	// ---------------------------------------------------------------------
+	// Generate enough blocks to reach the stake enabled height while
+	// creating ticket purchases that spend from the coinbases matured
+	// above.  This will also populate the pool of immature tickets.
+	//
+	//   ... -> bm# ... -> bse0 -> bse1 -> ... -> bse#
+	// ---------------------------------------------------------------------
+
+	var ticketsPurchased int
+	for i := int64(0); int64(g.Tip().Header.Height) < stakeEnabledHeight; i++ {
+		outs := g.OldestCoinbaseOuts()
+		ticketOuts := outs[1:]
+		ticketsPurchased += len(ticketOuts)
+		blockName := fmt.Sprintf("bse%d", i)
+		g.NextBlock(blockName, nil, ticketOuts)
+		g.SaveTipCoinbaseOuts()
+		accepted()
+	}
+	g.AssertTipHeight(uint32(stakeEnabledHeight))
+	testThresholdState(testDummy1ID, blockchain.ThresholdDefined, invalidChoice)
+	testThresholdState(testDummy2ID, blockchain.ThresholdDefined, invalidChoice)
+
+	// ---------------------------------------------------------------------
+	// Generate enough blocks to reach the stake validation height while
+	// continuing to purchase tickets using the coinbases matured above and
+	// allowing the immature tickets to mature and thus become live.
+	//
+	// The blocks are also generated with version 3 to ensure stake version
+	// enforcement is reached.
+	// ---------------------------------------------------------------------
+
+	targetPoolSize := g.Params().TicketPoolSize * ticketsPerBlock
+	for i := int64(0); int64(g.Tip().Header.Height) < stakeValidationHeight; i++ {
+		// Only purchase tickets until the target ticket pool size is
+		// reached.
+		outs := g.OldestCoinbaseOuts()
+		ticketOuts := outs[1:]
+		if ticketsPurchased+len(ticketOuts) > int(targetPoolSize) {
+			ticketsNeeded := int(targetPoolSize) - ticketsPurchased
+			if ticketsNeeded > 0 {
+				ticketOuts = ticketOuts[1 : ticketsNeeded+1]
+			} else {
+				ticketOuts = nil
+			}
+		}
+		ticketsPurchased += len(ticketOuts)
+
+		blockName := fmt.Sprintf("bsv%d", i)
+		g.NextBlock(blockName, nil, ticketOuts,
+			chaingen.ReplaceBlockVersion(3))
+		g.SaveTipCoinbaseOuts()
+		accepted()
+	}
+	g.AssertTipHeight(uint32(stakeValidationHeight))
+	testThresholdState(testDummy1ID, blockchain.ThresholdDefined, invalidChoice)
+	testThresholdState(testDummy2ID, blockchain.ThresholdDefined, invalidChoice)
+
+	// ---------------------------------------------------------------------
+	// Generate enough blocks to reach one block before the next stake
+	// version interval with block version 3, stake version 0, and vote
+	// version 3.
+	//
+	// This will result in triggering enforcement of the stake version and
+	// that the stake version is 3.  The treshold state for the test dummy
+	// deployments must still be defined since a v4 majority proof-of-work
+	// and proof-of-stake upgrade are required before moving to started.
+	// ---------------------------------------------------------------------
+
+	blocksNeeded := stakeValidationHeight + stakeVerInterval - 1 -
+		int64(g.Tip().Header.Height)
+	for i := int64(0); i < blocksNeeded; i++ {
+		outs := g.OldestCoinbaseOuts()
+		blockName := fmt.Sprintf("bsvtA%d", i)
+		g.NextBlock(blockName, nil, outs[1:],
+			chaingen.ReplaceBlockVersion(3),
+			chaingen.ReplaceStakeVersion(0),
+			chaingen.ReplaceVoteVersions(3))
+		g.SaveTipCoinbaseOuts()
+		accepted()
+	}
+	g.AssertTipHeight(uint32(stakeValidationHeight + stakeVerInterval - 1))
+	g.AssertBlockVersion(3)
+	g.AssertStakeVersion(0)
+	testThresholdState(testDummy1ID, blockchain.ThresholdDefined, invalidChoice)
+	testThresholdState(testDummy2ID, blockchain.ThresholdDefined, invalidChoice)
+
+	// ---------------------------------------------------------------------
+	// Generate enough blocks to reach one block before the next rule change
+	// interval with block version 3, stake version 3, and vote version 3.
+	//
+	// The threshold state for the dummy deployments must still be defined
+	// since it can only change on a rule change boundary and it requires a
+	// v4 majority proof-of-work and proof-of-stake upgrade before moving to
+	// started.
+	// ---------------------------------------------------------------------
+
+	blocksNeeded = stakeValidationHeight + ruleChangeInterval - 1 -
+		int64(g.Tip().Header.Height)
+	for i := int64(0); i < blocksNeeded; i++ {
+		outs := g.OldestCoinbaseOuts()
+		blockName := fmt.Sprintf("bsvtB%d", i)
+		g.NextBlock(blockName, nil, outs[1:],
+			chaingen.ReplaceBlockVersion(3),
+			chaingen.ReplaceStakeVersion(3),
+			chaingen.ReplaceVoteVersions(3))
+		g.SaveTipCoinbaseOuts()
+		accepted()
+	}
+	g.AssertTipHeight(uint32(stakeValidationHeight + ruleChangeInterval - 1))
+	g.AssertBlockVersion(3)
+	g.AssertStakeVersion(3)
+	testThresholdState(testDummy1ID, blockchain.ThresholdDefined, invalidChoice)
+	testThresholdState(testDummy2ID, blockchain.ThresholdDefined, invalidChoice)
+
+	// ---------------------------------------------------------------------
+	// Generate enough blocks to reach one block before the next stake
+	// version interval with block version 3, stake version 3, and vote
+	// version 4.
+	//
+	// This will result in achieving stake version 4 enforcement.
+	//
+	// The treshold state for the dummy deployments must still be defined
+	// since it can only change on a rule change boundary and it still
+	// requires a v4 majority proof-of-work upgrade before moving to
+	// started.
+	// ---------------------------------------------------------------------
+
+	blocksNeeded = stakeVerInterval + int64(g.Tip().Header.Height+1)%
+		stakeVerInterval
+	for i := int64(0); i < blocksNeeded; i++ {
+		outs := g.OldestCoinbaseOuts()
+		blockName := fmt.Sprintf("bsvtC%d", i)
+		g.NextBlock(blockName, nil, outs[1:],
+			chaingen.ReplaceBlockVersion(3),
+			chaingen.ReplaceStakeVersion(3),
+			chaingen.ReplaceVoteVersions(4))
+		g.SaveTipCoinbaseOuts()
+		accepted()
+	}
+	g.AssertTipHeight(uint32(stakeValidationHeight + stakeVerInterval*4 - 1))
+	g.AssertBlockVersion(3)
+	g.AssertStakeVersion(3)
+	testThresholdState(testDummy1ID, blockchain.ThresholdDefined, invalidChoice)
+	testThresholdState(testDummy2ID, blockchain.ThresholdDefined, invalidChoice)
+
+	// ---------------------------------------------------------------------
+	// Generate enough blocks to reach the next rule change interval with
+	// block version 3 majority, stake version 4, and vote version 4.  Set
+	// the final two blocks to block version 4 so that majority version 4
+	// is not achieved, but the final block in the interval is version 4.
+	//
+	// The treshold state for the dummy deployments must still be defined
+	// since it still requires a v4 majority proof-of-work upgrade before
+	// moving to started.
+	// ---------------------------------------------------------------------
+
+	blocksNeeded = stakeValidationHeight + ruleChangeInterval*2 -
+		int64(g.Tip().Header.Height)
+	for i := int64(0); i < blocksNeeded; i++ {
+		outs := g.OldestCoinbaseOuts()
+		blockName := fmt.Sprintf("bsvtD%d", i)
+		blockVersion := int32(3)
+		if i >= blocksNeeded-2 {
+			blockVersion = 4
+		}
+		g.NextBlock(blockName, nil, outs[1:],
+			chaingen.ReplaceBlockVersion(blockVersion),
+			chaingen.ReplaceStakeVersion(4),
+			chaingen.ReplaceVoteVersions(4))
+		g.SaveTipCoinbaseOuts()
+		accepted()
+	}
+	g.AssertTipHeight(uint32(stakeValidationHeight + ruleChangeInterval*2))
+	g.AssertBlockVersion(4)
+	g.AssertStakeVersion(4)
+	testThresholdState(testDummy1ID, blockchain.ThresholdDefined, invalidChoice)
+	testThresholdState(testDummy2ID, blockchain.ThresholdDefined, invalidChoice)
+
+	// ---------------------------------------------------------------------
+	// Generate enough blocks to achieve proof-of-work block version lockin
+	// with block version 4, stake version 4, and vote version 4.  Also, set
+	// the vote bits to include yes votes for the first test dummy agenda
+	// and no for the second test dummy agenda for an upcoming test.
+	//
+	// Since v4 majority proof-of-stake upgrade has been already been
+	// achieved and this will achieve v4 majority proof-of-work upgrade,
+	// voting can begin at the next rule change interval.
+	//
+	// The treshold state for the dummy deployments must still be defined
+	// since even though all required upgrade conditions are met, the state
+	// change must not happen until the start of the next rule change
+	// interval.
+	// ---------------------------------------------------------------------
+
+	for i := int64(0); i < powNumToCheck; i++ {
+		outs := g.OldestCoinbaseOuts()
+		blockName := fmt.Sprintf("bsvtE%d", i)
+		g.NextBlock(blockName, nil, outs[1:],
+			chaingen.ReplaceBlockVersion(4),
+			chaingen.ReplaceStakeVersion(4),
+			chaingen.ReplaceVotes(vbPrevBlockValid|vbTestDummy1Yes|
+				vbTestDummy2No, 4))
+		g.SaveTipCoinbaseOuts()
+		accepted()
+	}
+	g.AssertTipHeight(uint32(stakeValidationHeight + ruleChangeInterval*2 +
+		powNumToCheck))
+	g.AssertBlockVersion(4)
+	g.AssertStakeVersion(4)
+	testThresholdState(testDummy1ID, blockchain.ThresholdDefined, invalidChoice)
+	testThresholdState(testDummy2ID, blockchain.ThresholdDefined, invalidChoice)
+
+	// ---------------------------------------------------------------------
+	// Generate enough blocks to reach the next rule change interval with
+	// block version 4, stake version 4, and vote version 4.  Also, set the
+	// vote bits to include yes votes for the first test dummy agenda and
+	// no for the second test dummy agenda to ensure they aren't counted.
+	//
+	// The treshold state for the dummy deployments must move to started.
+	// Even though the majority of the votes have already been voting yes
+	// for the first test dummy agenda, and no for the second one, they must
+	// not count, otherwise it would move straight to lockedin or failed,
+	// respectively.
+	// ---------------------------------------------------------------------
+
+	blocksNeeded = stakeValidationHeight + ruleChangeInterval*3 -
+		int64(g.Tip().Header.Height)
+	for i := int64(0); i < blocksNeeded; i++ {
+		outs := g.OldestCoinbaseOuts()
+		blockName := fmt.Sprintf("bsvtF%d", i)
+		g.NextBlock(blockName, nil, outs[1:],
+			chaingen.ReplaceBlockVersion(4),
+			chaingen.ReplaceStakeVersion(4),
+			chaingen.ReplaceVotes(vbPrevBlockValid|vbTestDummy1Yes|
+				vbTestDummy2No, 4))
+		g.SaveTipCoinbaseOuts()
+		accepted()
+	}
+	g.AssertTipHeight(uint32(stakeValidationHeight + ruleChangeInterval*3))
+	g.AssertBlockVersion(4)
+	g.AssertStakeVersion(4)
+	testThresholdState(testDummy1ID, blockchain.ThresholdStarted, invalidChoice)
+	testThresholdState(testDummy2ID, blockchain.ThresholdStarted, invalidChoice)
+
+	// ---------------------------------------------------------------------
+	// Generate enough blocks to reach the next rule change interval with
+	// block version 4, stake version 4, and vote version 4.  Also, set the
+	// vote bits to yes for the first test dummy agenda and no to the second
+	// one.
+	//
+	// The treshold state for the first dummy deployment must move to
+	// lockedin since a majority yes vote was achieved while the second
+	// dummy deployment must move to failed since a majority no vote was
+	// achieved.
+	// ---------------------------------------------------------------------
+
+	blocksNeeded = stakeValidationHeight + ruleChangeInterval*4 -
+		int64(g.Tip().Header.Height)
+	for i := int64(0); i < blocksNeeded; i++ {
+		outs := g.OldestCoinbaseOuts()
+		blockName := fmt.Sprintf("bsvtG%d", i)
+		g.NextBlock(blockName, nil, outs[1:],
+			chaingen.ReplaceBlockVersion(4),
+			chaingen.ReplaceStakeVersion(4),
+			chaingen.ReplaceVotes(vbPrevBlockValid|vbTestDummy1Yes|
+				vbTestDummy2No, 4))
+		g.SaveTipCoinbaseOuts()
+		accepted()
+	}
+	g.AssertTipHeight(uint32(stakeValidationHeight + ruleChangeInterval*4))
+	g.AssertBlockVersion(4)
+	g.AssertStakeVersion(4)
+	testThresholdState(testDummy1ID, blockchain.ThresholdLockedIn, testDummy1YesIndex)
+	testThresholdState(testDummy2ID, blockchain.ThresholdFailed, testDummy2NoIndex)
+
+	// ---------------------------------------------------------------------
+	// Generate enough blocks to reach the next rule change interval with
+	// block version 4, stake version 4, and vote version 4.  Also, set the
+	// vote bits to include no votes for the first test dummy agenda and
+	// yes votes for the second one.
+	//
+	// The treshold state for the first dummy deployment must move to active
+	// since even though the interval had a majority no votes, lockedin
+	// status has already been achieved and can't be undone without a new
+	// agenda.  Similarly, the second one must remain in failed even though
+	// the interval had a majority yes votes since a failed state can't be
+	// undone.
+	// ---------------------------------------------------------------------
+
+	blocksNeeded = stakeValidationHeight + ruleChangeInterval*5 -
+		int64(g.Tip().Header.Height)
+	for i := int64(0); i < blocksNeeded; i++ {
+		outs := g.OldestCoinbaseOuts()
+		blockName := fmt.Sprintf("bsvtH%d", i)
+		g.NextBlock(blockName, nil, outs[1:],
+			chaingen.ReplaceBlockVersion(4),
+			chaingen.ReplaceStakeVersion(4),
+			chaingen.ReplaceVotes(vbPrevBlockValid|vbTestDummy1No|
+				vbTestDummy2Yes, 4))
+		g.SaveTipCoinbaseOuts()
+		accepted()
+	}
+	g.AssertTipHeight(uint32(stakeValidationHeight + ruleChangeInterval*5))
+	g.AssertBlockVersion(4)
+	g.AssertStakeVersion(4)
+	testThresholdState(testDummy1ID, blockchain.ThresholdActive, testDummy1YesIndex)
+	testThresholdState(testDummy2ID, blockchain.ThresholdFailed, testDummy2NoIndex)
+}

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 package blockchain_test
@@ -9,6 +9,7 @@ import (
 	"compress/bzip2"
 	"encoding/gob"
 	"encoding/hex"
+	"math"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -2151,7 +2152,8 @@ var simNetParams = &chaincfg.Params{
 	ReduceMinDifficulty:      false,
 	MinDiffReductionTime:     0, // Does not apply since ReduceMinDifficulty false
 	GenerateSupported:        true,
-	MaximumBlockSize:         1000000,
+	MaximumBlockSizes:        []int{1000000, 1310720},
+	MaxTxSize:                1000000,
 	TargetTimePerBlock:       time.Second,
 	WorkDiffAlpha:            1,
 	WorkDiffWindowSize:       8,
@@ -2179,6 +2181,36 @@ var simNetParams = &chaincfg.Params{
 	RuleChangeActivationMultiplier: 3,   // 75%
 	RuleChangeActivationDivisor:    4,
 	RuleChangeActivationInterval:   320, // 320 seconds
+	Deployments: map[uint32][]chaincfg.ConsensusDeployment{
+		4: {{
+			Vote: chaincfg.Vote{
+				Id:          chaincfg.VoteIDMaxBlockSize,
+				Description: "Change maximum allowed block size from 1MiB to 1.25MB",
+				Mask:        0x0006, // Bits 1 and 2
+				Choices: []chaincfg.Choice{{
+					Id:          "abstain",
+					Description: "abstain voting for change",
+					Bits:        0x0000,
+					IsIgnore:    true,
+					IsNo:        false,
+				}, {
+					Id:          "no",
+					Description: "reject changing max allowed block size",
+					Bits:        0x0002, // Bit 1
+					IsIgnore:    false,
+					IsNo:        true,
+				}, {
+					Id:          "yes",
+					Description: "accept changing max allowed block size",
+					Bits:        0x0004, // Bit 2
+					IsIgnore:    false,
+					IsNo:        false,
+				}},
+			},
+			StartTime:  0,             // Always available for vote
+			ExpireTime: math.MaxInt64, // Never expires
+		}},
+	},
 
 	// Enforce current block version once majority of the network has
 	// upgraded.

--- a/blockchain/votebits_test.go
+++ b/blockchain/votebits_test.go
@@ -50,14 +50,13 @@ var (
 func defaultParams() chaincfg.Params {
 	params := chaincfg.SimNetParams
 	params.Deployments = make(map[uint32][]chaincfg.ConsensusDeployment)
-	params.Deployments[posVersion] = []chaincfg.ConsensusDeployment{
-		{
-			Vote: pedro,
-			StartTime: uint64(time.Now().Add(time.Duration(params.RuleChangeActivationInterval) *
-				time.Second).Unix()),
-			ExpireTime: uint64(time.Now().Add(24 * time.Hour).Unix()),
-		},
-	}
+	params.Deployments[posVersion] = []chaincfg.ConsensusDeployment{{
+		Vote: pedro,
+		StartTime: uint64(time.Now().Add(time.Duration(
+			params.RuleChangeActivationInterval) *
+			time.Second).Unix()),
+		ExpireTime: uint64(time.Now().Add(24 * time.Hour).Unix()),
+	}}
 
 	return params
 }

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"time"
 
@@ -90,15 +91,15 @@ type Checkpoint struct {
 //			IsNo:        false,
 //		},
 //		{
-//			Id:          "yes",
-//			Description: "accept changing block height to uint64",
+//			Id:          "no",
+//			Description: "reject changing block height to uint64",
 //			Bits:        0x0002,
 //			IsIgnore:    false,
 //			IsNo:        false,
 //		},
 //		{
-//			Id:          "no",
-//			Description: "reject changing block height to uint64",
+//			Id:          "yes",
+//			Description: "accept changing block height to uint64",
 //			Bits:        0x0004,
 //			IsIgnore:    false,
 //			IsNo:        true,
@@ -180,6 +181,12 @@ func (v *Vote) IsNo(vote uint16) (bool, error) {
 	return false, VoteBitsNotFound
 }
 
+const (
+	// VoteIDMaxBlockSize is the vote ID for the the maximum block size
+	// increase agenda used for the hard fork demo.
+	VoteIDMaxBlockSize = "maxblocksize"
+)
+
 // ConsensusDeployment defines details related to a specific consensus rule
 // change that is voted in.  This is part of BIP0009.
 type ConsensusDeployment struct {
@@ -250,9 +257,17 @@ type Params struct {
 	// GenerateSupported specifies whether or not CPU mining is allowed.
 	GenerateSupported bool
 
-	// MaximumBlockSize is the maximum size of a block that can be generated
-	// on the network.
-	MaximumBlockSize int
+	// MaximumBlockSizes are the maximum sizes of a block that can be
+	// generated on the network.  It is an array because the max block size
+	// can be different values depending on the results of a voting agenda.
+	// The first entry is the initial block size for the network, while the
+	// other entries are potential block size changes which take effect when
+	// the vote for the associated agenda succeeds.
+	MaximumBlockSizes []int
+
+	// MaxTxSize is the maximum number of bytes a serialized transaction can
+	// be in order to be considered valid by consensus.
+	MaxTxSize int
 
 	// TargetTimePerBlock is the desired amount of time to generate each
 	// block.
@@ -474,7 +489,8 @@ var MainNetParams = Params{
 	ReduceMinDifficulty:      false,
 	MinDiffReductionTime:     0, // Does not apply since ReduceMinDifficulty false
 	GenerateSupported:        false,
-	MaximumBlockSize:         393216,
+	MaximumBlockSizes:        []int{393216},
+	MaxTxSize:                393216,
 	TargetTimePerBlock:       time.Minute * 5,
 	WorkDiffAlpha:            1,
 	WorkDiffWindowSize:       144,
@@ -589,7 +605,8 @@ var TestNetParams = Params{
 	ReduceMinDifficulty:      false,
 	MinDiffReductionTime:     0, // Does not apply since ReduceMinDifficulty false
 	GenerateSupported:        true,
-	MaximumBlockSize:         1000000,
+	MaximumBlockSizes:        []int{1000000, 1310720},
+	MaxTxSize:                1000000,
 	TargetTimePerBlock:       time.Minute * 2,
 	WorkDiffAlpha:            1,
 	WorkDiffWindowSize:       144,
@@ -629,6 +646,36 @@ var TestNetParams = Params{
 	RuleChangeActivationMultiplier: 3,    // 75%
 	RuleChangeActivationDivisor:    4,
 	RuleChangeActivationInterval:   5040, // 1 week
+	Deployments: map[uint32][]ConsensusDeployment{
+		4: {{
+			Vote: Vote{
+				Id:          VoteIDMaxBlockSize,
+				Description: "Change maximum allowed block size from 1MiB to 1.25MB",
+				Mask:        0x0006, // Bits 1 and 2
+				Choices: []Choice{{
+					Id:          "abstain",
+					Description: "abstain voting for change",
+					Bits:        0x0000,
+					IsIgnore:    true,
+					IsNo:        false,
+				}, {
+					Id:          "no",
+					Description: "reject changing max allowed block size",
+					Bits:        0x0002, // Bit 1
+					IsIgnore:    false,
+					IsNo:        true,
+				}, {
+					Id:          "yes",
+					Description: "accept changing max allowed block size",
+					Bits:        0x0004, // Bit 2
+					IsIgnore:    false,
+					IsNo:        false,
+				}},
+			},
+			StartTime:  1486598400, // Feb 9th, 2017
+			ExpireTime: 1496966400, // Jun 9th, 2017
+		}},
+	},
 
 	// Enforce current block version once majority of the network has
 	// upgraded.
@@ -708,7 +755,8 @@ var SimNetParams = Params{
 	ReduceMinDifficulty:      false,
 	MinDiffReductionTime:     0, // Does not apply since ReduceMinDifficulty false
 	GenerateSupported:        true,
-	MaximumBlockSize:         1000000,
+	MaximumBlockSizes:        []int{1000000, 1310720},
+	MaxTxSize:                1000000,
 	TargetTimePerBlock:       time.Second,
 	WorkDiffAlpha:            1,
 	WorkDiffWindowSize:       8,
@@ -736,6 +784,36 @@ var SimNetParams = Params{
 	RuleChangeActivationMultiplier: 3,   // 75%
 	RuleChangeActivationDivisor:    4,
 	RuleChangeActivationInterval:   320, // 320 seconds
+	Deployments: map[uint32][]ConsensusDeployment{
+		4: {{
+			Vote: Vote{
+				Id:          VoteIDMaxBlockSize,
+				Description: "Change maximum allowed block size from 1MiB to 1.25MB",
+				Mask:        0x0006, // Bits 1 and 2
+				Choices: []Choice{{
+					Id:          "abstain",
+					Description: "abstain voting for change",
+					Bits:        0x0000,
+					IsIgnore:    true,
+					IsNo:        false,
+				}, {
+					Id:          "no",
+					Description: "reject changing max allowed block size",
+					Bits:        0x0002, // Bit 1
+					IsIgnore:    false,
+					IsNo:        true,
+				}, {
+					Id:          "yes",
+					Description: "accept changing max allowed block size",
+					Bits:        0x0004, // Bit 2
+					IsIgnore:    false,
+					IsNo:        false,
+				}},
+			},
+			StartTime:  0,             // Always available for vote
+			ExpireTime: math.MaxInt64, // Never expires
+		}},
+	},
 
 	// Enforce current block version once majority of the network has
 	// upgraded.

--- a/mining.go
+++ b/mining.go
@@ -30,13 +30,17 @@ const (
 	// transaction to be considered high priority.
 	minHighPriority = dcrutil.AtomsPerCoin * 144.0 / 250
 
-	// generatedBlockVersion is the version of the block being generated.
-	// It is defined as a constant here rather than using the
-	// wire.BlockVersion constant since a change in the block version
+	// generatedBlockVersion is the version of the block being generated for
+	// the main network.  It is defined as a constant here rather than using
+	// the wire.BlockVersion constant since a change in the block version
 	// will require changes to the generated block.  Using the wire constant
 	// for generated block version could allow creation of invalid blocks
 	// for the updated version.
 	generatedBlockVersion = 3
+
+	// generatedBlockVersionTest is the version of the block being generated
+	// for networks other than the main network.
+	generatedBlockVersionTest = 4
 
 	// blockHeaderOverhead is the max number of bytes it takes to serialize
 	// a block header and max possible transaction count.
@@ -2105,6 +2109,12 @@ mempoolLoop:
 		}
 	}
 
+	// Choose the block version to generate based on the network.
+	blockVersion := int32(generatedBlockVersion)
+	if server.chainParams.Net != wire.MainNet {
+		blockVersion = generatedBlockVersionTest
+	}
+
 	// Figure out stake version.
 	generatedStakeVersion, err := blockManager.chain.CalcStakeVersionByHash(prevHash)
 	if err != nil {
@@ -2117,7 +2127,7 @@ mempoolLoop:
 
 	var msgBlock wire.MsgBlock
 	msgBlock.Header = wire.BlockHeader{
-		Version:      generatedBlockVersion,
+		Version:      blockVersion,
 		PrevBlock:    *prevHash,
 		MerkleRoot:   *merkles[len(merkles)-1],
 		StakeRoot:    *merklesStake[len(merklesStake)-1],

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -2860,6 +2860,15 @@ func (state *gbtWorkState) blockTemplateResult(bm *blockManager,
 		return nil, err
 	}
 
+	// Choose the correct maximum block size as defined by the  network
+	// parameters and the current status of any hard fork votes to change it
+	// when serialized.
+	maxBlockSize, err := bm.chain.MaxBlockSize()
+	if err != nil {
+		context := "Failed to obtain maximum block size"
+		return nil, internalRPCError(err.Error(), context)
+	}
+
 	// Generate the block template reply.  Note that following mutations are
 	// implied by the included or omission of fields:
 	//  Including MinTime -> time/decrement
@@ -2869,7 +2878,7 @@ func (state *gbtWorkState) blockTemplateResult(bm *blockManager,
 	reply := dcrjson.GetBlockTemplateResult{
 		Header:        hex.EncodeToString(headerBytes),
 		SigOpLimit:    blockchain.MaxSigOpsPerBlock,
-		SizeLimit:     int64(bm.server.chainParams.MaximumBlockSize),
+		SizeLimit:     maxBlockSize,
 		Transactions:  transactions,
 		STransactions: stransactions,
 		LongPollID:    templateID,

--- a/wire/msgblock_test.go
+++ b/wire/msgblock_test.go
@@ -51,11 +51,20 @@ func TestBlock(t *testing.T) {
 
 	// Ensure max payload is expected value for latest protocol version.
 	// Num addresses (varInt) + max allowed addresses.
-	wantPayload := uint32(1000000)
+	wantPayload := uint32(1310720)
 	maxPayload := msg.MaxPayloadLength(pver)
 	if maxPayload != wantPayload {
 		t.Errorf("MaxPayloadLength: wrong max payload length for "+
 			"protocol version %d - got %v, want %v", pver,
+			maxPayload, wantPayload)
+	}
+
+	// Ensure max payload is expected value for protocol version 3.
+	wantPayload = uint32(1000000)
+	maxPayload = msg.MaxPayloadLength(3)
+	if maxPayload != wantPayload {
+		t.Errorf("MaxPayloadLength: wrong max payload length for "+
+			"protocol version %d - got %v, want %v", 3,
 			maxPayload, wantPayload)
 	}
 

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -1538,6 +1538,11 @@ func (msg *MsgTx) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgTx) MaxPayloadLength(pver uint32) uint32 {
+	// Protocol version 3 and lower have a different max block payload.
+	if pver <= 3 {
+		return MaxBlockPayloadV3
+	}
+
 	return MaxBlockPayload
 }
 

--- a/wire/msgtx_test.go
+++ b/wire/msgtx_test.go
@@ -37,11 +37,20 @@ func TestTx(t *testing.T) {
 
 	// Ensure max payload is expected value for latest protocol version.
 	// Num addresses (varInt) + max allowed addresses.
-	wantPayload := uint32(1000 * 1000)
+	wantPayload := uint32(1310720)
 	maxPayload := msg.MaxPayloadLength(pver)
 	if maxPayload != wantPayload {
 		t.Errorf("MaxPayloadLength: wrong max payload length for "+
 			"protocol version %d - got %v, want %v", pver,
+			maxPayload, wantPayload)
+	}
+
+	// Ensure max payload is expected value for protocol version 3.
+	wantPayload = uint32(1000000)
+	maxPayload = msg.MaxPayloadLength(3)
+	if maxPayload != wantPayload {
+		t.Errorf("MaxPayloadLength: wrong max payload length for "+
+			"protocol version %d - got %v, want %v", 3,
 			maxPayload, wantPayload)
 	}
 

--- a/wire/protocol.go
+++ b/wire/protocol.go
@@ -17,7 +17,7 @@ const (
 	InitialProcotolVersion uint32 = 1
 
 	// ProtocolVersion is the latest protocol version this package supports.
-	ProtocolVersion uint32 = 3
+	ProtocolVersion uint32 = 4
 
 	// BIP0111Version is the protocol version which added the SFNodeBloom
 	// service flag.


### PR DESCRIPTION
**This requires PR #542**

This implements a new voting agenda for the testnet and simnet networks for increasing the maximum block size from 1MiB to 1.25MB.

The following is an overview of the changes:

- Bump the maximum protocol block size limit to 1.25MB
- Bump the protocol version to 4
- Add wire tests for v3 protocol sizes and update tests for latest
- Update all wire values that are defined in terms of the max block size to respect the protocol version
- Update the `MaxSigOpsPerBlock` constant to maintain existing value regardless of the raised max protocol block size
- Decouple the maximum tx size from the block size by creating a chain parameter for it with the current sizes so it is not a part of the hard fork vote
- Add definition for new version 4 stake vote along with agenda to vote on block size to the testnet and simnet networks
- Convert the `MaximumBlockSize` chain parameter to a slice in order to hold the different possible sizes
- Add a new function that returns the maximum block size based upon the result of the vote
- Change the existing context-free block size check to enforce the max protocol size and introduce a context-specific check which enforces a restricted size based upon the network consensus parameters and the result of the vote
- Set the max allowed size in generated block templates based upon the network params and result of the vote
- Generate version 4 blocks and reject version 3 blocks after a super majority has been reached (only on non mainnet networks)