### PR TITLE
multi: Handle detected data race conditions 

### DIFF
--- a/addrmgr/addrmanager.go
+++ b/addrmgr/addrmanager.go
@@ -183,7 +183,9 @@ func (a *AddrManager) updateAddress(netAddr, srcAddr *wire.NetAddress) {
 			naCopy := *ka.na
 			naCopy.Timestamp = netAddr.Timestamp
 			naCopy.AddService(netAddr.Services)
+			ka.mtx.Lock()
 			ka.na = &naCopy
+			ka.mtx.Unlock()
 		}
 
 		// If already in tried, we have nothing to do here.
@@ -823,9 +825,12 @@ func (a *AddrManager) Attempt(addr *wire.NetAddress) {
 	if ka == nil {
 		return
 	}
+
 	// set last tried time to now
+	ka.mtx.Lock()
 	ka.attempts++
 	ka.lastattempt = time.Now()
+	ka.mtx.Unlock()
 }
 
 // Connected Marks the given address as currently connected and working at the

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1861,12 +1861,12 @@ func (p *Peer) AssociateConnection(conn net.Conn) {
 		p.na = na
 	}
 
-	go func() {
-		if err := p.start(); err != nil {
-			log.Debugf("Cannot start peer %v: %v", p, err)
-			p.Disconnect()
+	go func(peer *Peer) {
+		if err := peer.start(); err != nil {
+			log.Debugf("Cannot start peer %v: %v", peer, err)
+			peer.Disconnect()
 		}
-	}()
+	}(p)
 }
 
 // Connected returns whether or not the peer is currently connected.


