### PR TITLE
server: send some vote hashes

### DIFF
--- a/server.go
+++ b/server.go
@@ -467,6 +467,9 @@ func (sp *serverPeer) pushMiningStateMsg(height uint32, blockHashes []chainhash.
 		if err != nil {
 			return err
 		}
+		if i+1 >= wire.MaxMSBlocksAtHeadPerMsg {
+			break
+		}
 	}
 
 	sp.QueueMessage(msg, nil)

--- a/wire/msgminingstate.go
+++ b/wire/msgminingstate.go
@@ -107,7 +107,10 @@ func (msg *MsgMiningState) BtcDecode(r io.Reader, pver uint32) error {
 		if err != nil {
 			return err
 		}
-		msg.AddVoteHash(&hash)
+		err = msg.AddVoteHash(&hash)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
If there are more vote hashes than wire.MaxMSBlocksAtHeadPerMsg, send
the max instead of none.  Also, add a missing error check for safety.