### PR TITLE
blockchain: Explicit block fetch semantics.

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -296,7 +296,7 @@ func (b *BlockChain) maybeAcceptBlock(block *dcrutil.Block, flags BehaviorFlags)
 
 	// Grab the parent block since it is required throughout the block
 	// connection process.
-	parent, err := b.fetchBlockFromHash(&newNode.parentHash)
+	parent, err := b.fetchBlockByHash(&newNode.parentHash)
 	if err != nil {
 		return false, err
 	}

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1656,15 +1656,14 @@ func (b *BlockChain) BlockByHeight(blockHeight int64) (*dcrutil.Block, error) {
 	return block, err
 }
 
-// BlockByHash returns the block from the main chain with the given hash with
-// the appropriate chain height set.
+// BlockByHash returns the block from the main chain with the given hash.
 //
 // This function is safe for concurrent access.
 func (b *BlockChain) BlockByHash(hash *chainhash.Hash) (*dcrutil.Block, error) {
 	b.chainLock.RLock()
 	defer b.chainLock.RUnlock()
 
-	return b.fetchBlockFromHash(hash)
+	return b.fetchMainChainBlockByHash(hash)
 }
 
 // HeightRange returns a range of block hashes for the given start and end

--- a/blockchain/stakenode.go
+++ b/blockchain/stakenode.go
@@ -65,7 +65,7 @@ func (b *BlockChain) fetchNewTicketsForNode(node *blockNode) ([]chainhash.Hash, 
 		return nil, err
 	}
 
-	matureBlock, errBlock := b.fetchBlockFromHash(&matureNode.hash)
+	matureBlock, errBlock := b.fetchBlockByHash(&matureNode.hash)
 	if errBlock != nil {
 		return nil, errBlock
 	}

--- a/blockchain/utxoviewpoint.go
+++ b/blockchain/utxoviewpoint.go
@@ -1089,11 +1089,11 @@ func (b *BlockChain) FetchUtxoView(tx *dcrutil.Tx, treeValid bool) (*UtxoViewpoi
 	view := NewUtxoViewpoint()
 	if treeValid {
 		view.SetStakeViewpoint(ViewpointPrevValidRegular)
-		block, err := b.fetchBlockFromHash(&b.bestNode.hash)
+		block, err := b.fetchMainChainBlockByHash(&b.bestNode.hash)
 		if err != nil {
 			return nil, err
 		}
-		parent, err := b.fetchBlockFromHash(&b.bestNode.parentHash)
+		parent, err := b.fetchMainChainBlockByHash(&b.bestNode.parentHash)
 		if err != nil {
 			return nil, err
 		}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1901,7 +1901,7 @@ func handleGetBlock(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (i
 	if err != nil {
 		return nil, rpcDecodeHexError(c.Hash)
 	}
-	blk, err := s.server.blockManager.chain.FetchBlockFromHash(hash)
+	blk, err := s.server.blockManager.chain.FetchBlockByHash(hash)
 	if err != nil {
 		return nil, &dcrjson.RPCError{
 			Code:    dcrjson.ErrRPCBlockNotFound,

--- a/server.go
+++ b/server.go
@@ -1123,7 +1123,7 @@ func (s *server) pushTxMsg(sp *serverPeer, hash *chainhash.Hash, doneChan chan<-
 // pushBlockMsg sends a block message for the provided block hash to the
 // connected peer.  An error is returned if the block hash is not known.
 func (s *server) pushBlockMsg(sp *serverPeer, hash *chainhash.Hash, doneChan chan<- struct{}, waitChan <-chan struct{}) error {
-	block, err := sp.server.blockManager.chain.FetchBlockFromHash(hash)
+	block, err := sp.server.blockManager.chain.FetchBlockByHash(hash)
 	if err != nil {
 		peerLog.Tracef("Unable to fetch requested block hash %v: %v",
 			hash, err)


### PR DESCRIPTION
**This requires #998**.

This makes the semantics of block fetching much more explicit by introducing a new function named `fetchMainChainBlockByHash` which only attempts to the load a block from the main chain block cache and then falls back to the database.  While currently only blocks in the main chain are in the database, the intention is for future commits to allow the database to house side chain blocks as well, so having clearly defined semantics will help make that transition easier to verify.

While here, it also renames `{f,F}etchBlockFromHash` to `{f,F}etchBlockByHash` to be consistent with the naming used by the other existing functions and updates the comments to better describe the function semantics.