### PR TITLE
rpctest: Cleanup resources on failed setup.

### DIFF
--- a/rpcserver_test.go
+++ b/rpcserver_test.go
@@ -118,6 +118,13 @@ func TestMain(m *testing.M) {
 	// purposes.
 	if err := primaryHarness.SetUp(true, 25); err != nil {
 		fmt.Println("unable to setup test chain: ", err)
+
+		// Even though the harness was not fully setup, it still needs
+		// to be torn down to ensure all resources such as temp
+		// directories are cleaned up.  The error is intentionally
+		// ignored since this is already an error path and nothing else
+		// could be done about it anyways.
+		_ = primaryHarness.TearDown()
 		os.Exit(1)
 	}
 

--- a/rpctest/rpc_harness_test.go
+++ b/rpctest/rpc_harness_test.go
@@ -441,6 +441,13 @@ func TestMain(m *testing.M) {
 	// 25 mature coinbases to allow spending from for testing purposes.
 	if err = mainHarness.SetUp(true, numMatureOutputs); err != nil {
 		fmt.Println("unable to setup test chain: ", err)
+
+		// Even though the harness was not fully setup, it still needs
+		// to be torn down to ensure all resources such as temp
+		// directories are cleaned up.  The error is intentionally
+		// ignored since this is already an error path and nothing else
+		// could be done about it anyways.
+		_ = mainHarness.TearDown()
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
This contains the following upstream commits:
- 5e93b1664e4a57aa997b77c6e4a8a90b4c90dd98
  - This commit originated from downstream so it is a NOOP
- 0ddd10add60683ce24cafcc1d9b38832ad1920ef
  - This commit has been reverted since it has already been done.
- fb90c334dffc6c91843d8d36ac31e7f7eb6c7594

---

This modifies the rpctest harness to call the TearDown function in the SetUp error path. This ensures any resources, such as temp directories, that were created during setup before whatever the failure that caused the error are properly cleaned up.
