### PR TITLE
blockchain: Refactor main block index logic.

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -144,7 +144,7 @@ func (b *BlockChain) checkBlockContext(block *dcrutil.Block, prevNode *blockNode
 			return err
 		}
 		if lnFeaturesActive {
-			medianTime, err := b.calcPastMedianTime(prevNode)
+			medianTime, err := b.index.CalcPastMedianTime(prevNode)
 			if err != nil {
 				return err
 			}
@@ -252,7 +252,7 @@ func (b *BlockChain) maybeAcceptBlock(block *dcrutil.Block, flags BehaviorFlags)
 
 	// Get a block node for the block previous to this one.  Will be nil
 	// if this is the genesis block.
-	prevNode, err := b.getPrevNodeFromBlock(block)
+	prevNode, err := b.index.PrevNodeFromBlock(block)
 	if err != nil {
 		log.Debugf("getPrevNodeFromBlock: %v", err)
 		return false, err

--- a/blockchain/blockindex.go
+++ b/blockchain/blockindex.go
@@ -1,0 +1,502 @@
+// Copyright (c) 2013-2017 The btcsuite developers
+// Copyright (c) 2018 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package blockchain
+
+import (
+	"fmt"
+	"math/big"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/decred/dcrd/blockchain/stake"
+	"github.com/decred/dcrd/chaincfg"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/database"
+	"github.com/decred/dcrd/dcrutil"
+	"github.com/decred/dcrd/wire"
+)
+
+// VoteVersionTuple contains the extracted vote bits and version from votes
+// (SSGen).
+type VoteVersionTuple struct {
+	Version uint32
+	Bits    uint16
+}
+
+// blockNode represents a block within the block chain and is primarily used to
+// aid in selecting the best chain to be the main chain.  The main chain is
+// stored into the block database.
+type blockNode struct {
+	// parent is the parent block for this node.
+	parent *blockNode
+
+	// children contains the child nodes for this node.  Typically there
+	// will only be one, but sometimes there can be more than one and that
+	// is when the best chain selection algorithm is used.
+	children []*blockNode
+
+	// hash is the hash of the block this node represents.
+	hash chainhash.Hash
+
+	// parentHash is the hash of the parent block of the block this node
+	// represents.  This is kept here over simply relying on parent.hash
+	// directly since block nodes are sparse and the parent node might not be
+	// in memory when its hash is needed.
+	parentHash chainhash.Hash
+
+	// height is the position in the block chain.
+	height int64
+
+	// workSum is the total amount of work in the chain up to and including
+	// this node.
+	workSum *big.Int
+
+	// inMainChain denotes whether the block node is currently on the
+	// the main chain or not.  This is used to help find the common
+	// ancestor when switching chains.
+	inMainChain bool
+
+	// Some fields from block headers to aid in best chain selection and
+	// reconstructing headers from memory.  These must be treated as
+	// immutable and are intentionally ordered to avoid padding on 64-bit
+	// platforms.
+	blockVersion int32
+	voteBits     uint16
+	finalState   [6]byte
+	voters       uint16
+	freshStake   uint8
+	poolSize     uint32
+	bits         uint32
+	sbits        int64
+	timestamp    int64
+	merkleRoot   chainhash.Hash
+	stakeRoot    chainhash.Hash
+	revocations  uint8
+	blockSize    uint32
+	nonce        uint32
+	extraData    [32]byte
+	stakeVersion uint32
+
+	// stakeNode contains all the consensus information required for the
+	// staking system.  The node also caches information required to add or
+	// remove stake nodes, so that the stake node itself may be pruneable
+	// to save memory while maintaining high throughput efficiency for the
+	// evaluation of sidechains.  The lotteryIV contains the initialization
+	// vector for the deterministic PRNG used to determine winning tickets.
+	lotteryIV      chainhash.Hash
+	stakeNode      *stake.Node
+	newTickets     []chainhash.Hash
+	stakeUndoData  stake.UndoTicketDataSlice
+	ticketsSpent   []chainhash.Hash
+	ticketsRevoked []chainhash.Hash
+
+	// Keep track of all vote version and bits in this block.
+	votes []stake.VoteVersionTuple
+}
+
+// newBlockNode returns a new block node for the given block header.  It is
+// completely disconnected from the chain and the workSum value is just the work
+// for the passed block.  The work sum is updated accordingly when the node is
+// inserted into a chain.
+func newBlockNode(blockHeader *wire.BlockHeader, spentTickets *stake.SpentTicketsInBlock) *blockNode {
+	// Serialize the block header for use in calculating the initialization
+	// vector for the ticket lottery.  The only way this can fail is if the
+	// process is out of memory in which case it would panic anyways, so
+	// although panics are generally frowned upon in package code, it is
+	// acceptable here.
+	hB, err := blockHeader.Bytes()
+	if err != nil {
+		panic(err)
+	}
+
+	var ticketsSpent, ticketsRevoked []chainhash.Hash
+	var votes []stake.VoteVersionTuple
+	if spentTickets != nil {
+		ticketsSpent = spentTickets.VotedTickets
+		ticketsRevoked = spentTickets.RevokedTickets
+		votes = spentTickets.Votes
+	}
+
+	// Make a copy of the hash so the node doesn't keep a reference to part
+	// of the full block/block header preventing it from being garbage
+	// collected.
+	node := blockNode{
+		hash:           blockHeader.BlockHash(),
+		parentHash:     blockHeader.PrevBlock,
+		workSum:        CalcWork(blockHeader.Bits),
+		height:         int64(blockHeader.Height),
+		blockVersion:   blockHeader.Version,
+		voteBits:       blockHeader.VoteBits,
+		finalState:     blockHeader.FinalState,
+		voters:         blockHeader.Voters,
+		freshStake:     blockHeader.FreshStake,
+		poolSize:       blockHeader.PoolSize,
+		bits:           blockHeader.Bits,
+		sbits:          blockHeader.SBits,
+		timestamp:      blockHeader.Timestamp.Unix(),
+		merkleRoot:     blockHeader.MerkleRoot,
+		stakeRoot:      blockHeader.StakeRoot,
+		revocations:    blockHeader.Revocations,
+		blockSize:      blockHeader.Size,
+		nonce:          blockHeader.Nonce,
+		extraData:      blockHeader.ExtraData,
+		stakeVersion:   blockHeader.StakeVersion,
+		lotteryIV:      stake.CalcHash256PRNGIV(hB),
+		ticketsSpent:   ticketsSpent,
+		ticketsRevoked: ticketsRevoked,
+		votes:          votes,
+	}
+
+	return &node
+}
+
+// Header constructs a block header from the node and returns it.
+//
+// This function is safe for concurrent access.
+func (node *blockNode) Header() wire.BlockHeader {
+	// No lock is needed because all accessed fields are immutable.
+	return wire.BlockHeader{
+		Version:      node.blockVersion,
+		PrevBlock:    node.parentHash,
+		MerkleRoot:   node.merkleRoot,
+		StakeRoot:    node.stakeRoot,
+		VoteBits:     node.voteBits,
+		FinalState:   node.finalState,
+		Voters:       node.voters,
+		FreshStake:   node.freshStake,
+		Revocations:  node.revocations,
+		PoolSize:     node.poolSize,
+		Bits:         node.bits,
+		SBits:        node.sbits,
+		Height:       uint32(node.height),
+		Size:         node.blockSize,
+		Timestamp:    time.Unix(node.timestamp, 0),
+		Nonce:        node.nonce,
+		ExtraData:    node.extraData,
+		StakeVersion: node.stakeVersion,
+	}
+}
+
+// removeChildNode deletes node from the provided slice of child block
+// nodes.  It ensures the final pointer reference is set to nil to prevent
+// potential memory leaks.  The original slice is returned unmodified if node
+// is invalid or not in the slice.
+//
+// This function MUST be called with the chain state lock held (for writes).
+func removeChildNode(children []*blockNode, node *blockNode) []*blockNode {
+	if node == nil {
+		return children
+	}
+
+	// An indexing for loop is intentionally used over a range here as range
+	// does not reevaluate the slice on each iteration nor does it adjust
+	// the index for the modified slice.
+	for i := 0; i < len(children); i++ {
+		if children[i].hash == node.hash {
+			copy(children[i:], children[i+1:])
+			children[len(children)-1] = nil
+			return children[:len(children)-1]
+		}
+	}
+	return children
+}
+
+// blockIndex provides facilities for keeping track of an in-memory index of the
+// block chain.  Although the name block chain suggest a single chain of blocks,
+// it is actually a tree-shaped structure where any node can have multiple
+// children.  However, there can only be one active branch which does indeed
+// form a chain from the tip all the way back to the genesis block.
+type blockIndex struct {
+	// The following fields are set when the instance is created and can't
+	// be changed afterwards, so there is no need to protect them with a
+	// separate mutex.
+	db          database.DB
+	chainParams *chaincfg.Params
+
+	sync.RWMutex
+	index    map[chainhash.Hash]*blockNode
+	depNodes map[chainhash.Hash][]*blockNode
+}
+
+// newBlockIndex returns a new empty instance of a block index.  The index will
+// be dynamically populated as block nodes are loaded from the database and
+// manually added.
+func newBlockIndex(db database.DB, chainParams *chaincfg.Params) *blockIndex {
+	return &blockIndex{
+		db:          db,
+		chainParams: chainParams,
+		index:       make(map[chainhash.Hash]*blockNode),
+		depNodes:    make(map[chainhash.Hash][]*blockNode),
+	}
+}
+
+// HaveBlock returns whether or not the block index contains the provided hash.
+//
+// This function is safe for concurrent access.
+func (bi *blockIndex) HaveBlock(hash *chainhash.Hash) bool {
+	bi.RLock()
+	_, hasBlock := bi.index[*hash]
+	bi.RUnlock()
+	return hasBlock
+}
+
+// loadBlockNode loads the block identified by hash from the block database,
+// creates a block node from it, and updates the memory block chain accordingly.
+// It is used mainly to dynamically load previous blocks from the database as
+// they are needed to avoid needing to put the entire block chain in memory.
+//
+// This function MUST be called with the block index lock held (for writes).
+// The database transaction may be read-only.
+func (bi *blockIndex) loadBlockNode(dbTx database.Tx, hash *chainhash.Hash) (*blockNode, error) {
+	// Load the block from the db.
+	block, err := dbFetchBlockByHash(dbTx, hash)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the new block node for the block.
+	blockHeader := block.MsgBlock().Header
+	node := newBlockNode(&blockHeader, stake.FindSpentTicketsInBlock(block.MsgBlock()))
+	node.inMainChain = true
+
+	// Add the node to the chain.
+	// There are a few possibilities here:
+	//  1) This node is a child of an existing block node
+	//  2) This node is the parent of one or more nodes
+	//  3) Neither 1 or 2 is true which implies it's an orphan block and
+	//     therefore is an error to insert into the chain
+	prevHash := &blockHeader.PrevBlock
+	if parentNode, ok := bi.index[*prevHash]; ok {
+		// Case 1 -- This node is a child of an existing block node.
+		// Update the node's work sum with the sum of the parent node's
+		// work sum and this node's work, append the node as a child of
+		// the parent node and set this node's parent to the parent
+		// node.
+		node.workSum = node.workSum.Add(parentNode.workSum, node.workSum)
+		parentNode.children = append(parentNode.children, node)
+		node.parent = parentNode
+
+	} else if childNodes, ok := bi.depNodes[*hash]; ok {
+		// Case 2 -- This node is the parent of one or more nodes.
+		// Update the node's work sum by subtracting this node's work
+		// from the sum of its first child, and connect the node to all
+		// of its children.
+		node.workSum.Sub(childNodes[0].workSum, node.workSum)
+		for _, childNode := range childNodes {
+			childNode.parent = node
+			node.children = append(node.children, childNode)
+		}
+
+	} else {
+		// Case 3 -- The node doesn't have a parent in the node cache
+		// and is not the parent of another node.  This means an arbitrary
+		// orphan block is trying to be loaded which is not allowed.
+		str := "loadBlockNode: attempt to insert orphan block %v"
+		return nil, AssertError(fmt.Sprintf(str, hash))
+	}
+
+	// Add the new node to the indices for faster lookups.
+	bi.index[*hash] = node
+	bi.depNodes[*prevHash] = append(bi.depNodes[*prevHash], node)
+
+	return node, nil
+}
+
+// PrevNodeFromBlock returns a block node for the block previous to the
+// passed block (the passed block's parent).  When it is already in the block
+// index, it simply returns it.  Otherwise, it loads the previous block header
+// from the block database, creates a new block node from it, and returns it.
+// The returned node will be nil if the genesis block is passed.
+//
+// This function is safe for concurrent access.
+func (bi *blockIndex) PrevNodeFromBlock(block *dcrutil.Block) (*blockNode, error) {
+	// Genesis block.
+	prevHash := &block.MsgBlock().Header.PrevBlock
+	if prevHash.IsEqual(zeroHash) {
+		return nil, nil
+	}
+
+	bi.Lock()
+	defer bi.Unlock()
+
+	// Return the existing previous block node if it's already there.
+	if bn, ok := bi.index[*prevHash]; ok {
+		return bn, nil
+	}
+
+	// Dynamically load the previous block from the block database, create
+	// a new block node for it, and update the memory chain accordingly.
+	var prevBlockNode *blockNode
+	err := bi.db.View(func(dbTx database.Tx) error {
+		var err error
+		prevBlockNode, err = bi.loadBlockNode(dbTx, prevHash)
+		return err
+	})
+	return prevBlockNode, err
+}
+
+// prevNodeFromNode returns a block node for the block previous to the passed
+// block node (the passed block node's parent).  When the node is already
+// connected to a parent, it simply returns it.  Otherwise, it loads the
+// associated block from the database to obtain the previous hash and uses that
+// to dynamically create a new block node and return it.  The memory block
+// chain is updated accordingly.  The returned node will be nil if the genesis
+// block is passed.
+//
+// This function MUST be called with the block index lock held (for writes).
+func (bi *blockIndex) prevNodeFromNode(node *blockNode) (*blockNode, error) {
+	// Return the existing previous block node if it's already there.
+	if node.parent != nil {
+		return node.parent, nil
+	}
+
+	// Genesis block.
+	if node.hash.IsEqual(bi.chainParams.GenesisHash) {
+		return nil, nil
+	}
+
+	// Dynamically load the previous block from the block database, create
+	// a new block node for it, and update the memory chain accordingly.
+	var prevBlockNode *blockNode
+	err := bi.db.View(func(dbTx database.Tx) error {
+		var err error
+		prevBlockNode, err = bi.loadBlockNode(dbTx, &node.parentHash)
+		return err
+	})
+	return prevBlockNode, err
+}
+
+// PrevNodeFromNode returns a block node for the block previous to the
+// passed block node (the passed block node's parent).  When the node is already
+// connected to a parent, it simply returns it.  Otherwise, it loads the
+// associated block from the database to obtain the previous hash and uses that
+// to dynamically create a new block node and return it.  The memory block
+// chain is updated accordingly.  The returned node will be nil if the genesis
+// block is passed.
+//
+// This function is safe for concurrent access.
+func (bi *blockIndex) PrevNodeFromNode(node *blockNode) (*blockNode, error) {
+	bi.Lock()
+	node, err := bi.prevNodeFromNode(node)
+	bi.Unlock()
+	return node, err
+}
+
+// AncestorNode returns the ancestor block node at the provided height by
+// following the chain backwards from the given node while dynamically loading
+// any pruned nodes from the database and updating the memory block chain as
+// needed.  The returned block will be nil when a height is requested that is
+// after the height of the passed node or is less than zero.
+//
+// This function is safe for concurrent access.
+func (bi *blockIndex) AncestorNode(node *blockNode, height int64) (*blockNode, error) {
+	// Nothing to do if the requested height is outside of the valid range.
+	if height > node.height || height < 0 {
+		return nil, nil
+	}
+
+	// Iterate backwards until the requested height is reached.
+	bi.Lock()
+	iterNode := node
+	for iterNode != nil && iterNode.height > height {
+		// Get the previous block node.  This function is used over
+		// simply accessing iterNode.parent directly as it will
+		// dynamically create previous block nodes as needed.  This
+		// helps allow only the pieces of the chain that are needed
+		// to remain in memory.
+		var err error
+		iterNode, err = bi.prevNodeFromNode(iterNode)
+		if err != nil {
+			log.Errorf("getPrevNodeFromNode: %v", err)
+			return nil, err
+		}
+	}
+	bi.Unlock()
+
+	return iterNode, nil
+}
+
+// AddNode adds the provided node to the block index.  Duplicate entries are not
+// checked so it is up to caller to avoid adding them.
+//
+// This function is safe for concurrent access.
+func (bi *blockIndex) AddNode(node *blockNode) {
+	bi.Lock()
+	bi.index[node.hash] = node
+	if prevHash := node.parentHash; prevHash != *zeroHash {
+		bi.depNodes[prevHash] = append(bi.depNodes[prevHash], node)
+	}
+	bi.Unlock()
+}
+
+// LookupNode returns the block node identified by the provided hash.  It will
+// return nil if there is no entry for the hash.
+//
+// This function is safe for concurrent access.
+func (bi *blockIndex) LookupNode(hash *chainhash.Hash) *blockNode {
+	bi.RLock()
+	node := bi.index[*hash]
+	bi.RUnlock()
+	return node
+}
+
+// CalcPastMedianTime calculates the median time of the previous few blocks
+// prior to, and including, the passed block node.
+//
+// This function is safe for concurrent access.
+func (bi *blockIndex) CalcPastMedianTime(startNode *blockNode) (time.Time, error) {
+	// Genesis block.
+	if startNode == nil {
+		return bi.chainParams.GenesisBlock.Header.Timestamp, nil
+	}
+
+	// Create a slice of the previous few block timestamps used to calculate
+	// the median per the number defined by the constant medianTimeBlocks.
+	timestamps := make([]int64, medianTimeBlocks)
+	numNodes := 0
+	iterNode := startNode
+	bi.Lock()
+	for i := 0; i < medianTimeBlocks && iterNode != nil; i++ {
+		timestamps[i] = iterNode.timestamp
+		numNodes++
+
+		// Get the previous block node.  This function is used over
+		// simply accessing iterNode.parent directly as it will
+		// dynamically create previous block nodes as needed.  This
+		// helps allow only the pieces of the chain that are needed
+		// to remain in memory.
+		var err error
+		iterNode, err = bi.prevNodeFromNode(iterNode)
+		if err != nil {
+			bi.Unlock()
+			log.Errorf("getPrevNodeFromNode failed to find node: %v", err)
+			return time.Time{}, err
+		}
+	}
+	bi.Unlock()
+
+	// Prune the slice to the actual number of available timestamps which
+	// will be fewer than desired near the beginning of the block chain
+	// and sort them.
+	timestamps = timestamps[:numNodes]
+	sort.Sort(timeSorter(timestamps))
+
+	// NOTE: bitcoind incorrectly calculates the median for even numbers of
+	// blocks.  A true median averages the middle two elements for a set
+	// with an even number of elements in it.   Since the constant for the
+	// previous number of blocks to be used is odd, this is only an issue
+	// for a few blocks near the beginning of the chain.  I suspect this is
+	// an optimization even though the result is slightly wrong for a few
+	// of the first blocks since after the first few blocks, there will
+	// always be an odd number of blocks in the set per the constant.
+	//
+	// This code follows suit to ensure the same rules are used as bitcoind
+	// however, be aware that should the medianTimeBlocks constant ever be
+	// changed to an even number, this code will be wrong.
+	medianTimestamp := timestamps[numNodes/2]
+	return time.Unix(medianTimestamp, 0), nil
+}

--- a/blockchain/blockindex_test.go
+++ b/blockchain/blockindex_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/decred/dcrd/blockchain/stake"
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/wire"
@@ -55,8 +54,8 @@ func TestBlockNodeHeader(t *testing.T) {
 		ExtraData:    [32]byte{0xbb},
 		StakeVersion: 5,
 	}
-	node := newBlockNode(&testHeader, &stake.SpentTicketsInBlock{})
-	bc.index[node.hash] = node
+	node := newBlockNode(&testHeader, nil)
+	bc.index.AddNode(node)
 	node.parent = bc.bestNode
 
 	// Ensure reconstructing the header for the node produces the same header

--- a/blockchain/blocklocator.go
+++ b/blockchain/blocklocator.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -39,14 +39,14 @@ type BlockLocator []*chainhash.Hash
 //  - If the passed hash is not currently known, the block locator will only
 //    consist of the passed hash
 //
-// This function MUST be called with the chain state lock held (for reads).
-func (b *BlockChain) blockLocatorFromHash(hash *chainhash.Hash) BlockLocator {
+// This function MUST be called with the block index lock held (for reads).
+func (bi *blockIndex) blockLocatorFromHash(hash *chainhash.Hash) BlockLocator {
 	// The locator contains the requested hash at the very least.
 	locator := make(BlockLocator, 0, wire.MaxBlockLocatorsPerMsg)
 	locator = append(locator, hash)
 
 	// Nothing more to do if a locator for the genesis hash was requested.
-	if hash.IsEqual(b.chainParams.GenesisHash) {
+	if hash.IsEqual(bi.chainParams.GenesisHash) {
 		return locator
 	}
 
@@ -55,13 +55,13 @@ func (b *BlockChain) blockLocatorFromHash(hash *chainhash.Hash) BlockLocator {
 	// which it forks from the main chain.
 	blockHeight := int64(-1)
 	forkHeight := int64(-1)
-	node, exists := b.index[*hash]
+	node, exists := bi.index[*hash]
 	if !exists {
 		// Try to look up the height for passed block hash.  Assume an
 		// error means it doesn't exist and just return the locator for
 		// the block itself.
 		var height int64
-		err := b.db.View(func(dbTx database.Tx) error {
+		err := bi.db.View(func(dbTx database.Tx) error {
 			var err error
 			height, err = dbFetchHeightByHash(dbTx, hash)
 			return err
@@ -94,7 +94,7 @@ func (b *BlockChain) blockLocatorFromHash(hash *chainhash.Hash) BlockLocator {
 	// could fail is if there is something wrong with the database which
 	// will be caught in short order anyways and it's also safe to ignore
 	// block locators.
-	_ = b.db.View(func(dbTx database.Tx) error {
+	_ = bi.db.View(func(dbTx database.Tx) error {
 		iterNode := node
 		increment := int64(1)
 		for len(locator) < wire.MaxBlockLocatorsPerMsg-1 {
@@ -113,7 +113,7 @@ func (b *BlockChain) blockLocatorFromHash(hash *chainhash.Hash) BlockLocator {
 			// height.
 			if forkHeight != -1 && blockHeight > forkHeight {
 				// Intentionally use parent field instead of the
-				// getPrevNodeFromNode function since we don't
+				// PrevNodeFromNode function since we don't
 				// want to dynamically load nodes when building
 				// block locators.  Side chain blocks should
 				// always be in memory already, and if they
@@ -145,7 +145,7 @@ func (b *BlockChain) blockLocatorFromHash(hash *chainhash.Hash) BlockLocator {
 	})
 
 	// Append the appropriate genesis block.
-	locator = append(locator, b.chainParams.GenesisHash)
+	locator = append(locator, bi.chainParams.GenesisHash)
 	return locator
 }
 
@@ -163,7 +163,9 @@ func (b *BlockChain) blockLocatorFromHash(hash *chainhash.Hash) BlockLocator {
 // This function is safe for concurrent access.
 func (b *BlockChain) BlockLocatorFromHash(hash *chainhash.Hash) BlockLocator {
 	b.chainLock.RLock()
-	locator := b.blockLocatorFromHash(hash)
+	b.index.RLock()
+	locator := b.index.blockLocatorFromHash(hash)
+	b.index.RUnlock()
 	b.chainLock.RUnlock()
 	return locator
 }
@@ -174,7 +176,9 @@ func (b *BlockChain) BlockLocatorFromHash(hash *chainhash.Hash) BlockLocator {
 // This function is safe for concurrent access.
 func (b *BlockChain) LatestBlockLocator() (BlockLocator, error) {
 	b.chainLock.RLock()
-	locator := b.blockLocatorFromHash(&b.bestNode.hash)
+	b.index.RLock()
+	locator := b.index.blockLocatorFromHash(&b.bestNode.hash)
+	b.index.RUnlock()
 	b.chainLock.RUnlock()
 	return locator, nil
 }

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -8,8 +8,6 @@ package blockchain
 import (
 	"container/list"
 	"fmt"
-	"math/big"
-	"sort"
 	"sync"
 	"time"
 
@@ -51,182 +49,12 @@ const (
 	maxSearchDepth = 2880
 )
 
-// blockNode represents a block within the block chain and is primarily used to
-// aid in selecting the best chain to be the main chain.  The main chain is
-// stored into the block database.
-type blockNode struct {
-	// parent is the parent block for this node.
-	parent *blockNode
-
-	// children contains the child nodes for this node.  Typically there
-	// will only be one, but sometimes there can be more than one and that
-	// is when the best chain selection algorithm is used.
-	children []*blockNode
-
-	// hash is the hash of the block this node represents.
-	hash chainhash.Hash
-
-	// parentHash is the hash of the parent block of the block this node
-	// represents.  This is kept here over simply relying on parent.hash
-	// directly since block nodes are sparse and the parent node might not be
-	// in memory when its hash is needed.
-	parentHash chainhash.Hash
-
-	// height is the position in the block chain.
-	height int64
-
-	// workSum is the total amount of work in the chain up to and including
-	// this node.
-	workSum *big.Int
-
-	// inMainChain denotes whether the block node is currently on the
-	// the main chain or not.  This is used to help find the common
-	// ancestor when switching chains.
-	inMainChain bool
-
-	// Some fields from block headers to aid in best chain selection and
-	// reconstructing headers from memory.  These must be treated as
-	// immutable and are intentionally ordered to avoid padding on 64-bit
-	// platforms.
-	blockVersion int32
-	voteBits     uint16
-	finalState   [6]byte
-	voters       uint16
-	freshStake   uint8
-	poolSize     uint32
-	bits         uint32
-	sbits        int64
-	timestamp    int64
-	merkleRoot   chainhash.Hash
-	stakeRoot    chainhash.Hash
-	revocations  uint8
-	blockSize    uint32
-	nonce        uint32
-	extraData    [32]byte
-	stakeVersion uint32
-
-	// stakeNode contains all the consensus information required for the
-	// staking system.  The node also caches information required to add or
-	// remove stake nodes, so that the stake node itself may be pruneable
-	// to save memory while maintaining high throughput efficiency for the
-	// evaluation of sidechains.  The lotteryIV contains the initialization
-	// vector for the deterministic PRNG used to determine winning tickets.
-	lotteryIV      chainhash.Hash
-	stakeNode      *stake.Node
-	newTickets     []chainhash.Hash
-	stakeUndoData  stake.UndoTicketDataSlice
-	ticketsSpent   []chainhash.Hash
-	ticketsRevoked []chainhash.Hash
-
-	// Keep track of all vote version and bits in this block.
-	votes []stake.VoteVersionTuple
-}
-
-// newBlockNode returns a new block node for the given block header.  It is
-// completely disconnected from the chain and the workSum value is just the work
-// for the passed block.  The work sum is updated accordingly when the node is
-// inserted into a chain.
-func newBlockNode(blockHeader *wire.BlockHeader, spentTickets *stake.SpentTicketsInBlock) *blockNode {
-	// Serialize the block header for use in calculating the initialization
-	// vector for the ticket lottery.  The only way this can fail is if the
-	// process is out of memory in which case it would panic anyways, so
-	// although panics are generally frowned upon in package code, it is
-	// acceptable here.
-	hB, err := blockHeader.Bytes()
-	if err != nil {
-		panic(err)
-	}
-
-	// Make a copy of the hash so the node doesn't keep a reference to part
-	// of the full block/block header preventing it from being garbage
-	// collected.
-	node := blockNode{
-		hash:           blockHeader.BlockHash(),
-		parentHash:     blockHeader.PrevBlock,
-		workSum:        CalcWork(blockHeader.Bits),
-		height:         int64(blockHeader.Height),
-		blockVersion:   blockHeader.Version,
-		voteBits:       blockHeader.VoteBits,
-		finalState:     blockHeader.FinalState,
-		voters:         blockHeader.Voters,
-		freshStake:     blockHeader.FreshStake,
-		poolSize:       blockHeader.PoolSize,
-		bits:           blockHeader.Bits,
-		sbits:          blockHeader.SBits,
-		timestamp:      blockHeader.Timestamp.Unix(),
-		merkleRoot:     blockHeader.MerkleRoot,
-		stakeRoot:      blockHeader.StakeRoot,
-		revocations:    blockHeader.Revocations,
-		blockSize:      blockHeader.Size,
-		nonce:          blockHeader.Nonce,
-		extraData:      blockHeader.ExtraData,
-		stakeVersion:   blockHeader.StakeVersion,
-		lotteryIV:      stake.CalcHash256PRNGIV(hB),
-		ticketsSpent:   spentTickets.VotedTickets,
-		ticketsRevoked: spentTickets.RevokedTickets,
-		votes:          spentTickets.Votes,
-	}
-
-	return &node
-}
-
-// Header constructs a block header from the node and returns it.
-//
-// This function is safe for concurrent access.
-func (node *blockNode) Header() wire.BlockHeader {
-	// No lock is needed because all accessed fields are immutable.
-	return wire.BlockHeader{
-		Version:      node.blockVersion,
-		PrevBlock:    node.parentHash,
-		MerkleRoot:   node.merkleRoot,
-		StakeRoot:    node.stakeRoot,
-		VoteBits:     node.voteBits,
-		FinalState:   node.finalState,
-		Voters:       node.voters,
-		FreshStake:   node.freshStake,
-		Revocations:  node.revocations,
-		PoolSize:     node.poolSize,
-		Bits:         node.bits,
-		SBits:        node.sbits,
-		Height:       uint32(node.height),
-		Size:         node.blockSize,
-		Timestamp:    time.Unix(node.timestamp, 0),
-		Nonce:        node.nonce,
-		ExtraData:    node.extraData,
-		StakeVersion: node.stakeVersion,
-	}
-}
-
 // orphanBlock represents a block that we don't yet have the parent for.  It
 // is a normal block plus an expiration time to prevent caching the orphan
 // forever.
 type orphanBlock struct {
 	block      *dcrutil.Block
 	expiration time.Time
-}
-
-// removeChildNode deletes node from the provided slice of child block
-// nodes.  It ensures the final pointer reference is set to nil to prevent
-// potential memory leaks.  The original slice is returned unmodified if node
-// is invalid or not in the slice.
-//
-// This function MUST be called with the chain state lock held (for writes).
-func removeChildNode(children []*blockNode, node *blockNode) []*blockNode {
-	if node == nil {
-		return children
-	}
-
-	// An indexing for loop is intentionally used over a range here as range
-	// does not reevaluate the slice on each iteration nor does it adjust
-	// the index for the modified slice.
-	for i := 0; i < len(children); i++ {
-		if children[i].hash == node.hash {
-			copy(children[i:], children[i+1:])
-			children[len(children)-1] = nil
-			return children[:len(children)-1]
-		}
-	}
-	return children
 }
 
 // BestState houses information about the current best block and other info
@@ -245,7 +73,7 @@ type BestState struct {
 	BlockSize    uint64          // The size of the block.
 	NumTxns      uint64          // The number of txns in the block.
 	TotalTxns    uint64          // The total number of txns in the chain.
-	MedianTime   time.Time       // Median time as per calcPastMedianTime.
+	MedianTime   time.Time       // Median time as per CalcPastMedianTime.
 	TotalSubsidy int64           // The total subsidy for the chain.
 }
 
@@ -296,8 +124,7 @@ type BlockChain struct {
 	// These fields are related to the memory block index.  They are
 	// protected by the chain lock.
 	bestNode *blockNode
-	index    map[chainhash.Hash]*blockNode
-	depNodes map[chainhash.Hash][]*blockNode
+	index    *blockIndex
 
 	// These fields are related to handling of orphan blocks.  They are
 	// protected by a combination of the chain lock and the orphan lock.
@@ -424,7 +251,7 @@ func (b *BlockChain) GetStakeVersions(hash *chainhash.Hash, count int32) ([]Stak
 
 		result = append(result, sv)
 
-		prevNode, err = b.getPrevNodeFromNode(prevNode)
+		prevNode, err = b.index.PrevNodeFromNode(prevNode)
 		if err != nil {
 			return nil, err
 		}
@@ -649,18 +476,17 @@ func (b *BlockChain) addOrphanBlock(block *dcrutil.Block) {
 // used by the mempool downstream to locate all potential block template
 // parents.
 func (b *BlockChain) getGeneration(h chainhash.Hash) ([]chainhash.Hash, error) {
-	node, err := b.findNode(&h, maxSearchDepth)
-
 	// This typically happens because the main chain has recently
 	// reorganized and the block the miner is looking at is on
 	// a fork.  Usually it corrects itself after failure.
+	node, err := b.findNode(&h, maxSearchDepth)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't find block node in best chain: %v",
 			err.Error())
 	}
 
 	// Get the parent of this node.
-	p, err := b.getPrevNodeFromNode(node)
+	p, err := b.index.PrevNodeFromNode(node)
 	if err != nil {
 		return nil, fmt.Errorf("block is orphan (parent missing)")
 	}
@@ -681,75 +507,6 @@ func (b *BlockChain) getGeneration(h chainhash.Hash) ([]chainhash.Hash, error) {
 // GetGeneration is the exported version of getGeneration.
 func (b *BlockChain) GetGeneration(hash chainhash.Hash) ([]chainhash.Hash, error) {
 	return b.getGeneration(hash)
-}
-
-// loadBlockNode loads the block identified by hash from the block database,
-// creates a block node from it, and updates the memory block chain accordingly.
-// It is used mainly to dynamically load previous blocks from the database as
-// they are needed to avoid needing to put the entire block chain in memory.
-//
-// This function MUST be called with the chain state lock held (for writes).
-// The database transaction may be read-only.
-func (b *BlockChain) loadBlockNode(dbTx database.Tx, hash *chainhash.Hash) (*blockNode, error) {
-	block, err := dbFetchBlockByHash(dbTx, hash)
-	if err != nil {
-		return nil, err
-	}
-
-	blockHeader := block.MsgBlock().Header
-	node := newBlockNode(&blockHeader, stake.FindSpentTicketsInBlock(block.MsgBlock()))
-	node.inMainChain = true
-	prevHash := &blockHeader.PrevBlock
-
-	// Add the node to the chain.
-	// There are a few possibilities here:
-	//  1) This node is a child of an existing block node
-	//  2) This node is the parent of one or more nodes
-	//  3) Neither 1 or 2 is true which implies it's an orphan block and
-	//     therefore is an error to insert into the chain
-	if parentNode, ok := b.index[*prevHash]; ok {
-		// Case 1 -- This node is a child of an existing block node.
-		// Update the node's work sum with the sum of the parent node's
-		// work sum and this node's work, append the node as a child of
-		// the parent node and set this node's parent to the parent
-		// node.
-		node.workSum = node.workSum.Add(parentNode.workSum, node.workSum)
-		parentNode.children = append(parentNode.children, node)
-		node.parent = parentNode
-	} else if childNodes, ok := b.depNodes[*hash]; ok {
-		// Case 2 -- This node is the parent of one or more nodes.
-		// Update the node's work sum by subtracting this node's work
-		// from the sum of its first child, and connect the node to all
-		// of its children.
-		node.workSum.Sub(childNodes[0].workSum, node.workSum)
-		for _, childNode := range childNodes {
-			childNode.parent = node
-			node.children = append(node.children, childNode)
-		}
-	} else {
-		// Case 3 -- The node doesn't have a parent in the node cache
-		// and is not the parent of another node.  This means an arbitrary
-		// orphan block is trying to be loaded which is not allowed.
-		// Before we return, check and make sure there isn't a parent
-		// further down the line in the blockchain to which the block
-		// could be attached, for example if the node had been pruned from
-		// the index.
-		foundParent, err := b.findNode(&node.parentHash, maxSearchDepth)
-		if err == nil {
-			node.workSum = node.workSum.Add(foundParent.workSum, node.workSum)
-			foundParent.children = append(foundParent.children, node)
-			node.parent = foundParent
-		} else {
-			str := "loadBlockNode: attempt to insert orphan block %v"
-			return nil, AssertError(fmt.Sprintf(str, hash))
-		}
-	}
-
-	// Add the new node to the indices for faster lookups.
-	b.index[*hash] = node
-	b.depNodes[*prevHash] = append(b.depNodes[*prevHash], node)
-
-	return node, nil
 }
 
 // findNode finds the node scaling backwards from best chain or return an
@@ -782,7 +539,7 @@ func (b *BlockChain) findNode(nodeHash *chainhash.Hash, searchDepth int) (*block
 				last := foundPrev.parentHash
 				foundPrev = foundPrev.parent
 				if foundPrev == nil {
-					parent, err := b.loadBlockNode(dbTx, &last)
+					parent, err := b.index.loadBlockNode(dbTx, &last)
 					if err != nil {
 						return err
 					}
@@ -805,99 +562,6 @@ func (b *BlockChain) findNode(nodeHash *chainhash.Hash, searchDepth int) (*block
 	})
 
 	return node, err
-}
-
-// getPrevNodeFromBlock returns a block node for the block previous to the
-// passed block (the passed block's parent).  When it is already in the memory
-// block chain, it simply returns it.  Otherwise, it loads the previous block
-// header from the block database, creates a new block node from it, and returns
-// it.  The returned node will be nil if the genesis block is passed.
-//
-// This function MUST be called with the chain state lock held (for writes).
-func (b *BlockChain) getPrevNodeFromBlock(block *dcrutil.Block) (*blockNode, error) {
-	// Genesis block.
-	prevHash := &block.MsgBlock().Header.PrevBlock
-	if prevHash.IsEqual(zeroHash) {
-		return nil, nil
-	}
-
-	// Return the existing previous block node if it's already there.
-	if bn, ok := b.index[*prevHash]; ok {
-		return bn, nil
-	}
-
-	// Dynamically load the previous block from the block database, create
-	// a new block node for it, and update the memory chain accordingly.
-	var prevBlockNode *blockNode
-	err := b.db.View(func(dbTx database.Tx) error {
-		var err error
-		prevBlockNode, err = b.loadBlockNode(dbTx, prevHash)
-		return err
-	})
-	return prevBlockNode, err
-}
-
-// getPrevNodeFromNode returns a block node for the block previous to the
-// passed block node (the passed block node's parent).  When the node is already
-// connected to a parent, it simply returns it.  Otherwise, it loads the
-// associated block from the database to obtain the previous hash and uses that
-// to dynamically create a new block node and return it.  The memory block
-// chain is updated accordingly.  The returned node will be nil if the genesis
-// block is passed.
-//
-// This function MUST be called with the chain state lock held (for writes).
-func (b *BlockChain) getPrevNodeFromNode(node *blockNode) (*blockNode, error) {
-	// Return the existing previous block node if it's already there.
-	if node.parent != nil {
-		return node.parent, nil
-	}
-
-	// Genesis block.
-	if node.hash.IsEqual(b.chainParams.GenesisHash) {
-		return nil, nil
-	}
-
-	// Dynamically load the previous block from the block database, create
-	// a new block node for it, and update the memory chain accordingly.
-	var prevBlockNode *blockNode
-	err := b.db.View(func(dbTx database.Tx) error {
-		var err error
-		prevBlockNode, err = b.loadBlockNode(dbTx, &node.parentHash)
-		return err
-	})
-	return prevBlockNode, err
-}
-
-// ancestorNode returns the ancestor block node at the provided height by
-// following the chain backwards from the given node while dynamically loading
-// any pruned nodes from the database and updating the memory block chain as
-// needed.  The returned block will be nil when a height is requested that is
-// after the height of the passed node or is less than zero.
-//
-// This function MUST be called with the chain state lock held (for writes).
-func (b *BlockChain) ancestorNode(node *blockNode, height int64) (*blockNode, error) {
-	// Nothing to do if the requested height is outside of the valid range.
-	if height > node.height || height < 0 {
-		return nil, nil
-	}
-
-	// Iterate backwards until the requested height is reached.
-	iterNode := node
-	for iterNode != nil && iterNode.height > height {
-		// Get the previous block node.  This function is used over
-		// simply accessing iterNode.parent directly as it will
-		// dynamically create previous block nodes as needed.  This
-		// helps allow only the pieces of the chain that are needed
-		// to remain in memory.
-		var err error
-		iterNode, err = b.getPrevNodeFromNode(iterNode)
-		if err != nil {
-			log.Errorf("getPrevNodeFromNode: %v", err)
-			return nil, err
-		}
-	}
-
-	return iterNode, nil
 }
 
 // fetchBlockFromHash searches the internal chain block stores and the database in
@@ -1033,68 +697,13 @@ func (b *BlockChain) isMajorityVersion(minVer int32, startNode *blockNode, numRe
 		// helps allow only the pieces of the chain that are needed
 		// to remain in memory.
 		var err error
-		iterNode, err = b.getPrevNodeFromNode(iterNode)
+		iterNode, err = b.index.PrevNodeFromNode(iterNode)
 		if err != nil {
 			break
 		}
 	}
 
 	return numFound >= numRequired
-}
-
-// calcPastMedianTime calculates the median time of the previous few blocks
-// prior to, and including, the passed block node.  It is primarily used to
-// validate new blocks have sane timestamps.
-//
-// This function MUST be called with the chain state lock held (for writes).
-func (b *BlockChain) calcPastMedianTime(startNode *blockNode) (time.Time, error) {
-	// Genesis block.
-	if startNode == nil {
-		return b.chainParams.GenesisBlock.Header.Timestamp, nil
-	}
-
-	// Create a slice of the previous few block timestamps used to calculate
-	// the median per the number defined by the constant medianTimeBlocks.
-	timestamps := make([]int64, medianTimeBlocks)
-	numNodes := 0
-	iterNode := startNode
-	for i := 0; i < medianTimeBlocks && iterNode != nil; i++ {
-		timestamps[i] = iterNode.timestamp
-		numNodes++
-
-		// Get the previous block node.  This function is used over
-		// simply accessing iterNode.parent directly as it will
-		// dynamically create previous block nodes as needed.  This
-		// helps allow only the pieces of the chain that are needed
-		// to remain in memory.
-		var err error
-		iterNode, err = b.getPrevNodeFromNode(iterNode)
-		if err != nil {
-			log.Errorf("getPrevNodeFromNode failed to find node: %v", err)
-			return time.Time{}, err
-		}
-	}
-
-	// Prune the slice to the actual number of available timestamps which
-	// will be fewer than desired near the beginning of the block chain
-	// and sort them.
-	timestamps = timestamps[:numNodes]
-	sort.Sort(timeSorter(timestamps))
-
-	// NOTE: bitcoind incorrectly calculates the median for even numbers of
-	// blocks.  A true median averages the middle two elements for a set
-	// with an even number of elements in it.   Since the constant for the
-	// previous number of blocks to be used is odd, this is only an issue
-	// for a few blocks near the beginning of the chain.  I suspect this is
-	// an optimization even though the result is slightly wrong for a few
-	// of the first blocks since after the first few blocks, there will
-	// always be an odd number of blocks in the set per the constant.
-	//
-	// This code follows suit to ensure the same rules are used as bitcoind
-	// however, be aware that should the medianTimeBlocks constant ever be
-	// changed to an even number, this code will be wrong.
-	medianTimestamp := timestamps[numNodes/2]
-	return time.Unix(medianTimestamp, 0), nil
 }
 
 // getReorganizeNodes finds the fork point between the main chain and the passed
@@ -1212,7 +821,7 @@ func (b *BlockChain) connectBlock(node *blockNode, block *dcrutil.Block, view *U
 	}
 
 	// Calculate the median time for the block.
-	medianTime, err := b.calcPastMedianTime(node)
+	medianTime, err := b.index.CalcPastMedianTime(node)
 	if err != nil {
 		return err
 	}
@@ -1308,8 +917,7 @@ func (b *BlockChain) connectBlock(node *blockNode, block *dcrutil.Block, view *U
 	// Add the new node to the memory main chain indices for faster
 	// lookups.
 	node.inMainChain = true
-	b.index[node.hash] = node
-	b.depNodes[prevHash] = append(b.depNodes[prevHash], node)
+	b.index.AddNode(node)
 
 	// This node is now the end of the best chain.
 	b.bestNode = node
@@ -1400,13 +1008,13 @@ func (b *BlockChain) disconnectBlock(node *blockNode, block *dcrutil.Block, view
 	// accessing node.parent directly as it will dynamically create previous
 	// block nodes as needed.  This helps allow only the pieces of the chain
 	// that are needed to remain in memory.
-	prevNode, err := b.getPrevNodeFromNode(node)
+	prevNode, err := b.index.PrevNodeFromNode(node)
 	if err != nil {
 		return err
 	}
 
 	// Calculate the median time for the previous block.
-	medianTime, err := b.calcPastMedianTime(prevNode)
+	medianTime, err := b.index.CalcPastMedianTime(prevNode)
 	if err != nil {
 		return err
 	}
@@ -1789,7 +1397,7 @@ func (b *BlockChain) reorganizeChain(detachNodes, attachNodes *list.List, flags 
 
 	// Log the point where the chain forked.
 	firstAttachNode := attachNodes.Front().Value.(*blockNode)
-	forkNode, err := b.getPrevNodeFromNode(firstAttachNode)
+	forkNode, err := b.index.PrevNodeFromNode(firstAttachNode)
 	if err == nil {
 		log.Infof("REORGANIZE: Chain forks at %v, height %v",
 			forkNode.hash,
@@ -2006,7 +1614,9 @@ func (b *BlockChain) connectBestChain(node *blockNode, block *dcrutil.Block, fla
 	b.blockCacheLock.Lock()
 	b.blockCache[node.hash] = block
 	b.blockCacheLock.Unlock()
-	b.index[node.hash] = node
+	b.index.Lock()
+	b.index.index[node.hash] = node
+	b.index.Unlock()
 
 	// Connect the parent node to this node.
 	node.inMainChain = false
@@ -2020,7 +1630,9 @@ func (b *BlockChain) connectBestChain(node *blockNode, block *dcrutil.Block, fla
 			children = removeChildNode(children, node)
 			node.parent.children = children
 
-			delete(b.index, node.hash)
+			b.index.Lock()
+			delete(b.index.index, node.hash)
+			b.index.Unlock()
 			b.blockCacheLock.Lock()
 			delete(b.blockCache, node.hash)
 			b.blockCacheLock.Unlock()
@@ -2042,7 +1654,7 @@ func (b *BlockChain) connectBestChain(node *blockNode, block *dcrutil.Block, fla
 				break
 			}
 			var err error
-			fork, err = b.getPrevNodeFromNode(fork)
+			fork, err = b.index.PrevNodeFromNode(fork)
 			if err != nil {
 				return false, err
 			}
@@ -2191,10 +1803,7 @@ func (b *BlockChain) MaxBlockSize() (int64, error) {
 // This function is safe for concurrent access.
 func (b *BlockChain) FetchHeader(hash *chainhash.Hash) (wire.BlockHeader, error) {
 	// Reconstruct the header from the block index if possible.
-	b.chainLock.RLock()
-	node, ok := b.index[*hash]
-	b.chainLock.RUnlock()
-	if ok {
+	if node := b.index.LookupNode(hash); node != nil {
 		return node.Header(), nil
 	}
 
@@ -2305,9 +1914,7 @@ func New(config *Config) (*BlockChain, error) {
 		notifications:                 config.Notifications,
 		sigCache:                      config.SigCache,
 		indexManager:                  config.IndexManager,
-		bestNode:                      nil,
-		index:                         make(map[chainhash.Hash]*blockNode),
-		depNodes:                      make(map[chainhash.Hash][]*blockNode),
+		index:                         newBlockIndex(config.DB, params),
 		orphans:                       make(map[chainhash.Hash]*orphanBlock),
 		prevOrphans:                   make(map[chainhash.Hash][]*orphanBlock),
 		blockCache:                    make(map[chainhash.Hash]*dcrutil.Block),

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1272,12 +1272,12 @@ func (b *BlockChain) createChainState() error {
 	// Create a new node from the genesis block and set it as the best node.
 	genesisBlock := dcrutil.NewBlock(b.chainParams.GenesisBlock)
 	header := &genesisBlock.MsgBlock().Header
-	node := newBlockNode(header, &stake.SpentTicketsInBlock{})
+	node := newBlockNode(header, nil)
 	node.inMainChain = true
 	b.bestNode = node
 
 	// Add the new node to the index which is used for faster lookups.
-	b.index[node.hash] = node
+	b.index.AddNode(node)
 
 	// Initialize the state related to the best block.  Since it is the
 	// genesis block, use its timestamp for the median time.
@@ -1455,12 +1455,10 @@ func (b *BlockChain) initChainState() error {
 		b.bestNode = node
 
 		// Add the new node to the indices for faster lookups.
-		prevHash := &node.parentHash
-		b.index[node.hash] = node
-		b.depNodes[*prevHash] = append(b.depNodes[*prevHash], node)
+		b.index.AddNode(node)
 
 		// Calculate the median time for the block.
-		medianTime, err := b.calcPastMedianTime(node)
+		medianTime, err := b.index.CalcPastMedianTime(node)
 		if err != nil {
 			return err
 		}

--- a/blockchain/difficulty.go
+++ b/blockchain/difficulty.go
@@ -10,7 +10,6 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/decred/dcrd/blockchain/stake"
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/wire"
@@ -221,9 +220,9 @@ func (b *BlockChain) findPrevTestNetDifficulty(startNode *blockNode) (uint32, er
 		// helps allow only the pieces of the chain that are needed
 		// to remain in memory.
 		var err error
-		iterNode, err = b.getPrevNodeFromNode(iterNode)
+		iterNode, err = b.index.PrevNodeFromNode(iterNode)
 		if err != nil {
-			log.Errorf("getPrevNodeFromNode: %v", err)
+			log.Errorf("PrevNodeFromNode: %v", err)
 			return 0, err
 		}
 	}
@@ -377,7 +376,7 @@ func (b *BlockChain) calcNextRequiredDifficulty(curNode *blockNode, newBlockTime
 		// to remain in memory.
 		var err error
 		tempNode := oldNode
-		oldNode, err = b.getPrevNodeFromNode(oldNode)
+		oldNode, err = b.index.PrevNodeFromNode(oldNode)
 		if err != nil {
 			return 0, err
 		}
@@ -585,7 +584,7 @@ func (b *BlockChain) calcNextRequiredStakeDifficultyV1(curNode *blockNode) (int6
 		// Get the previous block node.
 		var err error
 		tempNode := oldNode
-		oldNode, err = b.getPrevNodeFromNode(oldNode)
+		oldNode, err = b.index.PrevNodeFromNode(oldNode)
 		if err != nil {
 			return 0, err
 		}
@@ -680,7 +679,7 @@ func (b *BlockChain) calcNextRequiredStakeDifficultyV1(curNode *blockNode) (int6
 		// Get the previous block node.
 		var err error
 		tempNode := oldNode
-		oldNode, err = b.getPrevNodeFromNode(oldNode)
+		oldNode, err = b.index.PrevNodeFromNode(oldNode)
 		if err != nil {
 			return 0, err
 		}
@@ -803,7 +802,7 @@ func (b *BlockChain) sumPurchasedTickets(startNode *blockNode, numToSum int64) (
 		// helps allow only the pieces of the chain that are needed
 		// to remain in memory.
 		var err error
-		node, err = b.getPrevNodeFromNode(node)
+		node, err = b.index.PrevNodeFromNode(node)
 		if err != nil {
 			return 0, err
 		}
@@ -922,7 +921,7 @@ func (b *BlockChain) calcNextRequiredStakeDifficultyV2(curNode *blockNode) (int6
 	// originally calculated.
 	var prevPoolSize int64
 	prevRetargetHeight := nextHeight - intervalSize - 1
-	prevRetargetNode, err := b.ancestorNode(curNode, prevRetargetHeight)
+	prevRetargetNode, err := b.index.AncestorNode(curNode, prevRetargetHeight)
 	if err != nil {
 		return 0, err
 	}
@@ -1088,7 +1087,7 @@ func (b *BlockChain) estimateNextStakeDifficultyV1(curNode *blockNode, ticketsIn
 			// Connect the header.
 			emptyHeader.PrevBlock = topNode.hash
 
-			thisNode := newBlockNode(&emptyHeader, &stake.SpentTicketsInBlock{})
+			thisNode := newBlockNode(&emptyHeader, nil)
 			thisNode.parent = topNode
 			topNode = thisNode
 		}
@@ -1153,7 +1152,7 @@ func (b *BlockChain) estimateNextStakeDifficultyV1(curNode *blockNode, ticketsIn
 		// Get the previous block node.
 		var err error
 		tempNode := oldNode
-		oldNode, err = b.getPrevNodeFromNode(oldNode)
+		oldNode, err = b.index.PrevNodeFromNode(oldNode)
 		if err != nil {
 			return 0, err
 		}
@@ -1248,7 +1247,7 @@ func (b *BlockChain) estimateNextStakeDifficultyV1(curNode *blockNode, ticketsIn
 		// Get the previous block node.
 		var err error
 		tempNode := oldNode
-		oldNode, err = b.getPrevNodeFromNode(oldNode)
+		oldNode, err = b.index.PrevNodeFromNode(oldNode)
 		if err != nil {
 			return 0, err
 		}
@@ -1380,7 +1379,7 @@ func (b *BlockChain) estimateNextStakeDifficultyV2(curNode *blockNode, newTicket
 	// originally calculated.
 	var prevPoolSize int64
 	prevRetargetHeight := nextRetargetHeight - intervalSize - 1
-	prevRetargetNode, err := b.ancestorNode(curNode, prevRetargetHeight)
+	prevRetargetNode, err := b.index.AncestorNode(curNode, prevRetargetHeight)
 	if err != nil {
 		return 0, err
 	}
@@ -1417,7 +1416,8 @@ func (b *BlockChain) estimateNextStakeDifficultyV2(curNode *blockNode, newTicket
 	// maturing at the height in which they mature since they are not
 	// eligible for selection until the next block, so exclude them by
 	// starting one block before the next maturity floor.
-	nextMaturityFloorNode, err := b.ancestorNode(curNode, nextMaturityFloor-1)
+	nextMaturityFloorNode, err := b.index.AncestorNode(curNode,
+		nextMaturityFloor-1)
 	if err != nil {
 		return 0, err
 	}

--- a/blockchain/difficulty_test.go
+++ b/blockchain/difficulty_test.go
@@ -10,7 +10,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/decred/dcrd/blockchain/stake"
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/wire"
 )
@@ -429,8 +428,7 @@ nextTest:
 					FreshStake: ticketInfo.newTickets,
 					PoolSize:   poolSize,
 				}
-				node := newBlockNode(header,
-					&stake.SpentTicketsInBlock{})
+				node := newBlockNode(header, nil)
 				node.parent = bc.bestNode
 
 				// Update the pool size for the next header.
@@ -731,8 +729,7 @@ nextTest:
 					FreshStake: ticketInfo.newTickets,
 					PoolSize:   poolSize,
 				}
-				node := newBlockNode(header,
-					&stake.SpentTicketsInBlock{})
+				node := newBlockNode(header, nil)
 				node.parent = bc.bestNode
 
 				// Update the pool size for the next header.

--- a/blockchain/process.go
+++ b/blockchain/process.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -44,8 +44,8 @@ const (
 //
 // This function MUST be called with the chain state lock held (for reads).
 func (b *BlockChain) blockExists(hash *chainhash.Hash) (bool, error) {
-	// Check memory chain first (could be main chain or side chain blocks).
-	if _, ok := b.index[*hash]; ok {
+	// Check block index first (could be main chain or side chain blocks).
+	if b.index.HaveBlock(hash) {
 		return true, nil
 	}
 

--- a/blockchain/sequencelock.go
+++ b/blockchain/sequencelock.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The Decred developers
+// Copyright (c) 2017-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -101,14 +101,14 @@ func (b *BlockChain) calcSequenceLock(node *blockNode, tx *dcrutil.Tx, view *Utx
 			if prevInputHeight < 0 {
 				prevInputHeight = 0
 			}
-			blockNode, err := b.ancestorNode(node, prevInputHeight)
+			blockNode, err := b.index.AncestorNode(node, prevInputHeight)
 			if err != nil {
 				return sequenceLock, err
 			}
 
 			// Calculate the past median time of the block prior to
 			// the one which included the output being spent.
-			medianTime, err := b.calcPastMedianTime(blockNode)
+			medianTime, err := b.index.CalcPastMedianTime(blockNode)
 			if err != nil {
 				return sequenceLock, err
 			}

--- a/blockchain/sequencelock_test.go
+++ b/blockchain/sequencelock_test.go
@@ -41,7 +41,7 @@ func TestCalcSequenceLock(t *testing.T) {
 	for i := uint32(0); i < numBlocks; i++ {
 		blockTime = blockTime.Add(time.Second)
 		node = newFakeNode(node, 1, 1, 0, blockTime)
-		bc.index[node.hash] = node
+		bc.index.AddNode(node)
 		bc.bestNode = node
 	}
 
@@ -74,11 +74,11 @@ func TestCalcSequenceLock(t *testing.T) {
 	// Obtain the median time past from the PoV of the input created above.
 	// The median time for the input is the median time from the PoV of the
 	// block *prior* to the one that included it.
-	medianNode, err := bc.ancestorNode(node, node.height-5)
+	medianNode, err := bc.index.AncestorNode(node, node.height-5)
 	if err != nil {
 		t.Fatalf("Unable to obtain median node: %v", err)
 	}
-	medianT, err := bc.calcPastMedianTime(medianNode)
+	medianT, err := bc.index.CalcPastMedianTime(medianNode)
 	if err != nil {
 		t.Fatalf("Unable to obtain median node time: %v", err)
 	}
@@ -88,7 +88,7 @@ func TestCalcSequenceLock(t *testing.T) {
 	// test chain.  For unconfirmed inputs, this value will be used since
 	// the median time will be calculated from the PoV of the
 	// yet-to-be-mined block.
-	nextMedianT, err := bc.calcPastMedianTime(node)
+	nextMedianT, err := bc.index.CalcPastMedianTime(node)
 	if err != nil {
 		t.Fatalf("Unable to obtain next median node time: %v", err)
 	}

--- a/blockchain/stakeext.go
+++ b/blockchain/stakeext.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -51,7 +51,7 @@ func (b *BlockChain) lotteryDataForNode(node *blockNode) ([]chainhash.Hash, int,
 // held for write access.
 func (b *BlockChain) lotteryDataForBlock(hash *chainhash.Hash) ([]chainhash.Hash, int, [6]byte, error) {
 	var node *blockNode
-	if n, exists := b.index[*hash]; exists {
+	if n := b.index.LookupNode(hash); n != nil {
 		node = n
 	} else {
 		var err error

--- a/blockchain/stakenode.go
+++ b/blockchain/stakenode.go
@@ -22,7 +22,7 @@ func (b *BlockChain) nodeAtHeightFromTopNode(node *blockNode, toTraverse int64) 
 
 	for i := 0; i < int(toTraverse); i++ {
 		// Get the previous block node.
-		oldNode, err = b.getPrevNodeFromNode(oldNode)
+		oldNode, err = b.index.PrevNodeFromNode(oldNode)
 		if err != nil {
 			return nil, err
 		}

--- a/blockchain/stakeversion.go
+++ b/blockchain/stakeversion.go
@@ -75,7 +75,7 @@ func (b *BlockChain) findStakeVersionPriorNode(prevNode *blockNode) (*blockNode,
 	iterNode := prevNode
 	for iterNode.height > wantHeight {
 		var err error
-		iterNode, err = b.getPrevNodeFromNode(iterNode)
+		iterNode, err = b.index.PrevNodeFromNode(iterNode)
 		if err != nil {
 			return nil, err
 		}
@@ -123,7 +123,7 @@ func (b *BlockChain) isVoterMajorityVersion(minVer uint32, prevNode *blockNode) 
 		}
 
 		var err error
-		iterNode, err = b.getPrevNodeFromNode(iterNode)
+		iterNode, err = b.index.PrevNodeFromNode(iterNode)
 		if err != nil {
 			return false
 		}
@@ -175,7 +175,7 @@ func (b *BlockChain) isStakeMajorityVersion(minVer uint32, prevNode *blockNode) 
 		}
 
 		var err error
-		iterNode, err = b.getPrevNodeFromNode(iterNode)
+		iterNode, err = b.index.PrevNodeFromNode(iterNode)
 		if err != nil {
 			b.isStakeMajorityVersionCache[key] = false
 			return false
@@ -222,7 +222,7 @@ func (b *BlockChain) calcPriorStakeVersion(prevNode *blockNode) (uint32, error) 
 		versions[iterNode.stakeVersion]++
 
 		var err error
-		iterNode, err = b.getPrevNodeFromNode(iterNode)
+		iterNode, err = b.index.PrevNodeFromNode(iterNode)
 		if err != nil {
 			return 0, err
 		}
@@ -273,7 +273,7 @@ func (b *BlockChain) calcVoterVersionInterval(prevNode *blockNode) (uint32, erro
 			versions[v.Version]++
 		}
 
-		iterNode, err = b.getPrevNodeFromNode(iterNode)
+		iterNode, err = b.index.PrevNodeFromNode(iterNode)
 		if err != nil {
 			return 0, err
 		}
@@ -329,7 +329,7 @@ func (b *BlockChain) calcVoterVersion(prevNode *blockNode) (uint32, *blockNode) 
 
 		// findStakeVersionPriorNode increases the height so we need to
 		// compensate by loading the prior node.
-		iterNode, err = b.getPrevNodeFromNode(iterNode)
+		iterNode, err = b.index.PrevNodeFromNode(iterNode)
 		if err != nil {
 			break
 		}
@@ -370,7 +370,7 @@ func (b *BlockChain) calcStakeVersion(prevNode *blockNode) uint32 {
 	iterNode := node
 	for iterNode.height > startIntervalHeight {
 		var err error
-		iterNode, err = b.getPrevNodeFromNode(iterNode)
+		iterNode, err = b.index.PrevNodeFromNode(iterNode)
 		if err != nil || iterNode == nil {
 			b.calcStakeVersionCache[node.hash] = 0
 			return 0

--- a/blockchain/stakeversion_test.go
+++ b/blockchain/stakeversion_test.go
@@ -22,10 +22,10 @@ import (
 func newFakeChain(params *chaincfg.Params) *BlockChain {
 	// Create a genesis block node and block index populated with it for use
 	// when creating the fake chain below.
-	node := newBlockNode(&params.GenesisBlock.Header, &stake.SpentTicketsInBlock{})
+	node := newBlockNode(&params.GenesisBlock.Header, nil)
 	node.inMainChain = true
-	index := make(map[chainhash.Hash]*blockNode)
-	index[node.hash] = node
+	index := newBlockIndex(nil, params)
+	index.AddNode(node)
 
 	return &BlockChain{
 		chainParams:      params,
@@ -53,7 +53,7 @@ func newFakeNode(parent *blockNode, blockVersion int32, stakeVersion uint32, bit
 		Timestamp:    timestamp,
 		StakeVersion: stakeVersion,
 	}
-	node := newBlockNode(header, &stake.SpentTicketsInBlock{})
+	node := newBlockNode(header, nil)
 	node.parent = parent
 	node.workSum.Add(parent.workSum, node.workSum)
 	return node

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -682,9 +682,9 @@ func (b *BlockChain) checkBlockHeaderContext(header *wire.BlockHeader, prevNode 
 
 		// Ensure the timestamp for the block header is after the
 		// median time of the last several blocks (medianTimeBlocks).
-		medianTime, err := b.calcPastMedianTime(prevNode)
+		medianTime, err := b.index.CalcPastMedianTime(prevNode)
 		if err != nil {
-			log.Errorf("calcPastMedianTime: %v", err)
+			log.Errorf("CalcPastMedianTime: %v", err)
 			return err
 		}
 		if !header.Timestamp.After(medianTime) {
@@ -2482,7 +2482,7 @@ func (b *BlockChain) checkConnectBlock(node *blockNode, block *dcrutil.Block, ut
 		// Use the past median time of the *previous* block in order
 		// to determine if the transactions in the current block are
 		// final.
-		prevMedianTime, err = b.calcPastMedianTime(node.parent)
+		prevMedianTime, err = b.index.CalcPastMedianTime(node.parent)
 		if err != nil {
 			return err
 		}
@@ -2620,10 +2620,6 @@ func (b *BlockChain) CheckConnectBlock(block *dcrutil.Block) error {
 		stake.FindSpentTicketsInBlock(block.MsgBlock()))
 	newNode.parent = prevNode
 	newNode.workSum.Add(prevNode.workSum, newNode.workSum)
-	if prevNode != nil {
-		newNode.parent = prevNode
-		newNode.workSum.Add(prevNode.workSum, newNode.workSum)
-	}
 
 	// If we are extending the main (best) chain with a new block, just use
 	// the ticket database we already have.

--- a/blockchain/votebits_test.go
+++ b/blockchain/votebits_test.go
@@ -168,7 +168,7 @@ func TestNoQuorum(t *testing.T) {
 	for i := uint32(0); i < uint32(params.StakeValidationHeight); i++ {
 		node = newFakeNode(node, powVersion, posVersion, 0, curTimestamp)
 		bc.bestNode = node
-		bc.index[node.hash] = node
+		bc.index.AddNode(node)
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
 	ts, err := bc.ThresholdState(&node.hash, posVersion, pedro.Id)
@@ -189,7 +189,7 @@ func TestNoQuorum(t *testing.T) {
 		node = newFakeNode(node, powVersion, posVersion, 0, curTimestamp)
 		appendFakeVotes(node, params.TicketsPerBlock, posVersion, 0x01)
 		bc.bestNode = node
-		bc.index[node.hash] = node
+		bc.index.AddNode(node)
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
 
@@ -220,7 +220,7 @@ func TestNoQuorum(t *testing.T) {
 		}
 
 		bc.bestNode = node
-		bc.index[node.hash] = node
+		bc.index.AddNode(node)
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
 
@@ -257,7 +257,7 @@ func TestNoQuorum(t *testing.T) {
 		}
 
 		bc.bestNode = node
-		bc.index[node.hash] = node
+		bc.index.AddNode(node)
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
 
@@ -294,7 +294,7 @@ func TestNoQuorum(t *testing.T) {
 		}
 
 		bc.bestNode = node
-		bc.index[node.hash] = node
+		bc.index.AddNode(node)
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
 
@@ -325,7 +325,7 @@ func TestYesQuorum(t *testing.T) {
 		node = newFakeNode(node, powVersion, posVersion, 0, curTimestamp)
 
 		bc.bestNode = node
-		bc.index[node.hash] = node
+		bc.index.AddNode(node)
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
 	ts, err := bc.ThresholdState(&node.hash, posVersion, pedro.Id)
@@ -346,7 +346,7 @@ func TestYesQuorum(t *testing.T) {
 		node = newFakeNode(node, powVersion, posVersion, 0, curTimestamp)
 		appendFakeVotes(node, params.TicketsPerBlock, posVersion, 0x01)
 		bc.bestNode = node
-		bc.index[node.hash] = node
+		bc.index.AddNode(node)
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
 
@@ -377,7 +377,7 @@ func TestYesQuorum(t *testing.T) {
 		}
 
 		bc.bestNode = node
-		bc.index[node.hash] = node
+		bc.index.AddNode(node)
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
 
@@ -414,7 +414,7 @@ func TestYesQuorum(t *testing.T) {
 		}
 
 		bc.bestNode = node
-		bc.index[node.hash] = node
+		bc.index.AddNode(node)
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
 
@@ -452,7 +452,7 @@ func TestYesQuorum(t *testing.T) {
 		}
 
 		bc.bestNode = node
-		bc.index[node.hash] = node
+		bc.index.AddNode(node)
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
 
@@ -1521,7 +1521,7 @@ func TestVoting(t *testing.T) {
 					vote.Version, vote.Bits)
 
 				bc.bestNode = node
-				bc.index[node.hash] = node
+				bc.index.AddNode(node)
 				curTimestamp = curTimestamp.Add(time.Second)
 			}
 			t.Logf("Height %v, Start time %v, curTime %v, delta %v",
@@ -1750,7 +1750,7 @@ func TestParallelVoting(t *testing.T) {
 					vote.Version, vote.Bits)
 
 				bc.bestNode = node
-				bc.index[node.hash] = node
+				bc.index.AddNode(node)
 				curTimestamp = curTimestamp.Add(time.Second)
 			}
 			for i := range test.vote {


### PR DESCRIPTION
**This requires #989**.

This refactors the block index logic into a separate struct and introduces an individual lock for it so it can be queried independent of the chain lock.

It also modifies the `newBlockNode` function to accept nil for the ticket spend information parameter and updates all of the test code that doesn't require it to use nil.

