### PR TITLE
rpcserver: check whether ticketUtx was found

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -932,8 +932,8 @@ func handleCreateRawSSGenTx(s *rpcServer, cmd interface{}, closeChan <-chan stru
 
 	// Try to fetch the ticket from the block database.
 	ticketUtx, err := s.chain.FetchUtxoEntry(txHash)
-	if err != nil {
-		rpcNoTxInfoError(txHash)
+	if ticketUtx == nil || err != nil {
+		return nil, rpcNoTxInfoError(txHash)
 	}
 	if t := ticketUtx.TransactionType(); t != stake.TxTypeSStx {
 		return nil, rpcDeserializationError("Invalid Tx type: %v", t)
@@ -1089,7 +1089,7 @@ func handleCreateRawSSRtx(s *rpcServer, cmd interface{}, closeChan <-chan struct
 
 	// Try to fetch the ticket from the block database.
 	ticketUtx, err := s.chain.FetchUtxoEntry(txHash)
-	if err != nil {
+	if ticketUtx == nil || err != nil {
 		return nil, rpcNoTxInfoError(txHash)
 	}
 	if t := ticketUtx.TransactionType(); t != stake.TxTypeSStx {


### PR DESCRIPTION
This fixes a possible panic when attempting to issue createrawssrtx with a txid that is not found.