### PR TITLE
blockchain: Simplify blocknode construction.

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -126,8 +126,6 @@ func (b *BlockChain) maybeAcceptBlock(block *dcrutil.Block, flags BehaviorFlags)
 		return false, ruleError(ErrMissingParent, str)
 	}
 
-	blockHeight := block.Height()
-
 	// The block must pass all of the validation rules which depend on the
 	// position of the block within the block chain.
 	err = b.checkBlockContext(block, prevNode, flags)
@@ -160,11 +158,8 @@ func (b *BlockChain) maybeAcceptBlock(block *dcrutil.Block, flags BehaviorFlags)
 	// Create a new block node for the block and add it to the in-memory
 	// block chain (could be either a side chain or the main chain).
 	blockHeader := &block.MsgBlock().Header
-	newNode := newBlockNode(blockHeader)
+	newNode := newBlockNode(blockHeader, prevNode)
 	newNode.populateTicketInfo(stake.FindSpentTicketsInBlock(block.MsgBlock()))
-	newNode.parent = prevNode
-	newNode.height = blockHeight
-	newNode.workSum.Add(prevNode.workSum, newNode.workSum)
 
 	// Fetching a stake node could enable a new DoS vector, so restrict
 	// this only to blocks that are recent in history.

--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -160,8 +160,8 @@ func (b *BlockChain) maybeAcceptBlock(block *dcrutil.Block, flags BehaviorFlags)
 	// Create a new block node for the block and add it to the in-memory
 	// block chain (could be either a side chain or the main chain).
 	blockHeader := &block.MsgBlock().Header
-	newNode := newBlockNode(blockHeader,
-		stake.FindSpentTicketsInBlock(block.MsgBlock()))
+	newNode := newBlockNode(blockHeader)
+	newNode.populateTicketInfo(stake.FindSpentTicketsInBlock(block.MsgBlock()))
 	newNode.parent = prevNode
 	newNode.height = blockHeight
 	newNode.workSum.Add(prevNode.workSum, newNode.workSum)

--- a/blockchain/blockindex_test.go
+++ b/blockchain/blockindex_test.go
@@ -54,9 +54,8 @@ func TestBlockNodeHeader(t *testing.T) {
 		ExtraData:    [32]byte{0xbb},
 		StakeVersion: 5,
 	}
-	node := newBlockNode(&testHeader)
+	node := newBlockNode(&testHeader, bc.bestNode)
 	bc.index.AddNode(node)
-	node.parent = bc.bestNode
 
 	// Ensure reconstructing the header for the node produces the same header
 	// used to create the node.

--- a/blockchain/blockindex_test.go
+++ b/blockchain/blockindex_test.go
@@ -54,7 +54,7 @@ func TestBlockNodeHeader(t *testing.T) {
 		ExtraData:    [32]byte{0xbb},
 		StakeVersion: 5,
 	}
