### PR TITLE
txscript: Force extracted addrs to compressed.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 153a3e6a1f31b2b29a113e953098f2b42a645103ee3e10040b5e03727a7b003c
-updated: 2017-07-26T12:10:25.6313172-05:00
+updated: 2017-07-30T06:56:59.170962642Z
 imports:
 - name: github.com/agl/ed25519
   version: 278e1ec8e8a6e017cd07577924d6766039146ced
@@ -51,7 +51,7 @@ imports:
 - name: github.com/decred/dcrrpcclient
   version: a634f8dff51115b4122664efbed1a9327063dcf0
 - name: github.com/decred/dcrutil
-  version: 58e046aab848365647c44b295f4fab078fbc3392
+  version: c12bb391708716e0420d02cf9e7e28ba50bba062
   subpackages:
   - base58
   - bloom

--- a/txscript/sign_test.go
+++ b/txscript/sign_test.go
@@ -670,9 +670,10 @@ func TestSignTxOutput(t *testing.T) {
 
 				keyDB, _, _, err := secp256k1.GenerateKey(rand.Reader)
 				key, pk := secp256k1.PrivKeyFromBytes(keyDB)
-				pkBytes := pk.SerializeUncompressed()
-
-				address, err := dcrutil.NewAddressSecpPubKey(pkBytes,
+				// For address generation, consensus rules require using
+				// a compressed public key. Look up ExtractPkScriptAddrs
+				// for more details
+				address, err := dcrutil.NewAddressSecpPubKeyCompressed(pk,
 					testingParams)
 				if err != nil {
 					t.Errorf("failed to make address for %s: %v",
@@ -722,8 +723,10 @@ func TestSignTxOutput(t *testing.T) {
 				case secp:
 					keyDB, _, _, _ = secp256k1.GenerateKey(rand.Reader)
 					key, pk = secp256k1.PrivKeyFromBytes(keyDB)
-					pkBytes = pk.SerializeUncompressed()
-					address, err = dcrutil.NewAddressSecpPubKey(pkBytes,
+					// For address generation, consensus rules require using
+					// a compressed public key. Look up ExtractPkScriptAddrs
+					// for more details
+					address, err = dcrutil.NewAddressSecpPubKeyCompressed(pk,
 						testingParams)
 					if err != nil {
 						t.Errorf("failed to make address for %s: %v",
@@ -813,8 +816,10 @@ func TestSignTxOutput(t *testing.T) {
 				case secp:
 					keyDB, _, _, _ = secp256k1.GenerateKey(rand.Reader)
 					key, pk = secp256k1.PrivKeyFromBytes(keyDB)
-					pkBytes = pk.SerializeCompressed()
-					address, err = dcrutil.NewAddressSecpPubKey(pkBytes,
+					// For address generation, consensus rules require using
+					// a compressed public key. Look up ExtractPkScriptAddrs
+					// for more details
+					address, err = dcrutil.NewAddressSecpPubKeyCompressed(pk,
 						testingParams)
 					if err != nil {
 						t.Errorf("failed to make address for %s: %v",
@@ -889,8 +894,7 @@ func TestSignTxOutput(t *testing.T) {
 				case secp:
 					keyDB, _, _, _ = secp256k1.GenerateKey(rand.Reader)
 					key, pk = secp256k1.PrivKeyFromBytes(keyDB)
-					pkBytes = pk.SerializeCompressed()
-					address, err = dcrutil.NewAddressSecpPubKey(pkBytes,
+					address, err = dcrutil.NewAddressSecpPubKeyCompressed(pk,
 						testingParams)
 					if err != nil {
 						t.Errorf("failed to make address for %s: %v",
@@ -1324,8 +1328,10 @@ func TestSignTxOutput(t *testing.T) {
 				case secp:
 					keyDB, _, _, _ = secp256k1.GenerateKey(rand.Reader)
 					key, pk = secp256k1.PrivKeyFromBytes(keyDB)
-					pkBytes = pk.SerializeUncompressed()
-					address, err = dcrutil.NewAddressSecpPubKey(pkBytes,
+					// For address generation, consensus rules require using
+					// a compressed public key. Look up ExtractPkScriptAddrs
+					// for more details
+					address, err = dcrutil.NewAddressSecpPubKeyCompressed(pk,
 						testingParams)
 					if err != nil {
 						t.Errorf("failed to make address for %s: %v",
@@ -1419,8 +1425,10 @@ func TestSignTxOutput(t *testing.T) {
 				case secp:
 					keyDB, _, _, _ = secp256k1.GenerateKey(rand.Reader)
 					key, pk = secp256k1.PrivKeyFromBytes(keyDB)
-					pkBytes = pk.SerializeUncompressed()
-					address, err = dcrutil.NewAddressSecpPubKey(pkBytes,
+					// For address generation, consensus rules require using
+					// a compressed public key. Look up ExtractPkScriptAddrs
+					// for more details
+					address, err = dcrutil.NewAddressSecpPubKeyCompressed(pk,
 						testingParams)
 					if err != nil {
 						t.Errorf("failed to make address for %s: %v",
@@ -1529,8 +1537,7 @@ func TestSignTxOutput(t *testing.T) {
 				case secp:
 					keyDB, _, _, _ = secp256k1.GenerateKey(rand.Reader)
 					key, pk = secp256k1.PrivKeyFromBytes(keyDB)
-					pkBytes = pk.SerializeCompressed()
-					address, err = dcrutil.NewAddressSecpPubKey(pkBytes,
+					address, err = dcrutil.NewAddressSecpPubKeyCompressed(pk,
 						testingParams)
 					if err != nil {
 						t.Errorf("failed to make address for %s: %v",
@@ -1624,8 +1631,7 @@ func TestSignTxOutput(t *testing.T) {
 				case secp:
 					keyDB, _, _, _ = secp256k1.GenerateKey(rand.Reader)
 					key, pk = secp256k1.PrivKeyFromBytes(keyDB)
-					pkBytes = pk.SerializeCompressed()
-					address, err = dcrutil.NewAddressSecpPubKey(pkBytes,
+					address, err = dcrutil.NewAddressSecpPubKeyCompressed(pk,
 						testingParams)
 					if err != nil {
 						t.Errorf("failed to make address for %s: %v",
@@ -1725,9 +1731,8 @@ func TestSignTxOutput(t *testing.T) {
 
 			keyDB1, _, _, err := secp256k1.GenerateKey(rand.Reader)
 			key1, pk1 := secp256k1.PrivKeyFromBytes(keyDB1)
-			pk1Bytes := pk1.SerializeUncompressed()
 
-			address1, err := dcrutil.NewAddressSecpPubKey(pk1Bytes,
+			address1, err := dcrutil.NewAddressSecpPubKeyCompressed(pk1,
 				testingParams)
 			if err != nil {
 				t.Errorf("failed to make address for %s: %v",
@@ -1737,9 +1742,8 @@ func TestSignTxOutput(t *testing.T) {
 
 			keyDB2, _, _, err := secp256k1.GenerateKey(rand.Reader)
 			key2, pk2 := secp256k1.PrivKeyFromBytes(keyDB2)
-			pk2Bytes := pk2.SerializeUncompressed()
 
-			address2, err := dcrutil.NewAddressSecpPubKey(pk2Bytes,
+			address2, err := dcrutil.NewAddressSecpPubKeyCompressed(pk2,
 				testingParams)
 			if err != nil {
 				t.Errorf("failed to make address 2 for %s: %v",
@@ -1802,9 +1806,8 @@ func TestSignTxOutput(t *testing.T) {
 
 			keyDB1, _, _, err := secp256k1.GenerateKey(rand.Reader)
 			key1, pk1 := secp256k1.PrivKeyFromBytes(keyDB1)
-			pk1Bytes := pk1.SerializeUncompressed()
 
-			address1, err := dcrutil.NewAddressSecpPubKey(pk1Bytes,
+			address1, err := dcrutil.NewAddressSecpPubKeyCompressed(pk1,
 				testingParams)
 			if err != nil {
 				t.Errorf("failed to make address for %s: %v",
@@ -1814,9 +1817,8 @@ func TestSignTxOutput(t *testing.T) {
 
 			keyDB2, _, _, err := secp256k1.GenerateKey(rand.Reader)
 			key2, pk2 := secp256k1.PrivKeyFromBytes(keyDB2)
-			pk2Bytes := pk2.SerializeUncompressed()
 
-			address2, err := dcrutil.NewAddressSecpPubKey(pk2Bytes,
+			address2, err := dcrutil.NewAddressSecpPubKeyCompressed(pk2,
 				testingParams)
 			if err != nil {
 				t.Errorf("failed to make address 2 for %s: %v",
@@ -1899,9 +1901,8 @@ func TestSignTxOutput(t *testing.T) {
 
 			keyDB1, _, _, err := secp256k1.GenerateKey(rand.Reader)
 			key1, pk1 := secp256k1.PrivKeyFromBytes(keyDB1)
-			pk1Bytes := pk1.SerializeUncompressed()
 
-			address1, err := dcrutil.NewAddressSecpPubKey(pk1Bytes,
+			address1, err := dcrutil.NewAddressSecpPubKeyCompressed(pk1,
 				testingParams)
 			if err != nil {
 				t.Errorf("failed to make address for %s: %v",
@@ -1911,9 +1912,7 @@ func TestSignTxOutput(t *testing.T) {
 
 			keyDB2, _, _, err := secp256k1.GenerateKey(rand.Reader)
 			key2, pk2 := secp256k1.PrivKeyFromBytes(keyDB2)
-			pk2Bytes := pk2.SerializeUncompressed()
-
-			address2, err := dcrutil.NewAddressSecpPubKey(pk2Bytes,
+			address2, err := dcrutil.NewAddressSecpPubKeyCompressed(pk2,
 				testingParams)
 			if err != nil {
 				t.Errorf("failed to make address 2 for %s: %v",

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -1198,9 +1198,12 @@ func ExtractPkScriptAddrs(version uint16, pkScript []byte,
 		// Therefore the pubkey is the first item on the stack.
 		// Skip the pubkey if it's invalid for some reason.
 		requiredSigs = 1
-		addr, err := dcrutil.NewAddressSecpPubKey(pops[0].data, chainParams)
+		pk, err := chainec.Secp256k1.ParsePubKey(pops[0].data)
 		if err == nil {
-			addrs = append(addrs, addr)
+			addr, err := dcrutil.NewAddressSecpPubKeyCompressed(pk, chainParams)
+			if err == nil {
+				addrs = append(addrs, addr)
+			}
 		}
 
 	case PubkeyAltTy:
@@ -1291,10 +1294,13 @@ func ExtractPkScriptAddrs(version uint16, pkScript []byte,
 		// Extract the public keys while skipping any that are invalid.
 		addrs = make([]dcrutil.Address, 0, numPubKeys)
 		for i := 0; i < numPubKeys; i++ {
-			addr, err := dcrutil.NewAddressSecpPubKey(pops[i+1].data,
-				chainParams)
+			pubkey, err := chainec.Secp256k1.ParsePubKey(pops[i+1].data)
 			if err == nil {
-				addrs = append(addrs, addr)
+				addr, err := dcrutil.NewAddressSecpPubKeyCompressed(pubkey,
+					chainParams)
+				if err == nil {
+					addrs = append(addrs, addr)
+				}
 			}
 		}
 


### PR DESCRIPTION
~~This requires PR decred/dcrutil#55~~.

Decred's consensus rules require address generation to use a compressed pubkey format, this was hacked
into `btcutil.NewAddressSecpPubKey`. This commit removes the hack and provides `btcutil.NewAddressSecpPubKeyCompressed` to enforce the consensus prerequisite