### PR TITLE
multi: Simplify code per gosimple linter.

### DIFF
--- a/rpctest/rpc_harness.go
+++ b/rpctest/rpc_harness.go
@@ -251,12 +251,10 @@ func (h *Harness) SetUp(createTestChain bool, numMatureOutputs uint32) error {
 		return err
 	}
 	ticker := time.NewTicker(time.Millisecond * 100)
-out:
-	for {
-		<-ticker.C
+	for range ticker.C {
 		walletHeight := h.wallet.SyncedHeight()
 		if walletHeight == height {
-			break out
+			break
 		}
 	}
 

--- a/service_windows.go
+++ b/service_windows.go
@@ -157,12 +157,7 @@ func installService() error {
 	// messges instead of needing to create our own message catalog.
 	eventlog.Remove(svcName)
 	eventsSupported := uint32(eventlog.Error | eventlog.Warning | eventlog.Info)
-	err = eventlog.InstallAsEventCreate(svcName, eventsSupported)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return eventlog.InstallAsEventCreate(svcName, eventsSupported)
 }
 
 // removeService attempts to uninstall the dcrd service.  Typically this should
@@ -185,12 +180,7 @@ func removeService() error {
 	defer service.Close()
 
 	// Remove the service.
-	err = service.Delete()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return service.Delete()
 }
 
 // startService attempts to start the dcrd service.


### PR DESCRIPTION
This simplifies the code based on the recommendations of the `gosimple` lint tool.