### PR TITLE
blockchain: Don't store full header in block node.

### DIFF
--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1285,7 +1285,7 @@ func (b *BlockChain) createChainState() error {
 	numTxns := uint64(len(genesisBlock.MsgBlock().Transactions))
 	blockSize := uint64(genesisBlock.MsgBlock().SerializeSize())
 	b.stateSnapshot = newBestState(b.bestNode, blockSize, numTxns, numTxns,
-		b.bestNode.header.Timestamp, 0)
+		time.Unix(b.bestNode.timestamp, 0), 0)
 
 	// Create the initial the database chain state including creating the
 	// necessary index buckets and inserting the genesis block.
@@ -1445,7 +1445,7 @@ func (b *BlockChain) initChainState() error {
 		// set.
 		if dbInfo.version >= 2 {
 			node.stakeNode, err = stake.LoadBestNode(dbTx, uint32(node.height),
-				node.hash, node.header, b.chainParams)
+				node.hash, *header, b.chainParams)
 			if err != nil {
 				return err
 			}
@@ -1456,9 +1456,9 @@ func (b *BlockChain) initChainState() error {
 		b.bestNode = node
 
 		// Add the new node to the indices for faster lookups.
-		prevHash := node.header.PrevBlock
+		prevHash := &node.parentHash
 		b.index[node.hash] = node
-		b.depNodes[prevHash] = append(b.depNodes[prevHash], node)
+		b.depNodes[*prevHash] = append(b.depNodes[*prevHash], node)
 
 		// Calculate the median time for the block.
 		medianTime, err := b.calcPastMedianTime(node)

--- a/blockchain/difficulty_test.go
+++ b/blockchain/difficulty_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015-2017 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -421,7 +421,7 @@ nextTest:
 
 			for i := uint32(0); i < ticketInfo.numNodes; i++ {
 				// Make up a header.
-				nextHeight := bc.bestNode.header.Height + 1
+				nextHeight := uint32(bc.bestNode.height) + 1
 				header := &wire.BlockHeader{
 					Version:    4,
 					SBits:      ticketInfo.stakeDiff,
@@ -723,7 +723,7 @@ nextTest:
 
 			for i := uint32(0); i < ticketInfo.numNodes; i++ {
 				// Make up a header.
-				nextHeight := bc.bestNode.header.Height + 1
+				nextHeight := uint32(bc.bestNode.height) + 1
 				header := &wire.BlockHeader{
 					Version:    4,
 					SBits:      ticketInfo.stakeDiff,

--- a/blockchain/internal_test.go
+++ b/blockchain/internal_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -15,7 +15,6 @@ package blockchain
 
 import (
 	"sort"
-	"time"
 
 	"github.com/decred/dcrd/blockchain/stake"
 	"github.com/decred/dcrd/wire"
@@ -23,7 +22,7 @@ import (
 
 // TstTimeSorter makes the internal timeSorter type available to the test
 // package.
-func TstTimeSorter(times []time.Time) sort.Interface {
+func TstTimeSorter(times []int64) sort.Interface {
 	return timeSorter(times)
 }
 

--- a/blockchain/sequencelock_test.go
+++ b/blockchain/sequencelock_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The Decred developers
+// Copyright (c) 2017-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -37,7 +37,7 @@ func TestCalcSequenceLock(t *testing.T) {
 	params := &chaincfg.SimNetParams
 	bc := newFakeChain(params)
 	node := bc.bestNode
-	blockTime := node.header.Timestamp
+	blockTime := time.Unix(node.timestamp, 0)
 	for i := uint32(0); i < numBlocks; i++ {
 		blockTime = blockTime.Add(time.Second)
 		node = newFakeNode(node, 1, 1, 0, blockTime)

--- a/blockchain/stakeversion.go
+++ b/blockchain/stakeversion.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 The Decred developers
+// Copyright (c) 2016-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -170,7 +170,7 @@ func (b *BlockChain) isStakeMajorityVersion(minVer uint32, prevNode *blockNode) 
 	versionCount := int32(0)
 	iterNode := node
 	for i := int64(0); i < b.chainParams.StakeVersionInterval && iterNode != nil; i++ {
-		if iterNode.header.StakeVersion >= minVer {
+		if iterNode.stakeVersion >= minVer {
 			versionCount += 1
 		}
 
@@ -219,7 +219,7 @@ func (b *BlockChain) calcPriorStakeVersion(prevNode *blockNode) (uint32, error) 
 	versions := make(map[uint32]int32) // [version][count]
 	iterNode := node
 	for i := int64(0); i < b.chainParams.StakeVersionInterval && iterNode != nil; i++ {
-		versions[iterNode.header.StakeVersion]++
+		versions[iterNode.stakeVersion]++
 
 		var err error
 		iterNode, err = b.getPrevNodeFromNode(iterNode)

--- a/blockchain/stakeversion_test.go
+++ b/blockchain/stakeversion_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 The Decred developers
+// Copyright (c) 2016-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -350,8 +350,8 @@ func TestCalcStakeVersionByNode(t *testing.T) {
 			set: func(node *blockNode) {
 				if int64(node.height) > svh {
 					appendFakeVotes(node, tpb, 3, 0)
-					node.header.StakeVersion = 2
-					node.header.Version = 3
+					node.stakeVersion = 2
+					node.blockVersion = 3
 				}
 			},
 		},
@@ -362,8 +362,8 @@ func TestCalcStakeVersionByNode(t *testing.T) {
 			set: func(node *blockNode) {
 				if int64(node.height) > svh {
 					appendFakeVotes(node, tpb, 2, 0)
-					node.header.StakeVersion = 3
-					node.header.Version = 3
+					node.stakeVersion = 3
+					node.blockVersion = 3
 				}
 			},
 		},
@@ -705,7 +705,7 @@ func TestIsStakeMajorityVersion(t *testing.T) {
 		// Create new BlockChain in order to blow away cache.
 		bc := newFakeChain(params)
 		node := bc.bestNode
-		node.header.StakeVersion = test.startStakeVersion
+		node.stakeVersion = test.startStakeVersion
 
 		ticketCount = 0
 
@@ -778,7 +778,7 @@ func TestLarge(t *testing.T) {
 		// Create new BlockChain in order to blow away cache.
 		bc := newFakeChain(params)
 		node := bc.bestNode
-		node.header.StakeVersion = test.startStakeVersion
+		node.stakeVersion = test.startStakeVersion
 
 		for i := int64(1); i <= test.numNodes; i++ {
 			node = newFakeNode(node, test.blockVersion,

--- a/blockchain/subsidy.go
+++ b/blockchain/subsidy.go
@@ -282,7 +282,7 @@ func BlockOneCoinbasePaysTokens(tx *dcrutil.Tx, params *chaincfg.Params) error {
 
 // CoinbasePaysTax checks to see if a given block's coinbase correctly pays
 // tax to the developer organization.
-func CoinbasePaysTax(subsidyCache *SubsidyCache, tx *dcrutil.Tx, height uint32, voters uint16, params *chaincfg.Params) error {
+func CoinbasePaysTax(subsidyCache *SubsidyCache, tx *dcrutil.Tx, height int64, voters uint16, params *chaincfg.Params) error {
 	// Taxes only apply from block 2 onwards.
 	if height <= 1 {
 		return nil
@@ -311,7 +311,7 @@ func CoinbasePaysTax(subsidyCache *SubsidyCache, tx *dcrutil.Tx, height uint32, 
 
 	// Get the amount of subsidy that should have been paid out to
 	// the organization, then check it.
-	orgSubsidy := CalcBlockTaxSubsidy(subsidyCache, int64(height), voters, params)
+	orgSubsidy := CalcBlockTaxSubsidy(subsidyCache, height, voters, params)
 	if orgSubsidy != taxOutput.Value {
 		errStr := fmt.Sprintf("amount in output 0 has non matching org "+
 			"calculated amount; got %v, want %v", taxOutput.Value,

--- a/blockchain/timesorter.go
+++ b/blockchain/timesorter.go
@@ -1,17 +1,13 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package blockchain
 
-import (
-	"time"
-)
-
 // timeSorter implements sort.Interface to allow a slice of timestamps to
 // be sorted.
-type timeSorter []time.Time
+type timeSorter []int64
 
 // Len returns the number of timestamps in the slice.  It is part of the
 // sort.Interface implementation.
@@ -28,5 +24,5 @@ func (s timeSorter) Swap(i, j int) {
 // Less returns whether the timstamp with index i should sort before the
 // timestamp with index j.  It is part of the sort.Interface implementation.
 func (s timeSorter) Less(i, j int) bool {
-	return s[i].Before(s[j])
+	return s[i] < s[j]
 }

--- a/blockchain/timesorter_test.go
+++ b/blockchain/timesorter_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -9,7 +9,6 @@ import (
 	"reflect"
 	"sort"
 	"testing"
-	"time"
 
 	"github.com/decred/dcrd/blockchain"
 )
@@ -17,31 +16,29 @@ import (
 // TestTimeSorter tests the timeSorter implementation.
 func TestTimeSorter(t *testing.T) {
 	tests := []struct {
-		in   []time.Time
-		want []time.Time
+		in   []int64
+		want []int64
 	}{
 		{
-			in: []time.Time{
-				time.Unix(1351228575, 0), // Fri Oct 26 05:16:15 UTC 2012 (Block #205000)
-				time.Unix(1351228575, 1), // Fri Oct 26 05:16:15 UTC 2012 (+1 nanosecond)
-				time.Unix(1348310759, 0), // Sat Sep 22 10:45:59 UTC 2012 (Block #200000)
-				time.Unix(1305758502, 0), // Wed May 18 22:41:42 UTC 2011 (Block #125000)
-				time.Unix(1347777156, 0), // Sun Sep 16 06:32:36 UTC 2012 (Block #199000)
-				time.Unix(1349492104, 0), // Sat Oct  6 02:55:04 UTC 2012 (Block #202000)
+			in: []int64{
+				1351228575, // Fri Oct 26 05:16:15 UTC 2012 (Block #205000)
+				1348310759, // Sat Sep 22 10:45:59 UTC 2012 (Block #200000)
+				1305758502, // Wed May 18 22:41:42 UTC 2011 (Block #125000)
+				1347777156, // Sun Sep 16 06:32:36 UTC 2012 (Block #199000)
+				1349492104, // Sat Oct  6 02:55:04 UTC 2012 (Block #202000)
 			},
-			want: []time.Time{
-				time.Unix(1305758502, 0), // Wed May 18 22:41:42 UTC 2011 (Block #125000)
-				time.Unix(1347777156, 0), // Sun Sep 16 06:32:36 UTC 2012 (Block #199000)
-				time.Unix(1348310759, 0), // Sat Sep 22 10:45:59 UTC 2012 (Block #200000)
-				time.Unix(1349492104, 0), // Sat Oct  6 02:55:04 UTC 2012 (Block #202000)
-				time.Unix(1351228575, 0), // Fri Oct 26 05:16:15 UTC 2012 (Block #205000)
-				time.Unix(1351228575, 1), // Fri Oct 26 05:16:15 UTC 2012 (+1 nanosecond)
+			want: []int64{
+				1305758502, // Wed May 18 22:41:42 UTC 2011 (Block #125000)
+				1347777156, // Sun Sep 16 06:32:36 UTC 2012 (Block #199000)
+				1348310759, // Sat Sep 22 10:45:59 UTC 2012 (Block #200000)
+				1349492104, // Sat Oct  6 02:55:04 UTC 2012 (Block #202000)
+				1351228575, // Fri Oct 26 05:16:15 UTC 2012 (Block #205000)
 			},
 		},
 	}
 
 	for i, test := range tests {
-		result := make([]time.Time, len(test.in))
+		result := make([]int64, len(test.in))
 		copy(result, test.in)
 		sort.Sort(blockchain.TstTimeSorter(result))
 		if !reflect.DeepEqual(result, test.want) {

--- a/blockchain/utxoviewpoint.go
+++ b/blockchain/utxoviewpoint.go
@@ -1093,7 +1093,7 @@ func (b *BlockChain) FetchUtxoView(tx *dcrutil.Tx, treeValid bool) (*UtxoViewpoi
 		if err != nil {
 			return nil, err
 		}
-		parent, err := b.fetchBlockFromHash(&b.bestNode.header.PrevBlock)
+		parent, err := b.fetchBlockFromHash(&b.bestNode.parentHash)
 		if err != nil {
 			return nil, err
 		}

--- a/blockchain/votebits.go
+++ b/blockchain/votebits.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The decred developers
+// Copyright (c) 2017-2018 The Decred developers
 // Copyright (c) 2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.

--- a/blockchain/votebits_test.go
+++ b/blockchain/votebits_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The Decred developers
+// Copyright (c) 2017-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -161,7 +161,7 @@ func TestNoQuorum(t *testing.T) {
 	params := defaultParams(pedro)
 	bc := newFakeChain(&params)
 	node := bc.bestNode
-	node.header.StakeVersion = posVersion
+	node.stakeVersion = posVersion
 
 	// get to svi
 	curTimestamp := time.Now()
@@ -317,7 +317,7 @@ func TestYesQuorum(t *testing.T) {
 	params := defaultParams(pedro)
 	bc := newFakeChain(&params)
 	node := bc.bestNode
-	node.header.StakeVersion = posVersion
+	node.stakeVersion = posVersion
 
 	// get to svi
 	curTimestamp := time.Now()
@@ -1493,7 +1493,7 @@ func TestVoting(t *testing.T) {
 		// We have to reset the cache for every test.
 		bc := newFakeChain(&params)
 		node := bc.bestNode
-		node.header.StakeVersion = test.startStakeVersion
+		node.stakeVersion = test.startStakeVersion
 
 		t.Logf("running: %v", test.name)
 
@@ -1526,8 +1526,7 @@ func TestVoting(t *testing.T) {
 			}
 			t.Logf("Height %v, Start time %v, curTime %v, delta %v",
 				node.height, params.Deployments[4][0].StartTime,
-				node.header.Timestamp.Unix(),
-				node.header.Timestamp.Unix()-
+				node.timestamp, node.timestamp-
 					int64(params.Deployments[4][0].StartTime))
 			ts, err := bc.ThresholdState(&node.hash, posVersion,
 				test.vote.Id)
@@ -1738,7 +1737,7 @@ func TestParallelVoting(t *testing.T) {
 		// We have to reset the cache for every test.
 		bc := newFakeChain(&params)
 		node := bc.bestNode
-		node.header.StakeVersion = test.startStakeVersion
+		node.stakeVersion = test.startStakeVersion
 
 		curTimestamp := time.Now()
 		for k := range test.expectedState[0] {


### PR DESCRIPTION
**NOTE: This requires #986 and #987**.

This modifies the block node structure to include only the specifically used fields, some of which in a more compact format, as opposed to copying the entire header and updates all code and tests accordingly.

Not only is this a more efficient approach that helps pave the way for future optimizations, it is also consistent with the upstream code which helps minimize the differences to facilitate easier syncs due to less merge conflicts.

In particular, since the merkle and stake roots, number of revocations, size, nonce, and extradata fields aren't used currently, they are no longer copied into the block node.  Also, the block node already had a height field, which is also in the header, so this change also removes that duplication.

Another change is that the block node now stores the timestamp as an int64 unix-style timestamp which is only 8 bytes versus the old timestamp that was in the header which is a time.Time and thus 24 bytes.

It should be noted that future optimizations will very likely end up adding most of the omitted header fields back to the block node as individual fields so the headers can be efficiently reconstructed from memory, however, these changes are still beneficial due to the ability to decouple the block node storage format from the header struct which allows more compact representations and reording of the fields for optimal struct packing.

Ultimately, the need for the parent hash can also be removed, which will save an additional 32 bytes which would not be possible without this decoupling.

