### PR TITLE
multi: Error descriptions should be lowercase.

### DIFF
--- a/config.go
+++ b/config.go
@@ -221,7 +221,7 @@ func parseAndSetDebugLevels(debugLevel string) error {
 	if !strings.Contains(debugLevel, ",") && !strings.Contains(debugLevel, "=") {
 		// Validate debug log level.
 		if !validLogLevel(debugLevel) {
-			str := "The specified debug level [%v] is invalid"
+			str := "the specified debug level [%v] is invalid"
 			return fmt.Errorf(str, debugLevel)
 		}
 
@@ -235,7 +235,7 @@ func parseAndSetDebugLevels(debugLevel string) error {
 	// issues and update the log levels accordingly.
 	for _, logLevelPair := range strings.Split(debugLevel, ",") {
 		if !strings.Contains(logLevelPair, "=") {
-			str := "The specified debug level contains an invalid " +
+			str := "the specified debug level contains an invalid " +
 				"subsystem/level pair [%v]"
 			return fmt.Errorf(str, logLevelPair)
 		}
@@ -246,14 +246,14 @@ func parseAndSetDebugLevels(debugLevel string) error {
 
 		// Validate subsystem.
 		if _, exists := subsystemLoggers[subsysID]; !exists {
-			str := "The specified subsystem [%v] is invalid -- " +
+			str := "the specified subsystem [%v] is invalid -- " +
 				"supported subsytems %v"
 			return fmt.Errorf(str, subsysID, supportedSubsystems())
 		}
 
 		// Validate log level.
 		if !validLogLevel(logLevel) {
-			str := "The specified debug level [%v] is invalid"
+			str := "the specified debug level [%v] is invalid"
 			return fmt.Errorf(str, logLevel)
 		}
 
@@ -492,7 +492,7 @@ func loadConfig() (*config, []string, error) {
 			}
 		}
 
-		str := "%s: Failed to create home directory: %v"
+		str := "%s: failed to create home directory: %v"
 		err := fmt.Errorf(str, funcName, err)
 		fmt.Fprintln(os.Stderr, err)
 		return nil, nil, err
@@ -514,7 +514,7 @@ func loadConfig() (*config, []string, error) {
 		cfg.DisableDNSSeed = true
 	}
 	if numNets > 1 {
-		str := "%s: The testnet and simnet params can't be " +
+		str := "%s: the testnet and simnet params can't be " +
 			"used together -- choose one of the three"
 		err := fmt.Errorf(str, funcName)
 		fmt.Fprintln(os.Stderr, err)
@@ -581,7 +581,7 @@ func loadConfig() (*config, []string, error) {
 
 	// Validate database type.
 	if !validDbType(cfg.DbType) {
-		str := "%s: The specified database type [%v] is invalid -- " +
+		str := "%s: the specified database type [%v] is invalid -- " +
 			"supported types %v"
 		err := fmt.Errorf(str, funcName, cfg.DbType, knownDbTypes)
 		fmt.Fprintln(os.Stderr, err)
@@ -603,7 +603,7 @@ func loadConfig() (*config, []string, error) {
 
 	// Don't allow ban durations that are too short.
 	if cfg.BanDuration < time.Second {
-		str := "%s: The banduration option may not be less than 1s -- parsed [%v]"
+		str := "%s: the banduration option may not be less than 1s -- parsed [%v]"
 		err := fmt.Errorf(str, funcName, cfg.BanDuration)
 		fmt.Fprintln(os.Stderr, err)
 		fmt.Fprintln(os.Stderr, usageMessage)
@@ -620,7 +620,7 @@ func loadConfig() (*config, []string, error) {
 			if err != nil {
 				ip = net.ParseIP(addr)
 				if ip == nil {
-					str := "%s: The whitelist value of '%s' is invalid"
+					str := "%s: the whitelist value of '%s' is invalid"
 					err = fmt.Errorf(str, funcName, addr)
 					fmt.Fprintln(os.Stderr, err)
 					fmt.Fprintln(os.Stderr, usageMessage)
@@ -712,7 +712,7 @@ func loadConfig() (*config, []string, error) {
 	}
 
 	if cfg.RPCMaxConcurrentReqs < 0 {
-		str := "%s: The rpcmaxwebsocketconcurrentrequests option may " +
+		str := "%s: the rpcmaxwebsocketconcurrentrequests option may " +
 			"not be less than 0 -- parsed [%d]"
 		err := fmt.Errorf(str, funcName, cfg.RPCMaxConcurrentReqs)
 		fmt.Fprintln(os.Stderr, err)
@@ -734,7 +734,7 @@ func loadConfig() (*config, []string, error) {
 	if cfg.BlockMaxSize < blockMaxSizeMin || cfg.BlockMaxSize >
 		blockMaxSizeMax {
 
-		str := "%s: The blockmaxsize option must be in between %d " +
+		str := "%s: the blockmaxsize option must be in between %d " +
 			"and %d -- parsed [%d]"
 		err := fmt.Errorf(str, funcName, blockMaxSizeMin,
 			blockMaxSizeMax, cfg.BlockMaxSize)
@@ -745,7 +745,7 @@ func loadConfig() (*config, []string, error) {
 
 	// Limit the max orphan count to a sane vlue.
 	if cfg.MaxOrphanTxs < 0 {
-		str := "%s: The maxorphantx option may not be less than 0 " +
+		str := "%s: the maxorphantx option may not be less than 0 " +
 			"-- parsed [%d]"
 		err := fmt.Errorf(str, funcName, cfg.MaxOrphanTxs)
 		fmt.Fprintln(os.Stderr, err)

--- a/database/cmd/dbtool/globalconfig.go
+++ b/database/cmd/dbtool/globalconfig.go
@@ -81,7 +81,7 @@ func setupGlobalConfig() error {
 
 	// Validate database type.
 	if !validDbType(cfg.DbType) {
-		str := "The specified database type [%v] is invalid -- " +
+		str := "the specified database type [%v] is invalid -- " +
 			"supported types %v"
 		return fmt.Errorf(str, cfg.DbType, knownDbTypes)
 	}

--- a/database/cmd/dbtool/insecureimport.go
+++ b/database/cmd/dbtool/insecureimport.go
@@ -170,7 +170,7 @@ out:
 		// notify the status handler with the error and bail.
 		serializedBlock, err := bi.readBlock()
 		if err != nil {
-			bi.errChan <- fmt.Errorf("Error reading from input "+
+			bi.errChan <- fmt.Errorf("error reading from input "+
 				"file: %v", err.Error())
 			break out
 		}
@@ -334,7 +334,7 @@ func (cmd *importCmd) Execute(args []string) error {
 
 	// Ensure the specified block file exists.
 	if !fileExists(cmd.InFile) {
-		str := "The specified block file [%v] does not exist"
+		str := "the specified block file [%v] does not exist"
 		return fmt.Errorf(str, cmd.InFile)
 	}
 

--- a/database/ffldb/driver_test.go
+++ b/database/ffldb/driver_test.go
@@ -210,7 +210,7 @@ func TestPersistence(t *testing.T) {
 	db.Close()
 	db, err = database.Open(dbType, dbPath, blockDataNet)
 	if err != nil {
-		t.Errorf("Failed to open test database (%s) %v", dbType, err)
+		t.Errorf("failed to open test database (%s) %v", dbType, err)
 		return
 	}
 	defer db.Close()
@@ -264,7 +264,7 @@ func TestInterface(t *testing.T) {
 	_ = os.RemoveAll(dbPath)
 	db, err := database.Create(dbType, dbPath, blockDataNet)
 	if err != nil {
-		t.Errorf("Failed to create test database (%s) %v", dbType, err)
+		t.Errorf("failed to create test database (%s) %v", dbType, err)
 		return
 	}
 	defer os.RemoveAll(dbPath)

--- a/wire/msgversion.go
+++ b/wire/msgversion.go
@@ -81,7 +81,7 @@ func (msg *MsgVersion) AddService(service ServiceFlag) {
 func (msg *MsgVersion) BtcDecode(r io.Reader, pver uint32) error {
 	buf, ok := r.(*bytes.Buffer)
 	if !ok {
-		return fmt.Errorf("MsgVersion.BtcDecode reader is not a " +
+		return fmt.Errorf("in method MsgVersion.BtcDecode reader is not a " +
 			"*bytes.Buffer")
 	}
 


### PR DESCRIPTION
As per https://github.com/golang/go/wiki/CodeReviewComments#error-strings,
error strings should not be capitalized
 - Replace Capitalized by lower cases
 - Also, at some places, made a judgement call and added a prefix