### PR TITLE
blockchain: Use next detach block in reorg chain.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1438,10 +1438,11 @@ func (b *BlockChain) reorganizeChain(detachNodes, attachNodes *list.List, flags 
 	for i, e := 0, detachNodes.Front(); e != nil; i, e = i+1, e.Next() {
 		// Since the blocks are being detached in reverse order, the parent of
 		// current block being detached is the next one being detached up to
-		// the  point of the fork at which point it's the fork block.
+		// the final one at which point it's the block that is already saved
+		// from the next block to detach above.
 		n := e.Value.(*blockNode)
 		block := detachBlocks[i]
-		parent := forkBlock
+		parent := nextBlockToDetach
 		if i < len(detachBlocks)-1 {
 			parent = detachBlocks[i+1]
 		}


### PR DESCRIPTION
This corrects the generalized reorg logic in `reorganizeChain` for the case when there are only nodes being detached since the fork block would be nil in that case.

It should be noted that nothing currently calls this code under that scenario so this case would never be hit, but that could change in the future, so the logic needs to account for it.