### PR DESCRIPTION
Following are 3 instances of data race as per report from race detector:
```
================================================================
             				1
================================================================
WARNING: DATA RACE
Write at 0x00c4299e4eb8 by goroutine 70:
  github.com/decred/dcrd/addrmgr.(*AddrManager).Attempt()
      /Users/maicalal/go/src/github.com/decred/dcrd/addrmgr/addrmanager.go:828 +0x112
  main.(*server).outboundPeerConnected()
      /Users/maicalal/go/src/github.com/decred/dcrd/server.go:1678 +0x656
  main.(*server).(main.outboundPeerConnected)-fm()
      /Users/maicalal/go/src/github.com/decred/dcrd/server.go:2535 +0x5f

Previous read at 0x00c4299e4eb8 by goroutine 49:
  main.newServer.func6()
      /Users/maicalal/go/src/github.com/decred/dcrd/addrmgr/knownaddress.go:34 +0x473
  github.com/decred/dcrd/connmgr.(*ConnManager).NewConnReq()
      /Users/maicalal/go/src/github.com/decred/dcrd/connmgr/connmanager.go:289 +0x123

Goroutine 70 (running) created at:
  github.com/decred/dcrd/connmgr.(*ConnManager).connHandler()
      /Users/maicalal/go/src/github.com/decred/dcrd/connmgr/connmanager.go:237 +0x541

Goroutine 49 (finished) created at:
  github.com/decred/dcrd/connmgr.(*ConnManager).Start()
      /Users/maicalal/go/src/github.com/decred/dcrd/connmgr/connmanager.go:378 +0x17c
================================================================
             				2
================================================================
WARNING: DATA RACE
Write at 0x00c4266441e0 by goroutine 87:
  github.com/decred/dcrd/addrmgr.(*AddrManager).updateAddress()
      /Users/maicalal/go/src/github.com/decred/dcrd/addrmgr/addrmanager.go:186 +0x2c4
  github.com/decred/dcrd/addrmgr.(*AddrManager).AddAddresses()
      /Users/maicalal/go/src/github.com/decred/dcrd/addrmgr/addrmanager.go:579 +0xa8
  main.(*serverPeer).OnAddr()
      /Users/maicalal/go/src/github.com/decred/dcrd/server.go:1017 +0x3e9
  main.(*serverPeer).OnAddr-fm()
      /Users/maicalal/go/src/github.com/decred/dcrd/server.go:1633 +0x55
  github.com/decred/dcrd/peer.(*Peer).inHandler()
      /Users/maicalal/go/src/github.com/decred/dcrd/peer/peer.go:1437 +0x1c55

Previous read at 0x00c4266441e0 by goroutine 45:
  main.newServer.func6()
      /Users/maicalal/go/src/github.com/decred/dcrd/addrmgr/knownaddress.go:29 +0x1f3
  github.com/decred/dcrd/connmgr.(*ConnManager).NewConnReq()
      /Users/maicalal/go/src/github.com/decred/dcrd/connmgr/connmanager.go:289 +0x123

Goroutine 87 (running) created at:
  github.com/decred/dcrd/peer.(*Peer).start()
      /Users/maicalal/go/src/github.com/decred/dcrd/peer/peer.go:1922 +0x39f
  github.com/decred/dcrd/peer.(*Peer).AssociateConnection.func1()
      /Users/maicalal/go/src/github.com/decred/dcrd/peer/peer.go:1865 +0x3c

Goroutine 45 (running) created at:
  github.com/decred/dcrd/connmgr.(*ConnManager).Start()
      /Users/maicalal/go/src/github.com/decred/dcrd/connmgr/connmanager.go:378 +0x17c
================================================================
             				3
================================================================
WARNING: DATA RACE
Write at 0x00c426827688 by goroutine 90:
  github.com/decred/dcrd/addrmgr.(*AddrManager).updateAddress()
      /Users/maicalal/go/src/github.com/decred/dcrd/addrmgr/addrmanager.go:186 +0x2da
  github.com/decred/dcrd/addrmgr.(*AddrManager).AddAddresses()
      /Users/maicalal/go/src/github.com/decred/dcrd/addrmgr/addrmanager.go:579 +0xa8
  main.(*serverPeer).OnAddr()
      /Users/maicalal/go/src/github.com/decred/dcrd/server.go:1017 +0x3e9
  main.(*serverPeer).OnAddr-fm()
      /Users/maicalal/go/src/github.com/decred/dcrd/server.go:1633 +0x55
  github.com/decred/dcrd/peer.(*Peer).inHandler()
      /Users/maicalal/go/src/github.com/decred/dcrd/peer/peer.go:1437 +0x1c55

Previous read at 0x00c426827688 by goroutine 57:
  github.com/decred/dcrd/addrmgr.(*KnownAddress).NetAddress()
      /Users/maicalal/go/src/github.com/decred/dcrd/addrmgr/knownaddress.go:33 +0x7f
  main.newServer.func6()
      /Users/maicalal/go/src/github.com/decred/dcrd/server.go:2516 +0x334
  github.com/decred/dcrd/connmgr.(*ConnManager).NewConnReq()
      /Users/maicalal/go/src/github.com/decred/dcrd/connmgr/connmanager.go:289 +0x123

Goroutine 90 (running) created at:
  github.com/decred/dcrd/peer.(*Peer).start()
      /Users/maicalal/go/src/github.com/decred/dcrd/peer/peer.go:1922 +0x39f
  github.com/decred/dcrd/peer.(*Peer).AssociateConnection.func1()
      /Users/maicalal/go/src/github.com/decred/dcrd/peer/peer.go:1865 +0x3c

Goroutine 57 (running) created at:
  github.com/decred/dcrd/connmgr.(*ConnManager).handleFailedConn()
      /Users/maicalal/go/src/github.com/decred/dcrd/connmgr/connmanager.go:208 +0x6d5
  github.com/decred/dcrd/connmgr.(*ConnManager).connHandler()
      /Users/maicalal/go/src/github.com/decred/dcrd/connmgr/connmanager.go:264 +0xb15
==========================================================
```

All instances are related to accessing KnownAddress elements, except for peer.go where its related to closure.
As part of fix have made following changes:

1. knownaddress.go -> Added  KnownAddress.mtx (sync.Mutex) and used same to sync access points
2. addrmanager.go -> Used KnownAddress.mtx to sync access
3. peer.go -> passed local copy to the closure

This Fixes #646 
