### PR TITLE
blockchain: Max revocations in block sanity.

### DIFF
--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -49,6 +49,10 @@ const (
 	// earlyVoteBitsValue is the only value of VoteBits allowed in a block
 	// header before stake validation height.
 	earlyVoteBitsValue = 0x0001
+
+	// maxRevocationsPerBlock is the maximum number of revocations that are
+	// allowed per block.
+	maxRevocationsPerBlock = 255
 )
 
 var (
@@ -642,6 +646,15 @@ func checkBlockSanity(block *dcrutil.Block, timeSource MedianTimeSource, flags B
 		}
 	}
 
+	// A block must not contain more than the maximum allowed number of
+	// revocations.
+	if totalRevocations > maxRevocationsPerBlock {
+		errStr := fmt.Sprintf("block contains %d revocations which "+
+			"exceeds the maximum allowed amount of %d",
+			totalRevocations, maxRevocationsPerBlock)
+		return ruleError(ErrTooManyRevocations, errStr)
+	}
+
 	// A block header must commit to the actual number of tickets purchases that
 	// are in the block.
 	if int64(header.FreshStake) != totalTickets {
@@ -1227,7 +1240,6 @@ func (b *BlockChain) CheckBlockStakeSanity(stakeValidationHeight int64, node *bl
 	// PER BLOCK
 	// 3. Check and make sure that we have the same number of SSRtx tx as
 	//    we do revocations.
-	// 4. Check for revocation overflows.
 	numSSRtxTx := 0
 	for _, staketx := range stakeTransactions {
 		msgTx := staketx.MsgTx()
@@ -1258,15 +1270,6 @@ func (b *BlockChain) CheckBlockStakeSanity(stakeValidationHeight int64, node *bl
 
 	// 3. Check and make sure that we have the same number of SSRtx tx as
 	//    we do revocations.  Already checked in checkBlockSanity.
-
-	// 4. Check for revocation overflows.  Should be impossible given the
-	//    above check, but check anyway.
-	if numSSRtxTx > math.MaxUint8 {
-		errStr := fmt.Sprintf("Error in stake consensus: the number "+
-			"of SSRtx tx in block %v was %v, overflowing the "+
-			"maximum allowed (255)", blockHash, numSSRtxTx)
-		return ruleError(ErrTooManyRevocations, errStr)
-	}
 
 	// -------------------------------------------------------------------
 	// Final Checks


### PR DESCRIPTION
This moves the check for validating that the number of revocations does not exceed the maximum allowed to the `checkBlockSanity` function where it more naturally belongs since it does not require access to any previous chain context.

It should be noted that this check previously used `math.MaxUint8` and was rather implicitly limited by the fact the header uses a `uint8` for the field, so this makes the requirement more explicit by defining a constant.
