### PR TITLE
chaincfg: Allow non-std transactions on testnet2.

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -772,7 +772,7 @@ var TestNet2Params = Params{
 	BlockUpgradeNumToCheck:  100,
 
 	// Mempool parameters
-	RelayNonStdTxs: false,
+	RelayNonStdTxs: true,
 
 	// Address encoding magics
 	NetworkAddressPrefix: "T",


### PR DESCRIPTION
The test network should allow any scripts and transaction types that are valid according to consensus rules as opposed to the more strict standardness rules that apply to mainnet.  This allows new script forms and types to be tested before they go to mainnet.

Also, this is the same setting as the previous test network.