### PR TITLE
mining: introduce a block template generator.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -58,6 +58,13 @@ type VoteVersionTuple struct {
 	Bits    uint16
 }
 
+// VoteTx is a struct describing a block vote (SSGen).
+type VoteTx struct {
+	SsgenHash chainhash.Hash // Vote
+	SstxHash  chainhash.Hash // Ticket
+	Vote      bool
+}
+
 // blockNode represents a block within the block chain and is primarily used to
 // aid in selecting the best chain to be the main chain.  The main chain is
 // stored into the block database.

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -313,85 +313,6 @@ type headerNode struct {
 	hash   *chainhash.Hash
 }
 
-// chainState tracks the state of the best chain as blocks are inserted.  This
-// is done because blockchain is currently not safe for concurrent access and the
-// block manager is typically quite busy processing block and inventory.
-// Therefore, requesting this information from chain through the block manager
-// would not be anywhere near as efficient as simply updating it as each block
-// is inserted and protecting it with a mutex.
-type chainState struct {
-	sync.Mutex
-	newestHash          *chainhash.Hash
-	newestHeight        int64
-	nextFinalState      [6]byte
-	nextPoolSize        uint32
-	nextStakeDifficulty int64
-	winningTickets      []chainhash.Hash
-	missedTickets       []chainhash.Hash
-	curPrevHash         chainhash.Hash
-	pastMedianTime      time.Time
-}
-
-// Best returns the block hash and height known for the tip of the best known
-// chain.
-//
-// This function is safe for concurrent access.
-func (c *chainState) Best() (*chainhash.Hash, int64) {
-	c.Lock()
-	defer c.Unlock()
-
-	return c.newestHash, c.newestHeight
-}
-
-// NextWPO returns next winner, potential, and overflow for the current top block
-// of the blockchain.
-//
-// This function is safe for concurrent access.
-func (c *chainState) NextFinalState() [6]byte {
-	c.Lock()
-	defer c.Unlock()
-
-	return c.nextFinalState
-}
-
-func (c *chainState) NextPoolSize() uint32 {
-	c.Lock()
-	defer c.Unlock()
-
-	return c.nextPoolSize
-}
-
-// NextWinners returns the eligible SStx hashes to vote on the
-// next block as inputs for SSGen.
-//
-// This function is safe for concurrent access.
-func (c *chainState) NextWinners() []chainhash.Hash {
-	c.Lock()
-	defer c.Unlock()
-
-	return c.winningTickets
-}
-
-// CurrentlyMissed returns the eligible SStx hashes that can be revoked.
-//
-// This function is safe for concurrent access.
-func (c *chainState) CurrentlyMissed() []chainhash.Hash {
-	c.Lock()
-	defer c.Unlock()
-
-	return c.missedTickets
-}
-
-// GetTopPrevHash returns the current previous block hash.
-//
-// This function is safe for concurrent access.
-func (c *chainState) GetTopPrevHash() chainhash.Hash {
-	c.Lock()
-	defer c.Unlock()
-
-	return c.curPrevHash
-}
-
 // blockManager provides a concurrency safe block manager for handling all
 // incoming blocks.
 type blockManager struct {
@@ -407,7 +328,6 @@ type blockManager struct {
 	progressLogger      *blockProgressLogger
 	syncPeer            *serverPeer
 	msgChan             chan interface{}
-	chainState          chainState
 	wg                  sync.WaitGroup
 	quit                chan struct{}
 
@@ -443,29 +363,6 @@ func (b *blockManager) resetHeaderState(newestHash *chainhash.Hash, newestHeight
 		node := headerNode{height: newestHeight, hash: newestHash}
 		b.headerList.PushBack(&node)
 	}
-}
-
-// updateChainState updates the chain state associated with the block manager.
-// This allows fast access to chain information since blockchain is currently not
-// safe for concurrent access and the block manager is typically quite busy
-// processing block and inventory.
-func (b *blockManager) updateChainState(newestHash *chainhash.Hash,
-	newestHeight int64, finalState [6]byte, poolSize uint32,
-	nextStakeDiff int64, winningTickets []chainhash.Hash,
-	missedTickets []chainhash.Hash, curPrevHash chainhash.Hash) {
-
-	b.chainState.Lock()
-	defer b.chainState.Unlock()
-
-	b.chainState.newestHash = newestHash
-	b.chainState.newestHeight = newestHeight
-	b.chainState.pastMedianTime = b.chain.BestSnapshot().MedianTime
-	b.chainState.nextFinalState = finalState
-	b.chainState.nextPoolSize = poolSize
-	b.chainState.nextStakeDifficulty = nextStakeDiff
-	b.chainState.winningTickets = winningTickets
-	b.chainState.missedTickets = missedTickets
-	b.chainState.curPrevHash = curPrevHash
 }
 
 // findNextHeaderCheckpoint returns the next checkpoint after the passed height.
@@ -1084,7 +981,7 @@ func (b *blockManager) handleBlockMsg(bmsg *blockMsg) {
 
 		// Determine if this block is recent enough that we need to calculate
 		// block lottery data for it.
-		_, bestHeight := b.chainState.Best()
+		bestHeight := b.chain.BestSnapshot().Height
 		blockHeight := int64(bmsg.block.MsgBlock().Header.Height)
 		tooOldForLotteryData := blockHeight <=
 			(bestHeight - maxLotteryDataBlockDelta)
@@ -1139,16 +1036,6 @@ func (b *blockManager) handleBlockMsg(bmsg *blockMsg) {
 			// a reorg.
 			best := b.chain.BestSnapshot()
 
-			// Query the DB for the missed tickets for the next top block.
-			missedTickets, err := b.chain.MissedTickets()
-			if err != nil {
-				bmgrLog.Warnf("Failed to get missed tickets "+
-					"for best block %v: %v", best.Hash, err)
-			}
-
-			// Retrieve the current previous block hash.
-			curPrevHash := b.chain.BestPrevHash()
-
 			nextStakeDiff, errSDiff :=
 				b.chain.CalcNextRequiredStakeDifficulty()
 			if errSDiff != nil {
@@ -1168,17 +1055,6 @@ func (b *blockManager) handleBlockMsg(bmsg *blockMsg) {
 					best.Height)
 				b.server.txMemPool.PruneExpiredTx(best.Height)
 			}
-
-			winningTickets, poolSize, finalState, err :=
-				b.chain.LotteryDataForBlock(blockHash)
-			if err != nil {
-				bmgrLog.Warnf("Failed to get determine lottery "+
-					"data for new best block: %v", err)
-			}
-
-			b.updateChainState(best.Hash, best.Height, finalState,
-				uint32(poolSize), nextStakeDiff, winningTickets,
-				missedTickets, curPrevHash)
 
 			// Update this peer's latest block height, for future
 			// potential sync node candidancy.
@@ -1700,17 +1576,11 @@ out:
 				err := b.chain.ForceHeadReorganization(
 					msg.formerBest, msg.newBest)
 
-				// Reorganizing has succeeded, so we need to
-				// update the chain state.
 				if err == nil {
 					// Query the db for the latest best block since
 					// the block that was processed could be on a
 					// side chain or have caused a reorg.
 					best := b.chain.BestSnapshot()
-
-					// Fetch the required lottery data.
-					winningTickets, poolSize, finalState, err :=
-						b.chain.LotteryDataForBlock(best.Hash)
 
 					// Update registered websocket clients on the
 					// current stake difficulty.
@@ -1732,26 +1602,6 @@ out:
 							best.Height)
 						b.server.txMemPool.PruneExpiredTx(best.Height)
 					}
-
-					missedTickets, err := b.chain.MissedTickets()
-					if err != nil {
-						bmgrLog.Warnf("Failed to get missed tickets"+
-							": %v", err)
-					}
-
-					// The blockchain should be updated, so fetch the
-					// latest snapshot.
-					best = b.chain.BestSnapshot()
-					curPrevHash := b.chain.BestPrevHash()
-
-					b.updateChainState(best.Hash,
-						best.Height,
-						finalState,
-						uint32(poolSize),
-						nextStakeDiff,
-						winningTickets,
-						missedTickets,
-						curPrevHash)
 				}
 
 				msg.reply <- forceReorganizationResponse{
@@ -1787,7 +1637,7 @@ out:
 				// Get the winning tickets if the block is not an
 				// orphan and if it's recent. If they've yet to be
 				// broadcasted, broadcast them.
-				_, bestHeight := b.chainState.Best()
+				bestHeight := b.chain.BestSnapshot().Height
 				blockHeight := int64(msg.block.MsgBlock().Header.Height)
 				tooOldForLotteryData := blockHeight <=
 					(bestHeight - maxLotteryDataBlockDelta)
@@ -1861,30 +1711,6 @@ out:
 						best.Height)
 					b.server.txMemPool.PruneExpiredTx(
 						best.Height)
-
-					missedTickets, err := b.chain.MissedTickets()
-					if err != nil {
-						bmgrLog.Warnf("Failed to get missing tickets for "+
-							"incoming block %v: %v", best.Hash, err)
-					}
-					curPrevHash := b.chain.BestPrevHash()
-
-					winningTickets, poolSize, finalState, err :=
-						b.chain.LotteryDataForBlock(msg.block.Hash())
-					if err != nil {
-						bmgrLog.Warnf("Failed to determine block "+
-							"lottery data for incoming best block %v: %v",
-							best.Hash, err)
-					}
-
-					b.updateChainState(best.Hash,
-						best.Height,
-						finalState,
-						uint32(poolSize),
-						nextStakeDiff,
-						winningTickets,
-						missedTickets,
-						curPrevHash)
 				}
 
 				// Allow any clients performing long polling via the
