### PR TITLE
rpcclient: Remove docker info from README.md.

### DIFF
--- a/rpcclient/README.md
+++ b/rpcclient/README.md
@@ -47,24 +47,6 @@ implement and the API is not stable yet.
 $ go get -u github.com/decred/dcrd/rpcclient
 ```
 
-## Docker
-
-All tests and linters may be run in a docker container using the script
-`run_tests.sh`.  This script defaults to using the current supported version of
-go.  You can run it with the major version of go you would like to use as the
-only arguement to test a previous on a previous version of go (generally decred
-supports the current version of go and the previous one).
-
-```
-./run_tests.sh 1.7
-```
-
-To run the tests locally without docker:
-
-```
-./run_tests.sh local
-```
-
 ## License
 
 Package rpcclient is licensed under the [copyfree](http://copyfree.org) ISC


### PR DESCRIPTION
This information no longer applies since the `rpcclient` was merged into dcrd proper.