### PR TITLE
rpcclient: json unmarshal into unexported embedded pointer

### DIFF
--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -314,6 +314,8 @@ func (c *Client) handleMessage(msg []byte) {
 	// Attempt to unmarshal the message as either a notification or
 	// response.
 	var in inMessage
+	in.rawResponse = &rawResponse{}
+	in.rawNotification = &rawNotification{}
 	err := json.Unmarshal(msg, &in)
 	if err != nil {
 		log.Warnf("Remote server sent invalid message: %v", err)


### PR DESCRIPTION
[go1.10 fixes a bug](https://go-review.googlesource.com/c/go/+/82135) in encoding/json that allowed it to allocate an unexported field, but `(*rpcclient.Client).handleMessage` relied on this behaviour to unmarshal into `inMessage`.  Address the go1.10 fix by allocating the unexported pointer types (`rawResponse` and `rawNotification`).

There may be other uses of `json.Unmarshal` that rely on the pre-go1.10 behaviour that we should look out for.