### PR TITLE
sec256k1: update func signatures.

### DIFF
--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -1233,7 +1233,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	// ---------------------------------------------------------------------
 
 	// Create a private/public key pair for signing transactions.
-	privKey, err := secp256k1.GeneratePrivateKey(secp256k1.S256())
+	privKey, err := secp256k1.GeneratePrivateKey()
 	if err != nil {
 		panic(err)
 	}

--- a/chaincfg/chainec/secp256k1.go
+++ b/chaincfg/chainec/secp256k1.go
@@ -192,14 +192,14 @@ func newSecp256k1DSA() DSA {
 			if d == nil {
 				return nil
 			}
-			pk := secp256k1.NewPrivateKey(secp256k1Curve, d)
+			pk := secp256k1.NewPrivateKey(d)
 			if pk != nil {
 				return PrivateKey(pk)
 			}
 			return nil
 		},
 		privKeyFromBytes: func(pk []byte) (PrivateKey, PublicKey) {
-			priv, pub := secp256k1.PrivKeyFromBytes(secp256k1Curve, pk)
+			priv, pub := secp256k1.PrivKeyFromBytes(pk)
 			if priv == nil {
 				return nil, nil
 			}
@@ -211,7 +211,7 @@ func newSecp256k1DSA() DSA {
 			return tpriv, tpub
 		},
 		privKeyFromScalar: func(pk []byte) (PrivateKey, PublicKey) {
-			priv, pub := secp256k1.PrivKeyFromScalar(secp256k1Curve, pk)
+			priv, pub := secp256k1.PrivKeyFromScalar(pk)
 			if priv == nil {
 				return nil, nil
 			}
@@ -228,12 +228,12 @@ func newSecp256k1DSA() DSA {
 
 		// Public keys
 		newPublicKey: func(x *big.Int, y *big.Int) PublicKey {
-			pk := secp256k1.NewPublicKey(secp256k1Curve, x, y)
+			pk := secp256k1.NewPublicKey(x, y)
 			tpk := PublicKey(pk)
 			return tpk
 		},
 		parsePubKey: func(pubKeyStr []byte) (PublicKey, error) {
-			pk, err := secp256k1.ParsePubKey(pubKeyStr, secp256k1Curve)
+			pk, err := secp256k1.ParsePubKey(pubKeyStr)
 			if err != nil {
 				return nil, err
 			}
@@ -276,7 +276,7 @@ func newSecp256k1DSA() DSA {
 			return ts, err
 		},
 		recoverCompact: func(signature, hash []byte) (PublicKey, bool, error) {
-			pk, bl, err := secp256k1.RecoverCompact(secp256k1Curve, signature,
+			pk, bl, err := secp256k1.RecoverCompact(signature,
 				hash)
 			tpk := PublicKey(pk)
 			return tpk, bl, err
@@ -284,7 +284,7 @@ func newSecp256k1DSA() DSA {
 
 		// ECDSA
 		generateKey: func(rand io.Reader) ([]byte, *big.Int, *big.Int, error) {
-			return secp256k1.GenerateKey(secp256k1Curve, rand)
+			return secp256k1.GenerateKey(rand)
 		},
 		sign: func(priv PrivateKey, hash []byte) (r, s *big.Int, err error) {
 			if priv.GetType() != ECTypeSecp256k1 {
@@ -302,28 +302,28 @@ func newSecp256k1DSA() DSA {
 			return
 		},
 		verify: func(pub PublicKey, hash []byte, r, s *big.Int) bool {
-			spub := secp256k1.NewPublicKey(secp256k1Curve, pub.GetX(), pub.GetY())
+			spub := secp256k1.NewPublicKey(pub.GetX(), pub.GetY())
 			ssig := secp256k1.NewSignature(r, s)
 			return ssig.Verify(hash, spub)
 		},
 
 		// Symmetric cipher encryption
 		generateSharedSecret: func(privkey []byte, x, y *big.Int) []byte {
-			sprivkey, _ := secp256k1.PrivKeyFromBytes(secp256k1Curve, privkey)
+			sprivkey, _ := secp256k1.PrivKeyFromBytes(privkey)
 			if sprivkey == nil {
 				return nil
 			}
-			spubkey := secp256k1.NewPublicKey(secp256k1Curve, x, y)
+			spubkey := secp256k1.NewPublicKey(x, y)
 
 			return secp256k1.GenerateSharedSecret(sprivkey, spubkey)
 		},
 		encrypt: func(x, y *big.Int, in []byte) ([]byte, error) {
-			spubkey := secp256k1.NewPublicKey(secp256k1Curve, x, y)
+			spubkey := secp256k1.NewPublicKey(x, y)
 
 			return secp256k1.Encrypt(spubkey, in)
 		},
 		decrypt: func(privkey []byte, in []byte) ([]byte, error) {
-			sprivkey, _ := secp256k1.PrivKeyFromBytes(secp256k1Curve, privkey)
+			sprivkey, _ := secp256k1.PrivKeyFromBytes(privkey)
 			if sprivkey == nil {
 				return nil, fmt.Errorf("failure deserializing privkey")
 			}

--- a/chaincfg/chainec/secschnorr.go
+++ b/chaincfg/chainec/secschnorr.go
@@ -185,14 +185,14 @@ func newSecSchnorrDSA() DSA {
 
 		// Private keys
 		newPrivateKey: func(d *big.Int) PrivateKey {
-			pk := secp256k1.NewPrivateKey(secp256k1Curve, d)
+			pk := secp256k1.NewPrivateKey(d)
 			if pk != nil {
 				return PrivateKey(pk)
 			}
 			return nil
 		},
 		privKeyFromBytes: func(pk []byte) (PrivateKey, PublicKey) {
-			priv, pub := secp256k1.PrivKeyFromBytes(secp256k1Curve, pk)
+			priv, pub := secp256k1.PrivKeyFromBytes(pk)
 			if priv == nil {
 				return nil, nil
 			}
@@ -204,7 +204,7 @@ func newSecSchnorrDSA() DSA {
 			return tpriv, tpub
 		},
 		privKeyFromScalar: func(pk []byte) (PrivateKey, PublicKey) {
-			priv, pub := secp256k1.PrivKeyFromScalar(secp256k1Curve, pk)
+			priv, pub := secp256k1.PrivKeyFromScalar(pk)
 			if priv == nil {
 				return nil, nil
 			}
@@ -224,7 +224,7 @@ func newSecSchnorrDSA() DSA {
 		// as they are secp256k1 you still have access to the other
 		// serialization types.
 		newPublicKey: func(x *big.Int, y *big.Int) PublicKey {
-			pk := secp256k1.NewPublicKey(secp256k1Curve, x, y)
+			pk := secp256k1.NewPublicKey(x, y)
 			tpk := PublicKey(pk)
 			return tpk
 		},
@@ -266,7 +266,7 @@ func newSecSchnorrDSA() DSA {
 			return ts, err
 		},
 		recoverCompact: func(signature, hash []byte) (PublicKey, bool, error) {
-			pk, bl, err := schnorr.RecoverPubkey(secp256k1Curve, signature,
+			pk, bl, err := schnorr.RecoverPubkey(signature,
 				hash)
 			tpk := PublicKey(pk)
 			return tpk, bl, err
@@ -274,34 +274,34 @@ func newSecSchnorrDSA() DSA {
 
 		// ECDSA
 		generateKey: func(rand io.Reader) ([]byte, *big.Int, *big.Int, error) {
-			return secp256k1.GenerateKey(secp256k1Curve, rand)
+			return secp256k1.GenerateKey(rand)
 		},
 		sign: func(priv PrivateKey, hash []byte) (r, s *big.Int, err error) {
-			spriv := secp256k1.NewPrivateKey(secp256k1Curve, priv.GetD())
-			return schnorr.Sign(secp256k1Curve, spriv, hash)
+			spriv := secp256k1.NewPrivateKey(priv.GetD())
+			return schnorr.Sign(spriv, hash)
 		},
 		verify: func(pub PublicKey, hash []byte, r, s *big.Int) bool {
-			spub := secp256k1.NewPublicKey(secp256k1Curve, pub.GetX(), pub.GetY())
-			return schnorr.Verify(secp256k1Curve, spub, hash, r, s)
+			spub := secp256k1.NewPublicKey(pub.GetX(), pub.GetY())
+			return schnorr.Verify(spub, hash, r, s)
 		},
 
 		// Symmetric cipher encryption
 		generateSharedSecret: func(privkey []byte, x, y *big.Int) []byte {
-			sprivkey, _ := secp256k1.PrivKeyFromBytes(secp256k1Curve, privkey)
+			sprivkey, _ := secp256k1.PrivKeyFromBytes(privkey)
 			if sprivkey == nil {
 				return nil
 			}
-			spubkey := secp256k1.NewPublicKey(secp256k1Curve, x, y)
+			spubkey := secp256k1.NewPublicKey(x, y)
 
 			return secp256k1.GenerateSharedSecret(sprivkey, spubkey)
 		},
 		encrypt: func(x, y *big.Int, in []byte) ([]byte, error) {
-			spubkey := secp256k1.NewPublicKey(secp256k1Curve, x, y)
+			spubkey := secp256k1.NewPublicKey(x, y)
 
 			return secp256k1.Encrypt(spubkey, in)
 		},
 		decrypt: func(privkey []byte, in []byte) ([]byte, error) {
-			sprivkey, _ := secp256k1.PrivKeyFromBytes(secp256k1Curve, privkey)
+			sprivkey, _ := secp256k1.PrivKeyFromBytes(privkey)
 			if sprivkey == nil {
 				return nil, fmt.Errorf("failure deserializing privkey")
 			}

--- a/dcrec/secp256k1/btcec_test.go
+++ b/dcrec/secp256k1/btcec_test.go
@@ -780,7 +780,7 @@ func TestSplitKRand(t *testing.T) {
 
 // Test this curve's usage with the ecdsa package.
 func testKeyGeneration(t *testing.T, c *KoblitzCurve, tag string) {
-	priv, err := GeneratePrivateKey(c)
+	priv, err := GeneratePrivateKey()
 	if err != nil {
 		t.Errorf("%s: error: %s", tag, err)
 		return
@@ -795,9 +795,9 @@ func TestKeyGeneration(t *testing.T) {
 }
 
 func testSignAndVerify(t *testing.T, c *KoblitzCurve, tag string) {
-	priv, _ := GeneratePrivateKey(c)
+	priv, _ := GeneratePrivateKey()
 	pubx, puby := priv.Public()
-	pub := NewPublicKey(c, pubx, puby)
+	pub := NewPublicKey(pubx, puby)
 
 	hashed := []byte("testing")
 	sig, err := priv.Sign(hashed)

--- a/dcrec/secp256k1/ciphering.go
+++ b/dcrec/secp256k1/ciphering.go
@@ -69,7 +69,7 @@ func GenerateSharedSecret(privkey *PrivateKey, pubkey *PublicKey) []byte {
 // The primary aim is to ensure byte compatibility with Pyelliptic.  Also, refer
 // to section 5.8.1 of ANSI X9.63 for rationale on this format.
 func Encrypt(pubkey *PublicKey, in []byte) ([]byte, error) {
-	ephemeral, err := GeneratePrivateKey(S256())
+	ephemeral, err := GeneratePrivateKey()
 	if err != nil {
 		return nil, err
 	}
@@ -86,8 +86,7 @@ func Encrypt(pubkey *PublicKey, in []byte) ([]byte, error) {
 		return nil, err
 	}
 	// start writing public key
-	kc, _ := ephemeral.PublicKey.Curve.(*KoblitzCurve)
-	pbk := NewPublicKey(kc, ephemeral.PublicKey.X, ephemeral.PublicKey.Y)
+	pbk := NewPublicKey(ephemeral.PublicKey.X, ephemeral.PublicKey.Y)
 	pb := pbk.SerializeUncompressed()
 	offset := aes.BlockSize
 
@@ -158,7 +157,7 @@ func Decrypt(priv *PrivateKey, in []byte) ([]byte, error) {
 	copy(pb[1:33], xBytes)
 	copy(pb[33:], yBytes)
 	// check if (X, Y) lies on the curve and create a Pubkey if it does
-	pubkey, err := ParsePubKey(pb, S256())
+	pubkey, err := ParsePubKey(pb)
 	if err != nil {
 		return nil, err
 	}

--- a/dcrec/secp256k1/ciphering_test.go
+++ b/dcrec/secp256k1/ciphering_test.go
@@ -12,22 +12,21 @@ import (
 )
 
 func TestGenerateSharedSecret(t *testing.T) {
-	c := S256()
-	privKey1, err := GeneratePrivateKey(c)
+	privKey1, err := GeneratePrivateKey()
 	if err != nil {
 		t.Errorf("private key generation error: %s", err)
 		return
 	}
-	privKey2, err := GeneratePrivateKey(c)
+	privKey2, err := GeneratePrivateKey()
 	if err != nil {
 		t.Errorf("private key generation error: %s", err)
 		return
 	}
 
 	pk1x, pk1y := privKey1.Public()
-	pk1 := NewPublicKey(c, pk1x, pk1y)
+	pk1 := NewPublicKey(pk1x, pk1y)
 	pk2x, pk2y := privKey2.Public()
-	pk2 := NewPublicKey(c, pk2x, pk2y)
+	pk2 := NewPublicKey(pk2x, pk2y)
 	secret1 := GenerateSharedSecret(privKey1, pk2)
 	secret2 := GenerateSharedSecret(privKey2, pk1)
 	if !bytes.Equal(secret1, secret2) {
@@ -38,8 +37,7 @@ func TestGenerateSharedSecret(t *testing.T) {
 
 // Test 1: Encryption and decryption
 func TestCipheringBasic(t *testing.T) {
-	c := S256()
-	privkey, err := GeneratePrivateKey(c)
+	privkey, err := GeneratePrivateKey()
 	if err != nil {
 		t.Fatal("failed to generate private key")
 	}
@@ -47,7 +45,7 @@ func TestCipheringBasic(t *testing.T) {
 	in := []byte("Hey there dude. How are you doing? This is a test.")
 
 	pk1x, pk1y := privkey.Public()
-	pk1 := NewPublicKey(c, pk1x, pk1y)
+	pk1 := NewPublicKey(pk1x, pk1y)
 	out, err := Encrypt(pk1, in)
 	if err != nil {
 		t.Fatal("failed to encrypt:", err)
@@ -67,7 +65,7 @@ func TestCipheringBasic(t *testing.T) {
 func TestCiphering(t *testing.T) {
 	pb, _ := hex.DecodeString("fe38240982f313ae5afb3e904fb8215fb11af1200592b" +
 		"fca26c96c4738e4bf8f")
-	privkey, _ := PrivKeyFromBytes(S256(), pb)
+	privkey, _ := PrivKeyFromBytes(pb)
 
 	in := []byte("This is just a test.")
 	out, _ := hex.DecodeString("b0d66e5adaa5ed4e2f0ca68e17b8f2fc02ca002009e3" +
@@ -87,7 +85,7 @@ func TestCiphering(t *testing.T) {
 }
 
 func TestCipheringErrors(t *testing.T) {
-	privkey, err := GeneratePrivateKey(S256())
+	privkey, err := GeneratePrivateKey()
 	if err != nil {
 		t.Fatal("failed to generate private key")
 	}

--- a/dcrec/secp256k1/example_test.go
+++ b/dcrec/secp256k1/example_test.go
@@ -23,7 +23,7 @@ func Example_signMessage() {
 		fmt.Println(err)
 		return
 	}
-	privKey, pubKey := secp256k1.PrivKeyFromBytes(secp256k1.S256(), pkBytes)
+	privKey, pubKey := secp256k1.PrivKeyFromBytes(pkBytes)
 
 	// Sign a message using the private key.
 	message := "test message"
@@ -57,7 +57,7 @@ func Example_verifySignature() {
 		fmt.Println(err)
 		return
 	}
-	pubKey, err := secp256k1.ParsePubKey(pubKeyBytes, secp256k1.S256())
+	pubKey, err := secp256k1.ParsePubKey(pubKeyBytes)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -99,7 +99,7 @@ func Example_encryptMessage() {
 		fmt.Println(err)
 		return
 	}
-	pubKey, err := secp256k1.ParsePubKey(pubKeyBytes, secp256k1.S256())
+	pubKey, err := secp256k1.ParsePubKey(pubKeyBytes)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -121,7 +121,7 @@ func Example_encryptMessage() {
 		return
 	}
 	// note that we already have corresponding pubKey
-	privKey, _ := secp256k1.PrivKeyFromBytes(secp256k1.S256(), pkBytes)
+	privKey, _ := secp256k1.PrivKeyFromBytes(pkBytes)
 
 	// Try decrypting and verify if it's the same message.
 	plaintext, err := secp256k1.Decrypt(privKey, ciphertext)
@@ -147,7 +147,7 @@ func Example_decryptMessage() {
 		return
 	}
 
-	privKey, _ := secp256k1.PrivKeyFromBytes(secp256k1.S256(), pkBytes)
+	privKey, _ := secp256k1.PrivKeyFromBytes(pkBytes)
 
 	ciphertext, err := hex.DecodeString("35f644fbfb208bc71e57684c3c8b437402ca" +
 		"002047a2f1b38aa1a8f1d5121778378414f708fe13ebf7b4a7bb74407288c1958969" +

--- a/dcrec/secp256k1/privkey.go
+++ b/dcrec/secp256k1/privkey.go
@@ -19,22 +19,23 @@ type PrivateKey ecdsa.PrivateKey
 
 // NewPrivateKey instantiates a new private key from a scalar encoded as a
 // big integer.
-func NewPrivateKey(curve *KoblitzCurve, d *big.Int) *PrivateKey {
+func NewPrivateKey(d *big.Int) *PrivateKey {
 	b := make([]byte, 0, PrivKeyBytesLen)
 	dB := paddedAppend(PrivKeyBytesLen, b, d.Bytes())
-	priv, _ := PrivKeyFromBytes(curve, dB)
+	priv, _ := PrivKeyFromBytes(dB)
 	return priv
 }
 
 // PrivKeyFromBytes returns a private and public key for `curve' based on the
 // private key passed as an argument as a byte slice.
-func PrivKeyFromBytes(curve *KoblitzCurve, pk []byte) (*PrivateKey,
+func PrivKeyFromBytes(pk []byte) (*PrivateKey,
 	*PublicKey) {
+	curve := S256()
 	x, y := curve.ScalarBaseMult(pk)
 
 	priv := &ecdsa.PrivateKey{
 		PublicKey: ecdsa.PublicKey{
-			Curve: curve,
+			Curve: S256(),
 			X:     x,
 			Y:     y,
 		},
@@ -45,15 +46,15 @@ func PrivKeyFromBytes(curve *KoblitzCurve, pk []byte) (*PrivateKey,
 }
 
 // PrivKeyFromScalar is the same as PrivKeyFromBytes in secp256k1.
-func PrivKeyFromScalar(curve *KoblitzCurve, s []byte) (*PrivateKey,
+func PrivKeyFromScalar(s []byte) (*PrivateKey,
 	*PublicKey) {
-	return PrivKeyFromBytes(curve, s)
+	return PrivKeyFromBytes(s)
 }
 
 // GeneratePrivateKey is a wrapper for ecdsa.GenerateKey that returns a PrivateKey
 // instead of the normal ecdsa.PrivateKey.
-func GeneratePrivateKey(curve *KoblitzCurve) (*PrivateKey, error) {
-	key, err := ecdsa.GenerateKey(curve, rand.Reader)
+func GeneratePrivateKey() (*PrivateKey, error) {
+	key, err := ecdsa.GenerateKey(S256(), rand.Reader)
 	if err != nil {
 		return nil, err
 	}
@@ -62,9 +63,9 @@ func GeneratePrivateKey(curve *KoblitzCurve) (*PrivateKey, error) {
 
 // GenerateKey generates a key using a random number generator, returning
 // the private scalar and the corresponding public key points.
-func GenerateKey(curve *KoblitzCurve, rand io.Reader) (priv []byte, x,
+func GenerateKey(rand io.Reader) (priv []byte, x,
 	y *big.Int, err error) {
-	key, err := ecdsa.GenerateKey(curve, rand)
+	key, err := ecdsa.GenerateKey(S256(), rand)
 	priv = key.D.Bytes()
 	x = key.PublicKey.X
 	y = key.PublicKey.Y

--- a/dcrec/secp256k1/privkey_test.go
+++ b/dcrec/secp256k1/privkey_test.go
@@ -27,9 +27,9 @@ func TestPrivKeys(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		priv, pub := PrivKeyFromBytes(S256(), test.key)
+		priv, pub := PrivKeyFromBytes(test.key)
 
-		_, err := ParsePubKey(pub.SerializeUncompressed(), S256())
+		_, err := ParsePubKey(pub.SerializeUncompressed())
 		if err != nil {
 			t.Errorf("%s privkey: %v", test.name, err)
 			continue

--- a/dcrec/secp256k1/pubkey.go
+++ b/dcrec/secp256k1/pubkey.go
@@ -25,10 +25,11 @@ func isOdd(a *big.Int) bool {
 
 // decompressPoint decompresses a point on the given curve given the X point and
 // the solution to use.
-func decompressPoint(curve *KoblitzCurve, x *big.Int, ybit bool) (*big.Int, error) {
+func decompressPoint(x *big.Int, ybit bool) (*big.Int, error) {
 	// TODO(oga) This will probably only work for secp256k1 due to
 	// optimizations.
 
+	curve := S256()
 	// Y = +-sqrt(x^3 + B)
 	x3 := new(big.Int).Mul(x, x)
 	x3.Mul(x3, x)
@@ -56,17 +57,17 @@ const (
 )
 
 // NewPublicKey instantiates a new public key with the given X,Y coordinates.
-func NewPublicKey(curve *KoblitzCurve, x *big.Int, y *big.Int) *PublicKey {
-	return &PublicKey{curve, x, y}
+func NewPublicKey(x *big.Int, y *big.Int) *PublicKey {
+	return &PublicKey{S256(), x, y}
 }
 
 // ParsePubKey parses a public key for a koblitz curve from a bytestring into a
 // ecdsa.Publickey, verifying that it is valid. It supports compressed,
 // uncompressed and hybrid signature formats.
-func ParsePubKey(pubKeyStr []byte, curve *KoblitzCurve) (key *PublicKey,
+func ParsePubKey(pubKeyStr []byte) (key *PublicKey,
 	err error) {
 	pubkey := PublicKey{}
-	pubkey.Curve = curve
+	pubkey.Curve = S256()
 
 	if len(pubKeyStr) == 0 {
 		return nil, errors.New("pubkey string is empty")
@@ -98,7 +99,7 @@ func ParsePubKey(pubKeyStr []byte, curve *KoblitzCurve) (key *PublicKey,
 				"pubkey string: %d", pubKeyStr[0])
 		}
 		pubkey.X = new(big.Int).SetBytes(pubKeyStr[1:33])
-		pubkey.Y, err = decompressPoint(curve, pubkey.X, ybit)
+		pubkey.Y, err = decompressPoint(pubkey.X, ybit)
 		if err != nil {
 			return nil, err
 		}

--- a/dcrec/secp256k1/pubkey_test.go
+++ b/dcrec/secp256k1/pubkey_test.go
@@ -217,7 +217,7 @@ var pubKeyTests = []pubKeyTest{
 
 func TestPubKeys(t *testing.T) {
 	for _, test := range pubKeyTests {
-		pk, err := ParsePubKey(test.key, S256())
+		pk, err := ParsePubKey(test.key)
 		if err != nil {
 			if test.isValid {
 				t.Errorf("%s pubkey failed when shouldn't %v",
@@ -255,7 +255,6 @@ func TestPublicKeyIsEqual(t *testing.T) {
 			0x25, 0x21, 0x88, 0x7e, 0x97, 0x66, 0x90, 0xb6, 0xb4,
 			0x7f, 0x5b, 0x2a, 0x4b, 0x7d, 0x44, 0x8e,
 		},
-		S256(),
 	)
 	if err != nil {
 		t.Fatalf("failed to parse raw bytes for pubKey1: %v", err)
@@ -267,7 +266,6 @@ func TestPublicKeyIsEqual(t *testing.T) {
 			0x2e, 0x9c, 0x51, 0x0f, 0x8e, 0xf5, 0x2b, 0xd0, 0x21,
 			0xa9, 0xa1, 0xf4, 0x80, 0x9d, 0x3b, 0x4d,
 		},
-		S256(),
 	)
 	if err != nil {
 		t.Fatalf("failed to parse raw bytes for pubKey2: %v", err)

--- a/dcrec/secp256k1/schnorr/pubkey.go
+++ b/dcrec/secp256k1/schnorr/pubkey.go
@@ -42,5 +42,5 @@ func ParsePubKey(curve *secp256k1.KoblitzCurve,
 		return
 	}
 
-	return secp256k1.ParsePubKey(pubKeyStr, curve)
+	return secp256k1.ParsePubKey(pubKeyStr)
 }

--- a/dcrec/secp256k1/schnorr/threshold.go
+++ b/dcrec/secp256k1/schnorr/threshold.go
@@ -22,9 +22,9 @@ var BlakeVersionStringRFC6979 = []byte("Schnorr+BLAKE256")
 
 // CombinePubkeys combines a slice of public keys into a single public key
 // by adding them together with point addition.
-func CombinePubkeys(curve *secp256k1.KoblitzCurve,
-	pks []*secp256k1.PublicKey) *secp256k1.PublicKey {
+func CombinePubkeys(pks []*secp256k1.PublicKey) *secp256k1.PublicKey {
 	numPubKeys := len(pks)
+	curve := secp256k1.S256()
 
 	// Have to have at least two pubkeys.
 	if numPubKeys < 1 {
@@ -54,7 +54,7 @@ func CombinePubkeys(curve *secp256k1.KoblitzCurve,
 		return nil
 	}
 
-	return secp256k1.NewPublicKey(curve, pkSumX, pkSumY)
+	return secp256k1.NewPublicKey(pkSumX, pkSumY)
 }
 
 // nonceRFC6979 is a local instatiation of deterministic nonce generation
@@ -72,11 +72,12 @@ func nonceRFC6979(privkey []byte, hash []byte, extra []byte,
 // generateNoncePair deterministically generate a nonce pair for use in
 // partial signing of a message. Returns a public key (nonce to dissemanate)
 // and a private nonce to keep as a secret for the signer.
-func generateNoncePair(curve *secp256k1.KoblitzCurve, msg []byte, priv []byte,
+func generateNoncePair(msg []byte, priv []byte,
 	nonceFunction func([]byte, []byte, []byte, []byte) []byte, extra []byte,
 	version []byte) ([]byte, *secp256k1.PublicKey, error) {
 	k := nonceFunction(priv, msg, extra, version)
 	bigK := new(big.Int).SetBytes(k)
+	curve := secp256k1.S256()
 
 	// k scalar sanity checks.
 	if bigK.Cmp(bigZero) == 0 {
@@ -90,7 +91,7 @@ func generateNoncePair(curve *secp256k1.KoblitzCurve, msg []byte, priv []byte,
 	bigK.SetInt64(0)
 
 	pubx, puby := curve.ScalarBaseMult(k)
-	pubnonce := secp256k1.NewPublicKey(curve, pubx, puby)
+	pubnonce := secp256k1.NewPublicKey(pubx, puby)
 
 	return k, pubnonce, nil
 }
@@ -99,14 +100,13 @@ func generateNoncePair(curve *secp256k1.KoblitzCurve, msg []byte, priv []byte,
 func GenerateNoncePair(curve *secp256k1.KoblitzCurve, msg []byte,
 	privkey *secp256k1.PrivateKey, extra []byte,
 	version []byte) (*secp256k1.PrivateKey, *secp256k1.PublicKey, error) {
-	priv, pubNonce, err := generateNoncePair(curve, msg, privkey.Serialize(),
+	priv, pubNonce, err := generateNoncePair(msg, privkey.Serialize(),
 		nonceRFC6979, extra, version)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	privNonce := secp256k1.NewPrivateKey(curve,
-		EncodedBytesToBigInt(copyBytes(priv)))
+	privNonce := secp256k1.NewPrivateKey(EncodedBytesToBigInt(copyBytes(priv)))
 	return privNonce, pubNonce, nil
 }
 
@@ -163,7 +163,7 @@ func schnorrPartialSign(curve *secp256k1.KoblitzCurve, msg []byte, priv []byte,
 		return nil, schnorrError(ErrInputValue, str)
 	}
 
-	return schnorrSign(curve, msg, priv, privNonce, pubSum.GetX(),
+	return schnorrSign(msg, priv, privNonce, pubSum.GetX(),
 		pubSum.GetY(), hashFunc)
 }
 

--- a/dcrec/secp256k1/signature_test.go
+++ b/dcrec/secp256k1/signature_test.go
@@ -438,19 +438,19 @@ func TestSignatureSerialize(t *testing.T) {
 	}
 }
 
-func testSignCompact(t *testing.T, tag string, curve *KoblitzCurve,
+func testSignCompact(t *testing.T, tag string,
 	data []byte, isCompressed bool) {
-	tmp, _ := GeneratePrivateKey(curve)
+	tmp, _ := GeneratePrivateKey()
 	priv := (*PrivateKey)(tmp)
 
 	hashed := []byte("testing")
-	sig, err := SignCompact(curve, priv, hashed, isCompressed)
+	sig, err := SignCompact(priv, hashed, isCompressed)
 	if err != nil {
 		t.Errorf("%s: error signing: %s", tag, err)
 		return
 	}
 
-	pk, wasCompressed, err := RecoverCompact(curve, sig, hashed)
+	pk, wasCompressed, err := RecoverCompact(sig, hashed)
 	if err != nil {
 		t.Errorf("%s: error recovering: %s", tag, err)
 		return
@@ -474,7 +474,7 @@ func testSignCompact(t *testing.T, tag string, curve *KoblitzCurve,
 		sig[0] += 4
 	}
 
-	pk, wasCompressed, err = RecoverCompact(curve, sig, hashed)
+	pk, wasCompressed, err = RecoverCompact(sig, hashed)
 	if err != nil {
 		t.Errorf("%s: error recovering (2): %s", tag, err)
 		return
@@ -502,7 +502,7 @@ func TestSignCompact(t *testing.T) {
 			continue
 		}
 		compressed := i%2 != 0
-		testSignCompact(t, name, S256(), data, compressed)
+		testSignCompact(t, name, data, compressed)
 	}
 }
 
@@ -557,7 +557,7 @@ func TestRFC6979(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		privKey, _ := PrivKeyFromBytes(S256(), decodeHex(test.key))
+		privKey, _ := PrivKeyFromBytes(decodeHex(test.key))
 		hash := sha256.Sum256([]byte(test.msg))
 
 		// Ensure deterministically generated nonce is the expected value.

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -350,7 +350,7 @@ func newPoolHarness(chainParams *chaincfg.Params) (*poolHarness, []spendableOutp
 	if err != nil {
 		return nil, nil, err
 	}
-	signKey, signPub := secp256k1.PrivKeyFromBytes(secp256k1.S256(), keyBytes)
+	signKey, signPub := secp256k1.PrivKeyFromBytes(keyBytes)
 
 	// Generate associated pay-to-script-hash address and resulting payment
 	// script.


### PR DESCRIPTION
This simplifies sec256k1 & schnorr related func signatures by removing the koblitz curve param. The secp256k1 curve is used implicitly instead.

This is work towards #923.