### PR TITLE
multi: Abstract standard verification flags.

### DIFF
--- a/mempool/policy.go
+++ b/mempool/policy.go
@@ -55,6 +55,22 @@ const (
 	// in a multi-signature transaction output script for it to be
 	// considered standard.
 	maxStandardMultiSigKeys = 3
+
+	// BaseStandardVerifyFlags defines the script flags that should be used
+	// when executing transaction scripts to enforce additional checks which
+	// are required for the script to be considered standard regardless of
+	// the state of any agenda votes.  The full set of standard verification
+	// flags must include these flags as well as any additional flags that
+	// are conditionally enabled depending on the result of agenda votes.
+	BaseStandardVerifyFlags = txscript.ScriptBip16 |
+		txscript.ScriptVerifyDERSignatures |
+		txscript.ScriptVerifyStrictEncoding |
+		txscript.ScriptVerifyMinimalData |
+		txscript.ScriptDiscourageUpgradableNops |
+		txscript.ScriptVerifyCleanStack |
+		txscript.ScriptVerifyCheckLockTimeVerify |
+		txscript.ScriptVerifyCheckSequenceVerify |
+		txscript.ScriptVerifyLowS
 )
 
 // calcMinRequiredTxRelayFee returns the minimum transaction fee required for a

--- a/mining.go
+++ b/mining.go
@@ -1149,6 +1149,13 @@ func NewBlockTemplate(policy *mining.Policy, server *server,
 	chainState := &blockManager.chainState
 	subsidyCache := blockManager.chain.FetchSubsidyCache()
 
+	// All transaction scripts are verified using the more strict standarad
+	// flags.
+	scriptFlags, err := standardScriptVerifyFlags(blockManager.chain)
+	if err != nil {
+		return nil, err
+	}
+
 	// Extend the most recently known best block.
 	// The most recently known best block is the top block that has the most
 	// ssgen votes for it. We only need this after the height in which stake voting
@@ -1599,7 +1606,7 @@ mempoolLoop:
 			continue
 		}
 		err = blockchain.ValidateTransactionScripts(tx, blockUtxos,
-			txscript.StandardVerifyFlags, server.sigCache)
+			scriptFlags, server.sigCache)
 		if err != nil {
 			minrLog.Tracef("Skipping tx %s due to error in "+
 				"ValidateTransactionScripts: %v", tx.Hash(), err)

--- a/server.go
+++ b/server.go
@@ -2213,6 +2213,14 @@ out:
 	s.wg.Done()
 }
 
+// standardScriptVerifyFlags returns the script flags that should be used when
+// executing transaction scripts to enforce additional checks which are required
+// for the script to be considered standard.  Note these flags are different
+// than what is required for the consensus rules in that they are more strict.
+func standardScriptVerifyFlags(chain *blockchain.BlockChain) (txscript.ScriptFlags, error) {
+	return mempool.BaseStandardVerifyFlags, nil
+}
+
 // newServer returns a new dcrd server configured to listen on addr for the
 // decred network type specified by chainParams.  Use start to begin accepting
 // connections from peers.
@@ -2421,6 +2429,9 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 			MaxSigOpsPerTx:       blockchain.MaxSigOpsPerBlock / 5,
 			MinRelayTxFee:        cfg.minRelayTxFee,
 			AllowOldVotes:        cfg.AllowOldVotes,
