### PR TITLE
rpcserver: Disable getblocktemplate.

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -202,7 +202,6 @@ var rpcHandlersBeforeInit = map[string]commandHandler{
 	"getblockcount":         handleGetBlockCount,
 	"getblockhash":          handleGetBlockHash,
 	"getblockheader":        handleGetBlockHeader,
-	"getblocktemplate":      handleGetBlockTemplate,
 	"getcoinsupply":         handleGetCoinSupply,
 	"getconnectioncount":    handleGetConnectionCount,
 	"getcurrentnet":         handleGetCurrentNet,
@@ -309,6 +308,7 @@ var rpcAskWallet = map[string]struct{}{
 var rpcUnimplemented = map[string]struct{}{
 	"estimatefee":       {},
 	"estimatepriority":  {},
+	"getblocktemplate":  {},
 	"getblockchaininfo": {},
 	"getchaintips":      {},
 	"getnetworkinfo":    {},


### PR DESCRIPTION
This disables the `getblocktemplate` RPC handler since it does not at all work as intended.  Fixing it is going to be a larger effort, so just disable it until it can be properly implemented.