### PR TITLE
secp256k1: Unexport idents that do not need to be.

### DIFF
--- a/dcrec/secp256k1/bench_test.go
+++ b/dcrec/secp256k1/bench_test.go
@@ -11,17 +11,17 @@ import "testing"
 // Z values of 1 so that the associated optimizations are used.
 func BenchmarkAddJacobian(b *testing.B) {
 	b.StopTimer()
-	x1 := new(FieldVal).SetHex("34f9460f0e4f08393d192b3c5133a6ba099aa0ad9fd54ebccfacdfa239ff49c6")
-	y1 := new(FieldVal).SetHex("0b71ea9bd730fd8923f6d25a7a91e7dd7728a960686cb5a901bb419e0f2ca232")
-	z1 := new(FieldVal).SetHex("1")
-	x2 := new(FieldVal).SetHex("34f9460f0e4f08393d192b3c5133a6ba099aa0ad9fd54ebccfacdfa239ff49c6")
-	y2 := new(FieldVal).SetHex("0b71ea9bd730fd8923f6d25a7a91e7dd7728a960686cb5a901bb419e0f2ca232")
-	z2 := new(FieldVal).SetHex("1")
-	x3, y3, z3 := new(FieldVal), new(FieldVal), new(FieldVal)
+	x1 := new(fieldVal).SetHex("34f9460f0e4f08393d192b3c5133a6ba099aa0ad9fd54ebccfacdfa239ff49c6")
+	y1 := new(fieldVal).SetHex("0b71ea9bd730fd8923f6d25a7a91e7dd7728a960686cb5a901bb419e0f2ca232")
+	z1 := new(fieldVal).SetHex("1")
+	x2 := new(fieldVal).SetHex("34f9460f0e4f08393d192b3c5133a6ba099aa0ad9fd54ebccfacdfa239ff49c6")
+	y2 := new(fieldVal).SetHex("0b71ea9bd730fd8923f6d25a7a91e7dd7728a960686cb5a901bb419e0f2ca232")
+	z2 := new(fieldVal).SetHex("1")
+	x3, y3, z3 := new(fieldVal), new(fieldVal), new(fieldVal)
 	curve := S256()
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		curve.AddJacobian(x1, y1, z1, x2, y2, z2, x3, y3, z3)
+		curve.addJacobian(x1, y1, z1, x2, y2, z2, x3, y3, z3)
 	}
 }
 
@@ -30,17 +30,17 @@ func BenchmarkAddJacobian(b *testing.B) {
 // Z=1 aren't used.
 func BenchmarkAddJacobianNotZOne(b *testing.B) {
 	b.StopTimer()
-	x1 := new(FieldVal).SetHex("d3e5183c393c20e4f464acf144ce9ae8266a82b67f553af33eb37e88e7fd2718")
-	y1 := new(FieldVal).SetHex("5b8f54deb987ec491fb692d3d48f3eebb9454b034365ad480dda0cf079651190")
-	z1 := new(FieldVal).SetHex("2")
-	x2 := new(FieldVal).SetHex("91abba6a34b7481d922a4bd6a04899d5a686f6cf6da4e66a0cb427fb25c04bd4")
-	y2 := new(FieldVal).SetHex("03fede65e30b4e7576a2abefc963ddbf9fdccbf791b77c29beadefe49951f7d1")
-	z2 := new(FieldVal).SetHex("3")
-	x3, y3, z3 := new(FieldVal), new(FieldVal), new(FieldVal)
+	x1 := new(fieldVal).SetHex("d3e5183c393c20e4f464acf144ce9ae8266a82b67f553af33eb37e88e7fd2718")
+	y1 := new(fieldVal).SetHex("5b8f54deb987ec491fb692d3d48f3eebb9454b034365ad480dda0cf079651190")
+	z1 := new(fieldVal).SetHex("2")
+	x2 := new(fieldVal).SetHex("91abba6a34b7481d922a4bd6a04899d5a686f6cf6da4e66a0cb427fb25c04bd4")
+	y2 := new(fieldVal).SetHex("03fede65e30b4e7576a2abefc963ddbf9fdccbf791b77c29beadefe49951f7d1")
+	z2 := new(fieldVal).SetHex("3")
+	x3, y3, z3 := new(fieldVal), new(fieldVal), new(fieldVal)
 	curve := S256()
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		curve.AddJacobian(x1, y1, z1, x2, y2, z2, x3, y3, z3)
+		curve.addJacobian(x1, y1, z1, x2, y2, z2, x3, y3, z3)
 	}
 }
 

