### PR TITLE
rpctest: Use ports based on the process id.

### DIFF
--- a/blockchain/scriptval_test.go
+++ b/blockchain/scriptval_test.go
@@ -32,6 +32,11 @@ func TestCheckBlockScripts(t *testing.T) {
 		}
 		if len(blocks) > 1 {
 			t.Errorf("The test block file must only have one block in it")
+			return
+		}
+		if len(blocks) == 0 {
+			t.Errorf("The test block file may not be empty")
+			return
 		}
 
 		storeDataFile := fmt.Sprintf("%d.utxostore.bz2", testBlockNum)

--- a/rpctest/rpc_harness_test.go
+++ b/rpctest/rpc_harness_test.go
@@ -6,9 +6,7 @@ package rpctest
 
 import (
 	"fmt"
-	"net"
 	"os"
-	"strconv"
 	"testing"
 	"time"
 
@@ -94,14 +92,12 @@ func testSendOutputs(r *Harness, t *testing.T) {
 }
 
 func assertConnectedTo(t *testing.T, nodeA *Harness, nodeB *Harness) {
-	nodePort := defaultP2pPort + (2 * nodeB.nodeNum)
-	nodeAddr := net.JoinHostPort("127.0.0.1", strconv.Itoa(nodePort))
-
 	nodeAPeers, err := nodeA.Node.GetPeerInfo()
 	if err != nil {
 		t.Fatalf("unable to get nodeA's peer info")
 	}
 
+	nodeAddr := nodeB.node.config.listen
 	addrFound := false
 	for _, peerInfo := range nodeAPeers {
 		if peerInfo.Addr == nodeAddr {

--- a/rpctest/utils.go
+++ b/rpctest/utils.go
@@ -6,9 +6,7 @@
 package rpctest
 
 import (
-	"net"
 	"reflect"
-	"strconv"
 	"time"
 
 	"github.com/decred/dcrd/dcrjson"
@@ -110,18 +108,13 @@ func syncBlocks(nodes []*Harness) error {
 // therefore in the case of disconnects, "from" will attempt to reestablish a
 // connection to the "to" harness.
 func ConnectNode(from *Harness, to *Harness) error {
-	// Calculate the target p2p addr+port for the node to be connected to.
-	// p2p ports uses within the package are always even, so we multiply
-	// the node number by two before offsetting from the defaultP2pPort.
-	targetPort := defaultP2pPort + (2 * to.nodeNum)
-	targetAddr := net.JoinHostPort("127.0.0.1", strconv.Itoa(targetPort))
-
 	peerInfo, err := from.Node.GetPeerInfo()
 	if err != nil {
 		return err
 	}
 	numPeers := len(peerInfo)
 
+	targetAddr := to.node.config.listen
 	if err := from.Node.AddNode(targetAddr, dcrrpcclient.ANAdd); err != nil {
 		return err
 	}


### PR DESCRIPTION
This contains the following upstream commits:
- c20db1cf148ce3b06d6a97c24172d1d034995dbb
  - This is commented out in the Decred tests, so merged with the commented code
- daac24626e01996e925c3f55d371d460b25e4c6d
  - This has been reverted since the Decred build system is different and it therefore does not apply
- 7cf9ec81909f69c267f4cb130bc1bbe04ff488b0

---

This modifies the ports that are selected for use for the p2p and rpc ports to start with a port that is based on the process id instead of a hard-coded value.  The chosen ports are incremented for each running instance similar to the previous code except the p2p and rpc ports and now split into ranges instead of being 2 apart.

This is being done because the previous code only worked for a single process which means it prevented the ability to run tests in parallel.

The new approach will work with multiple processes, however it must be stated that there is still a very small probability that the stars could align resulting in the same ports being selected.