### PR TITLE
rpcserver: skip generating certs when nolisten set

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -6355,7 +6355,7 @@ func newRPCServer(listenAddrs []string, policy *mining.Policy, s *server) (*rpcS
 
 	// Setup TLS if not disabled.
 	listenFunc := net.Listen
-	if !cfg.DisableTLS {
+	if !cfg.DisableListen && !cfg.DisableTLS {
 		// Generate the TLS cert and key file if both don't already
 		// exist.
 		if !fileExists(cfg.RPCKey) && !fileExists(cfg.RPCCert) {


### PR DESCRIPTION
Closes #931.