### PR TITLE
txscript: Remove max money from json test data.

### DIFF
--- a/txscript/data/tx_invalid.json
+++ b/txscript/data/tx_invalid.json
@@ -31,36 +31,34 @@
 
 ["Tests for CheckTransaction()"],
 ["No inputs"],
-["Skipped because this is not checked by dcrscript, this is a problem for chain."],
+["Skipped because this is not checked by txscript, this is a problem for chain."],
 
 ["No outputs"],
 [[["0000000000000000000000000000000000000000000000000000000000000100", 0, "HASH160 0x14 0x207b9fa91f9acc57e371d9cc1daed0eb29ee913b EQUAL"]],
 "01000000010001000000000000000000000000000000000000000000000000000000000000000000006d483045022100f16703104aab4e4088317c862daec83440242411b039d14280e03dd33b487ab802201318a7be236672c5c56083eb7a5a195bc57a40af7923ff8545016cd3b571e2a601232103c40e5d339df3f30bf753e7e04450ae4ef76c9e45587d1d993bdc4cd06f0651c7acffffffff0000000000", "P2SH"],
 
 ["Negative output"],
-["Removed because dcrscript doesn't do tx sanity checking."],
+["Removed because txscript doesn't do tx sanity checking."],
 
 ["MAX_MONEY + 1 output"],
-[[["0000000000000000000000000000000000000000000000000000000000000100", 0, "HASH160 0x14 0x49ca9a7f9ad0c9389ea46fcfdb0bc8d9861cb9d9 EQUAL"]],
-"01000000010001000000000000000000000000000000000000000000000000000000000000000000006e493046022100e1eadba00d9296c743cb6ecc703fd9ddc9b3cd12906176a226ae4c18d6b00796022100a71aef7d2874deff681ba6080f1b278bac7bb99c61b08a85f4311970ffe7f63f012321030c0588dc44d92bdcbf8e72093466766fdc265ead8db64517b0c542275b70fffbacffffffff010140075af0750700015100000000", "P2SH"],
+["Removed because txscript doesn't do tx sanity checking."],
 
 ["MAX_MONEY output + 1 output"],
-[[["0000000000000000000000000000000000000000000000000000000000000100", 0, "HASH160 0x14 0xc1dd7eda80da850d8226e1a33409064e8d6d22b1 EQUAL"]],
-"01000000010001000000000000000000000000000000000000000000000000000000000000000000006d483045022027deccc14aa6668e78a8c9da3484fbcd4f9dcc9bb7d1b85146314b21b9ae4d86022100d0b43dece8cfb07348de0ca8bc5b86276fa88f7f2138381128b7c36ab2e42264012321029bb13463ddd5d2cc05da6e84e37536cb9525703cfd8f43afdb414988987a92f6acffffffff020040075af075070001510001000000000000015100000000", "P2SH"],
+["Removed because txscript doesn't do tx sanity checking."],
 
 ["Duplicate inputs"],
-["Removed because dcrscript doesn't check input duplication, chain does"],
+["Removed because txscript doesn't check input duplication, chain does"],
 
 ["Coinbase of size 1"],
 ["Note the input is just required to make the tester happy"],
-["Removed because dcrscript doesn't handle coinbase checking, chain does"],
+["Removed because txscript doesn't handle coinbase checking, chain does"],
 
 ["Coinbase of size 101"],
 ["Note the input is just required to make the tester happy"],
-["Removed because dcrscript doesn't handle coinbase checking, chain does"],
+["Removed because txscript doesn't handle coinbase checking, chain does"],
 
 ["Null txin"],
-["Removed because dcrscript doesn't do tx sanity checking."],
+["Removed because txscript doesn't do tx sanity checking."],
 
 ["Same as the transactions in valid with one input SIGHASH_ALL and one SIGHASH_ANYONECANPAY, but we set the _ANYONECANPAY sequence number, invalidating the SIGHASH_ALL signature"],
 [[["0000000000000000000000000000000000000000000000000000000000000100", 0, "0x21 0x035e7f0d4d0841bcd56c39337ed086b1a633ee770c1ffdd94ac552a95ac2ce0efc CHECKSIG"],


### PR DESCRIPTION
This removes the tests related to max money checks since `txscript` does not do sanity checking on the monetary amounts as that is done by the consensus rules in `blockchain`.

While here, update `dcrscript` -> `txscript` in the comments to reflect reality.

As an aside, the existing tests were invalid anyways since the signatures were invalid and thus the tests were failing for the wrong reason.