### PR TITLE
multi: Error descriptions are in lower case.

### DIFF
--- a/addrmgr/addrmanager.go
+++ b/addrmgr/addrmanager.go
@@ -481,7 +481,7 @@ func (a *AddrManager) deserializePeers(filePath string) error {
 		for _, val := range sam.NewBuckets[i] {
 			ka, ok := a.addrIndex[val]
 			if !ok {
-				return fmt.Errorf("newbucket contains %s but "+
+				return fmt.Errorf("new buckets contains %s but "+
 					"none in address list", val)
 			}
 
@@ -496,7 +496,7 @@ func (a *AddrManager) deserializePeers(filePath string) error {
 		for _, val := range sam.TriedBuckets[i] {
 			ka, ok := a.addrIndex[val]
 			if !ok {
-				return fmt.Errorf("Newbucket contains %s but "+
+				return fmt.Errorf("tried buckets contains %s but "+
 					"none in address list", val)
 			}
 

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1412,7 +1412,7 @@ func (b *BlockChain) initChainState() error {
 
 		// Die here if we started an upgrade and failed to finish it.
 		if dbInfo.upgradeStarted {
-			return fmt.Errorf("The blockchain database began an upgrade " +
+			return fmt.Errorf("the blockchain database began an upgrade " +
 				"but failed to complete it; delete the database and resync " +
 				"the blockchain")
 		}
@@ -1422,14 +1422,14 @@ func (b *BlockChain) initChainState() error {
 		// to ensure that the database is upgraded to the current version
 		// before hitting this.
 		if dbInfo.version > currentDatabaseVersion {
-			return fmt.Errorf("The blockchain database's version is %v "+
+			return fmt.Errorf("the blockchain database's version is %v "+
 				"but the current version of the software is %v",
 				dbInfo.version, currentDatabaseVersion)
 		}
 
 		// Die here if we're not on the current compression version, too.
 		if dbInfo.compVer > currentCompressionVersion {
-			return fmt.Errorf("The blockchain database's compression "+
+			return fmt.Errorf("the blockchain database's compression "+
 				"version is %v but the current version of the software is %v",
 				dbInfo.version, currentDatabaseVersion)
 		}

--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -353,7 +353,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 			case error:
 				err = rt
 			default:
-				err = errors.New("Unknown panic")
+				err = errors.New("unknown panic")
 			}
 		}
 	}()

--- a/cmd/addblock/config.go
+++ b/cmd/addblock/config.go
@@ -119,7 +119,7 @@ func loadConfig() (*config, []string, error) {
 		activeNetParams = &chaincfg.SimNetParams
 	}
 	if numNets > 1 {
-		str := "%s: The testnet, regtest, and simnet params can't be " +
+		str := "%s: the testnet, regtest, and simnet params can't be " +
 			"used together -- choose one of the three"
 		err := fmt.Errorf(str, funcName)
 		fmt.Fprintln(os.Stderr, err)
@@ -129,7 +129,7 @@ func loadConfig() (*config, []string, error) {
 
 	// Validate database type.
 	if !validDbType(cfg.DbType) {
-		str := "%s: The specified database type [%v] is invalid -- " +
+		str := "%s: the specified database type [%v] is invalid -- " +
 			"supported types %v"
 		err := fmt.Errorf(str, "loadConfig", cfg.DbType, knownDbTypes)
 		fmt.Fprintln(os.Stderr, err)
@@ -147,7 +147,7 @@ func loadConfig() (*config, []string, error) {
 
 	// Ensure the specified block file exists.
 	if !fileExists(cfg.InFile) {
-		str := "%s: The specified block file [%v] does not exist"
+		str := "%s: the specified block file [%v] does not exist"
 		err := fmt.Errorf(str, "loadConfig", cfg.InFile)
 		fmt.Fprintln(os.Stderr, err)
 		parser.WriteHelp(os.Stderr)

--- a/cmd/addblock/import.go
+++ b/cmd/addblock/import.go
@@ -159,7 +159,7 @@ out:
 		// notify the status handler with the error and bail.
 		serializedBlock, err := bi.readBlock()
 		if err != nil {
-			bi.errChan <- fmt.Errorf("Error reading from input "+
+			bi.errChan <- fmt.Errorf("error reading from input "+
 				"file: %v", err.Error())
 			break out
 		}

--- a/cmd/dcrctl/config.go
+++ b/cmd/dcrctl/config.go
@@ -269,7 +269,7 @@ func loadConfig() (*config, []string, error) {
 		numNets++
 	}
 	if numNets > 1 {
-		str := "%s: The testnet and simnet params can't be used " +
+		str := "%s: the testnet and simnet params can't be used " +
 			"together -- choose one of the two"
 		err := fmt.Errorf(str, "loadConfig")
 		fmt.Fprintln(os.Stderr, err)

--- a/cmd/findcheckpoint/config.go
+++ b/cmd/findcheckpoint/config.go
@@ -106,7 +106,7 @@ func loadConfig() (*config, []string, error) {
 		activeNetParams = &chaincfg.SimNetParams
 	}
 	if numNets > 1 {
-		str := "%s: The testnet, regtest, and simnet params can't be " +
+		str := "%s: the testnet, regtest, and simnet params can't be " +
 			"used together -- choose one of the three"
 		err := fmt.Errorf(str, funcName)
 		fmt.Fprintln(os.Stderr, err)
@@ -116,7 +116,7 @@ func loadConfig() (*config, []string, error) {
 
 	// Validate database type.
 	if !validDbType(cfg.DbType) {
-		str := "%s: The specified database type [%v] is invalid -- " +
+		str := "%s: the specified database type [%v] is invalid -- " +
 			"supported types %v"
 		err := fmt.Errorf(str, "loadConfig", cfg.DbType, knownDbTypes)
 		fmt.Fprintln(os.Stderr, err)

--- a/config.go
+++ b/config.go
@@ -640,7 +640,7 @@ func loadConfig() (*config, []string, error) {
 	if cfg.Profile != "" {
 		profilePort, err := strconv.Atoi(cfg.Profile)
 		if err != nil || profilePort < 1024 || profilePort > 65535 {
-			str := "%s: The profile port must be between 1024 and 65535"
+			str := "%s: the profile port must be between 1024 and 65535"
 			err := fmt.Errorf(str, funcName)
 			fmt.Fprintln(os.Stderr, err)
 			fmt.Fprintln(os.Stderr, usageMessage)
@@ -968,7 +968,7 @@ func loadConfig() (*config, []string, error) {
 	if cfg.Proxy != "" {
 		_, _, err := net.SplitHostPort(cfg.Proxy)
 		if err != nil {
-			str := "%s: Proxy address '%s' is invalid: %v"
+			str := "%s: proxy address '%s' is invalid: %v"
 			err := fmt.Errorf(str, funcName, cfg.Proxy, err)
 			fmt.Fprintln(os.Stderr, err)
 			fmt.Fprintln(os.Stderr, usageMessage)

--- a/connmgr/connmanager.go
+++ b/connmgr/connmanager.go
@@ -21,7 +21,7 @@ const maxFailedAttempts = 25
 
 var (
 	//ErrDialNil is used to indicate that Dial cannot be nil in the configuration.
-	ErrDialNil = errors.New("Config: Dial cannot be nil")
+	ErrDialNil = errors.New("config: dial cannot be nil")
 
 	// maxRetryDuration is the max duration of time retrying of a persistent
 	// connection is allowed to grow to.  This is necessary since the retry

--- a/cpuminer.go
+++ b/cpuminer.go
@@ -560,7 +560,7 @@ func (m *CPUMiner) GenerateNBlocks(n uint32) ([]*chainhash.Hash, error) {
 	// Respond with an error if there's virtually 0 chance of CPU-mining a block.
 	if !m.server.chainParams.GenerateSupported {
 		m.Unlock()
-		return nil, errors.New("No support for `generate` on the current " +
+		return nil, errors.New("no support for `generate` on the current " +
 			"network, " + m.server.chainParams.Net.String() +
 			", as it's unlikely to be possible to CPU-mine a block.")
 	}
@@ -568,7 +568,7 @@ func (m *CPUMiner) GenerateNBlocks(n uint32) ([]*chainhash.Hash, error) {
 	// Respond with an error if server is already mining.
 	if m.started || m.discreteMining {
 		m.Unlock()
-		return nil, errors.New("Server is already CPU mining. Please call " +
+		return nil, errors.New("server is already CPU mining. Please call " +
 			"`setgenerate 0` before calling discrete `generate` commands.")
 	}
 

--- a/database/cmd/dbtool/globalconfig.go
+++ b/database/cmd/dbtool/globalconfig.go
@@ -75,7 +75,7 @@ func setupGlobalConfig() error {
 		activeNetParams = &chaincfg.SimNetParams
 	}
 	if numNets > 1 {
-		return errors.New("The testnet and simnet params can't be " +
+		return errors.New("the testnet and simnet params can't be " +
 			"used together -- choose one of the two")
 	}
 

--- a/database/ffldb/driver_test.go
+++ b/database/ffldb/driver_test.go
@@ -225,7 +225,7 @@ func TestPersistence(t *testing.T) {
 
 		bucket1 := metadataBucket.Bucket(bucket1Key)
 		if bucket1 == nil {
-			return fmt.Errorf("Bucket1: unexpected nil bucket")
+			return fmt.Errorf("bucket1: unexpected nil bucket")
 		}
 
 		for k, v := range storeValues {

--- a/database/ffldb/interface_test.go
+++ b/database/ffldb/interface_test.go
@@ -916,7 +916,7 @@ func testMetadataTxInterface(tc *testContext) bool {
 
 		bucket1 := metadataBucket.Bucket(bucket1Name)
 		if bucket1 == nil {
-			return fmt.Errorf("Bucket1: unexpected nil bucket")
+			return fmt.Errorf("bucket1: unexpected nil bucket")
 		}
 
 		tc.isWritable = false
@@ -957,7 +957,7 @@ func testMetadataTxInterface(tc *testContext) bool {
 
 		bucket1 := metadataBucket.Bucket(bucket1Name)
 		if bucket1 == nil {
-			return fmt.Errorf("Bucket1: unexpected nil bucket")
+			return fmt.Errorf("bucket1: unexpected nil bucket")
 		}
 
 		tc.isWritable = true
@@ -1012,7 +1012,7 @@ func testMetadataTxInterface(tc *testContext) bool {
 
 		bucket1 := metadataBucket.Bucket(bucket1Name)
 		if bucket1 == nil {
-			return fmt.Errorf("Bucket1: unexpected nil bucket")
+			return fmt.Errorf("bucket1: unexpected nil bucket")
 		}
 
 		if !testPutValues(tc, bucket1, keyValues) {
@@ -1037,7 +1037,7 @@ func testMetadataTxInterface(tc *testContext) bool {
 
 		bucket1 := metadataBucket.Bucket(bucket1Name)
 		if bucket1 == nil {
-			return fmt.Errorf("Bucket1: unexpected nil bucket")
+			return fmt.Errorf("bucket1: unexpected nil bucket")
 		}
 
 		if !testGetValues(tc, bucket1, toGetValues(keyValues)) {
@@ -1062,7 +1062,7 @@ func testMetadataTxInterface(tc *testContext) bool {
 
 		bucket1 := metadataBucket.Bucket(bucket1Name)
 		if bucket1 == nil {
-			return fmt.Errorf("Bucket1: unexpected nil bucket")
+			return fmt.Errorf("bucket1: unexpected nil bucket")
 		}
 
 		if !testDeleteValues(tc, bucket1, keyValues) {

--- a/txscript/stack_test.go
+++ b/txscript/stack_test.go
@@ -161,7 +161,7 @@ func TestStack(t *testing.T) {
 					return err
 				}
 				if v != 0 {
-					return errors.New("0 != 0 on popInt")
+					return errors.New("0 != 0 on PopInt")
 				}
 				return nil
 			},
@@ -177,7 +177,7 @@ func TestStack(t *testing.T) {
 					return err
 				}
 				if v != 0 {
-					return errors.New("-0 != 0 on popInt")
+					return errors.New("-0 != 0 on PopInt")
 				}
 				return nil
 			},
@@ -193,7 +193,7 @@ func TestStack(t *testing.T) {
 					return err
 				}
 				if v != 1 {
-					return errors.New("1 != 1 on popInt")
+					return errors.New("1 != 1 on PopInt")
 				}
 				return nil
 			},
@@ -210,7 +210,7 @@ func TestStack(t *testing.T) {
 				}
 				if v != 1 {
 					fmt.Printf("%v != %v\n", v, 1)
-					return errors.New("1 != 1 on popInt")
+					return errors.New("1 != 1 on PopInt")
 				}
 				return nil
 			},
@@ -226,7 +226,7 @@ func TestStack(t *testing.T) {
 					return err
 				}
 				if v != -1 {
-					return errors.New("-1 != -1 on popInt")
+					return errors.New("-1 != -1 on PopInt")
 				}
 				return nil
 			},
@@ -243,7 +243,7 @@ func TestStack(t *testing.T) {
 				}
 				if v != -1 {
 					fmt.Printf("%v != %v\n", v, -1)
-					return errors.New("-1 != -1 on popInt")
+					return errors.New("-1 != -1 on PopInt")
 				}
 				return nil
 			},
@@ -261,7 +261,7 @@ func TestStack(t *testing.T) {
 				}
 				if v != -513 {
 					fmt.Printf("%v != %v\n", v, -513)
-					return errors.New("1 != 1 on popInt")
+					return errors.New("1 != 1 on PopInt")
 				}
 				return nil
 			},
@@ -279,7 +279,7 @@ func TestStack(t *testing.T) {
 				}
 				if v != -1 {
 					fmt.Printf("%v != %v\n", v, -1)
-					return errors.New("-1 != -1 on popInt")
+					return errors.New("-1 != -1 on PeekInt")
 				}
 				return nil
 			},

--- a/upnp.go
+++ b/upnp.go
@@ -239,22 +239,22 @@ func getServiceURL(rootURL string) (url string, err error) {
 	}
 	a := &root.Device
 	if a.DeviceType != "urn:schemas-upnp-org:device:InternetGatewayDevice:1" {
-		err = errors.New("no InternetGatewayDevice")
+		err = errors.New("no internet gateway device")
 		return
 	}
 	b := getChildDevice(a, "urn:schemas-upnp-org:device:WANDevice:1")
 	if b == nil {
-		err = errors.New("no WANDevice")
+		err = errors.New("no WAN device")
 		return
 	}
 	c := getChildDevice(b, "urn:schemas-upnp-org:device:WANConnectionDevice:1")
 	if c == nil {
-		err = errors.New("no WANConnectionDevice")
+		err = errors.New("no WAN connection device")
 		return
 	}
 	d := getChildService(c, "urn:schemas-upnp-org:service:WANIPConnection:1")
 	if d == nil {
-		err = errors.New("no WANIPConnection")
+		err = errors.New("no WAN IP connection")
 		return
 	}
 	url = combineURL(rootURL, d.ControlURL)
@@ -314,7 +314,7 @@ func soapRequest(url, function, message string) (replyXML []byte, err error) {
 
 	if r.StatusCode >= 400 {
 		// log.Stderr(function, r.StatusCode)
-		err = errors.New("Error " + strconv.Itoa(r.StatusCode) + " for " + function)
+		err = errors.New("error " + strconv.Itoa(r.StatusCode) + " for " + function)
 		r = nil
 		return
 	}


### PR DESCRIPTION
Fixes #363

Functions fmt.Error(), errors.New() are inspected.

Files under the dcrd/vendor directory are ignored.