### PR TITLE
Add new getstakeversioninfo command

### DIFF
--- a/dcrjson/dcrdcmds.go
+++ b/dcrjson/dcrdcmds.go
@@ -116,6 +116,20 @@ func NewGetStakeDifficultyCmd() *GetStakeDifficultyCmd {
 	return &GetStakeDifficultyCmd{}
 }
 
+// GetStakeVersionInfoCmd returns stake version info for the current interval.
+// Optionally, Count indicates how many additional intervals to return.
+type GetStakeVersionInfoCmd struct {
+	Count *int32
+}
+
+// NewGetStakeVersionInfoCmd returns a new instance which can be used to
+// issue a JSON-RPC getstakeversioninfo command.
+func NewGetStakeVersionInfoCmd(count int32) *GetStakeVersionInfoCmd {
+	return &GetStakeVersionInfoCmd{
+		Count: &count,
+	}
+}
+
 // GetStakeVersionsCmd returns stake version for a range of blocks.
 // Count indicates how many blocks are walked backwards.
 type GetStakeVersionsCmd struct {
@@ -273,6 +287,7 @@ func init() {
 	MustRegisterCmd("existsmempooltxs", (*ExistsMempoolTxsCmd)(nil), flags)
 	MustRegisterCmd("getcoinsupply", (*GetCoinSupplyCmd)(nil), flags)
 	MustRegisterCmd("getstakedifficulty", (*GetStakeDifficultyCmd)(nil), flags)
+	MustRegisterCmd("getstakeversioninfo", (*GetStakeVersionInfoCmd)(nil), flags)
 	MustRegisterCmd("getstakeversions", (*GetStakeVersionsCmd)(nil), flags)
 	MustRegisterCmd("getticketpoolvalue", (*GetTicketPoolValueCmd)(nil), flags)
 	MustRegisterCmd("getvoteinfo", (*GetVoteInfoCmd)(nil), flags)

--- a/dcrjson/dcrdresults.go
+++ b/dcrjson/dcrdresults.go
@@ -12,6 +12,28 @@ type GetStakeDifficultyResult struct {
 	NextStakeDifficulty    float64 `json:"next"`
 }
 
+// VersionCount models a generic version:count tupple.
+type VersionCount struct {
+	Version uint32 `json:"version"`
+	Count   uint32 `json:"count"`
+}
+
+// VersionInterval models a cooked version count for an interval.
+type VersionInterval struct {
+	StartHeight  int64          `json:"startheight"`
+	EndHeight    int64          `json:"endheight"`
+	PoSVersions  []VersionCount `json:"posversions"`
+	VoteVersions []VersionCount `json:"voteversions"`
+}
+
+// GetStakeVersionInfoResult models the resulting data for getstakeversioninfo
+// command.
+type GetStakeVersionInfoResult struct {
+	CurrentHeight int64             `json:"currentheight"`
+	Hash          string            `json:"hash"`
+	Intervals     []VersionInterval `json:"intervals"`
+}
+
 // StakeVersions models the data for GetStakeVersionsResult.
 type StakeVersions struct {
 	Hash          string   `json:"hash"`
@@ -27,6 +49,7 @@ type GetStakeVersionsResult struct {
 	StakeVersions []StakeVersions `json:"stakeversions"`
 }
 
+// Choice models an individual choice inside an Agenda.
 type Choice struct {
 	Id          string  `json:"id"`
 	Description string  `json:"description"`
@@ -37,7 +60,7 @@ type Choice struct {
 	Progress    float64 `json:"progress"`
 }
 
-// Agenda
+// Agenda models an individual agenda including it's choices.
 type Agenda struct {
 	Id             string   `json:"id"`
 	Description    string   `json:"description"`

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -408,6 +408,19 @@ var helpDescsEnUS = map[string]string{
 	"getstakedifficultyresult-current": "The current top block's stake difficulty",
 	"getstakedifficultyresult-next":    "The calculated stake difficulty of the next block",
 
+	// GetStakeVersionInfoCmd help.
+	"getstakeversioninfo--synopsis":           "Returns the stake versions statistics.",
+	"getstakeversioninfo-count":               "Number of intervals to return.",
+	"getstakeversioninforesult-currentheight": "Top of the chain height.",
+	"getstakeversioninforesult-hash":          "Top of the chain hash.",
+	"getstakeversioninforesult-intervals":     "Array of total stake and vote counts.",
+	"versioncount-count":                      "Number of votes.",
+	"versioncount-version":                    "Version of the vote.",
+	"versioninterval-startheight":             "Start of the interval.",
+	"versioninterval-endheight":               "End of the interval.",
+	"versioninterval-voteversions":            "Tally of all vote versions.",
+	"versioninterval-posversions":             "Tally of the stake versions.",
+
 	// GetStakeDifficultyCmd help.
 	"getstakeversions--synopsis":           "Returns the stake versions statistics.",
 	"getstakeversions-hash":                "The start block hash.",
@@ -881,6 +894,7 @@ var rpcResultTypes = map[string][]interface{}{
 	"getcurrentnet":         {(*uint32)(nil)},
 	"getdifficulty":         {(*float64)(nil)},
 	"getstakedifficulty":    {(*dcrjson.GetStakeDifficultyResult)(nil)},
+	"getstakeversioninfo":   {(*dcrjson.GetStakeVersionInfoResult)(nil)},
 	"getstakeversions":      {(*dcrjson.GetStakeVersionsResult)(nil)},
 	"getgenerate":           {(*bool)(nil)},
 	"gethashespersec":       {(*float64)(nil)},


### PR DESCRIPTION
We need a "better" getstakeversions command that returns cooked values instead of just raw data.