### PR TITLE
secp256k1: Optimize normalize and NAF, correct normalize, and add tests. 

### DIFF
--- a/dcrec/secp256k1/bench_test.go
+++ b/dcrec/secp256k1/bench_test.go
@@ -112,3 +112,13 @@ func BenchmarkSigVerify(b *testing.B) {
 		sig.Verify(msgHash.Bytes(), &pubKey)
 	}
 }
+
+// BenchmarkFieldNormalize benchmarks how long it takes the internal field
+// to perform normalization (which includes modular reduction).
+func BenchmarkFieldNormalize(b *testing.B) {
+	// The normalize function is constant time so default value is fine.
+	f := new(fieldVal)
+	for i := 0; i < b.N; i++ {
+		f.Normalize()
+	}
+}

--- a/dcrec/secp256k1/btcec.go
+++ b/dcrec/secp256k1/btcec.go
@@ -751,9 +751,9 @@ func NAF(k []byte) ([]byte, []byte) {
 	}
 	if carry {
 		retPos[0] = 1
+		return retPos, retNeg
 	}
-
-	return retPos, retNeg
+	return retPos[1:], retNeg[1:]
 }
 
 // ScalarMult returns k*(Bx, By) where k is a big endian integer.

--- a/dcrec/secp256k1/btcec_test.go
+++ b/dcrec/secp256k1/btcec_test.go
@@ -66,7 +66,6 @@ func TestAddJacobian(t *testing.T) {
 			"131c670d414c4546b88ac3ff664611b1c38ceb1c21d76369d7a7a0969d61d97d",
 			"1",
 		},
-
 		// Addition with z1=z2=1 different x values.
 		{
 			"34f9460f0e4f08393d192b3c5133a6ba099aa0ad9fd54ebccfacdfa239ff49c6",
@@ -398,6 +397,15 @@ func TestDoubleJacobian(t *testing.T) {
 			"2b53702c466dcf6e984a35671756c506c67c2fcb8adb408c44dd125dc91cb988",
 			"6e3d537ae61fb1247eda4b4f523cfbaee5152c0d0d96b520376833c2e5944a11",
 		},
+		// From btcd issue #709.
+		{
+			"201e3f75715136d2f93c4f4598f91826f94ca01f4233a5bd35de9708859ca50d",
+			"bdf18566445e7562c6ada68aef02d498d7301503de5b18c6aef6e2b1722412e1",
+			"0000000000000000000000000000000000000000000000000000000000000001",
+			"4a5e0559863ebb4e9ed85f5c4fa76003d05d9a7626616e614a1f738621e3c220",
+			"00000000000000000000000000000000000000000000000000000001b1388778",
+			"7be30acc88bceac58d5b4d15de05a931ae602a07bcb6318d5dedc563e4482993",
+		},
 	}
 
 	t.Logf("Running %d tests", len(tests))
