### PR TITLE
config: Improve config file handling.

### DIFF
--- a/sampleconfig.go
+++ b/sampleconfig.go
@@ -1,4 +1,10 @@
-[Application Options]
+// Copyright (c) 2017 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+var sampleConfigFileContents = `[Application Options]
 
 ; ------------------------------------------------------------------------------
 ; Data settings
@@ -109,7 +115,7 @@
 ; Disable banning of misbehaving peers.
 ; nobanning=1
 
-; Maximum allowed ban score before disconnecting and banning misbehaving peers.`
+; Maximum allowed ban score before disconnecting and banning misbehaving peers.
 ; banthreshold=100
 
 ; How long to ban misbehaving peers. Valid time units are {s, m, h}.
@@ -330,3 +336,4 @@
 ; be disabled if this option is not specified.  The profile information can be
 ; accessed at http://localhost:<profileport>/debug/pprof once running.
 ; profile=6061
+`


### PR DESCRIPTION
This improves the default config file creation process so that it will only create a default config file when the user has not overridden the config file path.

It also now works properly when a different `appdata` path is provided in that it will still create a default config file in that new path if one doesn't already exist, but only if the user did not also override the config file path.

Finally, instead of copying a separate sample config file from the filesystem, which didn't work properly under several scenarios such as when it wasn't already available or the `appdata` directory was changed, the code now specifies the entire sample config as a string in the source code.  This means it will work as intended under all scenarios.

Fixes #533.