### PR TITLE
rpcserver: Fix gettxout includemempool handling.

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4005,11 +4005,8 @@ func handleGetTxOut(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (i
 	}
 	var txFromMempool *dcrutil.Tx
 	if includeMempool {
-		txFromMempool, err = s.server.txMemPool.FetchTransaction(txHash,
+		txFromMempool, _ = s.server.txMemPool.FetchTransaction(txHash,
 			true)
-		if err != nil {
-			return nil, rpcNoTxInfoError(txHash)
-		}
 	}
 	if txFromMempool != nil {
 		mtx := txFromMempool.MsgTx()


### PR DESCRIPTION
When the includemempool parameter is set to true, transactions in the mempool
should be additionally considered.  However, the previous code used a buggy
implementation which would return an error if this parameter was set and the
transaction was not found in the mempool, without ever querying a mined utxo.

Fixes #658.