### PR TITLE
WIP: mining/mempool: Move priority code to mining pkg.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -58,6 +58,13 @@ type VoteVersionTuple struct {
 	Bits    uint16
 }
 
+// VoteTx is a struct describing a block vote (SSGen).
+type VoteTx struct {
+	SsgenHash chainhash.Hash // Vote
+	SstxHash  chainhash.Hash // Ticket
+	Vote      bool
+}
+
 // blockNode represents a block within the block chain and is primarily used to
 // aid in selecting the best chain to be the main chain.  The main chain is
 // stored into the block database.

--- a/cpuminer.go
+++ b/cpuminer.go
@@ -315,7 +315,7 @@ out:
 		// Hacks to make dcr work with Decred PoC (simnet only)
 		// TODO Remove before production.
 		if cfg.SimNet {
-			_, curHeight := m.server.blockManager.chainState.Best()
+			curHeight := m.server.blockManager.chain.BestSnapshot().Height
 
 			if curHeight == 1 {
 				time.Sleep(5500 * time.Millisecond) // let wallet reconn

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -246,8 +246,10 @@ func (mp *TxPool) insertVote(ssgen *dcrutil.Tx) error {
 	// Append the new vote.
 	voteBits := stake.SSGenVoteBits(msgTx)
 	vote := dcrutil.IsFlagSet16(voteBits, dcrutil.BlockValid)
-	mp.votes[blockHash] = append(vts, &blockchain.VoteTx{*voteHash, *ticketHash,
-		vote})
+	mp.votes[blockHash] = append(vts, &blockchain.VoteTx{
+		SsgenHash: *voteHash,
+		SstxHash:  *ticketHash,
+		Vote:      vote})
 
 	log.Debugf("Accepted vote %v for block hash %v (height %v), voting "+
 		"%v on the transaction tree", voteHash, blockHash, blockHeight,

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -38,10 +38,6 @@ const (
 	// transaction to be considered high priority.
 	MinHighPriority = dcrutil.AtomsPerCoin * 144.0 / 250
 
-	// mempoolHeight is the height used for the "block" height field of the
-	// contextual transaction information provided in a transaction view.
-	mempoolHeight = 0x7fffffff
-
 	// maxRelayFeeMultiplier is the factor that we disallow fees / kB above the
 	// minimum tx fee.  At the current default minimum relay fee of 0.001
 	// DCR/kB, this results in a maximum allowed high fee of 1 DCR/kB.
@@ -624,7 +620,7 @@ func (mp *TxPool) addTransaction(utxoView *blockchain.UtxoViewpoint,
 			Height: height,
 			Fee:    fee,
 		},
-		StartingPriority: CalcPriority(msgTx, utxoView, height),
+		StartingPriority: mining.CalcPriority(msgTx, utxoView, height),
 	}
 	for _, txIn := range msgTx.TxIn {
 		mp.outpoints[txIn.PreviousOutPoint] = tx
@@ -723,7 +719,7 @@ func (mp *TxPool) fetchInputUtxos(tx *dcrutil.Tx) (*blockchain.UtxoViewpoint, er
 		}
 
 		if poolTxDesc, exists := mp.pool[originHash]; exists {
-			utxoView.AddTxOuts(poolTxDesc.Tx, mempoolHeight,
+			utxoView.AddTxOuts(poolTxDesc.Tx, mining.UnminedHeight,
 				wire.NullBlockIndex)
 		}
 	}
@@ -1099,7 +1095,7 @@ func (mp *TxPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit, allow
 	if isNew && !mp.cfg.Policy.DisableRelayPriority && txFee < minFee &&
 		txType == stake.TxTypeRegular {
 
-		currentPriority := CalcPriority(msgTx, utxoView,
+		currentPriority := mining.CalcPriority(msgTx, utxoView,
 			nextBlockHeight)
 		if currentPriority <= MinHighPriority {
 			str := fmt.Sprintf("transaction %v has insufficient "+
@@ -1532,7 +1528,7 @@ func (mp *TxPool) RawMempoolVerbose(filterType *stake.TxType) map[string]*dcrjso
 		var currentPriority float64
 		utxos, err := mp.fetchInputUtxos(tx)
 		if err == nil {
-			currentPriority = CalcPriority(tx.MsgTx(), utxos,
+			currentPriority = mining.CalcPriority(tx.MsgTx(), utxos,
 				bestHeight+1)
 		}
 

--- a/mempool/policy.go
+++ b/mempool/policy.go
@@ -98,82 +98,6 @@ func calcMinRequiredTxRelayFee(serializedSize int64, minRelayTxFee dcrutil.Amoun
 	return minFee
 }
 
-// CalcPriority returns a transaction priority given a transaction and the sum
-// of each of its input values multiplied by their age (# of confirmations).
-// Thus, the final formula for the priority is:
-// sum(inputValue * inputAge) / adjustedTxSize
-func CalcPriority(tx *wire.MsgTx, utxoView *blockchain.UtxoViewpoint, nextBlockHeight int64) float64 {
-	// In order to encourage spending multiple old unspent transaction
-	// outputs thereby reducing the total set, don't count the constant
-	// overhead for each input as well as enough bytes of the signature
-	// script to cover a pay-to-script-hash redemption with a compressed
-	// pubkey.  This makes additional inputs free by boosting the priority
-	// of the transaction accordingly.  No more incentive is given to avoid
-	// encouraging gaming future transactions through the use of junk
-	// outputs.  This is the same logic used in the reference
-	// implementation.
-	//
-	// The constant overhead for a txin is 41 bytes since the previous
-	// outpoint is 36 bytes + 4 bytes for the sequence + 1 byte the
-	// signature script length.
-	//
-	// A compressed pubkey pay-to-script-hash redemption with a maximum len
-	// signature is of the form:
-	// [OP_DATA_73 <73-byte sig> + OP_DATA_35 + {OP_DATA_33
-	// <33 byte compresed pubkey> + OP_CHECKSIG}]
-	//
-	// Thus 1 + 73 + 1 + 1 + 33 + 1 = 110
-	overhead := 0
-	for _, txIn := range tx.TxIn {
-		// Max inputs + size can't possibly overflow here.
-		overhead += 41 + minInt(110, len(txIn.SignatureScript))
-	}
-
-	serializedTxSize := tx.SerializeSize()
-	if overhead >= serializedTxSize {
-		return 0.0
-	}
-
-	inputValueAge := calcInputValueAge(tx, utxoView, nextBlockHeight)
-	return inputValueAge / float64(serializedTxSize-overhead)
-}
-
-// calcInputValueAge is a helper function used to calculate the input age of
-// a transaction.  The input age for a txin is the number of confirmations
-// since the referenced txout multiplied by its output value.  The total input
-// age is the sum of this value for each txin.  Any inputs to the transaction
-// which are currently in the mempool and hence not mined into a block yet,
-// contribute no additional input age to the transaction.
-func calcInputValueAge(tx *wire.MsgTx, utxoView *blockchain.UtxoViewpoint, nextBlockHeight int64) float64 {
-	var totalInputAge float64
-	for _, txIn := range tx.TxIn {
-		// Don't attempt to accumulate the total input age if the
-		// referenced transaction output doesn't exist.
-		originHash := &txIn.PreviousOutPoint.Hash
-		originIndex := txIn.PreviousOutPoint.Index
-		txEntry := utxoView.LookupEntry(originHash)
-		if txEntry != nil && !txEntry.IsOutputSpent(originIndex) {
-			// Inputs with dependencies currently in the mempool
-			// have their block height set to a special constant.
-			// Their input age should be computed as zero since
-			// their parent hasn't made it into a block yet.
-			var inputAge int64
-			originHeight := txEntry.BlockHeight()
-			if originHeight == mempoolHeight {
-				inputAge = 0
-			} else {
-				inputAge = nextBlockHeight - originHeight
-			}
-
-			// Sum the input value times age.
-			inputValue := txEntry.AmountByIndex(originIndex)
-			totalInputAge += float64(inputValue * inputAge)
-		}
-	}
-
-	return totalInputAge
-}
-
 // checkInputsStandard performs a series of checks on a transaction's inputs
 // to ensure they are "standard".  A standard transaction input within the
 // context of this function is one whose referenced public key script is of a
@@ -463,13 +387,4 @@ func checkTransactionStandard(tx *dcrutil.Tx, txType stake.TxType, height int64,
 	}
 
 	return nil
-}
-
-// minInt is a helper function to return the minimum of two ints.  This avoids
-// a math import and the need to cast to floats.
-func minInt(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
 }

--- a/mining.go
+++ b/mining.go
@@ -1398,7 +1398,7 @@ mempoolLoop:
 		// Calculate the final transaction priority using the input
 		// value age sum as well as the adjusted transaction size.  The
 		// formula is: sum(inputValue * inputAge) / adjustedTxSize
-		prioItem.priority = mempool.CalcPriority(tx.MsgTx(), utxos,
+		prioItem.priority = mining.CalcPriority(tx.MsgTx(), utxos,
 			nextBlockHeight)
 
 		// Calculate the fee in Atoms/KB.

--- a/mining.go
+++ b/mining.go
@@ -281,7 +281,7 @@ func (b byNumberOfVotes) Less(i, j int) bool {
 // at least a majority number of votes) sorted by number of votes, descending.
 //
 // This function is safe for concurrent access.
-func SortParentsByVotes(mp *mempool.TxPool, currentTopBlock chainhash.Hash, blocks []chainhash.Hash, params *chaincfg.Params) []chainhash.Hash {
+func SortParentsByVotes(txSource mining.TxSource, currentTopBlock chainhash.Hash, blocks []chainhash.Hash, params *chaincfg.Params) []chainhash.Hash {
 	// Return now when no blocks were provided.
 	lenBlocks := len(blocks)
 	if lenBlocks == 0 {
@@ -292,7 +292,7 @@ func SortParentsByVotes(mp *mempool.TxPool, currentTopBlock chainhash.Hash, bloc
 	// mempool and filter out any blocks that do not have the minimum
 	// required number of votes.
 	minVotesRequired := (params.TicketsPerBlock / 2) + 1
-	voteMetadata := mp.VotesForBlocks(blocks)
+	voteMetadata := txSource.VotesForBlocks(blocks)
 	filtered := make([]*blockWithNumVotes, 0, lenBlocks)
 	for i := range blocks {
 		numVotes := uint16(len(voteMetadata[i]))
@@ -321,7 +321,7 @@ func SortParentsByVotes(mp *mempool.TxPool, currentTopBlock chainhash.Hash, bloc
 	// the same amount of votes as the current leader after the sort. After this
 	// point, all blocks listed in sortedUsefulBlocks definitely also have the
 	// minimum number of votes required.
-	curVoteMetadata := mp.VotesForBlocks([]chainhash.Hash{currentTopBlock})
+	curVoteMetadata := txSource.VotesForBlocks([]chainhash.Hash{currentTopBlock})
 	numTopBlockVotes := uint16(len(curVoteMetadata))
 	if filtered[0].NumVotes == numTopBlockVotes && filtered[0].Hash !=
 		currentTopBlock {
@@ -486,38 +486,6 @@ func getCoinbaseExtranonces(msgBlock *wire.MsgBlock) []uint64 {
 		msgBlock.Transactions[0].TxOut[1].PkScript[30:38])
 
 	return ens
-}
-
-// UpdateExtraNonce updates the extra nonce in the coinbase script of the passed
-// block by regenerating the coinbase script with the passed value and block
-// height.  It also recalculates and updates the new merkle root that results
-// from changing the coinbase script.
-func UpdateExtraNonce(msgBlock *wire.MsgBlock, blockHeight int64,
-	extraNonces []uint64) error {
-	// First block has no extranonce.
-	if blockHeight == 1 {
-		return nil
-	}
-	if len(extraNonces) != 4 {
-		return fmt.Errorf("not enough nonce information passed")
-	}
-
-	coinbaseOpReturn, err := standardCoinbaseOpReturn(uint32(blockHeight),
-		extraNonces)
-	if err != nil {
-		return err
-	}
-	msgBlock.Transactions[0].TxOut[1].PkScript = coinbaseOpReturn
-
-	// TODO(davec): A dcrutil.Block should use saved in the state to avoid
-	// recalculating all of the other transaction hashes.
-	// block.Transactions[0].InvalidateCache()
-
-	// Recalculate the merkle root with the updated extra nonce.
-	block := dcrutil.NewBlockDeepCopyCoinbase(msgBlock)
-	merkles := blockchain.BuildMerkleTreeStore(block.Transactions())
-	msgBlock.Header.MerkleRoot = *merkles[len(merkles)-1]
-	return nil
 }
 
 // createCoinbaseTx returns a coinbase transaction paying an appropriate subsidy
@@ -803,9 +771,11 @@ func deepCopyBlockTemplate(blockTemplate *BlockTemplate) *BlockTemplate {
 func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache,
 	nextHeight int64,
 	miningAddress dcrutil.Address,
-	bm *blockManager) (*BlockTemplate, error) {
-	timeSource := bm.server.timeSource
-	stakeValidationHeight := bm.server.chainParams.StakeValidationHeight
+	generator *BlkTmplGenerator) (*BlockTemplate, error) {
+	timeSource := generator.timeSource
+	chainParams := generator.chainParams
+	stakeValidationHeight := chainParams.StakeValidationHeight
+	bm := generator.blockManager
 	curTemplate := bm.GetCurrentTemplate()
 
 	// Check to see if we've fallen off the chain, for example if a
@@ -836,7 +806,7 @@ func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache,
 
 				// If we're on testnet, the time since this last block
 				// listed as the parent must be taken into consideration.
-				if bm.server.chainParams.ReduceMinDifficulty {
+				if chainParams.ReduceMinDifficulty {
 					parentHash := cptCopy.Block.Header.PrevBlock
 
 					requiredDifficulty, err :=
@@ -854,14 +824,16 @@ func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache,
 				// same block and choose the same winners as before.
 				ens := cptCopy.getCoinbaseExtranonces()
 				ens[0]++
-				err := UpdateExtraNonce(cptCopy.Block, cptCopy.Height, ens)
+				err := generator.UpdateExtraNonce(cptCopy.Block, cptCopy.Height,
+					ens)
 				if err != nil {
 					return nil, err
 				}
 
 				// Update extranonce of the original template too, so
 				// we keep getting unique numbers.
-				err = UpdateExtraNonce(curTemplate.Block, curTemplate.Height, ens)
+				err = generator.UpdateExtraNonce(curTemplate.Block,
+					curTemplate.Height, ens)
 				if err != nil {
 					return nil, err
 				}
@@ -869,8 +841,8 @@ func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache,
 				// Make sure the block validates.
 				block := dcrutil.NewBlockDeepCopyCoinbase(cptCopy.Block)
 				if err := blockchain.CheckWorklessBlockSanity(block,
-					bm.server.timeSource,
-					bm.server.chainParams); err != nil {
+					timeSource,
+					chainParams); err != nil {
 					return nil, miningRuleError(ErrCheckConnectBlock,
 						err.Error())
 				}
@@ -916,7 +888,7 @@ func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache,
 					topBlock.Height(),
 					miningAddress,
 					topBlock.MsgBlock().Header.Voters,
-					bm.server.chainParams)
+					chainParams)
 				if err != nil {
 					return nil, err
 				}
@@ -936,7 +908,7 @@ func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache,
 
 				// If we're on testnet, the time since this last block
 				// listed as the parent must be taken into consideration.
-				if bm.server.chainParams.ReduceMinDifficulty {
+				if chainParams.ReduceMinDifficulty {
 					parentHash := topBlock.MsgBlock().Header.PrevBlock
 
 					requiredDifficulty, err :=
@@ -973,8 +945,8 @@ func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache,
 				// Make sure the block validates.
 				btBlock := dcrutil.NewBlockDeepCopyCoinbase(btMsgBlock)
 				if err := blockchain.CheckWorklessBlockSanity(btBlock,
-					bm.server.timeSource,
-					bm.server.chainParams); err != nil {
+					timeSource,
+					chainParams); err != nil {
 					str := fmt.Sprintf("failed to check sanity of template "+
 						"while constructing a new parent: %v",
 						err.Error())
@@ -1041,6 +1013,42 @@ func handleCreatedBlockTemplate(blockTemplate *BlockTemplate,
 	}
 
 	return blockTemplate, nil
+}
+
+// BlkTmplGenerator provides a type that can be used to generate block templates
+// based on a given mining policy and source of transactions to choose from.
+// It also houses additional state required in order to ensure the templates
+// are built on top of the current best chain and adhere to the consensus rules.
+//
+// See the NewBlockTemplate method for a detailed description of how the block
+// template is generated.
+type BlkTmplGenerator struct {
+	policy       *mining.Policy
+	chainParams  *chaincfg.Params
+	txSource     mining.TxSource
+	sigCache     *txscript.SigCache
+	blockManager *blockManager
+	timeSource   blockchain.MedianTimeSource
+}
+
+// newBlkTmplGenerator returns a new block template generator for the given
+// policy using transactions from the provided transaction source.
+//
+// The additional state-related fields are required in order to ensure the
+// templates are built on top of the current best chain and adhere to the
+// consensus rules.
+func newBlkTmplGenerator(policy *mining.Policy, params *chaincfg.Params,
+	txSource mining.TxSource, sigCache *txscript.SigCache,
+	blockManager *blockManager, timeSource blockchain.MedianTimeSource) *BlkTmplGenerator {
+
+	return &BlkTmplGenerator{
+		policy:       policy,
+		chainParams:  params,
+		txSource:     txSource,
+		sigCache:     sigCache,
+		blockManager: blockManager,
+		timeSource:   timeSource,
+	}
 }
 
 // NewBlockTemplate returns a new block template that is ready to be solved
@@ -1125,16 +1133,13 @@ func handleCreatedBlockTemplate(blockTemplate *BlockTemplate,
 //
 //  This function returns nil, nil if there are not enough voters on any of
 //  the current top blocks to create a new block template.
-func NewBlockTemplate(policy *mining.Policy, server *server,
-	payToAddress dcrutil.Address) (*BlockTemplate, error) {
+func (g *BlkTmplGenerator) NewBlockTemplate(payToAddress dcrutil.Address) (*BlockTemplate, error) {
+	// Locals for faster access.
+	policy := g.policy
+	blockManager := g.blockManager
+	timeSource := g.timeSource
 
-	// TODO: The mempool should be completely separated via the TxSource
-	// interface so this function is fully decoupled.
-	mp := server.txMemPool
-
-	var txSource mining.TxSource = server.txMemPool
-	blockManager := server.blockManager
-	timeSource := server.timeSource
+	var txSource mining.TxSource = g.txSource
 	subsidyCache := blockManager.chain.FetchSubsidyCache()
 
 	// All transaction scripts are verified using the more strict standarad
@@ -1201,7 +1206,7 @@ func NewBlockTemplate(policy *mining.Policy, server *server,
 	medianTime := chainBest.MedianTime
 
 	// Calculate the stake enabled height.
-	stakeValidationHeight := server.chainParams.StakeValidationHeight
+	stakeValidationHeight := g.chainParams.StakeValidationHeight
 
 	if nextBlockHeight >= stakeValidationHeight {
 		// Obtain the entire generation of blocks stemming from this parent.
@@ -1213,13 +1218,13 @@ func NewBlockTemplate(policy *mining.Policy, server *server,
 		// Get the list of blocks that we can actually build on top of. If we're
 		// not currently on the block that has the most votes, switch to that
 		// block.
-		eligibleParents := SortParentsByVotes(mp, *prevHash, children,
-			blockManager.server.chainParams)
+		eligibleParents := SortParentsByVotes(txSource, *prevHash, children,
+			g.chainParams)
 		if len(eligibleParents) == 0 {
 			minrLog.Debugf("Too few voters found on any HEAD block, " +
 				"recycling a parent block to mine on")
 			return handleTooFewVoters(subsidyCache, nextBlockHeight,
-				payToAddress, server.blockManager)
+				payToAddress, g)
 		}
 
 		minrLog.Debugf("Found eligible parent %v with enough votes to build "+
@@ -1238,13 +1243,13 @@ func NewBlockTemplate(policy *mining.Policy, server *server,
 
 				// Check to make sure we actually have the transactions
 				// (votes) we need in the mempool.
-				voteHashes := mp.VoteHashesForBlock(newHead)
+				voteHashes := txSource.VoteHashesForBlock(newHead)
 				if len(voteHashes) == 0 {
 					return nil, fmt.Errorf("no vote metadata for block %v",
 						newHead)
 				}
 
-				if exist := mp.CheckIfTxsExist(voteHashes); !exist {
+				if exist := txSource.CheckIfTxsExist(voteHashes); !exist {
 					continue
 				} else {
 					prevHash = &newHead
@@ -1296,7 +1301,7 @@ func NewBlockTemplate(policy *mining.Policy, server *server,
 
 	minrLog.Debugf("Considering %d transactions for inclusion to new block",
 		len(sourceTxns))
-	treeValid := mp.IsTxTreeValid(prevHash)
+	treeValid := txSource.IsTxTreeValid(prevHash)
 
 mempoolLoop:
 	for _, txDesc := range sourceTxns {
@@ -1467,7 +1472,7 @@ mempoolLoop:
 
 		// Skip if we already have too many SStx.
 		if isSStx && (numSStx >=
-			int(server.chainParams.MaxFreshStakePerBlock)) {
+			int(g.chainParams.MaxFreshStakePerBlock)) {
 			minrLog.Tracef("Skipping sstx %s because it would exceed "+
 				"the max number of sstx allowed in a block", tx.Hash())
 			logSkippedDeps(tx, deps)
@@ -1601,7 +1606,7 @@ mempoolLoop:
 		// The fraud proof is not checked because it will be filled in
 		// by the miner.
 		_, err = blockchain.CheckTransactionInputs(subsidyCache, tx,
-			nextBlockHeight, blockUtxos, false, server.chainParams)
+			nextBlockHeight, blockUtxos, false, g.chainParams)
 		if err != nil {
 			minrLog.Tracef("Skipping tx %s due to error in "+
 				"CheckTransactionInputs: %v", tx.Hash(), err)
@@ -1609,7 +1614,7 @@ mempoolLoop:
 			continue
 		}
 		err = blockchain.ValidateTransactionScripts(tx, blockUtxos,
-			scriptFlags, server.sigCache)
+			scriptFlags, g.sigCache)
 		if err != nil {
 			minrLog.Tracef("Skipping tx %s due to error in "+
 				"ValidateTransactionScripts: %v", tx.Hash(), err)
@@ -1802,7 +1807,7 @@ mempoolLoop:
 		}
 
 		// Don't let this overflow.
-		if freshStake >= int(server.chainParams.MaxFreshStakePerBlock) {
+		if freshStake >= int(g.chainParams.MaxFreshStakePerBlock) {
 			break
 		}
 	}
@@ -1861,7 +1866,7 @@ mempoolLoop:
 		nextBlockHeight,
 		payToAddress,
 		uint16(voters),
-		server.chainParams)
+		g.chainParams)
 	if err != nil {
 		return nil, err
 	}
@@ -1933,7 +1938,7 @@ mempoolLoop:
 	// If we're greater than or equal to stake validation height, scale the
 	// fees according to the number of voters.
 	totalFees *= int64(voters)
-	totalFees /= int64(server.chainParams.TicketsPerBlock)
+	totalFees /= int64(g.chainParams.TicketsPerBlock)
 
 	// Now that the actual transactions have been selected, update the
 	// block size for the real transaction count and coinbase value with
@@ -1960,13 +1965,12 @@ mempoolLoop:
 	// bit for the mempool to sync with the votes map and we end up down
 	// here despite having the relevant votes available in the votes map.
 	minimumVotesRequired :=
-		int((server.chainParams.TicketsPerBlock / 2) + 1)
+		int((g.chainParams.TicketsPerBlock / 2) + 1)
 	if nextBlockHeight >= stakeValidationHeight &&
 		voters < minimumVotesRequired {
 		minrLog.Warnf("incongruent number of voters in mempool " +
 			"vs mempool.voters; not enough voters found")
-		return handleTooFewVoters(subsidyCache, nextBlockHeight, payToAddress,
-			server.blockManager)
+		return handleTooFewVoters(subsidyCache, nextBlockHeight, payToAddress, g)
 	}
 
 	// Correct transaction index fraud proofs for any transactions that
@@ -2045,7 +2049,7 @@ mempoolLoop:
 
 	// Choose the block version to generate based on the network.
 	blockVersion := int32(generatedBlockVersion)
-	if server.chainParams.Net != wire.MainNet {
+	if g.chainParams.Net != wire.MainNet {
 		blockVersion = generatedBlockVersionTest
 	}
 
@@ -2099,8 +2103,8 @@ mempoolLoop:
 	block := dcrutil.NewBlockDeepCopyCoinbase(&msgBlock)
 
 	if err := blockchain.CheckWorklessBlockSanity(block,
-		server.timeSource,
-		server.chainParams); err != nil {
+		g.timeSource,
+		g.chainParams); err != nil {
 		str := fmt.Sprintf("failed to do final check for block workless "+
 			"sanity when making new block template: %v",
 			err.Error())
@@ -2130,7 +2134,7 @@ mempoolLoop:
 		ValidPayAddress: payToAddress != nil,
 	}
 
-	return handleCreatedBlockTemplate(blockTemplate, server.blockManager)
+	return handleCreatedBlockTemplate(blockTemplate, blockManager)
 }
 
 // UpdateBlockTime updates the timestamp in the header of the passed block to
@@ -2139,24 +2143,56 @@ mempoolLoop:
 // consensus rules.  Finally, it will update the target difficulty if needed
 // based on the new time for the test networks since their target difficulty can
 // change based upon time.
-func UpdateBlockTime(msgBlock *wire.MsgBlock, bManager *blockManager) error {
+func (g *BlkTmplGenerator) UpdateBlockTime(msgBlock *wire.MsgBlock) error {
 	// The new timestamp is potentially adjusted to ensure it comes after
 	// the median time of the last several blocks per the chain consensus
 	// rules.
-	chainBest := bManager.chain.BestSnapshot()
-	newTimestamp := medianAdjustedTime(chainBest, bManager.server.timeSource)
+	chain := g.blockManager.chain
+	chainBest := chain.BestSnapshot()
+	newTimestamp := medianAdjustedTime(chainBest, g.timeSource)
 	msgBlock.Header.Timestamp = newTimestamp
 
 	// If running on a network that requires recalculating the difficulty,
 	// do so now.
 	if activeNetParams.ReduceMinDifficulty {
-		difficulty, err := bManager.chain.CalcNextRequiredDifficulty(
-			newTimestamp)
+		difficulty, err := chain.CalcNextRequiredDifficulty(newTimestamp)
 		if err != nil {
 			return miningRuleError(ErrGettingDifficulty, err.Error())
 		}
 		msgBlock.Header.Bits = difficulty
 	}
 
+	return nil
+}
+
+// UpdateExtraNonce updates the extra nonce in the coinbase script of the passed
+// block by regenerating the coinbase script with the passed value and block
+// height.  It also recalculates and updates the new merkle root that results
+// from changing the coinbase script.
+func (g *BlkTmplGenerator) UpdateExtraNonce(msgBlock *wire.MsgBlock, blockHeight int64,
+	extraNonces []uint64) error {
+	// First block has no extranonce.
+	if blockHeight == 1 {
+		return nil
+	}
+	if len(extraNonces) != 4 {
+		return fmt.Errorf("not enough nonce information passed")
+	}
+
+	coinbaseOpReturn, err := standardCoinbaseOpReturn(uint32(blockHeight),
+		extraNonces)
+	if err != nil {
+		return err
+	}
+	msgBlock.Transactions[0].TxOut[1].PkScript = coinbaseOpReturn
+
+	// TODO(davec): A dcrutil.Block should use saved in the state to avoid
+	// recalculating all of the other transaction hashes.
+	// block.Transactions[0].InvalidateCache()
+
+	// Recalculate the merkle root with the updated extra nonce.
+	block := dcrutil.NewBlockDeepCopyCoinbase(msgBlock)
+	merkles := blockchain.BuildMerkleTreeStore(block.Transactions())
+	msgBlock.Header.MerkleRoot = *merkles[len(merkles)-1]
 	return nil
 }

--- a/mining/mining.go
+++ b/mining/mining.go
@@ -8,6 +8,7 @@ package mining
 import (
 	"time"
 
+	"github.com/decred/dcrd/blockchain"
 	"github.com/decred/dcrd/blockchain/stake"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil"
@@ -50,4 +51,20 @@ type TxSource interface {
 	// HaveTransaction returns whether or not the passed transaction hash
 	// exists in the source pool.
 	HaveTransaction(hash *chainhash.Hash) bool
+
+	// VoteHashesForBlock returns the hashes for all votes on the provided block
+	// hash that are currently available in the mempool.
+	VoteHashesForBlock(hash chainhash.Hash) []chainhash.Hash
+
+	// CheckIfTxsExist checks a list of transaction hashes against the mempool
+	// and returns true if they all exist in the mempool, otherwise false.
+	CheckIfTxsExist(hashes []chainhash.Hash) bool
+
+	// IsTxTreeValid checks the map of votes for a block to see if the tx
+	// tree regular for the block at HEAD is valid.
+	IsTxTreeValid(hash *chainhash.Hash) bool
+
+	// VotesForBlocks returns the vote metadata for all votes on the provided
+	// block hashes that are currently available in the mempool.
+	VotesForBlocks(hashes []chainhash.Hash) [][]*blockchain.VoteTx
 }

--- a/mining/policy.go
+++ b/mining/policy.go
@@ -5,7 +5,18 @@
 
 package mining
 
-import "github.com/decred/dcrd/dcrutil"
+import (
+	"github.com/decred/dcrd/blockchain"
+	"github.com/decred/dcrd/dcrutil"
+	"github.com/decred/dcrd/wire"
+)
+
+const (
+	// UnminedHeight is the height used for the "block" height field of the
+	// contextual transaction information provided in a transaction store
+	// when it has not yet been mined into a block.
+	UnminedHeight = 0x7fffffff
+)
 
 // Policy houses the policy (configuration parameters) which is used to control
 // the generation of block templates.  See the documentation for
@@ -27,4 +38,89 @@ type Policy struct {
 	// required for a transaction to be treated as free for mining purposes
 	// (block template generation).
 	TxMinFreeFee dcrutil.Amount
+}
+
+// minInt is a helper function to return the minimum of two ints.  This avoids
+// a math import and the need to cast to floats.
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// calcInputValueAge is a helper function used to calculate the input age of
+// a transaction.  The input age for a txin is the number of confirmations
+// since the referenced txout multiplied by its output value.  The total input
+// age is the sum of this value for each txin.  Any inputs to the transaction
+// which are currently in the mempool and hence not mined into a block yet,
+// contribute no additional input age to the transaction.
+func calcInputValueAge(tx *wire.MsgTx, utxoView *blockchain.UtxoViewpoint, nextBlockHeight int64) float64 {
+	var totalInputAge float64
+	for _, txIn := range tx.TxIn {
+		// Don't attempt to accumulate the total input age if the
+		// referenced transaction output doesn't exist.
+		originHash := &txIn.PreviousOutPoint.Hash
+		originIndex := txIn.PreviousOutPoint.Index
+		txEntry := utxoView.LookupEntry(originHash)
+		if txEntry != nil && !txEntry.IsOutputSpent(originIndex) {
+			// Inputs with dependencies currently in the mempool
+			// have their block height set to a special constant.
+			// Their input age should be computed as zero since
+			// their parent hasn't made it into a block yet.
+			var inputAge int64
+			originHeight := txEntry.BlockHeight()
+			if originHeight == UnminedHeight {
+				inputAge = 0
+			} else {
+				inputAge = nextBlockHeight - originHeight
+			}
+
+			// Sum the input value times age.
+			inputValue := txEntry.AmountByIndex(originIndex)
+			totalInputAge += float64(inputValue * inputAge)
+		}
+	}
+
+	return totalInputAge
+}
+
+// CalcPriority returns a transaction priority given a transaction and the sum
+// of each of its input values multiplied by their age (# of confirmations).
+// Thus, the final formula for the priority is:
+// sum(inputValue * inputAge) / adjustedTxSize
+func CalcPriority(tx *wire.MsgTx, utxoView *blockchain.UtxoViewpoint, nextBlockHeight int64) float64 {
+	// In order to encourage spending multiple old unspent transaction
+	// outputs thereby reducing the total set, don't count the constant
+	// overhead for each input as well as enough bytes of the signature
+	// script to cover a pay-to-script-hash redemption with a compressed
+	// pubkey.  This makes additional inputs free by boosting the priority
+	// of the transaction accordingly.  No more incentive is given to avoid
+	// encouraging gaming future transactions through the use of junk
+	// outputs.  This is the same logic used in the reference
+	// implementation.
+	//
+	// The constant overhead for a txin is 41 bytes since the previous
+	// outpoint is 36 bytes + 4 bytes for the sequence + 1 byte the
+	// signature script length.
+	//
+	// A compressed pubkey pay-to-script-hash redemption with a maximum len
+	// signature is of the form:
+	// [OP_DATA_73 <73-byte sig> + OP_DATA_35 + {OP_DATA_33
+	// <33 byte compresed pubkey> + OP_CHECKSIG}]
+	//
+	// Thus 1 + 73 + 1 + 1 + 33 + 1 = 110
+	overhead := 0
+	for _, txIn := range tx.TxIn {
+		// Max inputs + size can't possibly overflow here.
+		overhead += 41 + minInt(110, len(txIn.SignatureScript))
+	}
+
+	serializedTxSize := tx.SerializeSize()
+	if overhead >= serializedTxSize {
+		return 0.0
+	}
+
+	inputValueAge := calcInputValueAge(tx, utxoView, nextBlockHeight)
+	return inputValueAge / float64(serializedTxSize-overhead)
 }

--- a/mining/policy_test.go
+++ b/mining/policy_test.go
@@ -1,0 +1,169 @@
+// Copyright (c) 2016 The btcsuite developers
+// Copyright (c) 2016 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package mining
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/decred/dcrd/blockchain"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/dcrutil"
+	"github.com/decred/dcrd/wire"
+)
+
+// newHashFromStr converts the passed big-endian hex string into a
+// chainhash.Hash.  It only differs from the one available in chainhash in that
+// it panics on an error since it will only (and must only) be called with
+// hard-coded, and therefore known good, hashes.
+func newHashFromStr(hexStr string) *chainhash.Hash {
+	hash, err := chainhash.NewHashFromStr(hexStr)
+	if err != nil {
+		panic("invalid hash in source file: " + hexStr)
+	}
+	return hash
+}
+
+// hexToBytes converts the passed hex string into bytes and will panic if there
+// is an error.  This is only provided for the hard-coded constants so errors in
+// the source code can be detected. It will only (and must only) be called with
+// hard-coded values.
+func hexToBytes(s string) []byte {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		panic("invalid hex in source file: " + s)
+	}
+	return b
+}
+
+// newUtxoViewpoint returns a new utxo view populated with outputs of the
+// provided source transactions as if there were available at the respective
+// block height specified in the heights slice.  The length of the source txns
+// and source tx heights must match or it will panic.
+func newUtxoViewpoint(sourceTxns []*wire.MsgTx, sourceTxHeights []int64) *blockchain.UtxoViewpoint {
+	if len(sourceTxns) != len(sourceTxHeights) {
+		panic("each transaction must have its block height specified")
+	}
+
+	view := blockchain.NewUtxoViewpoint()
+	for i, tx := range sourceTxns {
+		view.AddTxOuts(dcrutil.NewTx(tx), sourceTxHeights[i], wire.NullBlockIndex)
+	}
+	return view
+}
+
+// TestCalcPriority ensures the priority calculations work as intended.
+func TestCalcPriority(t *testing.T) {
+	// commonSourceTx1 is a valid transaction used in the tests below as an
+	// input to transactions that are having their priority calculated.
+	//
+	// From block 7 in main Bitcoin blockchain.
+	// tx 0437cd7f8525ceed2324359c2d0ba26006d92d856a9c20fa0241106ee5a597c9
+	commonSourceTx1 := &wire.MsgTx{
+		Version: 1,
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: wire.OutPoint{
+				Hash:  chainhash.Hash{},
+				Index: wire.MaxPrevOutIndex,
+			},
+			SignatureScript: hexToBytes("04ffff001d0134"),
+			Sequence:        0xffffffff,
+		}},
+		TxOut: []*wire.TxOut{{
+			Value: 5000000000,
+			PkScript: hexToBytes("410411db93e1dcdb8a016b49840f8c5" +
+				"3bc1eb68a382e97b1482ecad7b148a6909a5cb2e0ead" +
+				"dfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8" +
+				"643f656b412a3ac"),
+		}},
+		LockTime: 0,
+	}
+
+	// commonRedeemTx1 is a valid transaction used in the tests below as the
+	// transaction to calculate the priority for.
+	//
+	// It originally came from block 170 in main Bitcoin blockchain.
+	commonRedeemTx1 := &wire.MsgTx{
+		Version: 1,
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: wire.OutPoint{
+				Hash: *newHashFromStr("0437cd7f8525ceed232435" +
+					"9c2d0ba26006d92d856a9c20fa0241106ee5" +
+					"a597c9"),
+				Index: 0,
+			},
+			SignatureScript: hexToBytes("47304402204e45e16932b8af" +
+				"514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5f" +
+				"b8cd410220181522ec8eca07de4860a4acdd12909d83" +
+				"1cc56cbbac4622082221a8768d1d0901"),
+			Sequence: 0xffffffff,
+		}},
+		TxOut: []*wire.TxOut{{
+			Value: 1000000000,
+			PkScript: hexToBytes("4104ae1a62fe09c5f51b13905f07f06" +
+				"b99a2f7159b2225f374cd378d71302fa28414e7aab37" +
+				"397f554a7df5f142c21c1b7303b8a0626f1baded5c72" +
+				"a704f7e6cd84cac"),
+		}, {
+			Value: 4000000000,
+			PkScript: hexToBytes("410411db93e1dcdb8a016b49840f8c5" +
+				"3bc1eb68a382e97b1482ecad7b148a6909a5cb2e0ead" +
+				"dfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8" +
+				"643f656b412a3ac"),
+		}},
+		LockTime: 0,
+	}
+
+	tests := []struct {
+		name       string                    // test description
+		tx         *wire.MsgTx               // tx to calc priority for
+		utxoView   *blockchain.UtxoViewpoint // inputs to tx
+		nextHeight int64                     // height for priority calc
+		want       float64                   // expected priority
+	}{
+		{
+			name: "one height 7 input, prio tx height 169",
+			tx:   commonRedeemTx1,
+			utxoView: newUtxoViewpoint([]*wire.MsgTx{commonSourceTx1},
+				[]int64{7}),
+			nextHeight: int64(169),
+			want:       5e9,
+		},
+		{
+			name: "one height 100 input, prio tx height 169",
+			tx:   commonRedeemTx1,
+			utxoView: newUtxoViewpoint([]*wire.MsgTx{commonSourceTx1},
+				[]int64{100}),
+			nextHeight: int64(169),
+			want:       2129629629.6296296,
+		},
+		{
+			name: "one height 7 input, prio tx height 100000",
+			tx:   commonRedeemTx1,
+			utxoView: newUtxoViewpoint([]*wire.MsgTx{commonSourceTx1},
+				[]int64{7}),
+			nextHeight: int64(100000),
+			want:       3086203703703.7036,
+		},
+		{
+			name: "one height 100 input, prio tx height 100000",
+			tx:   commonRedeemTx1,
+			utxoView: newUtxoViewpoint([]*wire.MsgTx{commonSourceTx1},
+				[]int64{100}),
+			nextHeight: int64(100000),
+			want:       3083333333333.3335,
+		},
+	}
+
+	for i, test := range tests {
+		got := CalcPriority(test.tx, test.utxoView, test.nextHeight)
+		if got != test.want {
+			t.Errorf("CalcPriority #%d (%q): unexpected priority "+
+				"got %v want %v", i, test.name, got, test.want)
+			continue
+		}
+	}
+}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -954,9 +954,9 @@ func handleCreateRawSSGenTx(s *rpcServer, cmd interface{}, closeChan <-chan stru
 		stake.SStxStakeOutputInfo(minimalOutputs)
 
 	// Get the current reward.
-	blockHash, curHeight := s.server.blockManager.chainState.Best()
+	chainBest := s.server.blockManager.chain.BestSnapshot()
 	stakeVoteSubsidy := blockchain.CalcStakeVoteSubsidy(
-		s.chain.FetchSubsidyCache(), curHeight, activeNetParams.Params)
+		s.chain.FetchSubsidyCache(), chainBest.Height, activeNetParams.Params)
 
 	// Calculate the output values from this data.
 	ssgenCalcAmts := stake.CalculateRewards(sstxAmts,
@@ -998,8 +998,8 @@ func handleCreateRawSSGenTx(s *rpcServer, cmd interface{}, closeChan <-chan stru
 	// outputs.
 	//
 	// Block reference output.
-	blockRefScript, err := txscript.GenerateSSGenBlockRef(*blockHash,
-		uint32(curHeight))
+	blockRefScript, err := txscript.GenerateSSGenBlockRef(*chainBest.Hash,
+		uint32(chainBest.Height))
 	if err != nil {
 		return nil, rpcInvalidError("Could not generate SSGen block "+
 			"reference: %v", err)
@@ -1501,7 +1501,7 @@ func handleEstimateStakeDiff(s *rpcServer, cmd interface{}, closeChan <-chan str
 	// The expected stake difficulty. Average the number of fresh stake
 	// since the last retarget to get the number of tickets per block,
 	// then use that to estimate the next stake difficulty.
-	_, bestHeight := s.server.blockManager.chainState.Best()
+	bestHeight := s.server.blockManager.chain.BestSnapshot().Height
 	lastAdjustment := (bestHeight / activeNetParams.StakeDiffWindowSize) *
 		activeNetParams.StakeDiffWindowSize
 	nextAdjustment := ((bestHeight / activeNetParams.StakeDiffWindowSize) +
@@ -2327,7 +2327,8 @@ func (state *gbtWorkState) updateBlockTemplate(s *rpcServer, useCoinbaseValue bo
 	// generated.
 	var msgBlock *wire.MsgBlock
 	var targetDifficulty string
-	latestHash, _ := s.server.blockManager.chainState.Best()
+	chainBest := s.server.blockManager.chain.BestSnapshot()
+	latestHash := chainBest.Hash
 	template := state.template
 	if template == nil || state.prevHash == nil ||
 		!state.prevHash.IsEqual(latestHash) ||
@@ -2368,23 +2369,16 @@ func (state *gbtWorkState) updateBlockTemplate(s *rpcServer, useCoinbaseValue bo
 		targetDifficulty = fmt.Sprintf("%064x",
 			blockchain.CompactToBig(msgBlock.Header.Bits))
 
-		// Find the minimum allowed timestamp for the block based on the
-		// median timestamp of the last several blocks per the chain
-		// consensus rules.
-		chainState := &s.server.blockManager.chainState
-		minTimestamp, err := minimumMedianTime(chainState)
-		if err != nil {
-			context := "Failed to get minimum median time"
-			return rpcInternalError(err.Error(), context)
-		}
-
 		// Update work state to ensure another block template isn't
 		// generated until needed.
 		state.template = deepCopyBlockTemplate(template)
 		state.lastGenerated = time.Now()
 		state.lastTxUpdate = lastTxUpdate
 		state.prevHash = latestHash
-		state.minTimestamp = minTimestamp
+		// Find the minimum allowed timestamp for the block based on the
+		// median timestamp of the last several blocks per the chain
+		// consensus rules.
+		state.minTimestamp = minimumMedianTime(chainBest)
 
 		rpcsLog.Debugf("Generated block template (timestamp %v, "+
 			"target %s, merkle root %s)",
@@ -2487,7 +2481,7 @@ func (state *gbtWorkState) blockTemplateResult(bm *blockManager, useCoinbaseValu
 		len(template.SigOpCounts) {
 		recalculateFeesAndSigsOps = false
 	}
-	newestBlock, _ := bm.chainState.Best()
+	newestBlock := bm.chain.BestSnapshot().Hash
 	if newestBlock == nil {
 		return nil, &dcrjson.RPCError{
 			Code:    dcrjson.ErrRPCBestBlockHash,
@@ -2953,7 +2947,7 @@ func handleGetBlockTemplateRequest(s *rpcServer, request *dcrjson.TemplateReques
 	}
 
 	// No point in generating or accepting work before the chain is synced.
-	_, currentHeight := s.server.blockManager.chainState.Best()
+	currentHeight := s.server.blockManager.chain.BestSnapshot().Height
 	if currentHeight != 0 && !s.server.blockManager.IsCurrent() {
 		return nil, &dcrjson.RPCError{
 			Code:    dcrjson.ErrRPCClientInInitialDownload,
@@ -3104,7 +3098,7 @@ func handleGetBlockTemplateProposal(s *rpcServer, request *dcrjson.TemplateReque
 	block := dcrutil.NewBlock(&msgBlock)
 
 	// Ensure the block is building from the expected previous block.
-	expectedPrevHash, _ := s.server.blockManager.chainState.Best()
+	expectedPrevHash := s.server.blockManager.chain.BestSnapshot().Hash
 	prevHash := &block.MsgBlock().Header.PrevBlock
 	if expectedPrevHash == nil || !expectedPrevHash.IsEqual(prevHash) {
 		return "bad-prevblk", nil
@@ -4109,7 +4103,8 @@ func handleGetWorkRequest(s *rpcServer) (interface{}, error) {
 	// it has been at least one minute since the last template was
 	// generated.
 	lastTxUpdate := s.server.txMemPool.LastUpdated()
-	latestHash, latestHeight := s.server.blockManager.chainState.Best()
+	chainBest := s.server.blockManager.chain.BestSnapshot()
+	latestHash, latestHeight := chainBest.Hash, chainBest.Height
 	msgBlock := state.msgBlock
 
 	// The current code pulls down a new template every second, however
@@ -4412,7 +4407,7 @@ func handleGetWork(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (in
 	}
 
 	// No point in generating or accepting work before the chain is synced.
-	_, currentHeight := s.server.blockManager.chainState.Best()
+	currentHeight := s.server.blockManager.chain.BestSnapshot().Height
 	if currentHeight != 0 && !s.server.blockManager.IsCurrent() {
 		return nil, &dcrjson.RPCError{
 			Code:    dcrjson.ErrRPCClientInInitialDownload,
@@ -4521,7 +4516,7 @@ func handlePing(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (inter
 
 // handleRebroadcastMissed implements the rebroadcastmissed command.
 func handleRebroadcastMissed(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
-	hash, height := s.server.blockManager.chainState.Best()
+	chainBest := s.server.blockManager.chain.BestSnapshot()
 	mt, err := s.server.blockManager.chain.MissedTickets()
 	if err != nil {
 		return nil, rpcInternalError("Could not get missed tickets "+
@@ -4535,8 +4530,8 @@ func handleRebroadcastMissed(s *rpcServer, cmd interface{}, closeChan <-chan str
 	}
 
 	missedTicketsNtfn := &blockchain.TicketNotificationsData{
-		Hash:            *hash,
-		Height:          height,
+		Hash:            *chainBest.Hash,
+		Height:          chainBest.Height,
 		StakeDifficulty: stakeDiff,
 		TicketsSpent:    []chainhash.Hash{},
 		TicketsMissed:   mt,
@@ -4550,8 +4545,8 @@ func handleRebroadcastMissed(s *rpcServer, cmd interface{}, closeChan <-chan str
 
 // handleRebroadcastWinners implements the rebroadcastwinners command.
 func handleRebroadcastWinners(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
-	hash, height := s.server.blockManager.chainState.Best()
-	blocks, err := s.server.blockManager.GetGeneration(*hash)
+	chainBest := s.server.blockManager.chain.BestSnapshot()
+	blocks, err := s.server.blockManager.GetGeneration(*chainBest.Hash)
 	if err != nil {
 		return nil, rpcInternalError("Could not get generation "+
 			err.Error(), "")
@@ -4565,8 +4560,8 @@ func handleRebroadcastWinners(s *rpcServer, cmd interface{}, closeChan <-chan st
 				"failed: "+err.Error(), "")
 		}
 		ntfnData := &WinningTicketsNtfnData{
-			BlockHash:   *hash,
-			BlockHeight: height,
+			BlockHash:   *chainBest.Hash,
+			BlockHeight: chainBest.Height,
 			Tickets:     winningTickets,
 		}
 
@@ -5435,10 +5430,7 @@ func ticketFeeInfoForRange(s *rpcServer, start int64, end int64, txType stake.Tx
 // handleTicketFeeInfo implements the ticketfeeinfo command.
 func handleTicketFeeInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
 	c := cmd.(*dcrjson.TicketFeeInfoCmd)
-
-	s.server.blockManager.chainState.Lock()
-	bestHeight := s.server.blockManager.chainState.newestHeight
-	s.server.blockManager.chainState.Unlock()
+	bestHeight := s.server.blockManager.chain.BestSnapshot().Height
 
 	// Memory pool first.
 	feeInfoMempool := feeInfoForMempool(s, stake.TxTypeSStx)
@@ -5549,7 +5541,7 @@ func handleTicketVWAP(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) 
 
 	// The default VWAP is for the past WorkDiffWindows * WorkDiffWindowSize
 	// many blocks.
-	_, bestHeight := s.server.blockManager.chainState.Best()
+	bestHeight := s.server.blockManager.chain.BestSnapshot().Height
 	start := uint32(0)
 	if c.Start == nil {
 		toEval := activeNetParams.WorkDiffWindows *
@@ -5605,10 +5597,7 @@ func handleTicketVWAP(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) 
 // handleTxFeeInfo implements the txfeeinfo command.
 func handleTxFeeInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
 	c := cmd.(*dcrjson.TxFeeInfoCmd)
-
-	s.server.blockManager.chainState.Lock()
-	bestHeight := s.server.blockManager.chainState.newestHeight
-	s.server.blockManager.chainState.Unlock()
+	bestHeight := s.server.blockManager.chain.BestSnapshot().Height
 
 	// Memory pool first.
 	feeInfoMempool := feeInfoForMempool(s, stake.TxTypeRegular)

--- a/server.go
+++ b/server.go
@@ -2475,7 +2475,14 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 	}
 	blockTemplateGenerator := newBlkTmplGenerator(&policy, s.chainParams,
 		s.txMemPool, s.sigCache, bm, s.timeSource)
-	s.cpuMiner = newCPUMiner(blockTemplateGenerator, &s)
+	s.cpuMiner = newCPUMiner(&Config{
+		ChainParams:            s.chainParams,
+		BlockTemplateGenerator: blockTemplateGenerator,
+		MiningAddrs:            cfg.miningAddrs,
+		ProcessBlock:           bm.ProcessBlock,
+		ConnectedCount:         s.ConnectedCount,
+		IsCurrent:              bm.IsCurrent,
+	})
 
 	// Only setup a function to return new addresses to connect to when
 	// not running in connect-only mode.  The simulation network is always

--- a/server.go
+++ b/server.go
@@ -2462,7 +2462,9 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 	}
 	s.txMemPool = mempool.New(&txC)
 
-	// Create the mining policy based on the configuration options.
+	// Create the mining policy and block template generator based on the
+	// configuration options.
+	//
 	// NOTE: The CPU miner relies on the mempool, so the mempool has to be
 	// created before calling the function to create the CPU miner.
 	policy := mining.Policy{
@@ -2471,7 +2473,9 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 		BlockPrioritySize: cfg.BlockPrioritySize,
 		TxMinFreeFee:      cfg.minRelayTxFee,
 	}
-	s.cpuMiner = newCPUMiner(&policy, &s)
+	blockTemplateGenerator := newBlkTmplGenerator(&policy, s.chainParams,
+		s.txMemPool, s.sigCache, bm, s.timeSource)
+	s.cpuMiner = newCPUMiner(blockTemplateGenerator, &s)
 
 	// Only setup a function to return new addresses to connect to when
 	// not running in connect-only mode.  The simulation network is always
@@ -2556,7 +2560,8 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 	}
 
 	if !cfg.DisableRPC {
-		s.rpcServer, err = newRPCServer(cfg.RPCListeners, &policy, &s)
+		s.rpcServer, err = newRPCServer(cfg.RPCListeners,
+			blockTemplateGenerator, &s)
 		if err != nil {
 			return nil, err
 		}

--- a/server.go
+++ b/server.go
@@ -449,7 +449,8 @@ func (sp *serverPeer) OnGetMiningState(p *peer.Peer, msg *wire.MsgGetMiningState
 	// Access the block manager and get the list of best blocks to mine on.
 	bm := sp.server.blockManager
 	mp := sp.server.txMemPool
-	newest, height := bm.chainState.Best()
+	chainBest := bm.chain.BestSnapshot()
+	newest, height := chainBest.Hash, chainBest.Height
 
 	// Send out blank mining states if it's early in the blockchain.
 	if height < activeNetParams.StakeValidationHeight-1 {
@@ -2446,10 +2447,7 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 		},
 		ChainParams: chainParams,
 		NextStakeDifficulty: func() (int64, error) {
-			bm.chainState.Lock()
-			sDiff := bm.chainState.nextStakeDifficulty
-			bm.chainState.Unlock()
-			return sDiff, nil
+			return bm.chain.CalcNextRequiredStakeDifficulty()
 		},
 		FetchUtxoView:    bm.chain.FetchUtxoView,
 		BlockByHash:      bm.chain.BlockByHash,


### PR DESCRIPTION
**This requires PRs #910, #911 and #912.**

Port over the changes from https://github.com/btcsuite/btcd/pull/813 , see description there. Part of #709.

TODO: tests in `mining/policy_test.go` are failing:

```
--- FAIL: TestCalcPriority (0.00s)
	policy_test.go:164: CalcPriority #0 ("one height 7 input, prio tx height 169"): unexpected priority got 0 want 5e+09
	policy_test.go:164: CalcPriority #1 ("one height 100 input, prio tx height 169"): unexpected priority got 0 want 2.1296296296296296e+09
	policy_test.go:164: CalcPriority #2 ("one height 7 input, prio tx height 100000"): unexpected priority got 0 want 3.0862037037037036e+12
	policy_test.go:164: CalcPriority #3 ("one height 100 input, prio tx height 100000"): unexpected priority got 0 want 3.0833333333333335e+12
FAIL
FAIL	github.com/decred/dcrd/mining	1.857s
```

The call to `utxoView.LookupEntry` in `calcInputValueAge` is always returning `nil`: probably the Bitcoin transaction data need adjustment to work in Decred tests.