### PR TITLE
Tupleize version:bits

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -209,16 +209,16 @@ func ticketsRevokedInBlock(bl *dcrutil.Block) []chainhash.Hash {
 }
 
 // voteBitsInBlock returns a list of vote bits for the voters in this block.
-func voteBitsInBlock(bl *dcrutil.Block) []voteVersionTuple {
-	var voteBits []voteVersionTuple
+func voteBitsInBlock(bl *dcrutil.Block) []VoteVersionTuple {
+	var voteBits []VoteVersionTuple
 	for _, stx := range bl.MsgBlock().STransactions {
 		if is, _ := stake.IsSSGen(stx); !is {
 			continue
 		}
 
-		voteBits = append(voteBits, voteVersionTuple{
-			version: stake.SSGenVersion(stx),
-			bits:    stake.SSGenVoteBits(stx),
+		voteBits = append(voteBits, VoteVersionTuple{
+			Version: stake.SSGenVersion(stx),
+			Bits:    stake.SSGenVoteBits(stx),
 		})
 	}
 

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -51,11 +51,11 @@ const (
 	maxSearchDepth = 2880
 )
 
-// voteVersionTuple contains the extracted vote bits and version from votes
+// VoteVersionTuple contains the extracted vote bits and version from votes
 // (SSGen).
-type voteVersionTuple struct {
-	version uint32
-	bits    uint16
+type VoteVersionTuple struct {
+	Version uint32
+	Bits    uint16
 }
 
 // blockNode represents a block within the block chain and is primarily used to
@@ -101,14 +101,14 @@ type blockNode struct {
 	ticketsRevoked []chainhash.Hash
 
 	// Keep track of all vote version and bits in this block.
-	votes []voteVersionTuple
+	votes []VoteVersionTuple
 }
 
 // newBlockNode returns a new block node for the given block header.  It is
 // completely disconnected from the chain and the workSum value is just the work
 // for the passed block.  The work sum is updated accordingly when the node is
 // inserted into a chain.
-func newBlockNode(blockHeader *wire.BlockHeader, blockHash *chainhash.Hash, height int64, ticketsSpent []chainhash.Hash, ticketsRevoked []chainhash.Hash, votes []voteVersionTuple) *blockNode {
+func newBlockNode(blockHeader *wire.BlockHeader, blockHash *chainhash.Hash, height int64, ticketsSpent []chainhash.Hash, ticketsRevoked []chainhash.Hash, votes []VoteVersionTuple) *blockNode {
 	// Make a copy of the hash so the node doesn't keep a reference to part
 	// of the full block/block header preventing it from being garbage
 	// collected.
@@ -277,11 +277,11 @@ type BlockChain struct {
 // StakeVersions is a condensed form of a dcrutil.Block that is used to prevent
 // using gigabytes of memory.
 type StakeVersions struct {
-	Hash          chainhash.Hash
-	Height        int64
-	BlockVersion  int32
-	StakeVersion  uint32
-	StakeVersions []uint32
+	Hash         chainhash.Hash
+	Height       int64
+	BlockVersion int32
+	StakeVersion uint32
+	Votes        []VoteVersionTuple
 }
 
 // GetStakeVersions returns a cooked array of StakeVersions.  We do this in
@@ -303,12 +303,7 @@ func (b *BlockChain) GetStakeVersions(hash *chainhash.Hash, count int32) ([]Stak
 			Height:       prevNode.height,
 			BlockVersion: prevNode.header.Version,
 			StakeVersion: prevNode.header.StakeVersion,
-			StakeVersions: make([]uint32, 0,
-				len(prevNode.votes)),
-		}
-
-		for _, v := range prevNode.votes {
-			sv.StakeVersions = append(sv.StakeVersions, v.version)
+			Votes:        prevNode.votes,
 		}
 
 		result = append(result, sv)

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1322,7 +1322,7 @@ func (b *BlockChain) createChainState() error {
 	genesisBlock := dcrutil.NewBlock(b.chainParams.GenesisBlock)
 	header := &genesisBlock.MsgBlock().Header
 	node := newBlockNode(header, genesisBlock.Hash(), 0, []chainhash.Hash{},
-		[]chainhash.Hash{}, []voteVersionTuple{})
+		[]chainhash.Hash{}, []VoteVersionTuple{})
 	node.inMainChain = true
 	b.bestNode = node
 

--- a/blockchain/internal_test.go
+++ b/blockchain/internal_test.go
@@ -49,6 +49,6 @@ func (b *BlockChain) TstCheckBlockHeaderContext(header *wire.BlockHeader, prevNo
 
 // TstNewBlockNode makes the internal newBlockNode function available to the
 // test package.
-func TstNewBlockNode(blockHeader *wire.BlockHeader, blockHash *chainhash.Hash, height int64, ticketsSpent []chainhash.Hash, ticketsRevoked []chainhash.Hash, voteBits []voteVersionTuple) *blockNode {
+func TstNewBlockNode(blockHeader *wire.BlockHeader, blockHash *chainhash.Hash, height int64, ticketsSpent []chainhash.Hash, ticketsRevoked []chainhash.Hash, voteBits []VoteVersionTuple) *blockNode {
 	return newBlockNode(blockHeader, blockHash, height, ticketsSpent, ticketsRevoked, voteBits)
 }

--- a/blockchain/stakeversion.go
+++ b/blockchain/stakeversion.go
@@ -100,7 +100,7 @@ func (b *BlockChain) isVoterMajorityVersion(minVer uint32, prevNode *blockNode) 
 	for i := int64(0); i < b.chainParams.StakeVersionInterval && iterNode != nil; i++ {
 		totalVotesFound += int32(len(iterNode.votes))
 		for _, v := range iterNode.votes {
-			if v.version >= minVer {
+			if v.Version >= minVer {
 				versionCount += 1
 			}
 		}
@@ -225,7 +225,7 @@ func (b *BlockChain) calcVoterVersionInterval(prevNode *blockNode) (uint32, erro
 	for i := int64(0); i < b.chainParams.StakeVersionInterval && iterNode != nil; i++ {
 		totalVotesFound += int32(len(iterNode.votes))
 		for _, v := range iterNode.votes {
-			versions[v.version]++
+			versions[v.Version]++
 		}
 
 		iterNode, err = b.getPrevNodeFromNode(iterNode)

--- a/blockchain/stakeversion_test.go
+++ b/blockchain/stakeversion_test.go
@@ -110,7 +110,7 @@ func newFakeNode(blockVersion int32, height int64, currentNode *blockNode) *bloc
 		Nonce:   0,
 	}
 	node := newBlockNode(header, &chainhash.Hash{}, 0, []chainhash.Hash{},
-		[]chainhash.Hash{}, []voteVersionTuple{})
+		[]chainhash.Hash{}, []VoteVersionTuple{})
 	node.height = height
 	node.parent = currentNode
 
@@ -151,7 +151,7 @@ func TestCalcStakeVersionCorners(t *testing.T) {
 		// Set stake versions.
 		for x := uint16(0); x < params.TicketsPerBlock; x++ {
 			node.votes = append(node.votes,
-				voteVersionTuple{version: 2})
+				VoteVersionTuple{Version: 2})
 		}
 
 		sv, err := bc.calcStakeVersionByNode(currentNode)
@@ -184,7 +184,7 @@ func TestCalcStakeVersionCorners(t *testing.T) {
 		// Set stake versions.
 		for x := uint16(0); x < params.TicketsPerBlock; x++ {
 			node.votes = append(node.votes,
-				voteVersionTuple{version: 4})
+				VoteVersionTuple{Version: 4})
 		}
 
 		sv, err := bc.calcStakeVersionByNode(currentNode)
@@ -219,7 +219,7 @@ func TestCalcStakeVersionCorners(t *testing.T) {
 		// Set stake versions.
 		for x := uint16(0); x < params.TicketsPerBlock; x++ {
 			node.votes = append(node.votes,
-				voteVersionTuple{version: 2})
+				VoteVersionTuple{Version: 2})
 		}
 
 		sv, err := bc.calcStakeVersionByNode(currentNode)
@@ -255,7 +255,7 @@ func TestCalcStakeVersionCorners(t *testing.T) {
 		// Set stake versions.
 		for x := uint16(0); x < params.TicketsPerBlock; x++ {
 			node.votes = append(node.votes,
-				voteVersionTuple{version: 5})
+				VoteVersionTuple{Version: 5})
 		}
 
 		sv, err := bc.calcStakeVersionByNode(currentNode)
@@ -294,7 +294,7 @@ func TestCalcStakeVersionCorners(t *testing.T) {
 		// Set stake versions.
 		for x := uint16(0); x < params.TicketsPerBlock; x++ {
 			node.votes = append(node.votes,
-				voteVersionTuple{version: 4})
+				VoteVersionTuple{Version: 4})
 		}
 
 		sv, err := bc.calcStakeVersionByNode(currentNode)
@@ -333,7 +333,7 @@ func TestCalcStakeVersionCorners(t *testing.T) {
 		// Set stake versions.
 		for x := uint16(0); x < params.TicketsPerBlock; x++ {
 			node.votes = append(node.votes,
-				voteVersionTuple{version: 4})
+				VoteVersionTuple{Version: 4})
 		}
 
 		sv, err := bc.calcStakeVersionByNode(currentNode)
@@ -383,7 +383,7 @@ func TestCalcStakeVersionByNode(t *testing.T) {
 					// set voter versions
 					for x := 0; x < int(params.TicketsPerBlock); x++ {
 						b.votes = append(b.votes,
-							voteVersionTuple{version: 3})
+							VoteVersionTuple{Version: 3})
 					}
 
 					// set header stake version
@@ -402,7 +402,7 @@ func TestCalcStakeVersionByNode(t *testing.T) {
 					// set voter versions
 					for x := 0; x < int(params.TicketsPerBlock); x++ {
 						b.votes = append(b.votes,
-							voteVersionTuple{version: 2})
+							VoteVersionTuple{Version: 2})
 					}
 
 					// set header stake version
@@ -430,7 +430,7 @@ func TestCalcStakeVersionByNode(t *testing.T) {
 			}
 			node := newBlockNode(header, &chainhash.Hash{}, 0,
 				[]chainhash.Hash{}, []chainhash.Hash{},
-				[]voteVersionTuple{})
+				[]VoteVersionTuple{})
 			node.height = i
 			node.parent = currentNode
 
@@ -505,7 +505,7 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 				if int64(b.header.Height) > params.StakeValidationHeight {
 					for x := 0; x < int(params.TicketsPerBlock); x++ {
 						b.votes = append(b.votes,
-							voteVersionTuple{version: 2})
+							VoteVersionTuple{Version: 2})
 					}
 				}
 			},
@@ -525,7 +525,7 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 				if int64(b.header.Height) < params.StakeValidationHeight+params.StakeVersionInterval {
 					for x := 0; x < int(params.TicketsPerBlock); x++ {
 						b.votes = append(b.votes,
-							voteVersionTuple{version: 1})
+							VoteVersionTuple{Version: 1})
 					}
 					return
 				}
@@ -538,7 +538,7 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 						v = 2
 					}
 					b.votes = append(b.votes,
-						voteVersionTuple{version: v})
+						VoteVersionTuple{Version: v})
 					ticketCount++
 				}
 			},
@@ -558,7 +558,7 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 				if int64(b.header.Height) < params.StakeValidationHeight+params.StakeVersionInterval {
 					for x := 0; x < int(params.TicketsPerBlock); x++ {
 						b.votes = append(b.votes,
-							voteVersionTuple{version: 1})
+							VoteVersionTuple{Version: 1})
 					}
 					return
 				}
@@ -571,7 +571,7 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 						v = 2
 					}
 					b.votes = append(b.votes,
-						voteVersionTuple{version: v})
+						VoteVersionTuple{Version: v})
 					ticketCount++
 				}
 			},
