### PR TITLE
blockchain: Use hash values in structs.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -67,20 +67,20 @@ type orphanBlock struct {
 // However, the returned snapshot must be treated as immutable since it is
 // shared by all callers.
 type BestState struct {
-	Hash         *chainhash.Hash // The hash of the block.
-	Height       int64           // The height of the block.
-	Bits         uint32          // The difficulty bits of the block.
-	BlockSize    uint64          // The size of the block.
-	NumTxns      uint64          // The number of txns in the block.
-	TotalTxns    uint64          // The total number of txns in the chain.
-	MedianTime   time.Time       // Median time as per CalcPastMedianTime.
-	TotalSubsidy int64           // The total subsidy for the chain.
+	Hash         chainhash.Hash // The hash of the block.
+	Height       int64          // The height of the block.
+	Bits         uint32         // The difficulty bits of the block.
+	BlockSize    uint64         // The size of the block.
+	NumTxns      uint64         // The number of txns in the block.
+	TotalTxns    uint64         // The total number of txns in the chain.
+	MedianTime   time.Time      // Median time as per CalcPastMedianTime.
+	TotalSubsidy int64          // The total subsidy for the chain.
 }
 
 // newBestState returns a new best stats instance for the given parameters.
 func newBestState(node *blockNode, blockSize, numTxns, totalTxns uint64, medianTime time.Time, totalSubsidy int64) *BestState {
 	return &BestState{
-		Hash:         &node.hash,
+		Hash:         node.hash,
 		Height:       node.height,
 		Bits:         node.bits,
 		BlockSize:    blockSize,

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1254,7 +1254,7 @@ func deserializeBestChainState(serializedData []byte) (bestChainState, error) {
 func dbPutBestState(dbTx database.Tx, snapshot *BestState, workSum *big.Int) error {
 	// Serialize the current best chain state.
 	serializedData := serializeBestChainState(bestChainState{
-		hash:         *snapshot.Hash,
+		hash:         snapshot.Hash,
 		height:       uint32(snapshot.Height),
 		totalTxns:    snapshot.TotalTxns,
 		totalSubsidy: snapshot.TotalSubsidy,

--- a/blockchain/fullblocks_test.go
+++ b/blockchain/fullblocks_test.go
@@ -161,7 +161,7 @@ func TestFullBlocks(t *testing.T) {
 
 		// Ensure hash and height match.
 		best := chain.BestSnapshot()
-		if *best.Hash != item.Block.BlockHash() ||
+		if best.Hash != item.Block.BlockHash() ||
 			best.Height != int64(blockHeight) {
 
 			t.Fatalf("block %q (hash %s, height %d) should be "+

--- a/blockchain/upgrade.go
+++ b/blockchain/upgrade.go
@@ -71,7 +71,7 @@ func (b *BlockChain) upgradeToVersion2() error {
 
 			// Write the top block stake node to the database.
 			errLocal = stake.WriteConnectedBestNode(dbTx, bestStakeNode,
-				*best.Hash)
+				best.Hash)
 			if errLocal != nil {
 				return errLocal
 			}

--- a/cmd/findcheckpoint/findcheckpoint.go
+++ b/cmd/findcheckpoint/findcheckpoint.go
@@ -166,7 +166,7 @@ func main() {
 	fmt.Printf("Block database loaded with block height %d\n", best.Height)
 
 	// Find checkpoint candidates.
-	candidates, err := findCandidates(chain, best.Hash)
+	candidates, err := findCandidates(chain, &best.Hash)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Unable to identify candidates:", err)
 		return

--- a/mining.go
+++ b/mining.go
@@ -1196,7 +1196,7 @@ func NewBlockTemplate(policy *mining.Policy, server *server,
 	chainState.Unlock()
 
 	chainBest := blockManager.chain.BestSnapshot()
-	if *prevHash != *chainBest.Hash ||
+	if *prevHash != chainBest.Hash ||
 		nextBlockHeight-1 != chainBest.Height {
 		return nil, fmt.Errorf("chain state is not syncronized to the "+
 			"blockchain (got %v:%v, want %v,%v",

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3574,7 +3574,7 @@ func handleGetStakeVersionInfo(s *rpcServer, cmd interface{}, closeChan <-chan s
 	startHeight := snapshot.Height
 	endHeight := s.chain.CalcWantHeight(interval,
 		snapshot.Height) + 1
-	hash := snapshot.Hash
+	hash := &snapshot.Hash
 	adjust := int32(1) // We are off by one on the initial iteration.
 	for i := int32(0); i < count; i++ {
 		numBlocks := int32(startHeight - endHeight)
@@ -3705,7 +3705,7 @@ func handleGetVoteInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{})
 			"Could not count voter versions")
 	}
 
-	vi, err := s.chain.GetVoteInfo(snapshot.Hash, c.Version)
+	vi, err := s.chain.GetVoteInfo(&snapshot.Hash, c.Version)
 	if err != nil {
 		return nil, rpcInternalError(err.Error(),
 			"Could not obtain vote info")
@@ -3736,7 +3736,7 @@ func handleGetVoteInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{})
 		}
 
 		// Obtain status of agenda.
-		state, err := s.chain.ThresholdState(snapshot.Hash, c.Version,
+		state, err := s.chain.ThresholdState(&snapshot.Hash, c.Version,
 			agenda.Vote.Id)
 		if err != nil {
 			return nil, err

--- a/server.go
+++ b/server.go
@@ -225,7 +225,7 @@ func newServerPeer(s *server, isPersistent bool) *serverPeer {
 // required by the configuration for the peer package.
 func (sp *serverPeer) newestBlock() (*chainhash.Hash, int64, error) {
 	best := sp.server.blockManager.chain.BestSnapshot()
-	return best.Hash, best.Height, nil
+	return &best.Hash, best.Height, nil
 }
 
 // addKnownAddresses adds the given addresses to the set of known addreses to
@@ -1157,7 +1157,7 @@ func (s *server) pushBlockMsg(sp *serverPeer, hash *chainhash.Hash, doneChan cha
 	if sendInv {
 		best := sp.server.blockManager.chain.BestSnapshot()
 		invMsg := wire.NewMsgInvSizeHint(1)
-		iv := wire.NewInvVect(wire.InvTypeBlock, best.Hash)
+		iv := wire.NewInvVect(wire.InvTypeBlock, &best.Hash)
 		invMsg.AddInvVect(iv)
 		sp.QueueMessage(invMsg, doneChan)
 		sp.continueHash = nil
@@ -2452,7 +2452,7 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 		},
 		FetchUtxoView:    bm.chain.FetchUtxoView,
 		BlockByHash:      bm.chain.BlockByHash,
-		BestHash:         func() *chainhash.Hash { return bm.chain.BestSnapshot().Hash },
+		BestHash:         func() *chainhash.Hash { return &bm.chain.BestSnapshot().Hash },
 		BestHeight:       func() int64 { return bm.chain.BestSnapshot().Height },
 		CalcSequenceLock: bm.chain.CalcSequenceLock,
 		SubsidyCache:     bm.chain.FetchSubsidyCache(),


### PR DESCRIPTION
**This requires #990**

This modifies the `BestState` struct in the `blockchain` package to store hashes directly instead of pointers to them and updates callers to deal with the API change in the exported `BestState` struct.

In general, the preferred approach for hashes moving forward is to store hash values in complex data structures, particularly those that will be used for cache entries, and accept pointers to hashes in arguments to functions.

Some of the reasoning behind making this change is:

- It is generally preferred to avoid storing pointers to data in cache objects since doing so can easily lead to storing interior pointers into other structs that then can't be GC'd
- Keeping the hash values directly in the structs provides better cache locality
