### PR TITLE
gometalinter:  use --vendor to skip ./vendor/

### DIFF
--- a/cpuminer.go
+++ b/cpuminer.go
@@ -589,7 +589,7 @@ func (m *CPUMiner) GenerateNBlocks(n uint32) ([]*chainhash.Hash, error) {
 	minrLog.Tracef("Generating %d blocks", n)
 
 	i := uint32(0)
-	blockHashes := make([]*chainhash.Hash, n, n)
+	blockHashes := make([]*chainhash.Hash, n)
 
 	// Start a ticker which is used to signal checks for stale work and
 	// updates to the speed monitor.

--- a/dcrec/secp256k1/signature.go
+++ b/dcrec/secp256k1/signature.go
@@ -68,7 +68,7 @@ func (sig *Signature) Serialize() []byte {
 	// total length of returned signature is 1 byte for each magic and
 	// length (6 total), plus lengths of r and s
 	length := 6 + len(rb) + len(sb)
-	b := make([]byte, length, length)
+	b := make([]byte, length)
 
 	b[0] = 0x30
 	b[1] = byte(length - 2)

--- a/goclean.sh
+++ b/goclean.sh
@@ -2,8 +2,9 @@
 # The script does automatic checking on a Go package and its sub-packages, including:
 # 1. gofmt         (http://golang.org/cmd/gofmt/)
 # 2. go vet        (http://golang.org/cmd/vet)
-# 3. race detector (http://blog.golang.org/race-detector)
-# 4. test coverage (http://blog.golang.org/cover)
+# 3. unconvert     (https://github.com/mdempsky/unconvert)
+# 4. race detector (http://blog.golang.org/race-detector)
+# 5. test coverage (http://blog.golang.org/cover)
 
 # gometalinter (github.com/alecthomas/gometalinter) is used to run each each
 # static checker.
@@ -23,12 +24,12 @@ if [ ! -x "$(type -p gometalinter)" ]; then
   exit 1
 fi
 
-linter_targets=$(glide novendor)
-
 # Automatic checks
 test -z "$(gometalinter --disable-all \
 --enable=gofmt \
 --enable=vet \
---deadline=10m $linter_targets 2>&1 | tee /dev/stderr)"
+--enable=unconvert \
+--vendor \
+--deadline=10m . 2>&1 | tee /dev/stderr)"
 
-env GORACE="halt_on_error=1" go test -short -race $linter_targets
+env GORACE="halt_on_error=1" go test -short -race $(glide novendor)

--- a/mining.go
+++ b/mining.go
@@ -473,7 +473,7 @@ func standardCoinbaseOpReturn(height uint32, extraNonces []uint64) ([]byte,
 		return nil, fmt.Errorf("extranonces has wrong num uint64s")
 	}
 
-	enData := make([]byte, 36, 36)
+	enData := make([]byte, 36)
 	binary.LittleEndian.PutUint32(enData[0:4], height)
 	binary.LittleEndian.PutUint64(enData[4:12], extraNonces[0])
 	binary.LittleEndian.PutUint64(enData[12:20], extraNonces[1])
@@ -498,7 +498,7 @@ func (bt *BlockTemplate) getCoinbaseExtranonces() []uint64 {
 		return []uint64{0, 0, 0, 0}
 	}
 
-	ens := make([]uint64, 4, 4) // 32-bytes
+	ens := make([]uint64, 4) // 32-bytes
 	ens[0] = binary.LittleEndian.Uint64(
 		bt.Block.Transactions[0].TxOut[1].PkScript[6:14])
 	ens[1] = binary.LittleEndian.Uint64(
@@ -522,7 +522,7 @@ func getCoinbaseExtranonces(msgBlock *wire.MsgBlock) []uint64 {
 		return []uint64{0, 0, 0, 0}
 	}
 
-	ens := make([]uint64, 4, 4) // 32-bytes
+	ens := make([]uint64, 4) // 32-bytes
 	ens[0] = binary.LittleEndian.Uint64(
 		msgBlock.Transactions[0].TxOut[1].PkScript[6:14])
 	ens[1] = binary.LittleEndian.Uint64(
@@ -596,9 +596,7 @@ func createCoinbaseTx(subsidyCache *blockchain.SubsidyCache,
 	// Block one is a special block that might pay out tokens to a ledger.
 	if nextBlockHeight == 1 && len(params.BlockOneLedger) != 0 {
 		// Convert the addresses in the ledger into useable format.
-		addrs := make([]dcrutil.Address,
-			len(params.BlockOneLedger),
-			len(params.BlockOneLedger))
+		addrs := make([]dcrutil.Address, len(params.BlockOneLedger))
 		for i, payout := range params.BlockOneLedger {
 			addr, err := dcrutil.DecodeAddress(payout.Address, params)
 			if err != nil {
@@ -821,8 +819,7 @@ func deepCopyBlockTemplate(blockTemplate *BlockTemplate) *BlockTemplate {
 	// Copy transactions pointers. Duplicate the coinbase
 	// transaction, because it might update it by modifying
 	// the extra nonce.
-	transactionsCopy := make([]*wire.MsgTx, len(blockTemplate.Block.Transactions),
-		len(blockTemplate.Block.Transactions))
+	transactionsCopy := make([]*wire.MsgTx, len(blockTemplate.Block.Transactions))
 	coinbaseCopy :=
 		dcrutil.NewTxDeep(blockTemplate.Block.Transactions[0])
 	for i, mtx := range blockTemplate.Block.Transactions {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4470,8 +4470,7 @@ func handleGetWorkSubmission(s *rpcServer, hexData string) (interface{}, error) 
 	msgBlock := tempBlock.MsgBlock()
 	msgBlock.Header = submittedHeader
 	if msgBlock.Header.Height > 1 {
-		pkScriptCopy := make([]byte, len(blockInfo.pkScript),
-			len(blockInfo.pkScript))
+		pkScriptCopy := make([]byte, len(blockInfo.pkScript))
 		copy(pkScriptCopy, blockInfo.pkScript)
 		msgBlock.Transactions[0].TxOut[1].PkScript = blockInfo.pkScript
 		merkles := blockchain.BuildMerkleTreeStore(tempBlock.Transactions())
@@ -4622,7 +4621,7 @@ func handleLiveTickets(s *rpcServer, cmd interface{}, closeChan <-chan struct{})
 		return nil, err
 	}
 
-	ltString := make([]string, len(lt), len(lt))
+	ltString := make([]string, len(lt))
 	for i := range lt {
 		ltString[i] = lt[i].String()
 	}
@@ -4637,7 +4636,7 @@ func handleMissedTickets(s *rpcServer, cmd interface{}, closeChan <-chan struct{
 		return nil, err
 	}
 
-	mtString := make([]string, len(mt), len(mt))
+	mtString := make([]string, len(mt))
 	for i, hash := range mt {
 		mtString[i] = hash.String()
 	}
@@ -5655,7 +5654,7 @@ func handleTicketsForAddress(s *rpcServer, cmd interface{}, closeChan <-chan str
 		return nil, err
 	}
 
-	ticketStrings := make([]string, len(tickets), len(tickets))
+	ticketStrings := make([]string, len(tickets))
 	itr := 0
 	for _, ticket := range tickets {
 		ticketStrings[itr] = ticket.String()


### PR DESCRIPTION
While here, readd gosimple and unconvert