-	node := newBlockNode(&testHeader, nil)
+	node := newBlockNode(&testHeader)
 	bc.index.AddNode(node)
 	node.parent = bc.bestNode
 

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1268,7 +1268,7 @@ func (b *BlockChain) createChainState() error {
 	// Create a new node from the genesis block and set it as the best node.
 	genesisBlock := dcrutil.NewBlock(b.chainParams.GenesisBlock)
 	header := &genesisBlock.MsgBlock().Header
-	node := newBlockNode(header, nil)
+	node := newBlockNode(header)
 	node.inMainChain = true
 
 	// Initialize the state related to the best block.  Since it is the
@@ -1476,7 +1476,8 @@ func (b *BlockChain) initChainState(interrupt <-chan struct{}) error {
 		// Create a new node and set it as the best node.  The preceding
 		// nodes will be loaded on demand as needed.
 		header := &block.Header
-		node := newBlockNode(header, stake.FindSpentTicketsInBlock(&block))
+		node := newBlockNode(header)
+		node.populateTicketInfo(stake.FindSpentTicketsInBlock(&block))
 		node.inMainChain = true
 		node.workSum = state.workSum
 

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1268,7 +1268,7 @@ func (b *BlockChain) createChainState() error {
 	// Create a new node from the genesis block and set it as the best node.
 	genesisBlock := dcrutil.NewBlock(b.chainParams.GenesisBlock)
 	header := &genesisBlock.MsgBlock().Header
-	node := newBlockNode(header)
+	node := newBlockNode(header, nil)
 	node.inMainChain = true
 
 	// Initialize the state related to the best block.  Since it is the
@@ -1476,7 +1476,7 @@ func (b *BlockChain) initChainState(interrupt <-chan struct{}) error {
 		// Create a new node and set it as the best node.  The preceding
 		// nodes will be loaded on demand as needed.
 		header := &block.Header
-		node := newBlockNode(header)
+		node := newBlockNode(header, nil)
 		node.populateTicketInfo(stake.FindSpentTicketsInBlock(&block))
 		node.inMainChain = true
 		node.workSum = state.workSum

--- a/blockchain/difficulty.go
+++ b/blockchain/difficulty.go
@@ -1087,8 +1087,7 @@ func (b *BlockChain) estimateNextStakeDifficultyV1(curNode *blockNode, ticketsIn
 			// Connect the header.
 			emptyHeader.PrevBlock = topNode.hash
 
-			thisNode := newBlockNode(&emptyHeader)
-			thisNode.parent = topNode
+			thisNode := newBlockNode(&emptyHeader, topNode)
 			topNode = thisNode
 		}
 	}

--- a/blockchain/difficulty.go
+++ b/blockchain/difficulty.go
@@ -1087,7 +1087,7 @@ func (b *BlockChain) estimateNextStakeDifficultyV1(curNode *blockNode, ticketsIn
 			// Connect the header.
 			emptyHeader.PrevBlock = topNode.hash
 
-			thisNode := newBlockNode(&emptyHeader, nil)
+			thisNode := newBlockNode(&emptyHeader)
 			thisNode.parent = topNode
 			topNode = thisNode
 		}

--- a/blockchain/difficulty_test.go
+++ b/blockchain/difficulty_test.go
@@ -428,7 +428,7 @@ nextTest:
 					FreshStake: ticketInfo.newTickets,
 					PoolSize:   poolSize,
 				}
-				node := newBlockNode(header, nil)
+				node := newBlockNode(header)
 				node.parent = bc.bestNode
 
 				// Update the pool size for the next header.
@@ -729,7 +729,7 @@ nextTest:
 					FreshStake: ticketInfo.newTickets,
 					PoolSize:   poolSize,
 				}
-				node := newBlockNode(header, nil)
+				node := newBlockNode(header)
 				node.parent = bc.bestNode
 
 				// Update the pool size for the next header.

--- a/blockchain/difficulty_test.go
+++ b/blockchain/difficulty_test.go
@@ -428,8 +428,7 @@ nextTest:
 					FreshStake: ticketInfo.newTickets,
 					PoolSize:   poolSize,
 				}
-				node := newBlockNode(header)
-				node.parent = bc.bestNode
+				node := newBlockNode(header, bc.bestNode)
 
 				// Update the pool size for the next header.
 				// Notice how tickets that mature for this block
@@ -729,8 +728,7 @@ nextTest:
 					FreshStake: ticketInfo.newTickets,
 					PoolSize:   poolSize,
 				}
-				node := newBlockNode(header)
-				node.parent = bc.bestNode
+				node := newBlockNode(header, bc.bestNode)
 
 				// Update the pool size for the next header.
 				// Notice how tickets that mature for this block

