### PR TITLE
blockchain/stake: Use Hash256PRNG init vector.

### DIFF
--- a/blockchain/stakenode.go
+++ b/blockchain/stakenode.go
@@ -113,9 +113,8 @@ func (b *BlockChain) fetchStakeNode(node *blockNode) (*stake.Node, error) {
 				}
 			}
 
-			node.stakeNode, err = node.parent.stakeNode.ConnectNode(node.header,
-				node.ticketsSpent,
-				node.ticketsRevoked,
+			node.stakeNode, err = node.parent.stakeNode.ConnectNode(
+				node.lotteryIV, node.ticketsSpent, node.ticketsRevoked,
 				node.newTickets)
 			if err != nil {
 				return nil, err
@@ -145,7 +144,7 @@ func (b *BlockChain) fetchStakeNode(node *blockNode) (*stake.Node, error) {
 			if n.stakeNode == nil {
 				var errLocal error
 				n.stakeNode, errLocal =
-					current.stakeNode.DisconnectNode(n.header,
+					current.stakeNode.DisconnectNode(n.lotteryIV,
 						n.stakeUndoData, n.newTickets, dbTx)
 				if errLocal != nil {
 					return errLocal
@@ -166,7 +165,7 @@ func (b *BlockChain) fetchStakeNode(node *blockNode) (*stake.Node, error) {
 		if current.parent.stakeNode == nil {
 			var errLocal error
 			current.parent.stakeNode, errLocal =
-				current.stakeNode.DisconnectNode(current.parent.header,
+				current.stakeNode.DisconnectNode(current.parent.lotteryIV,
 					current.parent.stakeUndoData, current.parent.newTickets, dbTx)
 			if errLocal != nil {
 				return errLocal
@@ -206,7 +205,7 @@ func (b *BlockChain) fetchStakeNode(node *blockNode) (*stake.Node, error) {
 				}
 			}
 
-			n.stakeNode, err = current.stakeNode.ConnectNode(n.header,
+			n.stakeNode, err = current.stakeNode.ConnectNode(n.lotteryIV,
 				n.ticketsSpent, n.ticketsRevoked, n.newTickets)
 			if err != nil {
 				return nil, err

--- a/blockchain/upgrade.go
+++ b/blockchain/upgrade.go
@@ -58,9 +58,13 @@ func (b *BlockChain) upgradeToVersion2() error {
 
 			// Iteratively connect the stake nodes in memory.
 			header := block.MsgBlock().Header
-			bestStakeNode, errLocal = bestStakeNode.ConnectNode(header,
-				ticketsSpentInBlock(block), ticketsRevokedInBlock(block),
-				newTickets)
+			hB, errLocal := header.Bytes()
+			if errLocal != nil {
+				return errLocal
+			}
+			bestStakeNode, errLocal = bestStakeNode.ConnectNode(
+				stake.CalcHash256PRNGIV(hB), ticketsSpentInBlock(block),
+				ticketsRevokedInBlock(block), newTickets)
 			if errLocal != nil {
 				return errLocal
 			}


### PR DESCRIPTION
**NOTE: This requires PR #986**

This modifies the stake package to accept an initialization vector for the node connection and disconnection code so that the caller can provide a cached value versus the data having to be recomputed.  All tests in the stake package have been updated for the changes.

It also updates the `blockchain` package to calculate the iv for the block header and cache the value with each block node and updates the callers into the modified stake package functions to use the cached values.