### PR TITLE
blockchain/mining: Full checks in CCB.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1593,6 +1593,11 @@ func (b *BlockChain) forceHeadReorganization(formerBest chainhash.Hash, newBest 
 		return err
 	}
 
+	err = b.checkBlockContext(newBestBlock, newBestNode.parent, BFNone)
+	if err != nil {
+		return err
+	}
+
 	err = b.checkConnectBlock(newBestNode, newBestBlock, commonParentBlock,
 		view, nil)
 	if err != nil {

--- a/blockchain/reorganization_test.go
+++ b/blockchain/reorganization_test.go
@@ -31,7 +31,8 @@ func reorgTestLong(t *testing.T, params *chaincfg.Params) {
 
 	// The genesis block should fail to connect since it's already
 	// inserted.
-	err = chain.CheckConnectBlock(dcrutil.NewBlock(params.GenesisBlock))
+	err = chain.CheckConnectBlock(dcrutil.NewBlock(params.GenesisBlock),
+		blockchain.BFNone)
 	if err == nil {
 		t.Errorf("CheckConnectBlock: Did not receive expected error")
 	}
@@ -142,7 +143,8 @@ func reorgTestShort(t *testing.T, params *chaincfg.Params) {
 
 	// The genesis block should fail to connect since it's already
 	// inserted.
-	err = chain.CheckConnectBlock(dcrutil.NewBlock(params.GenesisBlock))
+	err = chain.CheckConnectBlock(dcrutil.NewBlock(params.GenesisBlock),
+		blockchain.BFNone)
 	if err == nil {
 		t.Errorf("CheckConnectBlock: Did not receive expected error")
 	}
@@ -258,7 +260,8 @@ func reorgTestForced(t *testing.T, params *chaincfg.Params) {
 
 	// The genesis block should fail to connect since it's already
 	// inserted.
-	err = chain.CheckConnectBlock(dcrutil.NewBlock(params.GenesisBlock))
+	err = chain.CheckConnectBlock(dcrutil.NewBlock(params.GenesisBlock),
+		blockchain.BFNone)
 	if err == nil {
 		t.Errorf("CheckConnectBlock: Did not receive expected error")
 	}

--- a/mining.go
+++ b/mining.go
@@ -877,14 +877,8 @@ func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache,
 
 				// Make sure the block validates.
 				block := dcrutil.NewBlockDeepCopyCoinbase(cptCopy.Block)
-				if err := blockchain.CheckWorklessBlockSanity(block,
-					bm.server.timeSource,
-					bm.server.chainParams); err != nil {
-					return nil, miningRuleError(ErrCheckConnectBlock,
-						err.Error())
-				}
-
-				if err := bm.chain.CheckConnectBlock(block); err != nil {
+				err = bm.chain.CheckConnectBlock(block, blockchain.BFNoPoWCheck)
+				if err != nil {
 					minrLog.Errorf("failed to check template while "+
 						"duplicating a parent: %v", err.Error())
 					return nil, miningRuleError(ErrCheckConnectBlock,
@@ -983,17 +977,8 @@ func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache,
 
 				// Make sure the block validates.
 				btBlock := dcrutil.NewBlockDeepCopyCoinbase(btMsgBlock)
-				if err := blockchain.CheckWorklessBlockSanity(btBlock,
-					bm.server.timeSource,
-					bm.server.chainParams); err != nil {
-					str := fmt.Sprintf("failed to check sanity of template "+
-						"while constructing a new parent: %v",
-						err.Error())
-					return nil, miningRuleError(ErrCheckConnectBlock,
-						str)
-				}
-
-				if err := bm.chain.CheckConnectBlock(btBlock); err != nil {
+				err = bm.chain.CheckConnectBlock(btBlock, blockchain.BFNoPoWCheck)
+				if err != nil {
 					str := fmt.Sprintf("failed to check template: %v while "+
 						"constructing a new parent", err.Error())
 					return nil, miningRuleError(ErrCheckConnectBlock,
@@ -2095,17 +2080,8 @@ mempoolLoop:
 	// consensus rules to ensure it properly connects to the current best
 	// chain with no issues.
 	block := dcrutil.NewBlockDeepCopyCoinbase(&msgBlock)
-
-	if err := blockchain.CheckWorklessBlockSanity(block,
-		server.timeSource,
-		server.chainParams); err != nil {
-		str := fmt.Sprintf("failed to do final check for block workless "+
-			"sanity when making new block template: %v",
-			err.Error())
-		return nil, miningRuleError(ErrCheckConnectBlock, str)
-	}
-
-	if err := blockManager.chain.CheckConnectBlock(block); err != nil {
+	err = blockManager.chain.CheckConnectBlock(block, blockchain.BFNoPoWCheck)
+	if err != nil {
 		str := fmt.Sprintf("failed to do final check for check connect "+
 			"block when making new block template: %v",
 			err.Error())


### PR DESCRIPTION
**This requires PR #1014**.

This modifies the exported `CheckConnectBlock` function to call the `checkBlockSanity` and `checkBlockContext` functions to ensure all validation rules are enforced from the mining code.

Since both the mining code and tests typically work with unsolved blocks, this also introduces a new parameter on `CheckConnectBlock` to pass behavior flags which allows the caller to skip the proof of work check.

It also modifies `forceHeadReorganization` to call `checkBlockContext` for the same reason.

Finally, all tests and call sites are updated with the appropriate flags and various tests are updated for the changes accordingly.