### PR TITLE
bloom: Fix link in README.

### DIFF
--- a/bloom/README.md
+++ b/bloom/README.md
@@ -15,7 +15,7 @@ $ go get -u github.com/decred/dcrd/bloom
 
 ## Examples
 
-* [NewFilter Example](http://godoc.org/github.com/decred/dcrd/bloom/bloom#example-NewFilter)
+* [NewFilter Example](https://godoc.org/github.com/decred/dcrd/bloom#example-package--NewFilter)
   Demonstrates how to create a new bloom filter, add a transaction hash to it,
   and check if the filter matches the transaction.
 


### PR DESCRIPTION
The link in the dcrd/bloom/README.md page led to a 'Not Found' page on
GoDoc. The link has now been changed. Fixes issue #921.