### PR TITLE
policy: Lower default relay fee to 0.001/kB.

### DIFF
--- a/mempool/policy.go
+++ b/mempool/policy.go
@@ -44,7 +44,7 @@ const (
 	// It is also used to help determine if a transaction is considered dust
 	// and as a base for calculating minimum required fees for larger
 	// transactions.  This value is in Atoms/1000 bytes.
-	DefaultMinRelayTxFee = dcrutil.Amount(1e6)
+	DefaultMinRelayTxFee = dcrutil.Amount(1e5)
 
 	// maxStandardMultiSigKeys is the maximum number of public keys allowed
 	// in a multi-signature transaction output script for it to be

--- a/mempool/policy_test.go
+++ b/mempool/policy_test.go
@@ -40,13 +40,13 @@ func TestCalcMinRequiredTxRelayFee(t *testing.T) {
 			"1000 bytes with default minimum relay fee",
 			1000,
 			DefaultMinRelayTxFee,
-			1000000,
+			1e5,
 		},
 		{
 			"max standard tx size with default minimum relay fee",
 			maxStandardTxSize,
 			DefaultMinRelayTxFee,
-			100000000,
+			1e7,
 		},
 		{
 			"max standard tx size with max relay fee",


### PR DESCRIPTION
This lowers the default minimum relay fee to 0.001 DCR/Kb from its previous value of 0.01 DCR/Kb.

It should be noted that this is only a default node policy change and as such does not affect the consensus rules in any way.