### PR TITLE
blockchain: Switch to FindSpentTicketsInBlock.

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -236,38 +236,6 @@ func voteBitsInBlock(bl *dcrutil.Block) []stake.VoteVersionTuple {
 	return voteBits
 }
 
-type ticketsInBlockInfo struct {
-	spentTickets   []chainhash.Hash
-	revokedTickets []chainhash.Hash
-	voteBits       []stake.VoteVersionTuple
-}
-
-// ticketsInBlock returns information about spent tickets of a given block. This
-// includes spent and revoked tickets and the vote bits of each spent ticket.
-//
-// This is faster than calling the individual functions (ticketsSpentInBlock,
-// etc) if all information regarding spent tickets is needed.
-//
-// No validation of the transactions is performed.
-func ticketsInBlock(bl *dcrutil.Block) *ticketsInBlockInfo {
-	res := &ticketsInBlockInfo{}
-
-	for _, stx := range bl.MsgBlock().STransactions {
-		if is, _ := stake.IsSSGen(stx); is {
-			res.spentTickets = append(res.spentTickets,
-				stx.TxIn[1].PreviousOutPoint.Hash)
-			res.voteBits = append(res.voteBits, stake.VoteVersionTuple{
-				Version: stake.SSGenVersion(stx),
-				Bits:    stake.SSGenVoteBits(stx),
-			})
-		} else if is, _ := stake.IsSSRtx(stx); is {
-			res.revokedTickets = append(res.revokedTickets,
-				stx.TxIn[0].PreviousOutPoint.Hash)
-		}
-	}
-	return res
-}
-
 // maybeAcceptBlock potentially accepts a block into the block chain and, if
 // accepted, returns whether or not it is on the main chain.  It performs
 // several validation checks which depend on its position within the block chain

--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -220,14 +220,14 @@ func ticketsRevokedInBlock(bl *dcrutil.Block) []chainhash.Hash {
 }
 
 // voteBitsInBlock returns a list of vote bits for the voters in this block.
