### PR TITLE
chaincfg: strictly enforce agenda assumptions.

### DIFF
--- a/chaincfg/init.go
+++ b/chaincfg/init.go
@@ -1,0 +1,187 @@
+// Copyright (c) 2017 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package chaincfg
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var (
+	ErrDuplicateVoteId = errors.New("duplicate vote id")
+	ErrInvalidMask     = errors.New("invalid mask")
+	ErrNotConsecutive  = errors.New("choices not consecutive")
+	ErrTooManyChoices  = errors.New("too many choices")
+	ErrInvalidIgnore   = errors.New("invalid ignore bits")
+	ErrInvalidBits     = errors.New("invalid vote bits")
+	ErrInvalidIsIgnore = errors.New("one and only one IsIgnore rule " +
+		"violation")
+	ErrInvalidIsNo      = errors.New("one and only one IsNo rule violation")
+	ErrInvalidBothFlags = errors.New("IsNo and IsIgnore may not be both " +
+		"set to true")
+	ErrDuplicateChoiceId = errors.New("duplicate choice ID")
+)
+
+// bitsSet counts number of bits set.
+// Proudly stolen from:
+// https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetKernighan
+func bitsSet(bits uint16) uint {
+	c := uint(0)
+	for v := bits; v != 0; c++ {
+		v &= v - 1
+	}
+	return c
+}
+
+// consecOnes count consecutive 1 bits set.
+func consecOnes(bits uint16) uint {
+	c := uint(0)
+	for v := bits; v != 0; c++ {
+		v = v & (v << 1)
+	}
+	return c
+}
+
+// shift calculates the number of bits that need shifting to get to an index.
+func shift(mask uint16) uint {
+	shift := uint(0)
+	for {
+		if mask&0x0001 == 0x0001 {
+			break
+		}
+		shift++
+		mask >>= 1
+	}
+	return shift
+}
+
+func validateChoices(mask uint16, choices []Choice) error {
+	var (
+		isIgnore, isNo int
+	)
+
+	// Check that mask is consecutive.
+	if consecOnes(mask) != bitsSet(mask) {
+		return ErrInvalidMask
+	}
+
+	// Check bits and choice bounds.
+	if len(choices) > 1<<bitsSet(mask) {
+		return ErrTooManyChoices
+	}
+
+	dups := make(map[string]struct{})
+	s := shift(mask)
+	for index, choice := range choices {
+		// Check that choice 0 is the ignore vote.
+		if mask&choice.Bits == 0 && !choice.IsIgnore {
+			return ErrInvalidIgnore
+		}
+
+		// Check mask bits.
+		if mask&choice.Bits != choice.Bits {
+			return ErrInvalidBits
+		}
+
+		// Check that index is consecutive.  This test is below the
+		// Check mask bits one for testing reasons.  Leave it here.
+		if uint16(index) != choice.Bits>>s {
+			return ErrNotConsecutive
+		}
+
+		// Check that both flags aren't set to true.
+		if choice.IsIgnore && choice.IsNo {
+			return ErrInvalidBothFlags
+		}
+
+		// Count flags.
+		if choice.IsIgnore {
+			isIgnore++
+		}
+		if choice.IsNo {
+			isNo++
+		}
+
+		// Check for duplicates.
+		id := strings.ToLower(choice.Id)
+		_, found := dups[id]
+		if found {
+			return ErrDuplicateChoiceId
+		}
+		dups[id] = struct{}{}
+	}
+
+	// Check that there is only one IsNo and IsIgnore flag set to true.
+	if isIgnore != 1 {
+		return ErrInvalidIsIgnore
+	}
+	if isNo != 1 {
+		return ErrInvalidIsNo
+	}
+
+	return nil
+}
+
+func validateAgenda(vote Vote) error {
+	return validateChoices(vote.Mask, vote.Choices)
+}
+
+func validateDeployments(deployments []ConsensusDeployment) (int, error) {
+	dups := make(map[string]struct{})
+	for index, deployment := range deployments {
+		// Check for duplicates.
+		id := strings.ToLower(deployment.Vote.Id)
+		_, found := dups[id]
+		if found {
+			return index, ErrDuplicateVoteId
+		}
+		dups[id] = struct{}{}
+	}
+
+	return -1, nil
+}
+
+func validateAgendas() {
+	for i := 0; i < 3; i++ {
+		var params Params
+		switch i {
+		case 0:
+			params = MainNetParams
+		case 1:
+			params = TestNetParams
+		case 2:
+			params = SimNetParams
+		default:
+			panic("invalid net")
+		}
+
+		for version, deployments := range params.Deployments {
+			index, err := validateDeployments(deployments)
+			if err != nil {
+				e := fmt.Sprintf("invalid agenda on %v "+
+					"version %v id %v: %v", params.Name,
+					version, deployments[index].Vote.Id,
+					err)
+				panic(e)
+			}
+
+			for _, deployment := range deployments {
+				err := validateAgenda(deployment.Vote)
+				if err != nil {
+					e := fmt.Sprintf("invalid agenda "+
+						"on %v version %v id %v: %v",
+						params.Name, version,
+						deployment.Vote.Id, err)
+					panic(e)
+				}
+			}
+		}
+	}
+}
+
+func init() {
+	validateAgendas()
+}

