### PR TITLE
multi: Rename vote choice IsIgnore to IsAbstain.

### DIFF
--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1845,11 +1845,11 @@ func DumpBlockChain(db database.DB, height int64) (map[int64][]byte, error) {
 //
 // The serialized value format for the choice array is:
 //
-//   <bits><isIgnore><isNo>
+//   <bits><isAbstain><isNo>
 //
 //   Field            Type      Size
 //   bits             uint16    2 bytes
-//   isIgnore         uint8     1 byte (bool)
+//   isAbstain        uint8     1 byte (bool)
 //   isNo             uint8     1 byte (bool)
 //
 // Finally, the main threshold bucket also contains the number of stored
@@ -1876,7 +1876,7 @@ func serializeDeploymentCacheParams(deployment *chaincfg.ConsensusDeployment) []
 	for i := 0; i < len(deployment.Vote.Choices); i++ {
 		byteOrder.PutUint16(serialized[20+i*4:],
 			deployment.Vote.Choices[i].Bits)
-		if deployment.Vote.Choices[i].IsIgnore {
+		if deployment.Vote.Choices[i].IsAbstain {
 			serialized[20+i*4+2] = 1
 		}
 		if deployment.Vote.Choices[i].IsNo {
@@ -1919,7 +1919,7 @@ func deserializeDeploymentCacheParams(serialized []byte) (chaincfg.ConsensusDepl
 		deployment.Vote.Choices[i].Bits =
 			byteOrder.Uint16(serialized[20+i*4:])
 		if serialized[20+i*4+2] != 0 {
-			deployment.Vote.Choices[i].IsIgnore = true
+			deployment.Vote.Choices[i].IsAbstain = true
 		}
 		if serialized[20+i*4+3] != 0 {
 			deployment.Vote.Choices[i].IsNo = true

--- a/blockchain/fullblocktests/params.go
+++ b/blockchain/fullblocktests/params.go
@@ -157,19 +157,19 @@ var simNetParams = &chaincfg.Params{
 					Id:          "abstain",
 					Description: "abstain voting for change",
 					Bits:        0x0000,
-					IsIgnore:    true,
+					IsAbstain:   true,
 					IsNo:        false,
 				}, {
 					Id:          "no",
 					Description: "reject changing max allowed block size",
 					Bits:        0x0002, // Bit 1
-					IsIgnore:    false,
+					IsAbstain:   false,
 					IsNo:        true,
 				}, {
 					Id:          "yes",
 					Description: "accept changing max allowed block size",
 					Bits:        0x0004, // Bit 2
-					IsIgnore:    false,
+					IsAbstain:   false,
 					IsNo:        false,
 				}},
 			},

--- a/blockchain/stake/tickets_test.go
+++ b/blockchain/stake/tickets_test.go
@@ -986,19 +986,19 @@ var simNetParams = &chaincfg.Params{
 					Id:          "abstain",
 					Description: "abstain voting for change",
 					Bits:        0x0000,
-					IsIgnore:    true,
+					IsAbstain:   true,
 					IsNo:        false,
 				}, {
 					Id:          "no",
 					Description: "reject changing max allowed block size",
 					Bits:        0x0002, // Bit 1
-					IsIgnore:    false,
+					IsAbstain:   false,
 					IsNo:        true,
 				}, {
 					Id:          "yes",
 					Description: "accept changing max allowed block size",
 					Bits:        0x0004, // Bit 2
-					IsIgnore:    false,
+					IsAbstain:   false,
 					IsNo:        false,
 				}},
 			},

--- a/blockchain/thresholdstate_test.go
+++ b/blockchain/thresholdstate_test.go
@@ -71,19 +71,19 @@ var (
 			Id:          "abstain",
 			Description: "abstain voting for change",
 			Bits:        0x0000,
-			IsIgnore:    true,
+			IsAbstain:   true,
 			IsNo:        false,
 		}, {
 			Id:          "no",
 			Description: "vote no",
 			Bits:        0x0002, // Bit 1
-			IsIgnore:    false,
+			IsAbstain:   false,
 			IsNo:        true,
 		}, {
 			Id:          "yes",
 			Description: "vote yes",
 			Bits:        0x0004, // Bit 2
-			IsIgnore:    false,
+			IsAbstain:   false,
 			IsNo:        false,
 		}},
 	}
