### PR TITLE
blockchain: move block validation rule tests into fullblocktests (1 of x).

### DIFF
--- a/blockchain/fullblocktests/README.md
+++ b/blockchain/fullblocktests/README.md
@@ -15,7 +15,7 @@ independent versions over the peer-to-peer network.
 
 This package has intentionally been designed so it can be used as a standalone
 package for any projects needing to test their implementation against a full set
-of blocks that excerise the consensus validation rules.
+of blocks that exercise the consensus validation rules.
 
 ## Installation and Updating
 


### PR DESCRIPTION
This PR  adds`AssertTipBlockStakeRoot` helper and moves the following block rejection cases into fullblocktests.
 - `ErrVotesOnWrongBlock` 
    - Attempt to add block with tickets voting on wrong block
 - `ErrIncongruentVotebit` 
    - Attempt to add block with incorrect votebits set
        - Everyone votes yea, but block header says nay
        - Everyone votes nay, but block header says yea
        - 3x nay 2x yea, but block header says yea
        - 2x nay 3x yea, but block header says nay
 - `ErrBadMerkleRoot`
    - Create block with an invalid stake root
 - `ErrWrongBlockSize`
    - Create block with an invalid block size
 - `ErrBadCoinbaseAmountIn`
    - Create block with an invalid subsidy for coinbase output
 - `ErrBadStakebaseAmountIn`
    - Create block with an invalid subsidy for a stakebase input
 - `ErrRevocationsMismatch`
    - Create block with a revocations count mismatch

Work towards #1030.