### PR TITLE
blockchain: Rename block index to main chain index.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1252,9 +1252,8 @@ func (b *BlockChain) connectBlock(node *blockNode, block *dcrutil.Block, view *U
 			return err
 		}
 
-		// Add the block hash and height to the block index which tracks
-		// the main chain.
-		err = dbPutBlockIndex(dbTx, block.Hash(), node.height)
+		// Add the block hash and height to the main chain index.
+		err = dbPutMainChainIndex(dbTx, block.Hash(), node.height)
 		if err != nil {
 			return err
 		}
@@ -1456,9 +1455,8 @@ func (b *BlockChain) disconnectBlock(node *blockNode, block *dcrutil.Block, view
 			return err
 		}
 
-		// Remove the block hash and height from the block index which
-		// tracks the main chain.
-		err = dbRemoveBlockIndex(dbTx, block.Hash(), node.height)
+		// Remove the block hash and height from the main chain index.
+		err = dbRemoveMainChainIndex(dbTx, block.Hash(), node.height)
 		if err != nil {
 			return err
 		}

--- a/blockchain/stakeversion_test.go
+++ b/blockchain/stakeversion_test.go
@@ -20,8 +20,8 @@ import (
 // it is not usable with all functions and the tests must take care when making
 // use of it.
 func newFakeChain(params *chaincfg.Params) *BlockChain {
-	// Create a genesis block node and block index index populated with it
-	// for use when creating the fake chain below.
+	// Create a genesis block node and block index populated with it for use
+	// when creating the fake chain below.
 	node := newBlockNode(&params.GenesisBlock.Header, &stake.SpentTicketsInBlock{})
 	node.inMainChain = true
 	index := make(map[chainhash.Hash]*blockNode)


### PR DESCRIPTION
The current serialized "block index" is actually a main chain index, so this renames the related functions to correctly denote it's a main chain index and updates the comments accordingly.

This is being done since future work intends to actually serialize the entire block index and renaming this now will make the introduction of full block index code more clear.