@@ -591,7 +591,7 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 				if int64(b.header.Height) < params.StakeValidationHeight+params.StakeVersionInterval {
 					for x := 0; x < int(params.TicketsPerBlock); x++ {
 						b.votes = append(b.votes,
-							voteVersionTuple{version: 1})
+							VoteVersionTuple{Version: 1})
 					}
 					return
 				}
@@ -604,7 +604,7 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 						v = 2
 					}
 					b.votes = append(b.votes,
-						voteVersionTuple{version: v})
+						VoteVersionTuple{Version: v})
 					ticketCount++
 				}
 			},
@@ -624,14 +624,14 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 				if int64(b.header.Height) < params.StakeValidationHeight+params.StakeVersionInterval {
 					for x := 0; x < int(params.TicketsPerBlock); x++ {
 						b.votes = append(b.votes,
-							voteVersionTuple{version: 1})
+							VoteVersionTuple{Version: 1})
 					}
 					return
 				}
 
 				for x := 0; x < int(params.TicketsPerBlock); x++ {
 					b.votes = append(b.votes,
-						voteVersionTuple{version: uint32(x) % 5})
+						VoteVersionTuple{Version: uint32(x) % 5})
 				}
 			},
 			startStakeVersion:    1,
@@ -649,7 +649,7 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 
 				for x := 0; x < int(params.TicketsPerBlock); x++ {
 					b.votes = append(b.votes,
-						voteVersionTuple{version: uint32(x) % 5})
+						VoteVersionTuple{Version: uint32(x) % 5})
 				}
 			},
 			startStakeVersion:    1,
