### PR TITLE
Only perform standard dust checks on regular transactions.

### DIFF
--- a/mempool/policy.go
+++ b/mempool/policy.go
@@ -429,8 +429,7 @@ func checkTransactionStandard(tx *dcrutil.Tx, txType stake.TxType, height int64,
 		// "dust".
 		if scriptClass == txscript.NullDataTy {
 			numNullDataOutputs++
-		} else if isDust(txOut, minRelayTxFee) &&
-			txType != stake.TxTypeSStx {
+		} else if txType == stake.TxTypeRegular && isDust(txOut, minRelayTxFee) {
 			str := fmt.Sprintf("transaction output %d: payment "+
 				"of %d is dust", i, txOut.Value)
 			return txRuleError(wire.RejectDust, str)


### PR DESCRIPTION
The old code ran dust checks on regular, vote, and revocation
transactions, while ignoring any dust checking on ticket purchases.
This change also removes the dust checking for votes and revocations
as these are required for the network to run and should not be
rejected just to minimize dust.  The output amounts for these votes
and revocations are determined by consensus rules so standard checks
must be relaxed on them.

If there were to be any dust checks performed on stake transactions,
it should only be done on the commitment amounts in ticket purchases.
By calculating the output amounts that a revocation would require
creating, the mempool could determine if the revocation outputs would
be considered dust with the current policy and reject the ticket
purchase.

Fixes #805.