### PR TITLE
sampleconfig: Update min relay fee.

### DIFF
--- a/sampleconfig/sampleconfig.go
+++ b/sampleconfig/sampleconfig.go
@@ -232,7 +232,7 @@ const FileContents = `[Application Options]
 ; ------------------------------------------------------------------------------
 
 ; Set the minimum transaction fee to be considered a non-zero fee,
-; minrelaytxfee=0.01
+; minrelaytxfee=0.001
 
 ; Rate-limit free transactions to the value 15 * 1000 bytes per
 ; minute.


### PR DESCRIPTION
This updates the minimum relay fee in the sample config file to match the actual default.  Note that it's commented anyways, so this does not result in any logical change.  However, the file aims to have the defaults commented out by default, so it makes sense to update the value accordingly.
  