### PR TITLE
blockchain: Accept header in CheckProofOfWork.

### DIFF
--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -360,8 +360,8 @@ func checkProofOfWork(header *wire.BlockHeader, powLimit *big.Int, flags Behavio
 // CheckProofOfWork ensures the block header bits which indicate the target
 // difficulty is in min/max range and that the block hash is less than the
 // target difficulty as claimed.
-func CheckProofOfWork(block *dcrutil.Block, powLimit *big.Int) error {
-	return checkProofOfWork(&block.MsgBlock().Header, powLimit, BFNone)
+func CheckProofOfWork(header *wire.BlockHeader, powLimit *big.Int) error {
+	return checkProofOfWork(header, powLimit, BFNone)
 }
 
 // checkBlockHeaderSanity performs some preliminary checks on a block header to

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4205,7 +4205,8 @@ func handleGetWorkSubmission(s *rpcServer, hexData string) (interface{}, error) 
 	block := dcrutil.NewBlockDeepCopyCoinbase(msgBlock)
 
 	// Ensure the submitted block hash is less than the target difficulty.
-	err = blockchain.CheckProofOfWork(block, activeNetParams.PowLimit)
+	err = blockchain.CheckProofOfWork(&block.MsgBlock().Header,
+		activeNetParams.PowLimit)
 	if err != nil {
 		// Anything other than a rule violation is an unexpected error,
 		// so return that error as an internal error.


### PR DESCRIPTION
This modifies the `CheckProofOfWork` function to accept a block header instead of an entire block since there is no reason to force the caller to have access to a full block when only the header is required.