### PR TITLE
mempool/wire: Don't make policy decisions in wire.

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -131,6 +131,11 @@ type Config struct {
 // Policy houses the policy (configuration parameters) which is used to
 // control the mempool.
 type Policy struct {
+	// MaxTxVersion is the max transaction version that the mempool should
+	// accept.  All transactions above this version are rejected as
+	// non-standard.
+	MaxTxVersion uint16
+
 	// DisableRelayPriority defines whether to relay free or low-fee
 	// transactions that do not have enough priority to be relayed.
 	DisableRelayPriority bool
@@ -818,7 +823,8 @@ func (mp *TxPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit, allow
 	// forbid their relaying.
 	if !mp.cfg.Policy.RelayNonStd {
 		err := checkTransactionStandard(tx, txType, nextBlockHeight,
-			mp.cfg.TimeSource, mp.cfg.Policy.MinRelayTxFee)
+			mp.cfg.TimeSource, mp.cfg.Policy.MinRelayTxFee,
+			mp.cfg.Policy.MaxTxVersion)
 		if err != nil {
 			// Attempt to extract a reject code from the error so
 			// it can be retained.  When not possible, fall back to

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -340,6 +340,7 @@ func newPoolHarness(chainParams *chaincfg.Params) (*poolHarness, []spendableOutp
 		chain: chain,
 		txPool: New(&Config{
 			Policy: Policy{
+				MaxTxVersion:         wire.TxVersion,
 				DisableRelayPriority: true,
 				FreeTxRelayLimit:     15.0,
 				MaxOrphanTxs:         5,

--- a/server.go
+++ b/server.go
@@ -2412,6 +2412,7 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 
 	txC := mempool.Config{
 		Policy: mempool.Policy{
+			MaxTxVersion:         1,
 			DisableRelayPriority: cfg.NoRelayPriority,
 			RelayNonStd:          cfg.RelayNonStd,
 			FreeTxRelayLimit:     cfg.FreeTxRelayLimit,

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -1581,10 +1581,3 @@ func writeTxOut(w io.Writer, pver uint32, version int32, to *TxOut) error {
 
 	return WriteVarBytes(w, pver, to.PkScript)
 }
-
-// IsSupportedMsgTxVersion returns if a transaction version is supported or not.
-// Currently, inclusion into the memory pool (and thus blocks) only supports
-// the DefaultMsgTxVersion.
-func IsSupportedMsgTxVersion(msgTx *MsgTx) bool {
-	return msgTx.Version == DefaultMsgTxVersion()
-}


### PR DESCRIPTION
This removes the function `IsSupportedMsgTxVersion` function from `wire` since that is a policy decision and does not belong in `wire`.

It also updates the mempool standard transaction checks to be more inline with the upstream code such that the maximum supported transaction version is specified via a field in the mempool policy
configuration struct.

Finally, it adds a new test to the standard transaction tests to ensure transactions that are not serialized with the full seriaization type are considered nonstandard.