### PR TITLE
Add -j/json option to dcrctl.

### DIFF
--- a/cmd/dcrctl/config.go
+++ b/cmd/dcrctl/config.go
@@ -101,6 +101,7 @@ type config struct {
 	RPCPassword   string `short:"P" long:"rpcpass" default-mask:"-" description:"RPC password"`
 	RPCServer     string `short:"s" long:"rpcserver" description:"RPC server to connect to"`
 	RPCCert       string `short:"c" long:"rpccert" description:"RPC server certificate chain for validation"`
+	PrintJSON     bool   `short:"j" long:"json" description:"Print json messages sent and received"`
 	NoTLS         bool   `long:"notls" description:"Disable TLS"`
 	Proxy         string `long:"proxy" description:"Connect via SOCKS5 proxy (eg. 127.0.0.1:9050)"`
 	ProxyUser     string `long:"proxyuser" description:"Username for proxy server"`

--- a/cmd/dcrctl/httpclient.go
+++ b/cmd/dcrctl/httpclient.go
@@ -76,6 +76,9 @@ func sendPostRequest(marshalledJSON []byte, cfg *config) ([]byte, error) {
 		protocol = "https"
 	}
 	url := protocol + "://" + cfg.RPCServer
+	if cfg.PrintJSON {
+		fmt.Println(string(marshalledJSON))
+	}
 	bodyReader := bytes.NewReader(marshalledJSON)
 	httpRequest, err := http.NewRequest("POST", url, bodyReader)
 	if err != nil {
@@ -117,6 +120,11 @@ func sendPostRequest(marshalledJSON []byte, cfg *config) ([]byte, error) {
 				http.StatusText(httpResponse.StatusCode))
 		}
 		return nil, fmt.Errorf("%s", respBytes)
+	}
+
+	// If requested, print raw json response.
+	if cfg.PrintJSON {
+		fmt.Println(string(respBytes))
 	}
 
 	// Unmarshal the response.


### PR DESCRIPTION
This option lets dcrctl print the raw json it both
sends and receives for commands.

Inspired by the similar option in dcrtime.

Closes #727