### PR TITLE
Improve gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,42 @@
-dcrd
-cmd/dcrctl/dcrctl
-cmd/promptsecret/promptsecret
+# Temp files
 *~
-*.pyc
-vendor/
+
+# Databases
+dcrd.db
+*-shm
+*-wal
+
+# Log files
+*.log
+
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+vendor
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+# Binaries
+*.exe
+dcrd
+cmd/addblock/addblock
+cmd/checkdevpremine/checkdevpremine
+cmd/dcrctl/dcrctl
+cmd/findcheckpoint/findcheckpoint
+cmd/gencerts/gencerts
+cmd/promptsecret/promptsecret


### PR DESCRIPTION
This syncs the `.gitignore` file with the upstream `btcd` project since it shouldn't have been completely changed to begin with.  While here, it also adds the Decred-specific binaries.