@@ -97,19 +97,19 @@ var (
 			Id:          "abstain",
 			Description: "abstain voting for change",
 			Bits:        0x0000,
-			IsIgnore:    true,
+			IsAbstain:   true,
 			IsNo:        false,
 		}, {
 			Id:          "no",
 			Description: "vote no",
 			Bits:        0x0008, // Bit 3
-			IsIgnore:    false,
+			IsAbstain:   false,
 			IsNo:        true,
 		}, {
 			Id:          "yes",
 			Description: "vote yes",
 			Bits:        0x0010, // Bit 4
-			IsIgnore:    false,
+			IsAbstain:   false,
 			IsNo:        false,
 		}},
 	}

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -2191,19 +2191,19 @@ var simNetParams = &chaincfg.Params{
 					Id:          "abstain",
 					Description: "abstain voting for change",
 					Bits:        0x0000,
-					IsIgnore:    true,
+					IsAbstain:   true,
 					IsNo:        false,
 				}, {
 					Id:          "no",
 					Description: "reject changing max allowed block size",
 					Bits:        0x0002, // Bit 1
-					IsIgnore:    false,
+					IsAbstain:   false,
 					IsNo:        true,
 				}, {
 					Id:          "yes",
 					Description: "accept changing max allowed block size",
 					Bits:        0x0004, // Bit 2
-					IsIgnore:    false,
+					IsAbstain:   false,
 					IsNo:        false,
 				}},
 			},

--- a/blockchain/votebits.go
+++ b/blockchain/votebits.go
@@ -113,7 +113,7 @@ func (c deploymentChecker) Condition(node *blockNode, version uint32) ([]thresho
 	// information into the thresholdConditionTally array.
 	tally := make([]thresholdConditionTally, len(c.deployment.Vote.Choices))
 	for t, choice := range c.deployment.Vote.Choices {
-		tally[t].isIgnore = choice.IsIgnore
+		tally[t].isAbstain = choice.IsAbstain
 		tally[t].isNo = choice.IsNo
 	}
 

--- a/blockchain/votebits_test.go
+++ b/blockchain/votebits_test.go
@@ -25,21 +25,21 @@ var (
 				Id:          "Abstain",
 				Description: "Abstain voting for Pedro",
 				Bits:        0x0, // 0b0000
-				IsIgnore:    true,
+				IsAbstain:   true,
 				IsNo:        false,
 			},
 			{
 				Id:          "Yes",
 				Description: "Vote for Pedro",
 				Bits:        0x2, // 0b0010
-				IsIgnore:    false,
+				IsAbstain:   false,
 				IsNo:        false,
 			},
 			{
 				Id:          "No",
 				Description: "Dont vote for Pedro",
 				Bits:        0x4, // 0b0100
-				IsIgnore:    false,
+				IsAbstain:   false,
 				IsNo:        true,
 			},
 		},
@@ -54,42 +54,42 @@ var (
 				Id:          "Abstain",
 				Description: "Abstain multiple choice",
 				Bits:        0x0, // 0b0000 0000
-				IsIgnore:    true,
+				IsAbstain:   true,
 				IsNo:        false,
 			},
 			{
 				Id:          "one",
 				Description: "Choice 1",
 				Bits:        0x10, // 0b0001 0000
-				IsIgnore:    false,
+				IsAbstain:   false,
 				IsNo:        false,
 			},
 			{
 				Id:          "Vote against",
 				Description: "Vote against all multiple ",
 				Bits:        0x20, // 0b0010 0000
-				IsIgnore:    false,
+				IsAbstain:   false,
 				IsNo:        true,
 			},
 			{
 				Id:          "two",
 				Description: "Choice 2",
 				Bits:        0x30, // 0b0011 0000
-				IsIgnore:    false,
+				IsAbstain:   false,
 				IsNo:        false,
 			},
 			{
 				Id:          "three",
 				Description: "Choice 3",
 				Bits:        0x40, // 0b0100 0000
-				IsIgnore:    false,
+				IsAbstain:   false,
 				IsNo:        false,
 			},
 			{
 				Id:          "four",
 				Description: "Choice 4",
 				Bits:        0x50, // 0b0101 0000
-				IsIgnore:    false,
+				IsAbstain:   false,
 				IsNo:        false,
 			},
 		},
