### PR TITLE
Rename one of the testnet seeders.

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -465,7 +465,6 @@ var MainNetParams = Params{
 	DNSSeeds: []string{
 		"mainnet-seed.decred.mindcry.org",
 		"mainnet-seed.decred.netpurgatory.com",
-		"mainnet.decredseed.org",
 		"mainnet-seed.decred.org",
 	},
 
@@ -672,7 +671,6 @@ var TestNet2Params = Params{
 	DNSSeeds: []string{
 		"testnet-seed.decred.mindcry.org",
 		"testnet-seed.decred.netpurgatory.com",
-		"testnet.decredseed.org",
 		"testnet-seed.decred.org",
 	},
 

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -671,7 +671,7 @@ var TestNet2Params = Params{
 	DefaultPort: "19108",
 	DNSSeeds: []string{
 		"testnet-seed.decred.mindcry.org",
-		"testnet-seed.decred.netpurgatory.org",
+		"testnet-seed.decred.netpurgatory.com",
 		"testnet.decredseed.org",
 		"testnet-seed.decred.org",
 	},


### PR DESCRIPTION
Switched the testnet seeder on netpurgatory to .com instead
of .org so it matches the mainnet one.

I'm consolidating/reorganizing some servers and domains so I'd like to move my testnet seeder to the same domain as my mainnet one.