### PR TITLE
multi: Enable vote for DCP0002 and DCP0003.

### DIFF
--- a/blockchain/agendas_test.go
+++ b/blockchain/agendas_test.go
@@ -1,0 +1,179 @@
+// Copyright (c) 2017 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package blockchain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/decred/dcrd/chaincfg"
+	"github.com/decred/dcrd/txscript"
+)
+
+// testLNFeaturesDeployment ensures the deployment of the LN features agenda
+// activates the expected changes for the provided network parameters and
+// expected deployment version.
+func testLNFeaturesDeployment(t *testing.T, params *chaincfg.Params, deploymentVer uint32) {
+	// baseConsensusScriptVerifyFlags are the expected script flags when the
+	// agenda is not active.
+	const baseConsensusScriptVerifyFlags = txscript.ScriptBip16 |
+		txscript.ScriptVerifyDERSignatures |
+		txscript.ScriptVerifyStrictEncoding |
+		txscript.ScriptVerifyMinimalData |
+		txscript.ScriptVerifyCleanStack |
+		txscript.ScriptVerifyCheckLockTimeVerify
+
+	// Find the correct deployment for the LN features agenda.
+	var deployment chaincfg.ConsensusDeployment
+	deployments := params.Deployments[deploymentVer]
+	for _, depl := range deployments {
+		if depl.Vote.Id == chaincfg.VoteIDLNFeatures {
+			deployment = depl
+		}
+	}
+	if deployment.Vote.Id != chaincfg.VoteIDLNFeatures {
+		t.Fatalf("Unable to find consensus deployement for %s",
+			chaincfg.VoteIDLNFeatures)
+	}
+
+	// Find the correct choice for the yes vote.
+	const yesVoteID = "yes"
+	var yesChoice chaincfg.Choice
+	for _, choice := range deployment.Vote.Choices {
+		if choice.Id == yesVoteID {
+			yesChoice = choice
+		}
+	}
+	if yesChoice.Id != yesVoteID {
+		t.Fatalf("Unable to find vote choice for id %q", yesVoteID)
+	}
+
+	// Shorter versions of params for convenience.
+	stakeValidationHeight := uint32(params.StakeValidationHeight)
+	ruleChangeActivationInterval := params.RuleChangeActivationInterval
+
+	tests := []struct {
+		name          string
+		numNodes      uint32 // num fake nodes to create
+		curActive     bool   // whether agenda active for current block
+		nextActive    bool   // whether agenda active for NEXT block
+		expectedFlags txscript.ScriptFlags
+	}{
+		{
+			name:          "stake validation height",
+			numNodes:      stakeValidationHeight,
+			curActive:     false,
+			nextActive:    false,
+			expectedFlags: baseConsensusScriptVerifyFlags,
+		},
+		{
+			name:          "started",
+			numNodes:      ruleChangeActivationInterval,
+			curActive:     false,
+			nextActive:    false,
+			expectedFlags: baseConsensusScriptVerifyFlags,
+		},
+		{
+			name:          "lockedin",
+			numNodes:      ruleChangeActivationInterval,
+			curActive:     false,
+			nextActive:    false,
+			expectedFlags: baseConsensusScriptVerifyFlags,
+		},
+		{
+			name:          "one before active",
+			numNodes:      ruleChangeActivationInterval - 1,
+			curActive:     false,
+			nextActive:    true,
+			expectedFlags: baseConsensusScriptVerifyFlags,
+		},
+		{
+			name:       "exactly active",
+			numNodes:   1,
+			curActive:  true,
+			nextActive: true,
+			expectedFlags: baseConsensusScriptVerifyFlags |
+				txscript.ScriptVerifyCheckSequenceVerify |
+				txscript.ScriptVerifySHA256,
+		},
+		{
+			name:       "one after active",
+			numNodes:   1,
+			curActive:  true,
+			nextActive: true,
+			expectedFlags: baseConsensusScriptVerifyFlags |
+				txscript.ScriptVerifyCheckSequenceVerify |
+				txscript.ScriptVerifySHA256,
+		},
+	}
+
+	curTimestamp := time.Now()
+	bc := newFakeChain(params)
+	node := bc.bestNode
+	for _, test := range tests {
+		for i := uint32(0); i < test.numNodes; i++ {
+			node = newFakeNode(node, int32(deploymentVer),
+				deploymentVer, 0, curTimestamp)
+
+			// Create fake votes that vote yes on the agenda to
+			// ensure it is activated.
+			for j := uint16(0); j < params.TicketsPerBlock; j++ {
+				node.votes = append(node.votes, VoteVersionTuple{
+					Version: deploymentVer,
+					Bits:    yesChoice.Bits | 0x01,
+				})
+			}
+			bc.bestNode = node
+			curTimestamp = curTimestamp.Add(time.Second)
+		}
+
+		// Ensure the agenda reports the expected activation status for
+		// the current block.
+		gotActive, err := bc.isLNFeaturesAgendaActive(node.parent)
+		if err != nil {
+			t.Errorf("%s: unexpected err: %v", test.name, err)
+			continue
+		}
+		if gotActive != test.curActive {
+			t.Errorf("%s: mismatched current active status - got: "+
+				"%v, want: %v", test.name, gotActive,
+				test.curActive)
+			continue
+		}
+
+		// Ensure the agenda reports the expected activation status for
+		// the NEXT block
+		gotActive, err = bc.IsLNFeaturesAgendaActive()
+		if err != nil {
+			t.Errorf("%s: unexpected err: %v", test.name, err)
+			continue
+		}
+		if gotActive != test.nextActive {
+			t.Errorf("%s: mismatched next active status - got: %v, "+
+				"want: %v", test.name, gotActive,
+				test.nextActive)
+			continue
+		}
+
+		// Ensure the consensus script verify flags are as expected.
+		gotFlags, err := bc.consensusScriptVerifyFlags(node)
+		if err != nil {
+			t.Errorf("%s: unexpected err: %v", test.name, err)
+			continue
+		}
+		if gotFlags != test.expectedFlags {
+			t.Errorf("%s: mismatched flags - got %v, want %v",
+				test.name, gotFlags, test.expectedFlags)
+			continue
+		}
+	}
+}
+
+// TestLNFeaturesDeployment ensures the deployment of the LN features agenda
+// activate the expected changes.
+func TestLNFeaturesDeployment(t *testing.T) {
+	testLNFeaturesDeployment(t, &chaincfg.MainNetParams, 5)
+	testLNFeaturesDeployment(t, &chaincfg.TestNet2Params, 6)
+}

