### PR TITLE
blockchain: Make node creation in tests consistent.

### DIFF
--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1321,8 +1321,7 @@ func (b *BlockChain) createChainState() error {
 	// Create a new node from the genesis block and set it as the best node.
 	genesisBlock := dcrutil.NewBlock(b.chainParams.GenesisBlock)
 	header := &genesisBlock.MsgBlock().Header
-	node := newBlockNode(header, genesisBlock.Hash(), 0, []chainhash.Hash{},
-		[]chainhash.Hash{}, []VoteVersionTuple{})
+	node := newBlockNode(header, genesisBlock.Hash(), 0, nil, nil, nil)
 	node.inMainChain = true
 	b.bestNode = node
 

--- a/blockchain/stakeversion_test.go
+++ b/blockchain/stakeversion_test.go
@@ -124,8 +124,7 @@ func newFakeNode(blockVersion int32, height int64, currentNode *blockNode) *bloc
 		Nonce:   0,
 	}
 	hash := header.BlockHash()
-	node := newBlockNode(header, &hash, 0, []chainhash.Hash{},
-		[]chainhash.Hash{}, []VoteVersionTuple{})
+	node := newBlockNode(header, &hash, 0, nil, nil, nil)
 	node.height = height
 	node.parent = currentNode
 
@@ -440,9 +439,7 @@ func TestCalcStakeVersionByNode(t *testing.T) {
 				Nonce:   uint32(0),
 			}
 			hash := header.BlockHash()
-			node := newBlockNode(header, &hash, 0,
-				[]chainhash.Hash{}, []chainhash.Hash{},
-				[]VoteVersionTuple{})
+			node := newBlockNode(header, &hash, 0, nil, nil, nil)
 			node.height = i
 			node.parent = currentNode
 
@@ -826,9 +823,7 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 				StakeVersion: test.startStakeVersion,
 			}
 			hash := header.BlockHash()
-			node := newBlockNode(header, &hash, 0,
-				[]chainhash.Hash{}, []chainhash.Hash{},
-				[]VoteVersionTuple{})
+			node := newBlockNode(header, &hash, 0, nil, nil, nil)
 			node.height = i
 			node.parent = currentNode
 

--- a/blockchain/votebits_test.go
+++ b/blockchain/votebits_test.go
@@ -132,9 +132,7 @@ func TestNoQuorum(t *testing.T) {
 			Timestamp:    currentTimestamp,
 		}
 		hash := header.BlockHash()
-		node := newBlockNode(header, &hash, 0,
-			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]VoteVersionTuple{})
+		node := newBlockNode(header, &hash, 0, nil, nil, nil)
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
@@ -171,9 +169,7 @@ func TestNoQuorum(t *testing.T) {
 			Timestamp:    currentTimestamp,
 		}
 		hash := header.BlockHash()
-		node := newBlockNode(header, &hash, 0,
-			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]VoteVersionTuple{})
+		node := newBlockNode(header, &hash, 0, nil, nil, nil)
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
@@ -219,9 +215,7 @@ func TestNoQuorum(t *testing.T) {
 			Timestamp:    currentTimestamp,
 		}
 		hash := header.BlockHash()
-		node := newBlockNode(header, &hash, 0,
-			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]VoteVersionTuple{})
+		node := newBlockNode(header, &hash, 0, nil, nil, nil)
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
@@ -273,9 +267,7 @@ func TestNoQuorum(t *testing.T) {
 			Timestamp:    currentTimestamp,
 		}
 		hash := header.BlockHash()
-		node := newBlockNode(header, &hash, 0,
-			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]VoteVersionTuple{})
+		node := newBlockNode(header, &hash, 0, nil, nil, nil)
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
@@ -337,9 +329,7 @@ func TestNoQuorum(t *testing.T) {
 			Timestamp:    currentTimestamp,
 		}
 		hash := header.BlockHash()
-		node := newBlockNode(header, &hash, 0,
-			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]VoteVersionTuple{})
+		node := newBlockNode(header, &hash, 0, nil, nil, nil)
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
@@ -416,9 +406,7 @@ func TestYesQuorum(t *testing.T) {
 			Timestamp:    currentTimestamp,
 		}
 		hash := header.BlockHash()
-		node := newBlockNode(header, &hash, 0,
-			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]VoteVersionTuple{})
+		node := newBlockNode(header, &hash, 0, nil, nil, nil)
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
@@ -455,9 +443,7 @@ func TestYesQuorum(t *testing.T) {
 			Timestamp:    currentTimestamp,
 		}
 		hash := header.BlockHash()
-		node := newBlockNode(header, &hash, 0,
-			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]VoteVersionTuple{})
+		node := newBlockNode(header, &hash, 0, nil, nil, nil)
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
@@ -503,9 +489,7 @@ func TestYesQuorum(t *testing.T) {
 			Timestamp:    currentTimestamp,
 		}
 		hash := header.BlockHash()
-		node := newBlockNode(header, &hash, 0,
-			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]VoteVersionTuple{})
+		node := newBlockNode(header, &hash, 0, nil, nil, nil)
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
@@ -557,9 +541,7 @@ func TestYesQuorum(t *testing.T) {
 			Timestamp:    currentTimestamp,
 		}
 		hash := header.BlockHash()
-		node := newBlockNode(header, &hash, 0,
-			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]VoteVersionTuple{})
+		node := newBlockNode(header, &hash, 0, nil, nil, nil)
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
@@ -621,9 +603,7 @@ func TestYesQuorum(t *testing.T) {
 			Timestamp:    currentTimestamp,
 		}
 		hash := header.BlockHash()
-		node := newBlockNode(header, &hash, 0,
-			[]chainhash.Hash{}, []chainhash.Hash{},
-			[]VoteVersionTuple{})
+		node := newBlockNode(header, &hash, 0, nil, nil, nil)
 		node.height = int64(currentHeight)
 		node.parent = currentNode
 
@@ -1176,9 +1156,8 @@ func TestVoting(t *testing.T) {
 					Timestamp:    currentTimestamp,
 				}
 				hash := header.BlockHash()
-				node := newBlockNode(header, &hash, 0,
-					[]chainhash.Hash{}, []chainhash.Hash{},
-					[]VoteVersionTuple{})
+				node := newBlockNode(header, &hash, 0, nil, nil,
+					nil)
 				node.height = int64(currentHeight)
 				node.parent = currentNode
 
@@ -1443,9 +1422,8 @@ func TestVotingParallel(t *testing.T) {
 					Timestamp:    currentTimestamp,
 				}
 				hash := header.BlockHash()
-				node := newBlockNode(header, &hash, 0,
-					[]chainhash.Hash{}, []chainhash.Hash{},
-					[]VoteVersionTuple{})
+				node := newBlockNode(header, &hash, 0, nil, nil,
+					nil)
 				node.height = int64(currentHeight)
 				node.parent = currentNode
 


### PR DESCRIPTION
This modifies all invocations of `newBlockNode` in the tests to use the already existing `zeroHash` instance and `nil` for all unused fields versus creating an empty object for them.  This is more consistent with existing code and avoids needlessly creating objects.