### PR TITLE
blockchain: Remove unused error code.

### DIFF
--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -324,10 +324,6 @@ const (
 	// of an SStx did not match those found in the commitment outputs.
 	ErrSStxCommitment
 
-	// ErrUnparseableSSGen indicates that the SSGen block vote or votebits data
-	// was unparseable from the null data outputs.
-	ErrUnparseableSSGen
-
 	// ErrInvalidSSGenInput indicates that the input SStx to the SSGen tx was
 	// invalid because it was not an SStx.
 	ErrInvalidSSGenInput
@@ -520,7 +516,6 @@ var errorCodeStrings = map[ErrorCode]string{
 	ErrRevocationsMismatch:    "ErrRevocationsMismatch",
 	ErrTooManyRevocations:     "ErrTooManyRevocations",
 	ErrSStxCommitment:         "ErrSStxCommitment",
-	ErrUnparseableSSGen:       "ErrUnparseableSSGen",
 	ErrInvalidSSGenInput:      "ErrInvalidSSGenInput",
 	ErrSSGenPayeeNum:          "ErrSSGenPayeeNum",
 	ErrSSGenPayeeOuts:         "ErrSSGenPayeeOuts",

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -1141,10 +1141,6 @@ func TestBlockValidationRules(t *testing.T) {
 	}
 
 	// ----------------------------------------------------------------------------
-	// ErrUnparseableSSGen
-	// This should be impossible to hit unless there's a local memory failure.
-
-	// ----------------------------------------------------------------------------
 	// ErrInvalidSSGenInput
 	// It doesn't look like this one can actually be hit since checking if
 	// IsSSGen should fail first.


### PR DESCRIPTION
This removes the `ErrUnparseableSSGen` error code since it is no longer used.
