### PR TITLE
chaincfg: Introduce new type DNSSeed 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ services:
   - docker
 
 env:
-  - GOVERSION = 1.8
-  - GOVERSION = 1.9
+  - GOVERSION=1.8
+  - GOVERSION=1.9
 
 install: true
 

--- a/blockchain/stake/internal/tickettreap/common.go
+++ b/blockchain/stake/internal/tickettreap/common.go
@@ -12,7 +12,9 @@ import (
 )
 
 const (
-	// ptrSize is the number of bytes in a native pointer
+	// ptrSize is the number of bytes in a native pointer.
+	//
+	// nolint: vet
 	ptrSize = 4 << (^uintptr(0) >> 63)
 
 	// staticDepth is the size of the static array to use for keeping track

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -40,7 +40,7 @@ testrepo () {
     --enable=vet \
     --enable=gosimple \
     --enable=unconvert \
-    --enable=ineffassign ./... | tee /dev/stderr
+    --enable=ineffassign "$TESTDIRS"
   if [ $? != 0 ]; then
     echo 'gometalinter has some complaints'
     exit 1

--- a/sampleconfig/sampleconfig.go
+++ b/sampleconfig/sampleconfig.go
@@ -232,7 +232,7 @@ const FileContents = `[Application Options]
 ; ------------------------------------------------------------------------------
 
 ; Set the minimum transaction fee to be considered a non-zero fee,
-; minrelaytxfee=0.01
+; minrelaytxfee=0.001
 
 ; Rate-limit free transactions to the value 15 * 1000 bytes per
 ; minute.


### PR DESCRIPTION
This PR contains the following upstream commits:

- [bca9877](https://github.com/decred/dcrd/commit/bca9877796e9590adca69818e3049fbcff9a08af)
  - NOOP
- [a09d052](https://github.com/decred/dcrd/commit/a09d052f96f5dc19d014e2ee8243ca87520882b8)
  - NOOP
- [0d508e6](https://github.com/decred/dcrd/commit/0d508e652258c10230c22651de1ce2c395f695d4)
  - NOOP
- [f161d6b](https://github.com/decred/dcrd/commit/f161d6b69e9adb97a04e51c28f26eb614f9f01a2)

---
DNSSeed defines a DNS Seed with a hostname and whether it supports
filtering by service flag bits.
  