@@ -668,7 +668,7 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 				if int64(b.header.Height) < params.StakeValidationHeight+params.StakeVersionInterval {
 					for x := 0; x < int(params.TicketsPerBlock-2); x++ {
 						b.votes = append(b.votes,
-							voteVersionTuple{version: 1})
+							VoteVersionTuple{Version: 1})
 					}
 					return
 				}
@@ -681,7 +681,7 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 						v = 2
 					}
 					b.votes = append(b.votes,
-						voteVersionTuple{version: v})
+						VoteVersionTuple{Version: v})
 					ticketCount++
 				}
 			},
@@ -701,7 +701,7 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 				if int64(b.header.Height) < params.StakeValidationHeight+params.StakeVersionInterval {
 					for x := 0; x < int(params.TicketsPerBlock-2); x++ {
 						b.votes = append(b.votes,
-							voteVersionTuple{version: 1})
+							VoteVersionTuple{Version: 1})
 					}
 					return
 				}
@@ -714,7 +714,7 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 						v = 2
 					}
 					b.votes = append(b.votes,
-						voteVersionTuple{version: v})
+						VoteVersionTuple{Version: v})
 					ticketCount++
 				}
 			},
@@ -734,7 +734,7 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 				if int64(b.header.Height) < params.StakeValidationHeight+params.StakeVersionInterval {
 					for x := 0; x < int(params.TicketsPerBlock-2); x++ {
 						b.votes = append(b.votes,
-							voteVersionTuple{version: 1})
+							VoteVersionTuple{Version: 1})
 					}
 					return
 				}
