### PR TITLE
glide: move to upstream agl/ed25519

### DIFF
--- a/dcrec/edwards/const.go
+++ b/dcrec/edwards/const.go
@@ -7,7 +7,7 @@ package edwards
 import (
 	"math/big"
 
-	"github.com/decred/ed25519/edwards25519"
+	"github.com/agl/ed25519/edwards25519"
 )
 
 var (

--- a/dcrec/edwards/curve.go
+++ b/dcrec/edwards/curve.go
@@ -8,7 +8,7 @@ import (
 	"crypto/elliptic"
 	"math/big"
 
-	"github.com/decred/ed25519/edwards25519"
+	"github.com/agl/ed25519/edwards25519"
 )
 
 // TwistedEdwardsCurve extended an elliptical curve set of

--- a/dcrec/edwards/ecdsa.go
+++ b/dcrec/edwards/ecdsa.go
@@ -12,11 +12,10 @@ import (
 	"hash"
 	"io"
 	"math/big"
-
 	"crypto/sha512"
 
-	"github.com/decred/ed25519"
-	"github.com/decred/ed25519/edwards25519"
+	"github.com/agl/ed25519"
+	"github.com/agl/ed25519/edwards25519"
 )
 
 // BIG CAVEAT

--- a/dcrec/edwards/primitives.go
+++ b/dcrec/edwards/primitives.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/decred/ed25519/edwards25519"
+	"github.com/agl/ed25519/edwards25519"
 )
 
 // Some notes on primitives in Ed25519:

--- a/dcrec/edwards/privkey.go
+++ b/dcrec/edwards/privkey.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/decred/ed25519"
+	"github.com/agl/ed25519"
 )
 
 // These constants define the lengths of serialized private keys.

--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,10 @@
-hash: 2b8970779e0f073a5720aa6d6558bfbf1919f12ef2e19b3921955f156edd93e3
-updated: 2017-05-18T11:21:32.466255698-04:00
+hash: 134468fdfb2f19fa76447939a94e40512c3891b8f0a8e1f1fa2b70bcbd40bdf4
+updated: 2017-05-31T22:00:42.668930312-04:00
 imports:
+- name: github.com/agl/ed25519
+  version: 278e1ec8e8a6e017cd07577924d6766039146ced
+  subpackages:
+  - edwards25519
 - name: github.com/btcsuite/btclog
   version: 73889fb79bd687870312b6e40effcecffbd57d30
 - name: github.com/btcsuite/go-flags
@@ -53,10 +57,6 @@ imports:
   subpackages:
   - base58
   - bloom
-- name: github.com/decred/ed25519
-  version: b0909d3f798b97a03c9e77023f97a5301a2a7900
-  subpackages:
-  - edwards25519
 - name: golang.org/x/crypto
   version: 0fe963104e9d1877082f8fb38f816fcd97eb1d10
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,9 @@
 package: github.com/decred/dcrd
 import:
+- package: github.com/agl/ed25519
+  version: 278e1ec8e8a6e017cd07577924d6766039146ced
+  subpackages:
+  - edwards25519
 - package: github.com/btcsuite/btclog
 - package: github.com/btcsuite/go-flags
 - package: github.com/btcsuite/go-socks
@@ -30,9 +34,6 @@ import:
 - package: github.com/decred/dcrutil
   subpackages:
   - bloom
-- package: github.com/decred/ed25519
-  subpackages:
-  - edwards25519
 - package: golang.org/x/crypto
   subpackages:
   - ripemd160


### PR DESCRIPTION
set to the version decred/ed25519 had been synced with.