### PR TITLE
rpcserver/chain: Bounds check getstakeversions.

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3936,14 +3936,17 @@ func handleGetStakeVersionInfo(s *rpcServer, cmd interface{}, closeChan <-chan s
 
 // handleGetStakeVersions implements the getstakeversions command.
 func handleGetStakeVersions(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
-	c, ok := cmd.(*dcrjson.GetStakeVersionsCmd)
-	if !ok {
-		return nil, internalRPCError("Invalid command",
-			"handleGetStakeVersions")
-	}
+	c := cmd.(*dcrjson.GetStakeVersionsCmd)
+
 	hash, err := chainhash.NewHashFromStr(c.Hash)
 	if err != nil {
-		return nil, err
+		return nil, rpcDecodeHexError(c.Hash)
+	}
+	if c.Count <= 0 {
+		return nil, &dcrjson.RPCError{
+			Code:    dcrjson.ErrRPCInvalidParameter,
+			Message: "Invalid parameter, count must be > 0",
+		}
 	}
 
 	sv, err := s.chain.GetStakeVersions(hash, c.Count)


### PR DESCRIPTION
This adds bounds check for the RPC parameters for the `getstakeversions` command to both the handler and the chain function itself which provides the data.

Also, while here simplify the for loop in `GetStakeVersions` to check `prevNode` in the for loops condition instead of in a separate if block, return more appropriate error types for RPC parameter type errors, and
make use a naked type cast of the command to be consistent with all of the other handlers.

Fixes #635 