### PR TITLE
blockchain: Don't require chain for db upgrades.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -2008,11 +2008,6 @@ func New(config *Config) (*BlockChain, error) {
 		}
 	}
 
-	// Apply any upgrades as needed.
-	if err := b.upgrade(); err != nil {
-		return nil, err
-	}
-
 	b.subsidyCache = NewSubsidyCache(b.bestNode.height, b.chainParams)
 	b.pruner = newChainPruner(&b)
 

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1435,6 +1435,11 @@ func (b *BlockChain) initChainState() error {
 		}
 	}
 
+	// Upgrade the database as needed.
+	if err := upgradeDB(b.db, b.chainParams, b.dbInfo); err != nil {
+		return err
+	}
+
 	// Attempt to load the chain state from the database.
 	err = b.db.View(func(dbTx database.Tx) error {
 		// Fetch the stored chain state from the database metadata.


### PR DESCRIPTION
**This require PRs #1045 and #1047**.

This modifies the database upgrade logic to avoid needing the chain and moves it earlier in the initialization process just after the initial database creation (if needed), but prior the final struct instance population from the database.

It is much simpler logic to have an already upgraded database prior to populating the initial chain state so all of the initial setup happens in one place.
