### PR TITLE
rpctest: Store logs and data in same path

### DIFF
--- a/rpctest/rpc_harness.go
+++ b/rpctest/rpc_harness.go
@@ -124,7 +124,7 @@ func New(activeNet *chaincfg.Params, handlers *dcrrpcclient.NotificationHandlers
 	miningAddr := fmt.Sprintf("--miningaddr=%s", wallet.coinbaseAddr)
 	extraArgs = append(extraArgs, miningAddr)
 
-	config, err := newConfig("rpctest", certFile, keyFile, extraArgs)
+	config, err := newConfig(nodeTestData, certFile, keyFile, extraArgs)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
logs and data directories are subdirs
of the harness dir, the node dcrd 
process is also run in the working dir
which is the harness dir

thanks to @davecgh for contributing