@@ -1976,7 +1802,7 @@ func (b *blockManager) handleNotifyMsg(notification *blockchain.Notification) {
 		// already been sent out.  Skip notifications if we're not
 		// yet synced to the latest checkpoint or if we're before
 		// the height where we begin voting.
-		_, bestHeight := b.chainState.Best()
+		bestHeight := b.chain.BestSnapshot().Height
 		blockHeight := int64(block.MsgBlock().Header.Height)
 		tooOldForLotteryData := blockHeight <=
 			(bestHeight - maxLotteryDataBlockDelta)
@@ -2596,35 +2422,6 @@ func newBlockManager(s *server, indexManager blockchain.IndexManager) (*blockMan
 
 		return nil, fmt.Errorf("closing after dumping blockchain")
 	}
-
-	// Query the DB for the current winning ticket data.
-	wt, ps, fs, err := bm.chain.LotteryDataForBlock(best.Hash)
-	if err != nil {
-		return nil, err
-	}
-
-	// Query the DB for the currently missed tickets.
-	missedTickets, err := bm.chain.MissedTickets()
-	if err != nil {
-		return nil, err
-	}
-
-	// Retrieve the current previous block hash and next stake difficulty.
-	curPrevHash := bm.chain.BestPrevHash()
-	nextStakeDiff, err := bm.chain.CalcNextRequiredStakeDifficulty()
-	if err != nil {
-		return nil, err
-	}
-
-	bm.updateChainState(best.Hash,
-		best.Height,
-		fs,
-		uint32(ps),
-		nextStakeDiff,
-		wt,
-		missedTickets,
-		curPrevHash)
-	bm.lotteryDataBroadcast = make(map[chainhash.Hash]struct{})
 
 	return &bm, nil
 }

