### PR TITLE
wire: Lower MaxUserAgentLen to 256.

### DIFF
--- a/wire/msgversion.go
+++ b/wire/msgversion.go
@@ -16,10 +16,10 @@ import (
 
 // MaxUserAgentLen is the maximum allowed length for the user agent field in a
 // version message (MsgVersion).
-const MaxUserAgentLen = 2000
+const MaxUserAgentLen = 256
 
 // DefaultUserAgent for wire in the stack
-const DefaultUserAgent = "/dcrwire:0.2.0/"
+const DefaultUserAgent = "/dcrwire:0.2.1/"
 
 // MsgVersion implements the Message interface and represents a decred version
 // message.  It is used for a peer to advertise itself as soon as an outbound

--- a/wire/msgversion_test.go
+++ b/wire/msgversion_test.go
@@ -114,7 +114,7 @@ func TestVersion(t *testing.T) {
 	// remote and local net addresses + nonce 8 bytes + length of user agent
 	// (varInt) + max allowed user agent length + last block 4 bytes +
 	// relay transactions flag 1 byte.
-	wantPayload := uint32(2102)
+	wantPayload := uint32(358)
 	maxPayload := msg.MaxPayloadLength(pver)
 	if maxPayload != wantPayload {
 		t.Errorf("MaxPayloadLength: wrong max payload length for "+


### PR DESCRIPTION
Upstream commit 763f731c5c97ab2f659f0c7dd3e6a8f48c723daa.

This updates wire to enforce a limit of 256 instead of the existing 2000 to coincide with the upstream btcd project, and consequently includes a wire version bump to 0.2.1 in the merge commit.
