### PR TITLE
multi: Separate tx serialization type from version.

### DIFF
--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2015-2016 The btcsuite developers
-// Copyright (c) 2016 The Decred developers
+// Copyright (c) 2016-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -264,7 +264,7 @@ type spentTxOut struct {
 	pkScript      []byte       // The public key script for the output.
 	stakeExtra    []byte       // Extra information for the staking system.
 	amount        int64        // The amount of the output.
-	txVersion     int32        // The txVersion of creating tx.
+	txVersion     uint16       // The version of creating tx.
 	height        uint32       // Height of the the block containing the tx.
 	index         uint32       // Index in the block of the transaction.
 	scriptVersion uint16       // The version of the scripting language.
@@ -393,7 +393,7 @@ func decodeSpentTxOut(serialized []byte, stxo *spentTxOut, amount int64,
 				"after version")
 		}
 
-		stxo.txVersion = int32(txVersion)
+		stxo.txVersion = uint16(txVersion)
 
 		if stxo.txType == stake.TxTypeSStx {
 			sz := readDeserializeSizeOfMinimalOutputs(serialized[offset:])
@@ -837,7 +837,7 @@ func deserializeUtxoEntry(serialized []byte) (*UtxoEntry, error) {
 
 	// Create a new utxo entry with the details deserialized above to house
 	// all of the utxos.
-	entry := newUtxoEntry(int32(version), uint32(blockHeight),
+	entry := newUtxoEntry(uint16(version), uint32(blockHeight),
 		uint32(blockIndex), isCoinBase, hasExpiry, txType)
 
 	// Add sparse output for unspent outputs 0 and 1 as needed based on the

--- a/blockchain/chainio_test.go
+++ b/blockchain/chainio_test.go
@@ -299,6 +299,7 @@ func TestSpendJournalSerialization(t *testing.T) {
 				stakeExtra:    nil,
 			}},
 			blockTxns: []*wire.MsgTx{{ // Coinbase omitted.
+				SerType: wire.TxSerializeFull,
 				Version: 1,
 				TxIn: []*wire.TxIn{{
 					PreviousOutPoint: wire.OutPoint{
@@ -351,6 +352,7 @@ func TestSpendJournalSerialization(t *testing.T) {
 				stakeExtra:    nil,
 			}},
 			blockTxns: []*wire.MsgTx{{ // Coinbase omitted.
+				SerType: wire.TxSerializeFull,
 				Version: 1,
 				TxIn: []*wire.TxIn{{
 					PreviousOutPoint: wire.OutPoint{
@@ -376,6 +378,7 @@ func TestSpendJournalSerialization(t *testing.T) {
 				LockTime: 0,
 				Expiry:   0,
 			}, {
+				SerType: wire.TxSerializeFull,
 				Version: 1,
 				TxIn: []*wire.TxIn{{
 					PreviousOutPoint: wire.OutPoint{
@@ -438,6 +441,7 @@ func TestSpendJournalSerialization(t *testing.T) {
 				compressed:    true,
 			}},
 			blockTxns: []*wire.MsgTx{{ // Coinbase omitted.
+				SerType: wire.TxSerializeFull,
 				Version: 1,
 				TxIn: []*wire.TxIn{{
 					PreviousOutPoint: wire.OutPoint{
@@ -542,6 +546,7 @@ func TestSpendJournalErrors(t *testing.T) {
 		{
 			name: "Force assertion due to missing stxos",
 			blockTxns: []*wire.MsgTx{{ // Coinbase omitted.
+				SerType: wire.TxSerializeFull,
 				Version: 1,
 				TxIn: []*wire.TxIn{{
 					PreviousOutPoint: wire.OutPoint{
@@ -559,6 +564,7 @@ func TestSpendJournalErrors(t *testing.T) {
 		{
 			name: "Force deserialization error in stxos",
 			blockTxns: []*wire.MsgTx{{ // Coinbase omitted.
+				SerType: wire.TxSerializeFull,
 				Version: 1,
 				TxIn: []*wire.TxIn{{
 					PreviousOutPoint: wire.OutPoint{

--- a/blockchain/fullblocktests/params.go
+++ b/blockchain/fullblocktests/params.go
@@ -69,6 +69,7 @@ var (
 			Height:      uint32(0),
 		},
 		Transactions: []*wire.MsgTx{{
+			SerType: wire.TxSerializeFull,
 			Version: 1,
 			TxIn: []*wire.TxIn{{
 				PreviousOutPoint: wire.OutPoint{

--- a/blockchain/stake/staketx_test.go
+++ b/blockchain/stake/staketx_test.go
@@ -1634,6 +1634,7 @@ var sstxTxOut4VerBad = wire.TxOut{
 // sstxMsgTx is a valid SStx MsgTx with an input and outputs and is used in various
 // tests
 var sstxMsgTx = &wire.MsgTx{
+	SerType: wire.TxSerializeFull,
 	Version: 1,
 	TxIn: []*wire.TxIn{
 		&sstxTxIn,
@@ -1655,6 +1656,7 @@ var sstxMsgTx = &wire.MsgTx{
 
 // sstxMsgTxExtraInputs is an invalid SStx MsgTx with too many inputs
 var sstxMsgTxExtraInput = &wire.MsgTx{
+	SerType: wire.TxSerializeFull,
 	Version: 1,
 	TxIn: []*wire.TxIn{
 		&sstxTxIn, &sstxTxIn, &sstxTxIn, &sstxTxIn, &sstxTxIn, &sstxTxIn,
@@ -1680,6 +1682,7 @@ var sstxMsgTxExtraInput = &wire.MsgTx{
 
 // sstxMsgTxExtraOutputs is an invalid SStx MsgTx with too many outputs
 var sstxMsgTxExtraOutputs = &wire.MsgTx{
+	SerType: wire.TxSerializeFull,
 	Version: 1,
 	TxIn: []*wire.TxIn{
 		&sstxTxIn,
@@ -1721,6 +1724,7 @@ var sstxMsgTxExtraOutputs = &wire.MsgTx{
 // sstxMismatchedInsOuts is an invalid SStx MsgTx with too many outputs for the
 // number of inputs it has
 var sstxMismatchedInsOuts = &wire.MsgTx{
+	SerType: wire.TxSerializeFull,
 	Version: 1,
 	TxIn: []*wire.TxIn{
 		&sstxTxIn,
@@ -1735,6 +1739,7 @@ var sstxMismatchedInsOuts = &wire.MsgTx{
 // sstxBadVersionOut is an invalid SStx MsgTx with an output containing a bad
 // version.
 var sstxBadVersionOut = &wire.MsgTx{
+	SerType: wire.TxSerializeFull,
 	Version: 1,
 	TxIn: []*wire.TxIn{
 		&sstxTxIn,
@@ -1757,6 +1762,7 @@ var sstxBadVersionOut = &wire.MsgTx{
 // sstxNullDataMissing is an invalid SStx MsgTx with no address push in the second
 // output
 var sstxNullDataMissing = &wire.MsgTx{
+	SerType: wire.TxSerializeFull,
 	Version: 1,
 	TxIn: []*wire.TxIn{
 		&sstxTxIn,
@@ -1771,6 +1777,7 @@ var sstxNullDataMissing = &wire.MsgTx{
 // sstxNullDataMisplaced is an invalid SStx MsgTx that has the commitment and
 // change outputs swapped
 var sstxNullDataMisplaced = &wire.MsgTx{
+	SerType: wire.TxSerializeFull,
 	Version: 1,
 	TxIn: []*wire.TxIn{
 		&sstxTxIn,
@@ -1926,6 +1933,7 @@ var ssgenTxOut3BadVer = wire.TxOut{
 // ssgenMsgTx is a valid SSGen MsgTx with an input and outputs and is used in
 // various testing scenarios
 var ssgenMsgTx = &wire.MsgTx{
+	SerType: wire.TxSerializeFull,
 	Version: 1,
 	TxIn: []*wire.TxIn{
 		&ssgenTxIn0,
@@ -1943,6 +1951,7 @@ var ssgenMsgTx = &wire.MsgTx{
 
 // ssgenMsgTxExtraInput is an invalid SSGen MsgTx with too many inputs
 var ssgenMsgTxExtraInput = &wire.MsgTx{
+	SerType: wire.TxSerializeFull,
 	Version: 1,
 	TxIn: []*wire.TxIn{
 		&ssgenTxIn0,
@@ -1960,6 +1969,7 @@ var ssgenMsgTxExtraInput = &wire.MsgTx{
 
 // ssgenMsgTxExtraOutputs is an invalid SSGen MsgTx with too many outputs
 var ssgenMsgTxExtraOutputs = &wire.MsgTx{
+	SerType: wire.TxSerializeFull,
 	Version: 1,
 	TxIn: []*wire.TxIn{
 		&ssgenTxIn0,
@@ -1992,6 +2002,7 @@ var ssgenMsgTxExtraOutputs = &wire.MsgTx{
 // ssgenMsgTxStakeBaseWrong is an invalid SSGen tx with the stakebase in the wrong
 // position
 var ssgenMsgTxStakeBaseWrong = &wire.MsgTx{
+	SerType: wire.TxSerializeFull,
 	Version: 1,
 	TxIn: []*wire.TxIn{
 		&ssgenTxIn1,
@@ -2009,6 +2020,7 @@ var ssgenMsgTxStakeBaseWrong = &wire.MsgTx{
 // ssgenMsgTxBadVerOut is an invalid SSGen tx that contains an output with a bad
 // version
 var ssgenMsgTxBadVerOut = &wire.MsgTx{
+	SerType: wire.TxSerializeFull,
 	Version: 1,
 	TxIn: []*wire.TxIn{
 		&ssgenTxIn0,
@@ -2027,6 +2039,7 @@ var ssgenMsgTxBadVerOut = &wire.MsgTx{
 // ssgenMsgTxWrongZeroethOut is an invalid SSGen tx with the first output being not
 // an OP_RETURN push
 var ssgenMsgTxWrongZeroethOut = &wire.MsgTx{
+	SerType: wire.TxSerializeFull,
 	Version: 1,
 	TxIn: []*wire.TxIn{
 		&ssgenTxIn0,
@@ -2044,6 +2057,7 @@ var ssgenMsgTxWrongZeroethOut = &wire.MsgTx{
 // ssgenMsgTxWrongFirstOut is an invalid SSGen tx with the second output being not
 // an OP_RETURN push
 var ssgenMsgTxWrongFirstOut = &wire.MsgTx{
+	SerType: wire.TxSerializeFull,
 	Version: 1,
 	TxIn: []*wire.TxIn{
 		&ssgenTxIn0,
@@ -2154,6 +2168,7 @@ var ssrtxTxOut2BadVer = wire.TxOut{
 // ssrtxMsgTx is a valid SSRtx MsgTx with an input and outputs and is used in
 // various testing scenarios
 var ssrtxMsgTx = &wire.MsgTx{
+	SerType: wire.TxSerializeFull,
 	Version: 1,
 	TxIn: []*wire.TxIn{
 		&ssrtxTxIn,
@@ -2169,6 +2184,7 @@ var ssrtxMsgTx = &wire.MsgTx{
 // ssrtxMsgTx is a valid SSRtx MsgTx with an input and outputs and is used in
 // various testing scenarios
 var ssrtxMsgTxTooManyInputs = &wire.MsgTx{
+	SerType: wire.TxSerializeFull,
 	Version: 1,
 	TxIn: []*wire.TxIn{
 		&ssrtxTxIn,
@@ -2184,6 +2200,7 @@ var ssrtxMsgTxTooManyInputs = &wire.MsgTx{
 // ssrtxMsgTx is a valid SSRtx MsgTx with an input and outputs and is used in
 // various testing scenarios
 var ssrtxMsgTxTooManyOutputs = &wire.MsgTx{
+	SerType: wire.TxSerializeFull,
 	Version: 1,
 	TxIn: []*wire.TxIn{
 		&ssrtxTxIn,
@@ -2210,6 +2227,7 @@ var ssrtxMsgTxTooManyOutputs = &wire.MsgTx{
 }
 
 var ssrtxMsgTxBadVerOut = &wire.MsgTx{
+	SerType: wire.TxSerializeFull,
 	Version: 1,
 	TxIn: []*wire.TxIn{
 		&ssrtxTxIn,

--- a/blockchain/stake/tickets_test.go
+++ b/blockchain/stake/tickets_test.go
@@ -1106,6 +1106,7 @@ var simNetGenesisMerkleRoot = genesisMerkleRoot
 // genesisCoinbaseTx legacy is the coinbase transaction for the genesis blocks for
 // the regression test network and test network.
 var genesisCoinbaseTxLegacy = wire.MsgTx{
+	SerType: wire.TxSerializeFull,
 	Version: 1,
 	TxIn: []*wire.TxIn{
 		{
@@ -1153,6 +1154,7 @@ var genesisCoinbaseTxLegacy = wire.MsgTx{
 var genesisMerkleRoot = genesisCoinbaseTxLegacy.TxHash()
 
 var regTestGenesisCoinbaseTx = wire.MsgTx{
+	SerType: wire.TxSerializeFull,
 	Version: 1,
 	TxIn: []*wire.TxIn{
 		{

--- a/blockchain/utxoviewpoint.go
+++ b/blockchain/utxoviewpoint.go
@@ -1,4 +1,5 @@
 // Copyright (c) 2015-2016 The btcsuite developers
+// Copyright (c) 2015-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -91,7 +92,7 @@ type UtxoEntry struct {
 	sparseOutputs map[uint32]*utxoOutput // Sparse map of unspent outputs.
 	stakeExtra    []byte                 // Extra data for the staking system.
 
-	txVersion int32        // The tx version of this tx.
+	txVersion uint16       // The tx version of this tx.
 	height    uint32       // Height of block containing tx.
 	index     uint32       // Index of containing tx in block.
 	txType    stake.TxType // The stake type of the transaction.
@@ -103,7 +104,7 @@ type UtxoEntry struct {
 
 // TxVersion returns the transaction version of the transaction the
 // utxo represents.
-func (entry *UtxoEntry) TxVersion() int32 {
+func (entry *UtxoEntry) TxVersion() uint16 {
 	return entry.txVersion
 }
 
@@ -260,7 +261,7 @@ func (entry *UtxoEntry) Clone() *UtxoEntry {
 
 // newUtxoEntry returns a new unspent transaction output entry with the provided
 // coinbase flag and block height ready to have unspent outputs added.
-func newUtxoEntry(txVersion int32, height uint32, index uint32, isCoinBase bool,
+func newUtxoEntry(txVersion uint16, height uint32, index uint32, isCoinBase bool,
 	hasExpiry bool, tt stake.TxType) *UtxoEntry {
 	return &UtxoEntry{
 		sparseOutputs: make(map[uint32]*utxoOutput),

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -2238,6 +2238,7 @@ var simNetGenesisMerkleRoot = genesisMerkleRoot
 // genesisCoinbaseTx legacy is the coinbase transaction for the genesis blocks for
 // the regression test network and test network.
 var genesisCoinbaseTxLegacy = wire.MsgTx{
+	SerType: wire.TxSerializeFull,
 	Version: 1,
 	TxIn: []*wire.TxIn{
 		{
@@ -2285,6 +2286,7 @@ var genesisCoinbaseTxLegacy = wire.MsgTx{
 var genesisMerkleRoot = genesisCoinbaseTxLegacy.TxHash()
 
 var regTestGenesisCoinbaseTx = wire.MsgTx{
+	SerType: wire.TxSerializeFull,
 	Version: 1,
 	TxIn: []*wire.TxIn{
 		{

--- a/chaincfg/genesis.go
+++ b/chaincfg/genesis.go
@@ -17,6 +17,7 @@ import (
 // genesisCoinbaseTx is the coinbase transaction for the genesis blocks for
 // the main network.
 var genesisCoinbaseTx = wire.MsgTx{
+	SerType: wire.TxSerializeFull,
 	Version: 1,
 	TxIn: []*wire.TxIn{
 		{
@@ -91,6 +92,7 @@ var genesisHash = genesisBlock.BlockHash()
 // genesisCoinbaseTxLegacy is the coinbase transaction for the genesis block for
 // the test network.
 var genesisCoinbaseTxLegacy = wire.MsgTx{
+	SerType: wire.TxSerializeFull,
 	Version: 1,
 	TxIn: []*wire.TxIn{
 		{
@@ -162,6 +164,7 @@ var testNet2GenesisHash = testNet2GenesisBlock.BlockHash()
 // SimNet -------------------------------------------------------------------------
 
 var regTestGenesisCoinbaseTx = wire.MsgTx{
+	SerType: wire.TxSerializeFull,
 	Version: 1,
 	TxIn: []*wire.TxIn{
 		{

--- a/mempool/policy.go
+++ b/mempool/policy.go
@@ -350,21 +350,17 @@ func checkTransactionStandard(tx *dcrutil.Tx, txType stake.TxType, height int64,
 	timeSource blockchain.MedianTimeSource, minRelayTxFee dcrutil.Amount,
 	maxTxVersion uint16) error {
 
-	// The transaction must be a currently supported version.
-	//
-	// The version includes the real transaction version in the lower 16
-	// bits and the transaction serialize type as the upper 16 bits.
+	// The transaction must be a currently supported version and serialize
+	// type.
 	msgTx := tx.MsgTx()
-	serType := wire.TxSerializeType(uint32(msgTx.Version) >> 16)
-	txVersion := uint16(uint32(msgTx.Version) & 0xffff)
-	if serType != wire.TxSerializeFull {
+	if msgTx.SerType != wire.TxSerializeFull {
 		str := fmt.Sprintf("transaction is not serialized with all "+
-			"required data -- type %v", serType)
+			"required data -- type %v", msgTx.SerType)
 		return txRuleError(wire.RejectNonstandard, str)
 	}
-	if txVersion > maxTxVersion || txVersion < 1 {
+	if msgTx.Version > maxTxVersion || msgTx.Version < 1 {
 		str := fmt.Sprintf("transaction version %d is not in the "+
-			"valid range of %d-%d", txVersion, 1, maxTxVersion)
+			"valid range of %d-%d", msgTx.Version, 1, maxTxVersion)
 		return txRuleError(wire.RejectNonstandard, str)
 	}
 

--- a/mempool/policy_test.go
+++ b/mempool/policy_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2016 The Decred developers
+// Copyright (c) 2016-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -332,6 +332,7 @@ func TestCheckTransactionStandard(t *testing.T) {
 		{
 			name: "Typical pay-to-pubkey-hash transaction",
 			tx: wire.MsgTx{
+				SerType:  wire.TxSerializeFull,
 				Version:  1,
 				TxIn:     []*wire.TxIn{&dummyTxIn},
 				TxOut:    []*wire.TxOut{&dummyTxOut},
@@ -343,7 +344,8 @@ func TestCheckTransactionStandard(t *testing.T) {
 		{
 			name: "Transaction serialize type not full",
 			tx: wire.MsgTx{
-				Version:  int32(uint32(wire.TxSerializeNoWitness)<<16 | 1),
+				SerType:  wire.TxSerializeNoWitness,
+				Version:  1,
 				TxIn:     []*wire.TxIn{&dummyTxIn},
 				TxOut:    []*wire.TxOut{&dummyTxOut},
 				LockTime: 0,
@@ -355,6 +357,7 @@ func TestCheckTransactionStandard(t *testing.T) {
 		{
 			name: "Transaction version too high",
 			tx: wire.MsgTx{
+				SerType:  wire.TxSerializeFull,
 				Version:  maxTxVersion + 1,
 				TxIn:     []*wire.TxIn{&dummyTxIn},
 				TxOut:    []*wire.TxOut{&dummyTxOut},
@@ -367,6 +370,7 @@ func TestCheckTransactionStandard(t *testing.T) {
 		{
 			name: "Transaction is not finalized",
 			tx: wire.MsgTx{
+				SerType: wire.TxSerializeFull,
 				Version: 1,
 				TxIn: []*wire.TxIn{{
 					PreviousOutPoint: dummyPrevOut,
@@ -383,6 +387,7 @@ func TestCheckTransactionStandard(t *testing.T) {
 		{
 			name: "Transaction size is too large",
 			tx: wire.MsgTx{
+				SerType: wire.TxSerializeFull,
 				Version: 1,
 				TxIn:    []*wire.TxIn{&dummyTxIn},
 				TxOut: []*wire.TxOut{{
@@ -399,6 +404,7 @@ func TestCheckTransactionStandard(t *testing.T) {
 		{
 			name: "Signature script size is too large",
 			tx: wire.MsgTx{
+				SerType: wire.TxSerializeFull,
 				Version: 1,
 				TxIn: []*wire.TxIn{{
 					PreviousOutPoint: dummyPrevOut,
@@ -416,6 +422,7 @@ func TestCheckTransactionStandard(t *testing.T) {
 		{
 			name: "Signature script that does more than push data",
 			tx: wire.MsgTx{
+				SerType: wire.TxSerializeFull,
 				Version: 1,
 				TxIn: []*wire.TxIn{{
 					PreviousOutPoint: dummyPrevOut,
@@ -433,6 +440,7 @@ func TestCheckTransactionStandard(t *testing.T) {
 		{
 			name: "Valid but non standard public key script",
 			tx: wire.MsgTx{
+				SerType: wire.TxSerializeFull,
 				Version: 1,
 				TxIn:    []*wire.TxIn{&dummyTxIn},
 				TxOut: []*wire.TxOut{{
@@ -448,6 +456,7 @@ func TestCheckTransactionStandard(t *testing.T) {
 		{
 			name: "More than four nulldata outputs",
 			tx: wire.MsgTx{
+				SerType: wire.TxSerializeFull,
 				Version: 1,
 				TxIn:    []*wire.TxIn{&dummyTxIn},
 				TxOut: []*wire.TxOut{{
@@ -475,6 +484,7 @@ func TestCheckTransactionStandard(t *testing.T) {
 		{
 			name: "Dust output",
 			tx: wire.MsgTx{
+				SerType: wire.TxSerializeFull,
 				Version: 1,
 				TxIn:    []*wire.TxIn{&dummyTxIn},
 				TxOut: []*wire.TxOut{{
@@ -490,6 +500,7 @@ func TestCheckTransactionStandard(t *testing.T) {
 		{
 			name: "One nulldata output with 0 amount (standard)",
 			tx: wire.MsgTx{
+				SerType: wire.TxSerializeFull,
 				Version: 1,
 				TxIn:    []*wire.TxIn{&dummyTxIn},
 				TxOut: []*wire.TxOut{{

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1350,7 +1350,7 @@ func createTxRawResult(chainParams *chaincfg.Params, mtx *wire.MsgTx, txHash str
 		Txid:        txHash,
 		Vin:         createVinList(mtx),
 		Vout:        createVoutList(mtx, chainParams, nil),
-		Version:     mtx.Version,
+		Version:     int32(mtx.Version),
 		LockTime:    mtx.LockTime,
 		Expiry:      mtx.Expiry,
 		BlockHeight: blkHeight,
@@ -1391,7 +1391,7 @@ func handleDecodeRawTransaction(s *rpcServer, cmd interface{}, closeChan <-chan 
 	// Create and return the result.
 	txReply := dcrjson.TxRawDecodeResult{
 		Txid:     mtx.TxHash().String(),
-		Version:  mtx.Version,
+		Version:  int32(mtx.Version),
 		Locktime: mtx.LockTime,
 		Expiry:   mtx.Expiry,
 		Vin:      createVinList(&mtx),
@@ -3961,7 +3961,7 @@ func handleGetTxOut(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (i
 	// from there, otherwise attempt to fetch from the block database.
 	var bestBlockHash string
 	var confirmations int64
-	var txVersion int32
+	var txVersion uint16
 	var value int64
 	var scriptVersion uint16
 	var pkScript []byte
@@ -4045,7 +4045,7 @@ func handleGetTxOut(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (i
 		BestBlock:     bestBlockHash,
 		Confirmations: confirmations,
 		Value:         dcrutil.Amount(value).ToUnit(dcrutil.AmountCoin),
-		Version:       txVersion,
+		Version:       int32(txVersion),
 		ScriptPubKey: dcrjson.ScriptPubKeyResult{
 			Asm:       disbuf,
 			Hex:       hex.EncodeToString(pkScript),
@@ -4972,7 +4972,7 @@ func handleSearchRawTransactions(s *rpcServer, cmd interface{}, closeChan <-chan
 				"Could not create vin list")
 		}
 		result.Vout = createVoutList(mtx, chainParams, filterAddrMap)
-		result.Version = mtx.Version
+		result.Version = int32(mtx.Version)
 		result.LockTime = mtx.LockTime
 
 		// Transactions grabbed from the mempool aren't yet in a block,

--- a/txscript/engine_test.go
+++ b/txscript/engine_test.go
@@ -33,6 +33,7 @@ func TestBadPC(t *testing.T) {
 	}
 	// tx with almost empty scripts.
 	tx := &wire.MsgTx{
+		SerType: wire.TxSerializeFull,
 		Version: 1,
 		TxIn: []*wire.TxIn{
 			{
@@ -93,6 +94,7 @@ func TestCheckErrorCondition(t *testing.T) {
 
 	// tx with almost empty scripts.
 	tx := &wire.MsgTx{
+		SerType: wire.TxSerializeFull,
 		Version: 1,
 		TxIn: []*wire.TxIn{
 			{
@@ -185,6 +187,7 @@ func TestInvalidFlagCombinations(t *testing.T) {
 
 	// tx with almost empty scripts.
 	tx := &wire.MsgTx{
+		SerType: wire.TxSerializeFull,
 		Version: 1,
 		TxIn: []*wire.TxIn{
 			{

--- a/txscript/script_test.go
+++ b/txscript/script_test.go
@@ -512,6 +512,8 @@ func TestIsPushOnlyScript(t *testing.T) {
 // TestCalcSignatureHash does some rudimentary testing of msg hash calculation.
 func TestCalcSignatureHash(t *testing.T) {
 	tx := new(wire.MsgTx)
+	tx.SerType = wire.TxSerializeFull
+	tx.Version = 1
 	for i := 0; i < 3; i++ {
 		txIn := new(wire.TxIn)
 		txIn.Sequence = 0xFFFFFFFF

--- a/txscript/sign_test.go
+++ b/txscript/sign_test.go
@@ -169,6 +169,7 @@ func TestSignTxOutput(t *testing.T) {
 		secSchnorr,
 	}
 	tx := &wire.MsgTx{
+		SerType: wire.TxSerializeFull,
 		Version: 1,
 		TxIn: []*wire.TxIn{
 			{

--- a/wire/bench_test.go
+++ b/wire/bench_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -19,6 +19,7 @@ import (
 // genesisCoinbaseTx is the coinbase transaction for the genesis blocks for
 // the main network, regression test network, and test network (version 3).
 var genesisCoinbaseTx = MsgTx{
+	SerType: TxSerializeFull,
 	Version: 1,
 	TxIn: []*TxIn{
 		{
@@ -83,6 +84,7 @@ var blockOne = MsgBlock{
 	},
 	Transactions: []*MsgTx{
 		{
+			SerType: TxSerializeFull,
 			Version: 1,
 			TxIn: []*TxIn{
 				{
@@ -316,7 +318,7 @@ func BenchmarkReadTxIn(b *testing.B) {
 	var txIn TxIn
 	for i := 0; i < b.N; i++ {
 		r.Seek(0, 0)
-		readTxInPrefix(r, 0, 0, &txIn)
+		readTxInPrefix(r, 0, TxSerializeFull, 0, &txIn)
 		scriptPool.Return(txIn.SignatureScript)
 	}
 }
@@ -373,7 +375,8 @@ func BenchmarkDeserializeTxSmall(b *testing.B) {
 // deserialize a very large transaction.
 func BenchmarkDeserializeTxLarge(b *testing.B) {
 	bigTx := new(MsgTx)
-	bigTx.Version = DefaultMsgTxVersion()
+	bigTx.SerType = TxSerializeFull
+	bigTx.Version = TxVersion
 	inputsLen := 1000
 	outputsLen := 2000
 	bigTx.TxIn = make([]*TxIn, inputsLen)

--- a/wire/blockheader.go
+++ b/wire/blockheader.go
@@ -37,7 +37,7 @@ type BlockHeader struct {
 	// Merkle tree reference to hash of all stake transactions for the block.
 	StakeRoot chainhash.Hash
 
-	// Votes on the previous merkleroot and yet undecided parameters. (TODO)
+	// Votes on the previous merkleroot and yet undecided parameters.
 	VoteBits uint16
 
 	// Final state of the PRNG used for ticket selection in the lottery.
@@ -93,9 +93,8 @@ func (h *BlockHeader) BlockHash() chainhash.Hash {
 	// transactions.  Ignore the error returns since there is no way the
 	// encode could fail except being out of memory which would cause a
 	// run-time panic.
-	var buf bytes.Buffer
-	buf.Grow(MaxBlockHeaderPayload)
-	_ = writeBlockHeader(&buf, 0, h)
+	buf := bytes.NewBuffer(make([]byte, 0, MaxBlockHeaderPayload))
+	_ = writeBlockHeader(buf, 0, h)
 
 	return chainhash.HashH(buf.Bytes())
 }
@@ -145,17 +144,12 @@ func (h *BlockHeader) Serialize(w io.Writer) error {
 // Bytes returns a byte slice containing the serialized contents of the block
 // header.
 func (h *BlockHeader) Bytes() ([]byte, error) {
-	// Serialize the MsgBlock.
-	var w bytes.Buffer
-	w.Grow(MaxBlockHeaderPayload)
-	err := h.Serialize(&w)
+	buf := bytes.NewBuffer(make([]byte, 0, MaxBlockHeaderPayload))
+	err := h.Serialize(buf)
 	if err != nil {
 		return nil, err
 	}
-	serializedBlockHeader := w.Bytes()
-
-	// Cache the serialized bytes and return them.
-	return serializedBlockHeader, nil
+	return buf.Bytes(), nil
 }
 
 // NewBlockHeader returns a new BlockHeader using the provided previous block

--- a/wire/blockheader_test.go
+++ b/wire/blockheader_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -195,9 +195,8 @@ func TestBlockHeaderWire(t *testing.T) {
 	for i, test := range tests {
 		// Encode to wire format.
 		// Former test (doesn't work because of capacity error)
-		var buf bytes.Buffer
-		buf.Grow(MaxBlockHeaderPayload)
-		err := writeBlockHeader(&buf, test.pver, test.in)
+		buf := bytes.NewBuffer(make([]byte, 0, MaxBlockHeaderPayload))
+		err := writeBlockHeader(buf, test.pver, test.in)
 		if err != nil {
 			t.Errorf("writeBlockHeader #%d error %v", i, err)
 			continue
@@ -209,7 +208,7 @@ func TestBlockHeaderWire(t *testing.T) {
 		}
 
 		buf.Reset()
-		err = test.in.BtcEncode(&buf, pver)
+		err = test.in.BtcEncode(buf, pver)
 		if err != nil {
 			t.Errorf("BtcEncode #%d error %v", i, err)
 			continue
@@ -320,14 +319,13 @@ func TestBlockHeaderSerialize(t *testing.T) {
 	}
 
 	t.Logf("Running %d tests", len(tests))
-	var buf bytes.Buffer
-	buf.Grow(MaxBlockHeaderPayload)
+	buf := bytes.NewBuffer(make([]byte, 0, MaxBlockHeaderPayload))
 	for i, test := range tests {
 		// Clear existing contents.
 		buf.Reset()
 
 		// Serialize the block header.
-		err := test.in.Serialize(&buf)
+		err := test.in.Serialize(buf)
 		if err != nil {
 			t.Errorf("Serialize #%d error %v", i, err)
 			continue

--- a/wire/msgblock.go
+++ b/wire/msgblock.go
@@ -107,7 +107,7 @@ func (msg *MsgBlock) BtcDecode(r io.Reader, pver uint32) error {
 
 	msg.Transactions = make([]*MsgTx, 0, txCount)
 	for i := uint64(0); i < txCount; i++ {
-		tx := MsgTx{}
+		var tx MsgTx
 		err := tx.BtcDecode(r, pver)
 		if err != nil {
 			return err
@@ -131,7 +131,7 @@ func (msg *MsgBlock) BtcDecode(r io.Reader, pver uint32) error {
 
 	msg.STransactions = make([]*MsgTx, 0, stakeTxCount)
 	for i := uint64(0); i < stakeTxCount; i++ {
-		tx := MsgTx{}
+		var tx MsgTx
 		err := tx.BtcDecode(r, pver)
 		if err != nil {
 			return err
@@ -202,7 +202,7 @@ func (msg *MsgBlock) DeserializeTxLoc(r *bytes.Buffer) ([]TxLoc, []TxLoc, error)
 	txLocs := make([]TxLoc, txCount)
 	for i := uint64(0); i < txCount; i++ {
 		txLocs[i].TxStart = fullLen - r.Len()
-		tx := MsgTx{}
+		var tx MsgTx
 		err := tx.Deserialize(r)
 		if err != nil {
 			return nil, nil, err
@@ -234,7 +234,7 @@ func (msg *MsgBlock) DeserializeTxLoc(r *bytes.Buffer) ([]TxLoc, []TxLoc, error)
 	sTxLocs := make([]TxLoc, stakeTxCount)
 	for i := uint64(0); i < stakeTxCount; i++ {
 		sTxLocs[i].TxStart = fullLen - r.Len()
-		tx := MsgTx{}
+		var tx MsgTx
 		err := tx.Deserialize(r)
 		if err != nil {
 			return nil, nil, err
@@ -301,14 +301,12 @@ func (msg *MsgBlock) Serialize(w io.Writer) error {
 
 // Bytes returns the serialized form of the block in bytes.
 func (msg *MsgBlock) Bytes() ([]byte, error) {
-	// Serialize the MsgTx.
-	var w bytes.Buffer
-	w.Grow(msg.SerializeSize())
-	err := msg.Serialize(&w)
+	buf := bytes.NewBuffer(make([]byte, 0, msg.SerializeSize()))
+	err := msg.Serialize(buf)
 	if err != nil {
 		return nil, err
 	}
-	return w.Bytes(), nil
+	return buf.Bytes(), nil
 }
 
 // SerializeSize returns the number of bytes it would take to serialize the

--- a/wire/msgblock_test.go
+++ b/wire/msgblock_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -314,9 +314,8 @@ func TestBlockSerialize(t *testing.T) {
 	t.Logf("Running %d tests", len(tests))
 	for i, test := range tests {
 		// Serialize the block.
-		var buf bytes.Buffer
-		buf.Grow(test.in.SerializeSize())
-		err := test.in.Serialize(&buf)
+		buf := bytes.NewBuffer(make([]byte, 0, test.in.SerializeSize()))
+		err := test.in.Serialize(buf)
 		if err != nil {
 			t.Errorf("Serialize #%d error %v", i, err)
 			continue
@@ -600,6 +599,7 @@ var testBlock = MsgBlock{
 	},
 	Transactions: []*MsgTx{
 		{
+			SerType: TxSerializeFull,
 			Version: 1,
 			TxIn: []*TxIn{
 				{
@@ -642,6 +642,7 @@ var testBlock = MsgBlock{
 	},
 	STransactions: []*MsgTx{
 		{
+			SerType: TxSerializeFull,
 			Version: 1,
 			TxIn: []*TxIn{
 				{


### PR DESCRIPTION
Decred's serialized format for transactions split the 32-bit version field into two 16-bit components such that the upper bits are used to encode a serialization type and the lower 16 bits are the actual
transaction version.

Unfortunately, when this was done, the in-memory transaction struct was not also updated to hide this complexity, which means that callers currently have to understand and take special care when dealing with the version field of the transaction.

Since the main purpose of the wire package is precisely to hide these details, this remedies the situation by introducing a new field on the in-memory transaction struct named `SerType` which houses the serialization type and changes the Version field back to having the desired semantics of actually being the real transaction version.  Also, since the maximum version can only be a 16-bit value, the Version field has been changed to a uint16 to properly reflect this.

The serialization and deserialization functions now deal with properly converting to and from these fields to the actual serialized format as intended.

Finally, these changes also include a fairly significant amount of related code cleanup and optimization along with some bug fixes in order to allow the transaction version to be bumped as intended.

The following is an overview of all changes:
- Introduce new `SerType` field to `MsgTx` to specify the serialization type
- Change `MsgTx.Version` to a uint16 to properly reflect its maximum allowed value
- Change the semantics of `MsgTx.Version` to be the actual transaction version as intended
- Update all callers that had special code to deal with the previous `Version` field semantics to use the new semantics
- Switch all of the code that deals with encoding and decoding the serialized version field to use more efficient masks and shifts instead of binary writes into buffers which cause allocations
- Correct several issues that would prevent producing expected serializations for transactions with actual transaction versions that are not 1
- Simplify the various serialize functions to use a single func which accepts the serialization type to reduce code duplication
- Make serialization type switch usage more consistent with the rest of the code base
- Update the `utxoview` and related code to use uint16s for the transaction version as well since it should not care about the serialization type due to using its own
- Make code more consistent in how it uses `bytes.Buffer`
- Clean up several of the comments regarding hashes and add some new comments to better describe the serialization types