### PR TITLE
fullblocktests: Sync upstream block validation.

### DIFF
--- a/blockchain/common_test.go
+++ b/blockchain/common_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -19,6 +19,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/database"
 	_ "github.com/decred/dcrd/database/ffldb"
+	"github.com/decred/dcrd/txscript"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -57,7 +58,7 @@ func isSupportedDbType(dbType string) bool {
 }
 
 // chainSetup is used to create a new db and chain instance with the genesis
-// block already inserted.  In addition to the new chain instnce, it returns
+// block already inserted.  In addition to the new chain instance, it returns
 // a teardown function the caller should invoke when done testing to clean up.
 func chainSetup(dbName string, params *chaincfg.Params) (*blockchain.BlockChain, func(), error) {
 	if !isSupportedDbType(testDbType) {
@@ -117,6 +118,7 @@ func chainSetup(dbName string, params *chaincfg.Params) (*blockchain.BlockChain,
 		DB:          db,
 		ChainParams: &paramsCopy,
 		TimeSource:  blockchain.NewMedianTime(),
+		SigCache:    txscript.NewSigCache(1000),
 	})
 
 	if err != nil {

--- a/blockchain/fullblocktests/README.md
+++ b/blockchain/fullblocktests/README.md
@@ -1,0 +1,29 @@
+fullblocktests
+==============
+
+[![Build Status](http://img.shields.io/travis/decred/dcrd.svg)](https://travis-ci.org/decred/dcrd)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/decred/dcrd/blockchain/fullblocktests)
+
+Package fullblocktests provides a set of full block tests to be used for testing
+the consensus validation rules.  The tests are intended to be flexible enough to
+allow both unit-style tests directly against the blockchain code as well as
+integration style tests over the peer-to-peer network.  To achieve that goal,
+each test contains additional information about the expected result, however
+that information can be ignored when doing comparison tests between two
+independent versions over the peer-to-peer network.
+
+This package has intentionally been designed so it can be used as a standalone
+package for any projects needing to test their implementation against a full set
+of blocks that excerise the consensus validation rules.
+
+## Installation and Updating
+
+```bash
+$ go get -u github.com/decred/dcrd/blockchain/fullblocktests
+```
+
+## License
+
+Package fullblocktests is licensed under the [copyfree](http://copyfree.org) ISC
+License.

--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -39,13 +39,13 @@ const (
 )
 
 var (
-	// lowFee is a single atom and exists to make the test code more
-	// readable.
-	lowFee = dcrutil.Amount(1)
-
 	// opTrueScript is a simple public key script that contains the OP_TRUE
 	// opcode.  It is defined here to reduce garbage creation.
 	opTrueScript = []byte{txscript.OP_TRUE}
+
+	// lowFee is a single atom and exists to make the test code more
+	// readable.
+	lowFee = dcrutil.Amount(1)
 )
 
 // TestInstance is an interface that describes a specific test instance returned


### PR DESCRIPTION
Upstream commit f21410e47c5ae0a14849c54f7b8076f5c2f874e9.

These tests have already been synced via a separate commit, so this primarily just minimizes a few differences and picks up the `README.md` for the `fullblocktests` package.

The merge commit modifies the paths in the `README.md`  for Decred accordingly.