@@ -747,7 +747,7 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 						v = 2
 					}
 					b.votes = append(b.votes,
-						voteVersionTuple{version: v})
+						VoteVersionTuple{Version: v})
 					ticketCount++
 				}
 			},
@@ -768,7 +768,7 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 				if int64(b.header.Height) < params.StakeValidationHeight+params.StakeVersionInterval {
 					for x := 0; x < int(params.TicketsPerBlock-2); x++ {
 						b.votes = append(b.votes,
-							voteVersionTuple{version: 1})
+							VoteVersionTuple{Version: 1})
 					}
 					return
 				}
@@ -781,7 +781,7 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 						v = 2
 					}
 					b.votes = append(b.votes,
-						voteVersionTuple{version: v})
+						VoteVersionTuple{Version: v})
 					ticketCount++
 				}
 			},
@@ -815,7 +815,7 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 			}
 			node := newBlockNode(header, &chainhash.Hash{}, 0,
 				[]chainhash.Hash{}, []chainhash.Hash{},
-				[]voteVersionTuple{})
+				[]VoteVersionTuple{})
 			node.height = i
 			node.parent = currentNode
 
@@ -825,7 +825,7 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 			} else {
 				for x := 0; x < int(params.TicketsPerBlock); x++ {
 					node.votes = append(node.votes,
-						voteVersionTuple{version: test.startStakeVersion})
+						VoteVersionTuple{Version: test.startStakeVersion})
 				}
 			}
 

