### PR TITLE
blockchain: Validate num votes in header sanity.

### DIFF
--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -795,6 +795,7 @@ func TestBlockValidationRules(t *testing.T) {
 	notEnoughVotes154.FromBytes(block154Bytes)
 	notEnoughVotes154.STransactions = notEnoughVotes154.STransactions[0:2]
 	notEnoughVotes154.Header.FreshStake = 0
+	notEnoughVotes154.Header.Voters = 2
 	recalculateMsgBlockMerkleRootsSize(notEnoughVotes154)
 	b154test = dcrutil.NewBlock(notEnoughVotes154)
 


### PR DESCRIPTION
This moves the test for validating the number of votes specified by the header is at least the required minimum into the `checkBlockHeaderSanity` function where it more naturally belongs since it is solely dependent on information the header.

Also, remove the redundant check for the same condition from `checkBlockSanity` since it has now already been checked according to the value the header commits to and therefore validating the header commitment for the number of votes implies correctness.