-func voteBitsInBlock(bl *dcrutil.Block) []VoteVersionTuple {
-	var voteBits []VoteVersionTuple
+func voteBitsInBlock(bl *dcrutil.Block) []stake.VoteVersionTuple {
+	var voteBits []stake.VoteVersionTuple
 	for _, stx := range bl.MsgBlock().STransactions {
 		if is, _ := stake.IsSSGen(stx); !is {
 			continue
 		}
 
-		voteBits = append(voteBits, VoteVersionTuple{
+		voteBits = append(voteBits, stake.VoteVersionTuple{
 			Version: stake.SSGenVersion(stx),
 			Bits:    stake.SSGenVoteBits(stx),
 		})
@@ -239,7 +239,7 @@ func voteBitsInBlock(bl *dcrutil.Block) []VoteVersionTuple {
 type ticketsInBlockInfo struct {
 	spentTickets   []chainhash.Hash
 	revokedTickets []chainhash.Hash
-	voteBits       []VoteVersionTuple
+	voteBits       []stake.VoteVersionTuple
 }
 
 // ticketsInBlock returns information about spent tickets of a given block. This
@@ -256,7 +256,7 @@ func ticketsInBlock(bl *dcrutil.Block) *ticketsInBlockInfo {
 		if is, _ := stake.IsSSGen(stx); is {
 			res.spentTickets = append(res.spentTickets,
 				stx.TxIn[1].PreviousOutPoint.Hash)
-			res.voteBits = append(res.voteBits, VoteVersionTuple{
+			res.voteBits = append(res.voteBits, stake.VoteVersionTuple{
 				Version: stake.SSGenVersion(stx),
 				Bits:    stake.SSGenVoteBits(stx),
 			})

--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -254,13 +254,15 @@ func ticketsInBlock(bl *dcrutil.Block) *ticketsInBlockInfo {
 
 	for _, stx := range bl.MsgBlock().STransactions {
 		if is, _ := stake.IsSSGen(stx); is {
-			res.spentTickets = append(res.spentTickets, stx.TxIn[1].PreviousOutPoint.Hash)
+			res.spentTickets = append(res.spentTickets,
+				stx.TxIn[1].PreviousOutPoint.Hash)
 			res.voteBits = append(res.voteBits, VoteVersionTuple{
 				Version: stake.SSGenVersion(stx),
 				Bits:    stake.SSGenVoteBits(stx),
 			})
 		} else if is, _ := stake.IsSSRtx(stx); is {
-			res.revokedTickets = append(res.revokedTickets, stx.TxIn[0].PreviousOutPoint.Hash)
+			res.revokedTickets = append(res.revokedTickets,
+				stx.TxIn[0].PreviousOutPoint.Hash)
 		}
 	}
 	return res

--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -276,8 +276,8 @@ func (b *BlockChain) maybeAcceptBlock(block *dcrutil.Block, flags BehaviorFlags)
 	// Create a new block node for the block and add it to the in-memory
 	// block chain (could be either a side chain or the main chain).
 	blockHeader := &block.MsgBlock().Header
-	newNode := newBlockNode(blockHeader, ticketsSpentInBlock(block),
-		ticketsRevokedInBlock(block), voteBitsInBlock(block))
+	newNode := newBlockNode(blockHeader,
+		stake.FindSpentTicketsInBlock(block.MsgBlock()))
 	if prevNode != nil {
 		newNode.parent = prevNode
 		newNode.height = blockHeight

--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -236,6 +236,36 @@ func voteBitsInBlock(bl *dcrutil.Block) []VoteVersionTuple {
 	return voteBits
 }
 
+type ticketsInBlockInfo struct {
+	spentTickets   []chainhash.Hash
+	revokedTickets []chainhash.Hash
+	voteBits       []VoteVersionTuple
+}
+
+// ticketsInBlock returns information about spent tickets of a given block. This
+// includes spent and revoked tickets and the vote bits of each spent ticket.
+//
+// This is faster than calling the individual functions (ticketsSpentInBlock,
+// etc) if all information regarding spent tickets is needed.
+//
+// No validation of the transactions is performed.
+func ticketsInBlock(bl *dcrutil.Block) *ticketsInBlockInfo {
+	res := &ticketsInBlockInfo{}
+
+	for _, stx := range bl.MsgBlock().STransactions {
+		if is, _ := stake.IsSSGen(stx); is {
+			res.spentTickets = append(res.spentTickets, stx.TxIn[1].PreviousOutPoint.Hash)
+			res.voteBits = append(res.voteBits, VoteVersionTuple{
+				Version: stake.SSGenVersion(stx),
+				Bits:    stake.SSGenVoteBits(stx),
+			})
+		} else if is, _ := stake.IsSSRtx(stx); is {
+			res.revokedTickets = append(res.revokedTickets, stx.TxIn[0].PreviousOutPoint.Hash)
+		}
+	}
+	return res
+}
+
 // maybeAcceptBlock potentially accepts a block into the block chain and, if
 // accepted, returns whether or not it is on the main chain.  It performs
 // several validation checks which depend on its position within the block chain

--- a/blockchain/agendas_test.go
+++ b/blockchain/agendas_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/decred/dcrd/blockchain/stake"
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/txscript"
 )
@@ -120,7 +121,7 @@ func testLNFeaturesDeployment(t *testing.T, params *chaincfg.Params, deploymentV
 			// Create fake votes that vote yes on the agenda to
 			// ensure it is activated.
 			for j := uint16(0); j < params.TicketsPerBlock; j++ {
-				node.votes = append(node.votes, VoteVersionTuple{
+				node.votes = append(node.votes, stake.VoteVersionTuple{
 					Version: deploymentVer,
 					Bits:    yesChoice.Bits | 0x01,
 				})

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -51,13 +51,6 @@ const (
 	maxSearchDepth = 2880
 )
 
-// VoteVersionTuple contains the extracted vote bits and version from votes
-// (SSGen).
-type VoteVersionTuple struct {
-	Version uint32
-	Bits    uint16
-}
-
 // blockNode represents a block within the block chain and is primarily used to
 // aid in selecting the best chain to be the main chain.  The main chain is
 // stored into the block database.
@@ -100,14 +93,14 @@ type blockNode struct {
 	ticketsRevoked []chainhash.Hash
 
 	// Keep track of all vote version and bits in this block.
-	votes []VoteVersionTuple
+	votes []stake.VoteVersionTuple
 }
 
 // newBlockNode returns a new block node for the given block header.  It is
 // completely disconnected from the chain and the workSum value is just the work
 // for the passed block.  The work sum is updated accordingly when the node is
 // inserted into a chain.
-func newBlockNode(blockHeader *wire.BlockHeader, ticketsSpent []chainhash.Hash, ticketsRevoked []chainhash.Hash, votes []VoteVersionTuple) *blockNode {
+func newBlockNode(blockHeader *wire.BlockHeader, ticketsSpent []chainhash.Hash, ticketsRevoked []chainhash.Hash, votes []stake.VoteVersionTuple) *blockNode {
 	// Make a copy of the hash so the node doesn't keep a reference to part
 	// of the full block/block header preventing it from being garbage
 	// collected.
@@ -300,7 +293,7 @@ type StakeVersions struct {
 	Height       int64
 	BlockVersion int32
 	StakeVersion uint32
-	Votes        []VoteVersionTuple
+	Votes        []stake.VoteVersionTuple
 }
 
 // GetStakeVersions returns a cooked array of StakeVersions.  We do this in

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -618,9 +618,9 @@ func (b *BlockChain) loadBlockNode(dbTx database.Tx, hash *chainhash.Hash) (*blo
 	}
 
 	blockHeader := block.MsgBlock().Header
-	tickets := ticketsInBlock(block)
-	node := newBlockNode(&blockHeader, tickets.spentTickets, tickets.revokedTickets,
-		tickets.voteBits)
+	tickets := stake.FindSpentTicketsInBlock(block.MsgBlock())
+	node := newBlockNode(&blockHeader, tickets.VotedTickets, tickets.RevokedTickets,
+		tickets.VoteBits)
 	node.inMainChain = true
 	prevHash := &blockHeader.PrevBlock
 

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -625,8 +625,9 @@ func (b *BlockChain) loadBlockNode(dbTx database.Tx, hash *chainhash.Hash) (*blo
 	}
 
 	blockHeader := block.MsgBlock().Header
-	node := newBlockNode(&blockHeader, ticketsSpentInBlock(block),
-		ticketsRevokedInBlock(block), voteBitsInBlock(block))
+	tickets := ticketsInBlock(block)
+	node := newBlockNode(&blockHeader, tickets.spentTickets, tickets.revokedTickets,
+		tickets.voteBits)
 	node.inMainChain = true
 	prevHash := &blockHeader.PrevBlock
 

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1277,7 +1277,7 @@ func (b *BlockChain) createChainState() error {
 	// Create a new node from the genesis block and set it as the best node.
 	genesisBlock := dcrutil.NewBlock(b.chainParams.GenesisBlock)
 	header := &genesisBlock.MsgBlock().Header
-	node := newBlockNode(header, nil, nil, nil)
+	node := newBlockNode(header, &stake.SpentTicketsInBlock{})
 	node.inMainChain = true
 	b.bestNode = node
 
@@ -1439,10 +1439,8 @@ func (b *BlockChain) initChainState() error {
 
 		// Create a new node and set it as the best node.  The preceding
 		// nodes will be loaded on demand as needed.
-		blk := dcrutil.NewBlock(&block)
 		header := &block.Header
-		node := newBlockNode(header, ticketsSpentInBlock(blk),
-			ticketsRevokedInBlock(blk), voteBitsInBlock(blk))
+		node := newBlockNode(header, stake.FindSpentTicketsInBlock(&block))
 		node.inMainChain = true
 		node.workSum = state.workSum
 

--- a/blockchain/difficulty_test.go
+++ b/blockchain/difficulty_test.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/decred/dcrd/blockchain/stake"
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/wire"
 )
@@ -429,7 +430,7 @@ nextTest:
 					PoolSize:   poolSize,
 				}
 				node := newBlockNode(header,
-					nil, nil, nil)
+					&stake.SpentTicketsInBlock{})
 				node.parent = bc.bestNode
 
 				// Update the pool size for the next header.
@@ -731,7 +732,7 @@ nextTest:
 					PoolSize:   poolSize,
 				}
 				node := newBlockNode(header,
-					nil, nil, nil)
+					&stake.SpentTicketsInBlock{})
 				node.parent = bc.bestNode
 
 				// Update the pool size for the next header.

--- a/blockchain/internal_test.go
+++ b/blockchain/internal_test.go
@@ -17,6 +17,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/decred/dcrd/blockchain/stake"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/wire"
 )
@@ -41,6 +42,6 @@ func (b *BlockChain) TstCheckBlockHeaderContext(header *wire.BlockHeader, prevNo
 
 // TstNewBlockNode makes the internal newBlockNode function available to the
 // test package.
-func TstNewBlockNode(blockHeader *wire.BlockHeader, ticketsSpent []chainhash.Hash, ticketsRevoked []chainhash.Hash, voteBits []VoteVersionTuple) *blockNode {
+func TstNewBlockNode(blockHeader *wire.BlockHeader, ticketsSpent []chainhash.Hash, ticketsRevoked []chainhash.Hash, voteBits []stake.VoteVersionTuple) *blockNode {
 	return newBlockNode(blockHeader, ticketsSpent, ticketsRevoked, voteBits)
 }

--- a/blockchain/internal_test.go
+++ b/blockchain/internal_test.go
@@ -42,6 +42,6 @@ func (b *BlockChain) TstCheckBlockHeaderContext(header *wire.BlockHeader, prevNo
 
 // TstNewBlockNode makes the internal newBlockNode function available to the
 // test package.
-func TstNewBlockNode(blockHeader *wire.BlockHeader, ticketsSpent []chainhash.Hash, ticketsRevoked []chainhash.Hash, voteBits []stake.VoteVersionTuple) *blockNode {
-	return newBlockNode(blockHeader, ticketsSpent, ticketsRevoked, voteBits)
+func TstNewBlockNode(blockHeader *wire.BlockHeader, spentTickets *stake.SpentTicketsInBlock) *blockNode {
+	return newBlockNode(blockHeader, spentTickets)
 }

--- a/blockchain/internal_test.go
+++ b/blockchain/internal_test.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/decred/dcrd/blockchain/stake"
-	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/wire"
 )
 

--- a/blockchain/stake/staketx.go
+++ b/blockchain/stake/staketx.go
@@ -205,7 +205,7 @@ type VoteVersionTuple struct {
 type SpentTicketsInBlock struct {
 	VotedTickets   []chainhash.Hash
 	RevokedTickets []chainhash.Hash
-	VoteBits       []VoteVersionTuple
+	Votes          []VoteVersionTuple
 }
 
 // --------------------------------------------------------------------------------
@@ -1236,7 +1236,7 @@ func FindSpentTicketsInBlock(block *wire.MsgBlock) *SpentTicketsInBlock {
 		if is, _ := IsSSGen(stx); is {
 			res.VotedTickets = append(res.VotedTickets,
 				stx.TxIn[1].PreviousOutPoint.Hash)
-			res.VoteBits = append(res.VoteBits, VoteVersionTuple{
+			res.Votes = append(res.Votes, VoteVersionTuple{
 				Version: SSGenVersion(stx),
 				Bits:    SSGenVoteBits(stx),
 			})

--- a/blockchain/stake/staketx.go
+++ b/blockchain/stake/staketx.go
@@ -193,6 +193,13 @@ type VoteBits struct {
 	ExtendedBits []byte
 }
 
+// VoteVersionTuple contains the extracted vote bits and version from votes
+// (SSGen).
+type VoteVersionTuple struct {
+	Version uint32
+	Bits    uint16
+}
+
 // --------------------------------------------------------------------------------
 // Accessory Stake Functions
 // --------------------------------------------------------------------------------

--- a/blockchain/stake/staketx.go
+++ b/blockchain/stake/staketx.go
@@ -200,6 +200,14 @@ type VoteVersionTuple struct {
 	Bits    uint16
 }
 
+// SpentTicketsInBlock stores the hashes of the spent (both voted and revoked)
+// tickets of a given block, along with the vote information.
+type SpentTicketsInBlock struct {
+	VotedTickets   []chainhash.Hash
+	RevokedTickets []chainhash.Hash
+	VoteBits       []VoteVersionTuple
+}
+
 // --------------------------------------------------------------------------------
 // Accessory Stake Functions
 // --------------------------------------------------------------------------------
@@ -1209,4 +1217,33 @@ func SetTxTree(tx *dcrutil.Tx) {
 // has passed IsSStx.
 func IsStakeSubmissionTxOut(index int) bool {
 	return (index % 2) != 0
+}
+
+// FindSpentTicketsInBlock returns information about tickets spent in a given
+// block. This includes voted and revoked tickets, and the vote bits of each
+// spent ticket. This is faster than calling the individual functions to
+// determine ticket state if all information regarding spent tickets is needed.
+//
+// Note that the returned hashes are of the originally purchased *tickets* and
+// **NOT** of the vote/revoke transaction.
+//
+// The tickets are determined **only** from the STransactions of the provided
+// block and no validation is performed.
+func FindSpentTicketsInBlock(block *wire.MsgBlock) *SpentTicketsInBlock {
+	res := &SpentTicketsInBlock{}
+
+	for _, stx := range block.STransactions {
+		if is, _ := IsSSGen(stx); is {
+			res.VotedTickets = append(res.VotedTickets,
+				stx.TxIn[1].PreviousOutPoint.Hash)
+			res.VoteBits = append(res.VoteBits, VoteVersionTuple{
+				Version: SSGenVersion(stx),
+				Bits:    SSGenVoteBits(stx),
+			})
+		} else if is, _ := IsSSRtx(stx); is {
+			res.RevokedTickets = append(res.RevokedTickets,
+				stx.TxIn[0].PreviousOutPoint.Hash)
+		}
+	}
+	return res
 }

--- a/blockchain/stakeversion_test.go
+++ b/blockchain/stakeversion_test.go
@@ -22,7 +22,7 @@ import (
 func newFakeChain(params *chaincfg.Params) *BlockChain {
 	// Create a genesis block node and block index index populated with it
 	// for use when creating the fake chain below.
-	node := newBlockNode(&params.GenesisBlock.Header, nil, nil, nil)
+	node := newBlockNode(&params.GenesisBlock.Header, &stake.SpentTicketsInBlock{})
 	node.inMainChain = true
 	index := make(map[chainhash.Hash]*blockNode)
 	index[node.hash] = node
@@ -53,7 +53,7 @@ func newFakeNode(parent *blockNode, blockVersion int32, stakeVersion uint32, bit
 		Timestamp:    timestamp,
 		StakeVersion: stakeVersion,
 	}
-	node := newBlockNode(header, nil, nil, nil)
+	node := newBlockNode(header, &stake.SpentTicketsInBlock{})
 	node.parent = parent
 	node.workSum.Add(parent.workSum, node.workSum)
 	return node

--- a/blockchain/stakeversion_test.go
+++ b/blockchain/stakeversion_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/decred/dcrd/blockchain/stake"
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/wire"
@@ -62,7 +63,7 @@ func newFakeNode(parent *blockNode, blockVersion int32, stakeVersion uint32, bit
 // provided version and vote bits.
 func appendFakeVotes(node *blockNode, numVotes uint16, voteVersion uint32, voteBits uint16) {
 	for i := uint16(0); i < numVotes; i++ {
-		node.votes = append(node.votes, VoteVersionTuple{
+		node.votes = append(node.votes, stake.VoteVersionTuple{
 			Version: voteVersion,
 			Bits:    voteBits,
 		})

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -2619,9 +2619,7 @@ func (b *BlockChain) CheckConnectBlock(block *dcrutil.Block) error {
 	}
 
 	newNode := newBlockNode(&block.MsgBlock().Header,
-		ticketsSpentInBlock(block),
-		ticketsRevokedInBlock(block),
-		voteBitsInBlock(block))
+		stake.FindSpentTicketsInBlock(block.MsgBlock()))
 	newNode.parent = prevNode
 	newNode.workSum.Add(prevNode.workSum, newNode.workSum)
 	if prevNode != nil {

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -2110,7 +2110,7 @@ func TestCheckBlockHeaderContext(t *testing.T) {
 	// fails.
 	block := dcrutil.NewBlock(&badBlock)
 	newNode := blockchain.TstNewBlockNode(&block.MsgBlock().Header,
-		&stake.SpentTicketsInBlock)
+		&stake.SpentTicketsInBlock{})
 	err = chain.TstCheckBlockHeaderContext(&block.MsgBlock().Header, newNode, blockchain.BFNone)
 	if err == nil {
 		t.Fatalf("Should fail due to bad diff in newNode\n")

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/decred/dcrd/blockchain"
+	"github.com/decred/dcrd/blockchain/stake"
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/database"
@@ -2109,7 +2110,7 @@ func TestCheckBlockHeaderContext(t *testing.T) {
 	// fails.
 	block := dcrutil.NewBlock(&badBlock)
 	newNode := blockchain.TstNewBlockNode(&block.MsgBlock().Header,
-		nil, nil, nil)
+		&stake.SpentTicketsInBlock)
 	err = chain.TstCheckBlockHeaderContext(&block.MsgBlock().Header, newNode, blockchain.BFNone)
 	if err == nil {
 		t.Fatalf("Should fail due to bad diff in newNode\n")

--- a/blockchain/votebits_test.go
+++ b/blockchain/votebits_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/decred/dcrd/blockchain/stake"
 	"github.com/decred/dcrd/chaincfg"
 )
 
@@ -477,7 +478,7 @@ func TestVoting(t *testing.T) {
 	svi := uint32(params.StakeVersionInterval)
 
 	type voteCount struct {
-		vote  VoteVersionTuple
+		vote  stake.VoteVersionTuple
 		count uint32
 	}
 
@@ -496,7 +497,7 @@ func TestVoting(t *testing.T) {
 			blockVersion:      powVersion,
 			startStakeVersion: posVersion,
 			voteBitsCounts: []voteCount{{
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
@@ -513,25 +514,25 @@ func TestVoting(t *testing.T) {
 			blockVersion:      powVersion,
 			startStakeVersion: posVersion - 1,
 			voteBitsCounts: []voteCount{{
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: svh,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: svi - 1,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: rci - svi,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x03,
 				},
@@ -557,25 +558,25 @@ func TestVoting(t *testing.T) {
 			blockVersion:      powVersion,
 			startStakeVersion: posVersion - 1,
 			voteBitsCounts: []voteCount{{
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion - 1,
 					Bits:    0x01,
 				},
 				count: svh + 2*svi - 1,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: rci % svi,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: rci,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x03},
 				count: rci,
@@ -600,25 +601,25 @@ func TestVoting(t *testing.T) {
 			blockVersion:      powVersion,
 			startStakeVersion: posVersion + 1,
 			voteBitsCounts: []voteCount{{
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: svh,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: rci - 1,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x03,
 				},
 				count: rci,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x03,
 				},
@@ -644,19 +645,19 @@ func TestVoting(t *testing.T) {
 			blockVersion:      powVersion - 1,
 			startStakeVersion: posVersion,
 			voteBitsCounts: []voteCount{{
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: svh,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: rci - 1,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x03,
 				},
@@ -679,25 +680,25 @@ func TestVoting(t *testing.T) {
 			blockVersion:      powVersion + 1,
 			startStakeVersion: posVersion,
 			voteBitsCounts: []voteCount{{
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: svh,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: rci - 1,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x03,
 				},
 				count: rci,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x03,
 				},
@@ -723,43 +724,43 @@ func TestVoting(t *testing.T) {
 			blockVersion:      powVersion,
 			startStakeVersion: posVersion,
 			voteBitsCounts: []voteCount{{
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion + 1,
 					Bits:    0x01,
 				},
 				count: svh,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion + 1,
 					Bits:    0x01,
 				},
 				count: rci - 1,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion + 1,
 					Bits:    0x03,
 				},
 				count: rci,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion + 1,
 					Bits:    0x03,
 				},
 				count: rci,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x03,
 				},
 				count: rci,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x03,
 				},
 				count: rci,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion + 1,
 					Bits:    0x01,
 				},
@@ -794,31 +795,31 @@ func TestVoting(t *testing.T) {
 			blockVersion:      powVersion,
 			startStakeVersion: posVersion,
 			voteBitsCounts: []voteCount{{
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: svh,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: rci - 1,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x03,
 				},
 				count: rci,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x03,
 				},
 				count: rci,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
@@ -847,31 +848,31 @@ func TestVoting(t *testing.T) {
 			blockVersion:      powVersion,
 			startStakeVersion: posVersion,
 			voteBitsCounts: []voteCount{{
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: svh,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: rci - 1,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x05,
 				},
 				count: rci,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x05,
 				},
 				count: rci,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
@@ -900,37 +901,37 @@ func TestVoting(t *testing.T) {
 			blockVersion:      powVersion,
 			startStakeVersion: posVersion,
 			voteBitsCounts: []voteCount{{
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: svh,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: rci - 1,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x06,
 				},
 				count: rci,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x06,
 				},
 				count: rci,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x03,
 				},
 				count: rci,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
@@ -962,31 +963,31 @@ func TestVoting(t *testing.T) {
 			blockVersion:      powVersion,
 			startStakeVersion: posVersion,
 			voteBitsCounts: []voteCount{{
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: svh,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: rci - 1,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: rci,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: rci,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
@@ -1019,19 +1020,19 @@ func TestVoting(t *testing.T) {
 					time.Duration(int64(svh)+int64(rci+rci/2))).Unix())
 			},
 			voteBitsCounts: []voteCount{{
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion - 1,
 					Bits:    0x01,
 				},
 				count: svh,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion - 1,
 					Bits:    0x05,
 				},
 				count: rci - 1,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion - 1,
 					Bits:    0x05,
 				},
@@ -1058,19 +1059,19 @@ func TestVoting(t *testing.T) {
 					time.Duration(int64(svh)+int64(rci+rci/2))).Unix())
 			},
 			voteBitsCounts: []voteCount{{
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: svh,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x05,
 				},
 				count: rci - 1,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x05,
 				},
@@ -1093,37 +1094,37 @@ func TestVoting(t *testing.T) {
 			blockVersion:      powVersion,
 			startStakeVersion: posVersion - 1,
 			voteBitsCounts: []voteCount{{
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion - 1,
 					Bits:    0x01,
 				},
 				count: svh + 19*svi - 1,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: svi - 1,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: 1,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x03,
 				},
 				count: uint32(rci) - 1,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x03,
 				},
 				count: 1,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
@@ -1155,19 +1156,19 @@ func TestVoting(t *testing.T) {
 			blockVersion:      powVersion,
 			startStakeVersion: posVersion,
 			voteBitsCounts: []voteCount{{
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: svh,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: rci - 1,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
@@ -1190,19 +1191,19 @@ func TestVoting(t *testing.T) {
 			blockVersion:      powVersion,
 			startStakeVersion: posVersion,
 			voteBitsCounts: []voteCount{{
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: svh,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: rci - 1,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x21,
 				},
@@ -1225,31 +1226,31 @@ func TestVoting(t *testing.T) {
 			blockVersion:      powVersion,
 			startStakeVersion: posVersion,
 			voteBitsCounts: []voteCount{{
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: svh,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: rci - 1,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x11,
 				},
 				count: rci,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x11,
 				},
 				count: rci,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
@@ -1278,31 +1279,31 @@ func TestVoting(t *testing.T) {
 			blockVersion:      powVersion,
 			startStakeVersion: posVersion,
 			voteBitsCounts: []voteCount{{
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: svh,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: rci - 1,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x31,
 				},
 				count: rci,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x31,
 				},
 				count: rci,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
@@ -1331,31 +1332,31 @@ func TestVoting(t *testing.T) {
 			blockVersion:      powVersion,
 			startStakeVersion: posVersion,
 			voteBitsCounts: []voteCount{{
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: svh,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: rci - 1,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x41,
 				},
 				count: rci,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x41,
 				},
 				count: rci,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
@@ -1384,31 +1385,31 @@ func TestVoting(t *testing.T) {
 			blockVersion:      powVersion,
 			startStakeVersion: posVersion,
 			voteBitsCounts: []voteCount{{
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: svh,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: rci - 1,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x51,
 				},
 				count: rci,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x51,
 				},
 				count: rci,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
@@ -1437,31 +1438,31 @@ func TestVoting(t *testing.T) {
 			blockVersion:      powVersion,
 			startStakeVersion: posVersion,
 			voteBitsCounts: []voteCount{{
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: svh,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: rci - 1,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x61,
 				},
 				count: rci,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x61,
 				},
 				count: rci,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
@@ -1632,7 +1633,7 @@ func TestParallelVoting(t *testing.T) {
 	params := defaultParallelParams()
 
 	type voteCount struct {
-		vote  VoteVersionTuple
+		vote  stake.VoteVersionTuple
 		count uint32
 	}
 
@@ -1650,37 +1651,37 @@ func TestParallelVoting(t *testing.T) {
 			blockVersion:      powVersion,
 			startStakeVersion: posVersion,
 			voteBitsCounts: []voteCount{{
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: uint32(params.StakeValidationHeight),
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: params.RuleChangeActivationInterval - 1,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion - 1,
 					Bits:    vbTestDummy1Yes | vbTestDummy2No,
 				},
 				count: params.RuleChangeActivationInterval,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    vbTestDummy1Yes | vbTestDummy2No,
 				},
 				count: params.RuleChangeActivationInterval,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},
 				count: params.RuleChangeActivationInterval,
 			}, {
-				vote: VoteVersionTuple{
+				vote: stake.VoteVersionTuple{
 					Version: posVersion,
 					Bits:    0x01,
 				},

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -2614,9 +2614,6 @@ func newBlockManager(s *server, indexManager blockchain.IndexManager) (*blockMan
 		return nil, err
 	}
 
-	// FIXME remove before merge
-	tstart := time.Now().UnixNano()
-
 	// Retrieve the current previous block hash and next stake difficulty.
 	curPrevHash := bm.chain.BestPrevHash()
 	nextStakeDiff, err := bm.chain.CalcNextRequiredStakeDifficulty()
@@ -2624,10 +2621,6 @@ func newBlockManager(s *server, indexManager blockchain.IndexManager) (*blockMan
 		return nil, err
 	}
 	bmgrLog.Infof("Next required Stake difficulty: %d", nextStakeDiff)
-
-	// FIXME remove before merge
-	tend := time.Now().UnixNano()
-	fmt.Printf("xxxxxxxxxxxxxxxxx Stake difficulty time %f\n", float64((tend-tstart)/1000000))
 
 	bm.updateChainState(best.Hash,
 		best.Height,

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -2614,12 +2614,20 @@ func newBlockManager(s *server, indexManager blockchain.IndexManager) (*blockMan
 		return nil, err
 	}
 
+	// FIXME remove before merge
+	tstart := time.Now().UnixNano()
+
 	// Retrieve the current previous block hash and next stake difficulty.
 	curPrevHash := bm.chain.BestPrevHash()
 	nextStakeDiff, err := bm.chain.CalcNextRequiredStakeDifficulty()
 	if err != nil {
 		return nil, err
 	}
+	bmgrLog.Infof("Next required Stake difficulty: %d", nextStakeDiff)
+
+	// FIXME remove before merge
+	tend := time.Now().UnixNano()
+	fmt.Printf("xxxxxxxxxxxxxxxxx Stake difficulty time %f\n", float64((tend-tstart)/1000000))
 
 	bm.updateChainState(best.Hash,
 		best.Height,


### PR DESCRIPTION
First try at improving #913.

This adds a new function `FindSpentTicketsInBlock` that extracts all spent and revoked tickets, plus the vote bits of a given block and uses that function instead of the individual functions when loading a new node into the blockchain.

This improves startup time a bit, as the `isSSGen`, `isSSRtx`, and `determineTxType` are somewhat slow, as they need to decode the output script of the transactions. Looping over the transactions once and doing a single test is faster.

The first commit adds a couple of instrumentation lines (to be removed before final merge).

Numbers for my computer:
```
| variation     | mainnet | testnet |
| with patch    |   23.7s |   42.6s |
| without patch |   35.9s |  118.0s |
```