### PR TITLE
blockchain: Cleanup various tests.

### DIFF
--- a/blockchain/difficulty_test.go
+++ b/blockchain/difficulty_test.go
@@ -395,7 +395,6 @@ func TestCalcNextRequiredStakeDiffV2(t *testing.T) {
 nextTest:
 	for _, test := range tests {
 		bc := newFakeChain(params)
-		bc.bestNode = genesisBlockNode(params)
 
 		// immatureTickets tracks which height the purchased tickets
 		// will mature and thus be eligible for admission to the live
@@ -698,7 +697,6 @@ func TestEstimateNextStakeDiffV2(t *testing.T) {
 nextTest:
 	for _, test := range tests {
 		bc := newFakeChain(params)
-		bc.bestNode = genesisBlockNode(params)
 
 		// immatureTickets track which height the purchased tickets will
 		// mature and thus be eligible for admission to the live ticket


### PR DESCRIPTION
This modifies the `newFakeChain` and `newFakeNode` functions to be easier to work with and then updates the various tests that use them to significantly simply them.  It also removes the `genesisBlockNode` function since it is no longer necessary due to the changes other changes.

While here, it also improves the comments on the tests to better describe what is being tested.