### PR TITLE
blockchain/stake: Rename tix spent to tix voted.

### DIFF
--- a/blockchain/blockindex.go
+++ b/blockchain/blockindex.go
@@ -91,7 +91,7 @@ type blockNode struct {
 	stakeNode      *stake.Node
 	newTickets     []chainhash.Hash
 	stakeUndoData  stake.UndoTicketDataSlice
-	ticketsSpent   []chainhash.Hash
+	ticketsVoted   []chainhash.Hash
 	ticketsRevoked []chainhash.Hash
 
 	// Keep track of all vote version and bits in this block.
@@ -113,10 +113,10 @@ func newBlockNode(blockHeader *wire.BlockHeader, spentTickets *stake.SpentTicket
 		panic(err)
 	}
 
-	var ticketsSpent, ticketsRevoked []chainhash.Hash
+	var ticketsVoted, ticketsRevoked []chainhash.Hash
 	var votes []stake.VoteVersionTuple
 	if spentTickets != nil {
-		ticketsSpent = spentTickets.VotedTickets
+		ticketsVoted = spentTickets.VotedTickets
 		ticketsRevoked = spentTickets.RevokedTickets
 		votes = spentTickets.Votes
 	}
@@ -146,7 +146,7 @@ func newBlockNode(blockHeader *wire.BlockHeader, spentTickets *stake.SpentTicket
 		extraData:      blockHeader.ExtraData,
 		stakeVersion:   blockHeader.StakeVersion,
 		lotteryIV:      stake.CalcHash256PRNGIV(hB),
-		ticketsSpent:   ticketsSpent,
+		ticketsVoted:   ticketsVoted,
 		ticketsRevoked: ticketsRevoked,
 		votes:          votes,
 	}

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -692,7 +692,7 @@ func (b *BlockChain) pruneStakeNodes() {
 			node.stakeNode = nil
 			node.stakeUndoData = nil
 			node.newTickets = nil
-			node.ticketsSpent = nil
+			node.ticketsVoted = nil
 			node.ticketsRevoked = nil
 		}
 	}
@@ -1003,7 +1003,7 @@ func (b *BlockChain) connectBlock(node *blockNode, block, parent *dcrutil.Block,
 		b.bestNode.parent.stakeNode = nil
 		b.bestNode.parent.stakeUndoData = nil
 		b.bestNode.parent.newTickets = nil
-		b.bestNode.parent.ticketsSpent = nil
+		b.bestNode.parent.ticketsVoted = nil
 		b.bestNode.parent.ticketsRevoked = nil
 	}
 

