### PR TITLE
 txscript: Cleanup and improve NullDataScript tests.

### DIFF
--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -1048,6 +1048,16 @@ func PayToAddrScript(addr dcrutil.Address) ([]byte, error) {
 	return nil, ErrUnsupportedAddress
 }
 
+// NullDataScript creates a provably-prunable script containing OP_RETURN
+// followed by the passed data.
+func NullDataScript(data []byte) ([]byte, error) {
+	if len(data) > MaxDataCarrierSize {
+		return nil, ErrStackLongScript
+	}
+
+	return NewScriptBuilder().AddOp(OP_RETURN).AddData(data).Script()
+}
+
 // MultiSigScript returns a valid script for a multisignature redemption where
 // nrequired of the keys in pubkeys are required to have signed the transaction
 // for success.  An ErrBadNumRequired will be returned if nrequired is larger


### PR DESCRIPTION
This PR contains the following upstream commits:

- [d0a9c03](https://github.com/btcsuite/btcd/commit/d0a9c03844a4a7f4c27e24fdc856333d17ec2f6f)
   - NOOP

- [b77654f](https://github.com/btcsuite/btcd/commit/b77654f8d4dc593d15bcfe5cfc8783606745fb69)

- [0731f2d](https://github.com/btcsuite/btcd/commit/0731f2ddc979708df658492bd947addaa79e114c)
    - Updated scripts used for `just right` and `too big`

---

This modifies the recently-added NullDataScript function in several
ways in an effort to make them more consistent with the tests in the
rest of the code base and improve/correct the logic:

- Use the hexToBytes and mustParseShortForm functions
- Consistently format the test errors
- Replace the valid bool flag with an expected error and test against it
- Ensure the returned script type is the expected type in all cases