### PR TITLE
sampleconfig: Add package README and doc.go.

### DIFF
--- a/config.go
+++ b/config.go
@@ -55,7 +55,6 @@ const (
 	defaultMaxOrphanTransactions = 1000
 	defaultMaxOrphanTxSize       = 5000
 	defaultSigCacheMaxSize       = 100000
-	sampleConfigFilename         = "sample-dcrd.conf"
 	defaultTxIndex               = false
 	defaultNoExistsAddrIndex     = false
 )

--- a/sampleconfig/README.md
+++ b/sampleconfig/README.md
@@ -1,0 +1,23 @@
+sampleconfig
+============
+
+[![Build Status](http://img.shields.io/travis/decred/dcrd.svg)](https://travis-ci.org/decred/dcrd)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/decred/dcrd/sampleconfig)
+
+Package sampleconfig provides a single constant that contains the contents of
+the sample configuration file for dcrd.  This is provided for tools that perform
+automatic configuration and would like to ensure the generated configuration
+file not only includes the specifically configured values, but also provides
+samples of other configuration options.
+
+## Installation and Updating
+
+```bash
+$ go get -u github.com/decred/dcrd/sampleconfig
+```
+
+## License
+
+Package sampleconfig is licensed under the [copyfree](http://copyfree.org) ISC
+License.

--- a/sampleconfig/doc.go
+++ b/sampleconfig/doc.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2017 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+/*
+Package sampleconfig provides a single constant that contains the contents of
+the sample configuration file for dcrd.  This is provided for tools that perform
+automatic configuration and would like to ensure the generated configuration
+file not only includes the specifically configured values, but also provides
+samples of other configuration options.
+*/
+package sampleconfig

--- a/sampleconfig/sampleconfig.go
+++ b/sampleconfig/sampleconfig.go
@@ -5,7 +5,7 @@
 package sampleconfig
 
 // FileContents is a string containing the commented example config for dcrd.
-var FileContents = `[Application Options]
+const FileContents = `[Application Options]
 
 ; ------------------------------------------------------------------------------
 ; Data settings


### PR DESCRIPTION
This adds a `readme` and `doc.go` for the `sampleconfig` package so it is consistent with all of the other packages.

While here, it also changes the exported value to a constant and removes
the unused `sampleConfigFilename` constant.