### PR TITLE
txscript: Correct nulldata standardness check.

### DIFF
--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -234,7 +234,8 @@ func isNullData(pops []parsedOpcode) bool {
 
 	return l == 2 &&
 		pops[0].opcode.value == OP_RETURN &&
-		pops[1].opcode.value <= OP_PUSHDATA4 &&
+		(isSmallInt(pops[1].opcode) || pops[1].opcode.value <=
+			OP_PUSHDATA4) &&
 		len(pops[1].data) <= MaxDataCarrierSize
 }
 


### PR DESCRIPTION
This PR contains the following upstream commits:

- [b60e354](https://github.com/btcsuite/btcd/commit/b60e3547d2602b23fedf191d44377f3084f65a9a)

---

This corrects the `isNullData` standard transaction type test to work properly with canonically-encoded data pushes.  In particular, single byte data pushes that are small integers (0-16) are converted to the
equivalent numeric opcodes when canonically encoded and the code failed to detect them properly.

It also adds several tests to ensure that both canonical and non-canonical nulldata scripts are recognized properly and modifies the test failure print to include the script that failed.

This does not affect consensus since it is just a standardness check.
