### PR TITLE
mempool: Optimize orphan map limiting

### DIFF
--- a/blockchain/fullblocktests/params.go
+++ b/blockchain/fullblocktests/params.go
@@ -246,7 +246,7 @@ var simNetParams = &chaincfg.Params{
 	BlockUpgradeNumToCheck:  100,
 
 	// Mempool parameters
-	RelayNonStdTxs: true,
+	AcceptNonStdTxs: true,
 
 	// Address encoding magics
 	NetworkAddressPrefix: "S",

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -360,7 +360,7 @@ type Params struct {
 	BlockUpgradeNumToCheck uint64
 
 	// Mempool parameters
-	RelayNonStdTxs bool
+	AcceptNonStdTxs bool
 
 	// NetworkAddressPrefix is the first letter of the network
 	// for any given address encoded as a string.
@@ -627,7 +627,7 @@ var MainNetParams = Params{
 	BlockUpgradeNumToCheck:  1000,
 
 	// Mempool parameters
-	RelayNonStdTxs: false,
+	AcceptNonStdTxs: false,
 
 	// Address encoding magics
 	NetworkAddressPrefix: "D",
@@ -806,7 +806,7 @@ var TestNet2Params = Params{
 	BlockUpgradeNumToCheck:  100,
 
 	// Mempool parameters
-	RelayNonStdTxs: true,
+	AcceptNonStdTxs: true,
 
 	// Address encoding magics
 	NetworkAddressPrefix: "T",
@@ -1000,7 +1000,7 @@ var SimNetParams = Params{
 	BlockUpgradeNumToCheck:  100,
 
 	// Mempool parameters
-	RelayNonStdTxs: true,
+	AcceptNonStdTxs: true,
 
 	// Address encoding magics
 	NetworkAddressPrefix: "S",

--- a/config.go
+++ b/config.go
@@ -150,7 +150,7 @@ type config struct {
 	NoMiningStateSync    bool          `long:"nominingstatesync" description:"Disable synchronizing the mining state with other nodes"`
 	AllowOldVotes        bool          `long:"allowoldvotes" description:"Enable the addition of very old votes to the mempool"`
 	BlocksOnly           bool          `long:"blocksonly" description:"Do not accept transactions from remote peers."`
-	RelayNonStd          bool          `long:"relaynonstd" description:"Relay non-standard transactions regardless of the default settings for the active network."`
+	AcceptNonStd         bool          `long:"acceptnonstd" description:"Accept non-standard transactions regardless of the default settings for the active network."`
 	RejectNonStd         bool          `long:"rejectnonstd" description:"Reject non-standard transactions regardless of the default settings for the active network."`
 	TxIndex              bool          `long:"txindex" description:"Maintain a full hash-based transaction index which makes all transactions available via the getrawtransaction RPC"`
 	DropTxIndex          bool          `long:"droptxindex" description:"Deletes the hash-based transaction index from the database on start up and then exits."`
@@ -570,25 +570,25 @@ func loadConfig() (*config, []string, error) {
 		return nil, nil, err
 	}
 
-	// Set the default policy for relaying non-standard transactions
+	// Set the default policy for accepting non-standard transactions
 	// according to the default of the active network. The set
 	// configuration value takes precedence over the default value for the
 	// selected network.
-	relayNonStd := activeNetParams.RelayNonStdTxs
+	acceptNonStd := activeNetParams.AcceptNonStdTxs
 	switch {
-	case cfg.RelayNonStd && cfg.RejectNonStd:
-		str := "%s: rejectnonstd and relaynonstd cannot be used " +
+	case cfg.AcceptNonStd && cfg.RejectNonStd:
+		str := "%s: rejectnonstd and acceptnonstd cannot be used " +
 			"together -- choose only one"
 		err := fmt.Errorf(str, funcName)
 		fmt.Fprintln(os.Stderr, err)
 		fmt.Fprintln(os.Stderr, usageMessage)
 		return nil, nil, err
 	case cfg.RejectNonStd:
-		relayNonStd = false
-	case cfg.RelayNonStd:
-		relayNonStd = true
+		acceptNonStd = false
+	case cfg.AcceptNonStd:
+		acceptNonStd = true
 	}
-	cfg.RelayNonStd = relayNonStd
+	cfg.AcceptNonStd = acceptNonStd
 
 	// Append the network type to the data directory so it is "namespaced"
 	// per network.  In addition to the block database, there are other

--- a/doc.go
+++ b/doc.go
@@ -121,7 +121,7 @@ Application Options:
       --sigcachemaxsize=    The maximum number of entries in the signature
                             verification cache.
       --blocksonly          Do not accept transactions from remote peers.
-      --relaynonstd         Relay non-standard transactions regardless of the
+      --acceptnonstd        Accept non-standard transactions regardless of the
                             default settings for the active network.
       --rejectnonstd        Reject non-standard transactions regardless of the
                             default settings for the active network.

--- a/docs/README.md
+++ b/docs/README.md
@@ -218,6 +218,9 @@ information.
     Decred scripts
   * [database](https://github.com/decred/dcrd/tree/master/database) -
     Provides a database interface for the Decred block chain
+  * [mempool](https://github.com/decred/dcrd/tree/master/mempool) -
+    Package mempool provides a policy-enforced pool of unmined Decred
+    transactions.
   * [dcrutil](https://github.com/decred/dcrd/tree/master/dcrutil) - Provides
     Decred-specific convenience functions and types
   * [chainhash](https://github.com/decred/dcrd/tree/master/chaincfg/chainhash) -

--- a/mempool/README.md
+++ b/mempool/README.md
@@ -5,9 +5,71 @@ mempool
 [![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
 [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/decred/dcrd/mempool)
 
-## Overview
+Package mempool provides a policy-enforced pool of unmined Decred transactions.
 
-This package is currently a work in progress.
+A key responsbility of the Decred network is mining user-generated transactions
+into blocks.  In order to facilitate this, the mining process relies on having a
+readily-available source of transactions to include in a block that is being
+solved.
+
+At a high level, this package satisfies that requirement by providing an
+in-memory pool of fully validated transactions that can also optionally be
+further filtered based upon a configurable policy.
+
+One of the policy configuration options controls whether or not "standard"
+transactions are accepted.  In essence, a "standard" transaction is one that
+satisfies a fairly strict set of requirements that are largley intended to help
+provide fair use of the system to all users.  It is important to note that what
+is considered a "standard" transaction changes over time.  For some insight, at
+the time of this writing, an example of _some_ of the criteria that are required
+for a transaction to be considered standard are that it is of the most-recently
+supported version, finalized, does not exceed a specific size, and only consists
+of specific script forms.
+
+Since this package does not deal with other Decred specifics such as network
+communication and transaction relay, it returns a list of transactions that were
+accepted which gives the caller a high level of flexibility in how they want to
+proceed.  Typically, this will involve things such as relaying the transactions
+to other peers on the network and notifying the mining process that new
+transactions are available.
+
+This package has intentionally been designed so it can be used as a standalone
+package for any projects needing the ability create an in-memory pool of Decred
+transactions that are not only valid by consensus rules, but also adhere to a
+configurable policy.
+
+## Feature Overview
+
+The following is a quick overview of the major features.  It is not intended to
+be an exhaustive list.
+
+- Maintain a pool of fully validated transactions
+  - Reject non-fully-spent duplicate transactions
+  - Reject coinbase transactions
+  - Reject double spends (both from the chain and other transactions in pool)
+  - Reject invalid transactions according to the network consensus rules
+  - Full script execution and validation with signature cache support
+  - Individual transaction query support
+- Orphan transaction support (transactions that spend from unknown outputs)
+  - Configurable limits (see transaction acceptance policy)
+  - Automatic addition of orphan transactions that are no longer orphans as new
+    transactions are added to the pool
+  - Individual orphan transaction query support
+- Configurable transaction acceptance policy
+  - Option to accept or reject standard transactions
+  - Option to accept or reject transactions based on priority calculations
+  - Rate limiting of low-fee and free transactions
+  - Non-zero fee threshold
+  - Max signature operations per transaction
+  - Max orphan transaction size
+  - Max number of orphan transactions allowed
+- Additional metadata tracking for each transaction
+  - Timestamp when the transaction was added to the pool
+  - Most recent block height when the transaction was added to the pool
+  - The fee the transaction pays
+  - The starting priority for the transaction
+- Manual control of transaction removal
+  - Recursive removal of all dependent transactions
 
 ## Installation and Updating
 

--- a/mempool/doc.go
+++ b/mempool/doc.go
@@ -3,6 +3,79 @@
 // license that can be found in the LICENSE file.
 
 /*
-Package mempool implements a memory pool to store (unconfirmed) transactions.
+Package mempool provides a policy-enforced pool of unmined Decred transactions.
+
+A key responsbility of the Decred network is mining user-generated transactions
+into blocks.  In order to facilitate this, the mining process relies on having a
+readily-available source of transactions to include in a block that is being
+solved.
+
+At a high level, this package satisfies that requirement by providing an
+in-memory pool of fully validated transactions that can also optionally be
+further filtered based upon a configurable policy.
+
+One of the policy configuration options controls whether or not "standard"
+transactions are accepted.  In essence, a "standard" transaction is one that
+satisfies a fairly strict set of requirements that are largley intended to help
+provide fair use of the system to all users.  It is important to note that what
+is considered a "standard" transaction changes over time.  For some insight, at
+the time of this writing, an example of SOME of the criteria that are required
+for a transaction to be considered standard are that it is of the most-recently
+supported version, finalized, does not exceed a specific size, and only consists
+of specific script forms.
+
+Since this package does not deal with other Decred specifics such as network
+communication and transaction relay, it returns a list of transactions that were
+accepted which gives the caller a high level of flexibility in how they want to
+proceed.  Typically, this will involve things such as relaying the transactions
+to other peers on the network and notifying the mining process that new
+transactions are available.
+
+Feature Overview
+
+The following is a quick overview of the major features.  It is not intended to
+be an exhaustive list.
+
+ - Maintain a pool of fully validated transactions
+   - Reject non-fully-spent duplicate transactions
+   - Reject coinbase transactions
+   - Reject double spends (both from the chain and other transactions in pool)
+   - Reject invalid transactions according to the network consensus rules
+   - Full script execution and validation with signature cache support
+   - Individual transaction query support
+ - Orphan transaction support (transactions that spend from unknown outputs)
+   - Configurable limits (see transaction acceptance policy)
+   - Automatic addition of orphan transactions that are no longer orphans as new
+     transactions are added to the pool
+   - Individual orphan transaction query support
+ - Configurable transaction acceptance policy
+   - Option to accept or reject standard transactions
+   - Option to accept or reject transactions based on priority calculations
+   - Rate limiting of low-fee and free transactions
+   - Non-zero fee threshold
+   - Max signature operations per transaction
+   - Max orphan transaction size
+   - Max number of orphan transactions allowed
+ - Additional metadata tracking for each transaction
+   - Timestamp when the transaction was added to the pool
+   - Most recent block height when the transaction was added to the pool
+   - The fee the transaction pays
+   - The starting priority for the transaction
+ - Manual control of transaction removal
+   - Recursive removal of all dependent transactions
+
+Errors
+
+Errors returned by this package are either the raw errors provided by underlying
+calls or of type mempool.RuleError.  Since there are two classes of rules
+(mempool acceptance rules and blockchain (consensus) acceptance rules), the
+mempool.RuleError type contains a single Err field which will, in turn, either
+be a mempool.TxRuleError or a blockchain.RuleError.  The first indicates a
+violation of mempool acceptance rules while the latter indicates a violation of
+consensus acceptance rules.  This allows the caller to easily differentiate
+between unexpected errors, such as database errors, versus errors due to rule
+violations through type assertions.  In addition, callers can programmatically
+determine the specific rule violation by type asserting the Err field to one of
+the aforementioned types and examining their underlying ErrorCode field.
 */
 package mempool

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -7,10 +7,8 @@ package mempool
 
 import (
 	"container/list"
-	"crypto/rand"
 	"fmt"
 	"math"
-	"math/big"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -147,11 +145,10 @@ type Policy struct {
 	// transactions that do not have enough priority to be relayed.
 	DisableRelayPriority bool
 
-	// RelayNonStd defines whether to relay non-standard transactions. If
-	// true, non-standard transactions will be accepted into the mempool
-	// and relayed. Otherwise, all non-standard transactions will be
-	// rejected.
-	RelayNonStd bool
+	// AcceptNonStd defines whether to accept non-standard transactions. If
+	// true, non-standard transactions will be accepted into the mempool.
+	// Otherwise, all non-standard transactions will be rejected.
+	AcceptNonStd bool
 
 	// FreeTxRelayLimit defines the given amount in thousands of bytes
 	// per minute that transactions with no fee are rate limited to.
@@ -353,35 +350,19 @@ func (mp *TxPool) RemoveOrphan(txHash *chainhash.Hash) {
 //
 // This function MUST be called with the mempool lock held (for writes).
 func (mp *TxPool) limitNumOrphans() error {
-	if len(mp.orphans)+1 > mp.cfg.Policy.MaxOrphanTxs &&
-		mp.cfg.Policy.MaxOrphanTxs > 0 {
+	if len(mp.orphans)+1 <= mp.cfg.Policy.MaxOrphanTxs {
+		return nil
+	}
 
-		// Generate a cryptographically random hash.
-		randHashBytes := make([]byte, chainhash.HashSize)
-		_, err := rand.Read(randHashBytes)
-		if err != nil {
-			return err
-		}
-		randHashNum := new(big.Int).SetBytes(randHashBytes)
-
-		// Try to find the first entry that is greater than the random
-		// hash.  Use the first entry (which is already pseudorandom due
-		// to Go's range statement over maps) as a fallback if none of
-		// the hashes in the orphan pool are larger than the random
-		// hash.
-		var foundHash *chainhash.Hash
-		for txHash := range mp.orphans {
-			if foundHash == nil {
-				foundHash = &txHash
-			}
-			txHashNum := blockchain.HashToBig(&txHash)
-			if txHashNum.Cmp(randHashNum) > 0 {
-				foundHash = &txHash
-				break
-			}
-		}
-
-		mp.removeOrphan(foundHash)
+	// Remove a random entry from the map.  For most compilers, Go's
+	// range statement iterates starting at a random item although
+	// that is not 100% guaranteed by the spec.  The iteration order
+	// is not important here because an adversary would have to be
+	// able to pull off preimage attacks on the hashing function in
+	// order to target eviction of specific entries anyways.
+	for txHash := range mp.orphans {
+		mp.removeOrphan(&txHash)
+		break
 	}
 
 	return nil
@@ -391,6 +372,11 @@ func (mp *TxPool) limitNumOrphans() error {
 //
 // This function MUST be called with the mempool lock held (for writes).
 func (mp *TxPool) addOrphan(tx *dcrutil.Tx) {
+	// Nothing to do if no orphans are allowed.
+	if mp.cfg.Policy.MaxOrphanTxs <= 0 {
+		return
+	}
+
 	// Limit the number orphan transactions to prevent memory exhaustion.  A
 	// random orphan is evicted to make room if needed.
 	mp.limitNumOrphans()
@@ -834,9 +820,9 @@ func (mp *TxPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit, allow
 	}
 
 	// Don't allow non-standard transactions if the network parameters
-	// forbid their relaying.
+	// forbid their acceptance.
 	medianTime := mp.cfg.PastMedianTime()
-	if !mp.cfg.Policy.RelayNonStd {
+	if !mp.cfg.Policy.AcceptNonStd {
 		err := checkTransactionStandard(tx, txType, nextBlockHeight,
 			medianTime, mp.cfg.Policy.MinRelayTxFee,
 			mp.cfg.Policy.MaxTxVersion)
@@ -1025,8 +1011,8 @@ func (mp *TxPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit, allow
 	}
 
 	// Don't allow transactions with non-standard inputs if the network
-	// parameters forbid their relaying.
-	if !mp.cfg.Policy.RelayNonStd {
+	// parameters forbid their acceptance.
+	if !mp.cfg.Policy.AcceptNonStd {
 		err := checkInputsStandard(tx, txType, utxoView)
 		if err != nil {
 			// Attempt to extract a reject code from the error so

--- a/sampleconfig/sampleconfig.go
+++ b/sampleconfig/sampleconfig.go
@@ -247,8 +247,8 @@ const FileContents = `[Application Options]
 ; Do not accept transactions from remote peers.
 ; blocksonly=1
 
-; Relay non-standard transactions regardless of default network settings.
-; relaynonstd=1
+; Accept non-standard transactions regardless of default network settings.
+; acceptnonstd=1
 
 ; Reject non-standard transactions regardless of default network settings.
 ; rejectnonstd=1

--- a/server.go
+++ b/server.go
@@ -2436,7 +2436,7 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 		Policy: mempool.Policy{
 			MaxTxVersion:         2,
 			DisableRelayPriority: cfg.NoRelayPriority,
-			RelayNonStd:          cfg.RelayNonStd,
+			AcceptNonStd:         cfg.AcceptNonStd,
 			FreeTxRelayLimit:     cfg.FreeTxRelayLimit,
 			MaxOrphanTxs:         cfg.MaxOrphanTxs,
 			MaxOrphanTxSize:      defaultMaxOrphanTxSize,


### PR DESCRIPTION
This PR contains the following upstream commits:

- [26e2279](https://github.com/btcsuite/btcd/commit/26e22790cd739386cdd80495ffcf6f43a0a29a50)
  - Extended rename to config field `RelayNonStd` and chaincfg.Param field `RelayNonStdTxs`
- [e90b0c9](https://github.com/btcsuite/btcd/commit/e90b0c967f5aa60610a557055843aaa8f8b1b493)
- [25de9ce](https://github.com/btcsuite/btcd/commit/25de9ce5d9d3c0b766b5b438a843723f6217ac9c)
- [e606259](https://github.com/btcsuite/btcd/commit/e6062595dbafc6576315b7aca2792a65980595fe)
   - NOOP
- [0e71867](https://github.com/btcsuite/btcd/commit/0e71867dfea2749357d3731381efd2c47b47a6a6)
---
This optimizes the way in which the mempool oprhan map is limited in the same way the server block manager maps were previously optimized.

Previously the code would read a cryptographically random value large enough to construct a hash, find the first entry larger than that value, and evict it.

That approach is quite inefficient and could easily become a bottleneck when processing transactions due to the need to read from a source such as /dev/urandom and all of the subsequent hash comparisons.

Luckily, strong cryptographic randomness is not needed here. The primary intent of limiting the maps is to control memory usage with a secondary concern of making it difficult for adversaries to force eviction of specific entries.

Consequently, this changes the code to make use of the pseudorandom iteration order of Go's maps along with the preimage resistance of the hashing function to provide the desired functionality. It has previously been discussed that the specific pseudorandom iteration order is not guaranteed by the Go spec even though in practice that is how it is implemented. This is not a concern however because even if the specific compiler doesn't implement that, the preimage resistance of the hashing function alone is enough.

The following is a before and after comparison of the function for both speed and memory allocations:

```
benchmark                    old ns/op     new ns/op     delta
----------------------------------------------------------------
BenchmarkLimitNumOrphans     3727          243           -93.48%

benchmark                    old allocs    new allocs    delta
-----------------------------------------------------------------
BenchmarkLimitNumOrphans     4             0             -100.00%
```