### PR TITLE
TravisCI: Remove a couple of linters.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: go
 go:
   - 1.7.x

--- a/goclean.sh
+++ b/goclean.sh
@@ -2,10 +2,8 @@
 # The script does automatic checking on a Go package and its sub-packages, including:
 # 1. gofmt         (http://golang.org/cmd/gofmt/)
 # 2. go vet        (http://golang.org/cmd/vet)
-# 3. gosimple      (https://github.com/dominikh/go-simple)
-# 4. unconvert     (https://github.com/mdempsky/unconvert)
-# 5. race detector (http://blog.golang.org/race-detector)
-# 6. test coverage (http://blog.golang.org/cover)
+# 3. race detector (http://blog.golang.org/race-detector)
+# 4. test coverage (http://blog.golang.org/cover)
 
 # gometalinter (github.com/alecthomas/gometalinter) is used to run each each
 # static checker.
@@ -31,8 +29,6 @@ linter_targets=$(glide novendor)
 test -z "$(gometalinter --disable-all \
 --enable=gofmt \
 --enable=vet \
---enable=gosimple \
---enable=unconvert \
---deadline=4m $linter_targets 2>&1 | tee /dev/stderr)"
+--deadline=10m $linter_targets 2>&1 | tee /dev/stderr)"
 
 env GORACE="halt_on_error=1" go test -short -race $linter_targets


### PR DESCRIPTION
The linters take quite a while to run in the TravisCI environment which causes the deadline to be exceeded.

While here, also increase the allowed deadline for the remaining linters to 10 minutes and also update Travis to use a new Ubuntu distribution.