### PR TITLE
rpc: Add localaddr and relaytxes to getpeerinfo

### DIFF
--- a/dcrjson/chainsvrresults.go
+++ b/dcrjson/chainsvrresults.go
@@ -197,6 +197,7 @@ type GetPeerInfoResult struct {
 	Addr           string  `json:"addr"`
 	AddrLocal      string  `json:"addrlocal,omitempty"`
 	Services       string  `json:"services"`
+	RelayTxes      bool    `json:"relaytxes"`
 	LastSend       int64   `json:"lastsend"`
 	LastRecv       int64   `json:"lastrecv"`
 	BytesSent      uint64  `json:"bytessent"`

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -687,6 +687,17 @@ func (p *Peer) LastRecv() time.Time {
 	return time.Unix(atomic.LoadInt64(&p.lastRecv), 0)
 }
 
+// LocalAddr returns the local address of the connection.
+//
+// This function is safe fo concurrent access.
+func (p *Peer) LocalAddr() net.Addr {
+	var localAddr net.Addr
+	if p.Connected() {
+		localAddr = p.conn.LocalAddr()
+	}
+	return localAddr
+}
+
 // BytesSent returns the total number of bytes sent by the peer.
 //
 // This function is safe for concurrent access.

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3463,7 +3463,9 @@ func handleGetPeerInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{})
 		info := &dcrjson.GetPeerInfoResult{
 			ID:             statsSnap.ID,
 			Addr:           statsSnap.Addr,
+			AddrLocal:      p.LocalAddr().String(),
 			Services:       fmt.Sprintf("%08d", uint64(statsSnap.Services)),
+			RelayTxes:      !p.disableRelayTx,
 			LastSend:       statsSnap.LastSend.Unix(),
 			LastRecv:       statsSnap.LastRecv.Unix(),
 			BytesSent:      statsSnap.BytesSent,

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -569,6 +569,7 @@ var helpDescsEnUS = map[string]string{
 	"getpeerinforesult-addr":           "The ip address and port of the peer",
 	"getpeerinforesult-addrlocal":      "Local address",
 	"getpeerinforesult-services":       "Services bitmask which represents the services supported by the peer",
+	"getpeerinforesult-relaytxes":      "Peer has requested transactions be relayed to it",
 	"getpeerinforesult-lastsend":       "Time the last message was received in seconds since 1 Jan 1970 GMT",
 	"getpeerinforesult-lastrecv":       "Time the last message was sent in seconds since 1 Jan 1970 GMT",
 	"getpeerinforesult-bytessent":      "Total bytes sent",


### PR DESCRIPTION
This PR contains the following upstream commits:

- [3b5bb9f](https://github.com/btcsuite/btcd/commit/3b5bb9fd43eaab2dc902c47b4900b8161b77330a)
   - NOOP, no concept of a`preciousblock` in decred.
- [07e1e30](https://github.com/btcsuite/btcd/commit/07e1e308f1469b56ad3b8d7d3dc02466673e0deb)