### PR TITLE
blockchain: Rework database versioning.

### DIFF
--- a/blockchain/chainio_test.go
+++ b/blockchain/chainio_test.go
@@ -1,4 +1,5 @@
 // Copyright (c) 2015-2016 The btcsuite developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -11,7 +12,6 @@ import (
 	"math/big"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/database"
@@ -1061,65 +1061,6 @@ func TestUtxoEntryDeserializeErrors(t *testing.T) {
 		if entry != nil {
 			t.Errorf("deserializeUtxoEntry (%s): returned entry "+
 				"is not nil", test.name)
-			continue
-		}
-	}
-}
-
-// TestDatabaseInfoSerialization ensures serializing and deserializing the
-// database version information works as expected.
-func TestDatabaseInfoSerialization(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name       string
-		info       databaseInfo
-		serialized []byte
-	}{
-		{
-			name: "not upgrade",
-			info: databaseInfo{
-				version:        2,
-				compVer:        1,
-				date:           time.Unix(int64(0x57acca95), 0),
-				upgradeStarted: false,
-			},
-			serialized: hexToBytes("020000000100000095caac57"),
-		},
-		{
-			name: "upgrade",
-			info: databaseInfo{
-				version:        2,
-				compVer:        1,
-				date:           time.Unix(int64(0x57acca95), 0),
-				upgradeStarted: true,
-			},
-			serialized: hexToBytes("020000800100000095caac57"),
-		},
-	}
-
-	for i, test := range tests {
-		// Ensure the state serializes to the expected value.
-		gotBytes := serializeDatabaseInfo(&test.info)
-		if !bytes.Equal(gotBytes, test.serialized) {
-			t.Errorf("serializeDatabaseInfo #%d (%s): mismatched "+
-				"bytes - got %x, want %x", i, test.name,
-				gotBytes, test.serialized)
-			continue
-		}
-
-		// Ensure the serialized bytes are decoded back to the expected
-		// state.
-		info, err := deserializeDatabaseInfo(test.serialized)
-		if err != nil {
-			t.Errorf("deserializeDatabaseInfo #%d (%s) "+
-				"unexpected error: %v", i, test.name, err)
-			continue
-		}
-		if !reflect.DeepEqual(info, &test.info) {
-			t.Errorf("deserializeDatabaseInfo #%d (%s) "+
-				"mismatched state - got %v, want %v", i,
-				test.name, info, test.info)
 			continue
 		}
 	}

--- a/blockchain/internal/dbnamespace/dbnamespace.go
+++ b/blockchain/internal/dbnamespace/dbnamespace.go
@@ -12,10 +12,24 @@ var (
 	// fields for storage in the database.
 	ByteOrder = binary.LittleEndian
 
-	// BlockChainDbInfoBucketName is the name of the database bucket used to
-	// house a single k->v that stores global versioning and date information for
-	// the database.
-	BlockChainDbInfoBucketName = []byte("dbinfo")
+	// BCDBInfoBucketName is the name of the database bucket used to house
+	// global versioning and date information for the blockchain database.
+	BCDBInfoBucketName = []byte("dbinfo")
+
+	// BCDBInfoVersionKeyName is the name of the database key used to house
+	// the database version.  It is itself under the BCDBInfoBucketName
+	// bucket.
+	BCDBInfoVersionKeyName = []byte("version")
+
+	// BCDBInfoCompressionVersionKeyName is the name of the database key
+	// used to house the database compression version.  It is itself under
+	// the BCDBInfoBucketName bucket.
+	BCDBInfoCompressionVersionKeyName = []byte("compver")
+
+	// BCDBInfoCreatedKeyName is the name of the database key used to house
+	// date the database was created.  It is itself under the
+	// BCDBInfoBucketName bucket.
+	BCDBInfoCreatedKeyName = []byte("created")
 
 	// HashIndexBucketName is the name of the db bucket used to house to the
 	// block hash -> block height index.


### PR DESCRIPTION
**This requires PR #1045**.

This modifies the database versioning to use separate keys within the version bucket for each component in order to simplify upgrade logic.

Having a single key for the various versions of the database components makes it difficult to use because the version isn't known until the data is read, however, modifying the format necessarily means the version is needed before that point to know which format to read.

While here, it uses a `uint64` to store the date instead of a `uint32` so the timestamp continues to work past 2106.

Also, it removes the upgrade started logic since it should be possible to stop in the middle of an upgrade and resume later.  Forcing a completely new database to be created because an upgrade was stopped in the middle is not ideal.