### PR TITLE
mempool: Use median time for tx finality checks.

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -108,14 +108,16 @@ type Config struct {
 	// the current best chain.
 	BestHeight func() int64
 
+	// PastMedianTime defines the function to use in order to access the
+	// median time calculated from the point-of-view of the current chain
+	// tip within the best chain.
+	PastMedianTime func() time.Time
+
 	// SubsidyCache defines a subsidy cache to use.
 	SubsidyCache *blockchain.SubsidyCache
 
 	// SigCache defines a signature cache to use.
 	SigCache *txscript.SigCache
-
-	// TimeSource defines the timesource to use.
-	TimeSource blockchain.MedianTimeSource
 
 	// AddrIndex defines the optional address index instance to use for
 	// indexing the unconfirmed transactions in the memory pool.
@@ -830,8 +832,9 @@ func (mp *TxPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit, allow
 	// Don't allow non-standard transactions if the network parameters
 	// forbid their relaying.
 	if !mp.cfg.Policy.RelayNonStd {
+		medianTime := mp.cfg.PastMedianTime()
 		err := checkTransactionStandard(tx, txType, nextBlockHeight,
-			mp.cfg.TimeSource, mp.cfg.Policy.MinRelayTxFee,
+			medianTime, mp.cfg.Policy.MinRelayTxFee,
 			mp.cfg.Policy.MaxTxVersion)
 		if err != nil {
 			// Attempt to extract a reject code from the error so

--- a/mempool/policy.go
+++ b/mempool/policy.go
@@ -7,6 +7,7 @@ package mempool
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/decred/dcrd/blockchain"
 	"github.com/decred/dcrd/blockchain/stake"
@@ -363,7 +364,7 @@ func isDust(txOut *wire.TxOut, minRelayTxFee dcrutil.Amount) bool {
 // of recognized forms, and not containing "dust" outputs (those that are
 // so small it costs more to process them than they are worth).
 func checkTransactionStandard(tx *dcrutil.Tx, txType stake.TxType, height int64,
-	timeSource blockchain.MedianTimeSource, minRelayTxFee dcrutil.Amount,
+	medianTime time.Time, minRelayTxFee dcrutil.Amount,
 	maxTxVersion uint16) error {
 
 	// The transaction must be a currently supported version and serialize
@@ -382,8 +383,7 @@ func checkTransactionStandard(tx *dcrutil.Tx, txType stake.TxType, height int64,
 
 	// The transaction must be finalized to be standard and therefore
 	// considered for inclusion in a block.
-	adjustedTime := timeSource.AdjustedTime()
-	if !blockchain.IsFinalizedTransaction(tx, height, adjustedTime) {
+	if !blockchain.IsFinalizedTransaction(tx, height, medianTime) {
 		return txRuleError(wire.RejectNonstandard,
 			"transaction is not finalized")
 	}

--- a/mempool/policy_test.go
+++ b/mempool/policy_test.go
@@ -9,8 +9,8 @@ import (
 	"bytes"
 	"math/big"
 	"testing"
+	"time"
 
-	"github.com/decred/dcrd/blockchain"
 	"github.com/decred/dcrd/blockchain/stake"
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainec"
@@ -514,12 +514,13 @@ func TestCheckTransactionStandard(t *testing.T) {
 		},
 	}
 
-	timeSource := blockchain.NewMedianTime()
+	medianTime := time.Now()
 	for _, test := range tests {
 		// Ensure standardness is as expected.
 		tx := dcrutil.NewTx(&test.tx)
 		err := checkTransactionStandard(tx, stake.DetermineTxType(&test.tx),
-			test.height, timeSource, DefaultMinRelayTxFee, maxTxVersion)
+			test.height, medianTime, DefaultMinRelayTxFee,
+			maxTxVersion)
 		if err == nil && test.isStandard {
 			// Test passes since function returned standard for a
 			// transaction which is intended to be standard.

--- a/server.go
+++ b/server.go
@@ -2446,7 +2446,7 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 		BestHeight:      func() int64 { return bm.chain.BestSnapshot().Height },
 		SubsidyCache:    bm.chain.FetchSubsidyCache(),
 		SigCache:        s.sigCache,
-		TimeSource:      s.timeSource,
+		PastMedianTime:  func() time.Time { return bm.chain.BestSnapshot().MedianTime },
 		AddrIndex:       s.addrIndex,
 		ExistsAddrIndex: s.existsAddrIndex,
 	}


### PR DESCRIPTION
This modifies the mempool transaction finality checks to use the past median time instead of the adjusted network time.  This ensures the standardness rules match the upcoming consensus rules which reject transactions that are not after the median time of the last several blocks.  Without this change, it is possible for transactions which can never make it into a block to be admitted to the mempool thereby wasting memory.

The following is an overview of the changes:

- Introduce a new callback to the mempool config named `PastMedianTime`  for obtaining the median time for the current best chain so it can remain decoupled from the chain
- Update the tx finality standardness check to use the callback
- Remove the now unused `TimeSource` mempool config parameter
- Update the mempool test harness and mock chain to use a mock median time
- Update server to provide a closure for the mempool config that uses the cached median time for the current best chain to negate any additional performance impact the new calculations would otherwise cause from recalculating the median time for every new candidate tx validation