### PR TITLE
Add Go 1.8 support, remove 1.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.6.x
   - 1.7.x
+  - 1.8.x
 sudo: false
 install:
   - go get -v github.com/Masterminds/glide

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ database optimization and other blockchain related technology improvements.
 
 ## Requirements
 
-[Go](http://golang.org) 1.6 or newer.
+[Go](http://golang.org) 1.7 or newer.
 
 ## Getting Started
 

--- a/dcrjson/chainsvrcmds_test.go
+++ b/dcrjson/chainsvrcmds_test.go
@@ -1137,8 +1137,8 @@ func TestChainSvrCmdErrors(t *testing.T) {
 	for i, test := range tests {
 		err := json.Unmarshal([]byte(test.marshalled), &test.result)
 		if reflect.TypeOf(err) != reflect.TypeOf(test.err) {
-			t.Errorf("Test #%d (%s) wrong error - got %T (%[2]v), "+
-				"want %T", i, test.name, err, test.err)
+			t.Errorf("Test #%d (%s) wrong error type - got `%T` (%v), got `%T`",
+				i, test.name, err, err, test.err)
 			continue
 		}
 

--- a/dcrjson/cmdparse_test.go
+++ b/dcrjson/cmdparse_test.go
@@ -388,8 +388,8 @@ func TestNewCmdErrors(t *testing.T) {
 	for i, test := range tests {
 		_, err := dcrjson.NewCmd(test.method, test.args...)
 		if reflect.TypeOf(err) != reflect.TypeOf(test.err) {
-			t.Errorf("Test #%d (%s) wrong error - got %T (%[2]v), "+
-				"want %T", i, test.name, err, test.err)
+			t.Errorf("Test #%d (%s) wrong error type - got `%T` (%v), want `%T`",
+				i, test.name, err, err, test.err)
 			continue
 		}
 		gotErrorCode := err.(dcrjson.Error).Code
@@ -436,8 +436,8 @@ func TestMarshalCmdErrors(t *testing.T) {
 	for i, test := range tests {
 		_, err := dcrjson.MarshalCmd(test.id, test.cmd)
 		if reflect.TypeOf(err) != reflect.TypeOf(test.err) {
-			t.Errorf("Test #%d (%s) wrong error - got %T (%[2]v), "+
-				"want %T", i, test.name, err, test.err)
+			t.Errorf("Test #%d (%s) wrong error type - got `%T` (%v), want `%T`",
+				i, test.name, err, err, test.err)
 			continue
 		}
 		gotErrorCode := err.(dcrjson.Error).Code
@@ -505,8 +505,8 @@ func TestUnmarshalCmdErrors(t *testing.T) {
 	for i, test := range tests {
 		_, err := dcrjson.UnmarshalCmd(&test.request)
 		if reflect.TypeOf(err) != reflect.TypeOf(test.err) {
-			t.Errorf("Test #%d (%s) wrong error - got %T (%[2]v), "+
-				"want %T", i, test.name, err, test.err)
+			t.Errorf("Test #%d (%s) wrong error type - got `%T` (%v), want `%T`",
+				i, test.name, err, err, test.err)
 			continue
 		}
 		gotErrorCode := err.(dcrjson.Error).Code

--- a/dcrjson/help_test.go
+++ b/dcrjson/help_test.go
@@ -700,8 +700,8 @@ func TestGenerateHelpErrors(t *testing.T) {
 		_, err := dcrjson.GenerateHelp(test.method, nil,
 			test.resultTypes...)
 		if reflect.TypeOf(err) != reflect.TypeOf(test.err) {
-			t.Errorf("Test #%d (%s) wrong error - got %T (%[2]v), "+
-				"want %T", i, test.name, err, test.err)
+			t.Errorf("Test #%d (%s) wrong error type - got `%T` (%v), want `%T`",
+				i, test.name, err, err, test.err)
 			continue
 		}
 		gotErrorCode := err.(dcrjson.Error).Code


### PR DESCRIPTION
Go 1.8 is out and by policy we only support the latest two Go releases.