### PR TITLE
blockchain: Store side chain blocks in database.

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/decred/dcrd/blockchain/stake"
+	"github.com/decred/dcrd/database"
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrd/txscript"
 )
@@ -122,6 +123,22 @@ func (b *BlockChain) maybeAcceptBlock(block *dcrutil.Block, flags BehaviorFlags)
 	// The block must pass all of the validation rules which depend on the
 	// position of the block within the block chain.
 	err = b.checkBlockContext(block, prevNode, flags)
+	if err != nil {
+		return false, err
+	}
+
+	// Insert the block into the database if it's not already there.  Even
+	// though it is possible the block will ultimately fail to connect, it
+	// has already passed all proof-of-work and validity tests which means
+	// it would be prohibitively expensive for an attacker to fill up the
+	// disk with a bunch of blocks that fail to connect.  This is necessary
+	// since it allows block download to be decoupled from the much more
+	// expensive connection logic.  It also has some other nice properties
+	// such as making blocks that never become part of the main chain or
+	// blocks that fail to connect available for further analysis.
+	err = b.db.Update(func(dbTx database.Tx) error {
+		return dbMaybeStoreBlock(dbTx, block)
+	})
 	if err != nil {
 		return false, err
 	}

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -2705,11 +2705,9 @@ func (b *BlockChain) CheckConnectBlock(block *dcrutil.Block, flags BehaviorFlags
 		// attached or the previous one that was attached for subsequent blocks
 		// to optimize.
 		n := e.Value.(*blockNode)
-		block, exists := b.blockCache[n.hash]
-		if !exists {
-			return fmt.Errorf("unable to find block %v in "+
-				"side chain cache for utxo view construction",
-				n.hash)
+		block, err := b.fetchBlockByHash(&n.hash)
+		if err != nil {
+			return err
 		}
 		parent := prevAttachBlock
 		if parent == nil {


### PR DESCRIPTION
This modifies the `blockchain` code to store all blocks that have passed proof-of-work and contextual validity tests in the database even if they may ultimately fail to connect.

This eliminates the need to store those blocks in memory, allows them to be available as orphans later even if they were never part of the main chain, and helps pave the way toward being able to separate the download logic from the connection logic.

Note that it also updates the `blockExists` function since the code base is currently in the process of changing over to decouple download and connection logic, but not all of the necessary parts are updated yet, to ensure blocks that are in the database, but do not have an associated main chain block index entry, are treated as if they do not exist for the purposes of chain connection and selection logic.
