### PR TITLE
rpctest: Gate rpctest-based behind a build tag.

### DIFF
--- a/rpcserver_test.go
+++ b/rpcserver_test.go
@@ -3,6 +3,9 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
+// This file is ignored during the regular tests due to the following build tag.
+// +build rpctest
+
 package main
 
 import (

--- a/rpctest/rpc_harness_test.go
+++ b/rpctest/rpc_harness_test.go
@@ -2,6 +2,10 @@
 // Copyright (c) 2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
+
+// This file is ignored during the regular tests due to the following build tag.
+// +build rpctest
+
 package rpctest
 
 import (

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -26,7 +26,9 @@ TESTCMD="test -z \"\$(gometalinter --disable-all \
   --enable=unconvert \
   --vendor \
   --deadline=10m . | tee /dev/stderr)\"&& \
-  env GORACE='halt_on_error=1' go test -short -race \$(glide novendor)"
+  env GORACE='halt_on_error=1' go test -short -race \
+  -tags rpctest \
+  \$(glide novendor)"
 
 if [ $GOVERSION == "local" ]; then
     eval $TESTCMD


### PR DESCRIPTION
Contains upstream commits:
- 99165eb5580b0cb3af1401a9dd641af867852300
  - This is a NOOP since it was already done in Decred when porting the `rpctest` framework
- 754c4fbe0cc528f7d7edd309d40db9aa873c7fe6

The merge commit also ports the necessary changes to run the tests in the new Decred build setup.

---

This adds a new build tag named `rpctest` which must be set in order for `rpctest`-based tests to be executed.  The new build tag is also added to the `run_tests.sh` script which is executed by Travis during continuous integration builds.

This change is being made because the `rpctest` framework requires additional careful user configuration to ensure the version of `dcrd` under test can be programmatically launched from the system path with
all of the necessary ports open whereas all of the other tests are self-contained within the test binary itself.

Since said additional configuration is typically not done, it leads to a lot of false positives.  Putting the tests behind a build tag allows them to remain to be available and run during continuous integration without imposing the additional configuration requirements on users.