--- a/cpuminer.go
+++ b/cpuminer.go
@@ -315,7 +315,7 @@ out:
 		// Hacks to make dcr work with Decred PoC (simnet only)
 		// TODO Remove before production.
 		if cfg.SimNet {
-			_, curHeight := m.server.blockManager.chainState.Best()
+			curHeight := m.server.blockManager.chain.BestSnapshot().Height
 
 			if curHeight == 1 {
 				time.Sleep(5500 * time.Millisecond) // let wallet reconn

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -69,13 +69,6 @@ const (
 	maxNullDataOutputs = 4
 )
 
-// VoteTx is a struct describing a block vote (SSGen).
-type VoteTx struct {
-	SsgenHash chainhash.Hash // Vote
-	SstxHash  chainhash.Hash // Ticket
-	Vote      bool
-}
-
 // Config is a descriptor containing the memory pool configuration.
 type Config struct {
 	// Policy defines the various mempool configuration options related
@@ -214,7 +207,7 @@ type TxPool struct {
 
 	// Votes on blocks.
 	votesMtx sync.Mutex
-	votes    map[chainhash.Hash][]*VoteTx
+	votes    map[chainhash.Hash][]*blockchain.VoteTx
 
 	pennyTotal    float64 // exponentially decaying total for penny spends.
 	lastPennyUnix int64   // unix time of last ``penny spend''
@@ -238,7 +231,7 @@ func (mp *TxPool) insertVote(ssgen *dcrutil.Tx) error {
 	// start a new buffered slice and store it.
 	vts, exists := mp.votes[blockHash]
 	if !exists {
-		vts = make([]*VoteTx, 0, mp.cfg.ChainParams.TicketsPerBlock)
+		vts = make([]*blockchain.VoteTx, 0, mp.cfg.ChainParams.TicketsPerBlock)
 		mp.votes[blockHash] = vts
 	}
 
@@ -252,7 +245,8 @@ func (mp *TxPool) insertVote(ssgen *dcrutil.Tx) error {
 	// Append the new vote.
 	voteBits := stake.SSGenVoteBits(msgTx)
 	vote := dcrutil.IsFlagSet16(voteBits, dcrutil.BlockValid)
-	mp.votes[blockHash] = append(vts, &VoteTx{*voteHash, *ticketHash, vote})
+	mp.votes[blockHash] = append(vts, &blockchain.VoteTx{*voteHash, *ticketHash,
+		vote})
 
 	log.Debugf("Accepted vote %v for block hash %v (height %v), voting "+
 		"%v on the transaction tree", voteHash, blockHash, blockHeight,
@@ -288,12 +282,12 @@ func (mp *TxPool) VoteHashesForBlock(blockHash chainhash.Hash) []chainhash.Hash 
 // block hashes that are currently available in the mempool.
 //
 // This function is safe for concurrent access.
-func (mp *TxPool) VotesForBlocks(hashes []chainhash.Hash) [][]*VoteTx {
-	result := make([][]*VoteTx, 0, len(hashes))
+func (mp *TxPool) VotesForBlocks(hashes []chainhash.Hash) [][]*blockchain.VoteTx {
+	result := make([][]*blockchain.VoteTx, 0, len(hashes))
 	mp.votesMtx.Lock()
 	for _, hash := range hashes {
 		votes := mp.votes[hash]
-		votesCopy := make([]*VoteTx, len(votes))
+		votesCopy := make([]*blockchain.VoteTx, len(votes))
 		copy(votesCopy, votes)
 		result = append(result, votesCopy)
 	}
@@ -1596,6 +1590,6 @@ func New(cfg *Config) *TxPool {
 		orphans:       make(map[chainhash.Hash]*dcrutil.Tx),
 		orphansByPrev: make(map[chainhash.Hash]map[chainhash.Hash]*dcrutil.Tx),
 		outpoints:     make(map[wire.OutPoint]*dcrutil.Tx),
-		votes:         make(map[chainhash.Hash][]*VoteTx),
+		votes:         make(map[chainhash.Hash][]*blockchain.VoteTx),
 	}
 }

--- a/mining.go
+++ b/mining.go
@@ -281,7 +281,7 @@ func (b byNumberOfVotes) Less(i, j int) bool {
 // at least a majority number of votes) sorted by number of votes, descending.
 //
 // This function is safe for concurrent access.
-func SortParentsByVotes(mp *mempool.TxPool, currentTopBlock chainhash.Hash, blocks []chainhash.Hash, params *chaincfg.Params) []chainhash.Hash {
+func SortParentsByVotes(txSource mining.TxSource, currentTopBlock chainhash.Hash, blocks []chainhash.Hash, params *chaincfg.Params) []chainhash.Hash {
 	// Return now when no blocks were provided.
 	lenBlocks := len(blocks)
 	if lenBlocks == 0 {
@@ -292,7 +292,7 @@ func SortParentsByVotes(mp *mempool.TxPool, currentTopBlock chainhash.Hash, bloc
 	// mempool and filter out any blocks that do not have the minimum
 	// required number of votes.
 	minVotesRequired := (params.TicketsPerBlock / 2) + 1
-	voteMetadata := mp.VotesForBlocks(blocks)
+	voteMetadata := txSource.VotesForBlocks(blocks)
 	filtered := make([]*blockWithNumVotes, 0, lenBlocks)
 	for i := range blocks {
 		numVotes := uint16(len(voteMetadata[i]))
@@ -321,7 +321,7 @@ func SortParentsByVotes(mp *mempool.TxPool, currentTopBlock chainhash.Hash, bloc
 	// the same amount of votes as the current leader after the sort. After this
 	// point, all blocks listed in sortedUsefulBlocks definitely also have the
 	// minimum number of votes required.
-	curVoteMetadata := mp.VotesForBlocks([]chainhash.Hash{currentTopBlock})
+	curVoteMetadata := txSource.VotesForBlocks([]chainhash.Hash{currentTopBlock})
 	numTopBlockVotes := uint16(len(curVoteMetadata))
 	if filtered[0].NumVotes == numTopBlockVotes && filtered[0].Hash !=
 		currentTopBlock {
@@ -486,38 +486,6 @@ func getCoinbaseExtranonces(msgBlock *wire.MsgBlock) []uint64 {
 		msgBlock.Transactions[0].TxOut[1].PkScript[30:38])
 
 	return ens
-}
-
-// UpdateExtraNonce updates the extra nonce in the coinbase script of the passed
-// block by regenerating the coinbase script with the passed value and block
-// height.  It also recalculates and updates the new merkle root that results
-// from changing the coinbase script.
-func UpdateExtraNonce(msgBlock *wire.MsgBlock, blockHeight int64,
-	extraNonces []uint64) error {
-	// First block has no extranonce.
-	if blockHeight == 1 {
-		return nil
-	}
-	if len(extraNonces) != 4 {
-		return fmt.Errorf("not enough nonce information passed")
-	}
-
-	coinbaseOpReturn, err := standardCoinbaseOpReturn(uint32(blockHeight),
-		extraNonces)
-	if err != nil {
-		return err
-	}
-	msgBlock.Transactions[0].TxOut[1].PkScript = coinbaseOpReturn
-
-	// TODO(davec): A dcrutil.Block should use saved in the state to avoid
-	// recalculating all of the other transaction hashes.
-	// block.Transactions[0].InvalidateCache()
-
-	// Recalculate the merkle root with the updated extra nonce.
-	block := dcrutil.NewBlockDeepCopyCoinbase(msgBlock)
-	merkles := blockchain.BuildMerkleTreeStore(block.Transactions())
-	msgBlock.Header.MerkleRoot = *merkles[len(merkles)-1]
-	return nil
 }
 
 // createCoinbaseTx returns a coinbase transaction paying an appropriate subsidy
@@ -803,9 +771,11 @@ func deepCopyBlockTemplate(blockTemplate *BlockTemplate) *BlockTemplate {
 func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache,
 	nextHeight int64,
 	miningAddress dcrutil.Address,
-	bm *blockManager) (*BlockTemplate, error) {
-	timeSource := bm.server.timeSource
-	stakeValidationHeight := bm.server.chainParams.StakeValidationHeight
+	generator *BlkTmplGenerator) (*BlockTemplate, error) {
+	timeSource := generator.timeSource
+	chainParams := generator.chainParams
+	stakeValidationHeight := chainParams.StakeValidationHeight
+	bm := generator.blockManager
 	curTemplate := bm.GetCurrentTemplate()
 
 	// Check to see if we've fallen off the chain, for example if a
@@ -836,7 +806,7 @@ func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache,
 
 				// If we're on testnet, the time since this last block
 				// listed as the parent must be taken into consideration.
-				if bm.server.chainParams.ReduceMinDifficulty {
+				if chainParams.ReduceMinDifficulty {
 					parentHash := cptCopy.Block.Header.PrevBlock
 
 					requiredDifficulty, err :=
@@ -854,14 +824,16 @@ func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache,
 				// same block and choose the same winners as before.
 				ens := cptCopy.getCoinbaseExtranonces()
 				ens[0]++
-				err := UpdateExtraNonce(cptCopy.Block, cptCopy.Height, ens)
+				err := generator.UpdateExtraNonce(cptCopy.Block, cptCopy.Height,
+					ens)
 				if err != nil {
 					return nil, err
 				}
 
 				// Update extranonce of the original template too, so
 				// we keep getting unique numbers.
-				err = UpdateExtraNonce(curTemplate.Block, curTemplate.Height, ens)
+				err = generator.UpdateExtraNonce(curTemplate.Block,
+					curTemplate.Height, ens)
 				if err != nil {
 					return nil, err
 				}
@@ -869,8 +841,8 @@ func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache,
 				// Make sure the block validates.
 				block := dcrutil.NewBlockDeepCopyCoinbase(cptCopy.Block)
 				if err := blockchain.CheckWorklessBlockSanity(block,
-					bm.server.timeSource,
-					bm.server.chainParams); err != nil {
+					timeSource,
+					chainParams); err != nil {
 					return nil, miningRuleError(ErrCheckConnectBlock,
 						err.Error())
 				}
@@ -916,7 +888,7 @@ func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache,
 					topBlock.Height(),
 					miningAddress,
 					topBlock.MsgBlock().Header.Voters,
-					bm.server.chainParams)
+					chainParams)
 				if err != nil {
 					return nil, err
 				}
@@ -936,7 +908,7 @@ func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache,
 
 				// If we're on testnet, the time since this last block
 				// listed as the parent must be taken into consideration.
-				if bm.server.chainParams.ReduceMinDifficulty {
+				if chainParams.ReduceMinDifficulty {
 					parentHash := topBlock.MsgBlock().Header.PrevBlock
 
 					requiredDifficulty, err :=
@@ -973,8 +945,8 @@ func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache,
 				// Make sure the block validates.
 				btBlock := dcrutil.NewBlockDeepCopyCoinbase(btMsgBlock)
 				if err := blockchain.CheckWorklessBlockSanity(btBlock,
-					bm.server.timeSource,
-					bm.server.chainParams); err != nil {
+					timeSource,
+					chainParams); err != nil {
 					str := fmt.Sprintf("failed to check sanity of template "+
 						"while constructing a new parent: %v",
 						err.Error())
@@ -1041,6 +1013,42 @@ func handleCreatedBlockTemplate(blockTemplate *BlockTemplate,
 	}
 
 	return blockTemplate, nil
+}
+
+// BlkTmplGenerator provides a type that can be used to generate block templates
+// based on a given mining policy and source of transactions to choose from.
+// It also houses additional state required in order to ensure the templates
+// are built on top of the current best chain and adhere to the consensus rules.
+//
+// See the NewBlockTemplate method for a detailed description of how the block
+// template is generated.
+type BlkTmplGenerator struct {
+	policy       *mining.Policy
+	chainParams  *chaincfg.Params
+	txSource     mining.TxSource
+	sigCache     *txscript.SigCache
+	blockManager *blockManager
+	timeSource   blockchain.MedianTimeSource
+}
+
+// newBlkTmplGenerator returns a new block template generator for the given
+// policy using transactions from the provided transaction source.
+//
+// The additional state-related fields are required in order to ensure the
+// templates are built on top of the current best chain and adhere to the
+// consensus rules.
+func newBlkTmplGenerator(policy *mining.Policy, params *chaincfg.Params,
+	txSource mining.TxSource, sigCache *txscript.SigCache,
+	blockManager *blockManager, timeSource blockchain.MedianTimeSource) *BlkTmplGenerator {
+
+	return &BlkTmplGenerator{
+		policy:       policy,
+		chainParams:  params,
+		txSource:     txSource,
+		sigCache:     sigCache,
+		blockManager: blockManager,
+		timeSource:   timeSource,
+	}
 }
 
 // NewBlockTemplate returns a new block template that is ready to be solved
@@ -1125,16 +1133,13 @@ func handleCreatedBlockTemplate(blockTemplate *BlockTemplate,
 //
 //  This function returns nil, nil if there are not enough voters on any of
 //  the current top blocks to create a new block template.
-func NewBlockTemplate(policy *mining.Policy, server *server,
-	payToAddress dcrutil.Address) (*BlockTemplate, error) {
+func (g *BlkTmplGenerator) NewBlockTemplate(payToAddress dcrutil.Address) (*BlockTemplate, error) {
+	// Locals for faster access.
+	policy := g.policy
+	blockManager := g.blockManager
+	timeSource := g.timeSource
 
-	// TODO: The mempool should be completely separated via the TxSource
-	// interface so this function is fully decoupled.
-	mp := server.txMemPool
-
-	var txSource mining.TxSource = server.txMemPool
-	blockManager := server.blockManager
-	timeSource := server.timeSource
+	var txSource mining.TxSource = g.txSource
 	subsidyCache := blockManager.chain.FetchSubsidyCache()
 
 	// All transaction scripts are verified using the more strict standarad
@@ -1201,7 +1206,7 @@ func NewBlockTemplate(policy *mining.Policy, server *server,
 	medianTime := chainBest.MedianTime
 
 	// Calculate the stake enabled height.
-	stakeValidationHeight := server.chainParams.StakeValidationHeight
+	stakeValidationHeight := g.chainParams.StakeValidationHeight
 
 	if nextBlockHeight >= stakeValidationHeight {
 		// Obtain the entire generation of blocks stemming from this parent.
@@ -1213,13 +1218,13 @@ func NewBlockTemplate(policy *mining.Policy, server *server,
 		// Get the list of blocks that we can actually build on top of. If we're
 		// not currently on the block that has the most votes, switch to that
 		// block.
-		eligibleParents := SortParentsByVotes(mp, *prevHash, children,
-			blockManager.server.chainParams)
+		eligibleParents := SortParentsByVotes(txSource, *prevHash, children,
+			g.chainParams)
 		if len(eligibleParents) == 0 {
 			minrLog.Debugf("Too few voters found on any HEAD block, " +
 				"recycling a parent block to mine on")
 			return handleTooFewVoters(subsidyCache, nextBlockHeight,
-				payToAddress, server.blockManager)
+				payToAddress, g)
 		}
 
 		minrLog.Debugf("Found eligible parent %v with enough votes to build "+
@@ -1238,13 +1243,13 @@ func NewBlockTemplate(policy *mining.Policy, server *server,
 
 				// Check to make sure we actually have the transactions
 				// (votes) we need in the mempool.
-				voteHashes := mp.VoteHashesForBlock(newHead)
+				voteHashes := txSource.VoteHashesForBlock(newHead)
 				if len(voteHashes) == 0 {
 					return nil, fmt.Errorf("no vote metadata for block %v",
 						newHead)
 				}
 
-				if exist := mp.CheckIfTxsExist(voteHashes); !exist {
+				if exist := txSource.CheckIfTxsExist(voteHashes); !exist {
 					continue
 				} else {
 					prevHash = &newHead
@@ -1296,7 +1301,7 @@ func NewBlockTemplate(policy *mining.Policy, server *server,
 
 	minrLog.Debugf("Considering %d transactions for inclusion to new block",
 		len(sourceTxns))
-	treeValid := mp.IsTxTreeValid(prevHash)
+	treeValid := txSource.IsTxTreeValid(prevHash)
 
 mempoolLoop:
 	for _, txDesc := range sourceTxns {
@@ -1467,7 +1472,7 @@ mempoolLoop:
 
 		// Skip if we already have too many SStx.
 		if isSStx && (numSStx >=
-			int(server.chainParams.MaxFreshStakePerBlock)) {
+			int(g.chainParams.MaxFreshStakePerBlock)) {
 			minrLog.Tracef("Skipping sstx %s because it would exceed "+
 				"the max number of sstx allowed in a block", tx.Hash())
 			logSkippedDeps(tx, deps)
@@ -1601,7 +1606,7 @@ mempoolLoop:
 		// The fraud proof is not checked because it will be filled in
 		// by the miner.
 		_, err = blockchain.CheckTransactionInputs(subsidyCache, tx,
-			nextBlockHeight, blockUtxos, false, server.chainParams)
+			nextBlockHeight, blockUtxos, false, g.chainParams)
 		if err != nil {
 			minrLog.Tracef("Skipping tx %s due to error in "+
 				"CheckTransactionInputs: %v", tx.Hash(), err)
@@ -1609,7 +1614,7 @@ mempoolLoop:
 			continue
 		}
 		err = blockchain.ValidateTransactionScripts(tx, blockUtxos,
-			scriptFlags, server.sigCache)
+			scriptFlags, g.sigCache)
 		if err != nil {
 			minrLog.Tracef("Skipping tx %s due to error in "+
 				"ValidateTransactionScripts: %v", tx.Hash(), err)
@@ -1802,7 +1807,7 @@ mempoolLoop:
 		}
 
 		// Don't let this overflow.
-		if freshStake >= int(server.chainParams.MaxFreshStakePerBlock) {
+		if freshStake >= int(g.chainParams.MaxFreshStakePerBlock) {
 			break
 		}
 	}
@@ -1861,7 +1866,7 @@ mempoolLoop:
 		nextBlockHeight,
 		payToAddress,
 		uint16(voters),
-		server.chainParams)
+		g.chainParams)
 	if err != nil {
 		return nil, err
 	}
@@ -1933,7 +1938,7 @@ mempoolLoop:
 	// If we're greater than or equal to stake validation height, scale the
 	// fees according to the number of voters.
 	totalFees *= int64(voters)
-	totalFees /= int64(server.chainParams.TicketsPerBlock)
+	totalFees /= int64(g.chainParams.TicketsPerBlock)
 
 	// Now that the actual transactions have been selected, update the
 	// block size for the real transaction count and coinbase value with
@@ -1960,13 +1965,12 @@ mempoolLoop:
 	// bit for the mempool to sync with the votes map and we end up down
 	// here despite having the relevant votes available in the votes map.
 	minimumVotesRequired :=
-		int((server.chainParams.TicketsPerBlock / 2) + 1)
+		int((g.chainParams.TicketsPerBlock / 2) + 1)
 	if nextBlockHeight >= stakeValidationHeight &&
 		voters < minimumVotesRequired {
 		minrLog.Warnf("incongruent number of voters in mempool " +
 			"vs mempool.voters; not enough voters found")
-		return handleTooFewVoters(subsidyCache, nextBlockHeight, payToAddress,
-			server.blockManager)
+		return handleTooFewVoters(subsidyCache, nextBlockHeight, payToAddress, g)
 	}
 
 	// Correct transaction index fraud proofs for any transactions that
@@ -2045,7 +2049,7 @@ mempoolLoop:
 
 	// Choose the block version to generate based on the network.
 	blockVersion := int32(generatedBlockVersion)
-	if server.chainParams.Net != wire.MainNet {
+	if g.chainParams.Net != wire.MainNet {
 		blockVersion = generatedBlockVersionTest
 	}
 
@@ -2099,8 +2103,8 @@ mempoolLoop:
 	block := dcrutil.NewBlockDeepCopyCoinbase(&msgBlock)
 
 	if err := blockchain.CheckWorklessBlockSanity(block,
-		server.timeSource,
-		server.chainParams); err != nil {
+		g.timeSource,
+		g.chainParams); err != nil {
 		str := fmt.Sprintf("failed to do final check for block workless "+
 			"sanity when making new block template: %v",
 			err.Error())
@@ -2130,7 +2134,7 @@ mempoolLoop:
 		ValidPayAddress: payToAddress != nil,
 	}
 
-	return handleCreatedBlockTemplate(blockTemplate, server.blockManager)
+	return handleCreatedBlockTemplate(blockTemplate, blockManager)
 }
 
 // UpdateBlockTime updates the timestamp in the header of the passed block to
@@ -2139,24 +2143,56 @@ mempoolLoop:
 // consensus rules.  Finally, it will update the target difficulty if needed
 // based on the new time for the test networks since their target difficulty can
 // change based upon time.
-func UpdateBlockTime(msgBlock *wire.MsgBlock, bManager *blockManager) error {
+func (g *BlkTmplGenerator) UpdateBlockTime(msgBlock *wire.MsgBlock) error {
 	// The new timestamp is potentially adjusted to ensure it comes after
 	// the median time of the last several blocks per the chain consensus
 	// rules.
-	chainBest := bManager.chain.BestSnapshot()
-	newTimestamp := medianAdjustedTime(chainBest, bManager.server.timeSource)
+	chain := g.blockManager.chain
+	chainBest := chain.BestSnapshot()
+	newTimestamp := medianAdjustedTime(chainBest, g.timeSource)
 	msgBlock.Header.Timestamp = newTimestamp
 
 	// If running on a network that requires recalculating the difficulty,
 	// do so now.
 	if activeNetParams.ReduceMinDifficulty {
-		difficulty, err := bManager.chain.CalcNextRequiredDifficulty(
-			newTimestamp)
+		difficulty, err := chain.CalcNextRequiredDifficulty(newTimestamp)
 		if err != nil {
 			return miningRuleError(ErrGettingDifficulty, err.Error())
 		}
 		msgBlock.Header.Bits = difficulty
 	}
 
+	return nil
+}
+
+// UpdateExtraNonce updates the extra nonce in the coinbase script of the passed
+// block by regenerating the coinbase script with the passed value and block
+// height.  It also recalculates and updates the new merkle root that results
+// from changing the coinbase script.
+func (g *BlkTmplGenerator) UpdateExtraNonce(msgBlock *wire.MsgBlock, blockHeight int64,
+	extraNonces []uint64) error {
+	// First block has no extranonce.
+	if blockHeight == 1 {
+		return nil
+	}
+	if len(extraNonces) != 4 {
+		return fmt.Errorf("not enough nonce information passed")
+	}
+
+	coinbaseOpReturn, err := standardCoinbaseOpReturn(uint32(blockHeight),
+		extraNonces)
+	if err != nil {
+		return err
+	}
+	msgBlock.Transactions[0].TxOut[1].PkScript = coinbaseOpReturn
+
+	// TODO(davec): A dcrutil.Block should use saved in the state to avoid
+	// recalculating all of the other transaction hashes.
+	// block.Transactions[0].InvalidateCache()
+
+	// Recalculate the merkle root with the updated extra nonce.
+	block := dcrutil.NewBlockDeepCopyCoinbase(msgBlock)
+	merkles := blockchain.BuildMerkleTreeStore(block.Transactions())
+	msgBlock.Header.MerkleRoot = *merkles[len(merkles)-1]
 	return nil
 }

--- a/mining/mining.go
+++ b/mining/mining.go
@@ -8,6 +8,7 @@ package mining
 import (
 	"time"
 
+	"github.com/decred/dcrd/blockchain"
 	"github.com/decred/dcrd/blockchain/stake"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil"
@@ -50,4 +51,20 @@ type TxSource interface {
 	// HaveTransaction returns whether or not the passed transaction hash
 	// exists in the source pool.
 	HaveTransaction(hash *chainhash.Hash) bool
+
+	// VoteHashesForBlock returns the hashes for all votes on the provided block
+	// hash that are currently available in the mempool.
+	VoteHashesForBlock(hash chainhash.Hash) []chainhash.Hash
+
+	// CheckIfTxsExist checks a list of transaction hashes against the mempool
+	// and returns true if they all exist in the mempool, otherwise false.
+	CheckIfTxsExist(hashes []chainhash.Hash) bool
+
+	// IsTxTreeValid checks the map of votes for a block to see if the tx
+	// tree regular for the block at HEAD is valid.
+	IsTxTreeValid(hash *chainhash.Hash) bool
+
+	// VotesForBlocks returns the vote metadata for all votes on the provided
+	// block hashes that are currently available in the mempool.
+	VotesForBlocks(hashes []chainhash.Hash) [][]*blockchain.VoteTx
 }

--- a/server.go
+++ b/server.go
@@ -2465,7 +2465,9 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 	}
 	s.txMemPool = mempool.New(&txC)
 
-	// Create the mining policy based on the configuration options.
+	// Create the mining policy and block template generator based on the
+	// configuration options.
+	//
 	// NOTE: The CPU miner relies on the mempool, so the mempool has to be
 	// created before calling the function to create the CPU miner.
 	policy := mining.Policy{
@@ -2474,7 +2476,9 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 		BlockPrioritySize: cfg.BlockPrioritySize,
 		TxMinFreeFee:      cfg.minRelayTxFee,
 	}
-	s.cpuMiner = newCPUMiner(&policy, &s)
+	blockTemplateGenerator := newBlkTmplGenerator(&policy, s.chainParams,
+		s.txMemPool, s.sigCache, bm, s.timeSource)
+	s.cpuMiner = newCPUMiner(blockTemplateGenerator, &s)
 
 	// Only setup a function to return new addresses to connect to when
 	// not running in connect-only mode.  The simulation network is always
@@ -2559,7 +2563,8 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 	}
 
 	if !cfg.DisableRPC {
-		s.rpcServer, err = newRPCServer(cfg.RPCListeners, &policy, &s)
+		s.rpcServer, err = newRPCServer(cfg.RPCListeners,
+			blockTemplateGenerator, &s)
 		if err != nil {
 			return nil, err
 		}

--- a/server.go
+++ b/server.go
@@ -449,7 +449,8 @@ func (sp *serverPeer) OnGetMiningState(p *peer.Peer, msg *wire.MsgGetMiningState
 	// Access the block manager and get the list of best blocks to mine on.
 	bm := sp.server.blockManager
 	mp := sp.server.txMemPool
-	newest, height := bm.chainState.Best()
+	chainBest := bm.chain.BestSnapshot()
+	newest, height := chainBest.Hash, chainBest.Height
 
 	// Send out blank mining states if it's early in the blockchain.
 	if height < activeNetParams.StakeValidationHeight-1 {
@@ -2449,10 +2450,7 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 		},
 		ChainParams: chainParams,
 		NextStakeDifficulty: func() (int64, error) {
-			bm.chainState.Lock()
-			sDiff := bm.chainState.nextStakeDifficulty
-			bm.chainState.Unlock()
-			return sDiff, nil
+			return bm.chain.CalcNextRequiredStakeDifficulty()
 		},
 		FetchUtxoView:    bm.chain.FetchUtxoView,
 		BlockByHash:      bm.chain.BlockByHash,


### PR DESCRIPTION
**This requires PR #910.**

Port over the changes from https://github.com/btcsuite/btcd/pull/810 , see description there. Part of #709.
Extend the `TxSource` interface and move the `VoteTx` type to `blockchain` because it's needed by both `mining` and `mempool`.

TODO - tests fail:
```
--- FAIL: TestHarness (0.86s)
	rpc_harness_test.go:101: unable to get nodeA's peer info
FAIL
FAIL	github.com/decred/dcrd/rpctest	2.745s
```