### PR TITLE
chain: Remove memory block node pruning.

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -256,13 +256,10 @@ func (b *BlockChain) maybeAcceptBlock(block *dcrutil.Block, flags BehaviorFlags)
 		return false, err
 	}
 
-	// Prune stake nodes and block nodes which are no longer needed before
-	// creating a new node.
+	// Prune stake nodes which are no longer needed before creating a new
+	// node.
 	if !dryRun {
-		err := b.pruner.pruneChainIfNeeded()
-		if err != nil {
-			return false, err
-		}
+		b.pruner.pruneChainIfNeeded()
 	}
 
 	// Create a new block node for the block and add it to the in-memory

--- a/blockchain/prune.go
+++ b/blockchain/prune.go
@@ -27,14 +27,13 @@ func newChainPruner(chain *BlockChain) *chainPruner {
 // If the blockchain hasn't been pruned in this time, it initiates a new pruning.
 //
 // pruneChainIfNeeded must be called with the chainLock held for writes.
-func (c *chainPruner) pruneChainIfNeeded() error {
+func (c *chainPruner) pruneChainIfNeeded() {
 	now := time.Now()
 	duration := now.Sub(c.lastNodeInsertTime)
 	if duration < time.Minute*pruningIntervalInMinutes {
-		return nil
+		return
 	}
 
 	c.lastNodeInsertTime = now
-
-	return c.chain.pruneNodes()
+	c.chain.pruneStakeNodes()
 }


### PR DESCRIPTION
This removes the memory block node (header) pruning.  It should be noted that this does not apply to stake node pruning.

This is being done for two primary reasons:

- The goal is to ultimately have all block nodes in memory in the same way the upstream code has done since it provides significant   optimization and code simplification opportunities
- Upcoming code that deals with calculating sequence locks on inputs far in the past requires the ability to quickly calculate the median time for arbitrarily old nodes and consequently pruning the memory block nodes could lead to significant performance implications under those conditions