### PR TITLE
blockchain: Simplify add/remove node logic.

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -160,6 +160,15 @@ func (b *BlockChain) maybeAcceptBlock(block *dcrutil.Block, flags BehaviorFlags)
 	blockHeader := &block.MsgBlock().Header
 	newNode := newBlockNode(blockHeader, prevNode)
 	newNode.populateTicketInfo(stake.FindSpentTicketsInBlock(block.MsgBlock()))
+	b.index.AddNode(newNode)
+
+	// Remove the node from the block index and disconnect it from the
+	// parent node when running in dry run mode.
+	if dryRun {
+		defer func() {
+			b.index.RemoveNode(newNode)
+		}()
+	}
 
 	// Fetching a stake node could enable a new DoS vector, so restrict
 	// this only to blocks that are recent in history.


### PR DESCRIPTION
This simplifies and consolidates the logic for adding and removing nodes to and from the block index by moving the initial add into `maybeAcceptBlock` just after the node is created, adding the child
connection logic to the `AddNode` function, and introducing a `RemoveNode` function that is called in dry run mode which undoes the aforementioned changes.

In addition to being simpler logic to follow, it helps make it clear that all blocks which are written to the database end up with a block index entry, even if they ultimately fail to connect.