@@ -592,6 +600,46 @@ func TestBaseMultVerify(t *testing.T) {
 }
 
 func TestScalarMult(t *testing.T) {
+	tests := []struct {
+		x  string
+		y  string
+		k  string
+		rx string
+		ry string
+	}{
+		// base mult, essentially.
+		{
+			"79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+			"483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8",
+			"18e14a7b6a307f426a94f8114701e7c8e774e7f9a47e2c2035db29a206321725",
+			"50863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b2352",
+			"2cd470243453a299fa9e77237716103abc11a1df38855ed6f2ee187e9c582ba6",
+		},
+		// From btcd issue #709.
+		{
+			"000000000000000000000000000000000000000000000000000000000000002c",
+			"420e7a99bba18a9d3952597510fd2b6728cfeafc21a4e73951091d4d8ddbe94e",
+			"a2e8ba2e8ba2e8ba2e8ba2e8ba2e8ba219b51835b55cc30ebfe2f6599bc56f58",
+			"a2112dcdfbcd10ae1133a358de7b82db68e0a3eb4b492cc8268d1e7118c98788",
+			"27fc7463b7bb3c5f98ecf2c84a6272bb1681ed553d92c69f2dfe25a9f9fd3836",
+		},
+	}
+
+	s256 := S256()
+	for i, test := range tests {
+		x, _ := new(big.Int).SetString(test.x, 16)
+		y, _ := new(big.Int).SetString(test.y, 16)
+		k, _ := new(big.Int).SetString(test.k, 16)
+		xWant, _ := new(big.Int).SetString(test.rx, 16)
+		yWant, _ := new(big.Int).SetString(test.ry, 16)
+		xGot, yGot := s256.ScalarMult(x, y, k.Bytes())
+		if xGot.Cmp(xWant) != 0 || yGot.Cmp(yWant) != 0 {
+			t.Fatalf("%d: bad output: got (%X, %X), want (%X, %X)", i, xGot, yGot, xWant, yWant)
+		}
+	}
+}
+
+func TestScalarMultRand(t *testing.T) {
 	// Strategy for this test:
 	// Get a random exponent from the generator point at first
 	// This creates a new point which is used in the next iteration
@@ -614,6 +662,118 @@ func TestScalarMult(t *testing.T) {
 		if x.Cmp(xWant) != 0 || y.Cmp(yWant) != 0 {
 			t.Fatalf("%d: bad output for %X: got (%X, %X), want (%X, %X)", i, data, x, y, xWant, yWant)
 			break
+		}
+	}
+}
+
+func TestSplitK(t *testing.T) {
+	tests := []struct {
+		k      string
+		k1, k2 string
+		s1, s2 int
+	}{
+		{
+			"6df2b5d30854069ccdec40ae022f5c948936324a4e9ebed8eb82cfd5a6b6d766",
+			"00000000000000000000000000000000b776e53fb55f6b006a270d42d64ec2b1",
+			"00000000000000000000000000000000d6cc32c857f1174b604eefc544f0c7f7",
+			-1, -1,
+		},
+		{
+			"6ca00a8f10632170accc1b3baf2a118fa5725f41473f8959f34b8f860c47d88d",
+			"0000000000000000000000000000000007b21976c1795723c1bfbfa511e95b84",
+			"00000000000000000000000000000000d8d2d5f9d20fc64fd2cf9bda09a5bf90",
+			1, -1,
+		},
+		{
+			"b2eda8ab31b259032d39cbc2a234af17fcee89c863a8917b2740b67568166289",
+			"00000000000000000000000000000000507d930fecda7414fc4a523b95ef3c8c",
+			"00000000000000000000000000000000f65ffb179df189675338c6185cb839be",
+			-1, -1,
+		},
+		{
+			"f6f00e44f179936f2befc7442721b0633f6bafdf7161c167ffc6f7751980e3a0",
+			"0000000000000000000000000000000008d0264f10bcdcd97da3faa38f85308d",
+			"0000000000000000000000000000000065fed1506eb6605a899a54e155665f79",
+			-1, -1,
+		},
+		{
+			"8679085ab081dc92cdd23091ce3ee998f6b320e419c3475fae6b5b7d3081996e",
+			"0000000000000000000000000000000089fbf24fbaa5c3c137b4f1cedc51d975",
+			"00000000000000000000000000000000d38aa615bd6754d6f4d51ccdaf529fea",
+			-1, -1,
+		},
+		{
+			"6b1247bb7931dfcae5b5603c8b5ae22ce94d670138c51872225beae6bba8cdb3",
+			"000000000000000000000000000000008acc2a521b21b17cfb002c83be62f55d",
+			"0000000000000000000000000000000035f0eff4d7430950ecb2d94193dedc79",
+			-1, -1,
+		},
+		{
+			"a2e8ba2e8ba2e8ba2e8ba2e8ba2e8ba219b51835b55cc30ebfe2f6599bc56f58",
+			"0000000000000000000000000000000045c53aa1bb56fcd68c011e2dad6758e4",
+			"00000000000000000000000000000000a2e79d200f27f2360fba57619936159b",
+			-1, -1,
+		},
+	}
+
+	s256 := S256()
+	for i, test := range tests {
+		k, ok := new(big.Int).SetString(test.k, 16)
+		if !ok {
+			t.Errorf("%d: bad value for k: %s", i, test.k)
+		}
+		k1, k2, k1Sign, k2Sign := s256.splitK(k.Bytes())
+		k1str := fmt.Sprintf("%064x", k1)
+		if test.k1 != k1str {
+			t.Errorf("%d: bad k1: got %v, want %v", i, k1str, test.k1)
+		}
+		k2str := fmt.Sprintf("%064x", k2)
+		if test.k2 != k2str {
+			t.Errorf("%d: bad k2: got %v, want %v", i, k2str, test.k2)
+		}
+		if test.s1 != k1Sign {
+			t.Errorf("%d: bad k1 sign: got %d, want %d", i, k1Sign, test.s1)
+		}
+		if test.s2 != k2Sign {
+			t.Errorf("%d: bad k2 sign: got %d, want %d", i, k2Sign, test.s2)
+		}
+		k1Int := new(big.Int).SetBytes(k1)
+		k1SignInt := new(big.Int).SetInt64(int64(k1Sign))
+		k1Int.Mul(k1Int, k1SignInt)
+		k2Int := new(big.Int).SetBytes(k2)
+		k2SignInt := new(big.Int).SetInt64(int64(k2Sign))
+		k2Int.Mul(k2Int, k2SignInt)
+		gotK := new(big.Int).Mul(k2Int, s256.lambda)
+		gotK.Add(k1Int, gotK)
+		gotK.Mod(gotK, s256.N)
+		if k.Cmp(gotK) != 0 {
+			t.Errorf("%d: bad k: got %X, want %X", i, gotK.Bytes(), k.Bytes())
+		}
+	}
+}
+
+func TestSplitKRand(t *testing.T) {
+	s256 := S256()
+	for i := 0; i < 1024; i++ {
+		bytesK := make([]byte, 32)
+		_, err := rand.Read(bytesK)
+		if err != nil {
+			t.Fatalf("failed to read random data at %d", i)
+			break
+		}
+		k := new(big.Int).SetBytes(bytesK)
+		k1, k2, k1Sign, k2Sign := s256.splitK(bytesK)
+		k1Int := new(big.Int).SetBytes(k1)
+		k1SignInt := new(big.Int).SetInt64(int64(k1Sign))
+		k1Int.Mul(k1Int, k1SignInt)
+		k2Int := new(big.Int).SetBytes(k2)
+		k2SignInt := new(big.Int).SetInt64(int64(k2Sign))
+		k2Int.Mul(k2Int, k2SignInt)
+		gotK := new(big.Int).Mul(k2Int, s256.lambda)
+		gotK.Add(k1Int, gotK)
+		gotK.Mod(gotK, s256.N)
+		if k.Cmp(gotK) != 0 {
+			t.Errorf("%d: bad k: got %X, want %X", i, gotK.Bytes(), k.Bytes())
 		}
 	}
 }
