### PR TITLE
blockchain: Remove exported CalcPastTimeMedian func.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -172,7 +172,7 @@ type BestState struct {
 	BlockSize    uint64          // The size of the block.
 	NumTxns      uint64          // The number of txns in the block.
 	TotalTxns    uint64          // The total number of txns in the chain.
-	MedianTime   time.Time       // Median time as per CalcPastMedianTime.
+	MedianTime   time.Time       // Median time as per calcPastMedianTime.
 	TotalSubsidy int64           // The total subsidy for the chain.
 }
 
@@ -1123,18 +1123,6 @@ func (b *BlockChain) calcPastMedianTime(startNode *blockNode) (time.Time, error)
 	// changed to an even number, this code will be wrong.
 	medianTimestamp := timestamps[numNodes/2]
 	return medianTimestamp, nil
-}
-
-// CalcPastMedianTime calculates the median time of the previous few blocks
-// prior to, and including, the end of the current best chain.  It is primarily
-// used to ensure new blocks have sane timestamps.
-//
-// This function is safe for concurrent access.
-func (b *BlockChain) CalcPastMedianTime() (time.Time, error) {
-	b.chainLock.Lock()
-	defer b.chainLock.Unlock()
-
-	return b.calcPastMedianTime(b.bestNode)
 }
 
 // getReorganizeNodes finds the fork point between the main chain and the passed

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -330,7 +330,6 @@ type chainState struct {
 	missedTickets       []chainhash.Hash
 	curPrevHash         chainhash.Hash
 	pastMedianTime      time.Time
-	pastMedianTimeErr   error
 	stakeVersion        uint32
 }
 
@@ -465,13 +464,7 @@ func (b *blockManager) updateChainState(newestHash *chainhash.Hash,
 
 	b.chainState.newestHash = newestHash
 	b.chainState.newestHeight = newestHeight
-	medianTime, err := b.chain.CalcPastMedianTime()
-	if err != nil {
-		b.chainState.pastMedianTimeErr = err
-	} else {
-		b.chainState.pastMedianTime = medianTime
-	}
-
+	b.chainState.pastMedianTime = b.chain.BestSnapshot().MedianTime
 	b.chainState.nextFinalState = finalState
 	b.chainState.nextPoolSize = poolSize
 	b.chainState.nextStakeDifficulty = nextStakeDiff

--- a/mining.go
+++ b/mining.go
@@ -678,9 +678,6 @@ func logSkippedDeps(tx *dcrutil.Tx, deps *list.List) {
 func minimumMedianTime(chainState *chainState) (time.Time, error) {
 	chainState.Lock()
 	defer chainState.Unlock()
-	if chainState.pastMedianTimeErr != nil {
-		return time.Time{}, chainState.pastMedianTimeErr
-	}
 
 	return chainState.pastMedianTime.Add(time.Second), nil
 }
@@ -692,9 +689,6 @@ func medianAdjustedTime(chainState *chainState,
 	timeSource blockchain.MedianTimeSource) (time.Time, error) {
 	chainState.Lock()
 	defer chainState.Unlock()
-	if chainState.pastMedianTimeErr != nil {
-		return time.Time{}, chainState.pastMedianTimeErr
-	}
 
 	// The timestamp for the block must not be before the median timestamp
 	// of the last several blocks.  Thus, choose the maximum between the


### PR DESCRIPTION
Upstream commit 1cba5c8fc0e39f9e65c5d0bb6f4750dfd1e3f02a.

---

This removes the exported `CalcPastTimeMedian` function from the `blockchain` package as it is no longer needed since the information is now available via the `BestState` snapshot.

Also, update the only known caller of this, which is the chain state in block manager, to use the snapshot instead.

