### PR TITLE
rpctest: Choose flags based on provided params.

### DIFF
--- a/rpctest/node.go
+++ b/rpctest/node.go
@@ -14,12 +14,10 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/decred/dcrd/certgen"
 	rpc "github.com/decred/dcrd/rpcclient"
-	"github.com/decred/dcrd/wire"
 )
 
 // nodeConfig contains all the args, and data required to launch a dcrd process
@@ -83,8 +81,6 @@ func (n *nodeConfig) setDefaults() error {
 // process.
 func (n *nodeConfig) arguments() []string {
 	args := []string{}
-	// --simnet
-	args = append(args, fmt.Sprintf("--%s", strings.ToLower(wire.SimNet.String())))
 	if n.rpcUser != "" {
 		// --rpcuser
 		args = append(args, fmt.Sprintf("--rpcuser=%s", n.rpcUser))

--- a/rpctest/rpc_harness.go
+++ b/rpctest/rpc_harness.go
@@ -104,6 +104,20 @@ func New(activeNet *chaincfg.Params, handlers *rpcclient.NotificationHandlers, e
 	harnessStateMtx.Lock()
 	defer harnessStateMtx.Unlock()
 
+	// Add a flag for the appropriate network type based on the provided
+	// chain params.
+	switch activeNet.Net {
+	case wire.MainNet:
+		// No extra flags since mainnet is the default
+	case wire.TestNet2:
+		extraArgs = append(extraArgs, "--testnet")
+	case wire.SimNet:
+		extraArgs = append(extraArgs, "--simnet")
+	default:
+		return nil, fmt.Errorf("rpctest.New must be called with one " +
+			"of the supported chain networks")
+	}
+
 	harnessID := strconv.Itoa(numTestInstances)
 	nodeTestData, err := ioutil.TempDir("", "rpctest-"+harnessID)
 	if err != nil {


### PR DESCRIPTION
This pr contains the following upstream commits:

- [59a3fc2](https://github.com/btcsuite/btcd/commit/59a3fc2f661a332d386e68f5f8ef3bf1d6d5a02a)
   - NOOP
- [49cbaf2](https://github.com/btcsuite/btcd/commit/49cbaf23dd94d2eb6a44eac3cc24e98f9a582aa5)
   - does not apply to dcrd
- [da04285](https://github.com/btcsuite/btcd/commit/da04285e0d65bd85078908bfd8d1d4c81c11435e)

---
This modifies the rpctest framework to start btcd with the appropriate
network flags depending on the provided parameters.

Previously, it always started btcd with --simnet even if other
parameters, such as those for the regression test network, were
provided.