### PR TITLE
blockchain: Validate block height in header context.

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -172,14 +172,6 @@ func (b *BlockChain) checkBlockContext(block *dcrutil.Block, prevNode *blockNode
 			}
 		}
 
-		// Check that the node is at the correct height in the blockchain,
-		// as specified in the block header.
-		if blockHeight != int64(block.MsgBlock().Header.Height) {
-			errStr := fmt.Sprintf("Block header height invalid; expected %v"+
-				" but %v was found", blockHeight, header.Height)
-			return ruleError(ErrBadBlockHeight, errStr)
-		}
-
 		// Check that the coinbase contains at minimum the block
 		// height in output 1.
 		if blockHeight > 1 {

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -749,6 +749,15 @@ func (b *BlockChain) checkBlockHeaderContext(header *wire.BlockHeader, prevNode 
 	// block.
 	blockHeight := prevNode.height + 1
 
+	// Ensure the header commits to the correct height based on the height it
+	// actually connects in the blockchain.
+	if int64(header.Height) != blockHeight {
+		errStr := fmt.Sprintf("block header commitment to height %d "+
+			"does not match chain height %d", header.Height,
+			blockHeight)
+		return ruleError(ErrBadBlockHeight, errStr)
+	}
+
 	// Ensure chain matches up to predetermined checkpoints.
 	blockHash := header.BlockHash()
 	if !b.verifyCheckpoint(blockHeight, &blockHash) {


### PR DESCRIPTION
This moves the test for validating the block height specified by the header matches the height it actually connects to the chain into the `checkBlockHeaderContext` function where it more naturally belongs since it is only dependent on the header and its contextual position within the chain.