### PR TITLE
rpcserver: Return handler errors to RPC client.

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2536,10 +2536,10 @@ func (state *gbtWorkState) blockTemplateResult(bm *blockManager, useCoinbaseValu
 			numSigOps += blockchain.CountSigOps(txU, false,
 				isSSGen)
 			if numSigOps > maxSigOpsPerTx {
-				context := fmt.Sprintf("transaction %v has "+
+				errStr := fmt.Sprintf("transaction %v has "+
 					"too many sigops: %d > %d", txHash,
 					numSigOps, maxSigOpsPerTx)
-				return nil, rpcInternalError("", context)
+				return nil, rpcInternalError(errStr, "")
 			}
 			sigOps = int64(numSigOps)
 		}
@@ -2612,9 +2612,9 @@ func (state *gbtWorkState) blockTemplateResult(bm *blockManager, useCoinbaseValu
 				len(msgBlock.STransactions)
 			if allTxCount != len(template.Fees) ||
 				allTxCount != len(template.SigOpCounts) {
-				context := "failed to build template due to " +
+				errStr := "failed to build template due to " +
 					"race"
-				return nil, rpcInternalError("", context)
+				return nil, rpcInternalError(errStr, "")
 			}
 
 			fee = template.Fees[i+len(msgBlock.Transactions)]
@@ -2655,12 +2655,10 @@ func (state *gbtWorkState) blockTemplateResult(bm *blockManager, useCoinbaseValu
 
 			numSigOps += blockchain.CountSigOps(txU, false, isSSGen)
 			if numSigOps > maxSigOpsPerTx {
-				context := "Too many sigops"
 				errStr := fmt.Sprintf("transaction %v has "+
 					"too many sigops: %d > %d", stxHash,
 					numSigOps, maxSigOpsPerTx)
-				return nil, rpcInternalError(errStr,
-					context)
+				return nil, rpcInternalError(errStr, "")
 			}
 			sigOps = int64(numSigOps)
 		}


### PR DESCRIPTION
Only the first parameter to the `rpcInternalError` function is returned to RPC clients, so any errors that originate in the handlers need to be passed as the first parameter.

The second context parameter is to allow additional context to be added to errors coming from underlying calls.  There is no additional context for errors generated by the RPC handlers themselves.