--- a/dcrec/secp256k1/btcec_test.go
+++ b/dcrec/secp256k1/btcec_test.go
@@ -18,14 +18,14 @@ import (
 
 // isJacobianOnS256Curve returns boolean if the point (x,y,z) is on the
 // secp256k1 curve.
-func isJacobianOnS256Curve(x, y, z *FieldVal) bool {
+func isJacobianOnS256Curve(x, y, z *fieldVal) bool {
 	// Elliptic curve equation for secp256k1 is: y^2 = x^3 + 7
 	// In Jacobian coordinates, Y = y/z^3 and X = x/z^2
 	// Thus:
 	// (y/z^3)^2 = (x/z^2)^3 + 7
 	// y^2/z^6 = x^3/z^6 + 7
 	// y^2 = x^3 + 7*z^6
-	var y2, z2, x3, result FieldVal
+	var y2, z2, x3, result fieldVal
 	y2.SquareVal(y).Normalize()
 	z2.SquareVal(z)
 	x3.SquareVal(x).Mul(x)
@@ -227,15 +227,15 @@ func TestAddJacobian(t *testing.T) {
 	t.Logf("Running %d tests", len(tests))
 	for i, test := range tests {
 		// Convert hex to field values.
-		x1 := new(FieldVal).SetHex(test.x1)
-		y1 := new(FieldVal).SetHex(test.y1)
-		z1 := new(FieldVal).SetHex(test.z1)
-		x2 := new(FieldVal).SetHex(test.x2)
-		y2 := new(FieldVal).SetHex(test.y2)
-		z2 := new(FieldVal).SetHex(test.z2)
-		x3 := new(FieldVal).SetHex(test.x3)
-		y3 := new(FieldVal).SetHex(test.y3)
-		z3 := new(FieldVal).SetHex(test.z3)
+		x1 := new(fieldVal).SetHex(test.x1)
+		y1 := new(fieldVal).SetHex(test.y1)
+		z1 := new(fieldVal).SetHex(test.z1)
+		x2 := new(fieldVal).SetHex(test.x2)
+		y2 := new(fieldVal).SetHex(test.y2)
+		z2 := new(fieldVal).SetHex(test.z2)
+		x3 := new(fieldVal).SetHex(test.x3)
+		y3 := new(fieldVal).SetHex(test.y3)
+		z3 := new(fieldVal).SetHex(test.z3)
 
 		// Ensure the test data is using points that are actually on
 		// the curve (or the point at infinity).
@@ -256,8 +256,8 @@ func TestAddJacobian(t *testing.T) {
 		}
 
 		// Add the two points.
-		rx, ry, rz := new(FieldVal), new(FieldVal), new(FieldVal)
-		S256().AddJacobian(x1, y1, z1, x2, y2, z2, rx, ry, rz)
+		rx, ry, rz := new(fieldVal), new(fieldVal), new(fieldVal)
+		S256().addJacobian(x1, y1, z1, x2, y2, z2, rx, ry, rz)
 
 		// Ensure result matches expected.
 		if !rx.Equals(x3) || !ry.Equals(y3) || !rz.Equals(z3) {
@@ -403,12 +403,12 @@ func TestDoubleJacobian(t *testing.T) {
 	t.Logf("Running %d tests", len(tests))
 	for i, test := range tests {
 		// Convert hex to field values.
-		x1 := new(FieldVal).SetHex(test.x1)
-		y1 := new(FieldVal).SetHex(test.y1)
-		z1 := new(FieldVal).SetHex(test.z1)
-		x3 := new(FieldVal).SetHex(test.x3)
-		y3 := new(FieldVal).SetHex(test.y3)
-		z3 := new(FieldVal).SetHex(test.z3)
+		x1 := new(fieldVal).SetHex(test.x1)
+		y1 := new(fieldVal).SetHex(test.y1)
+		z1 := new(fieldVal).SetHex(test.z1)
+		x3 := new(fieldVal).SetHex(test.x3)
+		y3 := new(fieldVal).SetHex(test.y3)
+		z3 := new(fieldVal).SetHex(test.z3)
 
 		// Ensure the test data is using points that are actually on
 		// the curve (or the point at infinity).
@@ -424,7 +424,7 @@ func TestDoubleJacobian(t *testing.T) {
 		}
 
 		// Double the point.
-		rx, ry, rz := new(FieldVal), new(FieldVal), new(FieldVal)
+		rx, ry, rz := new(fieldVal), new(fieldVal), new(fieldVal)
 		S256().doubleJacobian(x1, y1, z1, rx, ry, rz)
 
 		// Ensure result matches expected.

--- a/dcrec/secp256k1/field.go
+++ b/dcrec/secp256k1/field.go
@@ -105,7 +105,7 @@ const (
 	fieldPrimeWordOne = 0x3ffffbf
 )
 
-// FieldVal implements optimized fixed-precision arithmetic over the
+// fieldVal implements optimized fixed-precision arithmetic over the
 // secp256k1 finite field.  This means all arithmetic is performed modulo
 // 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f.  It
 // represents each 256-bit value as 10 32-bit integers in base 2^26.  This
@@ -135,20 +135,20 @@ const (
 // 	n[1] * 2^(26*1) = 2^23 * 2^26  = 2^49
 // 	n[0] * 2^(26*0) = 1    * 2^0   = 1
 // 	Sum: 0 + 0 + ... + 2^49 + 1 = 2^49 + 1
-type FieldVal struct {
+type fieldVal struct {
 	n [10]uint32
 }
 
 // String returns the field value as a human-readable hex string.
-func (f FieldVal) String() string {
-	t := new(FieldVal).Set(&f).Normalize()
+func (f fieldVal) String() string {
+	t := new(fieldVal).Set(&f).Normalize()
 	return hex.EncodeToString(t.Bytes()[:])
 }
 
 // Zero sets the field value to zero.  A newly created field value is already
 // set to zero.  This function can be useful to clear an existing field value
 // for reuse.
-func (f *FieldVal) Zero() {
+func (f *fieldVal) Zero() {
 	f.n[0] = 0
 	f.n[1] = 0
 	f.n[2] = 0
@@ -164,9 +164,9 @@ func (f *FieldVal) Zero() {
 // Set sets the field value equal to the passed value.
 //
 // The field value is returned to support chaining.  This enables syntax like:
-// f := new(FieldVal).Set(f2).Add(1) so that f = f2 + 1 where f2 is not
+// f := new(fieldVal).Set(f2).Add(1) so that f = f2 + 1 where f2 is not
 // modified.
-func (f *FieldVal) Set(val *FieldVal) *FieldVal {
+func (f *fieldVal) Set(val *fieldVal) *fieldVal {
 	*f = *val
 	return f
 }
@@ -176,8 +176,8 @@ func (f *FieldVal) Set(val *FieldVal) *FieldVal {
 // native integers.
 //
 // The field value is returned to support chaining.  This enables syntax such
-// as f := new(FieldVal).SetInt(2).Mul(f2) so that f = 2 * f2.
-func (f *FieldVal) SetInt(ui uint) *FieldVal {
+// as f := new(fieldVal).SetInt(2).Mul(f2) so that f = 2 * f2.
+func (f *fieldVal) SetInt(ui uint) *fieldVal {
 	f.Zero()
 	f.n[0] = uint32(ui)
 	return f
@@ -187,8 +187,8 @@ func (f *FieldVal) SetInt(ui uint) *FieldVal {
 // value representation.
 //
 // The field value is returned to support chaining.  This enables syntax like:
-// f := new(FieldVal).SetBytes(byteArray).Mul(f2) so that f = ba * f2.
-func (f *FieldVal) SetBytes(b *[32]byte) *FieldVal {
+// f := new(fieldVal).SetBytes(byteArray).Mul(f2) so that f = ba * f2.
+func (f *fieldVal) SetBytes(b *[32]byte) *fieldVal {
 	// Pack the 256 total bits across the 10 uint32 words with a max of
 	// 26-bits per word.  This could be done with a couple of for loops,
 	// but this unrolled version is significantly faster.  Benchmarks show
@@ -221,8 +221,8 @@ func (f *FieldVal) SetBytes(b *[32]byte) *FieldVal {
 // will be truncated.
 //
 // The field value is returned to support chaining.  This enables syntax like:
-// f := new(FieldVal).SetByteSlice(byteSlice)
-func (f *FieldVal) SetByteSlice(b []byte) *FieldVal {
+// f := new(fieldVal).SetByteSlice(byteSlice)
+func (f *fieldVal) SetByteSlice(b []byte) *fieldVal {
 	var b32 [32]byte
 	for i := 0; i < len(b); i++ {
 		if i < 32 {
@@ -236,8 +236,8 @@ func (f *FieldVal) SetByteSlice(b []byte) *FieldVal {
 // representation.  Only the first 32-bytes are used.
 //
 // The field value is returned to support chaining.  This enables syntax like:
-// f := new(FieldVal).SetHex("0abc").Add(1) so that f = 0x0abc + 1
-func (f *FieldVal) SetHex(hexString string) *FieldVal {
+// f := new(fieldVal).SetHex("0abc").Add(1) so that f = 0x0abc + 1
+func (f *fieldVal) SetHex(hexString string) *fieldVal {
 	if len(hexString)%2 != 0 {
 		hexString = "0" + hexString
 	}
@@ -248,7 +248,7 @@ func (f *FieldVal) SetHex(hexString string) *FieldVal {
 // Normalize normalizes the internal field words into the desired range and
 // performs fast modular reduction over the secp256k1 prime by making use of the
 // special form of the prime.
-func (f *FieldVal) Normalize() *FieldVal {
+func (f *fieldVal) Normalize() *fieldVal {
 	// The field representation leaves 6 bits of overflow in each
 	// word so intermediate calculations can be performed without needing
 	// to propagate the carry to each higher word during the calculations.
@@ -415,7 +415,7 @@ func (f *FieldVal) Normalize() *FieldVal {
 //
 // The field value must be normalized for this function to return the correct
 // result.
-func (f *FieldVal) PutBytes(b *[32]byte) {
+func (f *fieldVal) PutBytes(b *[32]byte) {
 	// Unpack the 256 total bits from the 10 uint32 words with a max of
 	// 26-bits per word.  This could be done with a couple of for loops,
 	// but this unrolled version is a bit faster.  Benchmarks show this is
@@ -461,14 +461,14 @@ func (f *FieldVal) PutBytes(b *[32]byte) {
 //
 // The field value must be normalized for this function to return correct
 // result.
-func (f *FieldVal) Bytes() *[32]byte {
+func (f *fieldVal) Bytes() *[32]byte {
 	b := new([32]byte)
 	f.PutBytes(b)
 	return b
 }
 
 // IsZero returns whether or not the field value is equal to zero.
-func (f *FieldVal) IsZero() bool {
+func (f *fieldVal) IsZero() bool {
 	// The value can only be zero if no bits are set in any of the words.
 	// This is a constant time implementation.
 	bits := f.n[0] | f.n[1] | f.n[2] | f.n[3] | f.n[4] |
@@ -481,7 +481,7 @@ func (f *FieldVal) IsZero() bool {
 //
 // The field value must be normalized for this function to return correct
 // result.
-func (f *FieldVal) IsOdd() bool {
+func (f *fieldVal) IsOdd() bool {
 	// Only odd numbers have the bottom bit set.
 	return f.n[0]&1 == 1
 }
@@ -489,7 +489,7 @@ func (f *FieldVal) IsOdd() bool {
 // Equals returns whether or not the two field values are the same.  Both
 // field values being compared must be normalized for this function to return
 // the correct result.
-func (f *FieldVal) Equals(val *FieldVal) bool {
+func (f *fieldVal) Equals(val *fieldVal) bool {
 	// Xor only sets bits when they are different, so the two field values
 	// can only be the same if no bits are set after xoring each word.
 	// This is a constant time implementation.
@@ -506,7 +506,7 @@ func (f *FieldVal) Equals(val *FieldVal) bool {
 //
 // The field value is returned to support chaining.  This enables syntax like:
 // f.NegateVal(f2).AddInt(1) so that f = -f2 + 1.
-func (f *FieldVal) NegateVal(val *FieldVal, magnitude uint32) *FieldVal {
+func (f *fieldVal) NegateVal(val *fieldVal, magnitude uint32) *fieldVal {
 	// Negation in the field is just the prime minus the value.  However,
 	// in order to allow negation against a field value without having to
 	// normalize/reduce it first, multiply by the magnitude (that is how
@@ -544,7 +544,7 @@ func (f *FieldVal) NegateVal(val *FieldVal, magnitude uint32) *FieldVal {
 //
 // The field value is returned to support chaining.  This enables syntax like:
 // f.Negate().AddInt(1) so that f = -f + 1.
-func (f *FieldVal) Negate(magnitude uint32) *FieldVal {
+func (f *fieldVal) Negate(magnitude uint32) *fieldVal {
 	return f.NegateVal(f, magnitude)
 }
 
@@ -554,7 +554,7 @@ func (f *FieldVal) Negate(magnitude uint32) *FieldVal {
 //
 // The field value is returned to support chaining.  This enables syntax like:
 // f.AddInt(1).Add(f2) so that f = f + 1 + f2.
-func (f *FieldVal) AddInt(ui uint) *FieldVal {
+func (f *fieldVal) AddInt(ui uint) *fieldVal {
 	// Since the field representation intentionally provides overflow bits,
 	// it's ok to use carryless addition as the carry bit is safely part of
 	// the word and will be normalized out.
@@ -568,7 +568,7 @@ func (f *FieldVal) AddInt(ui uint) *FieldVal {
 //
 // The field value is returned to support chaining.  This enables syntax like:
 // f.Add(f2).AddInt(1) so that f = f + f2 + 1.
-func (f *FieldVal) Add(val *FieldVal) *FieldVal {
+func (f *fieldVal) Add(val *fieldVal) *fieldVal {
 	// Since the field representation intentionally provides overflow bits,
 	// it's ok to use carryless addition as the carry bit is safely part of
 	// each word and will be normalized out.  This could obviously be done
@@ -591,7 +591,7 @@ func (f *FieldVal) Add(val *FieldVal) *FieldVal {
 //
 // The field value is returned to support chaining.  This enables syntax like:
 // f3.Add2(f, f2).AddInt(1) so that f3 = f + f2 + 1.
-func (f *FieldVal) Add2(val *FieldVal, val2 *FieldVal) *FieldVal {
+func (f *fieldVal) Add2(val *fieldVal, val2 *fieldVal) *fieldVal {
 	// Since the field representation intentionally provides overflow bits,
 	// it's ok to use carryless addition as the carry bit is safely part of
 	// each word and will be normalized out.  This could obviously be done
@@ -617,7 +617,7 @@ func (f *FieldVal) Add2(val *FieldVal, val2 *FieldVal) *FieldVal {
 //
 // The field value is returned to support chaining.  This enables syntax like:
 // f.MulInt(2).Add(f2) so that f = 2 * f + f2.
-func (f *FieldVal) MulInt(val uint) *FieldVal {
+func (f *fieldVal) MulInt(val uint) *fieldVal {
 	// Since each word of the field representation can hold up to
 	// fieldOverflowBits extra bits which will be normalized out, it's safe
 	// to multiply each word without using a larger type or carry
@@ -647,7 +647,7 @@ func (f *FieldVal) MulInt(val uint) *FieldVal {
 //
 // The field value is returned to support chaining.  This enables syntax like:
 // f.Mul(f2).AddInt(1) so that f = (f * f2) + 1.
-func (f *FieldVal) Mul(val *FieldVal) *FieldVal {
+func (f *fieldVal) Mul(val *fieldVal) *fieldVal {
 	return f.Mul2(f, val)
 }
 
@@ -659,7 +659,7 @@ func (f *FieldVal) Mul(val *FieldVal) *FieldVal {
 //
 // The field value is returned to support chaining.  This enables syntax like:
 // f3.Mul2(f, f2).AddInt(1) so that f3 = (f * f2) + 1.
-func (f *FieldVal) Mul2(val *FieldVal, val2 *FieldVal) *FieldVal {
+func (f *fieldVal) Mul2(val *fieldVal, val2 *fieldVal) *fieldVal {
 	// This could be done with a couple of for loops and an array to store
 	// the intermediate terms, but this unrolled version is significantly
 	// faster.
@@ -928,7 +928,7 @@ func (f *FieldVal) Mul2(val *FieldVal, val2 *FieldVal) *FieldVal {
 //
 // The field value is returned to support chaining.  This enables syntax like:
 // f.Square().Mul(f2) so that f = f^2 * f2.
-func (f *FieldVal) Square() *FieldVal {
+func (f *fieldVal) Square() *fieldVal {
 	return f.SquareVal(f)
 }
 
@@ -939,7 +939,7 @@ func (f *FieldVal) Square() *FieldVal {
 //
 // The field value is returned to support chaining.  This enables syntax like:
 // f3.SquareVal(f).Mul(f) so that f3 = f^2 * f = f^3.
-func (f *FieldVal) SquareVal(val *FieldVal) *FieldVal {
+func (f *fieldVal) SquareVal(val *fieldVal) *fieldVal {
 	// This could be done with a couple of for loops and an array to store
 	// the intermediate terms, but this unrolled version is significantly
 	// faster.
@@ -1159,7 +1159,7 @@ func (f *FieldVal) SquareVal(val *FieldVal) *FieldVal {
 //
 // The field value is returned to support chaining.  This enables syntax like:
 // f.Inverse().Mul(f2) so that f = f^-1 * f2.
-func (f *FieldVal) Inverse() *FieldVal {
+func (f *fieldVal) Inverse() *fieldVal {
 	// Fermat's little theorem states that for a nonzero number a and prime
 	// prime p, a^(p-1) = 1 (mod p).  Since the multipliciative inverse is
 	// a*b = 1 (mod p), it follows that b = a*a^(p-2) = a^(p-1) = 1 (mod p).
@@ -1173,7 +1173,7 @@ func (f *FieldVal) Inverse() *FieldVal {
 	// The secp256k1 prime - 2 is 2^256 - 4294968275.
 	//
 	// This has a cost of 258 field squarings and 33 field multiplications.
-	var a2, a3, a4, a10, a11, a21, a42, a45, a63, a1019, a1023 FieldVal
+	var a2, a3, a4, a10, a11, a21, a42, a45, a63, a1019, a1023 fieldVal
 	a2.SquareVal(f)
 	a3.Mul2(&a2, f)
 	a4.SquareVal(&a2)

--- a/dcrec/secp256k1/field_test.go
+++ b/dcrec/secp256k1/field_test.go
@@ -29,7 +29,7 @@ func TestSetInt(t *testing.T) {
 
 	t.Logf("Running %d tests", len(tests))
 	for i, test := range tests {
-		f := new(FieldVal).SetInt(test.in)
+		f := new(fieldVal).SetInt(test.in)
 		if !reflect.DeepEqual(f.n, test.raw) {
 			t.Errorf("fieldVal.Set #%d wrong result\ngot: %v\n"+
 				"want: %v", i, f.n, test.raw)
@@ -40,7 +40,7 @@ func TestSetInt(t *testing.T) {
 
 // TestZero ensures that zeroing a field value zero works as expected.
 func TestZero(t *testing.T) {
-	f := new(FieldVal).SetInt(2)
+	f := new(fieldVal).SetInt(2)
 	f.Zero()
 	for idx, rawInt := range f.n {
 		if rawInt != 0 {
@@ -52,7 +52,7 @@ func TestZero(t *testing.T) {
 
 // TestIsZero ensures that checking if a field IsZero works as expected.
 func TestIsZero(t *testing.T) {
-	f := new(FieldVal)
+	f := new(fieldVal)
 	if !f.IsZero() {
 		t.Errorf("new field value is not zero - got %v (rawints %x)", f,
 			f.n)
@@ -126,7 +126,7 @@ func TestStringer(t *testing.T) {
 			"ffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
 			"00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
 		},
-		// 2^256-4294968273 (the dcrec prime, so should result in 0)
+		// 2^256-4294968273 (the secp256k1 prime, so should result in 0)
 		{
 			"fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
 			"0000000000000000000000000000000000000000000000000000000000000000",
@@ -145,7 +145,7 @@ func TestStringer(t *testing.T) {
 
 	t.Logf("Running %d tests", len(tests))
 	for i, test := range tests {
-		f := new(FieldVal).SetHex(test.in)
+		f := new(fieldVal).SetHex(test.in)
 		result := f.String()
 		if result != test.expected {
 			t.Errorf("fieldVal.String #%d wrong result\ngot: %v\n"+
@@ -240,7 +240,7 @@ func TestNormalize(t *testing.T) {
 
 	t.Logf("Running %d tests", len(tests))
 	for i, test := range tests {
-		f := new(FieldVal)
+		f := new(fieldVal)
 		for rawIntIdx := 0; rawIntIdx < len(test.raw); rawIntIdx++ {
 			f.n[rawIntIdx] = test.raw[rawIntIdx]
 		}
@@ -272,7 +272,7 @@ func TestIsOdd(t *testing.T) {
 
 	t.Logf("Running %d tests", len(tests))
 	for i, test := range tests {
-		f := new(FieldVal).SetHex(test.in)
+		f := new(fieldVal).SetHex(test.in)
 		result := f.IsOdd()
 		if result != test.expected {
 			t.Errorf("fieldVal.IsOdd #%d wrong result\n"+
@@ -305,8 +305,8 @@ func TestEquals(t *testing.T) {
 
 	t.Logf("Running %d tests", len(tests))
 	for i, test := range tests {
-		f := new(FieldVal).SetHex(test.in1).Normalize()
-		f2 := new(FieldVal).SetHex(test.in2).Normalize()
+		f := new(fieldVal).SetHex(test.in1).Normalize()
+		f2 := new(fieldVal).SetHex(test.in2).Normalize()
 		result := f.Equals(f2)
 		if result != test.expected {
 			t.Errorf("fieldVal.Equals #%d wrong result\n"+
@@ -353,8 +353,8 @@ func TestNegate(t *testing.T) {
 
 	t.Logf("Running %d tests", len(tests))
 	for i, test := range tests {
-		f := new(FieldVal).SetHex(test.in).Normalize()
-		expected := new(FieldVal).SetHex(test.expected).Normalize()
+		f := new(fieldVal).SetHex(test.in).Normalize()
+		expected := new(fieldVal).SetHex(test.expected).Normalize()
 		result := f.Negate(1).Normalize()
 		if !result.Equals(expected) {
 			t.Errorf("fieldVal.Negate #%d wrong result\n"+
@@ -404,8 +404,8 @@ func TestAddInt(t *testing.T) {
 
 	t.Logf("Running %d tests", len(tests))
 	for i, test := range tests {
-		f := new(FieldVal).SetHex(test.in1).Normalize()
-		expected := new(FieldVal).SetHex(test.expected).Normalize()
+		f := new(fieldVal).SetHex(test.in1).Normalize()
+		expected := new(fieldVal).SetHex(test.expected).Normalize()
 		result := f.AddInt(test.in2).Normalize()
 		if !result.Equals(expected) {
 			t.Errorf("fieldVal.AddInt #%d wrong result\n"+
@@ -455,9 +455,9 @@ func TestAdd(t *testing.T) {
 
 	t.Logf("Running %d tests", len(tests))
 	for i, test := range tests {
-		f := new(FieldVal).SetHex(test.in1).Normalize()
-		f2 := new(FieldVal).SetHex(test.in2).Normalize()
-		expected := new(FieldVal).SetHex(test.expected).Normalize()
+		f := new(fieldVal).SetHex(test.in1).Normalize()
+		f2 := new(fieldVal).SetHex(test.in2).Normalize()
+		expected := new(fieldVal).SetHex(test.expected).Normalize()
 		result := f.Add(f2).Normalize()
 		if !result.Equals(expected) {
 			t.Errorf("fieldVal.Add #%d wrong result\n"+
@@ -507,9 +507,9 @@ func TestAdd2(t *testing.T) {
 
 	t.Logf("Running %d tests", len(tests))
 	for i, test := range tests {
-		f := new(FieldVal).SetHex(test.in1).Normalize()
-		f2 := new(FieldVal).SetHex(test.in2).Normalize()
-		expected := new(FieldVal).SetHex(test.expected).Normalize()
+		f := new(fieldVal).SetHex(test.in1).Normalize()
+		f2 := new(fieldVal).SetHex(test.in2).Normalize()
+		expected := new(fieldVal).SetHex(test.expected).Normalize()
 		result := f.Add2(f, f2).Normalize()
 		if !result.Equals(expected) {
 			t.Errorf("fieldVal.Add2 #%d wrong result\n"+
@@ -572,8 +572,8 @@ func TestMulInt(t *testing.T) {
 
 	t.Logf("Running %d tests", len(tests))
 	for i, test := range tests {
-		f := new(FieldVal).SetHex(test.in1).Normalize()
-		expected := new(FieldVal).SetHex(test.expected).Normalize()
+		f := new(fieldVal).SetHex(test.in1).Normalize()
+		expected := new(fieldVal).SetHex(test.expected).Normalize()
 		result := f.MulInt(test.in2).Normalize()
 		if !result.Equals(expected) {
 			t.Errorf("fieldVal.MulInt #%d wrong result\n"+
@@ -633,9 +633,9 @@ func TestMul(t *testing.T) {
 
 	t.Logf("Running %d tests", len(tests))
 	for i, test := range tests {
-		f := new(FieldVal).SetHex(test.in1).Normalize()
-		f2 := new(FieldVal).SetHex(test.in2).Normalize()
-		expected := new(FieldVal).SetHex(test.expected).Normalize()
+		f := new(fieldVal).SetHex(test.in1).Normalize()
+		f2 := new(fieldVal).SetHex(test.in2).Normalize()
+		expected := new(fieldVal).SetHex(test.expected).Normalize()
 		result := f.Mul(f2).Normalize()
 		if !result.Equals(expected) {
 			t.Errorf("fieldVal.Mul #%d wrong result\n"+
@@ -680,8 +680,8 @@ func TestSquare(t *testing.T) {
 
 	t.Logf("Running %d tests", len(tests))
 	for i, test := range tests {
-		f := new(FieldVal).SetHex(test.in).Normalize()
-		expected := new(FieldVal).SetHex(test.expected).Normalize()
+		f := new(fieldVal).SetHex(test.in).Normalize()
+		expected := new(fieldVal).SetHex(test.expected).Normalize()
 		result := f.Square().Normalize()
 		if !result.Equals(expected) {
 			t.Errorf("fieldVal.Square #%d wrong result\n"+
@@ -733,8 +733,8 @@ func TestInverse(t *testing.T) {
 
 	t.Logf("Running %d tests", len(tests))
 	for i, test := range tests {
-		f := new(FieldVal).SetHex(test.in).Normalize()
-		expected := new(FieldVal).SetHex(test.expected).Normalize()
+		f := new(fieldVal).SetHex(test.in).Normalize()
+		expected := new(fieldVal).SetHex(test.expected).Normalize()
 		result := f.Inverse().Normalize()
 		if !result.Equals(expected) {
 			t.Errorf("fieldVal.Inverse #%d wrong result\n"+

--- a/dcrec/secp256k1/precompute.go
+++ b/dcrec/secp256k1/precompute.go
@@ -42,7 +42,7 @@ func loadS256BytePoints() error {
 
 	// Deserialize the precomputed byte points and set the curve to them.
 	offset := 0
-	var bytePoints [32][256][3]FieldVal
+	var bytePoints [32][256][3]fieldVal
 	for byteNum := 0; byteNum < 32; byteNum++ {
 		// All points in this window.
 		for i := 0; i < 256; i++ {

--- a/dcrec/secp256k1/pubkey.go
+++ b/dcrec/secp256k1/pubkey.go
@@ -23,9 +23,9 @@ func isOdd(a *big.Int) bool {
 	return a.Bit(0) == 1
 }
 
-// DecompressPoint decompresses a point on the given curve given the X point and
+// decompressPoint decompresses a point on the given curve given the X point and
 // the solution to use.
-func DecompressPoint(curve *KoblitzCurve, x *big.Int, ybit bool) (*big.Int, error) {
+func decompressPoint(curve *KoblitzCurve, x *big.Int, ybit bool) (*big.Int, error) {
 	// TODO(oga) This will probably only work for secp256k1 due to
 	// optimizations.
 
@@ -98,7 +98,7 @@ func ParsePubKey(pubKeyStr []byte, curve *KoblitzCurve) (key *PublicKey,
 				"pubkey string: %d", pubKeyStr[0])
 		}
 		pubkey.X = new(big.Int).SetBytes(pubKeyStr[1:33])
-		pubkey.Y, err = DecompressPoint(curve, pubkey.X, ybit)
+		pubkey.Y, err = decompressPoint(curve, pubkey.X, ybit)
 		if err != nil {
 			return nil, err
 		}

--- a/dcrec/secp256k1/pubkey_test.go
+++ b/dcrec/secp256k1/pubkey_test.go
@@ -20,7 +20,7 @@ type pubKeyTest struct {
 }
 
 var pubKeyTests = []pubKeyTest{
-	// pubkey from decred blockchain tx
+	// pubkey from bitcoin blockchain tx
 	// 0437cd7f8525ceed2324359c2d0ba26006d92d85
 	{
 		name: "uncompressed ok",

--- a/dcrec/secp256k1/signature.go
+++ b/dcrec/secp256k1/signature.go
@@ -299,7 +299,7 @@ func recoverKeyFromSignature(curve *KoblitzCurve, sig *Signature, msg []byte,
 	// convert 02<Rx> to point R. (step 1.2 and 1.3). If we are on an odd
 	// iteration then 1.6 will be done with -R, so we calculate the other
 	// term when uncompressing the point.
-	Ry, err := DecompressPoint(curve, Rx, iter%2 == 1)
+	Ry, err := decompressPoint(curve, Rx, iter%2 == 1)
 	if err != nil {
 		return nil, err
 	}

--- a/dcrec/secp256k1/signature_test.go
+++ b/dcrec/secp256k1/signature_test.go
@@ -36,7 +36,7 @@ func decodeHex(hexStr string) []byte {
 }
 
 var signatureTests = []signatureTest{
-	// signatures from decred blockchain tx
+	// signatures from bitcoin blockchain tx
 	// 0437cd7f8525ceed2324359c2d0ba26006d92d85
 	{
 		name: "valid signature.",
@@ -358,7 +358,7 @@ func TestSignatureSerialize(t *testing.T) {
 		ecsig    *Signature
 		expected []byte
 	}{
-		// signature from decred blockchain tx
+		// signature from bitcoin blockchain tx
 		// 0437cd7f8525ceed2324359c2d0ba26006d92d85
 		{
 			"valid 1 - r and s most significant bits are zero",
@@ -378,7 +378,7 @@ func TestSignatureSerialize(t *testing.T) {
 				0x21, 0xa8, 0x76, 0x8d, 0x1d, 0x09,
 			},
 		},
-		// signature from decred blockchain tx
+		// signature from bitcoin blockchain tx
 		// cb00f8a0573b18faa8c4f467b049f5d202bf1101d9ef2633bc611be70376a4b4
 		{
 			"valid 2 - r most significant bit is one",
@@ -398,7 +398,7 @@ func TestSignatureSerialize(t *testing.T) {
 				0xac, 0xad, 0x7f, 0x9c, 0x86, 0x87, 0x24,
 			},
 		},
-		// signature from decred blockchain tx
+		// signature from bitcoin blockchain tx
 		// fda204502a3345e08afd6af27377c052e77f1fefeaeb31bdd45f1e1237ca5470
 		{
 			"valid 3 - s most significant bit is one",


### PR DESCRIPTION
**This PR depends on #722**

This unexports various functions, structs, and constants that were exported for some reason when porting this from the upstream project when they really should not have been since they deal with package internals.

While here, correct a few other minor differences that were introduced between the package and the upstream code and correct a few comments that appear to have had a blanket find/replace applied to them incorrectly.
