### PR TITLE
stake: Override false positive vet error.

### DIFF
--- a/blockchain/stake/internal/tickettreap/common.go
+++ b/blockchain/stake/internal/tickettreap/common.go
@@ -12,7 +12,9 @@ import (
 )
 
 const (
-	// ptrSize is the number of bytes in a native pointer
+	// ptrSize is the number of bytes in a native pointer.
+	//
+	// nolint: vet
 	ptrSize = 4 << (^uintptr(0) >> 63)
 
 	// staticDepth is the size of the static array to use for keeping track

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -40,7 +40,7 @@ testrepo () {
     --enable=vet \
     --enable=gosimple \
     --enable=unconvert \
-    --enable=ineffassign ./... | tee /dev/stderr
+    --enable=ineffassign "$TESTDIRS"
   if [ $? != 0 ]; then
     echo 'gometalinter has some complaints'
     exit 1


### PR DESCRIPTION
This adds a directive to instruct `gometalinter` to ignore a false positive produced by vet.  The code in question intentionally makes use of the property vet is warning about.