### PR TITLE
Ensure 'run_tests.sh local' fails correctly when gometalinter errors.

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -25,12 +25,13 @@ TESTCMD="test -z \"\$(gometalinter --disable-all \
   --enable=vet \
   --enable=unconvert \
   --vendor \
-  --deadline=10m . | tee /dev/stderr)\"&& \
+  --deadline=10m . 2>&1 | tee /dev/stderr)\"&& \
   env GORACE='halt_on_error=1' go test -short -race \
   -tags rpctest \
   \$(glide novendor)"
 
 if [ $GOVERSION == "local" ]; then
+    go get -v github.com/alecthomas/gometalinter; gometalinter --install
     eval $TESTCMD
     exit
 fi


### PR DESCRIPTION
For a clean install, gometalinter can return non-zero, or gometalinter
may not run at all if it is not present.

In these cases, the content of stdout is zero bytes, and the script
continues when it should error out.

This error can easily occur when initially setting up the dev project
and one has not installed gometalinter or unconvert.  (This is not
a problem for docker testing, as these are preinstalled.)

Also updated README.md to describe the testing dependencies.