### PR TITLE
blockchain: Validate early final state is zero.

### DIFF
--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -448,6 +448,10 @@ const (
 	// ErrInvalidEarlyVoteBits indicates that a block before stake validation
 	// height had an unallowed vote bits value.
 	ErrInvalidEarlyVoteBits
+
+	// ErrInvalidEarlyFinalState indicates that a block before stake validation
+	// height had a non-zero final state.
+	ErrInvalidEarlyFinalState
 )
 
 // Map of ErrorCode values back to their constant names for pretty printing.
@@ -547,6 +551,7 @@ var errorCodeStrings = map[ErrorCode]string{
 	ErrFraudBlockIndex:        "ErrFraudBlockIndex",
 	ErrZeroValueOutputSpend:   "ErrZeroValueOutputSpend",
 	ErrInvalidEarlyVoteBits:   "ErrInvalidEarlyVoteBits",
+	ErrInvalidEarlyFinalState: "ErrInvalidEarlyFinalState",
 }
 
 // String returns the ErrorCode as a human-readable name.


### PR DESCRIPTION
This modifies the `checkBlockHeaderSanity` function to include an additional check which ensures the final state is zero prior to stake validation height.

It should be noted that this is technically a hard fork since before this change it was possible to use any value for the final state prior to stake validation height.  However, no blocks on mainnet nor testnet ever used non-zero final states for blocks in that range and they are buried behind checkpoints in the minimum required version of the software due to the previous consensus votes, so it isn't possible to trigger a reorg that would fork old nodes off the network anyways, so it is safe to retroactively apply this check.

It also adds tests for the new consensus check which ensures the final state is zero prior to stake validation height to the `fulllblocktests` in order to ensure correctness.
