### PR TITLE
bloom: Add missing import to examples.

### DIFF
--- a/bloom/example_test.go
+++ b/bloom/example_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/decred/dcrd/bloom"
 	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/wire"
 )
 
 // This example demonstrates how to create a new bloom filter, add a transaction


### PR DESCRIPTION
The missing import is preventing `go test` from completing.