### PR TITLE
blockchain: Remove old version information.

### DIFF
--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1384,7 +1384,12 @@ func (b *BlockChain) initChainState(interrupt <-chan struct{}) error {
 		}
 
 		// Store the database version info using the new format.
-		return dbPutDatabaseInfo(dbTx, dbi)
+		if err := dbPutDatabaseInfo(dbTx, dbi); err != nil {
+			return err
+		}
+
+		// Remove the legacy version information.
+		return bucket.Delete(dbnamespace.BCDBInfoBucketName)
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
## NOTE: It is not possible to downgrade after running this PR. If you plan to test it, please make a copy of your data directory first.

This removes the legacy version details from the database to ensure that loading older versions of the software after the database has been upgraded fails as desired.

This is important because otherwise, the database could actually be using a new version that has been upgraded via the new scheme, but old software would still see this old information and believe the database was still on that older version.