### PR TITLE
stake/multi: Don't return errors for IsX functions.

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -223,7 +223,7 @@ func ticketsRevokedInBlock(bl *dcrutil.Block) []chainhash.Hash {
 func voteBitsInBlock(bl *dcrutil.Block) []stake.VoteVersionTuple {
 	var voteBits []stake.VoteVersionTuple
 	for _, stx := range bl.MsgBlock().STransactions {
-		if is, _ := stake.IsSSGen(stx); !is {
+		if stake.IsSSGen(stx) {
 			continue
 		}
 

--- a/blockchain/indexers/addrindex.go
+++ b/blockchain/indexers/addrindex.go
@@ -760,7 +760,7 @@ func (idx *AddrIndex) indexBlock(data writeIndexData, block, parent *dcrutil.Blo
 		msgTx := tx.MsgTx()
 		thisTxOffset := txIdx + len(parentRegularTxs)
 
-		isSSGen, _ := stake.IsSSGen(msgTx)
+		isSSGen := stake.IsSSGen(msgTx)
 		for i, txIn := range msgTx.TxIn {
 			// Skip stakebases.
 			if isSSGen && i == 0 {
@@ -786,7 +786,7 @@ func (idx *AddrIndex) indexBlock(data writeIndexData, block, parent *dcrutil.Blo
 				txType == stake.TxTypeSStx)
 		}
 
-		isSStx, _ := stake.IsSStx(msgTx)
+		isSStx := stake.IsSStx(msgTx)
 		for _, txOut := range msgTx.TxOut {
 			idx.indexPkScript(data, txOut.Version, txOut.PkScript,
 				thisTxOffset, isSStx)
@@ -992,7 +992,7 @@ func (idx *AddrIndex) AddUnconfirmedTx(tx *dcrutil.Tx, utxoView *blockchain.Utxo
 	// transaction has already been validated and thus all inputs are
 	// already known to exist.
 	msgTx := tx.MsgTx()
-	isSSGen, _ := stake.IsSSGen(msgTx)
+	isSSGen := stake.IsSSGen(msgTx)
 	for i, txIn := range msgTx.TxIn {
 		// Skip stakebase.
 		if i == 0 && isSSGen {
@@ -1014,7 +1014,7 @@ func (idx *AddrIndex) AddUnconfirmedTx(tx *dcrutil.Tx, utxoView *blockchain.Utxo
 	}
 
 	// Index addresses of all created outputs.
-	isSStx, _ := stake.IsSStx(msgTx)
+	isSStx := stake.IsSStx(msgTx)
 	for _, txOut := range msgTx.TxOut {
 		idx.indexUnconfirmedAddresses(txOut.Version, txOut.PkScript, tx,
 			isSStx)

--- a/blockchain/indexers/existsaddrindex.go
+++ b/blockchain/indexers/existsaddrindex.go
@@ -225,7 +225,7 @@ func (idx *ExistsAddrIndex) ConnectBlock(dbTx database.Tx, block, parent *dcruti
 
 	for _, tx := range allTxns {
 		msgTx := tx.MsgTx()
-		isSStx, _ := stake.IsSStx(msgTx)
+		isSStx := stake.IsSStx(msgTx)
 		for _, txIn := range msgTx.TxIn {
 			if txscript.IsMultisigSigScript(txIn.SignatureScript) {
 				rs, err :=
@@ -331,7 +331,7 @@ func (idx *ExistsAddrIndex) DisconnectBlock(dbTx database.Tx, block, parent *dcr
 // addUnconfirmedTx adds all addresses related to the transaction to the
 // unconfirmed (memory-only) exists address index.
 func (idx *ExistsAddrIndex) addUnconfirmedTx(tx *wire.MsgTx) {
-	isSStx, _ := stake.IsSStx(tx)
+	isSStx := stake.IsSStx(tx)
 	for _, txIn := range tx.TxIn {
 		if txscript.IsMultisigSigScript(txIn.SignatureScript) {
 			rs, err :=

--- a/blockchain/indexers/manager.go
+++ b/blockchain/indexers/manager.go
@@ -543,7 +543,7 @@ func makeUtxoView(dbTx database.Tx, block, parent *dcrutil.Block) (*blockchain.U
 
 	for _, tx := range block.STransactions() {
 		msgTx := tx.MsgTx()
-		isSSGen, _ := stake.IsSSGen(msgTx)
+		isSSGen := stake.IsSSGen(msgTx)
 
 		// Use the transaction index to load all of the referenced
 		// inputs and add their outputs to the view.

--- a/blockchain/sequencelock.go
+++ b/blockchain/sequencelock.go
@@ -32,8 +32,7 @@ type SequenceLock struct {
 // that does not care about the specific reason the transaction is not a
 // stakebase, rather only if it is one or not.
 func isStakeBaseTx(tx *wire.MsgTx) bool {
-	isStakeBase, _ := stake.IsSSGen(tx)
-	return isStakeBase
+	return stake.IsSSGen(tx)
 }
 
 // calcSequenceLock computes the relative lock times for the passed transaction

--- a/blockchain/stake/staketx_test.go
+++ b/blockchain/stake/staketx_test.go
@@ -20,15 +20,19 @@ import (
 
 // SSTX TESTING -------------------------------------------------------------------
 
-func TestIsSStx(t *testing.T) {
+// TestSStx ensures the CheckSStx and IsSStx functions correctly recognize stake
+// submission transactions.
+func TestSStx(t *testing.T) {
 	var sstx = dcrutil.NewTx(sstxMsgTx)
 	sstx.SetTree(wire.TxTreeStake)
 	sstx.SetIndex(0)
 
-	test, err := stake.IsSStx(sstx.MsgTx())
-	if !test || err != nil {
-		t.Errorf("IsSSTx should have returned true,<nil> but instead returned %v"+
-			",%v", test, err)
+	err := stake.CheckSStx(sstx.MsgTx())
+	if err != nil {
+		t.Errorf("CheckSStx: unexpected err: %v", err)
+	}
+	if !stake.IsSStx(sstx.MsgTx()) {
+		t.Errorf("IsSStx claimed a valid sstx is invalid")
 	}
 
 	// ---------------------------------------------------------------------------
@@ -52,14 +56,18 @@ func TestIsSStx(t *testing.T) {
 	sstx.SetTree(wire.TxTreeStake)
 	sstx.SetIndex(0)
 
-	test, err = stake.IsSStx(sstx.MsgTx())
-	if !test || err != nil {
-		t.Errorf("IsSSTx should have returned true,<nil> but instead returned %v"+
-			",%v", test, err)
+	err = stake.CheckSStx(sstx.MsgTx())
+	if err != nil {
+		t.Errorf("CheckSStx: unexpected err: %v", err)
+	}
+	if !stake.IsSStx(sstx.MsgTx()) {
+		t.Errorf("IsSStx claimed a valid sstx is invalid")
 	}
 }
 
-func TestIsSSTxErrors(t *testing.T) {
+// TestSSTxErrors ensures the CheckSStx and IsSStx functions correctly identify
+// errors in stake submission transactions and does not report them as valid.
+func TestSSTxErrors(t *testing.T) {
 	// Initialize the buffer for later manipulation
 	var buf bytes.Buffer
 	buf.Grow(sstxMsgTx.SerializeSize())
@@ -76,11 +84,13 @@ func TestIsSSTxErrors(t *testing.T) {
 	sstxExtraInputs.SetTree(wire.TxTreeStake)
 	sstxExtraInputs.SetIndex(0)
 
-	test, err := stake.IsSStx(sstxExtraInputs.MsgTx())
-	if test || err.(stake.RuleError).GetCode() !=
-		stake.ErrSStxTooManyInputs {
-		t.Errorf("IsSSTx should have returned false,%v but instead returned %v"+
-			",%v", stake.ErrSStxTooManyInputs, test, err)
+	err = stake.CheckSStx(sstxExtraInputs.MsgTx())
+	if err.(stake.RuleError).GetCode() != stake.ErrSStxTooManyInputs {
+		t.Errorf("CheckSStx should have returned %v but instead returned %v",
+			stake.ErrSStxTooManyInputs, err)
+	}
+	if stake.IsSStx(sstxExtraInputs.MsgTx()) {
+		t.Errorf("IsSStx claimed an invalid sstx is valid")
 	}
 
 	// ---------------------------------------------------------------------------
@@ -90,11 +100,13 @@ func TestIsSSTxErrors(t *testing.T) {
 	sstxExtraOutputs.SetTree(wire.TxTreeStake)
 	sstxExtraOutputs.SetIndex(0)
 
-	test, err = stake.IsSStx(sstxExtraOutputs.MsgTx())
-	if test || err.(stake.RuleError).GetCode() !=
-		stake.ErrSStxTooManyOutputs {
-		t.Errorf("IsSSTx should have returned false,%v but instead returned %v"+
-			",%v", stake.ErrSStxTooManyOutputs, test, err)
+	err = stake.CheckSStx(sstxExtraOutputs.MsgTx())
+	if err.(stake.RuleError).GetCode() != stake.ErrSStxTooManyOutputs {
+		t.Errorf("CheckSStx should have returned %v but instead returned %v",
+			stake.ErrSStxTooManyOutputs, err)
+	}
+	if stake.IsSStx(sstxExtraOutputs.MsgTx()) {
+		t.Errorf("IsSStx claimed an invalid sstx is valid")
 	}
 
 	// ---------------------------------------------------------------------------
@@ -119,11 +131,13 @@ func TestIsSSTxErrors(t *testing.T) {
 	sstxUntaggedOut.SetTree(wire.TxTreeStake)
 	sstxUntaggedOut.SetIndex(0)
 
-	test, err = stake.IsSStx(sstxUntaggedOut.MsgTx())
-	if test || err.(stake.RuleError).GetCode() !=
-		stake.ErrSStxInvalidOutputs {
-		t.Errorf("IsSSTx should have returned false,%v but instead returned %v"+
-			",%v", stake.ErrSStxInvalidOutputs, test, err)
+	err = stake.CheckSStx(sstxUntaggedOut.MsgTx())
+	if err.(stake.RuleError).GetCode() != stake.ErrSStxInvalidOutputs {
+		t.Errorf("CheckSStx should have returned %v but instead returned %v",
+			stake.ErrSStxInvalidOutputs, err)
+	}
+	if stake.IsSStx(sstxUntaggedOut.MsgTx()) {
+		t.Errorf("IsSStx claimed an invalid sstx is valid")
 	}
 
 	// ---------------------------------------------------------------------------
@@ -133,11 +147,13 @@ func TestIsSSTxErrors(t *testing.T) {
 	sstxInsOutsMismatched.SetTree(wire.TxTreeStake)
 	sstxInsOutsMismatched.SetIndex(0)
 
-	test, err = stake.IsSStx(sstxInsOutsMismatched.MsgTx())
-	if test || err.(stake.RuleError).GetCode() !=
-		stake.ErrSStxInOutProportions {
-		t.Errorf("IsSSTx should have returned false,%v but instead returned %v"+
-			",%v", stake.ErrSStxInOutProportions, test, err)
+	err = stake.CheckSStx(sstxInsOutsMismatched.MsgTx())
+	if err.(stake.RuleError).GetCode() != stake.ErrSStxInOutProportions {
+		t.Errorf("CheckSStx should have returned %v but instead returned %v",
+			stake.ErrSStxInOutProportions, err)
+	}
+	if stake.IsSStx(sstxInsOutsMismatched.MsgTx()) {
+		t.Errorf("IsSStx claimed an invalid sstx is valid")
 	}
 
 	// ---------------------------------------------------------------------------
@@ -146,11 +162,13 @@ func TestIsSSTxErrors(t *testing.T) {
 	sstxBadVerOut.SetTree(wire.TxTreeStake)
 	sstxBadVerOut.SetIndex(0)
 
-	test, err = stake.IsSStx(sstxBadVerOut.MsgTx())
-	if test || err.(stake.RuleError).GetCode() !=
-		stake.ErrSStxInvalidOutputs {
-		t.Errorf("IsSSTx should have returned false,%v but instead returned %v"+
-			",%v", stake.ErrSStxInvalidOutputs, test, err)
+	err = stake.CheckSStx(sstxBadVerOut.MsgTx())
+	if err.(stake.RuleError).GetCode() != stake.ErrSStxInvalidOutputs {
+		t.Errorf("CheckSStx should have returned %v but instead returned %v",
+			stake.ErrSStxInvalidOutputs, err)
+	}
+	if stake.IsSStx(sstxBadVerOut.MsgTx()) {
+		t.Errorf("IsSStx claimed an invalid sstx is valid")
 	}
 
 	// ---------------------------------------------------------------------------
@@ -160,11 +178,13 @@ func TestIsSSTxErrors(t *testing.T) {
 	sstxNoNullData.SetTree(wire.TxTreeStake)
 	sstxNoNullData.SetIndex(0)
 
-	test, err = stake.IsSStx(sstxNoNullData.MsgTx())
-	if test || err.(stake.RuleError).GetCode() !=
-		stake.ErrSStxInvalidOutputs {
-		t.Errorf("IsSSTx should have returned false,%v but instead returned %v"+
-			",%v", stake.ErrSStxInvalidOutputs, test, err)
+	err = stake.CheckSStx(sstxNoNullData.MsgTx())
+	if err.(stake.RuleError).GetCode() != stake.ErrSStxInvalidOutputs {
+		t.Errorf("CheckSStx should have returned %v but instead returned %v",
+			stake.ErrSStxInvalidOutputs, err)
+	}
+	if stake.IsSStx(sstxNoNullData.MsgTx()) {
+		t.Errorf("IsSStx claimed an invalid sstx is valid")
 	}
 
 	// ---------------------------------------------------------------------------
@@ -174,11 +194,13 @@ func TestIsSSTxErrors(t *testing.T) {
 	sstxNullDataMis.SetTree(wire.TxTreeStake)
 	sstxNullDataMis.SetIndex(0)
 
-	test, err = stake.IsSStx(sstxNullDataMis.MsgTx())
-	if test || err.(stake.RuleError).GetCode() !=
-		stake.ErrSStxInvalidOutputs {
-		t.Errorf("IsSSTx should have returned false,%v but instead returned %v"+
-			",%v", stake.ErrSStxInvalidOutputs, test, err)
+	err = stake.CheckSStx(sstxNullDataMis.MsgTx())
+	if err.(stake.RuleError).GetCode() != stake.ErrSStxInvalidOutputs {
+		t.Errorf("CheckSStx should have returned %v but instead returned %v",
+			stake.ErrSStxInvalidOutputs, err)
+	}
+	if stake.IsSStx(sstxNullDataMis.MsgTx()) {
+		t.Errorf("IsSStx claimed an invalid sstx is valid")
 	}
 
 	// ---------------------------------------------------------------------------
@@ -208,11 +230,13 @@ func TestIsSSTxErrors(t *testing.T) {
 	sstxWrongPKHLength.SetTree(wire.TxTreeStake)
 	sstxWrongPKHLength.SetIndex(0)
 
-	test, err = stake.IsSStx(sstxWrongPKHLength.MsgTx())
-	if test || err.(stake.RuleError).GetCode() !=
-		stake.ErrSStxInvalidOutputs {
-		t.Errorf("IsSSTx should have returned false,%v but instead returned %v"+
-			",%v", stake.ErrSStxInvalidOutputs, test, err)
+	err = stake.CheckSStx(sstxWrongPKHLength.MsgTx())
+	if err.(stake.RuleError).GetCode() != stake.ErrSStxInvalidOutputs {
+		t.Errorf("CheckSStx should have returned %v but instead returned %v",
+			stake.ErrSStxInvalidOutputs, err)
+	}
+	if stake.IsSStx(sstxWrongPKHLength.MsgTx()) {
+		t.Errorf("IsSStx claimed an invalid sstx is valid")
 	}
 
 	// ---------------------------------------------------------------------------
@@ -243,25 +267,31 @@ func TestIsSSTxErrors(t *testing.T) {
 	sstxWrongPrefix.SetTree(wire.TxTreeStake)
 	sstxWrongPrefix.SetIndex(0)
 
-	test, err = stake.IsSStx(sstxWrongPrefix.MsgTx())
-	if test || err.(stake.RuleError).GetCode() !=
-		stake.ErrSStxInvalidOutputs {
-		t.Errorf("IsSSTx should have returned false,%v but instead returned %v"+
-			",%v", stake.ErrSStxInvalidOutputs, test, err)
+	err = stake.CheckSStx(sstxWrongPrefix.MsgTx())
+	if err.(stake.RuleError).GetCode() != stake.ErrSStxInvalidOutputs {
+		t.Errorf("CheckSStx should have returned %v but instead returned %v",
+			stake.ErrSStxInvalidOutputs, err)
+	}
+	if stake.IsSStx(sstxWrongPrefix.MsgTx()) {
+		t.Errorf("IsSStx claimed an invalid sstx is valid")
 	}
 }
 
 // SSGEN TESTING ------------------------------------------------------------------
 
-func TestIsSSGen(t *testing.T) {
+// TestSSGen ensures the CheckSSGen and IsSSGen functions correctly recognize
+// stake submission generation transactions.
+func TestSSGen(t *testing.T) {
 	var ssgen = dcrutil.NewTx(ssgenMsgTx)
 	ssgen.SetTree(wire.TxTreeStake)
 	ssgen.SetIndex(0)
 
-	test, err := stake.IsSSGen(ssgen.MsgTx())
-	if !test || err != nil {
-		t.Errorf("IsSSGen should have returned true,<nil> but instead returned %v"+
-			",%v", test, err)
+	err := stake.CheckSSGen(ssgen.MsgTx())
+	if err != nil {
+		t.Errorf("IsSSGen: unexpected err: %v", err)
+	}
+	if !stake.IsSSGen(ssgen.MsgTx()) {
+		t.Errorf("IsSSGen claimed a valid ssgen is invalid")
 	}
 
 	// Test for an OP_RETURN VoteBits push of the maximum size
@@ -284,15 +314,20 @@ func TestIsSSGen(t *testing.T) {
 	ssgen.SetIndex(0)
 	ssgen.MsgTx().TxOut[1].PkScript = biggestPush
 
-	test, err = stake.IsSSGen(ssgen.MsgTx())
-	if !test || err != nil {
-		t.Errorf("IsSSGen should have returned true,<nil> but instead returned %v"+
-			",%v", test, err)
+	err = stake.CheckSSGen(ssgen.MsgTx())
+	if err != nil {
+		t.Errorf("IsSSGen: unexpected err: %v", err)
+	}
+	if !stake.IsSSGen(ssgen.MsgTx()) {
+		t.Errorf("IsSSGen claimed a valid ssgen is invalid")
 	}
 
 }
 
-func TestIsSSGenErrors(t *testing.T) {
+// TestSSGenErrors ensures the CheckSSGen and IsSSGen functions correctly
+// identify errors in stake submission generation transactions and does not
+// report them as valid.
+func TestSSGenErrors(t *testing.T) {
 	// Initialize the buffer for later manipulation
 	var buf bytes.Buffer
 	buf.Grow(ssgenMsgTx.SerializeSize())
@@ -309,11 +344,13 @@ func TestIsSSGenErrors(t *testing.T) {
 	ssgenExtraInputs.SetTree(wire.TxTreeStake)
 	ssgenExtraInputs.SetIndex(0)
 
-	test, err := stake.IsSSGen(ssgenExtraInputs.MsgTx())
-	if test || err.(stake.RuleError).GetCode() !=
-		stake.ErrSSGenWrongNumInputs {
-		t.Errorf("IsSSGen should have returned false,%v but instead returned %v"+
-			",%v", stake.ErrSSGenWrongNumInputs, test, err)
+	err = stake.CheckSSGen(ssgenExtraInputs.MsgTx())
+	if err.(stake.RuleError).GetCode() != stake.ErrSSGenWrongNumInputs {
+		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
+			stake.ErrSSGenWrongNumInputs, err)
+	}
+	if stake.IsSSGen(ssgenExtraInputs.MsgTx()) {
+		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
 	// ---------------------------------------------------------------------------
@@ -323,11 +360,13 @@ func TestIsSSGenErrors(t *testing.T) {
 	ssgenExtraOutputs.SetTree(wire.TxTreeStake)
 	ssgenExtraOutputs.SetIndex(0)
 
-	test, err = stake.IsSSGen(ssgenExtraOutputs.MsgTx())
-	if test || err.(stake.RuleError).GetCode() !=
-		stake.ErrSSGenTooManyOutputs {
-		t.Errorf("IsSSGen should have returned false,%v but instead returned %v"+
-			",%v", stake.ErrSSGenTooManyOutputs, test, err)
+	err = stake.CheckSSGen(ssgenExtraOutputs.MsgTx())
+	if err.(stake.RuleError).GetCode() != stake.ErrSSGenTooManyOutputs {
+		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
+			stake.ErrSSGenTooManyOutputs, err)
+	}
+	if stake.IsSSGen(ssgenExtraOutputs.MsgTx()) {
+		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
 	// ---------------------------------------------------------------------------
@@ -337,11 +376,13 @@ func TestIsSSGenErrors(t *testing.T) {
 	ssgenStakeBaseWrong.SetTree(wire.TxTreeStake)
 	ssgenStakeBaseWrong.SetIndex(0)
 
-	test, err = stake.IsSSGen(ssgenStakeBaseWrong.MsgTx())
-	if test || err.(stake.RuleError).GetCode() !=
-		stake.ErrSSGenNoStakebase {
-		t.Errorf("IsSSGen should have returned false,%v but instead returned %v"+
-			",%v", stake.ErrSSGenNoStakebase, test, err)
+	err = stake.CheckSSGen(ssgenStakeBaseWrong.MsgTx())
+	if err.(stake.RuleError).GetCode() != stake.ErrSSGenNoStakebase {
+		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
+			stake.ErrSSGenNoStakebase, err)
+	}
+	if stake.IsSSGen(ssgenStakeBaseWrong.MsgTx()) {
+		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
 	// ---------------------------------------------------------------------------
@@ -367,11 +408,13 @@ func TestIsSSGenErrors(t *testing.T) {
 	ssgenWrongTreeIns.SetTree(wire.TxTreeStake)
 	ssgenWrongTreeIns.SetIndex(0)
 
-	test, err = stake.IsSSGen(ssgenWrongTreeIns.MsgTx())
-	if test || err.(stake.RuleError).GetCode() !=
-		stake.ErrSSGenWrongTxTree {
-		t.Errorf("IsSSGen should have returned false,%v but instead returned %v"+
-			",%v", stake.ErrSSGenWrongTxTree, test, err)
+	err = stake.CheckSSGen(ssgenWrongTreeIns.MsgTx())
+	if err.(stake.RuleError).GetCode() != stake.ErrSSGenWrongTxTree {
+		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
+			stake.ErrSSGenWrongTxTree, err)
+	}
+	if stake.IsSSGen(ssgenWrongTreeIns.MsgTx()) {
+		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
 	// ---------------------------------------------------------------------------
@@ -380,11 +423,13 @@ func TestIsSSGenErrors(t *testing.T) {
 	ssgenTxBadVerOut.SetTree(wire.TxTreeStake)
 	ssgenTxBadVerOut.SetIndex(0)
 
-	test, err = stake.IsSSGen(ssgenTxBadVerOut.MsgTx())
-	if test || err.(stake.RuleError).GetCode() !=
-		stake.ErrSSGenBadGenOuts {
-		t.Errorf("IsSSGen should have returned false,%v but instead returned %v"+
-			",%v", stake.ErrSSGenBadGenOuts, test, err)
+	err = stake.CheckSSGen(ssgenTxBadVerOut.MsgTx())
+	if err.(stake.RuleError).GetCode() != stake.ErrSSGenBadGenOuts {
+		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
+			stake.ErrSSGenBadGenOuts, err)
+	}
+	if stake.IsSSGen(ssgenTxBadVerOut.MsgTx()) {
+		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
 	// ---------------------------------------------------------------------------
@@ -394,12 +439,15 @@ func TestIsSSGenErrors(t *testing.T) {
 	ssgenWrongZeroethOut.SetTree(wire.TxTreeStake)
 	ssgenWrongZeroethOut.SetIndex(0)
 
-	test, err = stake.IsSSGen(ssgenWrongZeroethOut.MsgTx())
-	if test || err.(stake.RuleError).GetCode() !=
-		stake.ErrSSGenNoReference {
-		t.Errorf("IsSSGen should have returned false,%v but instead returned %v"+
-			",%v", stake.ErrSSGenNoReference, test, err)
+	err = stake.CheckSSGen(ssgenWrongZeroethOut.MsgTx())
+	if err.(stake.RuleError).GetCode() != stake.ErrSSGenNoReference {
+		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
+			stake.ErrSSGenNoReference, err)
 	}
+	if stake.IsSSGen(ssgenWrongZeroethOut.MsgTx()) {
+		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
+	}
+
 	// ---------------------------------------------------------------------------
 	// Test for too short of an OP_RETURN push being given in the 0th tx out
 
@@ -433,11 +481,13 @@ func TestIsSSGenErrors(t *testing.T) {
 	ssgenWrongDataPush0Length.SetTree(wire.TxTreeStake)
 	ssgenWrongDataPush0Length.SetIndex(0)
 
-	test, err = stake.IsSSGen(ssgenWrongDataPush0Length.MsgTx())
-	if test || err.(stake.RuleError).GetCode() !=
-		stake.ErrSSGenBadReference {
-		t.Errorf("IsSSGen should have returned false,%v but instead returned %v"+
-			",%v", stake.ErrSSGenBadReference, test, err)
+	err = stake.CheckSSGen(ssgenWrongDataPush0Length.MsgTx())
+	if err.(stake.RuleError).GetCode() != stake.ErrSSGenBadReference {
+		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
+			stake.ErrSSGenBadReference, err)
+	}
+	if stake.IsSSGen(ssgenWrongDataPush0Length.MsgTx()) {
+		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
 	// ---------------------------------------------------------------------------
@@ -473,11 +523,13 @@ func TestIsSSGenErrors(t *testing.T) {
 	ssgenWrongNullData0Prefix.SetTree(wire.TxTreeStake)
 	ssgenWrongNullData0Prefix.SetIndex(0)
 
-	test, err = stake.IsSSGen(ssgenWrongNullData0Prefix.MsgTx())
-	if test || err.(stake.RuleError).GetCode() !=
-		stake.ErrSSGenBadReference {
-		t.Errorf("IsSSGen should have returned false,%v but instead returned %v"+
-			",%v", stake.ErrSSGenBadReference, test, err)
+	err = stake.CheckSSGen(ssgenWrongNullData0Prefix.MsgTx())
+	if err.(stake.RuleError).GetCode() != stake.ErrSSGenBadReference {
+		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
+			stake.ErrSSGenBadReference, err)
+	}
+	if stake.IsSSGen(ssgenWrongNullData0Prefix.MsgTx()) {
+		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
 	// ---------------------------------------------------------------------------
@@ -487,12 +539,15 @@ func TestIsSSGenErrors(t *testing.T) {
 	ssgenWrongFirstOut.SetTree(wire.TxTreeStake)
 	ssgenWrongFirstOut.SetIndex(0)
 
-	test, err = stake.IsSSGen(ssgenWrongFirstOut.MsgTx())
-	if test || err.(stake.RuleError).GetCode() !=
-		stake.ErrSSGenNoVotePush {
-		t.Errorf("IsSSGen should have returned false,%v but instead returned %v"+
-			",%v", stake.ErrSSGenNoVotePush, test, err)
+	err = stake.CheckSSGen(ssgenWrongFirstOut.MsgTx())
+	if err.(stake.RuleError).GetCode() != stake.ErrSSGenNoVotePush {
+		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
+			stake.ErrSSGenNoVotePush, err)
 	}
+	if stake.IsSSGen(ssgenWrongFirstOut.MsgTx()) {
+		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
+	}
+
 	// ---------------------------------------------------------------------------
 	// Test for too short of an OP_RETURN push being given in the 1st tx out
 	testDataPush1Length := bytes.Replace(bufBytes,
@@ -515,39 +570,13 @@ func TestIsSSGenErrors(t *testing.T) {
 	ssgenWrongDataPush1Length.SetTree(wire.TxTreeStake)
 	ssgenWrongDataPush1Length.SetIndex(0)
 
-	test, err = stake.IsSSGen(ssgenWrongDataPush1Length.MsgTx())
-	if test || err.(stake.RuleError).GetCode() !=
-		stake.ErrSSGenBadVotePush {
-		t.Errorf("IsSSGen should have returned false,%v but instead returned %v"+
-			",%v", stake.ErrSSGenBadVotePush, test, err)
+	err = stake.CheckSSGen(ssgenWrongDataPush1Length.MsgTx())
+	if err.(stake.RuleError).GetCode() != stake.ErrSSGenBadVotePush {
+		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
+			stake.ErrSSGenBadVotePush, err)
 	}
-
-	// ---------------------------------------------------------------------------
-	// Test for longer OP_RETURN push being given in the 1st tx out
-	testDataPush1Length = bytes.Replace(bufBytes,
-		[]byte{
-			0x04, 0x6a, 0x02, 0x94, 0x8c,
-		},
-		[]byte{
-			0x06, 0x6a, 0x04, 0x94, 0x8c, 0x8c, 0x8c,
-		},
-		1)
-
-	// Deserialize the manipulated tx
-	rbuf = bytes.NewReader(testDataPush1Length)
-	err = tx.Deserialize(rbuf)
-	if err != nil {
-		t.Errorf("Deserialize error %v", err)
-	}
-
-	var ssgenLongDataPush1Length = dcrutil.NewTx(&tx)
-	ssgenLongDataPush1Length.SetTree(wire.TxTreeStake)
-	ssgenLongDataPush1Length.SetIndex(0)
-
-	test, err = stake.IsSSGen(ssgenLongDataPush1Length.MsgTx())
-	if !test || err != nil {
-		t.Errorf("IsSSGen should have returned false,%v but instead returned %v"+
-			",%v", stake.ErrSSGenBadVotePush, test, err)
+	if stake.IsSSGen(ssgenWrongDataPush1Length.MsgTx()) {
+		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
 	// ---------------------------------------------------------------------------
@@ -573,11 +602,13 @@ func TestIsSSGenErrors(t *testing.T) {
 	ssgenWrongNullData1Prefix.SetTree(wire.TxTreeStake)
 	ssgenWrongNullData1Prefix.SetIndex(0)
 
-	test, err = stake.IsSSGen(ssgenWrongNullData1Prefix.MsgTx())
-	if test || err.(stake.RuleError).GetCode() !=
-		stake.ErrSSGenBadVotePush {
-		t.Errorf("IsSSGen should have returned false,%v but instead returned %v"+
-			",%v", stake.ErrSSGenBadVotePush, test, err)
+	err = stake.CheckSSGen(ssgenWrongNullData1Prefix.MsgTx())
+	if err.(stake.RuleError).GetCode() != stake.ErrSSGenBadVotePush {
+		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
+			stake.ErrSSGenBadVotePush, err)
+	}
+	if stake.IsSSGen(ssgenWrongNullData1Prefix.MsgTx()) {
+		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
 	// ---------------------------------------------------------------------------
@@ -603,28 +634,37 @@ func TestIsSSGenErrors(t *testing.T) {
 	ssgentestGenOutputUntagged.SetTree(wire.TxTreeStake)
 	ssgentestGenOutputUntagged.SetIndex(0)
 
-	test, err = stake.IsSSGen(ssgentestGenOutputUntagged.MsgTx())
-	if test || err.(stake.RuleError).GetCode() !=
-		stake.ErrSSGenBadGenOuts {
-		t.Errorf("IsSSGen should have returned false,%v but instead returned %v"+
-			",%v", stake.ErrSSGenBadGenOuts, test, err)
+	err = stake.CheckSSGen(ssgentestGenOutputUntagged.MsgTx())
+	if err.(stake.RuleError).GetCode() != stake.ErrSSGenBadGenOuts {
+		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
+			stake.ErrSSGenBadGenOuts, err)
+	}
+	if stake.IsSSGen(ssgentestGenOutputUntagged.MsgTx()) {
+		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 }
 
 // SSRTX TESTING ------------------------------------------------------------------
 
-func TestIsSSRtx(t *testing.T) {
+// TestSSRtx ensures the CheckSSRtx and IsSSRtx functions correctly recognize
+// stake submission revocation transactions.
+func TestSSRtx(t *testing.T) {
 	var ssrtx = dcrutil.NewTx(ssrtxMsgTx)
 	ssrtx.SetTree(wire.TxTreeStake)
 	ssrtx.SetIndex(0)
 
-	test, err := stake.IsSSRtx(ssrtx.MsgTx())
-	if !test || err != nil {
-		t.Errorf("IsSSRtx should have returned true,<nil> but instead returned %v"+
-			",%v", test, err)
+	err := stake.CheckSSRtx(ssrtx.MsgTx())
+	if err != nil {
+		t.Errorf("IsSSRtx: unexpected err: %v", err)
+	}
+	if !stake.IsSSRtx(ssrtx.MsgTx()) {
+		t.Errorf("IsSSRtx claimed a valid ssrtx is invalid")
 	}
 }
 
+// TestSSRtxErrors ensures the CheckSSRtx and IsSSRtx functions correctly
+// identify errors in stake submission revocation transactions and does not
+// report them as valid.
 func TestIsSSRtxErrors(t *testing.T) {
 	// Initialize the buffer for later manipulation
 	var buf bytes.Buffer
@@ -642,11 +682,13 @@ func TestIsSSRtxErrors(t *testing.T) {
 	ssrtxTooManyInputs.SetTree(wire.TxTreeStake)
 	ssrtxTooManyInputs.SetIndex(0)
 
-	test, err := stake.IsSSRtx(ssrtxTooManyInputs.MsgTx())
-	if test || err.(stake.RuleError).GetCode() !=
-		stake.ErrSSRtxWrongNumInputs {
-		t.Errorf("IsSSRtx should have returned false,%v but instead returned %v"+
-			",%v", stake.ErrSSRtxWrongNumInputs, test, err)
+	err = stake.CheckSSRtx(ssrtxTooManyInputs.MsgTx())
+	if err.(stake.RuleError).GetCode() != stake.ErrSSRtxWrongNumInputs {
+		t.Errorf("CheckSSRtx should have returned %v but instead returned %v",
+			stake.ErrSSRtxWrongNumInputs, err)
+	}
+	if stake.IsSSRtx(ssrtxTooManyInputs.MsgTx()) {
+		t.Errorf("IsSSRtx claimed an invalid ssrtx is valid")
 	}
 
 	// ---------------------------------------------------------------------------
@@ -656,11 +698,13 @@ func TestIsSSRtxErrors(t *testing.T) {
 	ssrtxTooManyOutputs.SetTree(wire.TxTreeStake)
 	ssrtxTooManyOutputs.SetIndex(0)
 
-	test, err = stake.IsSSRtx(ssrtxTooManyOutputs.MsgTx())
-	if test || err.(stake.RuleError).GetCode() !=
-		stake.ErrSSRtxTooManyOutputs {
-		t.Errorf("IsSSRtx should have returned false,%v but instead returned %v"+
-			",%v", stake.ErrSSRtxTooManyOutputs, test, err)
+	err = stake.CheckSSRtx(ssrtxTooManyOutputs.MsgTx())
+	if err.(stake.RuleError).GetCode() != stake.ErrSSRtxTooManyOutputs {
+		t.Errorf("CheckSSRtx should have returned %v but instead returned %v",
+			stake.ErrSSRtxTooManyOutputs, err)
+	}
+	if stake.IsSSRtx(ssrtxTooManyOutputs.MsgTx()) {
+		t.Errorf("IsSSRtx claimed an invalid ssrtx is valid")
 	}
 
 	// ---------------------------------------------------------------------------
@@ -669,11 +713,13 @@ func TestIsSSRtxErrors(t *testing.T) {
 	ssrtxTxBadVerOut.SetTree(wire.TxTreeStake)
 	ssrtxTxBadVerOut.SetIndex(0)
 
-	test, err = stake.IsSSRtx(ssrtxTxBadVerOut.MsgTx())
-	if test || err.(stake.RuleError).GetCode() !=
-		stake.ErrSSRtxBadOuts {
-		t.Errorf("IsSSRtx should have returned false,%v but instead returned %v"+
-			",%v", stake.ErrSSRtxBadOuts, test, err)
+	err = stake.CheckSSRtx(ssrtxTxBadVerOut.MsgTx())
+	if err.(stake.RuleError).GetCode() != stake.ErrSSRtxBadOuts {
+		t.Errorf("CheckSSRtx should have returned %v but instead returned %v",
+			stake.ErrSSRtxBadOuts, err)
+	}
+	if stake.IsSSRtx(ssrtxTxBadVerOut.MsgTx()) {
+		t.Errorf("IsSSRtx claimed an invalid ssrtx is valid")
 	}
 
 	// ---------------------------------------------------------------------------
@@ -699,11 +745,13 @@ func TestIsSSRtxErrors(t *testing.T) {
 	ssrtxTestRevocOutputUntagged.SetTree(wire.TxTreeStake)
 	ssrtxTestRevocOutputUntagged.SetIndex(0)
 
-	test, err = stake.IsSSRtx(ssrtxTestRevocOutputUntagged.MsgTx())
-	if test || err.(stake.RuleError).GetCode() !=
-		stake.ErrSSRtxBadOuts {
-		t.Errorf("IsSSGen should have returned false,%v but instead returned %v"+
-			",%v", stake.ErrSSRtxBadOuts, test, err)
+	err = stake.CheckSSRtx(ssrtxTestRevocOutputUntagged.MsgTx())
+	if err.(stake.RuleError).GetCode() != stake.ErrSSRtxBadOuts {
+		t.Errorf("CheckSSRtx should have returned %v but instead returned %v",
+			stake.ErrSSRtxBadOuts, err)
+	}
+	if stake.IsSSRtx(ssrtxTestRevocOutputUntagged.MsgTx()) {
+		t.Errorf("IsSSRtx claimed an invalid ssrtx is valid")
 	}
 
 	// ---------------------------------------------------------------------------
@@ -728,11 +776,13 @@ func TestIsSSRtxErrors(t *testing.T) {
 	ssrtxWrongTreeIns.SetTree(wire.TxTreeStake)
 	ssrtxWrongTreeIns.SetIndex(0)
 
-	test, err = stake.IsSSRtx(ssrtxWrongTreeIns.MsgTx())
-	if test || err.(stake.RuleError).GetCode() !=
-		stake.ErrSSRtxWrongTxTree {
-		t.Errorf("IsSSRtx should have returned false,%v but instead returned %v"+
-			",%v", stake.ErrSSGenWrongTxTree, test, err)
+	err = stake.CheckSSRtx(ssrtxWrongTreeIns.MsgTx())
+	if err.(stake.RuleError).GetCode() != stake.ErrSSRtxWrongTxTree {
+		t.Errorf("CheckSSRtx should have returned %v but instead returned %v",
+			stake.ErrSSGenWrongTxTree, err)
+	}
+	if stake.IsSSRtx(ssrtxWrongTreeIns.MsgTx()) {
+		t.Errorf("IsSSRtx claimed an invalid ssrtx is valid")
 	}
 }
 

--- a/blockchain/stakenode.go
+++ b/blockchain/stakenode.go
@@ -72,7 +72,7 @@ func (b *BlockChain) fetchNewTicketsForNode(node *blockNode) ([]chainhash.Hash, 
 
 	tickets := []chainhash.Hash{}
 	for _, stx := range matureBlock.MsgBlock().STransactions {
-		if is, _ := stake.IsSStx(stx); is {
+		if stake.IsSStx(stx) {
 			h := stx.TxHash()
 			tickets = append(tickets, h)
 		}

--- a/blockchain/subsidy.go
+++ b/blockchain/subsidy.go
@@ -336,7 +336,7 @@ func CalculateAddedSubsidy(block, parent *dcrutil.Block) int64 {
 	}
 
 	for _, stx := range block.MsgBlock().STransactions {
-		if isSSGen, _ := stake.IsSSGen(stx); isSSGen {
+		if stake.IsSSGen(stx) {
 			subsidy += stx.TxIn[0].ValueIn
 		}
 	}

--- a/blockchain/upgrade.go
+++ b/blockchain/upgrade.go
@@ -49,7 +49,7 @@ func (b *BlockChain) upgradeToVersion2() error {
 					return errLocal
 				}
 				for _, stx := range matureBlock.MsgBlock().STransactions {
-					if is, _ := stake.IsSStx(stx); is {
+					if stake.IsSStx(stx) {
 						h := stx.TxHash()
 						newTickets = append(newTickets, h)
 					}

--- a/blockchain/utxoviewpoint.go
+++ b/blockchain/utxoviewpoint.go
@@ -981,7 +981,7 @@ func (view *UtxoViewpoint) fetchInputUtxos(db database.DB, block, parent *dcruti
 		// the stake tx tree, so don't do any of those expensive checks and
 		// just append it to the tx slice.
 		for _, tx := range block.MsgBlock().STransactions {
-			isSSGen, _ := stake.IsSSGen(tx)
+			isSSGen := stake.IsSSGen(tx)
 
 			for i, txIn := range tx.TxIn {
 				// Ignore stakebases.
@@ -1118,7 +1118,7 @@ func (b *BlockChain) FetchUtxoView(tx *dcrutil.Tx, treeValid bool) (*UtxoViewpoi
 	txNeededSet := make(map[chainhash.Hash]struct{})
 	txNeededSet[*tx.Hash()] = struct{}{}
 	msgTx := tx.MsgTx()
-	isSSGen, _ := stake.IsSSGen(msgTx)
+	isSSGen := stake.IsSSGen(msgTx)
 	if !IsCoinBaseTx(msgTx) {
 		for i, txIn := range msgTx.TxIn {
 			if isSSGen && i == 0 {

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -791,8 +791,7 @@ func (b *blockManager) current() bool {
 func (b *blockManager) checkBlockForHiddenVotes(block *dcrutil.Block) {
 	var votesFromBlock []*dcrutil.Tx
 	for _, stx := range block.STransactions() {
-		isSSGen, _ := stake.IsSSGen(stx.MsgTx())
-		if isSSGen {
+		if stake.IsSSGen(stx.MsgTx()) {
 			votesFromBlock = append(votesFromBlock, stx)
 		}
 	}

--- a/cmd/checkdevpremine/checkdevpremine.go
+++ b/cmd/checkdevpremine/checkdevpremine.go
@@ -121,8 +121,7 @@ func traceDevPremineOuts(client *rpcclient.Client, txHash *chainhash.Hash) ([]wi
 		// stake generation transaction still need to be traced since
 		// they represent the coins that purchased the ticket.
 		txIns := tx.MsgTx().TxIn
-		isSSGen, _ := stake.IsSSGen(tx.MsgTx())
-		if isSSGen {
+		if stake.IsSSGen(tx.MsgTx()) {
 			txIns = txIns[1:]
 		}
 		for _, txIn := range txIns {

--- a/mining.go
+++ b/mining.go
@@ -723,7 +723,7 @@ func maybeInsertStakeTx(bm *blockManager, stx *dcrutil.Tx, treeValid bool) bool 
 		return false
 	}
 	mstx := stx.MsgTx()
-	isSSGen, _ := stake.IsSSGen(mstx)
+	isSSGen := stake.IsSSGen(mstx)
 	for i, txIn := range mstx.TxIn {
 		// Evaluate if this is a stakebase input or not. If it
 		// is, continue without evaluation of the input.
@@ -1688,7 +1688,7 @@ mempoolLoop:
 			break // No SSGen should be present before this height.
 		}
 
-		if isSSGen, _ := stake.IsSSGen(msgTx); isSSGen {
+		if stake.IsSSGen(msgTx) {
 			txCopy := dcrutil.NewTxDeepTxIns(msgTx)
 			if maybeInsertStakeTx(blockManager, txCopy, treeValid) {
 				vb := stake.SSGenVoteBits(txCopy.MsgTx())
@@ -1786,8 +1786,7 @@ mempoolLoop:
 	freshStake := 0
 	for _, tx := range blockTxns {
 		msgTx := tx.MsgTx()
-		isSStx, _ := stake.IsSStx(msgTx)
-		if tx.Tree() == wire.TxTreeStake && isSStx {
+		if tx.Tree() == wire.TxTreeStake && stake.IsSStx(msgTx) {
 			// A ticket can not spend an input from TxTreeRegular, since it
 			// has not yet been validated.
 			if containsTxIns(blockTxns, tx) {
@@ -1818,8 +1817,7 @@ mempoolLoop:
 		}
 
 		msgTx := tx.MsgTx()
-		isSSRtx, _ := stake.IsSSRtx(msgTx)
-		if tx.Tree() == wire.TxTreeStake && isSSRtx {
+		if tx.Tree() == wire.TxTreeStake && stake.IsSSRtx(msgTx) {
 			txCopy := dcrutil.NewTxDeepTxIns(msgTx)
 			if maybeInsertStakeTx(blockManager, txCopy, treeValid) {
 				blockTxnsStake = append(blockTxnsStake, txCopy)


### PR DESCRIPTION
This modifies the `IsSStx`, `IsSSGen`, and `IsSSRtx` functions to only return a `bool` and introduces `CheckSStx`, `CheckSSGen`, and `CheckSSRtx` to return the actual error as needed by consensus.

This is being done because "is" functions are much nicer to use when they don't return an error and the callers that use them almost never care why they aren't of the type, they just want to determine if they are.  In the few cases where the caller does care, they can use of the new check functions.

While here, also update the comments to call out what the more common names for the transaction types are and to add comments to the test functions for consistency.

Finally, it updates all callers in the repo accordingly.