### PR TITLE
Don't keep double vote information in blockNode

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/decred/dcrd/blockchain/stake"
-	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/txscript"
 	"github.com/decred/dcrutil"
@@ -209,19 +208,6 @@ func ticketsRevokedInBlock(bl *dcrutil.Block) []chainhash.Hash {
 	return tickets
 }
 
-// voteVersionsInBlock returns all versions in a block.
-func voteVersionsInBlock(bl *dcrutil.Block, params *chaincfg.Params) []uint32 {
-	versions := make([]uint32, 0, params.TicketsPerBlock)
-	for _, stx := range bl.MsgBlock().STransactions {
-		if is, _ := stake.IsSSGen(stx); !is {
-			continue
-		}
-		versions = append(versions, stake.SSGenVersion(stx))
-	}
-
-	return versions
-}
-
 // voteBitsInBlock returns a list of vote bits for the voters in this block.
 func voteBitsInBlock(bl *dcrutil.Block) []voteVersionTuple {
 	var voteBits []voteVersionTuple
@@ -290,7 +276,6 @@ func (b *BlockChain) maybeAcceptBlock(block *dcrutil.Block,
 	blockHeader := &block.MsgBlock().Header
 	newNode := newBlockNode(blockHeader, block.Hash(), blockHeight,
 		ticketsSpentInBlock(block), ticketsRevokedInBlock(block),
-		voteVersionsInBlock(block, b.chainParams),
 		voteBitsInBlock(block))
 	if prevNode != nil {
 		newNode.parent = prevNode

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1322,7 +1322,7 @@ func (b *BlockChain) createChainState() error {
 	genesisBlock := dcrutil.NewBlock(b.chainParams.GenesisBlock)
 	header := &genesisBlock.MsgBlock().Header
 	node := newBlockNode(header, genesisBlock.Hash(), 0, []chainhash.Hash{},
-		[]chainhash.Hash{}, []uint32{}, []voteVersionTuple{})
+		[]chainhash.Hash{}, []voteVersionTuple{})
 	node.inMainChain = true
 	b.bestNode = node
 
@@ -1486,7 +1486,6 @@ func (b *BlockChain) initChainState() error {
 		header := &block.Header
 		node := newBlockNode(header, &state.hash, int64(state.height),
 			ticketsSpentInBlock(blk), ticketsRevokedInBlock(blk),
-			voteVersionsInBlock(blk, b.chainParams),
 			voteBitsInBlock(blk))
 		node.inMainChain = true
 		node.workSum = state.workSum

--- a/blockchain/internal_test.go
+++ b/blockchain/internal_test.go
@@ -49,6 +49,6 @@ func (b *BlockChain) TstCheckBlockHeaderContext(header *wire.BlockHeader, prevNo
 
 // TstNewBlockNode makes the internal newBlockNode function available to the
 // test package.
-func TstNewBlockNode(blockHeader *wire.BlockHeader, blockHash *chainhash.Hash, height int64, ticketsSpent []chainhash.Hash, ticketsRevoked []chainhash.Hash, voterVersions []uint32, voteBits []voteVersionTuple) *blockNode {
-	return newBlockNode(blockHeader, blockHash, height, ticketsSpent, ticketsRevoked, voterVersions, voteBits)
+func TstNewBlockNode(blockHeader *wire.BlockHeader, blockHash *chainhash.Hash, height int64, ticketsSpent []chainhash.Hash, ticketsRevoked []chainhash.Hash, voteBits []voteVersionTuple) *blockNode {
+	return newBlockNode(blockHeader, blockHash, height, ticketsSpent, ticketsRevoked, voteBits)
 }

--- a/blockchain/stakeversion.go
+++ b/blockchain/stakeversion.go
@@ -98,9 +98,9 @@ func (b *BlockChain) isVoterMajorityVersion(minVer uint32, prevNode *blockNode) 
 	versionCount := int32(0)
 	iterNode := node
 	for i := int64(0); i < b.chainParams.StakeVersionInterval && iterNode != nil; i++ {
-		totalVotesFound += int32(len(iterNode.voterVersions))
-		for _, version := range iterNode.voterVersions {
-			if version >= minVer {
+		totalVotesFound += int32(len(iterNode.votes))
+		for _, v := range iterNode.votes {
+			if v.version >= minVer {
 				versionCount += 1
 			}
 		}
@@ -223,9 +223,9 @@ func (b *BlockChain) calcVoterVersionInterval(prevNode *blockNode) (uint32, erro
 	totalVotesFound := int32(0)
 	iterNode := prevNode
 	for i := int64(0); i < b.chainParams.StakeVersionInterval && iterNode != nil; i++ {
-		totalVotesFound += int32(len(iterNode.voterVersions))
-		for _, version := range iterNode.voterVersions {
-			versions[version]++
+		totalVotesFound += int32(len(iterNode.votes))
+		for _, v := range iterNode.votes {
+			versions[v.version]++
 		}
 
 		iterNode, err = b.getPrevNodeFromNode(iterNode)

--- a/blockchain/stakeversion_test.go
+++ b/blockchain/stakeversion_test.go
@@ -19,7 +19,7 @@ func genesisBlockNode(params *chaincfg.Params) *blockNode {
 	// Create a new node from the genesis block.
 	genesisBlock := dcrutil.NewBlock(params.GenesisBlock)
 	header := &genesisBlock.MsgBlock().Header
-	node := newBlockNode(header, genesisBlock.Hash(), 0, nil, nil, nil, nil)
+	node := newBlockNode(header, genesisBlock.Hash(), 0, nil, nil, nil)
 	node.inMainChain = true
 
 	return node
@@ -109,9 +109,8 @@ func newFakeNode(blockVersion int32, height int64, currentNode *blockNode) *bloc
 		Height:  uint32(height),
 		Nonce:   0,
 	}
-	node := newBlockNode(header, &chainhash.Hash{}, 0,
-		[]chainhash.Hash{}, []chainhash.Hash{},
-		[]uint32{}, []voteVersionTuple{})
+	node := newBlockNode(header, &chainhash.Hash{}, 0, []chainhash.Hash{},
+		[]chainhash.Hash{}, []voteVersionTuple{})
 	node.height = height
 	node.parent = currentNode
 
@@ -151,7 +150,8 @@ func TestCalcStakeVersionCorners(t *testing.T) {
 
 		// Set stake versions.
 		for x := uint16(0); x < params.TicketsPerBlock; x++ {
-			node.voterVersions = append(node.voterVersions, 2)
+			node.votes = append(node.votes,
+				voteVersionTuple{version: 2})
 		}
 
 		sv, err := bc.calcStakeVersionByNode(currentNode)
@@ -183,7 +183,8 @@ func TestCalcStakeVersionCorners(t *testing.T) {
 
 		// Set stake versions.
 		for x := uint16(0); x < params.TicketsPerBlock; x++ {
-			node.voterVersions = append(node.voterVersions, 4)
+			node.votes = append(node.votes,
+				voteVersionTuple{version: 4})
 		}
 
 		sv, err := bc.calcStakeVersionByNode(currentNode)
@@ -217,7 +218,8 @@ func TestCalcStakeVersionCorners(t *testing.T) {
 
 		// Set stake versions.
 		for x := uint16(0); x < params.TicketsPerBlock; x++ {
-			node.voterVersions = append(node.voterVersions, 2)
+			node.votes = append(node.votes,
+				voteVersionTuple{version: 2})
 		}
 
 		sv, err := bc.calcStakeVersionByNode(currentNode)
@@ -252,7 +254,8 @@ func TestCalcStakeVersionCorners(t *testing.T) {
 
 		// Set stake versions.
 		for x := uint16(0); x < params.TicketsPerBlock; x++ {
-			node.voterVersions = append(node.voterVersions, 5)
+			node.votes = append(node.votes,
+				voteVersionTuple{version: 5})
 		}
 
 		sv, err := bc.calcStakeVersionByNode(currentNode)
@@ -290,7 +293,8 @@ func TestCalcStakeVersionCorners(t *testing.T) {
 
 		// Set stake versions.
 		for x := uint16(0); x < params.TicketsPerBlock; x++ {
-			node.voterVersions = append(node.voterVersions, 4)
+			node.votes = append(node.votes,
+				voteVersionTuple{version: 4})
 		}
 
 		sv, err := bc.calcStakeVersionByNode(currentNode)
@@ -328,7 +332,8 @@ func TestCalcStakeVersionCorners(t *testing.T) {
 
 		// Set stake versions.
 		for x := uint16(0); x < params.TicketsPerBlock; x++ {
-			node.voterVersions = append(node.voterVersions, 4)
+			node.votes = append(node.votes,
+				voteVersionTuple{version: 4})
 		}
 
 		sv, err := bc.calcStakeVersionByNode(currentNode)
@@ -377,7 +382,8 @@ func TestCalcStakeVersionByNode(t *testing.T) {
 				if int64(b.header.Height) > params.StakeValidationHeight {
 					// set voter versions
 					for x := 0; x < int(params.TicketsPerBlock); x++ {
-						b.voterVersions = append(b.voterVersions, 3)
+						b.votes = append(b.votes,
+							voteVersionTuple{version: 3})
 					}
 
 					// set header stake version
@@ -395,7 +401,8 @@ func TestCalcStakeVersionByNode(t *testing.T) {
 				if int64(b.header.Height) > params.StakeValidationHeight {
 					// set voter versions
 					for x := 0; x < int(params.TicketsPerBlock); x++ {
-						b.voterVersions = append(b.voterVersions, 2)
+						b.votes = append(b.votes,
+							voteVersionTuple{version: 2})
 					}
 
 					// set header stake version
@@ -423,7 +430,7 @@ func TestCalcStakeVersionByNode(t *testing.T) {
 			}
 			node := newBlockNode(header, &chainhash.Hash{}, 0,
 				[]chainhash.Hash{}, []chainhash.Hash{},
-				[]uint32{}, []voteVersionTuple{})
+				[]voteVersionTuple{})
 			node.height = i
 			node.parent = currentNode
 
@@ -497,7 +504,8 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 			set: func(b *blockNode) {
 				if int64(b.header.Height) > params.StakeValidationHeight {
 					for x := 0; x < int(params.TicketsPerBlock); x++ {
-						b.voterVersions = append(b.voterVersions, 2)
+						b.votes = append(b.votes,
+							voteVersionTuple{version: 2})
 					}
 				}
 			},
@@ -516,7 +524,8 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 
 				if int64(b.header.Height) < params.StakeValidationHeight+params.StakeVersionInterval {
 					for x := 0; x < int(params.TicketsPerBlock); x++ {
-						b.voterVersions = append(b.voterVersions, uint32(1))
+						b.votes = append(b.votes,
+							voteVersionTuple{version: 1})
 					}
 					return
 				}
@@ -528,7 +537,8 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 					if ticketCount >= threshold {
 						v = 2
 					}
-					b.voterVersions = append(b.voterVersions, v)
+					b.votes = append(b.votes,
+						voteVersionTuple{version: v})
 					ticketCount++
 				}
 			},
@@ -547,7 +557,8 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 
 				if int64(b.header.Height) < params.StakeValidationHeight+params.StakeVersionInterval {
 					for x := 0; x < int(params.TicketsPerBlock); x++ {
-						b.voterVersions = append(b.voterVersions, uint32(1))
+						b.votes = append(b.votes,
+							voteVersionTuple{version: 1})
 					}
 					return
 				}
@@ -559,7 +570,8 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 					if ticketCount >= threshold {
 						v = 2
 					}
-					b.voterVersions = append(b.voterVersions, v)
+					b.votes = append(b.votes,
+						voteVersionTuple{version: v})
 					ticketCount++
 				}
 			},
@@ -578,7 +590,8 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 
 				if int64(b.header.Height) < params.StakeValidationHeight+params.StakeVersionInterval {
 					for x := 0; x < int(params.TicketsPerBlock); x++ {
-						b.voterVersions = append(b.voterVersions, uint32(1))
+						b.votes = append(b.votes,
+							voteVersionTuple{version: 1})
 					}
 					return
 				}
@@ -590,7 +603,8 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 					if ticketCount >= threshold {
 						v = 2
 					}
-					b.voterVersions = append(b.voterVersions, v)
+					b.votes = append(b.votes,
+						voteVersionTuple{version: v})
 					ticketCount++
 				}
 			},
@@ -609,13 +623,15 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 
 				if int64(b.header.Height) < params.StakeValidationHeight+params.StakeVersionInterval {
 					for x := 0; x < int(params.TicketsPerBlock); x++ {
-						b.voterVersions = append(b.voterVersions, uint32(1))
+						b.votes = append(b.votes,
+							voteVersionTuple{version: 1})
 					}
 					return
 				}
 
 				for x := 0; x < int(params.TicketsPerBlock); x++ {
-					b.voterVersions = append(b.voterVersions, uint32(x)%5)
+					b.votes = append(b.votes,
+						voteVersionTuple{version: uint32(x) % 5})
 				}
 			},
 			startStakeVersion:    1,
@@ -632,7 +648,8 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 				}
 
 				for x := 0; x < int(params.TicketsPerBlock); x++ {
-					b.voterVersions = append(b.voterVersions, uint32(x)%5)
+					b.votes = append(b.votes,
+						voteVersionTuple{version: uint32(x) % 5})
 				}
 			},
 			startStakeVersion:    1,
@@ -650,7 +667,8 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 
 				if int64(b.header.Height) < params.StakeValidationHeight+params.StakeVersionInterval {
 					for x := 0; x < int(params.TicketsPerBlock-2); x++ {
-						b.voterVersions = append(b.voterVersions, uint32(1))
+						b.votes = append(b.votes,
+							voteVersionTuple{version: 1})
 					}
 					return
 				}
@@ -662,7 +680,8 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 					if ticketCount >= threshold {
 						v = 2
 					}
-					b.voterVersions = append(b.voterVersions, v)
+					b.votes = append(b.votes,
+						voteVersionTuple{version: v})
 					ticketCount++
 				}
 			},
@@ -681,7 +700,8 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 
 				if int64(b.header.Height) < params.StakeValidationHeight+params.StakeVersionInterval {
 					for x := 0; x < int(params.TicketsPerBlock-2); x++ {
-						b.voterVersions = append(b.voterVersions, uint32(1))
+						b.votes = append(b.votes,
+							voteVersionTuple{version: 1})
 					}
 					return
 				}
@@ -693,7 +713,8 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 					if ticketCount >= threshold {
 						v = 2
 					}
-					b.voterVersions = append(b.voterVersions, v)
+					b.votes = append(b.votes,
+						voteVersionTuple{version: v})
 					ticketCount++
 				}
 			},
@@ -712,7 +733,8 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 
 				if int64(b.header.Height) < params.StakeValidationHeight+params.StakeVersionInterval {
 					for x := 0; x < int(params.TicketsPerBlock-2); x++ {
-						b.voterVersions = append(b.voterVersions, uint32(1))
+						b.votes = append(b.votes,
+							voteVersionTuple{version: 1})
 					}
 					return
 				}
@@ -724,7 +746,8 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 					if ticketCount >= threshold {
 						v = 2
 					}
-					b.voterVersions = append(b.voterVersions, v)
+					b.votes = append(b.votes,
+						voteVersionTuple{version: v})
 					ticketCount++
 				}
 			},
@@ -744,7 +767,8 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 
 				if int64(b.header.Height) < params.StakeValidationHeight+params.StakeVersionInterval {
 					for x := 0; x < int(params.TicketsPerBlock-2); x++ {
-						b.voterVersions = append(b.voterVersions, uint32(1))
+						b.votes = append(b.votes,
+							voteVersionTuple{version: 1})
 					}
 					return
 				}
@@ -756,7 +780,8 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 					if ticketCount >= threshold {
 						v = 2
 					}
-					b.voterVersions = append(b.voterVersions, v)
+					b.votes = append(b.votes,
+						voteVersionTuple{version: v})
 					ticketCount++
 				}
 			},
@@ -790,7 +815,7 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 			}
 			node := newBlockNode(header, &chainhash.Hash{}, 0,
 				[]chainhash.Hash{}, []chainhash.Hash{},
-				[]uint32{}, []voteVersionTuple{})
+				[]voteVersionTuple{})
 			node.height = i
 			node.parent = currentNode
 
@@ -799,7 +824,8 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 				test.set(node)
 			} else {
 				for x := 0; x < int(params.TicketsPerBlock); x++ {
-					node.voterVersions = append(node.voterVersions, test.startStakeVersion)
+					node.votes = append(node.votes,
+						voteVersionTuple{version: test.startStakeVersion})
 				}
 			}
 

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -2442,7 +2442,6 @@ func (b *BlockChain) CheckConnectBlock(block *dcrutil.Block) error {
 	newNode := newBlockNode(&block.MsgBlock().Header, block.Hash(),
 		block.Height(), ticketsSpentInBlock(block),
 		ticketsRevokedInBlock(block),
-		voteVersionsInBlock(block, b.chainParams),
 		voteBitsInBlock(block))
 	newNode.parent = prevNode
 	newNode.workSum.Add(prevNode.workSum, newNode.workSum)

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -2088,7 +2088,7 @@ func TestCheckBlockHeaderContext(t *testing.T) {
 	// fails.
 	block := dcrutil.NewBlock(&badBlock)
 	newNode := blockchain.TstNewBlockNode(&block.MsgBlock().Header, block.Hash(),
-		block.Height(), nil, nil, nil, nil)
+		block.Height(), nil, nil, nil)
 	err = chain.TstCheckBlockHeaderContext(&block.MsgBlock().Header, newNode, blockchain.BFNone)
 	if err == nil {
 		t.Fatalf("Should fail due to bad diff in newNode\n")

--- a/blockchain/votebits_test.go
+++ b/blockchain/votebits_test.go
@@ -134,7 +134,7 @@ func TestNoQuorum(t *testing.T) {
 		hash := header.BlockHash()
 		node := newBlockNode(header, &hash, 0,
 			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]uint32{}, []voteVersionTuple{})
+			[]voteVersionTuple{})
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
@@ -173,14 +173,12 @@ func TestNoQuorum(t *testing.T) {
 		hash := header.BlockHash()
 		node := newBlockNode(header, &hash, 0,
 			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]uint32{}, []voteVersionTuple{})
+			[]voteVersionTuple{})
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
 		// set stake versions and vote bits
 		for x := 0; x < int(params.TicketsPerBlock); x++ {
-			node.voterVersions = append(node.voterVersions,
-				posVersion)
 			node.votes = append(node.votes, voteVersionTuple{
 				version: posVersion,
 				bits:    0x01})
@@ -223,14 +221,12 @@ func TestNoQuorum(t *testing.T) {
 		hash := header.BlockHash()
 		node := newBlockNode(header, &hash, 0,
 			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]uint32{}, []voteVersionTuple{})
+			[]voteVersionTuple{})
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
 		// set stake versions and vote bits
 		for x := 0; x < int(params.TicketsPerBlock); x++ {
-			node.voterVersions = append(node.voterVersions,
-				posVersion)
 			v := voteVersionTuple{
 				version: posVersion,
 				bits:    0x01,
@@ -279,14 +275,12 @@ func TestNoQuorum(t *testing.T) {
 		hash := header.BlockHash()
 		node := newBlockNode(header, &hash, 0,
 			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]uint32{}, []voteVersionTuple{})
+			[]voteVersionTuple{})
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
 		// set stake versions and vote bits
 		for x := 0; x < int(params.TicketsPerBlock); x++ {
-			node.voterVersions = append(node.voterVersions,
-				posVersion)
 			v := voteVersionTuple{
 				version: posVersion,
 				bits:    0x01,
@@ -345,14 +339,12 @@ func TestNoQuorum(t *testing.T) {
 		hash := header.BlockHash()
 		node := newBlockNode(header, &hash, 0,
 			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]uint32{}, []voteVersionTuple{})
+			[]voteVersionTuple{})
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
 		// set stake versions and vote bits
 		for x := 0; x < int(params.TicketsPerBlock); x++ {
-			node.voterVersions = append(node.voterVersions,
-				posVersion)
 			v := voteVersionTuple{
 				version: posVersion,
 				bits:    0x01,
@@ -426,7 +418,7 @@ func TestYesQuorum(t *testing.T) {
 		hash := header.BlockHash()
 		node := newBlockNode(header, &hash, 0,
 			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]uint32{}, []voteVersionTuple{})
+			[]voteVersionTuple{})
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
@@ -465,14 +457,12 @@ func TestYesQuorum(t *testing.T) {
 		hash := header.BlockHash()
 		node := newBlockNode(header, &hash, 0,
 			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]uint32{}, []voteVersionTuple{})
+			[]voteVersionTuple{})
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
 		// set stake versions and vote bits
 		for x := 0; x < int(params.TicketsPerBlock); x++ {
-			node.voterVersions = append(node.voterVersions,
-				posVersion)
 			node.votes = append(node.votes, voteVersionTuple{
 				version: posVersion,
 				bits:    0x01})
@@ -515,14 +505,12 @@ func TestYesQuorum(t *testing.T) {
 		hash := header.BlockHash()
 		node := newBlockNode(header, &hash, 0,
 			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]uint32{}, []voteVersionTuple{})
+			[]voteVersionTuple{})
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
 		// set stake versions and vote bits
 		for x := 0; x < int(params.TicketsPerBlock); x++ {
-			node.voterVersions = append(node.voterVersions,
-				posVersion)
 			v := voteVersionTuple{
 				version: posVersion,
 				bits:    0x01,
@@ -571,14 +559,12 @@ func TestYesQuorum(t *testing.T) {
 		hash := header.BlockHash()
 		node := newBlockNode(header, &hash, 0,
 			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]uint32{}, []voteVersionTuple{})
+			[]voteVersionTuple{})
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
 		// set stake versions and vote bits
 		for x := 0; x < int(params.TicketsPerBlock); x++ {
-			node.voterVersions = append(node.voterVersions,
-				posVersion)
 			v := voteVersionTuple{
 				version: posVersion,
 				bits:    0x01,
@@ -637,14 +623,12 @@ func TestYesQuorum(t *testing.T) {
 		hash := header.BlockHash()
 		node := newBlockNode(header, &hash, 0,
 			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]uint32{}, []voteVersionTuple{})
+			[]voteVersionTuple{})
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
 		// set stake versions and vote bits
 		for x := 0; x < int(params.TicketsPerBlock); x++ {
-			node.voterVersions = append(node.voterVersions,
-				posVersion)
 			v := voteVersionTuple{
 				version: posVersion,
 				bits:    0x01,
@@ -1194,14 +1178,12 @@ func TestVoting(t *testing.T) {
 				hash := header.BlockHash()
 				node := newBlockNode(header, &hash, 0,
 					[]chainhash.Hash{}, []chainhash.Hash{},
-					[]uint32{}, []voteVersionTuple{})
+					[]voteVersionTuple{})
 				node.height = int64(currentHeight)
 				node.parent = currentNode
 
 				// set stake versions and vote bits
 				for x := 0; x < int(params.TicketsPerBlock); x++ {
-					node.voterVersions = append(node.voterVersions,
-						test.startStakeVersion)
 					node.votes = append(node.votes,
 						test.voteBitsCounts[k].vote)
 				}
@@ -1463,14 +1445,12 @@ func TestVotingParallel(t *testing.T) {
 				hash := header.BlockHash()
 				node := newBlockNode(header, &hash, 0,
 					[]chainhash.Hash{}, []chainhash.Hash{},
-					[]uint32{}, []voteVersionTuple{})
+					[]voteVersionTuple{})
 				node.height = int64(currentHeight)
 				node.parent = currentNode
 
 				// set stake versions and vote bits
 				for x := 0; x < int(params.TicketsPerBlock); x++ {
-					node.voterVersions = append(node.voterVersions,
-						test.startStakeVersion)
 					node.votes = append(node.votes,
 						test.voteBitsCounts[k].vote)
 				}


### PR DESCRIPTION
In order to keep the HF work as separate as possible, a new array was introduced in blockNode that keeps track of the version:bits tuple.  With the HF work completed, we can now get rid of the voterVersion array and reuse the tuple in the stake version code.

This PR is purely mechanical.

Fixes #576 