@@ -661,6 +821,42 @@ func TestSignAndVerify(t *testing.T) {
 }
 
 func TestNAF(t *testing.T) {
+	tests := []string{
+		"6df2b5d30854069ccdec40ae022f5c948936324a4e9ebed8eb82cfd5a6b6d766",
+		"b776e53fb55f6b006a270d42d64ec2b1",
+		"d6cc32c857f1174b604eefc544f0c7f7",
+		"45c53aa1bb56fcd68c011e2dad6758e4",
+		"a2e79d200f27f2360fba57619936159b",
+	}
+	negOne := big.NewInt(-1)
+	one := big.NewInt(1)
+	two := big.NewInt(2)
+	for i, test := range tests {
+		want, _ := new(big.Int).SetString(test, 16)
+		nafPos, nafNeg := NAF(want.Bytes())
+		got := big.NewInt(0)
+		// Check that the NAF representation comes up with the right number
+		for i := 0; i < len(nafPos); i++ {
+			bytePos := nafPos[i]
+			byteNeg := nafNeg[i]
+			for j := 7; j >= 0; j-- {
+				got.Mul(got, two)
+				if bytePos&0x80 == 0x80 {
+					got.Add(got, one)
+				} else if byteNeg&0x80 == 0x80 {
+					got.Add(got, negOne)
+				}
+				bytePos <<= 1
+				byteNeg <<= 1
+			}
+		}
+		if got.Cmp(want) != 0 {
+			t.Errorf("%d: Failed NAF got %X want %X", i, got, want)
+		}
+	}
+}
+
+func TestNAFRand(t *testing.T) {
 	negOne := big.NewInt(-1)
 	one := big.NewInt(1)
 	two := big.NewInt(2)

--- a/dcrec/secp256k1/field.go
+++ b/dcrec/secp256k1/field.go
@@ -249,39 +249,15 @@ func (f *fieldVal) SetHex(hexString string) *fieldVal {
 // performs fast modular reduction over the secp256k1 prime by making use of the
 // special form of the prime.
 func (f *fieldVal) Normalize() *fieldVal {
-	// The field representation leaves 6 bits of overflow in each
-	// word so intermediate calculations can be performed without needing
-	// to propagate the carry to each higher word during the calculations.
-	// In order to normalize, first we need to "compact" the full 256-bit
-	// value to the right and treat the additional 64 leftmost bits as
-	// the magnitude.
-	m := f.n[0]
-	t0 := m & fieldBaseMask
-	m = (m >> fieldBase) + f.n[1]
-	t1 := m & fieldBaseMask
-	m = (m >> fieldBase) + f.n[2]
-	t2 := m & fieldBaseMask
-	m = (m >> fieldBase) + f.n[3]
-	t3 := m & fieldBaseMask
-	m = (m >> fieldBase) + f.n[4]
-	t4 := m & fieldBaseMask
-	m = (m >> fieldBase) + f.n[5]
-	t5 := m & fieldBaseMask
-	m = (m >> fieldBase) + f.n[6]
-	t6 := m & fieldBaseMask
-	m = (m >> fieldBase) + f.n[7]
-	t7 := m & fieldBaseMask
-	m = (m >> fieldBase) + f.n[8]
-	t8 := m & fieldBaseMask
-	m = (m >> fieldBase) + f.n[9]
-	t9 := m & fieldMSBMask
-	m = m >> fieldMSBBits
-
-	// At this point, if the magnitude is greater than 0, the overall value
-	// is greater than the max possible 256-bit value.  In particular, it is
-	// "how many times larger" than the max value it is.  Since this field
-	// is doing arithmetic modulo the secp256k1 prime, we need to perform
-	// modular reduction over the prime.
+	// The field representation leaves 6 bits of overflow in each word so
+	// intermediate calculations can be performed without needing to
+	// propagate the carry to each higher word during the calculations.  In
+	// order to normalize, we need to "compact" the full 256-bit value to
+	// the right while propagating any carries through to the high order
+	// word.
+	//
+	// Since this field is doing arithmetic modulo the secp256k1 prime, we
+	// also need to perform modular reduction over the prime.
 	//
 	// Per [HAC] section 14.3.4: Reduction method of moduli of special form,
 	// when the modulus is of the special form m = b^t - c, highly efficient
@@ -297,101 +273,87 @@ func (f *fieldVal) Normalize() *fieldVal {
 	//
 	// The algorithm presented in the referenced section typically repeats
 	// until the quotient is zero.  However, due to our field representation
-	// we already know at least how many times we would need to repeat as
-	// it's the value currently in m.  Thus we can simply multiply the
-	// magnitude by the field representation of the prime and do a single
-	// iteration.  Notice that nothing will be changed when the magnitude is
-	// zero, so we could skip this in that case, however always running
-	// regardless allows it to run in constant time.
-	r := t0 + m*977
-	t0 = r & fieldBaseMask
-	r = (r >> fieldBase) + t1 + m*64
-	t1 = r & fieldBaseMask
-	r = (r >> fieldBase) + t2
-	t2 = r & fieldBaseMask
-	r = (r >> fieldBase) + t3
-	t3 = r & fieldBaseMask
-	r = (r >> fieldBase) + t4
-	t4 = r & fieldBaseMask
-	r = (r >> fieldBase) + t5
-	t5 = r & fieldBaseMask
-	r = (r >> fieldBase) + t6
-	t6 = r & fieldBaseMask
-	r = (r >> fieldBase) + t7
-	t7 = r & fieldBaseMask
-	r = (r >> fieldBase) + t8
-	t8 = r & fieldBaseMask
-	r = (r >> fieldBase) + t9
-	t9 = r & fieldMSBMask
+	// we already know to within one reduction how many times we would need
+	// to repeat as it's the uppermost bits of the high order word.  Thus we
+	// can simply multiply the magnitude by the field representation of the
+	// prime and do a single iteration.  After this step there might be an
+	// additional carry to bit 256 (bit 22 of the high order word).
+	t9 := f.n[9]
+	m := t9 >> fieldMSBBits
+	t9 = t9 & fieldMSBMask
+	t0 := f.n[0] + m*977
+	t1 := (t0 >> fieldBase) + f.n[1] + (m << 6)
+	t0 = t0 & fieldBaseMask
+	t2 := (t1 >> fieldBase) + f.n[2]
+	t1 = t1 & fieldBaseMask
+	t3 := (t2 >> fieldBase) + f.n[3]
+	t2 = t2 & fieldBaseMask
+	t4 := (t3 >> fieldBase) + f.n[4]
+	t3 = t3 & fieldBaseMask
+	t5 := (t4 >> fieldBase) + f.n[5]
+	t4 = t4 & fieldBaseMask
+	t6 := (t5 >> fieldBase) + f.n[6]
+	t5 = t5 & fieldBaseMask
+	t7 := (t6 >> fieldBase) + f.n[7]
+	t6 = t6 & fieldBaseMask
+	t8 := (t7 >> fieldBase) + f.n[8]
+	t7 = t7 & fieldBaseMask
+	t9 = (t8 >> fieldBase) + t9
+	t8 = t8 & fieldBaseMask
 
-	// At this point, the result will be in the range 0 <= result <=
-	// prime + (2^64 - c).  Therefore, one more subtraction of the prime
-	// might be needed if the current result is greater than or equal to the
-	// prime.  The following does the final reduction in constant time.
-	// Note that the if/else here intentionally does the bitwise OR with
-	// zero even though it won't change the value to ensure constant time
-	// between the branches.
-	var mask int32
-	if t0 < fieldPrimeWordZero {
-		mask |= -1
+	// At this point, the magnitude is guaranteed to be one, however, the
+	// value could still be greater than the prime if there was either a
+	// carry through to bit 256 (bit 22 of the higher order word) or the
+	// value is greater than or equal to the field characteristic.  The
+	// following determines if either or these conditions are true and does
+	// the final reduction in constant time.
+	//
+	// Note that the if/else statements here intentionally do the bitwise
+	// operators even when it won't change the value to ensure constant time
+	// between the branches.  Also note that 'm' will be zero when neither
+	// of the aforementioned conditions are true and the value will not be
+	// changed when 'm' is zero.
+	m = 1
+	if t9 == fieldMSBMask {
+		m &= 1
 	} else {
-		mask |= 0
+		m &= 0
 	}
-	if t1 < fieldPrimeWordOne {
-		mask |= -1
+	if t2&t3&t4&t5&t6&t7&t8 == fieldBaseMask {
+		m &= 1
 	} else {
-		mask |= 0
+		m &= 0
 	}
-	if t2 < fieldBaseMask {
-		mask |= -1
+	if ((t0+977)>>fieldBase + t1 + 64) > fieldBaseMask {
+		m &= 1
 	} else {
-		mask |= 0
+		m &= 0
 	}
-	if t3 < fieldBaseMask {
-		mask |= -1
+	if t9>>fieldMSBBits != 0 {
+		m |= 1
 	} else {
-		mask |= 0
+		m |= 0
 	}
-	if t4 < fieldBaseMask {
-		mask |= -1
-	} else {
-		mask |= 0
-	}
-	if t5 < fieldBaseMask {
-		mask |= -1
-	} else {
-		mask |= 0
-	}
-	if t6 < fieldBaseMask {
-		mask |= -1
-	} else {
-		mask |= 0
-	}
-	if t7 < fieldBaseMask {
-		mask |= -1
-	} else {
-		mask |= 0
-	}
-	if t8 < fieldBaseMask {
-		mask |= -1
-	} else {
-		mask |= 0
-	}
-	if t9 < fieldMSBMask {
-		mask |= -1
-	} else {
-		mask |= 0
-	}
-	t0 = t0 - uint32(^mask&fieldPrimeWordZero)
-	t1 = t1 - uint32(^mask&fieldPrimeWordOne)
-	t2 = t2 & uint32(mask)
-	t3 = t3 & uint32(mask)
-	t4 = t4 & uint32(mask)
-	t5 = t5 & uint32(mask)
-	t6 = t6 & uint32(mask)
-	t7 = t7 & uint32(mask)
-	t8 = t8 & uint32(mask)
-	t9 = t9 & uint32(mask)
+	t0 = t0 + m*977
+	t1 = (t0 >> fieldBase) + t1 + (m << 6)
+	t0 = t0 & fieldBaseMask
+	t2 = (t1 >> fieldBase) + t2
+	t1 = t1 & fieldBaseMask
+	t3 = (t2 >> fieldBase) + t3
+	t2 = t2 & fieldBaseMask
+	t4 = (t3 >> fieldBase) + t4
+	t3 = t3 & fieldBaseMask
+	t5 = (t4 >> fieldBase) + t5
+	t4 = t4 & fieldBaseMask
+	t6 = (t5 >> fieldBase) + t6
+	t5 = t5 & fieldBaseMask
+	t7 = (t6 >> fieldBase) + t7
+	t6 = t6 & fieldBaseMask
+	t8 = (t7 >> fieldBase) + t8
+	t7 = t7 & fieldBaseMask
+	t9 = (t8 >> fieldBase) + t9
+	t8 = t8 & fieldBaseMask
+	t9 = t9 & fieldMSBMask // Remove potential multiple of 2^256.
 
 	// Finally, set the normalized and reduced words.
 	f.n[0] = t0

--- a/dcrec/secp256k1/field_test.go
+++ b/dcrec/secp256k1/field_test.go
@@ -236,14 +236,72 @@ func TestNormalize(t *testing.T) {
 			[10]uint32{0xffffffff, 0xffffffc0, 0xffffffc0, 0xffffffc0, 0xffffffc0, 0xffffffc0, 0xffffffc0, 0xffffffc0, 0xffffffc0, 0x3fffc0},
 			[10]uint32{0x000003d0, 0x00000040, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x000000},
 		},
+		// Prime with field representation such that the initial
+		// reduction does not result in a carry to bit 256.
+		//
+		// 2^256 - 4294968273 (secp256k1 prime)
+		{
+			[10]uint32{0x03fffc2f, 0x03ffffbf, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x003fffff},
+			[10]uint32{0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000},
+		},
+		// Prime larger than P that reduces to a value which is still
+		// larger than P when it has a magnitude of 1 due to its first
+		// word and does not result in a carry to bit 256.
+		//
+		// 2^256 - 4294968272 (secp256k1 prime + 1)
+		{
+			[10]uint32{0x03fffc30, 0x03ffffbf, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x003fffff},
+			[10]uint32{0x00000001, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000},
+		},
+		// Prime larger than P that reduces to a value which is still
+		// larger than P when it has a magnitude of 1 due to its second
+		// word and does not result in a carry to bit 256.
+		//
+		// 2^256 - 4227859409 (secp256k1 prime + 0x4000000)
+		{
+			[10]uint32{0x03fffc2f, 0x03ffffc0, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x003fffff},
+			[10]uint32{0x00000000, 0x00000001, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000},
+		},
+		// Prime larger than P that reduces to a value which is still
+		// larger than P when it has a magnitude of 1 due to a carry to
+		// bit 256, but would not be without the carry.  These values
+		// come from the fact that P is 2^256 - 4294968273 and 977 is
+		// the low order word in the internal field representation.
+		//
+		// 2^256 * 5 - ((4294968273 - (977+1)) * 4)
+		{
+			[10]uint32{0x03ffffff, 0x03fffeff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x0013fffff},
+			[10]uint32{0x00001314, 0x00000040, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x000000000},
+		},
+		// Prime larger than P that reduces to a value which is still
+		// larger than P when it has a magnitude of 1 due to both a
+		// carry to bit 256 and the first word.
+		{
+			[10]uint32{0x03fffc30, 0x03ffffbf, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x07ffffff, 0x003fffff},
+			[10]uint32{0x00000001, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000001},
+		},
+		// Prime larger than P that reduces to a value which is still
+		// larger than P when it has a magnitude of 1 due to both a
+		// carry to bit 256 and the second word.
+		//
+		{
+			[10]uint32{0x03fffc2f, 0x03ffffc0, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x3ffffff, 0x07ffffff, 0x003fffff},
+			[10]uint32{0x00000000, 0x00000001, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x0000000, 0x00000000, 0x00000001},
+		},
+		// Prime larger than P that reduces to a value which is still
+		// larger than P when it has a magnitude of 1 due to a carry to
+		// bit 256 and the first and second words.
+		//
+		{
+			[10]uint32{0x03fffc30, 0x03ffffc0, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x07ffffff, 0x003fffff},
+			[10]uint32{0x00000001, 0x00000001, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000001},
+		},
 	}
 
 	t.Logf("Running %d tests", len(tests))
 	for i, test := range tests {
 		f := new(fieldVal)
-		for rawIntIdx := 0; rawIntIdx < len(test.raw); rawIntIdx++ {
-			f.n[rawIntIdx] = test.raw[rawIntIdx]
-		}
+		f.n = test.raw
 		f.Normalize()
 		if !reflect.DeepEqual(f.n, test.normalized) {
 			t.Errorf("fieldVal.Set #%d wrong normalized result\n"+


### PR DESCRIPTION
This modifies the normalize function of the internal field value to both optimize it and address an issue where the reduction could lead to an incorrect result with a small range of values along with some tests to ensure the behavior is correct.

It also contains contributions from @jimmysong to optimize NAF to avoid returning the unneeded bit when there is not a carry and adds a bunch of unit tests.

The following benchmark shows the relative speedups as a result of the optimization on my system.  In particular, the changes result in approximately a 14% speedup in Normalize, which ultimately translates to a 2% speedup in signature verifies.

```
benchmark                        old ns/op     new ns/op     delta
--------------------------------------------------------------------
BenchmarkAddJacobian             1364          1289          -5.50%
BenchmarkAddJacobianNotZOne      3150          3091          -1.87%
BenchmarkScalarBaseMult          134117        132816        -0.97%
BenchmarkScalarBaseMultLarge     135067        132966        -1.56%
BenchmarkScalarMult              411218        402217        -2.19%
BenchmarkSigVerify               671585        657833        -2.05%
BenchmarkFieldNormalize          36.0          31.0          -13.89%
```