### PR TITLE
mempool: Break dependency on chain instance.

### DIFF
--- a/server.go
+++ b/server.go
@@ -2359,22 +2359,17 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 			AllowOldVotes:        cfg.AllowOldVotes,
 		},
 		ChainParams: chainParams,
-		// EnableAddrIndex: !cfg.NoAddrIndex, TODO
-		NewestHash: func() (*chainhash.Hash, int64, error) {
-			bm.chainState.Lock()
-			hash := bm.chainState.newestHash
-			height := bm.chainState.newestHeight
-			bm.chainState.Unlock()
-			return hash, height, nil
-		},
 		NextStakeDifficulty: func() (int64, error) {
 			bm.chainState.Lock()
 			sDiff := bm.chainState.nextStakeDifficulty
 			bm.chainState.Unlock()
 			return sDiff, nil
 		},
-		FetchUtxoView:   s.blockManager.chain.FetchUtxoView,
-		Chain:           s.blockManager.chain,
+		FetchUtxoView:   bm.chain.FetchUtxoView,
+		BlockByHash:     bm.chain.BlockByHash,
+		BestHash:        func() *chainhash.Hash { return bm.chain.BestSnapshot().Hash },
+		BestHeight:      func() int64 { return bm.chain.BestSnapshot().Height },
+		SubsidyCache:    bm.chain.FetchSubsidyCache(),
 		SigCache:        s.sigCache,
 		TimeSource:      s.timeSource,
 		AddrIndex:       s.addrIndex,


### PR DESCRIPTION
Upstream commit 641182b2ade8fe31ffa3698c2ab758ef3851d16c.

In addition, the merge commit also adds two more functions to the config, named `BlockByHash` and `BestHash`, along with an additional field for the `SubsidyCache` in order to maintain the spirit of the upstream commit breaking the dependency on a specific chain instance.

---

This modifies the config for the new `mempool` package such that it takes a callback function to obtain the best chain height instead of requiring a fully initialized `blockchain.BlockChain` instance.

This will make it much easier to test the `mempool` since the tests will be able to provide their own height function to test various functionality without having create and manipulate full blocks and chain instances.
