### PR TITLE
blockchain: use next block stake version.

### DIFF
--- a/blockchain/stakeversion_test.go
+++ b/blockchain/stakeversion_test.go
@@ -18,7 +18,9 @@ import (
 // newFakeChain returns a chain that is usable for syntetic tests.
 func newFakeChain(params *chaincfg.Params) *BlockChain {
 	return &BlockChain{
-		chainParams:                   params,
+		chainParams:      params,
+		deploymentCaches: newThresholdCaches(params),
+		index:            make(map[chainhash.Hash]*blockNode),
 		isVoterMajorityVersionCache:   make(map[[stakeMajorityCacheKeySize]byte]bool),
 		isStakeMajorityVersionCache:   make(map[[stakeMajorityCacheKeySize]byte]bool),
 		calcPriorStakeVersionCache:    make(map[[chainhash.HashSize]byte]uint32),

--- a/blockchain/thresholdstate.go
+++ b/blockchain/thresholdstate.go
@@ -301,9 +301,8 @@ func (b *BlockChain) thresholdState(version uint32, prevNode *blockNode, checker
 
 		switch stateTuple.State {
 		case ThresholdDefined:
-			// Make sure we are on the correct stake version.
-			if prevNode.height < svh ||
-				prevNode.header.StakeVersion < version {
+			// Ensure we are at the minimal require height.
+			if prevNode.height < svh {
 				stateTuple.State = ThresholdDefined
 				break
 			}
@@ -318,6 +317,12 @@ func (b *BlockChain) thresholdState(version uint32, prevNode *blockNode, checker
 			medianTimeUnix := uint64(medianTime.Unix())
 			if medianTimeUnix >= checker.EndTime() {
 				stateTuple.State = ThresholdFailed
+				break
+			}
+
+			// Make sure we are on the correct stake version.
+			if b.calcStakeVersion(prevNode) < version {
+				stateTuple.State = ThresholdDefined
 				break
 			}
 


### PR DESCRIPTION
Modify threshold state to use the stake version that will be used in the
next block. That removes a full interval before voting can start and it
makes all voting intervals consistent.

Fixes #595
Requires #596 