--- a/blockchain/thresholdstate.go
+++ b/blockchain/thresholdstate.go
@@ -535,14 +535,14 @@ func (b *BlockChain) getVoteCounts(node *blockNode, version uint32, d chaincfg.C
 	for countNode.height > height {
 		for _, vote := range countNode.votes {
 			// Wrong versions do not count.
-			if vote.version != version {
+			if vote.Version != version {
 				continue
 			}
 
 			// Increase total votes.
 			result.Total++
 
-			index := d.Vote.VoteIndex(vote.bits)
+			index := d.Vote.VoteIndex(vote.Bits)
 			if index == -1 {
 				result.TotalIgnore++
 				continue
@@ -602,7 +602,7 @@ func (b *BlockChain) CountVoteVersion(version uint32) (uint32, error) {
 	for countNode.height > height {
 		for _, vote := range countNode.votes {
 			// Wrong versions do not count.
-			if vote.version != version {
+			if vote.Version != version {
 				continue
 			}
 

--- a/blockchain/votebits.go
+++ b/blockchain/votebits.go
@@ -116,12 +116,12 @@ func (c deploymentChecker) Condition(node *blockNode, version uint32) ([]thresho
 	}
 
 	for _, vote := range node.votes {
-		if version != vote.version {
+		if version != vote.Version {
 			// Wrong version, ignore.
 			continue
 		}
 
-		tally[c.deployment.Vote.Mask&vote.bits>>shift].count += 1
+		tally[c.deployment.Vote.Mask&vote.Bits>>shift].count += 1
 	}
 
 	return tally, nil

--- a/blockchain/votebits_test.go
+++ b/blockchain/votebits_test.go
@@ -134,7 +134,7 @@ func TestNoQuorum(t *testing.T) {
 		hash := header.BlockHash()
 		node := newBlockNode(header, &hash, 0,
 			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]voteVersionTuple{})
+			[]VoteVersionTuple{})
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
@@ -173,15 +173,15 @@ func TestNoQuorum(t *testing.T) {
 		hash := header.BlockHash()
 		node := newBlockNode(header, &hash, 0,
 			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]voteVersionTuple{})
+			[]VoteVersionTuple{})
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
 		// set stake versions and vote bits
 		for x := 0; x < int(params.TicketsPerBlock); x++ {
-			node.votes = append(node.votes, voteVersionTuple{
-				version: posVersion,
-				bits:    0x01})
+			node.votes = append(node.votes, VoteVersionTuple{
+				Version: posVersion,
+				Bits:    0x01})
 		}
 
 		currentNode = node
@@ -221,18 +221,18 @@ func TestNoQuorum(t *testing.T) {
 		hash := header.BlockHash()
 		node := newBlockNode(header, &hash, 0,
 			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]voteVersionTuple{})
+			[]VoteVersionTuple{})
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
 		// set stake versions and vote bits
 		for x := 0; x < int(params.TicketsPerBlock); x++ {
-			v := voteVersionTuple{
-				version: posVersion,
-				bits:    0x01,
+			v := VoteVersionTuple{
+				Version: posVersion,
+				Bits:    0x01,
 			}
 			if voteCount < params.RuleChangeActivationQuorum-1 {
-				v.bits = 0x05 // vote no
+				v.Bits = 0x05 // vote no
 			}
 			node.votes = append(node.votes, v)
 			voteCount++
@@ -275,27 +275,27 @@ func TestNoQuorum(t *testing.T) {
 		hash := header.BlockHash()
 		node := newBlockNode(header, &hash, 0,
 			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]voteVersionTuple{})
+			[]VoteVersionTuple{})
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
 		// set stake versions and vote bits
 		for x := 0; x < int(params.TicketsPerBlock); x++ {
-			v := voteVersionTuple{
-				version: posVersion,
-				bits:    0x01,
+			v := VoteVersionTuple{
+				Version: posVersion,
+				Bits:    0x01,
 			}
 			// 119 yes, 41 no -> 120 == 75% and 120 reaches quorum
 			quorum := params.RuleChangeActivationQuorum*
 				params.RuleChangeActivationMultiplier/
 				params.RuleChangeActivationDivisor - 1
 			if voteCount < quorum {
-				v.bits = 0x05 // vote no
+				v.Bits = 0x05 // vote no
 			} else {
 				if voteCount < params.RuleChangeActivationQuorum {
-					v.bits = 0x03 // vote yes
+					v.Bits = 0x03 // vote yes
 				} else {
-					v.bits = 0x01 // ignore
+					v.Bits = 0x01 // ignore
 				}
 			}
 			node.votes = append(node.votes, v)
@@ -339,27 +339,27 @@ func TestNoQuorum(t *testing.T) {
 		hash := header.BlockHash()
 		node := newBlockNode(header, &hash, 0,
 			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]voteVersionTuple{})
+			[]VoteVersionTuple{})
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
 		// set stake versions and vote bits
 		for x := 0; x < int(params.TicketsPerBlock); x++ {
-			v := voteVersionTuple{
-				version: posVersion,
-				bits:    0x01,
+			v := VoteVersionTuple{
+				Version: posVersion,
+				Bits:    0x01,
 			}
 			// 120 yes, 40 no -> 120 == 75% and 120 reaches quorum
 			quorum := params.RuleChangeActivationQuorum *
 				params.RuleChangeActivationMultiplier /
 				params.RuleChangeActivationDivisor
 			if voteCount < quorum {
-				v.bits = 0x05 // vote no
+				v.Bits = 0x05 // vote no
 			} else {
 				if voteCount < params.RuleChangeActivationQuorum {
-					v.bits = 0x03 // vote yes
+					v.Bits = 0x03 // vote yes
 				} else {
-					v.bits = 0x01 // ignore
+					v.Bits = 0x01 // ignore
 				}
 			}
 			node.votes = append(node.votes, v)
@@ -418,7 +418,7 @@ func TestYesQuorum(t *testing.T) {
 		hash := header.BlockHash()
 		node := newBlockNode(header, &hash, 0,
 			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]voteVersionTuple{})
+			[]VoteVersionTuple{})
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
@@ -457,15 +457,15 @@ func TestYesQuorum(t *testing.T) {
 		hash := header.BlockHash()
 		node := newBlockNode(header, &hash, 0,
 			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]voteVersionTuple{})
+			[]VoteVersionTuple{})
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
 		// set stake versions and vote bits
 		for x := 0; x < int(params.TicketsPerBlock); x++ {
-			node.votes = append(node.votes, voteVersionTuple{
-				version: posVersion,
-				bits:    0x01})
+			node.votes = append(node.votes, VoteVersionTuple{
+				Version: posVersion,
+				Bits:    0x01})
 		}
 
 		currentNode = node
@@ -505,18 +505,18 @@ func TestYesQuorum(t *testing.T) {
 		hash := header.BlockHash()
 		node := newBlockNode(header, &hash, 0,
 			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]voteVersionTuple{})
+			[]VoteVersionTuple{})
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
 		// set stake versions and vote bits
 		for x := 0; x < int(params.TicketsPerBlock); x++ {
-			v := voteVersionTuple{
-				version: posVersion,
-				bits:    0x01,
+			v := VoteVersionTuple{
+				Version: posVersion,
+				Bits:    0x01,
 			}
 			if voteCount < params.RuleChangeActivationQuorum-1 {
-				v.bits = 0x03 // vote yes
+				v.Bits = 0x03 // vote yes
 			}
 			node.votes = append(node.votes, v)
 			voteCount++
@@ -559,27 +559,27 @@ func TestYesQuorum(t *testing.T) {
 		hash := header.BlockHash()
 		node := newBlockNode(header, &hash, 0,
 			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]voteVersionTuple{})
+			[]VoteVersionTuple{})
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
 		// set stake versions and vote bits
 		for x := 0; x < int(params.TicketsPerBlock); x++ {
-			v := voteVersionTuple{
-				version: posVersion,
-				bits:    0x01,
+			v := VoteVersionTuple{
+				Version: posVersion,
+				Bits:    0x01,
 			}
 			// 119 yes, 41 no -> 120 == 75% and 120 reaches quorum
 			quorum := params.RuleChangeActivationQuorum*
 				params.RuleChangeActivationMultiplier/
 				params.RuleChangeActivationDivisor - 1
 			if voteCount < quorum {
-				v.bits = 0x03 // vote yes
+				v.Bits = 0x03 // vote yes
 			} else {
 				if voteCount < params.RuleChangeActivationQuorum {
-					v.bits = 0x05 // vote no
+					v.Bits = 0x05 // vote no
 				} else {
-					v.bits = 0x01 // ignore
+					v.Bits = 0x01 // ignore
 				}
 			}
 			node.votes = append(node.votes, v)
@@ -623,27 +623,27 @@ func TestYesQuorum(t *testing.T) {
 		hash := header.BlockHash()
 		node := newBlockNode(header, &hash, 0,
 			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]voteVersionTuple{})
+			[]VoteVersionTuple{})
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
 		// set stake versions and vote bits
 		for x := 0; x < int(params.TicketsPerBlock); x++ {
-			v := voteVersionTuple{
-				version: posVersion,
-				bits:    0x01,
+			v := VoteVersionTuple{
+				Version: posVersion,
+				Bits:    0x01,
 			}
 			// 120 yes, 40 no -> 120 == 75% and 120 reaches quorum
 			quorum := params.RuleChangeActivationQuorum *
 				params.RuleChangeActivationMultiplier /
 				params.RuleChangeActivationDivisor
 			if voteCount < quorum {
-				v.bits = 0x03 // vote yes
+				v.Bits = 0x03 // vote yes
 			} else {
 				if voteCount < params.RuleChangeActivationQuorum {
-					v.bits = 0x05 // vote no
+					v.Bits = 0x05 // vote no
 				} else {
-					v.bits = 0x01 // ignore
+					v.Bits = 0x01 // ignore
 				}
 			}
 			node.votes = append(node.votes, v)
@@ -678,7 +678,7 @@ func TestVoting(t *testing.T) {
 	params := defaultParams()
 
 	type voteCount struct {
-		vote  voteVersionTuple
+		vote  VoteVersionTuple
 		count uint32
 	}
 
@@ -697,9 +697,9 @@ func TestVoting(t *testing.T) {
 			startStakeVersion: posVersion,
 			voteBitsCounts: []voteCount{
 				{
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x01},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x01},
 					count: uint32(params.StakeValidationHeight) - 1,
 				},
 			},
@@ -717,21 +717,21 @@ func TestVoting(t *testing.T) {
 			startStakeVersion: posVersion - 1,
 			voteBitsCounts: []voteCount{
 				{
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x01},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x01},
 					count: uint32(params.StakeValidationHeight),
 				},
 				{
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x01},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x01},
 					count: params.RuleChangeActivationInterval - 1,
 				},
 				{
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x03},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x03},
 					count: params.RuleChangeActivationInterval,
 				},
 			},
@@ -757,27 +757,27 @@ func TestVoting(t *testing.T) {
 			startStakeVersion: posVersion + 1,
 			voteBitsCounts: []voteCount{
 				{
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x01},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x01},
 					count: uint32(params.StakeValidationHeight),
 				},
 				{
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x01},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x01},
 					count: params.RuleChangeActivationInterval - 1,
 				},
 				{
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x03},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x03},
 					count: params.RuleChangeActivationInterval,
 				},
 				{
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x03},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x03},
 					count: params.RuleChangeActivationInterval,
 				},
 			},
