### PR TITLE
stake: Static assert of vote commitment.

### DIFF
--- a/blockchain/stake/staketx.go
+++ b/blockchain/stake/staketx.go
@@ -452,17 +452,17 @@ func TxSSGenStakeOutputInfo(tx *wire.MsgTx, params *chaincfg.Params) ([]bool,
 //
 // This function is only safe to be called on a transaction that
 // has passed IsSSGen.
-func SSGenBlockVotedOn(tx *wire.MsgTx) (chainhash.Hash, uint32, error) {
-	// Get the block header hash.
-	blockHash, err := chainhash.NewHash(tx.TxOut[0].PkScript[2:34])
-	if err != nil {
-		return chainhash.Hash{}, 0, err
-	}
+func SSGenBlockVotedOn(tx *wire.MsgTx) (chainhash.Hash, uint32) {
+	// Get the block header hash.  Note that the actual number of bytes is
+	// specified here over using chainhash.HashSize in order to statically
+	// assert hash sizes have not changed.
+	var blockHash [32]byte
+	copy(blockHash[:], tx.TxOut[0].PkScript[2:34])
 
 	// Get the block height.
 	height := binary.LittleEndian.Uint32(tx.TxOut[0].PkScript[34:38])
 
-	return *blockHash, height, nil
+	return chainhash.Hash(blockHash), height
 }
 
 // SSGenVoteBits takes an SSGen tx as input and scans through its

--- a/blockchain/stake/staketx_test.go
+++ b/blockchain/stake/staketx_test.go
@@ -793,7 +793,7 @@ func TestGetSSGenBlockVotedOn(t *testing.T) {
 	ssgen.SetTree(wire.TxTreeStake)
 	ssgen.SetIndex(0)
 
-	blockHash, height, err := stake.SSGenBlockVotedOn(ssgen.MsgTx())
+	blockHash, height := stake.SSGenBlockVotedOn(ssgen.MsgTx())
 
 	correctBlockHash, _ := chainhash.NewHash(
 		[]byte{
@@ -809,18 +809,14 @@ func TestGetSSGenBlockVotedOn(t *testing.T) {
 
 	correctheight := uint32(0x2123e300)
 
-	if err != nil {
-		t.Errorf("Error thrown on TestGetSSGenBlockVotedOn: %v", err)
-	}
-
 	if !reflect.DeepEqual(blockHash, *correctBlockHash) {
 		t.Errorf("Error thrown on TestGetSSGenBlockVotedOn: Looking for "+
-			"hash %v, got hash %v: %v", *correctBlockHash, blockHash, err)
+			"hash %v, got hash %v", *correctBlockHash, blockHash)
 	}
 
 	if height != correctheight {
 		t.Errorf("Error thrown on TestGetSSGenBlockVotedOn: Looking for "+
-			"height %v, got height %v: %v", correctheight, height, err)
+			"height %v, got height %v", correctheight, height)
 	}
 }
 

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -1139,13 +1139,7 @@ func (b *BlockChain) CheckBlockStakeSanity(stakeValidationHeight int64, node *bl
 
 			// 3. Check to make sure that the SSGen tx votes on the
 			//    parent block of the block in which it is included.
-			voteHash, voteHgt, err := stake.SSGenBlockVotedOn(msgTx)
-			if err != nil {
-				errStr := fmt.Sprintf("unexpected vote tx "+
-					"decode error: %v", err)
-				return ruleError(ErrUnparseableSSGen, errStr)
-			}
-
+			voteHash, voteHgt := stake.SSGenBlockVotedOn(msgTx)
 			if !(voteHash.IsEqual(prevBlockHash)) ||
 				(voteHgt != uint32(block.Height())-1) {
 				txHash := msgTx.TxHash()
@@ -1419,14 +1413,7 @@ func CheckTransactionInputs(subsidyCache *SubsidyCache, tx *dcrutil.Tx, txHeight
 		// Calculate the theoretical stake vote subsidy by extracting
 		// the vote height.  Should be impossible because IsSSGen
 		// requires this byte string to be a certain number of bytes.
-		_, heightVotingOn, err := stake.SSGenBlockVotedOn(msgTx)
-		if err != nil {
-			errStr := fmt.Sprintf("Could not parse SSGen block "+
-				"vote information from SSGen %v:  %v", txHash,
-				err)
-			return 0, ruleError(ErrUnparseableSSGen, errStr)
-		}
-
+		_, heightVotingOn := stake.SSGenBlockVotedOn(msgTx)
 		stakeVoteSubsidy := CalcStakeVoteSubsidy(subsidyCache,
 			int64(heightVotingOn), chainParams)
 
@@ -1681,12 +1668,7 @@ func CheckTransactionInputs(subsidyCache *SubsidyCache, tx *dcrutil.Tx, txHeight
 		// Inputs won't exist for stakebase tx, so ignore them.
 		if isSSGen && idx == 0 {
 			// However, do add the reward amount.
-			_, heightVotingOn, err := stake.SSGenBlockVotedOn(msgTx)
-			if err != nil {
-				errStr := fmt.Sprintf("unexpected vote tx "+
-					"decode error: %v", err)
-				return 0, ruleError(ErrUnparseableSSGen, errStr)
-			}
+			_, heightVotingOn := stake.SSGenBlockVotedOn(msgTx)
 			stakeVoteSubsidy := CalcStakeVoteSubsidy(subsidyCache,
 				int64(heightVotingOn), chainParams)
 			totalAtomIn += stakeVoteSubsidy

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -229,10 +229,7 @@ func (mp *TxPool) insertVote(ssgen *dcrutil.Tx) error {
 	ticketHash := &msgTx.TxIn[1].PreviousOutPoint.Hash
 
 	// Get the block it is voting on; here we're agnostic of height.
-	blockHash, blockHeight, err := stake.SSGenBlockVotedOn(msgTx)
-	if err != nil {
-		return err
-	}
+	blockHash, blockHeight := stake.SSGenBlockVotedOn(msgTx)
 
 	// If there are currently no votes for this block,
 	// start a new buffered slice and store it.
@@ -923,11 +920,7 @@ func (mp *TxPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit, allow
 
 	// Votes that are on too old of blocks are rejected.
 	if txType == stake.TxTypeSSGen {
-		_, voteHeight, err := stake.SSGenBlockVotedOn(msgTx)
-		if err != nil {
-			return nil, err
-		}
-
+		_, voteHeight := stake.SSGenBlockVotedOn(msgTx)
 		if (int64(voteHeight) < nextBlockHeight-maximumVoteAgeDelta) &&
 			!mp.cfg.Policy.AllowOldVotes {
 			str := fmt.Sprintf("transaction %v votes on old "+

--- a/mining.go
+++ b/mining.go
@@ -1322,13 +1322,7 @@ mempoolLoop:
 		// the ticket number.
 		isSSGen := txDesc.Type == stake.TxTypeSSGen
 		if isSSGen {
-			blockHash, blockHeight, err := stake.SSGenBlockVotedOn(msgTx)
-			if err != nil { // Should theoretically never fail.
-				minrLog.Tracef("Skipping ssgen tx %s because of failure "+
-					"to extract block voting data", tx.Hash())
-				continue
-			}
-
+			blockHash, blockHeight := stake.SSGenBlockVotedOn(msgTx)
 			if !((blockHash == *prevHash) &&
 				(int64(blockHeight) == nextBlockHeight-1)) {
 				minrLog.Tracef("Skipping ssgen tx %s because it does "+


### PR DESCRIPTION
This modifies the `SSGenBlockVotedOn` function to directly copy the hash the vote commits to into a statically sized array versus calling the hash function and thus can remove the potential runtime error.

This is preferred because the code will fail to compile if the size of `chainhash.HashSize` is every changed which is desirable because it would mean the assumptions the code makes would be invalidated.

It also updates all callers in the repository accordingly.