### PR TITLE
rpctest: Correct several issues in tests and joins.

### DIFF
--- a/rpctest/rpc_harness_test.go
+++ b/rpctest/rpc_harness_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/dcrjson"
 	"github.com/decred/dcrd/txscript"
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrutil"
@@ -84,6 +85,12 @@ func testSendOutputs(r *Harness, t *testing.T) {
 		t.Fatalf("unable to generate single block: %v", err)
 	}
 	assertTxMined(txid, blockHashes[0])
+
+	// Generate another block to ensure the transaction is removed from the
+	// mempool.
+	if _, err := r.Node.Generate(1); err != nil {
+		t.Fatalf("unable to generate block: %v", err)
+	}
 }
 
 func assertConnectedTo(t *testing.T, nodeA *Harness, nodeB *Harness) {
@@ -109,25 +116,25 @@ func assertConnectedTo(t *testing.T, nodeA *Harness, nodeB *Harness) {
 }
 
 func testConnectNode(r *Harness, t *testing.T) {
-	// Create a fresh test harnesses.
+	// Create a fresh test harness.
 	harness, err := New(&chaincfg.SimNetParams, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := harness.SetUp(true, 0); err != nil {
+	if err := harness.SetUp(false, 0); err != nil {
 		t.Fatalf("unable to complete rpctest setup: %v", err)
 	}
 	defer harness.TearDown()
 
-	// Establish a p2p connection the main harness to our new local
+	// Establish a p2p connection from our new local harness to the main
 	// harness.
-	if err := ConnectNode(r, harness); err != nil {
-		t.Fatalf("unable to connect harness1 to harness2: %v", err)
+	if err := ConnectNode(harness, r); err != nil {
+		t.Fatalf("unable to connect local to main harness: %v", err)
 	}
 
-	// The main harness should show up in our loca harness' peer's list,
+	// The main harness should show up in our local harness' peer's list,
 	// and vice verse.
-	assertConnectedTo(t, r, harness)
+	assertConnectedTo(t, harness, r)
 }
 
 func testTearDownAll(t *testing.T) {
@@ -174,12 +181,23 @@ func testActiveHarnesses(r *Harness, t *testing.T) {
 }
 
 func testJoinMempools(r *Harness, t *testing.T) {
-	// Create a new local test harnesses, starting at the same height.
+	// Assert main test harness has no transactions in its mempool.
+	pooledHashes, err := r.Node.GetRawMempool(dcrjson.GRMAll)
+	if err != nil {
+		t.Fatalf("unable to get mempool for main test harness: %v", err)
+	}
+	if len(pooledHashes) != 0 {
+		t.Fatal("main test harness mempool not empty")
+	}
+
+	// Create a local test harness with only the genesis block.  The nodes
+	// will be synced below so the same transaction can be sent to both
+	// nodes without it being an orphan.
 	harness, err := New(&chaincfg.SimNetParams, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := harness.SetUp(true, numMatureOutputs); err != nil {
+	if err := harness.SetUp(false, 0); err != nil {
 		t.Fatalf("unable to complete rpctest setup: %v", err)
 	}
 	defer harness.TearDown()
@@ -189,42 +207,75 @@ func testJoinMempools(r *Harness, t *testing.T) {
 	// Both mempools should be considered synced as they are empty.
 	// Therefore, this should return instantly.
 	if err := JoinNodes(nodeSlice, Mempools); err != nil {
-		t.Fatalf("unable to join node on block height: %v", err)
+		t.Fatalf("unable to join node on mempools: %v", err)
 	}
 
-	// Generate a coinbase spend to a new address within harness1's
+	// Generate a coinbase spend to a new address within the main harness'
 	// mempool.
-	addr, err := harness.NewAddress()
+	addr, err := r.NewAddress()
 	addrScript, err := txscript.PayToAddrScript(addr)
 	if err != nil {
 		t.Fatalf("unable to generate pkscript to addr: %v", err)
 	}
 	output := wire.NewTxOut(5e8, addrScript)
-	if _, err = harness.SendOutputs([]*wire.TxOut{output}, 10); err != nil {
+	testTx, err := r.CreateTransaction([]*wire.TxOut{output}, 10)
+	if err != nil {
 		t.Fatalf("coinbase spend failed: %v", err)
 	}
+	if _, err := r.Node.SendRawTransaction(testTx, true); err != nil {
+		t.Fatalf("send transaction failed: %v", err)
+	}
 
+	// Wait until the transaction shows up to ensure the two mempools are
+	// not the same.
+	harnessSynced := make(chan struct{})
+	go func() {
+		for {
+			poolHashes, err := r.Node.GetRawMempool(dcrjson.GRMAll)
+			if err != nil {
+				t.Fatalf("failed to retrieve harness mempool: %v", err)
+			}
+			if len(poolHashes) > 0 {
+				break
+			}
+			time.Sleep(time.Millisecond * 100)
+		}
+		harnessSynced <- struct{}{}
+	}()
+	select {
+	case <-harnessSynced:
+	case <-time.After(time.Minute):
+		t.Fatalf("harness node never received transaction")
+	}
+
+	// This select case should fall through to the default as the goroutine
+	// should be blocked on the JoinNodes call.
 	poolsSynced := make(chan struct{})
 	go func() {
 		if err := JoinNodes(nodeSlice, Mempools); err != nil {
-			t.Fatalf("unable to join node on node mempools: %v", err)
+			t.Fatalf("unable to join node on mempools: %v", err)
 		}
 		poolsSynced <- struct{}{}
 	}()
-
-	// This select case should fall through to the default as the goroutine
-	// should be blocked on the JoinNodes calls.
 	select {
 	case <-poolsSynced:
-		t.Fatalf("mempools detected as synced yet harness1 has a new tx")
+		t.Fatalf("mempools detected as synced yet harness has a new tx")
 	default:
 	}
 
-	// Establish an outbound connection from harness1 to harness2. After
-	// the initial handshake both nodes should exchange inventory resulting
-	// in a synced mempool.
-	if err := ConnectNode(r, harness); err != nil {
+	// Establish an outbound connection from the local harness to the main
+	// harness and wait for the chains to be synced.
+	if err := ConnectNode(harness, r); err != nil {
 		t.Fatalf("unable to connect harnesses: %v", err)
+	}
+	if err := JoinNodes(nodeSlice, Blocks); err != nil {
+		t.Fatalf("unable to join node on blocks: %v", err)
+	}
+
+	// Send the transaction to the local harness which will result in synced
+	// mempools.
+	if _, err := harness.Node.SendRawTransaction(testTx, true); err != nil {
+		t.Fatalf("send transaction failed: %v", err)
 	}
 
 	// Select once again with a special timeout case after 1 minute. The
@@ -235,36 +286,27 @@ func testJoinMempools(r *Harness, t *testing.T) {
 	case <-poolsSynced:
 		// fall through
 	case <-time.After(time.Minute):
-		t.Fatalf("block heights never detected as synced")
+		t.Fatalf("mempools never detected as synced")
 	}
-
 }
 
 func testJoinBlocks(r *Harness, t *testing.T) {
-	// Create two test harnesses, with one being 5 blocks ahead of the other
-	// with respect to block height.
-	harness1, err := New(&chaincfg.SimNetParams, nil, nil)
+	// Create a second harness with only the genesis block so it is behind
+	// the main harness.
+	harness, err := New(&chaincfg.SimNetParams, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := harness1.SetUp(true, numMatureOutputs+5); err != nil {
+	if err := harness.SetUp(false, 0); err != nil {
 		t.Fatalf("unable to complete rpctest setup: %v", err)
 	}
-	defer harness1.TearDown()
-	harness2, err := New(&chaincfg.SimNetParams, nil, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := harness2.SetUp(true, numMatureOutputs); err != nil {
-		t.Fatalf("unable to complete rpctest setup: %v", err)
-	}
-	defer harness2.TearDown()
+	defer harness.TearDown()
 
-	nodeSlice := []*Harness{harness1, harness2}
+	nodeSlice := []*Harness{r, harness}
 	blocksSynced := make(chan struct{})
 	go func() {
 		if err := JoinNodes(nodeSlice, Blocks); err != nil {
-			t.Fatalf("unable to join node on block height: %v", err)
+			t.Fatalf("unable to join node on blocks: %v", err)
 		}
 		blocksSynced <- struct{}{}
 	}()
@@ -273,14 +315,14 @@ func testJoinBlocks(r *Harness, t *testing.T) {
 	// should be blocked on the JoinNodes calls.
 	select {
 	case <-blocksSynced:
-		t.Fatalf("blocks detected as synced yet harness2 is 5 blocks behind")
+		t.Fatalf("blocks detected as synced yet local harness is behind")
 	default:
 	}
 
-	// Extend harness2's chain by 5 blocks, this should cause JoinNodes to
-	// finally unblock and return.
-	if _, err := harness2.Node.Generate(5); err != nil {
-		t.Fatalf("unable to generate blocks: %v", err)
+	// Connect the local harness to the main harness which will sync the
+	// chains.
+	if err := ConnectNode(harness, r); err != nil {
+		t.Fatalf("unable to connect harnesses: %v", err)
 	}
 
 	// Select once again with a special timeout case after 1 minute. The
@@ -291,7 +333,7 @@ func testJoinBlocks(r *Harness, t *testing.T) {
 	case <-blocksSynced:
 		// fall through
 	case <-time.After(time.Minute):
-		t.Fatalf("block heights never detected as synced")
+		t.Fatalf("blocks never detected as synced")
 	}
 }
 
@@ -317,12 +359,12 @@ func testMemWalletReorg(r *Harness, t *testing.T) {
 
 	// Now connect this local harness to the main harness then wait for
 	// their chains to synchronize.
-	if err := ConnectNode(r, harness); err != nil {
+	if err := ConnectNode(harness, r); err != nil {
 		t.Fatalf("unable to connect harnesses: %v", err)
 	}
 	nodeSlice := []*Harness{r, harness}
 	if err := JoinNodes(nodeSlice, Blocks); err != nil {
-		t.Fatalf("unable to join node on block height: %v", err)
+		t.Fatalf("unable to join node on blocks: %v", err)
 	}
 
 	// The original wallet should now have a balance of 0 Coin as its entire
@@ -379,8 +421,8 @@ var harnessTestCases = []HarnessTestCase{
 	testSendOutputs,
 	testConnectNode,
 	testActiveHarnesses,
-	testJoinMempools,
 	testJoinBlocks,
+	testJoinMempools, // Depends on results of testJoinBlocks
 	testMemWalletReorg,
 	testMemWalletLockedOutputs,
 }


### PR DESCRIPTION
Contains the following upstream commits:
- c3d5371615c4869e3f899a355421089318976944
  - Reverted since Travis is already at a more recent version
- 7c4b169faa134b6716f574cff87d2e4340fba57b
  - Reverted since this is already done via the Decred docker setup
- 47ced81d440595b0bbe6c355236ac306e107c259
  - Reverted since it has already been fixed by connmanager sync
- 6cf60b5fae5cd076c863892038840a2327e345ce

Also, the merge commit contains the necessary Decred-specific alterations.

----

This corrects several issues with the new rpctest package.

The following is an overview of the issues that have been corrected:

- The JoinNodes code was incorrect for both mempool and blocks.
  - For mempool it was only checking the first node against itself
  - For blocks it was only testing the height instead of hash and height
    which means the chains could be different and it would claim they're
    synced
- The test for mempool joins was inaccurate in a few ways:
  - It was generating separate chains such that the generated
    transaction was invalid (an orphan) on one chain, but not
    the other
  - Mempools are not automatically synced when nodes are connected and
    there is a large random delay before any transaction rebroadcast
    happens, so it can't be relied on for the purposes of this test
- The test for block joins was generating two independent chains of the
  same height with the same difficulty and was only passing due to the
  aforementioned bug in JoinNodes
- All of the ConnectNode calls were connecting the main harness outbound
  to the local test harness instances
  - This is not correct because ConnectNode makes the outbound
    connection persistent, which means once the local test harness is
    gone, it would keep trying to connect for the remainder of the tests
    to a node that is never coming back and instead ends up connecting to
    an independent test harness.