@@ -807,21 +807,21 @@ func TestVoting(t *testing.T) {
 			startStakeVersion: posVersion,
 			voteBitsCounts: []voteCount{
 				{
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x01},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x01},
 					count: uint32(params.StakeValidationHeight),
 				},
 				{
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x01},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x01},
 					count: params.RuleChangeActivationInterval - 1,
 				},
 				{
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x03},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x03},
 					count: params.RuleChangeActivationInterval,
 				},
 			},
@@ -847,27 +847,27 @@ func TestVoting(t *testing.T) {
 			startStakeVersion: posVersion,
 			voteBitsCounts: []voteCount{
 				{
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x01},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x01},
 					count: uint32(params.StakeValidationHeight),
 				},
 				{
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x01},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x01},
 					count: params.RuleChangeActivationInterval - 1,
 				},
 				{
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x03},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x03},
 					count: params.RuleChangeActivationInterval,
 				},
 				{
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x03},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x03},
 					count: params.RuleChangeActivationInterval,
 				},
 			},
@@ -897,40 +897,40 @@ func TestVoting(t *testing.T) {
 			startStakeVersion: posVersion,
 			voteBitsCounts: []voteCount{
 				{
-					vote: voteVersionTuple{
-						version: posVersion + 1,
-						bits:    0x01},
+					vote: VoteVersionTuple{
+						Version: posVersion + 1,
+						Bits:    0x01},
 					count: uint32(params.StakeValidationHeight),
 				},
 				{
-					vote: voteVersionTuple{
-						version: posVersion + 1,
-						bits:    0x01},
+					vote: VoteVersionTuple{
+						Version: posVersion + 1,
+						Bits:    0x01},
 					count: params.RuleChangeActivationInterval - 1,
 				}, {
-					vote: voteVersionTuple{
-						version: posVersion + 1,
-						bits:    0x03},
+					vote: VoteVersionTuple{
+						Version: posVersion + 1,
+						Bits:    0x03},
 					count: params.RuleChangeActivationInterval,
 				}, {
-					vote: voteVersionTuple{
-						version: posVersion + 1,
-						bits:    0x03},
+					vote: VoteVersionTuple{
+						Version: posVersion + 1,
+						Bits:    0x03},
 					count: params.RuleChangeActivationInterval,
 				}, {
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x03},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x03},
 					count: params.RuleChangeActivationInterval,
 				}, {
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x03},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x03},
 					count: params.RuleChangeActivationInterval,
 				}, {
-					vote: voteVersionTuple{
-						version: posVersion + 1,
-						bits:    0x01},
+					vote: VoteVersionTuple{
+						Version: posVersion + 1,
+						Bits:    0x01},
 					count: params.RuleChangeActivationInterval,
 				},
 			},
