### PR TITLE
blockchain/indexers: Allow interrupts.

### DIFF
--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1357,7 +1357,7 @@ func (b *BlockChain) createChainState() error {
 // initChainState attempts to load and initialize the chain state from the
 // database.  When the db does not yet contain any chain state, both it and the
 // chain state are initialized to the genesis block.
-func (b *BlockChain) initChainState() error {
+func (b *BlockChain) initChainState(interrupt <-chan struct{}) error {
 	// Update database versioning scheme if needed.
 	err := b.db.Update(func(dbTx database.Tx) error {
 		// No versioning upgrade is needed if the dbinfo bucket does not
@@ -1436,7 +1436,8 @@ func (b *BlockChain) initChainState() error {
 	}
 
 	// Upgrade the database as needed.
-	if err := upgradeDB(b.db, b.chainParams, b.dbInfo); err != nil {
+	err = upgradeDB(b.db, b.chainParams, b.dbInfo, interrupt)
+	if err != nil {
 		return err
 	}
 

--- a/blockchain/indexers/addrindex.go
+++ b/blockchain/indexers/addrindex.go
@@ -1090,6 +1090,6 @@ func NewAddrIndex(db database.DB, chainParams *chaincfg.Params) *AddrIndex {
 
 // DropAddrIndex drops the address index from the provided database if it
 // exists.
-func DropAddrIndex(db database.DB) error {
-	return dropIndex(db, addrIndexKey, addrIndexName)
+func DropAddrIndex(db database.DB, interrupt <-chan struct{}) error {
+	return dropIndex(db, addrIndexKey, addrIndexName, interrupt)
 }

--- a/blockchain/indexers/existsaddrindex.go
+++ b/blockchain/indexers/existsaddrindex.go
@@ -410,6 +410,7 @@ func (idx *ExistsAddrIndex) AddUnconfirmedTx(tx *wire.MsgTx) {
 
 // DropExistsAddrIndex drops the exists address index from the provided
 // database if it exists.
-func DropExistsAddrIndex(db database.DB) error {
-	return dropIndex(db, existsAddrIndexKey, existsAddressIndexName)
+func DropExistsAddrIndex(db database.DB, interrupt <-chan struct{}) error {
+	return dropIndex(db, existsAddrIndexKey, existsAddressIndexName,
+		interrupt)
 }

--- a/blockchain/indexers/txindex.go
+++ b/blockchain/indexers/txindex.go
@@ -508,10 +508,11 @@ func dropBlockIDIndex(db database.DB) error {
 // DropTxIndex drops the transaction index from the provided database if it
 // exists.  Since the address index relies on it, the address index will also be
 // dropped when it exists.
-func DropTxIndex(db database.DB) error {
-	if err := dropIndex(db, addrIndexKey, addrIndexName); err != nil {
+func DropTxIndex(db database.DB, interrupt <-chan struct{}) error {
+	err := dropIndex(db, addrIndexKey, addrIndexName, interrupt)
+	if err != nil {
 		return err
 	}
 
-	return dropIndex(db, txIndexKey, txIndexName)
+	return dropIndex(db, txIndexKey, txIndexName, interrupt)
 }

--- a/blockchain/upgrade.go
+++ b/blockchain/upgrade.go
@@ -176,7 +176,7 @@ func upgradeToVersion2(db database.DB, chainParams *chaincfg.Params, dbInfo *dat
 // all possible upgrades iteratively.
 //
 // NOTE: The passed database info will be updated with the latest versions.
-func upgradeDB(db database.DB, chainParams *chaincfg.Params, dbInfo *databaseInfo) error {
+func upgradeDB(db database.DB, chainParams *chaincfg.Params, dbInfo *databaseInfo, interrupt <-chan struct{}) error {
 	if dbInfo.version == 1 {
 		if err := upgradeToVersion2(db, chainParams, dbInfo); err != nil {
 			return err

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -2550,7 +2550,7 @@ func (b *blockManager) SetParentTemplate(bt *BlockTemplate) {
 
 // newBlockManager returns a new decred block manager.
 // Use Start to begin processing asynchronous block and inv updates.
-func newBlockManager(s *server, indexManager blockchain.IndexManager) (*blockManager, error) {
+func newBlockManager(s *server, indexManager blockchain.IndexManager, interrupt <-chan struct{}) (*blockManager, error) {
 	bm := blockManager{
 		server:              s,
 		rejectedTxns:        make(map[chainhash.Hash]struct{}),
@@ -2569,6 +2569,7 @@ func newBlockManager(s *server, indexManager blockchain.IndexManager) (*blockMan
 	var err error
 	bm.chain, err = blockchain.New(&blockchain.Config{
 		DB:            s.db,
+		Interrupt:     interrupt,
 		ChainParams:   s.chainParams,
 		TimeSource:    s.timeSource,
 		Notifications: bm.handleNotifyMsg,

--- a/server.go
+++ b/server.go
@@ -2234,7 +2234,7 @@ func standardScriptVerifyFlags(chain *blockchain.BlockChain) (txscript.ScriptFla
 // newServer returns a new dcrd server configured to listen on addr for the
 // decred network type specified by chainParams.  Use start to begin accepting
 // connections from peers.
-func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Params) (*server, error) {
+func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Params, interrupt <-chan struct{}) (*server, error) {
 	services := defaultServices
 	if cfg.NoPeerBloomFilters {
 		services &^= wire.SFNodeBloom
@@ -2425,7 +2425,7 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 	if len(indexes) > 0 {
 		indexManager = indexers.NewManager(db, indexes, chainParams)
 	}
-	bm, err := newBlockManager(&s, indexManager)
+	bm, err := newBlockManager(&s, indexManager, interrupt)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**This requires PR #1051**.

This propagates the interrupt channel through to `blockchain` and the `indexers` so that it is possible to interrupt long-running operations such as catching up indexes.
