### PR TITLE
multi: Update markdown files for GFM changes.

### DIFF
--- a/dcrec/secp256k1/README.md
+++ b/dcrec/secp256k1/README.md
@@ -1,11 +1,9 @@
 secp256k1
 =====
 
-[![Build Status](http://img.shields.io/travis/decred/dcrd.svg)]
-(https://travis-ci.org/decred/dcrd) [![ISC License]
-(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
-(http://godoc.org/github.com/decred/dcrd/dcrec/secp256k1)
+[![Build Status](http://img.shields.io/travis/decred/dcrd.svg)](https://travis-ci.org/decred/dcrd)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/decred/dcrd/dcrec/secp256k1)
 
 Package dcrec implements elliptic curve cryptography needed for working with
 Decred (secp256k1 only for now). It is designed so that it may be used with the
@@ -27,23 +25,19 @@ $ go get -u github.com/decred/dcrd/dcrec
 
 ## Examples
 
-* [Sign Message]
-  (http://godoc.org/github.com/decred/dcrd/dcrec#example-package--SignMessage)  
+* [Sign Message](http://godoc.org/github.com/decred/dcrd/dcrec#example-package--SignMessage)  
   Demonstrates signing a message with a secp256k1 private key that is first
   parsed form raw bytes and serializing the generated signature.
 
-* [Verify Signature]
-  (http://godoc.org/github.com/decred/dcrd/dcrec#example-package--VerifySignature)  
+* [Verify Signature](http://godoc.org/github.com/decred/dcrd/dcrec#example-package--VerifySignature)  
   Demonstrates verifying a secp256k1 signature against a public key that is
   first parsed from raw bytes.  The signature is also parsed from raw bytes.
 
-* [Encryption]
-  (http://godoc.org/github.com/decred/dcrd/dcrec#example-package--EncryptMessage)
+* [Encryption](http://godoc.org/github.com/decred/dcrd/dcrec#example-package--EncryptMessage)  
   Demonstrates encrypting a message for a public key that is first parsed from
   raw bytes, then decrypting it using the corresponding private key.
 
-* [Decryption]
-  (http://godoc.org/github.com/decred/dcrdy/dcrec#example-package--DecryptMessage)
+* [Decryption](http://godoc.org/github.com/decred/dcrdy/dcrec#example-package--DecryptMessage)  
   Demonstrates decrypting a message using a private key that is first parsed
   from raw bytes.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@
     3. [The Decred-related Go Packages](#GoPackages)
 
 <a name="About" />
+
 ### 1. About
 dcrd is a full node decred implementation written in [Go](http://golang.org),
 licensed under the [copyfree](http://www.copyfree.org) ISC License.
@@ -36,21 +37,25 @@ strict checks which filter transactions based on miner requirements ("standard"
 transactions).
 
 <a name="GettingStarted" />
+
 ### 2. Getting Started
 
 <a name="Installation" />
+
 **2.1 Installation**<br />
 
 The first step is to install dcrd.  See one of the following sections for
 details on how to install on the supported operating systems.
 
 <a name="WindowsInstallation" />
+
 **2.1.1 Windows Installation**<br />
 
 * Install the MSI available at: https://github.com/decred/dcrd/releases
 * Launch dcrd from the Start Menu
 
 <a name="PosixInstallation" />
+
 **2.1.2 Linux/BSD/MacOSX/POSIX Installation**<br />
 
 * Install Go according to the installation instructions here: http://golang.org/doc/install
@@ -60,12 +65,14 @@ details on how to install on the supported operating systems.
 * Run dcrd: `$ dcrd`
 
 <a name="Configuration" />
+
 **2.2 Configuration**<br />
 
 dcrd has a number of [configuration](http://godoc.org/github.com/decred/dcrd)
 options, which can be viewed by running: `$ dcrd --help`.
 
 <a name="DcrctlConfig" />
+
 **2.3 Controlling and Querying dcrd via dcrctl**<br />
 
 dcrctl is a command line utility that can be used to both control and query dcrd
@@ -96,6 +103,7 @@ rpclimitpass=Limitedp4ssw0rd
 For a list of available options, run: `$ dcrctl --help`
 
 <a name="Mining" />
+
 **2.4 Mining**<br />
 dcrd supports both the `getwork` and `getblocktemplate` RPCs although the
 `getwork` RPC is deprecated and will likely be removed in a future release.
@@ -128,9 +136,11 @@ certificate into the default system Certificate Authority list.
 `$ cgminer -o https://127.0.0.1:9109 -u rpcuser -p rpcpassword`
 
 <a name="Help" />
+
 ### 3. Help
 
 <a name="Startup" />
+
 **3.1 Startup**<br />
 
 Typically dcrd will run and start downloading the block chain with no extra
@@ -138,10 +148,12 @@ configuration necessary, however, there is an optional method to use a
 `bootstrap.dat` file that may speed up the initial block chain download process.
 
 <a name="BootstrapDat" />
+
 **3.1.1 bootstrap.dat**<br />
 * [Using bootstrap.dat](https://github.com/decred/dcrd/tree/master/docs/using_bootstrap_dat.md)
 
 <a name="NetworkConfig" />
+
 **3.1.2 Network Configuration**<br />
 * [What Ports Are Used by Default?](https://github.com/decred/dcrd/tree/master/docs/default_ports.md)
 * [How To Listen on Specific Interfaces](https://github.com/decred/dcrd/tree/master/docs/configure_peer_server_listen_interfaces.md)
@@ -149,6 +161,7 @@ configuration necessary, however, there is an optional method to use a
 * [Configuring dcrd with Tor](https://github.com/decred/dcrd/tree/master/docs/configuring_tor.md)
 
 <a name="Wallet" />
+
 **3.1 Wallet**<br />
 
 dcrd was intentionally developed without an integrated wallet for security
@@ -156,13 +169,16 @@ reasons.  Please see [dcrwallet](https://github.com/decred/dcrwallet) for more
 information.
 
 <a name="Contact" />
+
 ### 4. Contact
 
 <a name="ContactIRC" />
+
 **4.1 IRC**<br />
 * [irc.freenode.net](irc://irc.freenode.net), channel #dcrd
 
 <a name="MailingLists" />
+
 **4.2 Mailing Lists**<br />
 * <a href="mailto:dcrd+subscribe@opensource.conformal.com">dcrd</a>: discussion
   of dcrd and its packages.
@@ -170,14 +186,18 @@ information.
   readonly mail-out of source code changes.
 
 <a name="DeveloperResources" />
+
 ### 5. Developer Resources
 
 <a name="ContributionGuidelines" />
+
 * [Code Contribution Guidelines](https://github.com/decred/dcrd/tree/master/docs/code_contribution_guidelines.md)
 <a name="JSONRPCReference" />
+
 * [JSON-RPC Reference](https://github.com/decred/dcrd/tree/master/docs/json_rpc_api.md)
     * [RPC Examples](https://github.com/decred/dcrd/tree/master/docs/json_rpc_api.md#ExampleCode)
 <a name="GoPackages" />
+
 * The Decred-related Go Packages:
     * [dcrrpcclient](https://github.com/decred/dcrrpcclient) - Implements a
 	  robust and easy to use Websocket-enabled Decred JSON-RPC client

--- a/docs/code_contribution_guidelines.md
+++ b/docs/code_contribution_guidelines.md
@@ -16,6 +16,7 @@
 6.2. [Licensing of Contributions](#Licensing)<br />
 
 <a name="Overview" />
+
 ### 1. Overview
 
 Developing cryptocurrencies is an exciting endeavor that touches a wide variety
@@ -38,6 +39,7 @@ We highly encourage code contributions, however it is imperative that you adhere
 to the guidelines established on this page.
 
 <a name="MinSkillset" />
+
 ### 2. Minimum Recommended Skillset
 
 The following list is a set of core competencies that we recommend you possess
@@ -63,6 +65,7 @@ understanding of the various aspects involved with cryptography such as the
 security and performance implications.
 
 <a name="ReqReading" />
+
 ### 3. Required Reading
 
 - [Effective Go](http://golang.org/doc/effective_go.html) - The entire dcrd
@@ -72,6 +75,7 @@ security and performance implications.
   foundation to build on will make the code much more comprehensible.
 
 <a name="DevelopmentPractices" />
+
 ### 4. Development Practices
 
 Developers are expected to work in their own trees and submit pull requests when
@@ -79,6 +83,7 @@ they feel their feature or bug fix is ready for integration into the  master
 branch.
 
 <a name="ShareEarly" />
+
 ### 4.1 Share Early, Share Often
 
 We firmly believe in the share early, share often approach.  The basic premise
@@ -101,6 +106,7 @@ This approach has several benefits:
   spend rebasing and otherwise trying to keep up with the main code base
 
 <a name="Testing" />
+
 ### 4.2 Testing
 
 One of the major design goals of all core dcrd packages is to aim for complete
@@ -127,6 +133,7 @@ A quick summary of test practices follows:
   to both prove it has been resolved and to prevent future regressions
 
 <a name="CodeDocumentation" />
+
 ### 4.3 Code Documentation and Commenting
 
 - At a minimum every function must be commented with its intended purpose and
@@ -196,6 +203,7 @@ but it was left as a magic number to show how much of a difference a good
 comment can make.
 
 <a name="ModelGitCommitMessages" />
+
 ### 4.4 Code Documentation and Commenting
 
 This project prefers to keep a clean commit history with well-formed commit
@@ -242,12 +250,14 @@ a good thing.
   reply indicators without overflow in an 80 column terminal.
 
 <a name="CodeApproval" />
+
 ### 5. Code Approval Process
 
 This section describes the code approval process that is used for code
 contributions.  This is how to get your changes into dcrd.
 
 <a name="CodeReview" />
+
 ### 5.1 Code Review
 
 All code which is submitted will need to be reviewed before inclusion into the
@@ -283,6 +293,7 @@ checks which are generally performed as follows:
   consensus
 
 <a name="CodeRework" />
+
 ### 5.2 Rework Code (if needed)
 
 After the code review, the change will be accepted immediately if no issues are
@@ -295,6 +306,7 @@ make the necessary changes.
 This process will continue until the code is finally accepted.
 
 <a name="CodeAcceptance" />
+
 ### 5.3 Acceptance
 
 Once your code is accepted, it will be integrated with the master branch.
@@ -306,9 +318,11 @@ the master branch and the pull request will be closed.
 Rejoice as you will now be listed as a [contributor](https://github.com/decred/dcrd/graphs/contributors)!
 
 <a name="Standards" />
+
 ### 6. Contribution Standards
 
 <a name="Checklist" />
+
 ### 6.1. Contribution Checklist
 
 - [&nbsp;&nbsp;] All changes are Go version 1.3 compliant
@@ -327,6 +341,7 @@ Rejoice as you will now be listed as a [contributor](https://github.com/decred/d
   report any **new** issues that did not already exist
 
 <a name="Licensing" />
+
 ### 6.2. Licensing of Contributions
 ****
 All contributions must be licensed with the

--- a/docs/configuring_tor.md
+++ b/docs/configuring_tor.md
@@ -18,6 +18,7 @@
 5.3 [Config File Example](#TorStreamIsolationFileExample)<br />
 
 <a name="Overview" />
+
 ### 1. Overview
 
 dcrd provides full support for anonymous networking via the
@@ -34,9 +35,11 @@ you are connecting to them.  We recommend you take the time to setup a Tor
 hidden service for this reason.
 
 <a name="Client" />
+
 ### 2. Client-Only
 
 <a name="ClientDescription" />
+
 **2.1 Description**<br />
 
 Configuring dcrd as a Tor client is straightforward.  The first step is
@@ -56,6 +59,7 @@ not be reachable for inbound connections unless you also configure a Tor
 [hidden service](#HiddenService).
 
 <a name="ClientCLIExample" />
+
 **2.2 Command Line Example**<br />
 
 ```bash
@@ -63,6 +67,7 @@ $ ./dcrd --proxy=127.0.0.1:9050
 ```
 
 <a name="ClientConfigFileExample" />
+
 **2.3 Config File Example**<br />
 
 ```text
@@ -72,9 +77,11 @@ proxy=127.0.0.1:9050
 ```
 
 <a name="HiddenService" />
+
 ### 3. Client-Server via Tor Hidden Service
 
 <a name="HiddenServiceDescription" />
+
 **3.1 Description**<br />
 
 The first step is to configure Tor to provide a hidden service.  Documentation
@@ -103,6 +110,7 @@ three flags:
 * `--externalip` to set the .onion address that is advertised to other peers
 
 <a name="HiddenServiceCLIExample" />
+
 **3.2 Command Line Example**<br />
 
 ```bash
@@ -110,6 +118,7 @@ $ ./dcrd --proxy=127.0.0.1:9050 --listen=127.0.0.1 --externalip=fooanon.onion
 ```
 
 <a name="HiddenServiceConfigFileExample" />
+
 **3.3 Config File Example**<br />
 
 ```text
@@ -121,9 +130,11 @@ externalip=fooanon.onion
 ```
 
 <a name="Bridge" />
+
 ### 4. Bridge Mode (Not Anonymous)
 
 <a name="BridgeDescription" />
+
 **4.1 Description**<br />
 
 dcrd provides support for operating as a bridge between regular nodes and hidden
@@ -144,6 +155,7 @@ mode, you only need to specify your hidden service's .onion address via the
 routed via Tor due to the `--onion` flag.
 
 <a name="BridgeCLIExample" />
+
 **4.2 Command Line Example**<br />
 
 ```bash
@@ -151,6 +163,7 @@ $ ./dcrd --onion=127.0.0.1:9050 --externalip=fooanon.onion
 ```
 
 <a name="BridgeConfigFileExample" />
+
 **4.3 Config File Example**<br />
 
 ```text
@@ -161,9 +174,11 @@ externalip=fooanon.onion
 ```
 
 <a name="TorStreamIsolation" />
+
 ### 5. Tor Stream Isolation
 
 <a name="TorStreamIsolationDescription" />
+
 **5.1 Description**<br />
 
 Tor stream isolation forces Tor to build a new circuit for each connection
@@ -173,6 +188,7 @@ dcrd provides support for Tor stream isolation by using the `--torisolation`
 flag.  This option requires --proxy or --onionproxy to be set.
 
 <a name="TorStreamIsolationCLIExample" />
+
 **5.2 Command Line Example**<br />
 
 ```bash
@@ -180,6 +196,7 @@ $ ./dcrd --proxy=127.0.0.1:9050 --torisolation
 ```
 
 <a name="TorStreamIsolationFileExample" />
+
 **5.3 Config File Example**<br />
 
 ```text

--- a/docs/json_rpc_api.md
+++ b/docs/json_rpc_api.md
@@ -23,6 +23,7 @@
 9.2. [node.js](#ExampleNodeJsCode)<br />
 
 <a name="Overview" />
+
 ### 1. Overview
 
 dcrd provides a [JSON-RPC](http://json-rpc.org/wiki/specification) API that is
@@ -59,6 +60,7 @@ progress, incomplete, and susceptible to changes (both additions and removals).
 The original bitcoind/bitcoin-qt JSON-RPC API documentation is available at [https://en.bitcoin.it/wiki/Original_Bitcoin_client/API_Calls_list](https://en.bitcoin.it/wiki/Original_Bitcoin_client/API_Calls_list)
 
 <a name="HttpPostVsWebsockets" />
+
 ### 2. HTTP POST Versus Websockets
 
 The dcrd RPC server supports both [HTTP POST](http://en.wikipedia.org/wiki/POST_%28HTTP%29)
@@ -81,9 +83,11 @@ JSON-RPC API are:
 |Scales well with large numbers of requests|No|Yes|
 
 <a name="Authentication" />
+
 ### 3. Authentication
 
 <a name="AuthenticationOverview" />
+
 **3.1 Authentication Overview**<br />
 
 The following authentication details are needed before establishing a connection
@@ -109,6 +113,7 @@ two, mutually exclusive, methods.
 - [Use the JSON-RPC "authenticate" command](#JSONAuth) - Websockets only
 
 <a name="HTTPAuth" />
+
 **3.2 HTTP Basic Access Authentication**<br />
 
 The dcrd RPC server uses HTTP [basic access authentication](http://en.wikipedia.org/wiki/Basic_access_authentication) with the **rpcuser**
@@ -116,6 +121,7 @@ and **rpcpass** detailed above.  If the supplied credentials are invalid, you
 will be disconnected immediately upon making the connection.
 
 <a name="JSONAuth" />
+
 **3.3 JSON-RPC Authenticate Command (Websocket-specific)**<br />
 
 While the HTTP basic access authentication method is the preferred method, the
@@ -129,6 +135,7 @@ authenticated will cause the websocket to be closed immediately.
 
 
 <a name="CLIUtil" />
+
 ### 4. Command-line Utility
 
 dcrd comes with a separate utility named `dcrctl` which can be used to issue
@@ -138,9 +145,11 @@ be used to communicate with any server/daemon/service which provides a JSON-RPC
 API compatible with the original bitcoind/bitcoin-qt client.
 
 <a name="Methods" />
+
 ### 5. Standard Methods
 
 <a name="MethodOverview" />
+
 **5.1 Method Overview**<br />
 
 The following is an overview of the RPC methods and their current status.  Click
@@ -181,6 +190,7 @@ the method name for further details such as parameter and return information.
 |31|[verifychain](#verifychain)|N|Verifies the block chain database.|
 
 <a name="MethodDetails" />
+
 **5.2 Method Details**<br />
 
 <a name="addnode"/>
@@ -568,9 +578,11 @@ Example Return|`{`<br />&nbsp;&nbsp;`"bytes": 310768,`<br />&nbsp;&nbsp;`"size":
 
 
 <a name="ExtensionMethods" />
+
 ### 6. Extension Methods
 
 <a name="ExtMethodOverview" />
+
 **6.1 Method Overview**<br />
 
 The following is an overview of the RPC methods which are implemented by dcrd, but not the original decredd client. Click the method name for further details such as parameter and return information.
@@ -586,6 +598,7 @@ The following is an overview of the RPC methods which are implemented by dcrd, b
 
 
 <a name="ExtMethodDetails" />
+
 **6.2 Method Details**<br />
 
 <a name="debuglevel"/>
@@ -665,9 +678,11 @@ The following is an overview of the RPC methods which are implemented by dcrd, b
 ***
 
 <a name="WSExtMethods" />
+
 ### 7. Websocket Extension Methods (Websocket-specific)
 
 <a name="WSExtMethodOverview" />
+
 **7.1 Method Overview**<br />
 
 The following is an overview of the RPC method requests available exclusively to Websocket clients.  All of these RPC methods are available to the limited
@@ -688,6 +703,7 @@ user.  Click the method name for further details such as parameter and return in
 |11|[session](#session)|Return details regarding a websocket client's current connection.|None|
 
 <a name="WSExtMethodDetails" />
+
 **7.2 Method Details**<br />
 
 <a name="authenticate"/>
@@ -832,11 +848,13 @@ user.  Click the method name for further details such as parameter and return in
 
 
 <a name="Notifications" />
+
 ### 8. Notifications (Websocket-specific)
 
 dcrd uses standard JSON-RPC notifications to notify clients of changes, rather than requiring clients to poll dcrd for updates.  JSON-RPC notifications are a subset of requests, but do not contain an ID.  The notification type is categorized by the `method` field and additional details are sent as a JSON array in the `params` field.
 
 <a name="NotificationOverview" />
+
 **8.1 Notification Overview**<br />
 
 The following is an overview of the JSON-RPC notifications used for Websocket connections.  Click the method name for further details of the context(s) in which they are sent and their parameters.
@@ -853,6 +871,7 @@ The following is an overview of the JSON-RPC notifications used for Websocket co
 |8|[rescanfinished](#rescanfinished)|A rescan operation has completed.|[rescan](#rescan)|
 
 <a name="NotificationDetails" />
+
 **8.2 Notification Details**<br />
 
 <a name="blockconnected"/>
@@ -959,6 +978,7 @@ The following is an overview of the JSON-RPC notifications used for Websocket co
 
 
 <a name="ExampleCode" />
+
 ### 9. Example Code
 
 This section provides example code for interacting with the JSON-RPC API in
@@ -968,6 +988,7 @@ various languages.
 * [node.js](#ExampleNodeJsCode)
 
 <a name="ExampleGoApp" />
+
 **9.1 Go**
 
 This section provides examples of using the RPC interface using Go and the
@@ -979,6 +1000,7 @@ This section provides examples of using the RPC interface using Go and the
 
 
 <a name="ExampleGetBlockCount" />
+
 **9.1.1 Using getblockcount to Retrieve the Current Block Height**<br />
 
 The following is an example Go application which uses the
@@ -1039,6 +1061,7 @@ Block count: 276978
 ```
 
 <a name="ExampleGetBlock" />
+
 **9.1.2 Using getblock to Retrieve the Genesis Block**<br />
 
 The following is an example Go application which uses the
@@ -1126,6 +1149,7 @@ Num transactions: 1
 ```
 
 <a name="ExampleNotifyBlocks" />
+
 **9.1.3 Using notifyblocks to Receive blockconnected and blockdisconnected
 Notifications (Websocket-specific)**<br />
 
@@ -1215,9 +1239,11 @@ Example output:
 ```
 
 <a name="ExampleNodeJsCode" />
+
 ### 9.2. Example node.js Code
 
 <a name="ExampleNotifyBlocks" />
+
 **9.2.1 Using notifyblocks to be Notified of Block Connects and Disconnects**<br />
 
 The following is example node.js code which uses [ws](https://github.com/einaros/ws)
@@ -1242,1291 +1268,6 @@ var password = "yourpassword";
 // its own certificate authority, so it needs to be specified in the 'ca' array
 // for the certificate to properly validate.
 var ws = new WebSocket('wss://127.0.0.1:9109/ws', {
-  headers: {
-    'Authorization': 'Basic '+new Buffer(user+':'+password).toString('base64')
-  },
-  cert: cert,
-  ca: [cert]
-});
-ws.on('open', function() {
-    console.log('CONNECTED');
-    // Send a JSON-RPC command to be notified when blocks are connected and
-    // disconnected from the chain.
-    ws.send('{"jsonrpc":"1.0","id":"0","method":"notifyblocks","params":[]}');
-});
-ws.on('message', function(data, flags) {
-    console.log(data);
-});
-ws.on('error', function(derp) {
-  console.log('ERROR:' + derp);
-})
-ws.on('close', function(data) {
-  console.log('DISCONNECTED');
-})
-```
-=======
-### Table of Contents
-1. [Overview](#Overview)<br />
-2. [HTTP POST Versus Websockets](#HttpPostVsWebsockets)<br />
-3. [Authentication](#Authentication)<br />
-3.1.  [Overview](#AuthenticationOverview)<br />
-3.2.  [HTTP Basic Access Authentication](#HTTPAuth)<br />
-3.3.  [JSON-RPC Authenticate Command (Websocket-specific)](#JSONAuth)<br />
-4. [Command-line Utility](#CLIUtil)<br />
-5. [Standard Methods](#Methods)<br />
-5.1. [Method Overview](#MethodOverview)<br />
-5.2. [Method Details](#MethodDetails)<br />
-6. [Extension Methods](#ExtensionMethods)<br />
-6.1. [Method Overview](#ExtMethodOverview)<br />
-6.2. [Method Details](#ExtMethodDetails)<br />
-7. [Websocket Extension Methods (Websocket-specific)](#WSExtMethods)<br />
-7.1. [Method Overview](#WSExtMethodOverview)<br />
-7.2. [Method Details](#WSExtMethodDetails)<br />
-8. [Notifications (Websocket-specific)](#Notifications)<br />
-8.1. [Notification Overview](#NotificationOverview)<br />
-8.2. [Notification Details](#NotificationDetails)<br />
-9. [Example Code](#ExampleCode)<br />
-9.1. [Go](#ExampleGoApp)<br />
-9.2. [node.js](#ExampleNodeJsCode)<br />
-
-<a name="Overview" />
-### 1. Overview
-
-btcd provides a [JSON-RPC](http://json-rpc.org/wiki/specification) API that is
-fully compatible with the original bitcoind/bitcoin-qt.  There are a few key
-differences between btcd and bitcoind as far as how RPCs are serviced:
-* Unlike bitcoind that has the wallet and chain intermingled in the same process
-  which leads to several issues, btcd intentionally splits the wallet and chain
-  services into independent processes.  See the blog post
-  [here](https://blog.conformal.com/btcd-not-your-moms-bitcoin-daemon/) for
-  further details on why they were separated.  This means that if you are
-  talking directly to btcd, only chain-related RPCs are available.  However both
-  chain-related and wallet-related RPCs are available via
-  [btcwallet](https://github.com/btcsuite/btcwallet).
-* btcd is secure by default which means that the RPC connection is TLS-enabled
-  by default
-* btcd provides access to the API through both
-  [HTTP POST](http://en.wikipedia.org/wiki/POST_%28HTTP%29) requests and
-  [Websockets](http://en.wikipedia.org/wiki/WebSocket)
-
-Websockets are the preferred transport for btcd RPC and are used by applications
-such as [btcwallet](https://github.com/btcsuite/btcwallet) for inter-process
-communication with btcd.  The websocket connection endpoint for btcd is
-`wss://your_ip_or_domain:8334/ws`.
-
-In addition to the [standard API](#Methods), an [extension API](#WSExtMethods)
-has been developed that is exclusive to clients using Websockets. In its current
-state, this API attempts to cover features found missing in the standard API
-during the development of btcwallet.
-
-While the [standard API](#Methods) is stable, the
-[Websocket extension API](#WSExtMethods) should be considered a work in
-progress, incomplete, and susceptible to changes (both additions and removals).
-
-The original bitcoind/bitcoin-qt JSON-RPC API documentation is available at [https://en.bitcoin.it/wiki/Original_Bitcoin_client/API_Calls_list](https://en.bitcoin.it/wiki/Original_Bitcoin_client/API_Calls_list)
-
-<a name="HttpPostVsWebsockets" />
-### 2. HTTP POST Versus Websockets
-
-The btcd RPC server supports both [HTTP POST](http://en.wikipedia.org/wiki/POST_%28HTTP%29)
-requests and the preferred [Websockets](http://en.wikipedia.org/wiki/WebSocket).
-All of the [standard](#Methods) and [extension](#ExtensionMethods) methods
-described in this documentation can be accessed through both.  As the name
-indicates, the [Websocket-specific extension](#WSExtMethods) methods can only be
-accessed when connected via Websockets.
-
-As mentioned in the [overview](#Overview), the websocket connection endpoint for
-btcd is `wss://your_ip_or_domain:8334/ws`.
-
-The most important differences between the two transports as it pertains to the
-JSON-RPC API are:
-
-|   |HTTP POST Requests|Websockets|
-|---|------------------|----------|
-|Allows multiple requests across a single connection|No|Yes|
-|Supports asynchronous notifications|No|Yes|
-|Scales well with large numbers of requests|No|Yes|
-
-<a name="Authentication" />
-### 3. Authentication
-
-<a name="AuthenticationOverview" />
-**3.1 Authentication Overview**<br />
-
-The following authentication details are needed before establishing a connection
-to a btcd RPC server:
-
-* **rpcuser** is the full-access username configured for the btcd RPC server
-* **rpcpass** is the full-access password configured for the btcd RPC server
-* **rpclimituser** is the limited username configured for the btcd RPC server
-* **rpclimitpass** is the limited password configured for the btcd RPC server
-* **rpccert** is the PEM-encoded X.509 certificate (public key) that the btcd
-  server is configured with.  It is automatically generated by btcd and placed
-  in the btcd home directory (which is typically `%LOCALAPPDATA%\Btcd` on
-  Windows and `~/.btcd` on POSIX-like OSes)
-
-**NOTE:** As mentioned above, btcd is secure by default which means the RPC
-server is not running unless configured with a **rpcuser** and **rpcpass**
-and/or a **rpclimituser** and **rpclimitpass**, and uses TLS authentication for
-all connections.
-
-Depending on which connection transaction you are using, you can choose one of
-two, mutually exclusive, methods.
-- [Use HTTP Authorization Header](#HTTPAuth) - HTTP POST requests and Websockets
-- [Use the JSON-RPC "authenticate" command](#JSONAuth) - Websockets only
-
-<a name="HTTPAuth" />
-**3.2 HTTP Basic Access Authentication**<br />
-
-The btcd RPC server uses HTTP [basic access authentication](http://en.wikipedia.org/wiki/Basic_access_authentication) with the **rpcuser**
-and **rpcpass** detailed above.  If the supplied credentials are invalid, you
-will be disconnected immediately upon making the connection.
-
-<a name="JSONAuth" />
-**3.3 JSON-RPC Authenticate Command (Websocket-specific)**<br />
-
-While the HTTP basic access authentication method is the preferred method, the
-ability to set HTTP headers from websockets is not always available.  In that
-case, you will need to use the [authenticate](#authenticate) JSON-RPC method.
-
-The [authenticate](#authenticate) command must be the first command sent after
-connecting to the websocket.  Sending any other commands before authenticating,
-supplying invalid credentials, or attempting to authenticate again when already
-authenticated will cause the websocket to be closed immediately.
-
-
-<a name="CLIUtil" />
-### 4. Command-line Utility
-
-btcd comes with a separate utility named `btcctl` which can be used to issue
-these RPC commands via HTTP POST requests to btcd after configuring it with the
-information in the [Authentication](#Authentication) section above.  It can also
-be used to communicate with any server/daemon/service which provides a JSON-RPC
-API compatible with the original bitcoind/bitcoin-qt client.
-
-<a name="Methods" />
-### 5. Standard Methods
-
-<a name="MethodOverview" />
-**5.1 Method Overview**<br />
-
-The following is an overview of the RPC methods and their current status.  Click
-the method name for further details such as parameter and return information.
-
-|#|Method|Safe for limited user?|Description|
-|---|------|----------|-----------|
-|1|[addnode](#addnode)|N|Attempts to add or remove a persistent peer.|
-|2|[createrawtransaction](#createrawtransaction)|Y|Returns a new transaction spending the provided inputs and sending to the provided addresses.|
-|3|[decoderawtransaction](#decoderawtransaction)|Y|Returns a JSON object representing the provided serialized, hex-encoded transaction.|
-|4|[decodescript](#decodescript)|Y|Returns a JSON object with information about the provided hex-encoded script.|
-|5|[getaddednodeinfo](#getaddednodeinfo)|N|Returns information about manually added (persistent) peers.|
-|6|[getbestblockhash](#getbestblockhash)|Y|Returns the hash of the of the best (most recent) block in the longest block chain.|
-|7|[getblock](#getblock)|Y|Returns information about a block given its hash.|
-|8|[getblockcount](#getblockcount)|Y|Returns the number of blocks in the longest block chain.|
-|9|[getblockhash](#getblockhash)|Y|Returns hash of the block in best block chain at the given height.|
-|10|[getblockheader](#getblockheader)|Y|Returns the block header of the block.|
-|11|[getconnectioncount](#getconnectioncount)|N|Returns the number of active connections to other peers.|
-|12|[getdifficulty](#getdifficulty)|Y|Returns the proof-of-work difficulty as a multiple of the minimum difficulty.|
-|13|[getgenerate](#getgenerate)|N|Return if the server is set to generate coins (mine) or not.|
-|14|[gethashespersec](#gethashespersec)|N|Returns a recent hashes per second performance measurement while generating coins (mining).|
-|15|[getinfo](#getinfo)|Y|Returns a JSON object containing various state info.|
-|16|[getmempoolinfo](#getmempoolinfo)|N|Returns a JSON object containing mempool-related information.|
-|17|[getmininginfo](#getmininginfo)|N|Returns a JSON object containing mining-related information.|
-|18|[getnettotals](#getnettotals)|Y|Returns a JSON object containing network traffic statistics.|
-|19|[getnetworkhashps](#getnetworkhashps)|Y|Returns the estimated network hashes per second for the block heights provided by the parameters.|
-|20|[getpeerinfo](#getpeerinfo)|N|Returns information about each connected network peer as an array of json objects.|
-|21|[getrawmempool](#getrawmempool)|Y|Returns an array of hashes for all of the transactions currently in the memory pool.|
-|22|[getrawtransaction](#getrawtransaction)|Y|Returns information about a transaction given its hash.|
-|23|[getwork](#getwork)|N|Returns formatted hash data to work on or checks and submits solved data.<br /><font color="orange">NOTE: Since btcd does not have the wallet integrated to provide payment addresses, btcd must be configured via the `--miningaddr` option to provide which payment addresses to pay created blocks to for this RPC to function.</font>|
-|24|[help](#help)|Y|Returns a list of all commands or help for a specified command.|
-|25|[ping](#ping)|N|Queues a ping to be sent to each connected peer.|
-|26|[sendrawtransaction](#sendrawtransaction)|Y|Submits the serialized, hex-encoded transaction to the local peer and relays it to the network.<br /><font color="orange">btcd does not yet implement the `allowhighfees` parameter, so it has no effect</font>|
-|27|[setgenerate](#setgenerate) |N|Set the server to generate coins (mine) or not.<br/>NOTE: Since btcd does not have the wallet integrated to provide payment addresses, btcd must be configured via the `--miningaddr` option to provide which payment addresses to pay created blocks to for this RPC to function.|
-|28|[stop](#stop)|N|Shutdown btcd.|
-|29|[submitblock](#submitblock)|Y|Attempts to submit a new serialized, hex-encoded block to the network.|
-|30|[validateaddress](#validateaddress)|Y|Verifies the given address is valid.  NOTE: Since btcd does not have a wallet integrated, btcd will only return whether the address is valid or not.|
-|31|[verifychain](#verifychain)|N|Verifies the block chain database.|
-
-<a name="MethodDetails" />
-**5.2 Method Details**<br />
-
-<a name="addnode"/>
-
-|   |   |
-|---|---|
-|Method|addnode|
-|Parameters|1. peer (string, required) - ip address and port of the peer to operate on<br />2. command (string, required) - `add` to add a persistent peer, `remove` to remove a persistent peer, or `onetry` to try a single connection to a peer|
-|Description|Attempts to add or remove a persistent peer.|
-|Returns|Nothing|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="createrawtransaction"/>
-
-|   |   |
-|---|---|
-|Method|createrawtransaction|
-|Parameters|1. transaction inputs (JSON array, required) - json array of json objects<br />`[`<br />&nbsp;&nbsp;`{`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"txid": "hash", (string, required) the hash of the input transaction`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"vout": n  (numeric, required) the specific output of the input transaction to redeem`<br />&nbsp;&nbsp;`}, ...`<br />`]`<br />2. addresses and amounts (JSON object, required) - json object with addresses as keys and amounts as values<br />`{`<br />&nbsp;&nbsp;`"address": n.nnn (numeric, required) the address to send to as the key and the amount in BTC as the value`<br />&nbsp;&nbsp;`, ...`<br />`}`<br />3. locktime (int64, optional, default=0) - specifies the transaction locktime.  If non-zero, the inputs will also have their locktimes activated. |
-|Description|Returns a new transaction spending the provided inputs and sending to the provided addresses.<br />The transaction inputs are not signed in the created transaction.<br />The `signrawtransaction` RPC command provided by wallet must be used to sign the resulting transaction.|
-|Returns|`"transaction" (string) hex-encoded bytes of the serialized transaction`|
-|Example Parameters|1. transaction inputs `[{"txid":"e6da89de7a6b8508ce8f371a3d0535b04b5e108cb1a6e9284602d3bfd357c018","vout":1}]`<br />2. addresses and amounts `{"13cgrTP7wgbZYWrY9BZ22BV6p82QXQT3nY": 0.49213337}`<br />3. locktime `0`|
-|Example Return|`010000000118c057d3bfd3024628e9a6b18c105e4bb035053d1a378fce08856b7ade89dae6010000`<br />`0000ffffffff0199efee02000000001976a9141cb013db35ecccc156fdfd81d03a11c51998f99388`<br />`ac00000000`<br /><font color="orange">**Newlines added for display purposes.  The actual return does not contain newlines.**</font>|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="decoderawtransaction"/>
-
-|   |   |
-|---|---|
-|Method|decoderawtransaction|
-|Parameters|1. data (string, required) - serialized, hex-encoded transaction|
-|Description|Returns a JSON object representing the provided serialized, hex-encoded transaction.|
-|Returns|`{ (json object)`<br />&nbsp;&nbsp;`"txid": "hash",  (string) the hash of the transaction`<br />&nbsp;&nbsp;`"version": n,  (numeric) the transaction version`<br />&nbsp;&nbsp;`"locktime": n,  (numeric) the transaction lock time`<br />&nbsp;&nbsp;`"vin": [  (array of json objects) the transaction inputs as json objects`<br />&nbsp;&nbsp;<font color="orange">For coinbase transactions:</font><br />&nbsp;&nbsp;&nbsp;&nbsp;`{ (json object)`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"coinbase": "data",  (string) the hex-encoded bytes of the signature script`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"sequence": n,  (numeric) the script sequence number`<br />&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;<font color="orange">For non-coinbase transactions:</font><br />&nbsp;&nbsp;&nbsp;&nbsp;`{ (json object)`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"txid": "hash", (string) the hash of the origin transaction`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"vout": n, (numeric) the index of the output being redeemed from the origin transaction`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"scriptSig": { (json object) the signature script used to redeem the origin transaction`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"asm": "asm", (string) disassembly of the script`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"hex": "data",  (string) hex-encoded bytes of the script`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"sequence": n,  (numeric) the script sequence number`<br />&nbsp;&nbsp;&nbsp;&nbsp;`}, ...`<br />&nbsp;&nbsp;`]`<br />&nbsp;&nbsp;`"vout": [  (array of json objects) the transaction outputs as json objects`<br />&nbsp;&nbsp;&nbsp;&nbsp;`{ (json object)`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"value": n, (numeric) the value in BTC`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"n": n, (numeric) the index of this transaction output`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"scriptPubKey": { (json object) the public key script used to pay coins`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"asm": "asm",  (string) disassembly of the script`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"hex": "data", (string) hex-encoded bytes of the script`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"reqSigs": n,  (numeric) the number of required signatures`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"type": "scripttype" (string) the type of the script (e.g. 'pubkeyhash')`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"addresses": [ (json array of string) the bitcoin addresses associated with this output`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"bitcoinaddress",  (string) the bitcoin address`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`...`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`]`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;&nbsp;&nbsp;`}, ...`<br />&nbsp;&nbsp;`]`<br />`}`|
-|Example Return|`{`<br />&nbsp;&nbsp;`"txid": "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",`<br />&nbsp;&nbsp;`"version": 1,`<br />&nbsp;&nbsp;`"locktime": 0,`<br />&nbsp;&nbsp;`"vin": [`<br />&nbsp;&nbsp;<font color="orange">For coinbase transactions:</font><br />&nbsp;&nbsp;&nbsp;&nbsp;`{ (json object)`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"coinbase": "04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6...",`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"sequence": 4294967295,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;<font color="orange">For non-coinbase transactions:</font><br />&nbsp;&nbsp;&nbsp;&nbsp;`{`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"txid": "60ac4b057247b3d0b9a8173de56b5e1be8c1d1da970511c626ef53706c66be04",`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"vout": 0,`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"scriptSig": {`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"asm": "3046022100cb42f8df44eca83dd0a727988dcde9384953e830b1f8004d57485e2ede1b9c8f0...",`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"hex": "493046022100cb42f8df44eca83dd0a727988dcde9384953e830b1f8004d57485e2ede1b9c8...",`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"sequence": 4294967295,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;`]`<br />&nbsp;&nbsp;`"vout": [`<br />&nbsp;&nbsp;&nbsp;&nbsp;`{`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"value": 50,`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"n": 0,`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"scriptPubKey": {`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"asm": "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4ce...",`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"hex": "4104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4...",`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"reqSigs": 1,`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"type": "pubkey"`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"addresses": [`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`]`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;`]`<br />`}`|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="decodescript"/>
-
-|   |   |
-|---|---|
-|Method|decodescript|
-|Parameters|1. script (string, required) - hex-encoded script|
-|Description|Returns a JSON object with information about the provided hex-encoded script.|
-|Returns|`{ (json object)`<br />&nbsp;&nbsp;`"asm": "asm",  (string) disassembly of the script`<br />&nbsp;&nbsp;`"reqSigs": n,  (numeric) the number of required signatures`<br />&nbsp;&nbsp;`"type": "scripttype",  (string) the type of the script (e.g. 'pubkeyhash')`<br />&nbsp;&nbsp;`"addresses": [ (json array of string) the bitcoin addresses associated with this script`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"bitcoinaddress",  (string) the bitcoin address`<br />&nbsp;&nbsp;&nbsp;&nbsp;`...`<br />&nbsp;&nbsp;`]`<br />&nbsp;&nbsp;`"p2sh": "scripthash",  (string) the script hash for use in pay-to-script-hash transactions`<br />`}`|
-|Example Return|`{`<br />&nbsp;&nbsp;`"asm": "OP_DUP OP_HASH160 b0a4d8a91981106e4ed85165a66748b19f7b7ad4 OP_EQUALVERIFY OP_CHECKSIG",`<br />&nbsp;&nbsp;`"reqSigs": 1,`<br />&nbsp;&nbsp;`"type": "pubkeyhash",`<br />&nbsp;&nbsp;`"addresses": [`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"1H71QVBpzuLTNUh5pewaH3UTLTo2vWgcRJ"`<br />&nbsp;&nbsp;`]`<br />&nbsp;&nbsp;`"p2sh": "359b84ff799f48231990ff0298206f54117b08b6"`<br />`}`|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="getaddednodeinfo"/>
-
-|   |   |
-|---|---|
-|Method|getaddednodeinfo|
-|Parameters|1. dns (boolean, required) - specifies whether the returned data is a JSON object including DNS and connection information, or just a list of added peers<br />2. node (string, optional) - only return information about this specific peer instead of all added peers.|
-|Description|Returns information about manually added (persistent) peers.|
-|Returns (dns=false)|`["ip:port", ...]`|
-|Returns (dns=true)|`[ (json array of objects)`<br />&nbsp;&nbsp;`{ (json object)`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"addednode": "ip_or_domain",  (string) the ip address or domain of the added peer`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"connected": true or false,  (boolean) whether or not the peer is currently connected`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"addresses": [  (json array or objects) DNS lookup and connection information about the peer`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`{ (json object)`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"address": "ip",  (string) the ip address for this DNS entry`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"connected": "inbound/outbound/false"  (string) the connection 'direction' (if connected)`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`}, ...`<br />&nbsp;&nbsp;&nbsp;&nbsp;`]`<br />&nbsp;&nbsp;`}, ...`<br />`]`|
-|Example Return (dns=false)|`["192.168.0.10:8333", "mydomain.org:8333"]`|
-|Example Return (dns=true)|`[`<br />&nbsp;&nbsp;`{`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"addednode": "mydomain.org:8333",`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"connected": true,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"addresses": [`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`{`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"address": "1.2.3.4",`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"connected": "outbound"`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`},`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`{`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"address": "5.6.7.8",`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"connected": "false"`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;&nbsp;&nbsp;`]`<br />&nbsp;&nbsp;`}`<br />`]`|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="getbestblockhash"/>
-
-|   |   |
-|---|---|
-|Method|getbestblockhash|
-|Parameters|None|
-|Description|Returns the hash of the of the best (most recent) block in the longest block chain.|
-|Returns|string|
-|Example Return|`0000000000000001f356adc6b29ab42b59f913a396e170f80190dba615bd1e60`|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="getblock"/>
-
-|   |   |
-|---|---|
-|Method|getblock|
-|Parameters|1. block hash (string, required) - the hash of the block<br />2. verbose (boolean, optional, default=true) - specifies the block is returned as a JSON object instead of hex-encoded string<br />3. verbosetx (boolean, optional, default=false) - specifies that each transaction is returned as a JSON object and only applies if the `verbose` flag is true.<font color="orange">**This parameter is a btcd extension**</font>|
-|Description|Returns information about a block given its hash.|
-|Returns (verbose=false)|`"data" (string) hex-encoded bytes of the serialized block`|
-|Returns (verbose=true, verbosetx=false)|`{ (json object)`<br />&nbsp;&nbsp;`"hash": "blockhash",  (string) the hash of the block (same as provided)`<br />&nbsp;&nbsp;`"confirmations": n,  (numeric) the number of confirmations`<br />&nbsp;&nbsp;`"size": n,  (numeric) the size of the block`<br />&nbsp;&nbsp;`"height": n,  (numeric) the height of the block in the block chain`<br />&nbsp;&nbsp;`"version": n,  (numeric) the block version`<br />&nbsp;&nbsp;`"merkleroot": "hash",  (string) root hash of the merkle tree`<br />&nbsp;&nbsp;`"tx": [ (json array of string) the transaction hashes`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"transactionhash",  (string) hash of the parent transaction`<br />&nbsp;&nbsp;&nbsp;&nbsp;`...`<br />&nbsp;&nbsp;`]`<br />&nbsp;&nbsp;`"time": n,  (numeric) the block time in seconds since 1 Jan 1970 GMT`<br />&nbsp;&nbsp;`"nonce": n,  (numeric) the block nonce`<br />&nbsp;&nbsp;`"bits", n,  (numeric) the bits which represent the block difficulty`<br />&nbsp;&nbsp;`difficulty: n.nn,  (numeric) the proof-of-work difficulty as a multiple of the minimum difficulty`<br />&nbsp;&nbsp;`"previousblockhash": "hash",  (string) the hash of the previous block`<br />&nbsp;&nbsp;`"nextblockhash": "hash",  (string) the hash of the next block (only if there is one)`<br />`}`|
-|Returns (verbose=true, verbosetx=true)|`{ (json object)`<br />&nbsp;&nbsp;`"hash": "blockhash",  (string) the hash of the block (same as provided)`<br />&nbsp;&nbsp;`"confirmations": n,  (numeric) the number of confirmations`<br />&nbsp;&nbsp;`"size": n,  (numeric) the size of the block`<br />&nbsp;&nbsp;`"height": n,  (numeric) the height of the block in the block chain`<br />&nbsp;&nbsp;`"version": n,  (numeric) the block version`<br />&nbsp;&nbsp;`"merkleroot": "hash",  (string) root hash of the merkle tree`<br />&nbsp;&nbsp;`"rawtx": [ (array of json objects) the transactions as json objects`<br />&nbsp;&nbsp;&nbsp;&nbsp;`(see getrawtransaction json object details)`<br />&nbsp;&nbsp;`]`<br />&nbsp;&nbsp;`"time": n,  (numeric) the block time in seconds since 1 Jan 1970 GMT`<br />&nbsp;&nbsp;`"nonce": n,  (numeric) the block nonce`<br />&nbsp;&nbsp;`"bits", n,  (numeric) the bits which represent the block difficulty`<br />&nbsp;&nbsp;`difficulty: n.nn,  (numeric) the proof-of-work difficulty as a multiple of the minimum difficulty`<br />&nbsp;&nbsp;`"previousblockhash": "hash",  (string) the hash of the previous block`<br />&nbsp;&nbsp;`"nextblockhash": "hash",  (string) the hash of the next block`<br />`}`|
-|Example Return (verbose=false)|`"010000000000000000000000000000000000000000000000000000000000000000000000`<br />`3ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49`<br />`ffff001d1dac2b7c01010000000100000000000000000000000000000000000000000000`<br />`00000000000000000000ffffffff4d04ffff001d0104455468652054696d65732030332f`<br />`4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f`<br />`6e64206261696c6f757420666f722062616e6b73ffffffff0100f2052a01000000434104`<br />`678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f`<br />`4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac00000000"`<br /><font color="orange">**Newlines added for display purposes.  The actual return does not contain newlines.**</font>|
-|Example Return (verbose=true, verbosetx=false)|`{`<br />&nbsp;&nbsp;`"hash": "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",`<br />&nbsp;&nbsp;`"confirmations": 277113,`<br />&nbsp;&nbsp;`"size": 285,`<br />&nbsp;&nbsp;`"height": 0,`<br />&nbsp;&nbsp;`"version": 1,`<br />&nbsp;&nbsp;`"merkleroot": "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",`<br />&nbsp;&nbsp;`"tx": [`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"`<br />&nbsp;&nbsp;`],`<br />&nbsp;&nbsp;`"time": 1231006505,`<br />&nbsp;&nbsp;`"nonce": 2083236893,`<br />&nbsp;&nbsp;`"bits": "1d00ffff",`<br />&nbsp;&nbsp;`"difficulty": 1,`<br />&nbsp;&nbsp;`"previousblockhash": "0000000000000000000000000000000000000000000000000000000000000000",`<br />&nbsp;&nbsp;`"nextblockhash": "00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048"`<br />`}`|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="getblockcount"/>
-
-|   |   |
-|---|---|
-|Method|getblockcount|
-|Parameters|None|
-|Description|Returns the number of blocks in the longest block chain.|
-|Returns|numeric|
-|Example Return|`276820`|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="getblockhash"/>
-
-|   |   |
-|---|---|
-|Method|getblockhash|
-|Parameters|1. block height (numeric, required)|
-|Description|Returns hash of the block in best block chain at the given height.|
-|Returns|string|
-|Example Return|`000000000000000096579458d1c0f1531fcfc58d57b4fce51eb177d8d10e784d`|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="getblockheader"/>
-
-|   |   |
-|---|---|
-|Method|getblockheader|
-|Parameters|1. block hash (string, required) - the hash of the block<br />2. verbose (boolean, optional, default=true) - specifies the block header is returned as a JSON object instead of a hex-encoded string|
-|Description|Returns hex-encoded bytes of the serialized block header.|
-|Returns (verbose=false)|`"data" (string) hex-encoded bytes of the serialized block`|
-|Returns (verbose=true)|`{ (json object)`<br />&nbsp;&nbsp;`"hash": "blockhash", (string) the hash of the block (same as provided)`<br />&nbsp;&nbsp;`"confirmations": n,  (numeric) the number of confirmations`<br />&nbsp;&nbsp;`"height": n, (numeric) the height of the block in the block chain`<br />&nbsp;&nbsp;`"version": n,  (numeric) the block version`<br />&nbsp;&nbsp;`"merkleroot": "hash",  (string) root hash of the merkle tree`<br />&nbsp;&nbsp;`"time": n,  (numeric) the block time in seconds since 1 Jan 1970 GMT`<br />&nbsp;&nbsp;`"nonce": n,  (numeric) the block nonce`<br />&nbsp;&nbsp;`"bits": n,  (numeric) the bits which represent the block difficulty`<br />&nbsp;&nbsp;`"difficulty": n.nn,  (numeric) the proof-of-work difficulty as a multiple of the minimum difficulty`<br />&nbsp;&nbsp;`"previousblockhash": "hash",  (string) the hash of the previous block`<br />&nbsp;&nbsp;`"nextblockhash": "hash",  (string) the hash of the next block (only if there is one)`<br />`}`|
-|Example Return (verbose=false)|`"0200000035ab154183570282ce9afc0b494c9fc6a3cfea05aa8c1add2ecc564900000000`<br />`38ba3d78e4500a5a7570dbe61960398add4410d278b21cd9708e6d9743f374d544fc0552`<br />`27f1001c29c1ea3b"`<br /><font color="orange">**Newlines added for display purposes.  The actual return does not contain newlines.**</font>|
-|Example Return (verbose=true)|`{`<br />&nbsp;&nbsp;`"hash": "00000000009e2958c15ff9290d571bf9459e93b19765c6801ddeccadbb160a1e",`<br />&nbsp;&nbsp;`"confirmations": 392076,`<br />&nbsp;&nbsp;`"height": 100000,`<br />&nbsp;&nbsp;`"version": 2,`<br />&nbsp;&nbsp;`"merkleroot": "d574f343976d8e70d91cb278d21044dd8a396019e6db70755a0a50e4783dba38",`<br />&nbsp;&nbsp;`"time": 1376123972,`<br />&nbsp;&nbsp;`"nonce": 1005240617,`<br />&nbsp;&nbsp;`"bits": "1c00f127",`<br />&nbsp;&nbsp;`"difficulty": 271.75767393,`<br />&nbsp;&nbsp;`"previousblockhash": "000000004956cc2edd1a8caa05eacfa3c69f4c490bfc9ace820257834115ab35",`<br />&nbsp;&nbsp;`"nextblockhash": "0000000000629d100db387f37d0f37c51118f250fb0946310a8c37316cbc4028"`<br />`}`|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="getconnectioncount"/>
-
-|   |   |
-|---|---|
-|Method|getconnectioncount|
-|Parameters|None|
-|Description|Returns the number of active connections to other peers|
-|Returns|numeric|
-|Example Return|`8`|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="getdifficulty"/>
-
-|   |   |
-|---|---|
-|Method|getdifficulty|
-|Parameters|None|
-|Description|Returns the proof-of-work difficulty as a multiple of the minimum difficulty.|
-|Returns|numeric|
-|Example Return|`1180923195.260000`|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="getgenerate"/>
-
-|   |   |
-|---|---|
-|Method|getgenerate|
-|Parameters|None|
-|Description|Return if the server is set to generate coins (mine) or not.|
-|Returns|`false` (boolean)|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="gethashespersec"/>
-
-|   |   |
-|---|---|
-|Method|gethashespersec|
-|Parameters|None|
-|Description|Returns a recent hashes per second performance measurement while generating coins (mining).|
-|Returns|`0` (numeric)|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="getinfo"/>
-
-|   |   |
-|---|---|
-|Method|getinfo|
-|Parameters|None|
-|Description|Returns a JSON object containing various state info.|
-|Notes|NOTE: Since btcd does NOT contain wallet functionality, wallet-related fields are not returned.  See getinfo in btcwallet for a version which includes that information.|
-|Returns|`{ (json object)`<br />&nbsp;&nbsp;`"version": n,  (numeric) the version of the server`<br />&nbsp;&nbsp;`"protocolversion": n,  (numeric) the latest supported protocol version`<br />&nbsp;&nbsp;`"blocks": n,  (numeric) the number of blocks processed`<br />&nbsp;&nbsp;`"timeoffset": n,  (numeric) the time offset`<br />&nbsp;&nbsp;`"connections": n,  (numeric) the number of connected peers`<br />&nbsp;&nbsp;`"proxy": "host:port",  (string) the proxy used by the server`<br />&nbsp;&nbsp;`"difficulty": n.nn,  (numeric) the current target difficulty`<br />&nbsp;&nbsp;`"testnet": true or false,  (boolean) whether or not server is using testnet`<br />&nbsp;&nbsp;`"relayfee": n.nn,  (numeric) the minimum relay fee for non-free transactions in BTC/KB`<br />`}`|
-|Example Return|`{`<br />&nbsp;&nbsp;`"version": 70000`<br />&nbsp;&nbsp;`"protocolversion": 70001,  `<br />&nbsp;&nbsp;`"blocks": 298963,`<br />&nbsp;&nbsp;`"timeoffset": 0,`<br />&nbsp;&nbsp;`"connections": 17,`<br />&nbsp;&nbsp;`"proxy": "",`<br />&nbsp;&nbsp;`"difficulty": 8000872135.97,`<br />&nbsp;&nbsp;`"testnet": false,`<br />&nbsp;&nbsp;`"relayfee": 0.00001,`<br />`}`|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="getmempoolinfo"/>
-
-|   |   |
-|---|---|
-|Method|getmempoolinfo|
-|Parameters|None|
-|Description|Returns a JSON object containing mempool-related information.|
-|Returns|`{ (json object)`<br />&nbsp;&nbsp;`"bytes": n,  (numeric) size in bytes of the mempool`<br />&nbsp;&nbsp;`"size": n,  (numeric) number of transactions in the mempool`<br />`}`|
-Example Return|`{`<br />&nbsp;&nbsp;`"bytes": 310768,`<br />&nbsp;&nbsp;`"size": 157,`<br />`}`|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="getmininginfo"/>
-
-|   |   |
-|---|---|
-|Method|getmininginfo|
-|Parameters|None|
-|Description|Returns a JSON object containing mining-related information.|
-|Returns|`{ (json object)`<br />&nbsp;&nbsp;`"blocks": n,  (numeric) latest best block`<br />&nbsp;&nbsp;`"currentblocksize": n,  (numeric) size of the latest best block`<br />&nbsp;&nbsp;`"currentblocktx": n,  (numeric) number of transactions in the latest best block`<br />&nbsp;&nbsp;`"difficulty": n.nn,  (numeric) current target difficulty`<br />&nbsp;&nbsp;`"errors": "errors",  (string) any current errors`<br />&nbsp;&nbsp;`"generate": true or false,  (boolean) whether or not server is set to generate coins`<br />&nbsp;&nbsp;`"genproclimit": n,  (numeric) number of processors to use for coin generation (-1 when disabled)`<br />&nbsp;&nbsp;`"hashespersec": n,  (numeric) recent hashes per second performance measurement while generating coins`<br />&nbsp;&nbsp;`"networkhashps": n,  (numeric) estimated network hashes per second for the most recent blocks`<br />&nbsp;&nbsp;`"pooledtx": n,  (numeric) number of transactions in the memory pool`<br />&nbsp;&nbsp;`"testnet": true or false,  (boolean) whether or not server is using testnet`<br />`}`|
-|Example Return|`{`<br />&nbsp;&nbsp;`"blocks": 236526,`<br />&nbsp;&nbsp;`"currentblocksize": 185,`<br />&nbsp;&nbsp;`"currentblocktx": 1,`<br />&nbsp;&nbsp;`"difficulty": 256,`<br />&nbsp;&nbsp;`"errors": "",`<br />&nbsp;&nbsp;`"generate": false,`<br />&nbsp;&nbsp;`"genproclimit": -1,`<br />&nbsp;&nbsp;`"hashespersec": 0,`<br />&nbsp;&nbsp;`"networkhashps": 33081554756,`<br />&nbsp;&nbsp;`"pooledtx": 8,`<br />&nbsp;&nbsp;`"testnet": true,`<br />`}`|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="getnettotals"/>
-
-|   |   |
-|---|---|
-|Method|getnettotals|
-|Parameters|None|
-|Description|Returns a JSON object containing network traffic statistics.|
-|Returns|`{`<br />&nbsp;&nbsp;`"totalbytesrecv": n,  (numeric) total bytes received`<br />&nbsp;&nbsp;`"totalbytessent": n,  (numeric) total bytes sent`<br />&nbsp;&nbsp;`"timemillis": n  (numeric) number of milliseconds since 1 Jan 1970 GMT`<br />`}`|
-|Example Return|`{`<br />&nbsp;&nbsp;`"totalbytesrecv": 1150990,`<br />&nbsp;&nbsp;`"totalbytessent": 206739,`<br />&nbsp;&nbsp;`"timemillis": 1391626433845`<br />`}`|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="getnetworkhashps"/>
-
-|   |   |
-|---|---|
-|Method|getnetworkhashps|
-|Parameters|1. blocks (numeric, optional, default=120) - The number of blocks, or -1 for blocks since last difficulty change<br />2. height (numeric, optional, default=-1) - Perform estimate ending with this height or -1 for current best chain block height|
-|Description|Returns the estimated network hashes per second for the block heights provided by the parameters.|
-|Returns|numeric|
-|Example Return|`6573971939`|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="getpeerinfo"/>
-
-|   |   |
-|---|---|
-|Method|getpeerinfo|
-|Parameters|None|
-|Description|Returns data about each connected network peer as an array of json objects.|
-|Returns|`[`<br />&nbsp;&nbsp;`{`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"addr": "host:port",  (string) the ip address and port of the peer`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"services": "00000001",  (string) the services supported by the peer`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"lastrecv": n,  (numeric) time the last message was received in seconds since 1 Jan 1970 GMT`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"lastsend": n,  (numeric) time the last message was sent in seconds since 1 Jan 1970 GMT`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"bytessent": n,  (numeric) total bytes sent`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"bytesrecv": n,  (numeric) total bytes received`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"conntime": n,  (numeric) time the connection was made in seconds since 1 Jan 1970 GMT`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"pingtime": n,  (numeric) number of microseconds the last ping took`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"pingwait": n,  (numeric) number of microseconds a queued ping has been waiting for a response`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"version": n,  (numeric) the protocol version of the peer`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"subver": "useragent",  (string) the user agent of the peer`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"inbound": true_or_false,  (boolean) whether or not the peer is an inbound connection`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"startingheight": n,  (numeric) the latest block height the peer knew about when the connection was established`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"currentheight": n,  (numeric) the latest block height the peer is known to have relayed since connected`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"syncnode": true_or_false,  (boolean) whether or not the peer is the sync peer`<br />&nbsp;&nbsp;`}, ...`<br />`]`|
-|Example Return|`[`<br />&nbsp;&nbsp;`{`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"addr": "178.172.xxx.xxx:8333",`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"services": "00000001",`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"lastrecv": 1388183523,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"lastsend": 1388185470,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"bytessent": 287592965,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"bytesrecv": 780340,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"conntime": 1388182973,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"pingtime": 405551,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"pingwait": 183023,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"version": 70001,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"subver": "/btcd:0.4.0/",`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"inbound": false,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"startingheight": 276921,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"currentheight": 276955,`<br/>&nbsp;&nbsp;&nbsp;&nbsp;`"syncnode": true,`<br />&nbsp;&nbsp;`}`<br />`]`|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="getrawtransaction"/>
-
-|   |   |
-|---|---|
-|Method|getrawtransaction|
-|Parameters|1. transaction hash (string, required) - the hash of the transaction<br />2. verbose (int, optional, default=0) - specifies the transaction is returned as a JSON object instead of hex-encoded string|
-|Description|Returns information about a transaction given its hash.|
-|Returns (verbose=0)|`"data" (string) hex-encoded bytes of the serialized transaction`|
-|Returns (verbose=1)|`{ (json object)`<br />&nbsp;&nbsp;`"hex": "data",  (string) hex-encoded transaction`<br />&nbsp;&nbsp;`"txid": "hash",  (string) the hash of the transaction`<br />&nbsp;&nbsp;`"version": n,  (numeric) the transaction version`<br />&nbsp;&nbsp;`"locktime": n,  (numeric) the transaction lock time`<br />&nbsp;&nbsp;`"vin": [  (array of json objects) the transaction inputs as json objects`<br />&nbsp;&nbsp;<font color="orange">For coinbase transactions:</font><br />&nbsp;&nbsp;&nbsp;&nbsp;`{ (json object)`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"coinbase": "data",  (string) the hex-encoded bytes of the signature script`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"sequence": n,  (numeric) the script sequence number`<br />&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;<font color="orange">For non-coinbase transactions:</font><br />&nbsp;&nbsp;&nbsp;&nbsp;`{ (json object)`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"txid": "hash", (string) the hash of the origin transaction`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"vout": n, (numeric) the index of the output being redeemed from the origin transaction`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"scriptSig": { (json object) the signature script used to redeem the origin transaction`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"asm": "asm", (string) disassembly of the script`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"hex": "data",  (string) hex-encoded bytes of the script`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"sequence": n,  (numeric) the script sequence number`<br />&nbsp;&nbsp;&nbsp;&nbsp;`}, ...`<br />&nbsp;&nbsp;`]`<br />&nbsp;&nbsp;`"vout": [  (array of json objects) the transaction outputs as json objects`<br />&nbsp;&nbsp;&nbsp;&nbsp;`{ (json object)`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"value": n, (numeric) the value in BTC`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"n": n, (numeric) the index of this transaction output`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"scriptPubKey": { (json object) the public key script used to pay coins`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"asm": "asm",  (string) disassembly of the script`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"hex": "data", (string) hex-encoded bytes of the script`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"reqSigs": n,  (numeric) the number of required signatures`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"type": "scripttype" (string) the type of the script (e.g. 'pubkeyhash')`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"addresses": [ (json array of string) the bitcoin addresses associated with this output`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"bitcoinaddress",  (string) the bitcoin address`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`...`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`]`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;&nbsp;&nbsp;`}, ...`<br />&nbsp;&nbsp;`]`<br />`}`|
-|Example Return (verbose=0)|`"010000000104be666c7053ef26c6110597dad1c1e81b5e6be53d17a8b9d0b34772054bac60000000`<br />`008c493046022100cb42f8df44eca83dd0a727988dcde9384953e830b1f8004d57485e2ede1b9c8f`<br />`022100fbce8d84fcf2839127605818ac6c3e7a1531ebc69277c504599289fb1e9058df0141045a33`<br />`76eeb85e494330b03c1791619d53327441002832f4bd618fd9efa9e644d242d5e1145cb9c2f71965`<br />`656e276633d4ff1a6db5e7153a0a9042745178ebe0f5ffffffff0280841e00000000001976a91406`<br />`f1b6703d3f56427bfcfd372f952d50d04b64bd88ac4dd52700000000001976a9146b63f291c295ee`<br />`abd9aee6be193ab2d019e7ea7088ac00000000`<br /><font color="orange">**Newlines added for display purposes.  The actual return does not contain newlines.**</font>|
-|Example Return (verbose=1)|`{`<br />&nbsp;&nbsp;`"hex": "01000000010000000000000000000000000000000000000000000000000000000000000000f...",`<br />&nbsp;&nbsp;`"txid": "90743aad855880e517270550d2a881627d84db5265142fd1e7fb7add38b08be9",`<br />&nbsp;&nbsp;`"version": 1,`<br />&nbsp;&nbsp;`"locktime": 0,`<br />&nbsp;&nbsp;`"vin": [`<br />&nbsp;&nbsp;<font color="orange">For coinbase transactions:</font><br />&nbsp;&nbsp;&nbsp;&nbsp;`{ (json object)`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"coinbase": "03708203062f503253482f04066d605108f800080100000ea2122f6f7a636f696e4065757374726174756d2f",`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"sequence": 0,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;<font color="orange">For non-coinbase transactions:</font><br />&nbsp;&nbsp;&nbsp;&nbsp;`{`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"txid": "60ac4b057247b3d0b9a8173de56b5e1be8c1d1da970511c626ef53706c66be04",`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"vout": 0,`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"scriptSig": {`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"asm": "3046022100cb42f8df44eca83dd0a727988dcde9384953e830b1f8004d57485e2ede1b9c8f0...",`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"hex": "493046022100cb42f8df44eca83dd0a727988dcde9384953e830b1f8004d57485e2ede1b9c8...",`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"sequence": 4294967295,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;`]`<br />&nbsp;&nbsp;`"vout": [`<br />&nbsp;&nbsp;&nbsp;&nbsp;`{`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"value": 25.1394,`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"n": 0,`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"scriptPubKey": {`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"asm": "OP_DUP OP_HASH160 ea132286328cfc819457b9dec386c4b5c84faa5c OP_EQUALVERIFY OP_CHECKSIG",`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"hex": "76a914ea132286328cfc819457b9dec386c4b5c84faa5c88ac",`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"reqSigs": 1,`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"type": "pubkeyhash"`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"addresses": [`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"1NLg3QJMsMQGM5KEUaEu5ADDmKQSLHwmyh",`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`]`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;`]`<br />`}`|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="getwork"/>
-
-|   |   |
-|---|---|
-|Method|getwork|
-|Parameters|1. data (string, optional) - The hex|
-|Description|Returns information about a transaction given its hash.|
-|Notes|<font color="orange">NOTE: Since btcd does not have the wallet integrated to provide payment addresses, btcd must be configured via the `--miningaddr` option to provide which payment addresses to pay created blocks to for this RPC to function.</font>
-|Returns (data not specified)|`{ (json object)`<br />&nbsp;&nbsp;`"data": "hex",  (string) hex-encoded block data`<br />&nbsp;&nbsp;`"hash1": "hex",  (string)  (DEPRECATED) hex-encoded formatted hash buffer`<br />&nbsp;&nbsp;`"midstate": "hex",  (string) (DEPRECATED) hex-encoded precomputed hash state after hashing first half of the data`<br />&nbsp;&nbsp;`"target": "hex",  (string) the hex-encoded little-endian hash target`<br />`}`|
-|Returns (data specified)|`true` or `false` (boolean)|
-|Example Return (data not specified)|`{`<br />&nbsp;&nbsp;`"data": "00000002c39b5d2b7a1e8f7356a1efce26b24bd15d7d906e85341ef9cec99b6a000000006474f...",`<br />&nbsp;&nbsp;`"hash1": "00000000000000000000000000000000000000000000000000000000000000000000008000000...",`<br />&nbsp;&nbsp;`"midstate": "ae4a80fc51476e452de855b4e20d5f33418c50fc7cae3b1ecd5badb819b8a584",`<br />&nbsp;&nbsp;`"target": "0000000000000000000000000000000000000000000000008c96010000000000",`<br />`}`|
-|Example Return (data specified)|`true`|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="help"/>
-
-|   |   |
-|---|---|
-|Method|help|
-|Parameters|1. command (string, optional) - the command to get help for|
-|Description|Returns a list of all commands or help for a specified command.<br />When no `command` parameter is specified, a list of avaialable commands is returned<br />When `command` is a valid method, the help text for that method is returned.|
-|Returns|string|
-|Example Return|getblockcount<br />Returns a numeric for the number of blocks in the longest block chain.|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="ping"/>
-
-|   |   |
-|---|---|
-|Method|ping|
-|Parameters|None|
-|Description|Queues a ping to be sent to each connected peer.<br />Ping times are provided by [getpeerinfo](#getpeerinfo) via the `pingtime` and `pingwait` fields.|
-|Returns|Nothing|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="getrawmempool"/>
-
-|   |   |
-|---|---|
-|Method|getrawmempool|
-|Parameters|1. verbose (boolean, optional, default=false)|
-|Description|Returns an array of hashes for all of the transactions currently in the memory pool.<br />The `verbose` flag specifies that each transaction is returned as a JSON object.|
-|Notes|<font color="orange">Since btcd does not perform any mining, the priority related fields `startingpriority` and `currentpriority` that are available when the `verbose` flag is set are always 0.</font>|
-|Returns (verbose=false)|`[ (json array of string)`<br />&nbsp;&nbsp;`"transactionhash", (string) hash of the transaction`<br />&nbsp;&nbsp;`...`<br />`]`|
-|Returns (verbose=true)|`{ (json object)`<br />&nbsp;&nbsp;`"transactionhash": { (json object)`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"size": n, (numeric) transaction size in bytes`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"fee" : n, (numeric) transaction fee in bitcoins`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"time": n, (numeric) local time transaction entered pool in seconds since 1 Jan 1970 GMT`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"height": n, (numeric) block height when transaction entered the pool`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"startingpriority": n, (numeric) priority when transaction entered the pool`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"currentpriority": n, (numeric) current priority`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"depends": [ (json array) unconfirmed transactions used as inputs for this transaction`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"transactionhash", (string) hash of the parent transaction`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`...`<br />&nbsp;&nbsp;&nbsp;&nbsp;`]`<br />&nbsp;&nbsp;`}, ...`<br />`}`|
-|Example Return (verbose=false)|`[`<br />&nbsp;&nbsp;`"3480058a397b6ffcc60f7e3345a61370fded1ca6bef4b58156ed17987f20d4e7",`<br />&nbsp;&nbsp;`"cbfe7c056a358c3a1dbced5a22b06d74b8650055d5195c1c2469e6b63a41514a"`<br />`]`|
-|Example Return (verbose=true)|`{`<br />&nbsp;&nbsp;`"1697a19cede08694278f19584e8dcc87945f40c6b59a942dd8906f133ad3f9cc": {`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"size": 226,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"fee" : 0.0001,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"time": 1387992789,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"height": 276836,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"startingpriority": 0,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"currentpriority": 0,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"depends": [`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"aa96f672fcc5a1ec6a08a94aa46d6b789799c87bd6542967da25a96b2dee0afb",`<br />&nbsp;&nbsp;&nbsp;&nbsp;`]`<br />`}`|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="setgenerate"/>
-
-|   |   |
-|---|---|
-|Method|setgenerate|
-|Parameters|1. generate (boolean, required) - `true` to enable generation, `false` to disable it<br />2. genproclimit (numeric, optional) - the number of processors (cores) to limit generation to or `-1` for default|
-|Description|Set the server to generate coins (mine) or not.|
-|Notes|NOTE: Since btcd does not have the wallet integrated to provide payment addresses, btcd must be configured via the `--miningaddr` option to provide which payment addresses to pay created blocks to for this RPC to function.|
-|Returns|Nothing|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="sendrawtransaction"/>
-
-|   |   |
-|---|---|
-|Method|sendrawtransaction|
-|Parameters|1. signedhex (string, required) serialized, hex-encoded signed transaction<br />2. allowhighfees (boolean, optional, default=false) whether or not to allow insanely high fees|
-|Description|Submits the serialized, hex-encoded transaction to the local peer and relays it to the network.|
-|Notes|<font color="orange">btcd does not yet implement the `allowhighfees` parameter, so it has no effect</font>|
-|Returns|`"hash" (string) the hash of the transaction`|
-|Example Return|`"1697a19cede08694278f19584e8dcc87945f40c6b59a942dd8906f133ad3f9cc"`|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="submitblock"/>
-
-|   |   |
-|---|---|
-|Method|submitblock|
-|Parameters|1. data (string, required) serialized, hex-encoded block<br />2. params (json object, optional, default=nil) this parameter is currently ignored|
-|Description|Attempts to submit a new serialized, hex-encoded block to the network.|
-|Returns (success)|Success: Nothing<br />Failure: `"rejected: reason"` (string)|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="stop"/>
-
-|   |   |
-|---|---|
-|Method|stop|
-|Parameters|None|
-|Description|Shutdown btcd.|
-|Returns|`"btcd stopping."` (string)|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="validateaddress"/>
-
-|   |   |
-|---|---|
-|Method|validateaddress|
-|Parameters|1. address (string, required) - bitcoin address|
-|Description|Verify an address is valid.|
-|Returns|`{ (json object)`<br />&nbsp;&nbsp;`"isvalid": true or false,  (bool) whether or not the address is valid.`<br />&nbsp;&nbsp;`"address": "bitcoinaddress", (string) the bitcoin address validated.`<br />}|
-[Return to Overview](#MethodOverview)<br />
-
-***
-<a name="verifychain"/>
-
-|   |   |
-|---|---|
-|Method|verifychain|
-|Parameters|1. checklevel (numeric, optional, default=3) - how in-depth the verification is (0=least amount of checks, higher levels are clamped to the highest supported level)<br />2. numblocks (numeric, optional, default=288) - the number of blocks starting from the end of the chain to verify|
-|Description|Verifies the block chain database.<br />The actual checks performed by the `checklevel` parameter is implementation specific.  For btcd this is:<br />`checklevel=0` - Look up each block and ensure it can be loaded from the database.<br />`checklevel=1` - Perform basic context-free sanity checks on each block.|
-|Notes|<font color="orange">Btcd currently only supports `checklevel` 0 and 1, but the default is still 3 for compatibility.  Per the information in the Parameters section above, higher levels are automatically clamped to the highest supported level, so this means the default is effectively 1 for btcd.</font>|
-|Returns|`true` or `false` (boolean)|
-|Example Return|`true`|
-[Return to Overview](#MethodOverview)<br />
-
-
-<a name="ExtensionMethods" />
-### 6. Extension Methods
-
-<a name="ExtMethodOverview" />
-**6.1 Method Overview**<br />
-
-The following is an overview of the RPC methods which are implemented by btcd, but not the original bitcoind client. Click the method name for further details such as parameter and return information.
-
-|#|Method|Safe for limited user?|Description|
-|---|------|----------|-----------|
-|1|[debuglevel](#debuglevel)|N|Dynamically changes the debug logging level.|
-|2|[getbestblock](#getbestblock)|Y|Get block height and hash of best block in the main chain.|None|
-|3|[getcurrentnet](#getcurrentnet)|Y|Get bitcoin network btcd is running on.|None|
-|4|[searchrawtransactions](#searchrawtransactions)|Y|Query for transactions related to a particular address.|None|
-|5|[node](#node)|N|Attempts to add or remove a peer. |None|
-|6|[generate](#generate)|N|When in simnet or regtest mode, generate a set number of blocks. |None|
-
-
-<a name="ExtMethodDetails" />
-**6.2 Method Details**<br />
-
-<a name="debuglevel"/>
-
-|   |   |
-|---|---|
-|Method|debuglevel|
-|Parameters|1. _levelspec_ (string)|
-|Description|Dynamically changes the debug logging level.<br />The levelspec can either a debug level or of the form `<subsystem>=<level>,<subsystem2>=<level2>,...`<br />The valid debug levels are `trace`, `debug`, `info`, `warn`, `error`, and `critical`.<br />The valid subsystems are `AMGR`, `ADXR`, `BCDB`, `BMGR`, `BTCD`, `CHAN`, `DISC`, `PEER`, `RPCS`, `SCRP`, `SRVR`, and `TXMP`.<br />Additionally, the special keyword `show` can be used to get a list of the available subsystems.|
-|Returns|string|
-|Example Return|`Done.`|
-|Example `show` Return|`Supported subsystems [AMGR ADXR BCDB BMGR BTCD CHAN DISC PEER RPCS SCRP SRVR TXMP]`|
-[Return to Overview](#ExtMethodOverview)<br />
-
-***
-
-<a name="getbestblock"/>
-
-|   |   |
-|---|---|
-|Method|getbestblock|
-|Parameters|None|
-|Description|Get block height and hash of best block in the main chain.|
-|Returns|`{ (json object)`<br />&nbsp;`"hash": "data",  (string) the hex-encoded bytes of the best block hash`<br />&nbsp;`"height": n (numeric) the block height of the best block`<br />`}`|
-[Return to Overview](#ExtMethodOverview)<br />
-
-***
-
-<a name="getcurrentnet"/>
-
-|   |   |
-|---|---|
-|Method|getcurrentnet|
-|Parameters|None|
-|Description|Get bitcoin network btcd is running on.|
-|Returns|numeric|
-|Example Return|`3652501241` (mainnet)<br />`118034699` (testnet3)|
-[Return to Overview](#ExtMethodOverview)<br />
-
-***
-
-<a name="searchrawtransactions"/>
-
-|   |   |
-|---|---|
-|Method|searchrawtransactions|
-|Parameters|1. address (string, required) - bitcoin address <br /> 2. verbose (int, optional, default=true) - specifies the transaction is returned as a JSON object instead of hex-encoded string <br />3. skip (int, optional, default=0) - the number of leading transactions to leave out of the final response <br /> 4. count (int, optional, default=100) - the maximum number of transactions to return <br /> 5. vinextra (int, optional, default=0) - Specify that extra data from previous output will be returned in vin <br /> 6. reverse (boolean, optional, default=false) - Specifies that the transactions should be returned in reverse chronological order|
-|Description|Returns raw data for transactions involving the passed address. Returned transactions are pulled from both the database, and transactions currently in the mempool. Transactions pulled from the mempool will have the `"confirmations"` field set to 0. Usage of this RPC requires the optional `--addrindex` flag to be activated, otherwise all responses will simply return with an error stating the address index has not yet been built up. Similarly, until the address index has caught up with the current best height, all requests will return an error response in order to avoid serving stale data.|
-|Returns (verbose=0)|`[ (json array of strings)` <br/>&nbsp;&nbsp; `"serializedtx", ... hex-encoded bytes of the serialized transaction` <br/>`]` |
-|Returns (verbose=1)|`[ (array of json objects)` <br/> &nbsp;&nbsp; `{ (json object)`<br />&nbsp;&nbsp;`"hex": "data",  (string) hex-encoded transaction`<br />&nbsp;&nbsp;`"txid": "hash",  (string) the hash of the transaction`<br />&nbsp;&nbsp;`"version": n,  (numeric) the transaction version`<br />&nbsp;&nbsp;`"locktime": n,  (numeric) the transaction lock time`<br />&nbsp;&nbsp;`"vin": [  (array of json objects) the transaction inputs as json objects`<br />&nbsp;&nbsp;<font color="orange">For coinbase transactions:</font><br />&nbsp;&nbsp;&nbsp;&nbsp;`{ (json object)`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"coinbase": "data",  (string) the hex-encoded bytes of the signature script`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"sequence": n,  (numeric) the script sequence number`<br />&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;<font color="orange">For non-coinbase transactions:</font><br />&nbsp;&nbsp;&nbsp;&nbsp;`{ (json object)`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"txid": "hash", (string) the hash of the origin transaction`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"vout": n, (numeric) the index of the output being redeemed from the origin transaction`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"scriptSig": { (json object) the signature script used to redeem the origin transaction`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"asm": "asm", (string) disassembly of the script`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"hex": "data",  (string) hex-encoded bytes of the script`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"prevOut": { (json object) Data from the origin transaction output with index vout.`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"addresses": ["value",...], (array of string) previous output addresses`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"value": n.nnn,             (numeric)         previous output value`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"sequence": n,  (numeric) the script sequence number`<br />&nbsp;&nbsp;&nbsp;&nbsp;`}, ...`<br />&nbsp;&nbsp;`]`<br />&nbsp;&nbsp;`"vout": [  (array of json objects) the transaction outputs as json objects`<br />&nbsp;&nbsp;&nbsp;&nbsp;`{ (json object)`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"value": n, (numeric) the value in BTC`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"n": n, (numeric) the index of this transaction output`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"scriptPubKey": { (json object) the public key script used to pay coins`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"asm": "asm",  (string) disassembly of the script`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"hex": "data", (string) hex-encoded bytes of the script`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"reqSigs": n,  (numeric) the number of required signatures`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"type": "scripttype" (string) the type of the script (e.g. 'pubkeyhash')`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"addresses": [ (json array of string) the bitcoin addresses associated with this output`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"address",  (string) the bitcoin address`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`...`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`]`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;&nbsp;&nbsp;`}, ...`<br /> &nbsp;&nbsp;&nbsp;`]`<br />&nbsp;&nbsp; `"blockhash":"hash" Hash of the block the transaction is part of.` <br /> &nbsp;&nbsp; `"confirmations":n,  Number of numeric confirmations of block.` <br /> &nbsp;&nbsp;&nbsp;`"time":t, Transaction time in seconds since the epoch.` <br /> &nbsp;&nbsp;&nbsp;`"blocktime":t, Block time in seconds since the epoch.`<br />`},...`<br/> `]`|
-[Return to Overview](#ExtMethodOverview)<br />
-
-***
-
-<a name="node"/>
-
-|   |   |
-|---|---|
-|Method|node|
-|Parameters|1. command (string, required) - `connect` to add a peer (defaults to temporary), `remove` to remove a persistent peer, or `disconnect` to remove all matching non-persistent peers <br /> 2. peer (string, required) - ip address and port, or ID of the peer to operate on<br /> 3. connection type (string, optional) - `perm` indicates the peer should be added as a permanent peer, `temp` indicates a connection should only be attempted once. |
-|Description|Attempts to add or remove a peer.|
-|Returns|Nothing|
-[Return to Overview](#MethodOverview)<br />
-
-***
-
-<a name="generate"/>
-
-|   |   |
-|---|---|
-|Method|generate|
-|Parameters|1. numblocks (int, required) - The number of blocks to generate |
-|Description|When in simnet or regtest mode, generates `numblocks` blocks. If blocks arrive from elsewhere, they are built upon but don't count toward the number of blocks to generate. Only generated blocks are returned. This RPC call will exit with an error if the server is already CPU mining, and will prevent the server from CPU mining for another command while it runs. |
-|Returns|`[ (json array of strings)` <br/>&nbsp;&nbsp; `"blockhash", ... hash of the generated block` <br/>`]` |
-[Return to Overview](#MethodOverview)<br />
-
-***
-
-<a name="WSExtMethods" />
-### 7. Websocket Extension Methods (Websocket-specific)
-
-<a name="WSExtMethodOverview" />
-**7.1 Method Overview**<br />
-
-The following is an overview of the RPC method requests available exclusively to Websocket clients.  All of these RPC methods are available to the limited
-user.  Click the method name for further details such as parameter and return information.
-
-|#|Method|Description|Notifications|
-|---|------|-----------|-------------|
-|1|[authenticate](#authenticate)|Authenticate the connection against the username and passphrase configured for the RPC server.<br /><font color="orange">NOTE: This is only required if an HTTP Authorization header is not being used.</font>|None|
-|2|[notifyblocks](#notifyblocks)|Send notifications when a block is connected or disconnected from the best chain.|[blockconnected](#blockconnected) and [blockdisconnected](#blockdisconnected)|
-|3|[stopnotifyblocks](#stopnotifyblocks)|Cancel registered notifications for whenever a block is connected or disconnected from the main (best) chain. |None|
-|4|[notifyreceived](#notifyreceived)|Send notifications when a txout spends to an address.|[recvtx](#recvtx) and [redeemingtx](#redeemingtx)|
-|5|[stopnotifyreceived](#stopnotifyreceived)|Cancel registered notifications for when a txout spends to any of the passed addresses.|None|
-|6|[notifyspent](#notifyspent)|Send notification when a txout is spent.|[redeemingtx](#redeemingtx)|
-|7|[stopnotifyspent](#stopnotifyspent)|Cancel registered spending notifications for each passed outpoint.|None|
-|8|[rescan](#rescan)|Rescan block chain for transactions to addresses and spent transaction outpoints.|[recvtx](#recvtx), [redeemingtx](#redeemingtx), [rescanprogress](#rescanprogress), and [rescanfinished](#rescanfinished) |
-|9|[notifynewtransactions](#notifynewtransactions)|Send notifications for all new transactions as they are accepted into the mempool.|[txaccepted](#txaccepted) or [txacceptedverbose](#txacceptedverbose)|
-|10|[stopnotifynewtransactions](#stopnotifynewtransactions)|Stop sending either a txaccepted or a txacceptedverbose notification when a new transaction is accepted into the mempool.|None|
-|11|[session](#session)|Return details regarding a websocket client's current connection.|None|
-
-<a name="WSExtMethodDetails" />
-**7.2 Method Details**<br />
-
-<a name="authenticate"/>
-
-|   |   |
-|---|---|
-|Method|authenticate|
-|Parameters|1. username (string, required)<br />2. passphrase (string, required)|
-|Description|Authenticate the connection against the username and password configured for the RPC server.<br />  Invoking any other method before authenticating with this command will close the connection.<br /><font color="orange">NOTE: This is only required if an HTTP Authorization header is not being used.</font>|
-|Returns|Success: Nothing<br />Failure: Nothing (websocket disconnected)|
-[Return to Overview](#WSExtMethodOverview)<br />
-
-***
-
-<a name="notifyblocks"/>
-
-|   |   |
-|---|---|
-|Method|notifyblocks|
-|Notifications|[blockconnected](#blockconnected) and [blockdisconnected](#blockdisconnected)|
-|Parameters|None|
-|Description|Request notifications for whenever a block is connected or disconnected from the main (best) chain.<br />NOTE: If a client subscribes to both block and transaction (recvtx and redeemingtx) notifications, the blockconnected notification will be sent after all transaction notifications have been sent.  This allows clients to know when all relevant transactions for a block have been received.|
-|Returns|Nothing|
-[Return to Overview](#WSExtMethodOverview)<br />
-
-***
-<a name="stopnotifyblocks"/>
-
-|   |   |
-|---|---|
-|Method|stopnotifyblocks|
-|Notifications|None|
-|Parameters|None|
-|Description|Cancel sending notifications for whenever a block is connected or disconnected from the main (best) chain.|
-|Returns|Nothing|
-[Return to Overview](#WSExtMethodOverview)<br />
-
-***
-
-<a name="notifyreceived"/>
-
-|   |   |
-|---|---|
-|Method|notifyreceived|
-|Notifications|[recvtx](#recvtx) and [redeemingtx](#redeemingtx)|
-|Parameters|1. Addresses (JSON array, required)<br />&nbsp;`[ (json array of strings)`<br />&nbsp;&nbsp;`"bitcoinaddress", (string) the bitcoin address`<br />&nbsp;&nbsp;`...`<br />&nbsp;`]`|
-|Description|Send a recvtx notification when a transaction added to mempool or appears in a newly-attached block contains a txout pkScript sending to any of the passed addresses.  Matching outpoints are automatically registered for redeemingtx notifications.|
-|Returns|Nothing|
-[Return to Overview](#WSExtMethodOverview)<br />
-
-***
-
-<a name="stopnotifyreceived"/>
-
-|   |   |
-|---|---|
-|Method|stopnotifyreceived|
-|Notifications|None|
-|Parameters|1. Addresses (JSON array, required)<br />&nbsp;`[ (json array of strings)`<br />&nbsp;&nbsp;`"bitcoinaddress", (string) the bitcoin address`<br />&nbsp;&nbsp;`...`<br />&nbsp;`]`|
-|Description|Cancel registered receive notifications for each passed address.|
-|Returns|Nothing|
-[Return to Overview](#WSExtMethodOverview)<br />
-
-***
-
-<a name="notifyspent"/>
-
-|   |   |
-|---|---|
-|Method|notifyspent|
-|Notifications|[redeemingtx](#redeemingtx)|
-|Parameters|1. Outpoints (JSON array, required)<br />&nbsp;`[ (JSON array)`<br />&nbsp;&nbsp;`{ (JSON object)`<br />&nbsp;&nbsp;&nbsp;`"hash":"data", (string) the hex-encoded bytes of the outpoint hash`<br />&nbsp;&nbsp;&nbsp;`"index":n (numeric) the txout index of the outpoint`<br />&nbsp;&nbsp;`},`<br />&nbsp;&nbsp;`...`<br />&nbsp;`]`|
-|Description|Send a redeemingtx notification when a transaction spending an outpoint appears in mempool (if relayed to this btcd instance) and when such a transaction first appears in a newly-attached block.|
-|Returns|Nothing|
-[Return to Overview](#WSExtMethodOverview)<br />
-
-***
-
-<a name="stopnotifyspent"/>
-
-|   |   |
-|---|---|
-|Method|stopnotifyspent|
-|Notifications|None|
-|Parameters|1. Outpoints (JSON array, required)<br />&nbsp;`[ (JSON array)`<br />&nbsp;&nbsp;`{ (JSON object)`<br />&nbsp;&nbsp;&nbsp;`"hash":"data", (string) the hex-encoded bytes of the outpoint hash`<br />&nbsp;&nbsp;&nbsp;`"index":n (numeric) the txout index of the outpoint`<br />&nbsp;&nbsp;`},`<br />&nbsp;&nbsp;`...`<br />&nbsp;`]`|
-|Description|Cancel registered spending notifications for each passed outpoint.|
-|Returns|Nothing|
-[Return to Overview](#WSExtMethodOverview)<br />
-
-***
-
-<a name="rescan"/>
-
-|   |   |
-|---|---|
-|Method|rescan|
-|Notifications|[recvtx](#recvtx), [redeemingtx](#redeemingtx), [rescanprogress](#rescanprogress), and [rescanfinished](#rescanfinished)|
-|Parameters|1. BeginBlock (string, required) block hash to begin rescanning from<br />2. Addresses (JSON array, required)<br />&nbsp;`[ (json array of strings)`<br />&nbsp;&nbsp;`"bitcoinaddress", (string) the bitcoin address`<br />&nbsp;&nbsp;`...` <br />&nbsp;`]`<br />3. Outpoints (JSON array, required)<br />&nbsp;`[ (JSON array)`<br />&nbsp;&nbsp;`{ (JSON object)`<br />&nbsp;&nbsp;&nbsp;`"hash":"data", (string) the hex-encoded bytes of the outpoint hash`<br />&nbsp;&nbsp;&nbsp;`"index":n (numeric) the txout index of the outpoint`<br />&nbsp;&nbsp;`},`<br />&nbsp;&nbsp;`...`<br />&nbsp;`]`<br />4. EndBlock (string, optional) hash of final block to rescan|
-|Description|Rescan block chain for transactions to addresses, starting at block BeginBlock and ending at EndBlock.  The current known UTXO set for all passed addresses at height BeginBlock should included in the Outpoints argument.  If EndBlock is omitted, the rescan continues through the best block in the main chain.  Additionally, if no EndBlock is provided, the client is automatically registered for transaction notifications for all rescanned addresses and the final UTXO set.  Rescan results are sent as recvtx and redeemingtx notifications.  This call returns once the rescan completes.|
-|Returns|Nothing|
-[Return to Overview](#WSExtMethodOverview)<br />
-
-***
-
-<a name="notifynewtransactions"/>
-
-|   |   |
-|---|---|
-|Method|notifynewtransactions|
-|Notifications|[txaccepted](#txaccepted) or [txacceptedverbose](#txacceptedverbose)|
-|Parameters|1. verbose (boolean, optional, default=false) - specifies which type of notification to receive.  If verbose is true, then the caller receives [txacceptedverbose](#txacceptedverbose), otherwise the caller receives [txaccepted](#txaccepted)|
-|Description|Send either a [txaccepted](#txaccepted) or a [txacceptedverbose](#txacceptedverbose) notification when a new transaction is accepted into the mempool.|
-|Returns|Nothing|
-[Return to Overview](#WSExtMethodOverview)<br />
-
-***
-
-<a name="stopnotifynewtransactions"/>
-
-|   |   |
-|---|---|
-|Method|stopnotifynewtransactions|
-|Notifications|None|
-|Parameters|None|
-|Description|Stop sending either a [txaccepted](#txaccepted) or a [txacceptedverbose](#txacceptedverbose) notification when a new transaction is accepted into the mempool.|
-|Returns|Nothing|
-[Return to Overview](#WSExtMethodOverview)<br />
-
-***
-
-<a name="session"/>
-
-|   |   |
-|---|---|
-|Method|session|
-|Notifications|None|
-|Parameters|None|
-|Description|Return a JSON object with details regarding a websocket client's current connection to the RPC server.  This currently only includes the session ID, a random unsigned 64-bit integer that is created for each newly connected client.  Session IDs may be used to verify that the current connection was not lost and subsequently reestablished.|
-|Returns|`{ (json object)`<br />&nbsp;&nbsp;`"sessionid": n  (numeric) the session ID`<br />`}`|
-|Example Return|`{`<br />&nbsp;&nbsp;`"sessionid": 67089679842`<br />`}`|
-[Return to Overview](#WSExtMethodOverview)<br />
-
-
-<a name="Notifications" />
-### 8. Notifications (Websocket-specific)
-
-btcd uses standard JSON-RPC notifications to notify clients of changes, rather than requiring clients to poll btcd for updates.  JSON-RPC notifications are a subset of requests, but do not contain an ID.  The notification type is categorized by the `method` field and additional details are sent as a JSON array in the `params` field.
-
-<a name="NotificationOverview" />
-**8.1 Notification Overview**<br />
-
-The following is an overview of the JSON-RPC notifications used for Websocket connections.  Click the method name for further details of the context(s) in which they are sent and their parameters.
-
-|#|Method|Description|Request|
-|---|------|-----------|-------|
-|1|[blockconnected](#blockconnected)|Block connected to the main chain.|[notifyblocks](#notifyblocks)|
-|2|[blockdisconnected](#blockdisconnected)|Block disconnected from the main chain.|[notifyblocks](#notifyblocks)|
-|3|[recvtx](#recvtx)|Processed a transaction output spending to a wallet address.|[notifyreceived](#notifyreceived) and [rescan](#rescan)|
-|4|[redeemingtx](#redeemingtx)|Processed a transaction that spends a registered outpoint.|[notifyspent](#notifyspent) and [rescan](#rescan)|
-|5|[txaccepted](#txaccepted)|Received a new transaction after requesting simple notifications of all new transactions accepted into the mempool.|[notifynewtransactions](#notifynewtransactions)|
-|6|[txacceptedverbose](#txacceptedverbose)|Received a new transaction after requesting verbose notifications of all new transactions accepted into the mempool.|[notifynewtransactions](#notifynewtransactions)|
-|7|[rescanprogress](#rescanprogress)|A rescan operation that is underway has made progress.|[rescan](#rescan)|
-|8|[rescanfinished](#rescanfinished)|A rescan operation has completed.|[rescan](#rescan)|
-
-<a name="NotificationDetails" />
-**8.2 Notification Details**<br />
-
-<a name="blockconnected"/>
-
-|   |   |
-|---|---|
-|Method|blockconnected|
-|Request|[notifyblocks](#notifyblocks)|
-|Parameters|1. BlockHash (string) hex-encoded bytes of the attached block hash<br />2. BlockHeight (numeric) height of the attached block<br />3. BlockTime (numeric) unix time of the attached block|
-|Description|Notifies when a block has been added to the main chain.  Notification is sent to all connected clients.|
-|Example|Example blockconnected notification for mainnet block 280330 (newlines added for readability):<br />`{`<br />&nbsp;`"jsonrpc": "1.0",`<br />&nbsp;`"method": "blockconnected",`<br />&nbsp;`"params":`<br />&nbsp;&nbsp;`[`<br />&nbsp;&nbsp;&nbsp;`"000000000000000004cbdfe387f4df44b914e464ca79838a8ab777b3214dbffd",`<br />&nbsp;&nbsp;&nbsp;`280330,`<br />&nbsp;&nbsp;&nbsp;`1389636265`<br />&nbsp;&nbsp;`],`<br />&nbsp;`"id": null`<br />`}`|
-[Return to Overview](#NotificationOverview)<br />
-
-***
-
-<a name="blockdisconnected"/>
-
-|   |   |
-|---|---|
-|Method|blockdisconnected|
-|Request|[notifyblocks](#notifyblocks)|
-|Parameters|1. BlockHash (string) hex-encoded bytes of the disconnected block hash<br />2. BlockHeight (numeric) height of the disconnected block<br />3. BlockTime (numeric) unix time of the disconnected block|
-|Description|Notifies when a block has been removed from the main chain.  Notification is sent to all connected clients.|
-|Example|Example blockdisconnected notification for mainnet block 280330 (newlines added for readability):<br />`{`<br />&nbsp;`"jsonrpc": "1.0",`<br />&nbsp;`"method": "blockdisconnected",`<br />&nbsp;`"params":`<br />&nbsp;&nbsp;`[`<br />&nbsp;&nbsp;&nbsp;`"000000000000000004cbdfe387f4df44b914e464ca79838a8ab777b3214dbffd",`<br />&nbsp;&nbsp;&nbsp;`280330,`<br />&nbsp;&nbsp;&nbsp;`1389636265`<br />&nbsp;&nbsp;`],`<br />&nbsp;`"id": null`<br />`}`|
-[Return to Overview](#NotificationOverview)<br />
-
-***
-
-<a name="recvtx"/>
-
-|   |   |
-|---|---|
-|Method|recvtx|
-|Request|[rescan](#rescan) or [notifyreceived](#notifyreceived)|
-|Parameters|1. Transaction (string) full transaction encoded as a hex string<br />2. Block details (object, optional) details about a block and the index of the transaction within a block, if the transaction is mined|
-|Description|Notifies a client when a transaction is processed that contains at least a single output with a pkScript sending to a requested address.  If multiple outputs send to requested addresses, a single notification is sent.  If a mempool (unmined) transaction is processed, the block details object (second parameter) is excluded.|
-|Example|Example recvtx notification for mainnet transaction 61d3696de4c888730cbe06b0ad8ecb6d72d6108e893895aa9bc067bd7eba3fad when processed by mempool (newlines added for readability):<br />`{`<br />&nbsp;`"jsonrpc": "1.0",`<br />&nbsp;`"method": "recvtx",`<br />&nbsp;`"params":`<br />&nbsp;&nbsp;`[`<br />&nbsp;&nbsp;&nbsp;`"010000000114d9ff358894c486b4ae11c2a8cf7851b1df64c53d2e511278eff17c22fb737300000000..."`<br />&nbsp;&nbsp;`],`<br />&nbsp;`"id": null`<br />`}`<br />The recvtx notification for the same txout, after the transaction was mined into block 276425:<br />`{`<br />&nbsp;`"jsonrpc": "1.0",`<br />&nbsp;`"method": "recvtx",`<br />&nbsp;`"params":`<br />&nbsp;&nbsp;`[`<br />&nbsp;&nbsp;&nbsp;`"010000000114d9ff358894c486b4ae11c2a8cf7851b1df64c53d2e511278eff17c22fb737300000000...",`<br />&nbsp;&nbsp;&nbsp;`{`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"height": 276425,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"hash": "000000000000000325474bb799b9e591f965ca4461b72cb7012b808db92bb2fc",`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"index": 684,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"time": 1387737310`<br />&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;`],`<br />&nbsp;`"id": null`<br />`}`|
-[Return to Overview](#NotificationOverview)<br />
-
-***
-
-<a name="redeemingtx"/>
-
-|   |   |
-|---|---|
-|Method|redeemingtx|
-|Requests|[notifyspent](#notifyspent) and [rescan](#rescan)|
-|Parameters|1. Transaction (string) full transaction encoded as a hex string<br />2. Block details (object, optional) details about a block and the index of the transaction within a block, if the transaction is mined|
-|Description|Notifies a client when an registered outpoint is spent by a transaction accepted to mempool and/or mined into a block.|
-|Example|Example redeemingtx notification for mainnet outpoint 61d3696de4c888730cbe06b0ad8ecb6d72d6108e893895aa9bc067bd7eba3fad:0 after being spent by transaction 4ad0c16ac973ff675dec1f3e5f1273f1c45be2a63554343f21b70240a1e43ece (newlines added for readability):<br />`{`<br />&nbsp;`"jsonrpc": "1.0",`<br />&nbsp;`"method": "redeemingtx",`<br />&nbsp;`"params":`<br />&nbsp;&nbsp;`[`<br />&nbsp;&nbsp;&nbsp;`"0100000003ad3fba7ebd67c09baa9538898e10d6726dcb8eadb006be0c7388c8e46d69d3610000000..."`<br />&nbsp;&nbsp;`],`<br />&nbsp;`"id": null`<br />`}`<br />The redeemingtx notification for the same txout, after the spending transaction was mined into block 279143:<br />`{`<br />&nbsp;`"jsonrpc": "1.0",`<br />&nbsp;`"method": "recvtx",`<br />&nbsp;`"params":`<br />&nbsp;&nbsp;`[`<br />&nbsp;&nbsp;&nbsp;`"0100000003ad3fba7ebd67c09baa9538898e10d6726dcb8eadb006be0c7388c8e46d69d3610000000...",`<br />&nbsp;&nbsp;&nbsp;`{`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"height": 279143,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"hash": "00000000000000017188b968a371bab95aa43522665353b646e41865abae02a4",`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"index": 6,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"time": 1389115004`<br />&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;`],`<br />&nbsp;`"id": null`<br />`}`|
-[Return to Overview](#NotificationOverview)<br />
-
-***
-
-<a name="txaccepted"/>
-
-|   |   |
-|---|---|
-|Method|txaccepted|
-|Request|[notifynewtransactions](#notifynewtransactions)|
-|Parameters|1. TxHash (string) hex-encoded bytes of the transaction hash<br />2. Amount (numeric) sum of the value of all the transaction outpoints|
-|Description|Notifies when a new transaction has been accepted and the client has requested standard transaction details.|
-|Example|Example txaccepted notification for mainnet transaction id "16c54c9d02fe570b9d41b518c0daefae81cc05c69bbe842058e84c6ed5826261" (newlines added for readability):<br />`{`<br />&nbsp;`"jsonrpc": "1.0",`<br />&nbsp;`"method": "txaccepted",`<br />&nbsp;`"params":`<br />&nbsp;&nbsp;`[`<br />&nbsp;&nbsp;&nbsp;`"16c54c9d02fe570b9d41b518c0daefae81cc05c69bbe842058e84c6ed5826261",`<br />&nbsp;&nbsp;&nbsp;`55838384`<br />&nbsp;&nbsp;`],`<br />&nbsp;`"id": null`<br />`}`|
-[Return to Overview](#NotificationOverview)<br />
-
-***
-
-<a name="txacceptedverbose"/>
-
-|   |   |
-|---|---|
-|Method|txacceptedverbose|
-|Request|[notifynewtransactions](#notifynewtransactions)|
-|Parameters|1. RawTx (json object) the transaction as a json object (see getrawtransaction json object details)|
-|Description|Notifies when a new transaction has been accepted and the client has requested verbose transaction details.|
-|Example|Example txacceptedverbose notification (newlines added for readability):<br />`{`<br />&nbsp;`"jsonrpc": "1.0",`<br />&nbsp;`"method": "txacceptedverbose",`<br />&nbsp;`"params":`<br />&nbsp;&nbsp;`[`<br />&nbsp;&nbsp;&nbsp;`{`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"hex": "01000000010000000000000000000000000000000000000000000000000000000000000000f...",`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"txid": "90743aad855880e517270550d2a881627d84db5265142fd1e7fb7add38b08be9",`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"version": 1,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"locktime": 0,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"vin": [`<br />&nbsp;&nbsp;&nbsp;&nbsp;<font color="orange">For coinbase transactions:</font><br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`{ (json object)`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"coinbase": "03708203062f503253482f04066d605108f800080100000ea2122f6f7a636f696e4065757374726174756d2f",`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"sequence": 0,`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;&nbsp;&nbsp;<font color="orange">For non-coinbase transactions:</font><br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`{`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"txid": "60ac4b057247b3d0b9a8173de56b5e1be8c1d1da970511c626ef53706c66be04",`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"vout": 0,`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"scriptSig": {`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"asm": "3046022100cb42f8df44eca83dd0a727988dcde9384953e830b1f8004d57485e2ede1b9c8f0...",`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"hex": "493046022100cb42f8df44eca83dd0a727988dcde9384953e830b1f8004d57485e2ede1b9c8...",`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"sequence": 4294967295,`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;&nbsp;&nbsp;`],`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"vout": [`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`{`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"value": 25.1394,`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"n": 0,`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"scriptPubKey": {`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"asm": "OP_DUP OP_HASH160 ea132286328cfc819457b9dec386c4b5c84faa5c OP_EQUALVERIFY OP_CHECKSIG",`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"hex": "76a914ea132286328cfc819457b9dec386c4b5c84faa5c88ac",`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"reqSigs": 1,`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"type": "pubkeyhash"`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"addresses": [`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"1NLg3QJMsMQGM5KEUaEu5ADDmKQSLHwmyh",`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`]`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;&nbsp;&nbsp;`]`<br />&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;`],`<br />&nbsp;`"id": null`<br />`}`|
-[Return to Overview](#NotificationOverview)<br />
-
-***
-
-<a name="rescanprogress"/>
-
-|   |   |
-|---|---|
-|Method|rescanprogress|
-|Request|[rescan](#rescan)|
-|Parameters|1. Hash (string) hash of the last processed block<br />2. Height (numeric) height of the last processed block<br />3. Time (numeric) UNIX time of the last processed block|
-|Description|Notifies a client with the current progress at periodic intervals when a long-running [rescan](#rescan) is underway.|
-|Example|`{`<br />&nbsp;`"jsonrpc": "1.0",`<br />&nbsp;`"method": "rescanprogress",`<br />&nbsp;`"params":`<br />&nbsp;&nbsp;`[`<br />&nbsp;&nbsp;&nbsp;`"0000000000000ea86b49e11843b2ad937ac89ae74a963c7edd36e0147079b89d",`<br />&nbsp;&nbsp;&nbsp;`127213,`<br />&nbsp;&nbsp;&nbsp;`1306533807`<br />&nbsp;&nbsp;`],`<br />&nbsp;`"id": null`<br />`}`|
-[Return to Overview](#NotificationOverview)<br />
-
-***
-
-<a name="rescanfinished"/>
-
-|   |   |
-|---|---|
-|Method|rescanfinished|
-|Request|[rescan](#rescan)|
-|Parameters|1. Hash (string) hash of the last rescanned block<br />2. Height (numeric) height of the last rescanned block<br />3. Time (numeric) UNIX time of the last rescanned block |
-|Description|Notifies a client that the [rescan](#rescan) has completed and no further notifications will be sent.|
-|Example|`{`<br />&nbsp;`"jsonrpc": "1.0",`<br />&nbsp;`"method": "rescanfinished",`<br />&nbsp;`"params":`<br />&nbsp;&nbsp;`[`<br />&nbsp;&nbsp;&nbsp;`"0000000000000ea86b49e11843b2ad937ac89ae74a963c7edd36e0147079b89d",`<br />&nbsp;&nbsp;&nbsp;`127213,`<br />&nbsp;&nbsp;&nbsp;`1306533807`<br />&nbsp;&nbsp;`],`<br />&nbsp;`"id": null`<br />`}`|
-[Return to Overview](#NotificationOverview)<br />
-
-
-<a name="ExampleCode" />
-### 9. Example Code
-
-This section provides example code for interacting with the JSON-RPC API in
-various languages.
-
-* [Go](#ExampleGoApp)
-* [node.js](#ExampleNodeJsCode)
-
-<a name="ExampleGoApp" />
-**9.1 Go**
-
-This section provides examples of using the RPC interface using Go and the
-[btcrpcclient](https://github.com/btcsuite/btcrpcclient) package.
-
-* [Using getblockcount to Retrieve the Current Block Height](#ExampleGetBlockCount)
-* [Using getblock to Retrieve the Genesis Block](#ExampleGetBlock)
-* [Using notifyblocks to Receive blockconnected and blockdisconnected Notifications (Websocket-specific)](#ExampleNotifyBlocks)
-
-
-<a name="ExampleGetBlockCount" />
-**9.1.1 Using getblockcount to Retrieve the Current Block Height**<br />
-
-The following is an example Go application which uses the
-[btcrpcclient](https://github.com/btcsuite/btcrpcclient) package to connect with
-a btcd instance via Websockets, issues [getblockcount](#getblockcount) to
-retrieve the current block height, and displays it.
-
-```Go
-package main
-
-import (
-	"github.com/btcsuite/btcrpcclient"
-	"github.com/btcsuite/btcutil"
-	"io/ioutil"
-	"log"
-	"path/filepath"
-)
-
-func main() {
-	// Load the certificate for the TLS connection which is automatically
-	// generated by btcd when it starts the RPC server and doesn't already
-	// have one.
-	btcdHomeDir := btcutil.AppDataDir("btcd", false)
-	certs, err := ioutil.ReadFile(filepath.Join(btcdHomeDir, "rpc.cert"))
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// Create a new RPC client using websockets.  Since this example is
-	// not long-lived, the connection will be closed as soon as the program
-	// exits.
-	connCfg := &btcrpcclient.ConnConfig{
-		Host:         "localhost:8334",
-		Endpoint:     "ws",
-		User:         "yourrpcuser",
-		Pass:         "yourrpcpass",
-		Certificates: certs,
-	}
-	client, err := btcrpcclient.New(connCfg, nil)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer client.Shutdown()
-
-	// Query the RPC server for the current block count and display it.
-	blockCount, err := client.GetBlockCount()
-	if err != nil {
-		log.Fatal(err)
-	}
-	log.Printf("Block count: %d", blockCount)
-}
-```
-
-Which results in:
-
-```bash
-Block count: 276978
-```
-
-<a name="ExampleGetBlock" />
-**9.1.2 Using getblock to Retrieve the Genesis Block**<br />
-
-The following is an example Go application which uses the
-[btcrpcclient](https://github.com/btcsuite/btcrpcclient) package to connect with
-a btcd instance via Websockets, issues [getblock](#getblock) to retrieve
-information about the Genesis block, and display a few details about it.
-
-```Go
-package main
-
-import (
-	"github.com/btcsuite/btcrpcclient"
-	"github.com/btcsuite/btcutil"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
-	"io/ioutil"
-	"log"
-	"path/filepath"
-	"time"
-)
-
-func main() {
-	// Load the certificate for the TLS connection which is automatically
-	// generated by btcd when it starts the RPC server and doesn't already
-	// have one.
-	btcdHomeDir := btcutil.AppDataDir("btcd", false)
-	certs, err := ioutil.ReadFile(filepath.Join(btcdHomeDir, "rpc.cert"))
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// Create a new RPC client using websockets.  Since this example is
-	// not long-lived, the connection will be closed as soon as the program
-	// exits.
-	connCfg := &btcrpcclient.ConnConfig{
-		Host:         "localhost:18334",
-		Endpoint:     "ws",
-		User:         "yourrpcuser",
-		Pass:         "yourrpcpass",
-		Certificates: certs,
-	}
-	client, err := btcrpcclient.New(connCfg, nil)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer client.Shutdown()
-
-	// Query the RPC server for the genesis block using the "getblock"
-	// command with the verbose flag set to true and the verboseTx flag
-	// set to false.
-	genesisHashStr := "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
-	blockHash, err := chainhash.NewHashFromStr(genesisHashStr)
-	if err != nil {
-		log.Fatal(err)
-	}
-	block, err := client.GetBlockVerbose(blockHash, false)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// Display some details about the returned block.
-	log.Printf("Hash: %v\n", block.Hash)
-	log.Printf("Previous Block: %v\n", block.PreviousHash)
-	log.Printf("Next Block: %v\n", block.NextHash)
-	log.Printf("Merkle root: %v\n", block.MerkleRoot)
-	log.Printf("Timestamp: %v\n", time.Unix(block.Time, 0).UTC())
-	log.Printf("Confirmations: %v\n", block.Confirmations)
-	log.Printf("Difficulty: %f\n", block.Difficulty)
-	log.Printf("Size (in bytes): %v\n", block.Size)
-	log.Printf("Num transactions: %v\n", len(block.Tx))
-}
-```
-
-Which results in:
-
-```bash
-Hash: 000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
-Previous Block: 0000000000000000000000000000000000000000000000000000000000000000
-Next Block: 00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048
-Merkle root: 4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b
-Timestamp: 2009-01-03 18:15:05 +0000 UTC
-Confirmations: 277290
-Difficulty: 1.000000
-Size (in bytes): 285
-Num transactions: 1
-```
-
-<a name="ExampleNotifyBlocks" />
-**9.1.3 Using notifyblocks to Receive blockconnected and blockdisconnected
-Notifications (Websocket-specific)**<br />
-
-The following is an example Go application which uses the
-[dcrrpcclient](https://github.com/decred/dcrrpcclient) package to connect with
-a btcd instance via Websockets and registers for
-[blockconnected](#blockconnected) and [blockdisconnected](#blockdisconnected)
-notifications with [notifyblocks](#notifyblocks).  It also sets up handlers for
-the notifications.
-
-```Go
-package main
-
-import (
-        "io/ioutil"
-        "log"
-        "path/filepath"
-        "time"
-
-        "github.com/decred/dcrd/wire"
-        "github.com/decred/dcrrpcclient"
-        "github.com/decred/dcrutil"
-)
-
-func main() {
-        // Setup handlers for blockconnected and blockdisconnected
-        // notifications.
-        ntfnHandlers := dcrrpcclient.NotificationHandlers{
-                OnBlockConnected: func(blockHeaderBytes []byte, transactions [][]byte) {
-                        var bh wire.BlockHeader
-                        err := bh.FromBytes(blockHeaderBytes)
-                        if err != nil {
-                                log.Printf("Unable to deserialize "+
-                                        "block header: %v", err)
-                                return
-                        }
-                        log.Printf("Block connected: %v (%d)",
-                                bh.BlockHash(), bh.Height)
-                },
-                OnBlockDisconnected: func(blockHeaderBytes []byte) {
-                        var bh wire.BlockHeader
-                        err := bh.FromBytes(blockHeaderBytes)
-                        if err != nil {
-                                log.Printf("Unable to deserialize "+
-                                        "block header: %v", err)
-                                return
-                        }
-                        log.Printf("Block disconnected: %v (%d)",
-                                bh.BlockHash(), bh.Height)
-                },
-        }
-
-        // Load the certificate for the TLS connection which is automatically
-        // generated by dcrd when it starts the RPC server and doesn't already
-        // have one.
-        dcrdHomeDir := dcrutil.AppDataDir("dcrd", false)
-        certs, err := ioutil.ReadFile(filepath.Join(dcrdHomeDir, "rpc.cert"))
-        if err != nil {
-                log.Fatal(err)
-        }
-
-        // Create a new RPC client using websockets.
-        connCfg := &dcrrpcclient.ConnConfig{
-                Host:         "localhost:8334",
-                Endpoint:     "ws",
-                User:         "yourrpcuser",
-                Pass:         "yourrpcpass",
-                Certificates: certs,
-        }
-        client, err := dcrrpcclient.New(connCfg, &ntfnHandlers)
-        if err != nil {
-                log.Fatal(err)
-        }
-
-        // Register for blockconnected and blockdisconneted notifications.
-        if err := client.NotifyBlocks(); err != nil {
-                client.Shutdown()
-                log.Fatal(err)
-        }
-
-        // For this example, gracefully shutdown the client after 10 seconds.
-        // Ordinarily when to shutdown the client is highly application
-        // specific.
-        log.Println("Client shutdown in 10 seconds...")
-        time.AfterFunc(time.Second*10, func() {
-                log.Println("Client shutting down...")
-                client.Shutdown()
-                log.Println("Client shutdown complete.")
-        })
-
-        // Wait until the client either shuts down gracefully (or the user
-        // terminates the process with Ctrl+C).
-        client.WaitForShutdown()
-}
-```
-
-Example output:
-
-```
-2014/05/12 20:33:17 Client shutdown in 10 seconds...
-2014/05/12 20:33:19 Block connected: 000000000000000007dff1f95f7b3f5eac2892a4123069517caf34e2c417650d (300461)
-2014/05/12 20:33:27 Client shutting down...
-2014/05/12 20:31:27 Client shutdown complete.
-```
-
-<a name="ExampleNodeJsCode" />
-### 9.2. Example node.js Code
-
-<a name="ExampleNotifyBlocks" />
-**9.2.1 Using notifyblocks to be Notified of Block Connects and Disconnects**<br />
-
-The following is example node.js code which uses [ws](https://github.com/einaros/ws)
-(can be installed with `npm install ws`) to connect with a dcrd instance,
-issues [notifyblocks](#notifyblocks) to register for
-[blockconnected](#blockconnected) and [blockdisconnected](#blockdisconnected)
-notifications, and displays all incoming messages.
-
-```javascript
-var fs = require('fs');
-var WebSocket = require('ws');
-
-// Load the certificate for the TLS connection which is automatically
-// generated by dcrd when it starts the RPC server and doesn't already
-// have one.
-var cert = fs.readFileSync('/path/to/dcrd/appdata/rpc.cert');
-Var user = "yourusername";
-var password = "yourpassword";
-
-
-// Initiate the websocket connection.  The dcrd generated certificate acts as
-// its own certificate authority, so it needs to be specified in the 'ca' array
-// for the certificate to properly validate.
-var ws = new WebSocket('wss://127.0.0.1:8334/ws', {
   headers: {
     'Authorization': 'Basic '+new Buffer(user+':'+password).toString('base64')
   },


### PR DESCRIPTION
The github markdown interpreter has been changed such that it no longer allows spaces in between the brackets and parenthesis of links and now requires a newline in between anchors and other formatting.  This
updates all of the markdown files accordingly.

While here, it also corrects a couple of inconsistencies in some of the `README.md` files and correct some previous merge conflicts.

Fixes #743 and includes changes missed by #711.