@@ -972,30 +972,30 @@ func TestVoting(t *testing.T) {
 			startStakeVersion: posVersion,
 			voteBitsCounts: []voteCount{
 				{
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x01},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x01},
 					count: uint32(params.StakeValidationHeight),
 				},
 				{
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x01},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x01},
 					count: params.RuleChangeActivationInterval - 1,
 				}, {
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x03},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x03},
 					count: params.RuleChangeActivationInterval,
 				}, {
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x03},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x03},
 					count: params.RuleChangeActivationInterval,
 				}, {
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x01},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x01},
 					count: params.RuleChangeActivationInterval,
 				},
 			},
@@ -1029,30 +1029,30 @@ func TestVoting(t *testing.T) {
 			startStakeVersion: posVersion,
 			voteBitsCounts: []voteCount{
 				{
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x01},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x01},
 					count: uint32(params.StakeValidationHeight),
 				},
 				{
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x01},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x01},
 					count: params.RuleChangeActivationInterval - 1,
 				}, {
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x05},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x05},
 					count: params.RuleChangeActivationInterval,
 				}, {
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x05},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x05},
 					count: params.RuleChangeActivationInterval,
 				}, {
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x01},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x01},
 					count: params.RuleChangeActivationInterval,
 				},
 			},
@@ -1086,30 +1086,30 @@ func TestVoting(t *testing.T) {
 			startStakeVersion: posVersion,
 			voteBitsCounts: []voteCount{
 				{
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x01},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x01},
 					count: uint32(params.StakeValidationHeight),
 				},
 				{
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x01},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x01},
 					count: params.RuleChangeActivationInterval - 1,
 				}, {
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x01},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x01},
 					count: params.RuleChangeActivationInterval,
 				}, {
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x01},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x01},
 					count: params.RuleChangeActivationInterval,
 				}, {
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x01},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x01},
 					count: params.RuleChangeActivationInterval,
 				},
 			},
@@ -1178,7 +1178,7 @@ func TestVoting(t *testing.T) {
 				hash := header.BlockHash()
 				node := newBlockNode(header, &hash, 0,
 					[]chainhash.Hash{}, []chainhash.Hash{},
-					[]voteVersionTuple{})
+					[]VoteVersionTuple{})
 				node.height = int64(currentHeight)
 				node.parent = currentNode
 
