### PR TITLE
txscript: enforce MaxDataCarrierSize for GenerateProvablyPruneableOut

### DIFF
--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -1000,6 +1000,10 @@ func GenerateSSGenVotes(votebits uint16) ([]byte, error) {
 
 // GenerateProvablyPruneableOut creates an OP_RETURN push of arbitrary data.
 func GenerateProvablyPruneableOut(data []byte) ([]byte, error) {
+	if len(data) > MaxDataCarrierSize {
+		return nil, ErrStackLongScript
+	}
+
 	return NewScriptBuilder().AddOp(OP_RETURN).AddData(data).Script()
 }
 
@@ -1046,16 +1050,6 @@ func PayToAddrScript(addr dcrutil.Address) ([]byte, error) {
 	}
 
 	return nil, ErrUnsupportedAddress
-}
-
-// NullDataScript creates a provably-prunable script containing OP_RETURN
-// followed by the passed data.
-func NullDataScript(data []byte) ([]byte, error) {
-	if len(data) > MaxDataCarrierSize {
-		return nil, ErrStackLongScript
-	}
-
-	return NewScriptBuilder().AddOp(OP_RETURN).AddData(data).Script()
 }
 
 // MultiSigScript returns a valid script for a multisignature redemption where

--- a/txscript/standard_test.go
+++ b/txscript/standard_test.go
@@ -1070,8 +1070,8 @@ func TestStringifyClass(t *testing.T) {
 	}
 }
 
-// TestNullDataScript tests whether NullDataScript returns a valid script.
-func TestNullDataScript(t *testing.T) {
+// TestGenerateProvablyPruneableOut tests whether GenerateProvablyPruneableOut returns a valid script.
+func TestGenerateProvablyPruneableOut(t *testing.T) {
 	tests := []struct {
 		name     string
 		data     []byte
@@ -1147,16 +1147,16 @@ func TestNullDataScript(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		script, err := txscript.NullDataScript(test.data)
+		script, err := txscript.GenerateProvablyPruneableOut(test.data)
 		if err != test.err {
-			t.Errorf("NullDataScript: #%d (%s) unexpected error: "+
+			t.Errorf("GenerateProvablyPruneableOut: #%d (%s) unexpected error: "+
 				"got %v, want %v", i, test.name, err, test.err)
 			continue
 		}
 
 		// Check that the expected result was returned.
 		if !bytes.Equal(script, test.expected) {
-			t.Errorf("NullDataScript: #%d (%s) wrong result\n"+
+			t.Errorf("GenerateProvablyPruneableOut: #%d (%s) wrong result\n"+
 				"got: %x\nwant: %x", i, test.name, script,
 				test.expected)
 			continue


### PR DESCRIPTION
This update removes `NullDataScript` in favour of `GenerateProvablyPruneableOut` as well as enforcing `MaxDataCarrierSize` for it. The null data test func is renamed and repurposed to use GenerateProvablyPruneableOut as well.

resolves #952