### PR TITLE
add docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM decred/decred-golang-builder-1.9 as builder
+COPY . /go/src/github.com/decred/dcrd
+WORKDIR /go/src/github.com/decred/dcrd
+RUN dep ensure
+ENV CGO_ENABLED=0
+RUN mkdir -p /tmp/output
+RUN go build -ldflags "-s -w" -a -tags netgo -o /tmp/output/dcrd .
+WORKDIR /go/src/github.com/decred/dcrd/cmd
+RUN for cmd in `echo *`; do go build -ldflags "-s -w" -a -tags netgo -o /tmp/output/$cmd ./$cmd; done
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+COPY --from=builder /tmp/output/* /usr/local/bin/
+VOLUME /var/lib/dcrd
+VOLUME /etc/dcrd
+EXPOSE 9108
+EXPOSE 9109
+ENTRYPOINT [ "/usr/local/bin/dcrd", "--datadir=/var/lib/dcrd", "--nofilelogging", "--configfile=/etc/dcrd/config", "--rpccert=/etc/dcrd/rpc.cert", "--rpckey=rpc.key" ]

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ our docs page at [docs.decred.org](https://docs.decred.org/getting-started/begin
 
 ## Docker
 
+### Build and tests
+
 All tests and linters may be run in a docker container using the script `run_tests.sh`.  This script defaults to using the current supported version of go.  You can run it with the major version of go you would like to use as the only arguement to test a previous on a previous version of go (generally decred supports the current version of go and the previous one).
 
 ```
@@ -95,6 +97,23 @@ To run the tests locally without docker:
 ```
 ./run_tests.sh local
 ```
+
+### Run
+
+You can also run `dcrd` with docker:
+
+Volumes:
+
+- `/etc/dcrd` hold `config`, `rpc.cert ` and `rpc.key` if you want to set any of these.
+- `/var/lib/dcrd` where is stored the blockchain
+
+Ports:
+
+- `9108` Network connections
+- `9109` RPC
+
+Any command passed to the container are `dcrd` arguments, like `--help`.
+
 
 ## Contact
 


### PR DESCRIPTION
docker is used to build and test, not to run. here is an image you can publish

note that it use multi stage docker, it need at least docker 17.05 to build (but not execute)