### PR TITLE
wire: Remove legacy transaction decoding.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 153a3e6a1f31b2b29a113e953098f2b42a645103ee3e10040b5e03727a7b003c
-updated: 2017-07-30T06:56:59.170962642Z
+updated: 2017-08-04T17:11:05.9130378-05:00
 imports:
 - name: github.com/agl/ed25519
   version: 278e1ec8e8a6e017cd07577924d6766039146ced
@@ -51,7 +51,7 @@ imports:
 - name: github.com/decred/dcrrpcclient
   version: a634f8dff51115b4122664efbed1a9327063dcf0
 - name: github.com/decred/dcrutil
-  version: c12bb391708716e0420d02cf9e7e28ba50bba062
+  version: 4ce0f41cf3f957fcdf3f0de049602ac834449b9c
   subpackages:
   - base58
   - bloom


### PR DESCRIPTION
This is no longer needed since the tests that used it were updated. It really should have never been in the production code anyways. Code only needed by tests should be in the associated test package.