### PR TITLE
chain/indexers: Allow reorg of block one.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1174,6 +1174,11 @@ func (b *BlockChain) getReorganizeNodes(node *blockNode) (*list.List, *list.List
 	// common ancestor adding each block to the list of nodes to detach from
 	// the main chain.
 	for n := b.bestNode; n != nil; n = n.parent {
+		if n.hash == ancestor.hash {
+			break
+		}
+		detachNodes.PushBack(n)
+
 		if n.parent == nil {
 			var err error
 			n.parent, err = b.findNode(&n.header.PrevBlock, maxSearchDepth)
@@ -1181,12 +1186,6 @@ func (b *BlockChain) getReorganizeNodes(node *blockNode) (*list.List, *list.List
 				return nil, nil, err
 			}
 		}
-
-		if n.hash == ancestor.hash {
-			break
-		}
-
-		detachNodes.PushBack(n)
 	}
 
 	return detachNodes, attachNodes, nil

--- a/blockchain/indexers/addrindex.go
+++ b/blockchain/indexers/addrindex.go
@@ -720,7 +720,7 @@ func (idx *AddrIndex) indexPkScript(data writeIndexData, scriptVersion uint16, p
 // transaction using the passed map.
 func (idx *AddrIndex) indexBlock(data writeIndexData, block, parent *dcrutil.Block, view *blockchain.UtxoViewpoint) {
 	var parentRegularTxs []*dcrutil.Tx
-	if approvesParent(block) {
+	if approvesParent(block) && block.Height() > 1 {
 		parentRegularTxs = parent.Transactions()
 	}
 	for txIdx, tx := range parentRegularTxs {

--- a/blockchain/indexers/txindex.go
+++ b/blockchain/indexers/txindex.go
@@ -308,7 +308,7 @@ func dbRemoveTxIndexEntries(dbTx database.Tx, block, parent *dcrutil.Block) erro
 	}
 
 	// Remove all of the regular transactions of the parent if voted valid.
-	if approvesParent(block) {
+	if approvesParent(block) && block.Height() > 1 {
 		if err := removeEntries(parent.Transactions()); err != nil {
 			return err
 		}


### PR DESCRIPTION
This modifies the code to permit a reorganization that includes block one.  Even though this will never happen on the main network since it's buried so deep, it is entirely possible for the first block to be
reorged away on test chains.

Not only is it more technically accurate to permit a reorg of the first block, so long as the new one satisfies all of consensus rules, it also facilitates upcoming test code which relies on that capability.

It should be noted that this is technically a hard fork, however, it only applies to the first block and so it would now require a reorg of over 150,000 blocks which is completely infeasible.
