### PR TITLE
multi: Optimize by removing defers

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -422,9 +422,9 @@ func (b *BlockChain) FetchSubsidyCache() *SubsidyCache {
 // This function is safe for concurrent access.
 func (b *BlockChain) HaveBlock(hash *chainhash.Hash) (bool, error) {
 	b.chainLock.RLock()
-	defer b.chainLock.RUnlock()
-
 	exists, err := b.blockExists(hash)
+	b.chainLock.RUnlock()
+
 	if err != nil {
 		return false, err
 	}
@@ -445,13 +445,10 @@ func (b *BlockChain) IsKnownOrphan(hash *chainhash.Hash) bool {
 	// Protect concurrent access.  Using a read lock only so multiple
 	// readers can query without blocking each other.
 	b.orphanLock.RLock()
-	defer b.orphanLock.RUnlock()
+	_, exists := b.orphans[*hash]
+	b.orphanLock.RUnlock()
 
-	if _, exists := b.orphans[*hash]; exists {
-		return true
-	}
-
-	return false
+	return exists
 }
 
 // GetOrphanRoot returns the head of the chain for the provided hash from the

--- a/peer/mruinvmap.go
+++ b/peer/mruinvmap.go
@@ -51,12 +51,10 @@ func (m *mruInventoryMap) String() string {
 // This function is safe for concurrent access.
 func (m *mruInventoryMap) Exists(iv *wire.InvVect) bool {
 	m.invMtx.Lock()
-	defer m.invMtx.Unlock()
+	_, exists := m.invMap[*iv]
+	m.invMtx.Unlock()
 
-	if _, exists := m.invMap[*iv]; exists {
-		return true
-	}
-	return false
+	return exists
 }
 
 // Add adds the passed inventory to the map and handles eviction of the oldest
@@ -110,12 +108,11 @@ func (m *mruInventoryMap) Add(iv *wire.InvVect) {
 // This function is safe for concurrent access.
 func (m *mruInventoryMap) Delete(iv *wire.InvVect) {
 	m.invMtx.Lock()
-	defer m.invMtx.Unlock()
-
 	if node, exists := m.invMap[*iv]; exists {
 		m.invList.Remove(node)
 		delete(m.invMap, *iv)
 	}
+	m.invMtx.Unlock()
 }
 
 // newMruInventoryMap returns a new inventory map that is limited to the number

--- a/peer/mrunoncemap.go
+++ b/peer/mrunoncemap.go
@@ -49,12 +49,10 @@ func (m *mruNonceMap) String() string {
 // This function is safe for concurrent access.
 func (m *mruNonceMap) Exists(nonce uint64) bool {
 	m.mtx.Lock()
-	defer m.mtx.Unlock()
+	_, exists := m.nonceMap[nonce]
+	m.mtx.Unlock()
 
-	if _, exists := m.nonceMap[nonce]; exists {
-		return true
-	}
-	return false
+	return exists
 }
 
 // Add adds the passed nonce to the map and handles eviction of the oldest item
@@ -108,12 +106,11 @@ func (m *mruNonceMap) Add(nonce uint64) {
 // This function is safe for concurrent access.
 func (m *mruNonceMap) Delete(nonce uint64) {
 	m.mtx.Lock()
-	defer m.mtx.Unlock()
-
 	if node, exists := m.nonceMap[nonce]; exists {
 		m.nonceList.Remove(node)
 		delete(m.nonceMap, nonce)
 	}
+	m.mtx.Unlock()
 }
 
 // newMruNonceMap returns a new nonce map that is limited to the number of

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -489,7 +489,6 @@ func (p *Peer) AddKnownInventory(invVect *wire.InvVect) {
 // This function is safe for concurrent access.
 func (p *Peer) StatsSnapshot() *StatsSnap {
 	p.statsMtx.RLock()
-	defer p.statsMtx.RUnlock()
 
 	p.flagsMtx.Lock()
 	id := p.id
@@ -500,7 +499,7 @@ func (p *Peer) StatsSnapshot() *StatsSnap {
 	p.flagsMtx.Unlock()
 
 	// Get a copy of all relevant flags and stats.
-	return &StatsSnap{
+	statsSnap := &StatsSnap{
 		ID:             id,
 		Addr:           addr,
 		UserAgent:      userAgent,
@@ -519,6 +518,9 @@ func (p *Peer) StatsSnapshot() *StatsSnap {
 		LastPingMicros: p.lastPingMicros,
 		LastPingTime:   p.lastPingTime,
 	}
+
+	p.statsMtx.RUnlock()
+	return statsSnap
 }
 
 // ID returns the peer id.
@@ -526,9 +528,10 @@ func (p *Peer) StatsSnapshot() *StatsSnap {
 // This function is safe for concurrent access.
 func (p *Peer) ID() int32 {
 	p.flagsMtx.Lock()
-	defer p.flagsMtx.Unlock()
+	id := p.id
+	p.flagsMtx.Unlock()
 
-	return p.id
+	return id
 }
 
 // NA returns the peer network address.
@@ -536,9 +539,10 @@ func (p *Peer) ID() int32 {
 // This function is safe for concurrent access.
 func (p *Peer) NA() *wire.NetAddress {
 	p.flagsMtx.Lock()
-	defer p.flagsMtx.Unlock()
+	na := p.na
+	p.flagsMtx.Unlock()
 
-	return p.na
+	return na
 }
 
 // Addr returns the peer address.
@@ -562,9 +566,10 @@ func (p *Peer) Inbound() bool {
 // This function is safe for concurrent access.
 func (p *Peer) Services() wire.ServiceFlag {
 	p.flagsMtx.Lock()
-	defer p.flagsMtx.Unlock()
+	services := p.services
+	p.flagsMtx.Unlock()
 
-	return p.services
+	return services
 }
 
 // UserAgent returns the user agent of the remote peer.
@@ -572,9 +577,10 @@ func (p *Peer) Services() wire.ServiceFlag {
 // This function is safe for concurrent access.
 func (p *Peer) UserAgent() string {
 	p.flagsMtx.Lock()
-	defer p.flagsMtx.Unlock()
+	userAgent := p.userAgent
+	p.flagsMtx.Unlock()
 
-	return p.userAgent
+	return userAgent
 }
 
 // LastAnnouncedBlock returns the last announced block of the remote peer.
@@ -582,9 +588,10 @@ func (p *Peer) UserAgent() string {
 // This function is safe for concurrent access.
 func (p *Peer) LastAnnouncedBlock() *chainhash.Hash {
 	p.statsMtx.RLock()
-	defer p.statsMtx.RUnlock()
+	lastAnnouncedBlock := p.lastAnnouncedBlock
+	p.statsMtx.RUnlock()
 
-	return p.lastAnnouncedBlock
+	return lastAnnouncedBlock
 }
 
 // LastPingNonce returns the last ping nonce of the remote peer.
@@ -592,9 +599,10 @@ func (p *Peer) LastAnnouncedBlock() *chainhash.Hash {
 // This function is safe for concurrent access.
 func (p *Peer) LastPingNonce() uint64 {
 	p.statsMtx.RLock()
-	defer p.statsMtx.RUnlock()
+	lastPingNonce := p.lastPingNonce
+	p.statsMtx.RUnlock()
 
-	return p.lastPingNonce
+	return lastPingNonce
 }
 
 // LastPingTime returns the last ping time of the remote peer.
@@ -602,9 +610,10 @@ func (p *Peer) LastPingNonce() uint64 {
 // This function is safe for concurrent access.
 func (p *Peer) LastPingTime() time.Time {
 	p.statsMtx.RLock()
-	defer p.statsMtx.RUnlock()
+	lastPingTime := p.lastPingTime
+	p.statsMtx.RUnlock()
 
-	return p.lastPingTime
+	return lastPingTime
 }
 
 // LastPingMicros returns the last ping micros of the remote peer.
@@ -612,9 +621,10 @@ func (p *Peer) LastPingTime() time.Time {
 // This function is safe for concurrent access.
 func (p *Peer) LastPingMicros() int64 {
 	p.statsMtx.RLock()
-	defer p.statsMtx.RUnlock()
+	lastPingMicros := p.lastPingMicros
+	p.statsMtx.RUnlock()
 
-	return p.lastPingMicros
+	return lastPingMicros
 }
 
 // VersionKnown returns the whether or not the version of a peer is known
@@ -623,9 +633,10 @@ func (p *Peer) LastPingMicros() int64 {
 // This function is safe for concurrent access.
 func (p *Peer) VersionKnown() bool {
 	p.flagsMtx.Lock()
-	defer p.flagsMtx.Unlock()
+	versionKnown := p.versionKnown
+	p.flagsMtx.Unlock()
 
-	return p.versionKnown
+	return versionKnown
 }
 
 // VerAckReceived returns whether or not a verack message was received by the
@@ -634,9 +645,10 @@ func (p *Peer) VersionKnown() bool {
 // This function is safe for concurrent access.
 func (p *Peer) VerAckReceived() bool {
 	p.flagsMtx.Lock()
-	defer p.flagsMtx.Unlock()
+	verAckReceived := p.verAckReceived
+	p.flagsMtx.Unlock()
 
-	return p.verAckReceived
+	return verAckReceived
 }
 
 // ProtocolVersion returns the negotiated peer protocol version.
@@ -644,9 +656,10 @@ func (p *Peer) VerAckReceived() bool {
 // This function is safe for concurrent access.
 func (p *Peer) ProtocolVersion() uint32 {
 	p.flagsMtx.Lock()
-	defer p.flagsMtx.Unlock()
+	protocolVersion := p.protocolVersion
+	p.flagsMtx.Unlock()
 
-	return p.protocolVersion
+	return protocolVersion
 }
 
 // LastBlock returns the last block of the peer.
@@ -654,9 +667,10 @@ func (p *Peer) ProtocolVersion() uint32 {
 // This function is safe for concurrent access.
 func (p *Peer) LastBlock() int64 {
 	p.statsMtx.RLock()
-	defer p.statsMtx.RUnlock()
+	lastBlock := p.lastBlock
+	p.statsMtx.RUnlock()
 
-	return p.lastBlock
+	return lastBlock
 }
 
 // LastSend returns the last send time of the peer.
@@ -692,9 +706,10 @@ func (p *Peer) BytesReceived() uint64 {
 // This function is safe for concurrent access.
 func (p *Peer) TimeConnected() time.Time {
 	p.statsMtx.RLock()
-	defer p.statsMtx.RUnlock()
+	timeConnected := p.timeConnected
+	p.statsMtx.RUnlock()
 
-	return p.timeConnected
+	return timeConnected
 }
 
 // TimeOffset returns the number of seconds the local time was offset from the
@@ -704,9 +719,10 @@ func (p *Peer) TimeConnected() time.Time {
 // This function is safe for concurrent access.
 func (p *Peer) TimeOffset() int64 {
 	p.statsMtx.RLock()
-	defer p.statsMtx.RUnlock()
+	timeOffset := p.timeOffset
+	p.statsMtx.RUnlock()
 
-	return p.timeOffset
+	return timeOffset
 }
 
 // StartingHeight returns the last known height the peer reported during the
@@ -715,9 +731,10 @@ func (p *Peer) TimeOffset() int64 {
 // This function is safe for concurrent access.
 func (p *Peer) StartingHeight() int64 {
 	p.statsMtx.RLock()
-	defer p.statsMtx.RUnlock()
+	startingHeight := p.startingHeight
+	p.statsMtx.RUnlock()
 
-	return p.startingHeight
+	return startingHeight
 }
 
 // WantsHeaders returns if the peer wants header messages instead of
@@ -726,9 +743,10 @@ func (p *Peer) StartingHeight() int64 {
 // This function is safe for concurrent access.
 func (p *Peer) WantsHeaders() bool {
 	p.flagsMtx.Lock()
-	defer p.flagsMtx.Unlock()
+	sendHeadersPreferred := p.sendHeadersPreferred
+	p.flagsMtx.Unlock()
 
-	return p.sendHeadersPreferred
+	return sendHeadersPreferred
 }
 
 // localVersionMsg creates a version message that can be used to send to the
@@ -1041,9 +1059,6 @@ func (p *Peer) handlePingMsg(msg *wire.MsgPing) {
 // version > BIP0031Version).  There is no effect for older clients or when a
 // ping was not previously sent.
 func (p *Peer) handlePongMsg(msg *wire.MsgPong) {
-	p.statsMtx.Lock()
-	defer p.statsMtx.Unlock()
-
 	// Arguably we could use a buffered channel here sending data
 	// in a fifo manner whenever we send a ping, or a list keeping track of
 	// the times of each ping. For now we just make a best effort and

--- a/rpcwebsocket.go
+++ b/rpcwebsocket.go
@@ -1611,9 +1611,10 @@ func (c *wsClient) QueueNotification(marshalledJSON []byte) error {
 // Disconnected returns whether or not the websocket client is disconnected.
 func (c *wsClient) Disconnected() bool {
 	c.Lock()
-	defer c.Unlock()
+	isDisconnected := c.disconnected
+	c.Unlock()
 
-	return c.disconnected
+	return isDisconnected
 }
 
 // Disconnect disconnects the websocket client.

--- a/server.go
+++ b/server.go
@@ -256,9 +256,10 @@ func (sp *serverPeer) setDisableRelayTx(disable bool) {
 // It is safe for concurrent access.
 func (sp *serverPeer) relayTxDisabled() bool {
 	sp.relayMtx.Lock()
-	defer sp.relayMtx.Unlock()
+	isDisabled := sp.disableRelayTx
+	sp.relayMtx.Unlock()
 
-	return sp.disableRelayTx
+	return isDisabled
 }
 
 // pushAddrMsg sends an addr message to the connected peer using the provided


### PR DESCRIPTION
Upstream commit b1621332cc6d5860f58a7526088569e92af05ae0.

---

Defers are nice for readability but they do add overhead.  This gets rid of defers where it is just as easy as not to use one.