@@ -1304,7 +1304,7 @@ func TestVotingParallel(t *testing.T) {
 	params := defaultParallelParams()
 
 	type voteCount struct {
-		vote  voteVersionTuple
+		vote  VoteVersionTuple
 		count uint32
 	}
 
@@ -1323,35 +1323,35 @@ func TestVotingParallel(t *testing.T) {
 			startStakeVersion: posVersion,
 			voteBitsCounts: []voteCount{
 				{
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x01},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x01},
 					count: uint32(params.StakeValidationHeight),
 				},
 				{
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x01},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x01},
 					count: params.RuleChangeActivationInterval - 1,
 				}, {
-					vote: voteVersionTuple{
-						version: posVersion - 1,
-						bits:    vbTestDummy1Yes | vbTestDummy2No},
+					vote: VoteVersionTuple{
+						Version: posVersion - 1,
+						Bits:    vbTestDummy1Yes | vbTestDummy2No},
 					count: params.RuleChangeActivationInterval,
 				}, {
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    vbTestDummy1Yes | vbTestDummy2No},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    vbTestDummy1Yes | vbTestDummy2No},
 					count: params.RuleChangeActivationInterval,
 				}, {
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x01},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x01},
 					count: params.RuleChangeActivationInterval,
 				}, {
-					vote: voteVersionTuple{
-						version: posVersion,
-						bits:    0x01},
+					vote: VoteVersionTuple{
+						Version: posVersion,
+						Bits:    0x01},
 					count: params.RuleChangeActivationInterval,
 				},
 			},
@@ -1445,7 +1445,7 @@ func TestVotingParallel(t *testing.T) {
 				hash := header.BlockHash()
 				node := newBlockNode(header, &hash, 0,
 					[]chainhash.Hash{}, []chainhash.Hash{},
-					[]voteVersionTuple{})
+					[]VoteVersionTuple{})
 				node.height = int64(currentHeight)
 				node.parent = currentNode
 

--- a/dcrjson/dcrdresults.go
+++ b/dcrjson/dcrdresults.go
@@ -34,13 +34,19 @@ type GetStakeVersionInfoResult struct {
 	Intervals     []VersionInterval `json:"intervals"`
 }
 
+// VersionBits models a generic version:bits tuple.
+type VersionBits struct {
+	Version uint32 `json:"version"`
+	Bits    uint16 `json:"bits"`
+}
+
 // StakeVersions models the data for GetStakeVersionsResult.
 type StakeVersions struct {
-	Hash          string   `json:"hash"`
-	Height        int64    `json:"height"`
-	BlockVersion  int32    `json:"blockversion"`
-	StakeVersion  uint32   `json:"stakeversion"`
-	VoterVersions []uint32 `json:"voterversions"`
+	Hash         string        `json:"hash"`
+	Height       int64         `json:"height"`
+	BlockVersion int32         `json:"blockversion"`
+	StakeVersion uint32        `json:"stakeversion"`
+	Votes        []VersionBits `json:"votes"`
 }
 
 // GetStakeVersionsResult models the data returned from the getstakeversions

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3909,8 +3909,8 @@ func handleGetStakeVersionInfo(s *rpcServer, cmd interface{}, closeChan <-chan s
 		voteVersions := make(map[int]int)
 		for _, v := range sv {
 			posVersions[int(v.StakeVersion)]++
-			for _, version := range v.StakeVersions {
-				voteVersions[int(version)]++
+			for _, vote := range v.Votes {
+				voteVersions[int(vote.Version)]++
 			}
 		}
 		versionInterval := dcrjson.VersionInterval{
@@ -3959,14 +3959,17 @@ func handleGetStakeVersions(s *rpcServer, cmd interface{}, closeChan <-chan stru
 	}
 	for _, v := range sv {
 		nsv := dcrjson.StakeVersions{
-			Hash:          v.Hash.String(),
-			Height:        v.Height,
-			BlockVersion:  v.BlockVersion,
-			StakeVersion:  v.StakeVersion,
-			VoterVersions: make([]uint32, 0, len(v.StakeVersions)),
+			Hash:         v.Hash.String(),
+			Height:       v.Height,
+			BlockVersion: v.BlockVersion,
+			StakeVersion: v.StakeVersion,
+			Votes: make([]dcrjson.VersionBits, 0,
+				len(v.Votes)),
 		}
-		for _, version := range v.StakeVersions {
-			nsv.VoterVersions = append(nsv.VoterVersions, version)
+		for _, vote := range v.Votes {
+			nsv.Votes = append(nsv.Votes,
+				dcrjson.VersionBits{Version: vote.Version,
+					Bits: vote.Bits})
 		}
 
 		result.StakeVersions = append(result.StakeVersions, nsv)

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -430,7 +430,9 @@ var helpDescsEnUS = map[string]string{
 	"stakeversions-height":                 "Height of the block.",
 	"stakeversions-blockversion":           "The block version",
 	"stakeversions-stakeversion":           "The stake version of the block",
-	"stakeversions-voterversions":          "The version of each vote in the block",
+	"stakeversions-votes":                  "The version and bits of each vote in the block",
+	"versionbits-version":                  "The version of the vote.",
+	"versionbits-bits":                     "The bits assigned by the vote.",
 
 	// GetVoteInfo
 	"getvoteinfo--synopsis":           "Returns the vote info statistics.",


### PR DESCRIPTION
We still return only the voteversion information but we have voteversion:bits available.  So return that instead so that we can get all version/vote/bits raw data in addition to the cooked values we already have.

Fixes #585 
