### PR TITLE
txscript: Allow external signature hash calc.

### DIFF
--- a/txscript/script.go
+++ b/txscript/script.go
@@ -292,12 +292,6 @@ func removeOpcodeByData(pkscript []parsedOpcode, data []byte) []parsedOpcode {
 
 }
 
-// CalcSignatureHash is an exported version for testing.
-func CalcSignatureHash(script []parsedOpcode, hashType SigHashType,
-	tx *wire.MsgTx, idx int, cachedPrefix *chainhash.Hash) ([]byte, error) {
-	return calcSignatureHash(script, hashType, tx, idx, cachedPrefix)
-}
-
 // calcSignatureHash will, given a script and hash type for the current script
 // engine instance, calculate the signature hash to be used for signing and
 // verification.
@@ -427,6 +421,20 @@ func calcSignatureHash(script []parsedOpcode, hashType SigHashType,
 	wbuf.Write(prefixHash[:])
 	wbuf.Write(witnessHash[:])
 	return chainhash.HashB(wbuf.Bytes()), nil
+}
+
+// CalcSignatureHash computes the signature hash for the specified input of
+// the target transaction observing the desired signature hash type.  The
+// cached prefix parameter allows the caller to optimize the calculation by
+// providing the prefix hash to be reused in the case of SigHashAll without the
+// SigHashAnyOneCanPay flag set.
+func CalcSignatureHash(script []byte, hashType SigHashType, tx *wire.MsgTx, idx int, cachedPrefix *chainhash.Hash) ([]byte, error) {
+	pops, err := parseScript(script)
+	if err != nil {
+		return nil, err
+	}
+
+	return calcSignatureHash(pops, hashType, tx, idx, cachedPrefix)
 }
 
 // asSmallInt returns the passed opcode, which must be true according to

--- a/txscript/script_test.go
+++ b/txscript/script_test.go
@@ -7,7 +7,6 @@ package txscript_test
 
 import (
 	"bytes"
-	"encoding/hex"
 	"reflect"
 	"testing"
 
@@ -524,35 +523,35 @@ func TestCalcSignatureHash(t *testing.T) {
 	}
 	for i := 0; i < 2; i++ {
 		txOut := new(wire.TxOut)
-		txOut.PkScript = []byte{0x01, 0x01, 0x02, 0x03}
+		txOut.PkScript = decodeHex("51")
 		txOut.Value = 0x0000FF00FF00FF00
 		tx.AddTxOut(txOut)
 	}
 
-	want, _ := hex.DecodeString("d09285b6f60c71329323bc2e76c48" +
-		"a462cde4e1032aa8f59c55823f1722c7f4a")
-	pops, _ := txscript.TstParseScript([]byte{0x01, 0x01, 0x02, 0x03})
+	want := decodeHex("4ce2cd042d64e35b36fdbd16aff0d38a5abebff0e5e8f6b6b31" +
+		"fcd4ac6957905")
+	script := decodeHex("51")
 
 	// Test prefix caching.
-	msg1, err := txscript.CalcSignatureHash(pops, txscript.SigHashAll, tx, 0, nil)
+	msg1, err := txscript.CalcSignatureHash(script, txscript.SigHashAll, tx, 0, nil)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err.Error())
 	}
 
 	prefixHash := tx.TxHash()
-	msg2, err := txscript.CalcSignatureHash(pops, txscript.SigHashAll, tx, 0,
+	msg2, err := txscript.CalcSignatureHash(script, txscript.SigHashAll, tx, 0,
 		&prefixHash)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err.Error())
 	}
 
 	if !bytes.Equal(msg1, want) {
-		t.Errorf("for sighash all sig noncached wrong msg %x given, want %x",
+		t.Errorf("for sighash all sig noncached wrong msg -- got %x, want %x",
 			msg1,
 			want)
 	}
 	if !bytes.Equal(msg2, want) {
-		t.Errorf("for sighash all sig cached wrong msg %x given, want %x",
+		t.Errorf("for sighash all sig cached wrong msg -- got %x, want %x",
 			msg1,
 			want)
 	}
@@ -565,7 +564,7 @@ func TestCalcSignatureHash(t *testing.T) {
 
 	// Move the index and make sure that we get a whole new hash, despite
 	// using the same TxOuts.
-	msg3, err := txscript.CalcSignatureHash(pops, txscript.SigHashAll, tx, 1,
+	msg3, err := txscript.CalcSignatureHash(script, txscript.SigHashAll, tx, 1,
 		&prefixHash)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err.Error())


### PR DESCRIPTION
This modifies the exported `CalcSignatureHash` function to accept a script as bytes instead of an array of parsed opcodes which are not available to callers outside of the package.

While here, it also adds a proper comment for the exported function since it is intended for more than testing as the previous comment claimed.

Finally, it updates the tests to use a valid script instead of the previous impossible to achieve constructed series of parsed opcodes.