--- a/blockchain/stakeversion_test.go
+++ b/blockchain/stakeversion_test.go
@@ -46,6 +46,7 @@ func newFakeNode(parent *blockNode, blockVersion int32, stakeVersion uint32, bit
 	header := &wire.BlockHeader{
 		Version:      blockVersion,
 		PrevBlock:    parent.hash,
+		VoteBits:     0x01,
 		Bits:         bits,
 		Height:       uint32(parent.height) + 1,
 		Timestamp:    timestamp,

--- a/server.go
+++ b/server.go
@@ -2218,7 +2218,18 @@ out:
 // for the script to be considered standard.  Note these flags are different
 // than what is required for the consensus rules in that they are more strict.
 func standardScriptVerifyFlags(chain *blockchain.BlockChain) (txscript.ScriptFlags, error) {
-	return mempool.BaseStandardVerifyFlags, nil
+	scriptFlags := mempool.BaseStandardVerifyFlags
+
+	// Enable validation of OP_SHA256 if the stake vote for the agenda is
+	// active.
+	isActive, err := chain.IsLNFeaturesAgendaActive()
+	if err != nil {
+		return 0, err
+	}
+	if isActive {
+		scriptFlags |= txscript.ScriptVerifySHA256
+	}
+	return scriptFlags, nil
 }
 
 // newServer returns a new dcrd server configured to listen on addr for the


### PR DESCRIPTION
**This requires PR #864**.

This implements the agenda for voting on the LN features as defined in [DCP0002](https://github.com/decred/dcps/blob/master/dcp-0002/dcp-0002.mediawiki) and [DCP0003](https://github.com/decred/dcps/blob/master/dcp-0003/dcp-0003.mediawiki) along with consensus tests to ensure its correctness.

The following is an overview of the changes:

- Generate new version blocks and reject old version blocks after a super majority has been reached
  - New block version on `mainnet` is version 5
  - New block version on `testnet` is version 6
- Introduce a convenience function for determining if the vote passed and is now active
- Introduce a new function for getting the consensus script verification flags and setting the appropriate flags to enforce the new consensus semantics in accordance with the state of the vote
- Enforce transaction finality checks based on the past median time in accordance with the state of the vote
- Enforce relative time locks via sequence numbers in accordance with the state of the vote
- Modify the more strict standardness checks (acceptance to the mempool and relay) to enforce DCP0002 in accordance with the state of the vote
  - It should be noted that the flag for DCP0003 is always set for the more strict standardness checks because it is a soft fork while the DCP0002 enforcement must depend on the result of the vote because it is a hard fork
- Add tests for determining consensus script verification flags for both `mainnet` and `testnet`
- Add tests for determining if the agenda is active for both `mainnet` and `testnet`