### PR TITLE
rpcserver: Do not rebroadcast stake transactions.

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -5008,10 +5008,24 @@ func handleSendRawTransaction(s *rpcServer, cmd interface{}, closeChan <-chan st
 
 	s.server.AnnounceNewTransactions(acceptedTxs)
 
-	// Keep track of all the sendrawtransaction request txns so that they
-	// can be rebroadcast if they don't make their way into a block.
-	iv := wire.NewInvVect(wire.InvTypeTx, tx.Hash())
-	s.server.AddRebroadcastInventory(iv, tx)
+	// Keep track of all the regular sendrawtransaction request txns so that
+	// they can be rebroadcast if they don't make their way into a block.
+	//
+	// Note that votes are only valid for a specific block and are time
+	// sensitive, so they should not be added to the rebroadcast logic.
+	//
+	// TODO: Ideally ticket purchases and revocations could be added to the
+	// rebroadcast logic as well, however, they would need to be removed under
+	// certain circumstances such as when the stake difficulty interval changes
+	// and if a revocation is for a ticket that was missed, but then becomes
+	// live again due to a reorg.  All stake transactions are ignored here since
+	// there is no clean infrastructure in place currently to handle those
+	// removals and perpetually broadcasting transactions which are no longer
+	// valid is not desirable.
+	if txType := stake.DetermineTxType(msgtx); txType == stake.TxTypeRegular {
+		iv := wire.NewInvVect(wire.InvTypeTx, tx.Hash())
+		s.server.AddRebroadcastInventory(iv, tx)
+	}
 
 	return tx.Hash().String(), nil
 }


### PR DESCRIPTION
This modifies the `sendrawtransaction` handler to avoid adding stake transactions to the rebroadcast logic since they should not be perpetually rebroadcast without special handling to remove them under certain circumstances other than showing up in a block.

This is particularly applicable to votes which are only valid for a specific block and are time sensitive, but it also applies to ticket purchases which are only valid for the duration of a stake difficulty interval, and revocations which could be invalidated in a reorg due to the associated missed or expired ticket being resurrected in a reorg.