--- a/blockchain/internal_test.go
+++ b/blockchain/internal_test.go
@@ -39,6 +39,6 @@ func (b *BlockChain) TstCheckBlockHeaderContext(header *wire.BlockHeader, prevNo
 
 // TstNewBlockNode makes the internal newBlockNode function available to the
 // test package.
-func TstNewBlockNode(blockHeader *wire.BlockHeader) *blockNode {
-	return newBlockNode(blockHeader)
+func TstNewBlockNode(blockHeader *wire.BlockHeader, parent *blockNode) *blockNode {
+	return newBlockNode(blockHeader, parent)
 }

--- a/blockchain/internal_test.go
+++ b/blockchain/internal_test.go
@@ -16,7 +16,6 @@ package blockchain
 import (
 	"sort"
 
-	"github.com/decred/dcrd/blockchain/stake"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -40,6 +39,6 @@ func (b *BlockChain) TstCheckBlockHeaderContext(header *wire.BlockHeader, prevNo
 
 // TstNewBlockNode makes the internal newBlockNode function available to the
 // test package.
-func TstNewBlockNode(blockHeader *wire.BlockHeader, spentTickets *stake.SpentTicketsInBlock) *blockNode {
-	return newBlockNode(blockHeader, spentTickets)
+func TstNewBlockNode(blockHeader *wire.BlockHeader) *blockNode {
+	return newBlockNode(blockHeader)
 }

--- a/blockchain/stakeversion_test.go
+++ b/blockchain/stakeversion_test.go
@@ -22,7 +22,7 @@ import (
 func newFakeChain(params *chaincfg.Params) *BlockChain {
 	// Create a genesis block node and block index populated with it for use
 	// when creating the fake chain below.
-	node := newBlockNode(&params.GenesisBlock.Header, nil)
+	node := newBlockNode(&params.GenesisBlock.Header)
 	node.inMainChain = true
 	index := newBlockIndex(nil, params)
 	index.AddNode(node)
@@ -53,7 +53,7 @@ func newFakeNode(parent *blockNode, blockVersion int32, stakeVersion uint32, bit
 		Timestamp:    timestamp,
 		StakeVersion: stakeVersion,
 	}
-	node := newBlockNode(header, nil)
+	node := newBlockNode(header)
 	node.parent = parent
 	node.workSum.Add(parent.workSum, node.workSum)
 	return node

--- a/blockchain/stakeversion_test.go
+++ b/blockchain/stakeversion_test.go
@@ -22,7 +22,7 @@ import (
 func newFakeChain(params *chaincfg.Params) *BlockChain {
 	// Create a genesis block node and block index populated with it for use
 	// when creating the fake chain below.
-	node := newBlockNode(&params.GenesisBlock.Header)
+	node := newBlockNode(&params.GenesisBlock.Header, nil)
 	node.inMainChain = true
 	index := newBlockIndex(nil, params)
 	index.AddNode(node)
@@ -53,10 +53,7 @@ func newFakeNode(parent *blockNode, blockVersion int32, stakeVersion uint32, bit
 		Timestamp:    timestamp,
 		StakeVersion: stakeVersion,
 	}
-	node := newBlockNode(header)
-	node.parent = parent
-	node.workSum.Add(parent.workSum, node.workSum)
-	return node
+	return newBlockNode(header, parent)
 }
 
 // appendFakeVotes appends the passed number of votes to the node with the

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -2601,8 +2601,8 @@ func (b *BlockChain) CheckConnectBlock(block *dcrutil.Block, flags BehaviorFlags
 		return err
 	}
 
-	newNode := newBlockNode(&block.MsgBlock().Header,
-		stake.FindSpentTicketsInBlock(block.MsgBlock()))
+	newNode := newBlockNode(&block.MsgBlock().Header)
+	newNode.populateTicketInfo(stake.FindSpentTicketsInBlock(block.MsgBlock()))
 	newNode.parent = prevNode
 	newNode.workSum.Add(prevNode.workSum, newNode.workSum)
 

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -2601,10 +2601,8 @@ func (b *BlockChain) CheckConnectBlock(block *dcrutil.Block, flags BehaviorFlags
 		return err
 	}
 
-	newNode := newBlockNode(&block.MsgBlock().Header)
+	newNode := newBlockNode(&block.MsgBlock().Header, prevNode)
 	newNode.populateTicketInfo(stake.FindSpentTicketsInBlock(block.MsgBlock()))
-	newNode.parent = prevNode
-	newNode.workSum.Add(prevNode.workSum, newNode.workSum)
 
 	// If we are extending the main (best) chain with a new block, just use
 	// the ticket database we already have.

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -2110,7 +2110,7 @@ func TestCheckWorklessBlockSanity(t *testing.T) {
 }
 
 // TestCheckBlockHeaderContext tests that genesis block passes context headers
-// because it's previousNode is nil.
+// because its parent is nil.
 func TestCheckBlockHeaderContext(t *testing.T) {
 	// Create a new database for the blocks.
 	params := &chaincfg.SimNetParams
@@ -2145,7 +2145,7 @@ func TestCheckBlockHeaderContext(t *testing.T) {
 	// Test failing checkBlockHeaderContext when calcNextRequiredDifficulty
 	// fails.
 	block := dcrutil.NewBlock(&badBlock)
-	newNode := blockchain.TstNewBlockNode(&block.MsgBlock().Header)
+	newNode := blockchain.TstNewBlockNode(&block.MsgBlock().Header, nil)
 	err = chain.TstCheckBlockHeaderContext(&block.MsgBlock().Header, newNode, blockchain.BFNone)
 	if err == nil {
 		t.Fatalf("Should fail due to bad diff in newNode\n")

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -2145,8 +2145,7 @@ func TestCheckBlockHeaderContext(t *testing.T) {
 	// Test failing checkBlockHeaderContext when calcNextRequiredDifficulty
 	// fails.
 	block := dcrutil.NewBlock(&badBlock)
-	newNode := blockchain.TstNewBlockNode(&block.MsgBlock().Header,
-		&stake.SpentTicketsInBlock{})
+	newNode := blockchain.TstNewBlockNode(&block.MsgBlock().Header)
 	err = chain.TstCheckBlockHeaderContext(&block.MsgBlock().Header, newNode, blockchain.BFNone)
 	if err == nil {
 		t.Fatalf("Should fail due to bad diff in newNode\n")


### PR DESCRIPTION
~**This requires PR #1057**.~ (now merged)

This consists of two commits to simplify the construction logic for block nodes.

The first separates the logic for populating the stake information in a block node from the construction of the node in order to better delineate the difference between the two and to pave the way for that information to be stored separately in the database versus needing to load full blocks to retrieve it.

The second modifies the `newBlockNode` function to accept the `parent` as an argument to automatically connect the newly created node.  When it is not `nil`, the work sum will automatically be summed and the parent of the new node will be set accordingly.  This simplifies the block node construction a bit and allows some redundant code to be removed.  It also paves the way for easier simpler full block index construction in the future.

