### PR TITLE
wire/peer: Implement feefilter p2p message.

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2016 The Decred developers
+// Copyright (c) 2016-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -28,7 +28,7 @@ import (
 
 const (
 	// MaxProtocolVersion is the max protocol version the peer supports.
-	MaxProtocolVersion = wire.MaxBlockSizeVersion
+	MaxProtocolVersion = wire.FeeFilterVersion
 
 	// outputBufferSize is the number of elements the output channels use.
 	outputBufferSize = 5000
@@ -146,6 +146,9 @@ type MessageListeners struct {
 	// OnGetHeaders is invoked when a peer receives a getheaders wire
 	// message.
 	OnGetHeaders func(p *Peer, msg *wire.MsgGetHeaders)
+
+	// OnFeeFilter is invoked when a peer receives a feefilter wire message.
+	OnFeeFilter func(p *Peer, msg *wire.MsgFeeFilter)
 
 	// OnFilterAdd is invoked when a peer receives a filteradd wire message.
 	OnFilterAdd func(p *Peer, msg *wire.MsgFilterAdd)
@@ -1489,6 +1492,11 @@ out:
 		case *wire.MsgGetHeaders:
 			if p.cfg.Listeners.OnGetHeaders != nil {
 				p.cfg.Listeners.OnGetHeaders(p, msg)
+			}
+
+		case *wire.MsgFeeFilter:
+			if p.cfg.Listeners.OnFeeFilter != nil {
+				p.cfg.Listeners.OnFeeFilter(p, msg)
 			}
 
 		case *wire.MsgFilterAdd:

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2015-2016 The btcsuite developers
-// Copyright (c) 2016 The Decred developers
+// Copyright (c) 2016-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -361,6 +361,9 @@ func TestPeerListeners(t *testing.T) {
 			OnGetHeaders: func(p *peer.Peer, msg *wire.MsgGetHeaders) {
 				ok <- msg
 			},
+			OnFeeFilter: func(p *peer.Peer, msg *wire.MsgFeeFilter) {
+				ok <- msg
+			},
 			OnFilterAdd: func(p *peer.Peer, msg *wire.MsgFilterAdd) {
 				ok <- msg
 			},
@@ -481,6 +484,10 @@ func TestPeerListeners(t *testing.T) {
 		{
 			"OnGetHeaders",
 			wire.NewMsgGetHeaders(),
+		},
+		{
+			"OnFeeFilter",
+			wire.NewMsgFeeFilter(15000),
 		},
 		{
 			"OnFilterAdd",
@@ -664,6 +671,7 @@ func TestOutboundPeer(t *testing.T) {
 	p2.QueueMessage(wire.NewMsgMemPool(), nil)
 	p2.QueueMessage(wire.NewMsgGetData(), nil)
 	p2.QueueMessage(wire.NewMsgGetHeaders(), nil)
+	p2.QueueMessage(wire.NewMsgFeeFilter(20000), nil)
 
 	p2.Disconnect()
 }

--- a/wire/doc.go
+++ b/wire/doc.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -157,5 +157,6 @@ This package includes spec changes outlined by the following BIPs:
 	BIP0037 (https://github.com/bitcoin/bips/blob/master/bip-0037.mediawiki)
 	BIP0111	(https://github.com/bitcoin/bips/blob/master/bip-0111.mediawiki)
 	BIP0130 (https://github.com/bitcoin/bips/blob/master/bip-0130.mediawiki)
+	BIP0133 (https://github.com/bitcoin/bips/blob/master/bip-0133.mediawiki)
 */
 package wire

--- a/wire/message.go
+++ b/wire/message.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -53,6 +53,7 @@ const (
 	CmdMerkleBlock    = "merkleblock"
 	CmdReject         = "reject"
 	CmdSendHeaders    = "sendheaders"
+	CmdFeeFilter      = "feefilter"
 )
 
 // Message is an interface that describes a decred message.  A type that
@@ -142,6 +143,9 @@ func makeEmptyMessage(command string) (Message, error) {
 
 	case CmdSendHeaders:
 		msg = &MsgSendHeaders{}
+
+	case CmdFeeFilter:
+		msg = &MsgFeeFilter{}
 
 	default:
 		return nil, fmt.Errorf("unhandled command [%s]", command)

--- a/wire/msgfeefilter.go
+++ b/wire/msgfeefilter.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2016 The btcsuite developers
+// Copyright (c) 2017 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"fmt"
+	"io"
+)
+
+// MsgFeeFilter implements the Message interface and represents a feefilter
+// message.  It is used to request the receiving peer does not announce any
+// transactions below the specified minimum fee rate.
+//
+// This message was not added until protocol versions starting with
+// FeeFilterVersion.
+type MsgFeeFilter struct {
+	MinFee int64
+}
+
+// BtcDecode decodes r using the protocol encoding into the receiver.
+// This is part of the Message interface implementation.
+func (msg *MsgFeeFilter) BtcDecode(r io.Reader, pver uint32) error {
+	if pver < FeeFilterVersion {
+		str := fmt.Sprintf("feefilter message invalid for protocol "+
+			"version %d", pver)
+		return messageError("MsgFeeFilter.BtcDecode", str)
+	}
+
+	err := readElement(r, &msg.MinFee)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// BtcEncode encodes the receiver to w using the protocol encoding.
+// This is part of the Message interface implementation.
+func (msg *MsgFeeFilter) BtcEncode(w io.Writer, pver uint32) error {
+	if pver < FeeFilterVersion {
+		str := fmt.Sprintf("feefilter message invalid for protocol "+
+			"version %d", pver)
+		return messageError("MsgFeeFilter.BtcEncode", str)
+	}
+
+	err := writeElement(w, msg.MinFee)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Command returns the protocol command string for the message.  This is part
+// of the Message interface implementation.
+func (msg *MsgFeeFilter) Command() string {
+	return CmdFeeFilter
+}
+
+// MaxPayloadLength returns the maximum length the payload can be for the
+// receiver.  This is part of the Message interface implementation.
+func (msg *MsgFeeFilter) MaxPayloadLength(pver uint32) uint32 {
+	// 8 bytes min fee.
+	return 8
+}
+
+// NewMsgFeeFilter returns a new feefilter message that conforms to the Message
+// interface.  See MsgFeeFilter for details.
+func NewMsgFeeFilter(minfee int64) *MsgFeeFilter {
+	return &MsgFeeFilter{
+		MinFee: minfee,
+	}
+}

--- a/wire/msgfeefilter_test.go
+++ b/wire/msgfeefilter_test.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2013-2016 The btcsuite developers
+// Copyright (c) 2017 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"bytes"
+	"io"
+	"math/rand"
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+// TestFeeFilterLatest tests the MsgFeeFilter API against the latest protocol version.
+func TestFeeFilterLatest(t *testing.T) {
+	pver := ProtocolVersion
+
+	minfee := rand.Int63()
+	msg := NewMsgFeeFilter(minfee)
+	if msg.MinFee != minfee {
+		t.Errorf("NewMsgFeeFilter: wrong minfee - got %v, want %v",
+			msg.MinFee, minfee)
+	}
+
+	// Ensure the command is expected value.
+	wantCmd := "feefilter"
+	if cmd := msg.Command(); cmd != wantCmd {
+		t.Errorf("NewMsgFeeFilter: wrong command - got %v want %v",
+			cmd, wantCmd)
+	}
+
+	// Ensure max payload is expected value for latest protocol version.
+	wantPayload := uint32(8)
+	maxPayload := msg.MaxPayloadLength(pver)
+	if maxPayload != wantPayload {
+		t.Errorf("MaxPayloadLength: wrong max payload length for "+
+			"protocol version %d - got %v, want %v", pver,
+			maxPayload, wantPayload)
+	}
+
+	// Test encode with latest protocol version.
+	var buf bytes.Buffer
+	err := msg.BtcEncode(&buf, pver)
+	if err != nil {
+		t.Errorf("encode of MsgFeeFilter failed %v err <%v>", msg, err)
+	}
+
+	// Test decode with latest protocol version.
+	readmsg := NewMsgFeeFilter(0)
+	err = readmsg.BtcDecode(&buf, pver)
+	if err != nil {
+		t.Errorf("decode of MsgFeeFilter failed [%v] err <%v>", buf, err)
+	}
+
+	// Ensure minfee is the same.
+	if msg.MinFee != readmsg.MinFee {
+		t.Errorf("Should get same minfee for protocol version %d", pver)
+	}
+
+	return
+}
+
+// TestFeeFilterWire tests the MsgFeeFilter wire encode and decode for various protocol
+// versions.
+func TestFeeFilterWire(t *testing.T) {
+	tests := []struct {
+		in   MsgFeeFilter // Message to encode
+		out  MsgFeeFilter // Expected decoded message
+		buf  []byte       // Wire encoding
+		pver uint32       // Protocol version for wire encoding
+	}{
+		// Latest protocol version.
+		{
+			MsgFeeFilter{MinFee: 123123}, // 0x1e0f3
+			MsgFeeFilter{MinFee: 123123}, // 0x1e0f3
+			[]byte{0xf3, 0xe0, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00},
+			ProtocolVersion,
+		},
+
+		// Protocol version FeeFilterVersion
+		{
+			MsgFeeFilter{MinFee: 456456}, // 0x6f708
+			MsgFeeFilter{MinFee: 456456}, // 0x6f708
+			[]byte{0x08, 0xf7, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00},
+			FeeFilterVersion,
+		},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		// Encode the message to wire format.
+		var buf bytes.Buffer
+		err := test.in.BtcEncode(&buf, test.pver)
+		if err != nil {
+			t.Errorf("BtcEncode #%d error %v", i, err)
+			continue
+		}
+		if !bytes.Equal(buf.Bytes(), test.buf) {
+			t.Errorf("BtcEncode #%d\n got: %s want: %s", i,
+				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
+			continue
+		}
+
+		// Decode the message from wire format.
+		var msg MsgFeeFilter
+		rbuf := bytes.NewReader(test.buf)
+		err = msg.BtcDecode(rbuf, test.pver)
+		if err != nil {
+			t.Errorf("BtcDecode #%d error %v", i, err)
+			continue
+		}
+		if !reflect.DeepEqual(msg, test.out) {
+			t.Errorf("BtcDecode #%d\n got: %s want: %s", i,
+				spew.Sdump(msg), spew.Sdump(test.out))
+			continue
+		}
+	}
+}
+
+// TestFeeFilterWireErrors performs negative tests against wire encode and decode
+// of MsgFeeFilter to confirm error paths work correctly.
+func TestFeeFilterWireErrors(t *testing.T) {
+	pver := ProtocolVersion
+	pverNoFeeFilter := FeeFilterVersion - 1
+	wireErr := &MessageError{}
+
+	baseFeeFilter := NewMsgFeeFilter(123123) // 0x1e0f3
+	baseFeeFilterEncoded := []byte{
+		0xf3, 0xe0, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+	}
+
+	tests := []struct {
+		in       *MsgFeeFilter // Value to encode
+		buf      []byte        // Wire encoding
+		pver     uint32        // Protocol version for wire encoding
+		max      int           // Max size of fixed buffer to induce errors
+		writeErr error         // Expected write error
+		readErr  error         // Expected read error
+	}{
+		// Latest protocol version with intentional read/write errors.
+		// Force error in minfee.
+		{baseFeeFilter, baseFeeFilterEncoded, pver, 0, io.ErrShortWrite, io.EOF},
+		// Force error due to unsupported protocol version.
+		{baseFeeFilter, baseFeeFilterEncoded, pverNoFeeFilter, 4, wireErr, wireErr},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		// Encode to wire format.
+		w := newFixedWriter(test.max)
+		err := test.in.BtcEncode(w, test.pver)
+		if reflect.TypeOf(err) != reflect.TypeOf(test.writeErr) {
+			t.Errorf("BtcEncode #%d wrong error got: %v, want: %v",
+				i, err, test.writeErr)
+			continue
+		}
+
+		// For errors which are not of type MessageError, check them for
+		// equality.
+		if _, ok := err.(*MessageError); !ok {
+			if err != test.writeErr {
+				t.Errorf("BtcEncode #%d wrong error got: %v, "+
+					"want: %v", i, err, test.writeErr)
+				continue
+			}
+		}
+
+		// Decode from wire format.
+		var msg MsgFeeFilter
+		r := newFixedReader(test.max, test.buf)
+		err = msg.BtcDecode(r, test.pver)
+		if reflect.TypeOf(err) != reflect.TypeOf(test.readErr) {
+			t.Errorf("BtcDecode #%d wrong error got: %v, want: %v",
+				i, err, test.readErr)
+			continue
+		}
+
+		// For errors which are not of type MessageError, check them for
+		// equality.
+		if _, ok := err.(*MessageError); !ok {
+			if err != test.readErr {
+				t.Errorf("BtcDecode #%d wrong error got: %v, "+
+					"want: %v", i, err, test.readErr)
+				continue
+			}
+		}
+
+	}
+}

--- a/wire/msgversion.go
+++ b/wire/msgversion.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -19,7 +19,7 @@ import (
 const MaxUserAgentLen = 256
 
 // DefaultUserAgent for wire in the stack
-const DefaultUserAgent = "/dcrwire:0.2.2/"
+const DefaultUserAgent = "/dcrwire:0.3.0/"
 
 // MsgVersion implements the Message interface and represents a decred version
 // message.  It is used for a peer to advertise itself as soon as an outbound

--- a/wire/protocol.go
+++ b/wire/protocol.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -17,7 +17,7 @@ const (
 	InitialProcotolVersion uint32 = 1
 
 	// ProtocolVersion is the latest protocol version this package supports.
-	ProtocolVersion uint32 = 4
+	ProtocolVersion uint32 = 5
 
 	// BIP0111Version is the protocol version which added the SFNodeBloom
 	// service flag.
@@ -30,6 +30,10 @@ const (
 	// MaxBlockSizeVersion is the protocol version which increased the
 	// original blocksize.
 	MaxBlockSizeVersion uint32 = 4
+
+	// FeeFilterVersion is the protocol version which added a new
+	// feefilter message.
+	FeeFilterVersion uint32 = 5
 )
 
 // ServiceFlag identifies services supported by a decred peer.


### PR DESCRIPTION
This contains the following upstream commits:
- ca4e9b82d639837e4d7b2071c9c32c0e54f49a4c
- 9935fe5dba371df20afa0af30eb4488d13d44931
- d009185a56930ee32e8415c55956f1000f59213d

The merge commit modifies the protocol versions and the wire default user agent version accordingly along with other minor changes in terms of copyright dates and comment changes.

---

feefilter is used to request the receiving peer does not announce any transactions below the specified minimum fee rate.

NOTE: This only implements the new message type in the `wire` and `peer` packages.  Further PRs will be needed to `dcrd` itself to implement and respond to the message.