### PR TITLE
stake: Modify ticket tests to use chaincfg params.

### DIFF
--- a/blockchain/stake/tickets_test.go
+++ b/blockchain/stake/tickets_test.go
@@ -9,20 +9,16 @@ import (
 	"compress/bzip2"
 	"encoding/gob"
 	"fmt"
-	"math"
-	"math/big"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/decred/dcrd/blockchain/stake/internal/tickettreap"
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/database"
 	_ "github.com/decred/dcrd/database/ffldb"
-	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrutil"
 )
 
@@ -252,6 +248,7 @@ func findDifferences(a *tickettreap.Immutable, b *tickettreap.Immutable) {
 
 func TestTicketDBLongChain(t *testing.T) {
 	// Declare some useful variables.
+	params := &chaincfg.SimNetParams
 	testBCHeight := int64(1001)
 	filename := filepath.Join("..", "/../blockchain/testdata", "testexpiry.bz2")
 	fi, err := os.Open(filename)
@@ -281,14 +278,14 @@ func TestTicketDBLongChain(t *testing.T) {
 	}
 
 	// Connect to the best block (1001).
-	bestNode := genesisNode(simNetParams)
+	bestNode := genesisNode(params)
 	nodesForward := make([]*Node, testBCHeight+1)
 	nodesForward[0] = bestNode
 	for i := int64(1); i <= testBCHeight; i++ {
 		block := testBlockchain[i]
 		ticketsToAdd := make([]chainhash.Hash, 0)
-		if i >= simNetParams.StakeEnabledHeight {
-			matureHeight := (i - int64(simNetParams.TicketMaturity))
+		if i >= params.StakeEnabledHeight {
+			matureHeight := (i - int64(params.TicketMaturity))
 			ticketsToAdd = ticketsInBlock(testBlockchain[matureHeight])
 		}
 		header := block.MsgBlock().Header
@@ -316,8 +313,8 @@ func TestTicketDBLongChain(t *testing.T) {
 	for i := testBCHeight; i >= int64(1); i-- {
 		parentBlock := testBlockchain[i-1]
 		ticketsToAdd := make([]chainhash.Hash, 0)
-		if i >= simNetParams.StakeEnabledHeight {
-			matureHeight := (i - 1 - int64(simNetParams.TicketMaturity))
+		if i >= params.StakeEnabledHeight {
+			matureHeight := (i - 1 - int64(params.TicketMaturity))
 			ticketsToAdd = ticketsInBlock(testBlockchain[matureHeight])
 		}
 		header := parentBlock.MsgBlock().Header
@@ -386,7 +383,7 @@ func TestTicketDBLongChain(t *testing.T) {
 		dbName := "ffldb_staketest"
 		dbPath := filepath.Join(testDbRoot, dbName)
 		_ = os.RemoveAll(dbPath)
-		testDb, err := database.Create(testDbType, dbPath, simNetParams.Net)
+		testDb, err := database.Create(testDbType, dbPath, params.Net)
 		if err != nil {
 			t.Fatalf("error creating db: %v", err)
 		}
@@ -399,7 +396,7 @@ func TestTicketDBLongChain(t *testing.T) {
 		// Load the genesis block and begin testing exported functions.
 		err = testDb.Update(func(dbTx database.Tx) error {
 			var errLocal error
-			bestNode, errLocal = InitDatabaseState(dbTx, simNetParams)
+			bestNode, errLocal = InitDatabaseState(dbTx, params)
 			if errLocal != nil {
 				return errLocal
 			}
@@ -420,8 +417,8 @@ func TestTicketDBLongChain(t *testing.T) {
 			for i := int64(1); i <= testBCHeight; i++ {
 				block := testBlockchain[i]
 				ticketsToAdd := make([]chainhash.Hash, 0)
-				if i >= simNetParams.StakeEnabledHeight {
-					matureHeight := (i - int64(simNetParams.TicketMaturity))
+				if i >= params.StakeEnabledHeight {
+					matureHeight := (i - int64(params.TicketMaturity))
 					ticketsToAdd = ticketsInBlock(testBlockchain[matureHeight])
 				}
 				header := block.MsgBlock().Header
@@ -454,7 +451,7 @@ func TestTicketDBLongChain(t *testing.T) {
 				// Reload the node from DB and make sure it's the same.
 				blockHash := block.Hash()
 				loadedNode, err := LoadBestNode(dbTx, bestNode.Height(),
-					*blockHash, header, simNetParams)
+					*blockHash, header, params)
 				if err != nil {
 					return fmt.Errorf("failed to load the best node: %v",
 						err.Error())
@@ -478,8 +475,8 @@ func TestTicketDBLongChain(t *testing.T) {
 		for i := testBCHeight; i >= int64(1); i-- {
 			parentBlock := testBlockchain[i-1]
 			ticketsToAdd := make([]chainhash.Hash, 0)
-			if i >= simNetParams.StakeEnabledHeight {
-				matureHeight := (i - 1 - int64(simNetParams.TicketMaturity))
+			if i >= params.StakeEnabledHeight {
+				matureHeight := (i - 1 - int64(params.TicketMaturity))
 				ticketsToAdd = ticketsInBlock(testBlockchain[matureHeight])
 			}
 			header := parentBlock.MsgBlock().Header
@@ -543,7 +540,7 @@ func TestTicketDBLongChain(t *testing.T) {
 			err = testDb.View(func(dbTx database.Tx) error {
 				parentBlockHash := parentBlock.Hash()
 				loadedNode, err := LoadBestNode(dbTx, bestNode.Height(),
-					*parentBlockHash, header, simNetParams)
+					*parentBlockHash, header, params)
 				if err != nil {
 					return fmt.Errorf("failed to load the best node: %v",
 						err.Error())
@@ -570,6 +567,7 @@ func TestTicketDBLongChain(t *testing.T) {
 
 func TestTicketDBGeneral(t *testing.T) {
 	// Declare some useful variables.
+	params := &chaincfg.SimNetParams
 	testBCHeight := int64(168)
 	filename := filepath.Join("..", "/../blockchain/testdata", "blocks0to168.bz2")
 	fi, err := os.Open(filename)
@@ -602,7 +600,7 @@ func TestTicketDBGeneral(t *testing.T) {
 	dbName := "ffldb_staketest"
 	dbPath := filepath.Join(testDbRoot, dbName)
 	_ = os.RemoveAll(dbPath)
-	testDb, err := database.Create(testDbType, dbPath, simNetParams.Net)
+	testDb, err := database.Create(testDbType, dbPath, params.Net)
 	if err != nil {
 		t.Fatalf("error creating db: %v", err)
 	}
@@ -616,7 +614,7 @@ func TestTicketDBGeneral(t *testing.T) {
 	var bestNode *Node
 	err = testDb.Update(func(dbTx database.Tx) error {
 		var errLocal error
-		bestNode, errLocal = InitDatabaseState(dbTx, simNetParams)
+		bestNode, errLocal = InitDatabaseState(dbTx, params)
 		return errLocal
 	})
 	if err != nil {
@@ -633,8 +631,8 @@ func TestTicketDBGeneral(t *testing.T) {
 		for i := int64(1); i <= testBCHeight; i++ {
 			block := testBlockchain[i]
 			ticketsToAdd := make([]chainhash.Hash, 0)
-			if i >= simNetParams.StakeEnabledHeight {
-				matureHeight := (i - int64(simNetParams.TicketMaturity))
+			if i >= params.StakeEnabledHeight {
+				matureHeight := (i - int64(params.TicketMaturity))
 				ticketsToAdd = ticketsInBlock(testBlockchain[matureHeight])
 			}
 			header := block.MsgBlock().Header
@@ -667,7 +665,7 @@ func TestTicketDBGeneral(t *testing.T) {
 			// Reload the node from DB and make sure it's the same.
 			blockHash = block.Hash()
 			loadedNode, err := LoadBestNode(dbTx, bestNode.Height(),
-				*blockHash, header, simNetParams)
+				*blockHash, header, params)
 			if err != nil {
 				return fmt.Errorf("failed to load the best node: %v",
 					err.Error())
@@ -691,8 +689,8 @@ func TestTicketDBGeneral(t *testing.T) {
 	for i := testBCHeight; i >= int64(1); i-- {
 		parentBlock := testBlockchain[i-1]
 		ticketsToAdd := make([]chainhash.Hash, 0)
-		if i >= simNetParams.StakeEnabledHeight {
-			matureHeight := (i - 1 - int64(simNetParams.TicketMaturity))
+		if i >= params.StakeEnabledHeight {
+			matureHeight := (i - 1 - int64(params.TicketMaturity))
 			ticketsToAdd = ticketsInBlock(testBlockchain[matureHeight])
 		}
 		header := parentBlock.MsgBlock().Header
@@ -760,7 +758,7 @@ func TestTicketDBGeneral(t *testing.T) {
 		err = testDb.View(func(dbTx database.Tx) error {
 			parentBlockHash := parentBlock.Hash()
 			loadedNode, err := LoadBestNode(dbTx, bestNode.Height(),
-				*parentBlockHash, header, simNetParams)
+				*parentBlockHash, header, params)
 			if err != nil {
 				return fmt.Errorf("failed to load the best node: %v",
 					err.Error())
@@ -917,318 +915,4 @@ func TestTicketDBGeneral(t *testing.T) {
 		t.Errorf("unexpected wrong or no error for "+
 			"Unknown undo data for disconnecting (revoked): %v", err)
 	}
-}
-
-// --------------------------------------------------------------------------------
-// TESTING VARIABLES BEGIN HERE
-
-// simNetPowLimit is the highest proof of work value a Decred block
-// can have for the simulation test network.  It is the value 2^255 - 1.
-var simNetPowLimit = new(big.Int).Sub(new(big.Int).Lsh(bigOne, 255), bigOne)
-
-// SimNetParams defines the network parameters for the simulation test Decred
-// network.  This network is similar to the normal test network except it is
-// intended for private use within a group of individuals doing simulation
-// testing.  The functionality is intended to differ in that the only nodes
-// which are specifically specified are used to create the network rather than
-// following normal discovery rules.  This is important as otherwise it would
-// just turn into another public testnet.
-var simNetParams = &chaincfg.Params{
-	Name:        "simnet",
-	Net:         wire.SimNet,
-	DefaultPort: "18555",
-	DNSSeeds:    nil, // NOTE: There must NOT be any seeds.
-
-	// Chain parameters
-	GenesisBlock:             &simNetGenesisBlock,
-	GenesisHash:              &simNetGenesisHash,
-	PowLimit:                 simNetPowLimit,
-	PowLimitBits:             0x207fffff,
-	ReduceMinDifficulty:      false,
-	MinDiffReductionTime:     0, // Does not apply since ReduceMinDifficulty false
-	GenerateSupported:        true,
-	MaximumBlockSizes:        []int{1000000, 1310720},
-	MaxTxSize:                1000000,
-	TargetTimePerBlock:       time.Second,
-	WorkDiffAlpha:            1,
-	WorkDiffWindowSize:       8,
-	WorkDiffWindows:          4,
-	TargetTimespan:           time.Second * 8, // TimePerBlock * WindowSize
-	RetargetAdjustmentFactor: 4,
-
-	// Subsidy parameters.
-	BaseSubsidy:              50000000000,
-	MulSubsidy:               100,
-	DivSubsidy:               101,
-	SubsidyReductionInterval: 128,
-	WorkRewardProportion:     6,
-	StakeRewardProportion:    3,
-	BlockTaxProportion:       1,
-
-	// Checkpoints ordered from oldest to newest.
-	Checkpoints: nil,
-
-	// BIP0009 consensus rule change deployments.
-	//
-	// The miner confirmation window is defined as:
-	//   target proof of work timespan / target proof of work spacing
-	RuleChangeActivationQuorum:     160, // 10 % of RuleChangeActivationInterval * TicketsPerBlock
-	RuleChangeActivationMultiplier: 3,   // 75%
-	RuleChangeActivationDivisor:    4,
-	RuleChangeActivationInterval:   320, // 320 seconds
-	Deployments: map[uint32][]chaincfg.ConsensusDeployment{
-		4: {{
-			Vote: chaincfg.Vote{
-				Id:          chaincfg.VoteIDMaxBlockSize,
-				Description: "Change maximum allowed block size from 1MiB to 1.25MB",
-				Mask:        0x0006, // Bits 1 and 2
-				Choices: []chaincfg.Choice{{
-					Id:          "abstain",
-					Description: "abstain voting for change",
-					Bits:        0x0000,
-					IsAbstain:   true,
-					IsNo:        false,
-				}, {
-					Id:          "no",
-					Description: "reject changing max allowed block size",
-					Bits:        0x0002, // Bit 1
-					IsAbstain:   false,
-					IsNo:        true,
-				}, {
-					Id:          "yes",
-					Description: "accept changing max allowed block size",
-					Bits:        0x0004, // Bit 2
-					IsAbstain:   false,
-					IsNo:        false,
-				}},
-			},
-			StartTime:  0,             // Always available for vote
-			ExpireTime: math.MaxInt64, // Never expires
-		}},
-		5: {{
-			Vote: chaincfg.Vote{
-				Id:          chaincfg.VoteIDSDiffAlgorithm,
-				Description: "Change stake difficulty algorithm as defined in DCP0001",
-				Mask:        0x0006, // Bits 1 and 2
-				Choices: []chaincfg.Choice{{
-					Id:          "abstain",
-					Description: "abstain voting for change",
-					Bits:        0x0000,
-					IsAbstain:   true,
-					IsNo:        false,
-				}, {
-					Id:          "no",
-					Description: "keep the existing algorithm",
-					Bits:        0x0002, // Bit 1
-					IsAbstain:   false,
-					IsNo:        true,
-				}, {
-					Id:          "yes",
-					Description: "change to the new algorithm",
-					Bits:        0x0004, // Bit 2
-					IsAbstain:   false,
-					IsNo:        false,
-				}},
-			},
-			StartTime:  0,             // Always available for vote
-			ExpireTime: math.MaxInt64, // Never expires
-		}},
-	},
-
-	// Enforce current block version once majority of the network has
-	// upgraded.
-	// 51% (51 / 100)
-	// Reject previous block versions once a majority of the network has
-	// upgraded.
-	// 75% (75 / 100)
-	BlockEnforceNumRequired: 51,
-	BlockRejectNumRequired:  75,
-	BlockUpgradeNumToCheck:  100,
-
-	// Mempool parameters
-	RelayNonStdTxs: true,
-
-	// Address encoding magics
-	NetworkAddressPrefix: "S",
-	PubKeyAddrID:         [2]byte{0x27, 0x6f}, // starts with Sk
-	PubKeyHashAddrID:     [2]byte{0x0e, 0x91}, // starts with Ss
-	PKHEdwardsAddrID:     [2]byte{0x0e, 0x71}, // starts with Se
-	PKHSchnorrAddrID:     [2]byte{0x0e, 0x53}, // starts with SS
-	ScriptHashAddrID:     [2]byte{0x0e, 0x6c}, // starts with Sc
-	PrivateKeyID:         [2]byte{0x23, 0x07}, // starts with Ps
-
-	// BIP32 hierarchical deterministic extended key magics
-	HDPrivateKeyID: [4]byte{0x04, 0x20, 0xb9, 0x03}, // starts with sprv
-	HDPublicKeyID:  [4]byte{0x04, 0x20, 0xbd, 0x3d}, // starts with spub
-
-	// BIP44 coin type used in the hierarchical deterministic path for
-	// address generation.
-	HDCoinType: 115, // ASCII for s
-
-	// Decred PoS parameters
-	MinimumStakeDiff:      20000,
-	TicketPoolSize:        64,
-	TicketsPerBlock:       5,
-	TicketMaturity:        16,
-	TicketExpiry:          384, // 6*TicketPoolSize
-	CoinbaseMaturity:      16,
-	SStxChangeMaturity:    1,
-	TicketPoolSizeWeight:  4,
-	StakeDiffAlpha:        1,
-	StakeDiffWindowSize:   8,
-	StakeDiffWindows:      8,
-	MaxFreshStakePerBlock: 20,            // 4*TicketsPerBlock
-	StakeEnabledHeight:    16 + 16,       // CoinbaseMaturity + TicketMaturity
-	StakeValidationHeight: 16 + (64 * 2), // CoinbaseMaturity + TicketPoolSize*2
-	StakeBaseSigScript:    []byte{0xde, 0xad, 0xbe, 0xef},
-
-	// Decred organization related parameters
-	OrganizationPkScript:        chaincfg.SimNetParams.OrganizationPkScript,
-	OrganizationPkScriptVersion: chaincfg.SimNetParams.OrganizationPkScriptVersion,
-	BlockOneLedger: []*chaincfg.TokenPayout{
-		{Address: "Sshw6S86G2bV6W32cbc7EhtFy8f93rU6pae", Amount: 100000 * 1e8},
-		{Address: "SsjXRK6Xz6CFuBt6PugBvrkdAa4xGbcZ18w", Amount: 100000 * 1e8},
-		{Address: "SsfXiYkYkCoo31CuVQw428N6wWKus2ZEw5X", Amount: 100000 * 1e8},
-	},
-}
-
-var bigOne = new(big.Int).SetInt64(1)
-
-// simNetGenesisHash is the hash of the first block in the block chain for the
-// simulation test network.
-var simNetGenesisHash = simNetGenesisBlock.BlockHash()
-
-// simNetGenesisMerkleRoot is the hash of the first transaction in the genesis
-// block for the simulation test network.  It is the same as the merkle root for
-// the main network.
-var simNetGenesisMerkleRoot = genesisMerkleRoot
-
-// genesisCoinbaseTx legacy is the coinbase transaction for the genesis blocks for
-// the regression test network and test network.
-var genesisCoinbaseTxLegacy = wire.MsgTx{
-	SerType: wire.TxSerializeFull,
-	Version: 1,
-	TxIn: []*wire.TxIn{
-		{
-			PreviousOutPoint: wire.OutPoint{
-				Hash:  chainhash.Hash{},
-				Index: 0xffffffff,
-			},
-			SignatureScript: []byte{
-				0x04, 0xff, 0xff, 0x00, 0x1d, 0x01, 0x04, 0x45, /* |.......E| */
-				0x54, 0x68, 0x65, 0x20, 0x54, 0x69, 0x6d, 0x65, /* |The Time| */
-				0x73, 0x20, 0x30, 0x33, 0x2f, 0x4a, 0x61, 0x6e, /* |s 03/Jan| */
-				0x2f, 0x32, 0x30, 0x30, 0x39, 0x20, 0x43, 0x68, /* |/2009 Ch| */
-				0x61, 0x6e, 0x63, 0x65, 0x6c, 0x6c, 0x6f, 0x72, /* |ancellor| */
-				0x20, 0x6f, 0x6e, 0x20, 0x62, 0x72, 0x69, 0x6e, /* | on brin| */
-				0x6b, 0x20, 0x6f, 0x66, 0x20, 0x73, 0x65, 0x63, /* |k of sec|*/
-				0x6f, 0x6e, 0x64, 0x20, 0x62, 0x61, 0x69, 0x6c, /* |ond bail| */
-				0x6f, 0x75, 0x74, 0x20, 0x66, 0x6f, 0x72, 0x20, /* |out for |*/
-				0x62, 0x61, 0x6e, 0x6b, 0x73, /* |banks| */
-			},
-			Sequence: 0xffffffff,
-		},
-	},
-	TxOut: []*wire.TxOut{
-		{
-			Value: 0x00000000,
-			PkScript: []byte{
-				0x41, 0x04, 0x67, 0x8a, 0xfd, 0xb0, 0xfe, 0x55, /* |A.g....U| */
-				0x48, 0x27, 0x19, 0x67, 0xf1, 0xa6, 0x71, 0x30, /* |H'.g..q0| */
-				0xb7, 0x10, 0x5c, 0xd6, 0xa8, 0x28, 0xe0, 0x39, /* |..\..(.9| */
-				0x09, 0xa6, 0x79, 0x62, 0xe0, 0xea, 0x1f, 0x61, /* |..yb...a| */
-				0xde, 0xb6, 0x49, 0xf6, 0xbc, 0x3f, 0x4c, 0xef, /* |..I..?L.| */
-				0x38, 0xc4, 0xf3, 0x55, 0x04, 0xe5, 0x1e, 0xc1, /* |8..U....| */
-				0x12, 0xde, 0x5c, 0x38, 0x4d, 0xf7, 0xba, 0x0b, /* |..\8M...| */
-				0x8d, 0x57, 0x8a, 0x4c, 0x70, 0x2b, 0x6b, 0xf1, /* |.W.Lp+k.| */
-				0x1d, 0x5f, 0xac, /* |._.| */
-			},
-		},
-	},
-	LockTime: 0,
-	Expiry:   0,
-}
-
-// genesisMerkleRoot is the hash of the first transaction in the genesis block
-// for the main network.
-var genesisMerkleRoot = genesisCoinbaseTxLegacy.TxHash()
-
-var regTestGenesisCoinbaseTx = wire.MsgTx{
-	SerType: wire.TxSerializeFull,
-	Version: 1,
-	TxIn: []*wire.TxIn{
-		{
-			PreviousOutPoint: wire.OutPoint{
-				Hash:  chainhash.Hash{},
-				Index: 0xffffffff,
-			},
-			SignatureScript: []byte{
-				0x04, 0xff, 0xff, 0x00, 0x1d, 0x01, 0x04, 0x45, /* |.......E| */
-				0x54, 0x68, 0x65, 0x20, 0x54, 0x69, 0x6d, 0x65, /* |The Time| */
-				0x73, 0x20, 0x30, 0x33, 0x2f, 0x4a, 0x61, 0x6e, /* |s 03/Jan| */
-				0x2f, 0x32, 0x30, 0x30, 0x39, 0x20, 0x43, 0x68, /* |/2009 Ch| */
-				0x61, 0x6e, 0x63, 0x65, 0x6c, 0x6c, 0x6f, 0x72, /* |ancellor| */
-				0x20, 0x6f, 0x6e, 0x20, 0x62, 0x72, 0x69, 0x6e, /* | on brin| */
-				0x6b, 0x20, 0x6f, 0x66, 0x20, 0x73, 0x65, 0x63, /* |k of sec|*/
-				0x6f, 0x6e, 0x64, 0x20, 0x62, 0x61, 0x69, 0x6c, /* |ond bail| */
-				0x6f, 0x75, 0x74, 0x20, 0x66, 0x6f, 0x72, 0x20, /* |out for |*/
-				0x62, 0x61, 0x6e, 0x6b, 0x73, /* |banks| */
-			},
-			Sequence: 0xffffffff,
-		},
-	},
-	TxOut: []*wire.TxOut{
-		{
-			Value:   0x00000000,
-			Version: 0x0000,
-			PkScript: []byte{
-				0x41, 0x04, 0x67, 0x8a, 0xfd, 0xb0, 0xfe, 0x55, /* |A.g....U| */
-				0x48, 0x27, 0x19, 0x67, 0xf1, 0xa6, 0x71, 0x30, /* |H'.g..q0| */
-				0xb7, 0x10, 0x5c, 0xd6, 0xa8, 0x28, 0xe0, 0x39, /* |..\..(.9| */
-				0x09, 0xa6, 0x79, 0x62, 0xe0, 0xea, 0x1f, 0x61, /* |..yb...a| */
-				0xde, 0xb6, 0x49, 0xf6, 0xbc, 0x3f, 0x4c, 0xef, /* |..I..?L.| */
-				0x38, 0xc4, 0xf3, 0x55, 0x04, 0xe5, 0x1e, 0xc1, /* |8..U....| */
-				0x12, 0xde, 0x5c, 0x38, 0x4d, 0xf7, 0xba, 0x0b, /* |..\8M...| */
-				0x8d, 0x57, 0x8a, 0x4c, 0x70, 0x2b, 0x6b, 0xf1, /* |.W.Lp+k.| */
-				0x1d, 0x5f, 0xac, /* |._.| */
-			},
-		},
-	},
-	LockTime: 0,
-	Expiry:   0,
-}
-
-// simNetGenesisBlock defines the genesis block of the block chain which serves
-// as the public transaction ledger for the simulation test network.
-var simNetGenesisBlock = wire.MsgBlock{
-	Header: wire.BlockHeader{
-		Version: 1,
-		PrevBlock: chainhash.Hash([chainhash.HashSize]byte{ // Make go vet happy.
-			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-		}),
-		MerkleRoot: simNetGenesisMerkleRoot,
-		StakeRoot: chainhash.Hash([chainhash.HashSize]byte{ // Make go vet happy.
-			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-		}),
-		VoteBits:     uint16(0x0000),
-		FinalState:   [6]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
-		Voters:       uint16(0x0000),
-		FreshStake:   uint8(0x00),
-		Revocations:  uint8(0x00),
-		Timestamp:    time.Unix(1401292357, 0), // 2009-01-08 20:54:25 -0600 CST
-		PoolSize:     uint32(0),
-		Bits:         0x207fffff, // 545259519
-		SBits:        int64(0x0000000000000000),
-		Nonce:        0x00000000,
-		StakeVersion: uint32(0),
-		Height:       uint32(0),
-	},
-	Transactions:  []*wire.MsgTx{&regTestGenesisCoinbaseTx},
-	STransactions: []*wire.MsgTx{},
 }


### PR DESCRIPTION
Rather than redefining the simnet parameters in the tests, just use the existing `chaincfg` simnet parameters.  This is acceptable because there are now full block consensus tests that have their own definitions and ensure the consensus handling for tickets is correct.

Further, if these tests really wanted to have their own versions, they should instead start with the definition in chain params, make a copy, and change whatever they require that is different versus redefining them which makes them cumbersome to update.