--- a/chaincfg/init_test.go
+++ b/chaincfg/init_test.go
@@ -1,0 +1,381 @@
+// Copyright (c) 2017 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package chaincfg
+
+import (
+	"testing"
+)
+
+var (
+	consecMask = Vote{
+		Id:          "voteforpedro",
+		Description: "You should always vote for Pedro",
+		Mask:        0xa, // 0b1010 XXX not consecutive mask
+		Choices: []Choice{
+			{
+				Id:          "Abstain",
+				Description: "Abstain voting for Pedro",
+				Bits:        0x0, // 0b0000
+				IsIgnore:    true,
+				IsNo:        false,
+			},
+			{
+				Id:          "Yes",
+				Description: "Vote for Pedro",
+				Bits:        0x2, // 0b0010
+				IsIgnore:    false,
+				IsNo:        false,
+			},
+			{
+				Id:          "No",
+				Description: "Dont vote for Pedro",
+				Bits:        0x4, // 0b0100
+				IsIgnore:    false,
+				IsNo:        true,
+			},
+		},
+	}
+
+	tooManyChoices = Vote{
+		Id:          "voteforpedro",
+		Description: "You should always vote for Pedro",
+		Mask:        0x6, // 0b0110
+		Choices: []Choice{
+			{
+				Id:          "Abstain",
+				Description: "Abstain voting for Pedro",
+				Bits:        0x0, // 0b0000
+				IsIgnore:    true,
+				IsNo:        false,
+			},
+			{
+				Id:          "Yes",
+				Description: "Vote for Pedro",
+				Bits:        0x2, // 0b0010
+				IsIgnore:    false,
+				IsNo:        false,
+			},
+			{
+				Id:          "No",
+				Description: "Dont vote for Pedro",
+				Bits:        0x4, // 0b0100
+				IsIgnore:    false,
+				IsNo:        true,
+			},
+			{
+				Id:          "Maybe",
+				Description: "Vote for Pedro",
+				Bits:        0x6, // 0b0110
+				IsIgnore:    false,
+				IsNo:        false,
+			},
+			// XXX here we go out of mask bounds
+			{
+				Id:          "Hmmmm",
+				Description: "Vote for Pedro",
+				Bits:        0x6, // 0b0110 XXX invalid bits too
+				IsIgnore:    false,
+				IsNo:        false,
+			},
+		},
+	}
+
+	notConsec = Vote{
+		Id:          "voteforpedro",
+		Description: "You should always vote for Pedro",
+		Mask:        0x6, // 0b0110
+		Choices: []Choice{
+			{
+				Id:          "Abstain",
+				Description: "Abstain voting for Pedro",
+				Bits:        0x0, // 0b0000
+				IsIgnore:    true,
+				IsNo:        false,
+			},
+			{
+				Id:          "Yes",
+				Description: "Vote for Pedro",
+				Bits:        0x2, // 0b0010
+				IsIgnore:    false,
+				IsNo:        false,
+			},
+			// XXX not consecutive
+			{
+				Id:          "Maybe",
+				Description: "Vote for Pedro",
+				Bits:        0x6, // 0b0110
+				IsIgnore:    false,
+				IsNo:        false,
+			},
+		},
+	}
+
+	invalidIgnore = Vote{
+		Id:          "voteforpedro",
+		Description: "You should always vote for Pedro",
+		Mask:        0x6, // 0b0110
+		Choices: []Choice{
+			{
+				Id:          "Abstain",
+				Description: "Abstain voting for Pedro",
+				Bits:        0x0,   // 0b0000
+				IsIgnore:    false, // XXX this is the invalid bit
+				IsNo:        false,
+			},
+			{
+				Id:          "Yes",
+				Description: "Vote for Pedro",
+				Bits:        0x2, // 0b0010
+				IsIgnore:    false,
+				IsNo:        false,
+			},
+			{
+				Id:          "No",
+				Description: "Dont vote for Pedro",
+				Bits:        0x4, // 0b0100
+				IsIgnore:    false,
+				IsNo:        true,
+			},
+		},
+	}
+
+	invalidVoteBits = Vote{
+		Id:          "voteforpedro",
+		Description: "You should always vote for Pedro",
+		Mask:        0x6, // 0b0110
+		Choices: []Choice{
+			{
+				Id:          "Abstain",
+				Description: "Abstain voting for Pedro",
+				Bits:        0x0, // 0b0000
+				IsIgnore:    true,
+				IsNo:        false,
+			},
+			{
+				Id:          "Yes",
+				Description: "Vote for Pedro",
+				Bits:        0x2, // 0b0010
+				IsIgnore:    false,
+				IsNo:        false,
+			},
+			{
+				Id:          "No",
+				Description: "Dont vote for Pedro",
+				Bits:        0xc, // 0b1100 XXX invalid bits
+				IsIgnore:    false,
+				IsNo:        true,
+			},
+		},
+	}
+
+	twoIsIgnore = Vote{
+		Id:          "voteforpedro",
+		Description: "You should always vote for Pedro",
+		Mask:        0x6, // 0b0110
+		Choices: []Choice{
+			{
+				Id:          "Abstain",
+				Description: "Abstain voting for Pedro",
+				Bits:        0x0, // 0b0000
+				IsIgnore:    true,
+				IsNo:        false,
+			},
+			{
+				Id:          "Yes",
+				Description: "Vote for Pedro",
+				Bits:        0x2,  // 0b0010
+				IsIgnore:    true, // XXX this is the invalid choice
+				IsNo:        false,
+			},
+			{
+				Id:          "No",
+				Description: "Dont vote for Pedro",
+				Bits:        0x4, // 0b0100
+				IsIgnore:    false,
+				IsNo:        true,
+			},
+		},
+	}
+
+	twoIsNo = Vote{
+		Id:          "voteforpedro",
+		Description: "You should always vote for Pedro",
+		Mask:        0x6, // 0b0110
+		Choices: []Choice{
+			{
+				Id:          "Abstain",
+				Description: "Abstain voting for Pedro",
+				Bits:        0x0, // 0b0000
+				IsIgnore:    true,
+				IsNo:        false,
+			},
+			{
+				Id:          "Yes",
+				Description: "Vote for Pedro",
+				Bits:        0x2, // 0b0010
+				IsIgnore:    false,
+				IsNo:        true, // XXX this is the invalid choice
+			},
+			{
+				Id:          "No",
+				Description: "Dont vote for Pedro",
+				Bits:        0x4, // 0b0100
+				IsIgnore:    false,
+				IsNo:        true,
+			},
+		},
+	}
+
+	bothFlags = Vote{
+		Id:          "voteforpedro",
+		Description: "You should always vote for Pedro",
+		Mask:        0x6, // 0b0110
+		Choices: []Choice{
+			{
+				Id:          "Abstain",
+				Description: "Abstain voting for Pedro",
+				Bits:        0x0, // 0b0000
+				IsIgnore:    true,
+				IsNo:        false,
+			},
+			{
+				Id:          "Yes",
+				Description: "Vote for Pedro",
+				Bits:        0x2,  // 0b0010
+				IsIgnore:    true, // XXX this is the invalid choice
+				IsNo:        true, // XXX this is the invalid choice
+			},
+			{
+				Id:          "No",
+				Description: "Dont vote for Pedro",
+				Bits:        0x4, // 0b0100
+				IsIgnore:    false,
+				IsNo:        true,
+			},
+		},
+	}
+
+	dupChoice = Vote{
+		Id:          "voteforpedro",
+		Description: "You should always vote for Pedro",
+		Mask:        0x6, // 0b0110
+		Choices: []Choice{
+			{
+				Id:          "Abstain",
+				Description: "Abstain voting for Pedro",
+				Bits:        0x0, // 0b0000
+				IsIgnore:    true,
+				IsNo:        false,
+			},
+			{
+				Id:          "Yes",
+				Description: "Vote for Pedro",
+				Bits:        0x2, // 0b0010
+				IsIgnore:    false,
+				IsNo:        false,
+			},
+			{
+				Id:          "Yes", // XXX this is the invalid ID
+				Description: "Dont vote for Pedro",
+				Bits:        0x4, // 0b0100
+				IsIgnore:    false,
+				IsNo:        true,
+			},
+		},
+	}
+)
+
+func TestChoices(t *testing.T) {
+	tests := []struct {
+		name     string
+		vote     Vote
+		expected error
+	}{
+		{
+			name:     "consecutive mask",
+			vote:     consecMask,
+			expected: ErrInvalidMask,
+		},
+		{
+			name:     "not consecutive choices",
+			vote:     notConsec,
+			expected: ErrNotConsecutive,
+		},
+		{
+			name:     "too many choices",
+			vote:     tooManyChoices,
+			expected: ErrTooManyChoices,
+		},
+		{
+			name:     "invalid ignore",
+			vote:     invalidIgnore,
+			expected: ErrInvalidIgnore,
+		},
+		{
+			name:     "invalid vote bits",
+			vote:     invalidVoteBits,
+			expected: ErrInvalidBits,
+		},
+		{
+			name:     "2 IsIgnore",
+			vote:     twoIsIgnore,
+			expected: ErrInvalidIsIgnore,
+		},
+		{
+			name:     "2 IsNo",
+			vote:     twoIsNo,
+			expected: ErrInvalidIsNo,
+		},
+		{
+			name:     "both IsIgnore IsNo",
+			vote:     bothFlags,
+			expected: ErrInvalidBothFlags,
+		},
+		{
+			name:     "duplicate choice id",
+			vote:     dupChoice,
+			expected: ErrDuplicateChoiceId,
+		},
+	}
+
+	for _, test := range tests {
+		t.Logf("running: %v", test.name)
+		err := validateAgenda(test.vote)
+		if err != test.expected {
+			t.Fatalf("%v: got '%v' expected '%v'", test.name, err,
+				test.expected)
+		}
+	}
+}
+
+var (
+	dupVote = []ConsensusDeployment{
+		{Vote: Vote{Id: "moo"}},
+		{Vote: Vote{Id: "moo"}},
+	}
+)
+
+func TestDeployments(t *testing.T) {
+	tests := []struct {
+		name        string
+		deployments []ConsensusDeployment
+		expected    error
+	}{
+		{
+			name:        "duplicate vote id",
+			deployments: dupVote,
+			expected:    ErrDuplicateVoteId,
+		},
+	}
+
+	for _, test := range tests {
+		t.Logf("running: %v", test.name)
+		_, err := validateDeployments(test.deployments)
+		if err != test.expected {
+			t.Fatalf("%v: got '%v' expected '%v'", test.name, err,
+				test.expected)
+		}
+	}
+}

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -75,7 +75,8 @@ type Checkpoint struct {
 
 // Vote describes a voting instance.  It is self-describing so that the UI can
 // be directly implemented using the fields.  Mask determines which bits can be
-// used.  Bits are enumerated.
+// used.  Bits are enumerated and must be consecutive.  Each vote requires one
+// and only one abstain (bits = 0) and reject vote (IsNo = true).
 //
 // For example, change block height from int64 to uint64.
 // Vote {
@@ -120,9 +121,9 @@ type Vote struct {
 	Choices []Choice
 }
 
-// Choice is an defins one of the possible Choices that make up a vote. The 0
-// value in Bits indicates the default choice.  Care should be taken not to
-// bias a vote with the default choice.
+// Choice defines one of the possible Choices that make up a vote. The 0 value
+// in Bits indicates the default choice.  Care should be taken not to bias a
+// vote with the default choice.
 type Choice struct {
 	// Single unique word identifying vote (e.g. yes)
 	Id string


### PR DESCRIPTION
Unfortunately, agendas require some assumptions.  In order to prevent bad agendas to be allowed in the code base we need an agenda validator.  This validator shall be called every time dcrd is loaded and straight up panic.  This will not adversely impact the user experience but will force developers to properly design dcrd agendas.

Fixes: #606
Requires: #602

These are the required tests to ensure vote integrity:
- [x] All choices shall be consecutive and enumerated.
- [x] Mask only contains consecutive 1 bits set.
- [x] Ensure IsIgnore and IsNo are never both set to true.
- [x] Ensure there is one and only one IsNo choice set to true.
- [x] Ensure there is one and only one IsIgnore choice set to true.
- [x] Ensure that the abstain choice is 0.
- [x] Ensure that the number of choices does not exceed the mask bits permissible size.
- [x] Ensure that choice bits match the mask bits.
- [x] Ensure there are no duplicate choice ids.
- [x] Ensure there are no duplicate vote ids.