### PR TITLE
blockchain: Validate max votes in header sanity.

### DIFF
--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -412,6 +412,14 @@ func checkBlockHeaderSanity(header *wire.BlockHeader, timeSource MedianTimeSourc
 		}
 	}
 
+	// The block header must not claim to contain more votes than the
+	// maximum allowed.
+	if header.Voters > chainParams.TicketsPerBlock {
+		errStr := fmt.Sprintf("block commits to too many votes (max: "+
+			"%d, got %d)", chainParams.TicketsPerBlock, header.Voters)
+		return ruleError(ErrTooManyVotes, errStr)
+	}
+
 	return nil
 }
 
@@ -530,14 +538,6 @@ func checkBlockSanity(block *dcrutil.Block, timeSource MedianTimeSource, flags B
 			"header reports %v", totalTickets,
 			block.MsgBlock().Header.FreshStake)
 		return ruleError(ErrFreshStakeMismatch, errStr)
-	}
-
-	if totalVotes > int(chainParams.TicketsPerBlock) {
-		errStr := fmt.Sprintf("the number of SSGen tx in block %v "+
-			"was %v, overflowing the maximum allowed (%v)",
-			block.Hash(), totalVotes,
-			int(chainParams.TicketsPerBlock))
-		return ruleError(ErrTooManyVotes, errStr)
 	}
 
 	if totalVotes != int(block.MsgBlock().Header.Voters) {


### PR DESCRIPTION
This changes the validation that the block does not exceed the maximum number of votes to make use of the value committed to by the header and thus moves the test into `checkBlockHeaderSanity` accordingly.

This is acceptable since the code also validates the header commitment for the number of votes later and therefore implies correctness.