### PR TITLE
TravisCI: Only run tests once.

### DIFF
--- a/goclean.sh
+++ b/goclean.sh
@@ -12,26 +12,3 @@ set -ex
 test -z "$(go fmt $(glide novendor) | tee /dev/stderr)"
 test -z "$(go vet $(glide novendor) 2>&1 | tee /dev/stderr)"
 env GORACE="halt_on_error=1" go test -short -race $(glide novendor)
-
-# Run test coverage on each subdirectories and merge the coverage profile.
-
-set +x
-echo "mode: count" > profile.cov
-
-# Standard go tooling behavior is to ignore dirs with leading underscores.
-for dir in $(find . -maxdepth 10 -not -path '.' -not -path './.git*' \
-    -not -path '*/_*' -not -path './cmd*' -not -path './release*' \
-    -not -path './vendor*' -type d)
-do
-if ls $dir/*.go &> /dev/null; then
-  go test -short -covermode=count -coverprofile=$dir/profile.tmp $dir
-  if [ -f $dir/profile.tmp ]; then
-    cat $dir/profile.tmp | tail -n +2 >> profile.cov
-    rm $dir/profile.tmp
-  fi
-fi
-done
-
-# To submit the test coverage result to coveralls.io,
-# use goveralls (https://github.com/mattn/goveralls)
-# goveralls -coverprofile=profile.cov -service=travis-ci


### PR DESCRIPTION
This modifies the `goclean.sh` script that is executed on Travis to only run the tests once.

While it is nice to see coverage reports in the log, unfortunately it appears that both the -race and -cover flags can't be used together, and the tests have grown in complexity such that they are starting to get close to TravisCI time limits.