### PR TITLE
hdkeychain: Work around go vet issue with examples.

### DIFF
--- a/dcrutil/hdkeychain/example_test.go
+++ b/dcrutil/hdkeychain/example_test.go
@@ -14,7 +14,7 @@ import (
 
 // This example demonstrates how to generate a cryptographically random seed
 // then use it to create a new master node (extended key).
-func ExampleNewMaster() {
+func Example_newMaster() {
 	// Generate a random seed at the recommended length.
 	seed, err := hdkeychain.GenerateSeed(hdkeychain.RecommendedSeedLen)
 	if err != nil {


### PR DESCRIPTION
This works around the issue with `go vet` via `gometalinter` as described in alecthomas/gometalinter#351 by showing the example at the package level instead of on the function itself.