@@ -140,11 +140,11 @@ func TestSerializeDeserialize(t *testing.T) {
 				deserialized.Vote.Choices[i].Bits,
 				ourDeployment.Vote.Choices[i].Bits)
 		}
-		if deserialized.Vote.Choices[i].IsIgnore !=
-			ourDeployment.Vote.Choices[i].IsIgnore {
-			t.Fatalf("invalid IsIgnore %v got %v expected %v", i,
-				deserialized.Vote.Choices[i].IsIgnore,
-				ourDeployment.Vote.Choices[i].IsIgnore)
+		if deserialized.Vote.Choices[i].IsAbstain !=
+			ourDeployment.Vote.Choices[i].IsAbstain {
+			t.Fatalf("invalid IsAbstain %v got %v expected %v", i,
+				deserialized.Vote.Choices[i].IsAbstain,
+				ourDeployment.Vote.Choices[i].IsAbstain)
 		}
 		if deserialized.Vote.Choices[i].IsNo !=
 			ourDeployment.Vote.Choices[i].IsNo {
@@ -1911,19 +1911,19 @@ var (
 			Id:          "abstain",
 			Description: "abstain voting for change",
 			Bits:        0x0000,
-			IsIgnore:    true,
+			IsAbstain:   true,
 			IsNo:        false,
 		}, {
 			Id:          "no",
 			Description: "vote no",
 			Bits:        0x0002, // Bit 1
-			IsIgnore:    false,
+			IsAbstain:   false,
 			IsNo:        true,
 		}, {
 			Id:          "yes",
 			Description: "vote yes",
 			Bits:        0x0004, // Bit 2
-			IsIgnore:    false,
+			IsAbstain:   false,
 			IsNo:        false,
 		}},
 	}
@@ -1937,19 +1937,19 @@ var (
 			Id:          "abstain",
 			Description: "abstain voting for change",
 			Bits:        0x0000,
-			IsIgnore:    true,
+			IsAbstain:   true,
 			IsNo:        false,
 		}, {
 			Id:          "no",
 			Description: "vote no",
 			Bits:        0x0008, // Bit 3
-			IsIgnore:    false,
+			IsAbstain:   false,
 			IsNo:        true,
 		}, {
 			Id:          "yes",
 			Description: "vote yes",
 			Bits:        0x0010, // Bit 4
-			IsIgnore:    false,
+			IsAbstain:   false,
 			IsNo:        false,
 		}},
 	}

