### PR TITLE
dcrctl: Add --walletrpcserver option.

### DIFF
--- a/cmd/dcrctl/sample-dcrctl.conf
+++ b/cmd/dcrctl/sample-dcrctl.conf
@@ -28,6 +28,9 @@
 ; RPC server to connect to
 ; rpcserver=localhost
 
+; Wallet RPC server to connect to
+; walletrpcserver=localhost
+
 ; RPC server certificate chain file for validation
 ; rpccert=~/.dcrd/rpc.cert
 


### PR DESCRIPTION
This option allows one to specify a different option for the wallet
rpc server it will connect to.  This is primarily meant to be used in
the config file so that a single dcrctl.conf may be used in the
situation where the wallet is on one host and dcrd is on another host.

Closes #735 