### PR TITLE
chaincfg: Introduce agenda for v5 lnfeatures vote.

### DIFF
--- a/blockchain/fullblocktests/params.go
+++ b/blockchain/fullblocktests/params.go
@@ -205,6 +205,34 @@ var simNetParams = &chaincfg.Params{
 			StartTime:  0,             // Always available for vote
 			ExpireTime: math.MaxInt64, // Never expires
 		}},
+		6: {{
+			Vote: chaincfg.Vote{
+				Id:          chaincfg.VoteIDLNFeatures,
+				Description: "Enable features defined in DCP0002 and DCP0003 necessary to support Lightning Network (LN)",
+				Mask:        0x0006, // Bits 1 and 2
+				Choices: []chaincfg.Choice{{
+					Id:          "abstain",
+					Description: "abstain voting for change",
+					Bits:        0x0000,
+					IsAbstain:   true,
+					IsNo:        false,
+				}, {
+					Id:          "no",
+					Description: "keep the existing consensus rules",
+					Bits:        0x0002, // Bit 1
+					IsAbstain:   false,
+					IsNo:        true,
+				}, {
+					Id:          "yes",
+					Description: "change to the new consensus rules",
+					Bits:        0x0004, // Bit 2
+					IsAbstain:   false,
+					IsNo:        false,
+				}},
+			},
+			StartTime:  0,             // Always available for vote
+			ExpireTime: math.MaxInt64, // Never expires
+		}},
 	},
 
 	// Enforce current block version once majority of the network has

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -168,6 +168,11 @@ const (
 	// VoteIDLNSupport is the vote ID for determining if the developers
 	// should work on integrating Lightning Network support.
 	VoteIDLNSupport = "lnsupport"
+
+	// VoteIDLNFeatures is the vote ID for the agenda that introduces
+	// features useful for the Lightning Network (among other uses) defined
+	// by DCP0002 and DCP0003.
+	VoteIDLNFeatures = "lnfeatures"
 )
 
 // ConsensusDeployment defines details related to a specific consensus rule
@@ -570,6 +575,34 @@ var MainNetParams = Params{
 			StartTime:  1493164800, // Apr 26th, 2017
 			ExpireTime: 1508976000, // Oct 26th, 2017
 		}},
+		5: {{
+			Vote: Vote{
+				Id:          VoteIDLNFeatures,
+				Description: "Enable features defined in DCP0002 and DCP0003 necessary to support Lightning Network (LN)",
+				Mask:        0x0006, // Bits 1 and 2
+				Choices: []Choice{{
+					Id:          "abstain",
+					Description: "abstain voting for change",
+					Bits:        0x0000,
+					IsAbstain:   true,
+					IsNo:        false,
+				}, {
+					Id:          "no",
+					Description: "keep the existing consensus rules",
+					Bits:        0x0002, // Bit 1
+					IsAbstain:   false,
+					IsNo:        true,
+				}, {
+					Id:          "yes",
+					Description: "change to the new consensus rules",
+					Bits:        0x0004, // Bit 2
+					IsAbstain:   false,
+					IsNo:        false,
+				}},
+			},
+			StartTime:  1505260800, // Sep 13th, 2017
+			ExpireTime: 1536796800, // Sep 13th, 2018
+		}},
 	},
 
 	// Enforce current block version once majority of the network has
@@ -718,6 +751,34 @@ var TestNet2Params = Params{
 			},
 			StartTime:  1493164800, // Apr 26th, 2017
 			ExpireTime: 1524700800, // Apr 26th, 2018
+		}},
+		6: {{
+			Vote: Vote{
+				Id:          VoteIDLNFeatures,
+				Description: "Enable features defined in DCP0002 and DCP0003 necessary to support Lightning Network (LN)",
+				Mask:        0x0006, // Bits 1 and 2
+				Choices: []Choice{{
+					Id:          "abstain",
+					Description: "abstain voting for change",
+					Bits:        0x0000,
+					IsAbstain:   true,
+					IsNo:        false,
+				}, {
+					Id:          "no",
+					Description: "keep the existing consensus rules",
+					Bits:        0x0002, // Bit 1
+					IsAbstain:   false,
+					IsNo:        true,
+				}, {
+					Id:          "yes",
+					Description: "change to the new consensus rules",
+					Bits:        0x0004, // Bit 2
+					IsAbstain:   false,
+					IsNo:        false,
+				}},
+			},
+			StartTime:  1505260800, // Sep 13th, 2017
+			ExpireTime: 1536796800, // Sep 13th, 2018
 		}},
 	},
 
@@ -877,6 +938,34 @@ var SimNetParams = Params{
 				}, {
 					Id:          "yes",
 					Description: "change to the new algorithm",
+					Bits:        0x0004, // Bit 2
+					IsAbstain:   false,
+					IsNo:        false,
+				}},
+			},
+			StartTime:  0,             // Always available for vote
+			ExpireTime: math.MaxInt64, // Never expires
+		}},
+		6: {{
+			Vote: Vote{
+				Id:          VoteIDLNFeatures,
+				Description: "Enable features defined in DCP0002 and DCP0003 necessary to support Lightning Network (LN)",
+				Mask:        0x0006, // Bits 1 and 2
+				Choices: []Choice{{
+					Id:          "abstain",
+					Description: "abstain voting for change",
+					Bits:        0x0000,
+					IsAbstain:   true,
+					IsNo:        false,
+				}, {
+					Id:          "no",
+					Description: "keep the existing consensus rules",
+					Bits:        0x0002, // Bit 1
+					IsAbstain:   false,
+					IsNo:        true,
+				}, {
+					Id:          "yes",
+					Description: "change to the new consensus rules",
 					Bits:        0x0004, // Bit 2
 					IsAbstain:   false,
 					IsNo:        false,


### PR DESCRIPTION
This adds a new definition for the upcoming agenda vote to enable the lnfeatures as defined by DCP0002 and DCP0003.  It does not include any code to make decisions or bump the versions.  It is only the definition.