--- a/chaincfg/init.go
+++ b/chaincfg/init.go
@@ -11,16 +11,16 @@ import (
 )
 
 var (
-	ErrDuplicateVoteId = errors.New("duplicate vote id")
-	ErrInvalidMask     = errors.New("invalid mask")
-	ErrNotConsecutive  = errors.New("choices not consecutive")
-	ErrTooManyChoices  = errors.New("too many choices")
-	ErrInvalidIgnore   = errors.New("invalid ignore bits")
-	ErrInvalidBits     = errors.New("invalid vote bits")
-	ErrInvalidIsIgnore = errors.New("one and only one IsIgnore rule " +
+	ErrDuplicateVoteId  = errors.New("duplicate vote id")
+	ErrInvalidMask      = errors.New("invalid mask")
+	ErrNotConsecutive   = errors.New("choices not consecutive")
+	ErrTooManyChoices   = errors.New("too many choices")
+	ErrInvalidAbstain   = errors.New("invalid abstain bits")
+	ErrInvalidBits      = errors.New("invalid vote bits")
+	ErrInvalidIsAbstain = errors.New("one and only one IsAbstain rule " +
 		"violation")
 	ErrInvalidIsNo      = errors.New("one and only one IsNo rule violation")
-	ErrInvalidBothFlags = errors.New("IsNo and IsIgnore may not be both " +
+	ErrInvalidBothFlags = errors.New("IsNo and IsAbstain may not be both " +
 		"set to true")
 	ErrDuplicateChoiceId = errors.New("duplicate choice ID")
 )
@@ -60,7 +60,7 @@ func shift(mask uint16) uint {
 
 func validateChoices(mask uint16, choices []Choice) error {
 	var (
-		isIgnore, isNo int
+		numAbstain, numNo int
 	)
 
 	// Check that mask is consecutive.
@@ -76,9 +76,9 @@ func validateChoices(mask uint16, choices []Choice) error {
 	dups := make(map[string]struct{})
 	s := shift(mask)
 	for index, choice := range choices {
-		// Check that choice 0 is the ignore vote.
-		if mask&choice.Bits == 0 && !choice.IsIgnore {
-			return ErrInvalidIgnore
+		// Check that choice 0 is the abstain vote.
+		if mask&choice.Bits == 0 && !choice.IsAbstain {
+			return ErrInvalidAbstain
 		}
 
 		// Check mask bits.
@@ -93,16 +93,16 @@ func validateChoices(mask uint16, choices []Choice) error {
 		}
 
 		// Check that both flags aren't set to true.
-		if choice.IsIgnore && choice.IsNo {
+		if choice.IsAbstain && choice.IsNo {
 			return ErrInvalidBothFlags
 		}
 
 		// Count flags.
-		if choice.IsIgnore {
-			isIgnore++
+		if choice.IsAbstain {
+			numAbstain++
 		}
 		if choice.IsNo {
-			isNo++
+			numNo++
 		}
 
 		// Check for duplicates.
@@ -114,11 +114,11 @@ func validateChoices(mask uint16, choices []Choice) error {
 		dups[id] = struct{}{}
 	}
 
-	// Check that there is only one IsNo and IsIgnore flag set to true.
-	if isIgnore != 1 {
-		return ErrInvalidIsIgnore
+	// Check that there is only one IsNo and IsAbstain flag set to true.
+	if numAbstain != 1 {
+		return ErrInvalidIsAbstain
 	}
-	if isNo != 1 {
+	if numNo != 1 {
 		return ErrInvalidIsNo
 	}
 

--- a/chaincfg/init_test.go
+++ b/chaincfg/init_test.go
@@ -18,21 +18,21 @@ var (
 				Id:          "Abstain",
 				Description: "Abstain voting for Pedro",
 				Bits:        0x0, // 0b0000
-				IsIgnore:    true,
+				IsAbstain:   true,
 				IsNo:        false,
 			},
 			{
 				Id:          "Yes",
 				Description: "Vote for Pedro",
 				Bits:        0x2, // 0b0010
-				IsIgnore:    false,
+				IsAbstain:   false,
 				IsNo:        false,
 			},
 			{
 				Id:          "No",
 				Description: "Dont vote for Pedro",
 				Bits:        0x4, // 0b0100
-				IsIgnore:    false,
+				IsAbstain:   false,
 				IsNo:        true,
 			},
 		},
@@ -47,28 +47,28 @@ var (
 				Id:          "Abstain",
 				Description: "Abstain voting for Pedro",
 				Bits:        0x0, // 0b0000
-				IsIgnore:    true,
+				IsAbstain:   true,
 				IsNo:        false,
 			},
 			{
 				Id:          "Yes",
 				Description: "Vote for Pedro",
 				Bits:        0x2, // 0b0010
-				IsIgnore:    false,
+				IsAbstain:   false,
 				IsNo:        false,
 			},
 			{
 				Id:          "No",
 				Description: "Dont vote for Pedro",
 				Bits:        0x4, // 0b0100
-				IsIgnore:    false,
+				IsAbstain:   false,
 				IsNo:        true,
 			},
 			{
 				Id:          "Maybe",
 				Description: "Vote for Pedro",
 				Bits:        0x6, // 0b0110
-				IsIgnore:    false,
+				IsAbstain:   false,
 				IsNo:        false,
 			},
 			// XXX here we go out of mask bounds
@@ -76,7 +76,7 @@ var (
 				Id:          "Hmmmm",
 				Description: "Vote for Pedro",
 				Bits:        0x6, // 0b0110 XXX invalid bits too
-				IsIgnore:    false,
+				IsAbstain:   false,
 				IsNo:        false,
 			},
 		},
@@ -91,14 +91,14 @@ var (
 				Id:          "Abstain",
 				Description: "Abstain voting for Pedro",
 				Bits:        0x0, // 0b0000
-				IsIgnore:    true,
+				IsAbstain:   true,
 				IsNo:        false,
 			},
 			{
 				Id:          "Yes",
 				Description: "Vote for Pedro",
 				Bits:        0x2, // 0b0010
-				IsIgnore:    false,
+				IsAbstain:   false,
 				IsNo:        false,
 			},
 			// XXX not consecutive
@@ -106,13 +106,13 @@ var (
 				Id:          "Maybe",
 				Description: "Vote for Pedro",
 				Bits:        0x6, // 0b0110
-				IsIgnore:    false,
+				IsAbstain:   false,
 				IsNo:        false,
 			},
 		},
 	}
 
-	invalidIgnore = Vote{
+	invalidAbstain = Vote{
 		Id:          "voteforpedro",
 		Description: "You should always vote for Pedro",
 		Mask:        0x6, // 0b0110
@@ -121,21 +121,21 @@ var (
 				Id:          "Abstain",
 				Description: "Abstain voting for Pedro",
 				Bits:        0x0,   // 0b0000
-				IsIgnore:    false, // XXX this is the invalid bit
+				IsAbstain:   false, // XXX this is the invalid bit
 				IsNo:        false,
 			},
 			{
 				Id:          "Yes",
 				Description: "Vote for Pedro",
 				Bits:        0x2, // 0b0010
-				IsIgnore:    false,
+				IsAbstain:   false,
 				IsNo:        false,
 			},
 			{
 				Id:          "No",
 				Description: "Dont vote for Pedro",
 				Bits:        0x4, // 0b0100
-				IsIgnore:    false,
+				IsAbstain:   false,
 				IsNo:        true,
 			},
 		},
@@ -150,27 +150,27 @@ var (
 				Id:          "Abstain",
 				Description: "Abstain voting for Pedro",
 				Bits:        0x0, // 0b0000
-				IsIgnore:    true,
+				IsAbstain:   true,
 				IsNo:        false,
 			},
 			{
 				Id:          "Yes",
 				Description: "Vote for Pedro",
 				Bits:        0x2, // 0b0010
-				IsIgnore:    false,
+				IsAbstain:   false,
 				IsNo:        false,
 			},
 			{
 				Id:          "No",
 				Description: "Dont vote for Pedro",
 				Bits:        0xc, // 0b1100 XXX invalid bits
-				IsIgnore:    false,
+				IsAbstain:   false,
 				IsNo:        true,
 			},
 		},
 	}
 
-	twoIsIgnore = Vote{
+	twoIsAbstain = Vote{
 		Id:          "voteforpedro",
 		Description: "You should always vote for Pedro",
 		Mask:        0x6, // 0b0110
@@ -179,21 +179,21 @@ var (
 				Id:          "Abstain",
 				Description: "Abstain voting for Pedro",
 				Bits:        0x0, // 0b0000
-				IsIgnore:    true,
+				IsAbstain:   true,
 				IsNo:        false,
 			},
 			{
 				Id:          "Yes",
 				Description: "Vote for Pedro",
 				Bits:        0x2,  // 0b0010
-				IsIgnore:    true, // XXX this is the invalid choice
+				IsAbstain:   true, // XXX this is the invalid choice
 				IsNo:        false,
 			},
 			{
 				Id:          "No",
 				Description: "Dont vote for Pedro",
 				Bits:        0x4, // 0b0100
-				IsIgnore:    false,
+				IsAbstain:   false,
 				IsNo:        true,
 			},
 		},
@@ -208,21 +208,21 @@ var (
 				Id:          "Abstain",
 				Description: "Abstain voting for Pedro",
 				Bits:        0x0, // 0b0000
-				IsIgnore:    true,
+				IsAbstain:   true,
 				IsNo:        false,
 			},
 			{
 				Id:          "Yes",
 				Description: "Vote for Pedro",
 				Bits:        0x2, // 0b0010
-				IsIgnore:    false,
+				IsAbstain:   false,
 				IsNo:        true, // XXX this is the invalid choice
 			},
 			{
 				Id:          "No",
 				Description: "Dont vote for Pedro",
 				Bits:        0x4, // 0b0100
-				IsIgnore:    false,
+				IsAbstain:   false,
 				IsNo:        true,
 			},
 		},
@@ -237,21 +237,21 @@ var (
 				Id:          "Abstain",
 				Description: "Abstain voting for Pedro",
 				Bits:        0x0, // 0b0000
-				IsIgnore:    true,
+				IsAbstain:   true,
 				IsNo:        false,
 			},
 			{
 				Id:          "Yes",
 				Description: "Vote for Pedro",
 				Bits:        0x2,  // 0b0010
-				IsIgnore:    true, // XXX this is the invalid choice
+				IsAbstain:   true, // XXX this is the invalid choice
 				IsNo:        true, // XXX this is the invalid choice
 			},
 			{
 				Id:          "No",
 				Description: "Dont vote for Pedro",
 				Bits:        0x4, // 0b0100
-				IsIgnore:    false,
+				IsAbstain:   false,
 				IsNo:        true,
 			},
 		},
@@ -266,21 +266,21 @@ var (
 				Id:          "Abstain",
 				Description: "Abstain voting for Pedro",
 				Bits:        0x0, // 0b0000
-				IsIgnore:    true,
+				IsAbstain:   true,
 				IsNo:        false,
 			},
 			{
 				Id:          "Yes",
 				Description: "Vote for Pedro",
 				Bits:        0x2, // 0b0010
-				IsIgnore:    false,
+				IsAbstain:   false,
 				IsNo:        false,
 			},
 			{
 				Id:          "Yes", // XXX this is the invalid ID
 				Description: "Dont vote for Pedro",
 				Bits:        0x4, // 0b0100
-				IsIgnore:    false,
+				IsAbstain:   false,
 				IsNo:        true,
 			},
 		},
@@ -310,8 +310,8 @@ func TestChoices(t *testing.T) {
 		},
 		{
 			name:     "invalid ignore",
-			vote:     invalidIgnore,
-			expected: ErrInvalidIgnore,
+			vote:     invalidAbstain,
+			expected: ErrInvalidAbstain,
 		},
 		{
 			name:     "invalid vote bits",
@@ -319,9 +319,9 @@ func TestChoices(t *testing.T) {
 			expected: ErrInvalidBits,
 		},
 		{
-			name:     "2 IsIgnore",
-			vote:     twoIsIgnore,
-			expected: ErrInvalidIsIgnore,
+			name:     "2 IsAbstain",
+			vote:     twoIsAbstain,
+			expected: ErrInvalidIsAbstain,
 		},
 		{
 			name:     "2 IsNo",
@@ -329,7 +329,7 @@ func TestChoices(t *testing.T) {
 			expected: ErrInvalidIsNo,
 		},
 		{
-			name:     "both IsIgnore IsNo",
+			name:     "both IsAbstain IsNo",
 			vote:     bothFlags,
 			expected: ErrInvalidBothFlags,
 		},

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -88,21 +88,21 @@ type Checkpoint struct {
 //			Id:          "abstain",
 //			Description: "abstain voting for change",
 //			Bits:        0x0000,
-//			IsIgnore:    true,
+//			IsAbstain:   true,
 //			IsNo:        false,
 //		},
 //		{
 //			Id:          "no",
 //			Description: "reject changing block height to uint64",
 //			Bits:        0x0002,
-//			IsIgnore:    false,
+//			IsAbstain:   false,
 //			IsNo:        false,
 //		},
 //		{
 //			Id:          "yes",
 //			Description: "accept changing block height to uint64",
 //			Bits:        0x0004,
-//			IsIgnore:    false,
+//			IsAbstain:   false,
 //			IsNo:        true,
 //		},
 //	},
@@ -134,9 +134,9 @@ type Choice struct {
 	// Bits used for this vote.
 	Bits uint16
 
-	// Ignore this choice.  By convention this must be the 0 vote (abstain)
-	// and exist only once in the Vote.Choices array.
-	IsIgnore bool
+	// This is the abstain choice.  By convention this must be the 0 vote
+	// (abstain) and exist only once in the Vote.Choices array.
+	IsAbstain bool
 
 	// This coince indicates a hard No Vote.  By convention this must exist
 	// only once in the Vote.Choices array.
@@ -732,19 +732,19 @@ var SimNetParams = Params{
 					Id:          "abstain",
 					Description: "abstain voting for change",
 					Bits:        0x0000,
-					IsIgnore:    true,
+					IsAbstain:   true,
 					IsNo:        false,
 				}, {
 					Id:          "no",
 					Description: "reject changing max allowed block size",
 					Bits:        0x0002, // Bit 1
-					IsIgnore:    false,
+					IsAbstain:   false,
 					IsNo:        true,
 				}, {
 					Id:          "yes",
 					Description: "accept changing max allowed block size",
 					Bits:        0x0004, // Bit 2
-					IsIgnore:    false,
+					IsAbstain:   false,
 					IsNo:        false,
 				}},
 			},

--- a/dcrjson/dcrdresults.go
+++ b/dcrjson/dcrdresults.go
@@ -60,7 +60,7 @@ type Choice struct {
 	Id          string  `json:"id"`
 	Description string  `json:"description"`
 	Bits        uint16  `json:"bits"`
-	IsIgnore    bool    `json:"isignore"`
+	IsAbstain   bool    `json:"isabstain"`
 	IsNo        bool    `json:"isno"`
 	Count       uint32  `json:"count"`
 	Progress    float64 `json:"progress"`

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -51,8 +51,8 @@ import (
 
 // API version constants
 const (
-	jsonrpcSemverString = "2.0.0"
-	jsonrpcSemverMajor  = 2
+	jsonrpcSemverString = "3.0.0"
+	jsonrpcSemverMajor  = 3
 	jsonrpcSemverMinor  = 0
 	jsonrpcSemverPatch  = 0
 )
@@ -3840,7 +3840,7 @@ func handleGetVoteInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{})
 				Id:          choice.Id,
 				Description: choice.Description,
 				Bits:        choice.Bits,
-				IsIgnore:    choice.IsIgnore,
+				IsAbstain:   choice.IsAbstain,
 				IsNo:        choice.IsNo,
 			}
 			a.Choices = append(a.Choices, c)
@@ -3870,9 +3870,9 @@ func handleGetVoteInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{})
 
 		// Calculate quorum.
 		qmin := quorum
-		totalNonIgnore := counts.Total - counts.TotalIgnore
-		if totalNonIgnore < quorum {
-			qmin = totalNonIgnore
+		totalNonAbstain := counts.Total - counts.TotalAbstain
+		if totalNonAbstain < quorum {
+			qmin = totalNonAbstain
 		}
 		a.QuorumProgress = float64(qmin) / float64(quorum)
 

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -456,7 +456,7 @@ var helpDescsEnUS = map[string]string{
 	"choice-id":                       "Unique identifier of this choice.",
 	"choice-description":              "Description of this choice.",
 	"choice-bits":                     "Bits that dentify this choice.",
-	"choice-isignore":                 "Should this vote be ignored.",
+	"choice-isabstain":                "This choice is to abstain from change.",
 	"choice-isno":                     "Hard no choice (1 and only 1 per agenda).",
 	"choice-count":                    "How many votes received.",
 	"choice-progress":                 "Progress of the overall count.",


### PR DESCRIPTION
This renames the `chaincfg` parameter for the vote choice which represents an abstaining vote to be named `IsAbstain` instead of `IsIgnore` since that more accurately describes its intent and behavior.

It also updates the RPC server choice result field for `isignore` to be named `isabstain` to match.

Finally, it renames other internal variables which make use of the choice to include the word abstain as well for clarity.

Closes #655.