### PR TITLE
config: introduce new flags to accept/reject non-std transactions 

### DIFF
--- a/config.go
+++ b/config.go
@@ -151,6 +151,8 @@ type config struct {
 	NoMiningStateSync    bool          `long:"nominingstatesync" description:"Disable synchronizing the mining state with other nodes"`
 	AllowOldVotes        bool          `long:"allowoldvotes" description:"Enable the addition of very old votes to the mempool"`
 	BlocksOnly           bool          `long:"blocksonly" description:"Do not accept transactions from remote peers."`
+	RelayNonStd          bool          `long:"relaynonstd" description:"Relay non-standard transactions regardless of the default settings for the active network."`
+	RejectNonStd         bool          `long:"rejectnonstd" description:"Reject non-standard transactions regardless of the default settings for the active network."`
 	TxIndex              bool          `long:"txindex" description:"Maintain a full hash-based transaction index which makes all transactions available via the getrawtransaction RPC"`
 	DropTxIndex          bool          `long:"droptxindex" description:"Deletes the hash-based transaction index from the database on start up and then exits."`
 	AddrIndex            bool          `long:"addrindex" description:"Maintain a full address-based transaction index which makes the searchrawtransactions RPC available"`
@@ -517,6 +519,26 @@ func loadConfig() (*config, []string, error) {
 		fmt.Fprintln(os.Stderr, usageMessage)
 		return nil, nil, err
 	}
+
+	// Set the default policy for relaying non-standard transactions
+	// according to the default of the active network. The set
+	// configuration value takes precedence over the default value for the
+	// selected network.
+	relayNonStd := activeNetParams.RelayNonStdTxs
+	switch {
+	case cfg.RelayNonStd && cfg.RejectNonStd:
+		str := "%s: rejectnonstd and relaynonstd cannot be used " +
+			"together -- choose only one"
+		err := fmt.Errorf(str, funcName)
+		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, usageMessage)
+		return nil, nil, err
+	case cfg.RejectNonStd:
+		relayNonStd = false
+	case cfg.RelayNonStd:
+		relayNonStd = true
+	}
+	cfg.RelayNonStd = relayNonStd
 
 	// Append the network type to the data directory so it is "namespaced"
 	// per network.  In addition to the block database, there are other

--- a/doc.go
+++ b/doc.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -118,6 +118,10 @@ Application Options:
       --sigcachemaxsize=    The maximum number of entries in the signature
                             verification cache.
       --blocksonly          Do not accept transactions from remote peers.
+      --relaynonstd         Relay non-standard transactions regardless of the
+                            default settings for the active network.
+      --rejectnonstd        Reject non-standard transactions regardless of the
+                            default settings for the active network.
 
 Help Options:
   -h, --help           Show this help message

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -134,6 +134,12 @@ type Policy struct {
 	// DisableRelayPriority defines whether to relay free or low-fee
 	// transactions that do not have enough priority to be relayed.
 	DisableRelayPriority bool
+
+	// RelayNonStd defines whether to relay non-standard transactions. If
+	// true, non-standard transactions will be accepted into the mempool
+	// and relayed. Otherwise, all non-standard transactions will be
+	// rejected.
+	RelayNonStd bool
 
 	// FreeTxRelayLimit defines the given amount in thousands of bytes
 	// per minute that transactions with no fee are rate limited to.
@@ -808,7 +814,7 @@ func (mp *TxPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit, allow
 
 	// Don't allow non-standard transactions if the network parameters
 	// forbid their relaying.
-	if !mp.cfg.ChainParams.RelayNonStdTxs {
+	if !mp.cfg.Policy.RelayNonStd {
 		err := checkTransactionStandard(tx, txType, nextBlockHeight,
 			mp.cfg.TimeSource, mp.cfg.Policy.MinRelayTxFee)
 		if err != nil {
@@ -982,7 +988,7 @@ func (mp *TxPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit, allow
 
 	// Don't allow transactions with non-standard inputs if the network
 	// parameters forbid their relaying.
-	if !mp.cfg.ChainParams.RelayNonStdTxs {
+	if !mp.cfg.Policy.RelayNonStd {
 		err := checkInputsStandard(tx, txType, utxoView)
 		if err != nil {
 			// Attempt to extract a reject code from the error so

--- a/rpcserver_test.go
+++ b/rpcserver_test.go
@@ -102,7 +102,12 @@ var primaryHarness *rpctest.Harness
 
 func TestMain(m *testing.M) {
 	var err error
-	primaryHarness, err = rpctest.New(&chaincfg.SimNetParams, nil, nil)
+
+	// In order to properly test scenarios on as if we were on mainnet,
+	// ensure that non-standard transactions aren't accepted into the
+	// mempool or relayed.
+	args := []string{"--rejectnonstd"}
+	primaryHarness, err = rpctest.New(&chaincfg.SimNetParams, nil, args)
 	if err != nil {
 		fmt.Println("unable to create primary harness: ", err)
 		os.Exit(1)
@@ -134,7 +139,7 @@ func TestRpcServer(t *testing.T) {
 	defer func() {
 		// If one of the integration tests caused a panic within the main
 		// goroutine, then tear down all the harnesses in order to avoid
-		// any leaked btcd processes.
+		// any leaked dcrd processes.
 		if r := recover(); r != nil {
 			fmt.Println("recovering from test panic: ", r)
 			if err := rpctest.TearDownAll(); err != nil {

--- a/sample-dcrd.conf
+++ b/sample-dcrd.conf
@@ -233,6 +233,12 @@
 ; Do not accept transactions from remote peers.
 ; blocksonly=1
 
+; Relay non-standard transactions regardless of default network settings.
+; relaynonstd=1
+
+; Reject non-standard transactions regardless of default network settings.
+; rejectnonstd=1
+
 
 ; ------------------------------------------------------------------------------
 ; Optional Transaction Indexes

--- a/server.go
+++ b/server.go
@@ -2351,6 +2351,7 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 	txC := mempool.Config{
 		Policy: mempool.Policy{
 			DisableRelayPriority: cfg.NoRelayPriority,
+			RelayNonStd:          cfg.RelayNonStd,
 			FreeTxRelayLimit:     cfg.FreeTxRelayLimit,
 			MaxOrphanTxs:         cfg.MaxOrphanTxs,
 			MaxOrphanTxSize:      defaultMaxOrphanTxSize,


### PR DESCRIPTION
This contains the following upstream commits:
- dc5486a579f7992c09c6f6cf2970f3e4fe7b8b53
- 815ded348ec5aa2d0dbe7cfbc1468616e3508252
- c6d50b7abfe5f43c60718398e12606d219725a57

The merge commit also includes the contains necessary Decred-specific alterations.

---

This PR adds two new cli flags: one for accepting non-std transactions, and the other for rejecting non-std transactions.

The two flag are rejected when used concurrently. Config parsing is set up such that, the desired policy expressed via the config always overrides the policy set by default for a particular chain.

The `mempool`'s `Policy` config has been modified to add a new `RelayNonStd` bool which is checked when validating transactions rather than the policy as dicated by the current `ChainParams` instance. 

Finally, the current set of integration tests has been modified to ensure the main harness always rejects non-standard transactions. With this change, although we're using `simnet` parameters, the harness' transaction validation/acceptance should reflect that policy on mainnet, 
