### PR TITLE
chaingen: Allow 32-bit compile.

### DIFF
--- a/blockchain/chaingen/generator.go
+++ b/blockchain/chaingen/generator.go
@@ -1092,7 +1092,7 @@ func winningTickets(voteBlock *wire.MsgBlock, liveTickets []*stakeTicket, numVot
 	if numLiveTickets > math.MaxUint32 {
 		return nil, chainhash.Hash{}, fmt.Errorf("live ticket pool "+
 			"has %d tickets which is more than the max allowed of "+
-			"%d", len(liveTickets), math.MaxUint32)
+			"%d", len(liveTickets), uint32(math.MaxUint32))
 	}
 	if uint32(numVotes) > numLiveTickets {
 		return nil, chainhash.Hash{}, fmt.Errorf("live ticket pool "+


### PR DESCRIPTION
The go compiler treats the `math.MaxUint32` constant as an integer in the error print which causes a compile error.  This casts the constant to avoid that thus allows the code to compile on 32-bit architectures.

Fixes #604