+			StandardVerifyFlags: func() (txscript.ScriptFlags, error) {
+				return standardScriptVerifyFlags(bm.chain)
+			},
 		},
 		ChainParams: chainParams,
 		NextStakeDifficulty: func() (int64, error) {

--- a/txscript/opcode_test.go
+++ b/txscript/opcode_test.go
@@ -16,6 +16,21 @@ import (
 	"github.com/decred/dcrd/wire"
 )
 
+// testScriptFlags are the script flags which are used in the tests when
+// executing transaction scripts to enforce additional checks.  Note these flags
+// are different than what is required for the consensus rules in that they are
+// more strict.
+const testScriptFlags = ScriptBip16 |
+	ScriptVerifyDERSignatures |
+	ScriptVerifyStrictEncoding |
+	ScriptVerifyMinimalData |
+	ScriptDiscourageUpgradableNops |
+	ScriptVerifyCleanStack |
+	ScriptVerifyCheckLockTimeVerify |
+	ScriptVerifyCheckSequenceVerify |
+	ScriptVerifyLowS |
+	ScriptVerifySHA256
+
 // TestOpcodeDisabled tests the opcodeDisabled function manually because all
 // disabled opcodes result in a script execution failure when executed normally,
 // so the function is not called under normal circumstances.
@@ -475,8 +490,8 @@ func TestNewlyEnabledOpCodes(t *testing.T) {
 			Value:    0x00FFFFFF00000000,
 			PkScript: []byte{0x01},
 		})
-		flags := StandardVerifyFlags
-		engine, err := NewEngine(test.pkScript, msgTx, 0, flags, 0, nil)
+		engine, err := NewEngine(test.pkScript, msgTx, 0,
+			testScriptFlags, 0, nil)
 		if err != nil {
 			t.Errorf("Bad script result for test %v because of error: %v",
 				test.name, err.Error())
@@ -544,9 +559,8 @@ func TestForVMFailure(t *testing.T) {
 				Value:    0x00FFFFFF00000000,
 				PkScript: []byte{0x01},
 			})
-			flags := StandardVerifyFlags
-			engine, err := NewEngine(tests[j], msgTx, 0, flags, 0,
-				nil)
+			engine, err := NewEngine(tests[j], msgTx, 0,
+				testScriptFlags, 0, nil)
 
 			if err == nil {
 				engine.Execute()

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -19,26 +19,6 @@ const (
 	// MaxDataCarrierSize is the maximum number of bytes allowed in pushed
 	// data to be considered a nulldata transaction.
 	MaxDataCarrierSize = 256
-
-	// StandardVerifyFlags are the script flags which are used when
-	// executing transaction scripts to enforce additional checks which
-	// are required for the script to be considered standard.  These checks
-	// help reduce issues related to transaction malleability as well as
-	// allow pay-to-script hash transactions.  Note these flags are
-	// different than what is required for the consensus rules in that they
-	// are more strict.
-	//
-	// TODO: This definition does not belong here.  It belongs in a policy
-	// package.
-	StandardVerifyFlags = ScriptBip16 |
-		ScriptVerifyDERSignatures |
-		ScriptVerifyStrictEncoding |
-		ScriptVerifyMinimalData |
-		ScriptDiscourageUpgradableNops |
-		ScriptVerifyCleanStack |
-		ScriptVerifyCheckLockTimeVerify |
-		ScriptVerifyCheckSequenceVerify |
-		ScriptVerifyLowS
 )
 
 // ScriptClass is an enumeration for the list of standard types of script.


### PR DESCRIPTION
This modifies the way standard verification flags are handled so that it is possible to selectively enable them based on the result of agenda votes.

First, it moves the `StandardVerifyFlags` constant from the `txscript` package to the `mempool/policy` code and renames it to `BaseStandardVerifyFlags`.  As the TODO in the comment of the moved constant indicated, these flags are policy related and thus really belong in policy.  Ideally there would be a completely separate policy package, but since the policy code currently lives in `mempool/policy.go`, the constant has been moved there.

Next, it introduces a new function named `standardScriptVerifyFlags`, which accepts the chain as an argument and, for now, just returns the `BaseStandardVerifyFlags` along with a `nil` error.  This will allow additional flags to be selectively enabled depending on the result of an agenda vote.

Finally, it updates the `mempool` policy struct to require a closure for obtaining the flags so it can remain decoupled from the chain which in turn allows easier and more robust unit testing of `mempool` functionality since it allows a mocks to be used.