--- a/blockchain/stake/tickets.go
+++ b/blockchain/stake/tickets.go
@@ -417,7 +417,7 @@ func safeDelete(t *tickettreap.Immutable, k tickettreap.Key) (*tickettreap.Immut
 // the argument node is the parent node, and that the child stake node is
 // returned after subsequent modification of the parent node's immutable
 // data.
-func connectNode(node *Node, lotteryIV chainhash.Hash, ticketsSpentInBlock, revokedTickets, newTickets []chainhash.Hash) (*Node, error) {
+func connectNode(node *Node, lotteryIV chainhash.Hash, ticketsVoted, revokedTickets, newTickets []chainhash.Hash) (*Node, error) {
 	if node == nil {
 		return nil, fmt.Errorf("missing stake node pointer input when connecting")
 	}
@@ -438,11 +438,11 @@ func connectNode(node *Node, lotteryIV chainhash.Hash, ticketsSpentInBlock, revo
 	var err error
 	if connectedNode.height >= uint32(connectedNode.params.StakeEnabledHeight) {
 		// Basic sanity check.
-		for i := range ticketsSpentInBlock {
-			if !hashInSlice(ticketsSpentInBlock[i], node.nextWinners) {
+		for i := range ticketsVoted {
+			if !hashInSlice(ticketsVoted[i], node.nextWinners) {
 				return nil, stakeRuleError(ErrUnknownTicketSpent,
 					fmt.Sprintf("unknown ticket %v spent in block",
-						ticketsSpentInBlock[i]))
+						ticketsVoted[i]))
 			}
 		}
 
@@ -463,7 +463,7 @@ func connectNode(node *Node, lotteryIV chainhash.Hash, ticketsSpentInBlock, revo
 			// ticket should still be in the live tickets treap, we probably
 			// do not have to use the safe delete functions, but do so anyway
 			// just to be safe.
-			if hashInSlice(ticket, ticketsSpentInBlock) {
+			if hashInSlice(ticket, ticketsVoted) {
 				v.Spent = true
 				v.Missed = false
 				connectedNode.liveTickets, err =
@@ -636,8 +636,8 @@ func connectNode(node *Node, lotteryIV chainhash.Hash, ticketsSpentInBlock, revo
 
 // ConnectNode connects a stake node to the node and returns a pointer
 // to the stake node of the child.
-func (sn *Node) ConnectNode(lotteryIV chainhash.Hash, ticketsSpentInBlock, revokedTickets, newTickets []chainhash.Hash) (*Node, error) {
-	return connectNode(sn, lotteryIV, ticketsSpentInBlock, revokedTickets,
+func (sn *Node) ConnectNode(lotteryIV chainhash.Hash, ticketsVoted, revokedTickets, newTickets []chainhash.Hash) (*Node, error) {
+	return connectNode(sn, lotteryIV, ticketsVoted, revokedTickets,
 		newTickets)
 }
 

--- a/blockchain/stakenode.go
+++ b/blockchain/stakenode.go
@@ -114,7 +114,7 @@ func (b *BlockChain) fetchStakeNode(node *blockNode) (*stake.Node, error) {
 			}
 
 			node.stakeNode, err = node.parent.stakeNode.ConnectNode(
-				node.lotteryIV, node.ticketsSpent, node.ticketsRevoked,
+				node.lotteryIV, node.ticketsVoted, node.ticketsRevoked,
 				node.newTickets)
 			if err != nil {
 				return nil, err
@@ -206,7 +206,7 @@ func (b *BlockChain) fetchStakeNode(node *blockNode) (*stake.Node, error) {
 			}
 
 			n.stakeNode, err = current.stakeNode.ConnectNode(n.lotteryIV,
-				n.ticketsSpent, n.ticketsRevoked, n.newTickets)
+				n.ticketsVoted, n.ticketsRevoked, n.newTickets)
 			if err != nil {
 				return nil, err
 			}

--- a/blockchain/upgrade.go
+++ b/blockchain/upgrade.go
@@ -13,12 +13,12 @@ import (
 	"github.com/decred/dcrd/dcrutil"
 )
 
-// ticketsSpentInBlock fetches a list of tickets that were spent in the
+// ticketsVotedInBlock fetches a list of tickets that were voted in the
 // block.
-func ticketsSpentInBlock(bl *dcrutil.Block) []chainhash.Hash {
+func ticketsVotedInBlock(bl *dcrutil.Block) []chainhash.Hash {
 	var tickets []chainhash.Hash
 	for _, stx := range bl.MsgBlock().STransactions {
-		if stake.DetermineTxType(stx) == stake.TxTypeSSGen {
+		if stake.IsSSGen(stx) {
 			tickets = append(tickets, stx.TxIn[1].PreviousOutPoint.Hash)
 		}
 	}
@@ -90,7 +90,7 @@ func (b *BlockChain) upgradeToVersion2() error {
 				return errLocal
 			}
 			bestStakeNode, errLocal = bestStakeNode.ConnectNode(
-				stake.CalcHash256PRNGIV(hB), ticketsSpentInBlock(block),
+				stake.CalcHash256PRNGIV(hB), ticketsVotedInBlock(block),
 				ticketsRevokedInBlock(block), newTickets)
 			if errLocal != nil {
 				return errLocal
@@ -108,7 +108,7 @@ func (b *BlockChain) upgradeToVersion2() error {
 				b.bestNode.stakeNode = bestStakeNode
 				b.bestNode.stakeUndoData = bestStakeNode.UndoData()
 				b.bestNode.newTickets = newTickets
-				b.bestNode.ticketsSpent = ticketsSpentInBlock(block)
+				b.bestNode.ticketsVoted = ticketsVotedInBlock(block)
 				b.bestNode.ticketsRevoked = ticketsRevokedInBlock(block)
 			}
 


### PR DESCRIPTION
This renames the fields dealing with the hashes of tickets that have been voted on from `ticketsSpent` to `ticketsVoted` to more accurately differentiate them from revocations which also technically spend tickets.