### PR TITLE
blockchain: Refactor block idx entry serialization.

### DIFF
--- a/blockchain/blockindex.go
+++ b/blockchain/blockindex.go
@@ -322,10 +322,15 @@ func (bi *blockIndex) loadBlockNode(dbTx database.Tx, hash *chainhash.Hash) (*bl
 
 	// Load the block node for the provided hash and height from the
 	// database.
-	node, err := dbFetchBlockNode(dbTx, hash, uint32(height))
+	entry, err := dbFetchBlockIndexEntry(dbTx, hash, uint32(height))
 	if err != nil {
 		return nil, err
 	}
+	node := new(blockNode)
+	initBlockNode(node, &entry.header, nil)
+	node.ticketsVoted = entry.ticketsVoted
+	node.ticketsRevoked = entry.ticketsRevoked
+	node.votes = entry.voteInfo
 	node.inMainChain = true
 
 	// Add the node to the chain.

--- a/blockchain/chainio_test.go
+++ b/blockchain/chainio_test.go
@@ -13,6 +13,7 @@ import (
 	"math/big"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/decred/dcrd/blockchain/stake"
 	"github.com/decred/dcrd/chaincfg/chainhash"
@@ -120,94 +121,97 @@ func TestErrNotInMainChain(t *testing.T) {
 	}
 }
 
-// TestBlockNodeSerialization ensures serializing and deserializing block nodes
-// works as expected.
-func TestBlockNodeSerialization(t *testing.T) {
+// TestBlockIndexSerialization ensures serializing and deserializing block index
+// entries works as expected.
+func TestBlockIndexSerialization(t *testing.T) {
 	t.Parallel()
 
-	// baseNode is based on block 150287 on mainnet and serves as a template
+	// base data is based on block 150287 on mainnet and serves as a template
 	// for the various tests below.
-	baseNode := blockNode{
-		hash:         *newHashFromStr("000000000000005d9820c21dc15d859cc18d660171aaf74fe835d736eaaffc26"),
-		blockVersion: 4,
-		parentHash:   *newHashFromStr("000000000000016916671ae225343a5ee131c999d5cadb6348805db25737731f"),
-		merkleRoot:   *newHashFromStr("5ef2bb79795d7503c0ccc5cb6e0d4731992fc8c8c5b332c1c0e2c687d864c666"),
-		stakeRoot:    *newHashFromStr("022965059b7527dc2bc18daaa533f806eda1f96fd0b04bbda2381f5552d7c2de"),
-		voteBits:     0x0001,
-		finalState:   hexToFinalState("313e16e64c0b"),
-		voters:       4,
-		freshStake:   3,
-		revocations:  2,
-		poolSize:     41332,
-		bits:         0x1a016f98,
-		sbits:        7473162478,
-		height:       150287,
-		blockSize:    11295,
-		timestamp:    1499907127,
-		nonce:        4116576260,
-		extraData:    hexToExtraData("8f01ed92645e0a6b11ee3b3c0000000000000000000000000000000000000000"),
-		stakeVersion: 4,
-		status:       statusDataStored | statusValid,
-		ticketsVoted: []chainhash.Hash{
-			*newHashFromStr("8b62a877544753ea80a822142a48ec066170e9381d21a9e8a84bc7373f0f9b2e"),
-			*newHashFromStr("4427a003a7aceb1404ffd9072e9aff1e128a24333a543332030e91668a389db7"),
-			*newHashFromStr("4415b88ac74881d7b6b15d41df465257cd1cc92d55e95f1b648434aef3a2110b"),
-			*newHashFromStr("9d2621b57352088809d3a069b04b76c832f30a76da14e56aece72208b3e5b87a"),
-		},
-		ticketsRevoked: []chainhash.Hash{
-			*newHashFromStr("8146f01b8ffca8008ebc80293d2978d63b1dffa5c456a73e7b39a9b1e695e8eb"),
-			*newHashFromStr("2292ff2461e725c58cc6e2051eac2a10e6ee6d1f62327ed676b7a196fb94be0c"),
-		},
-		votes: []stake.VoteVersionTuple{
-			{Version: 4, Bits: 0x0001},
-			{Version: 4, Bits: 0x0015},
-			{Version: 4, Bits: 0x0015},
-			{Version: 4, Bits: 0x0001},
-		},
+	baseHeader := wire.BlockHeader{
+		Version:      4,
+		PrevBlock:    *newHashFromStr("000000000000016916671ae225343a5ee131c999d5cadb6348805db25737731f"),
+		MerkleRoot:   *newHashFromStr("5ef2bb79795d7503c0ccc5cb6e0d4731992fc8c8c5b332c1c0e2c687d864c666"),
+		StakeRoot:    *newHashFromStr("022965059b7527dc2bc18daaa533f806eda1f96fd0b04bbda2381f5552d7c2de"),
+		VoteBits:     0x0001,
+		FinalState:   hexToFinalState("313e16e64c0b"),
+		Voters:       4,
+		FreshStake:   3,
+		Revocations:  2,
+		PoolSize:     41332,
+		Bits:         0x1a016f98,
+		SBits:        7473162478,
+		Height:       150287,
+		Size:         11295,
+		Timestamp:    time.Unix(1499907127, 0),
+		Nonce:        4116576260,
+		ExtraData:    hexToExtraData("8f01ed92645e0a6b11ee3b3c0000000000000000000000000000000000000000"),
+		StakeVersion: 4,
 	}
-	baseNode.workSum = CalcWork(baseNode.bits)
+	baseTicketsVoted := []chainhash.Hash{
+		*newHashFromStr("8b62a877544753ea80a822142a48ec066170e9381d21a9e8a84bc7373f0f9b2e"),
+		*newHashFromStr("4427a003a7aceb1404ffd9072e9aff1e128a24333a543332030e91668a389db7"),
+		*newHashFromStr("4415b88ac74881d7b6b15d41df465257cd1cc92d55e95f1b648434aef3a2110b"),
+		*newHashFromStr("9d2621b57352088809d3a069b04b76c832f30a76da14e56aece72208b3e5b87a"),
+	}
+	baseTicketsRevoked := []chainhash.Hash{
+		*newHashFromStr("8146f01b8ffca8008ebc80293d2978d63b1dffa5c456a73e7b39a9b1e695e8eb"),
+		*newHashFromStr("2292ff2461e725c58cc6e2051eac2a10e6ee6d1f62327ed676b7a196fb94be0c"),
+	}
+	baseVoteInfo := []stake.VoteVersionTuple{
+		{Version: 4, Bits: 0x0001},
+		{Version: 4, Bits: 0x0015},
+		{Version: 4, Bits: 0x0015},
+		{Version: 4, Bits: 0x0001},
+	}
 
 	tests := []struct {
 		name       string
-		node       blockNode
+		entry      blockIndexEntry
 		serialized []byte
 	}{
 		{
 			name: "no votes, no revokes",
-			node: func() blockNode {
-				node := baseNode
-				node.ticketsVoted = nil
-				node.votes = nil
-				node.ticketsRevoked = nil
-				return node
-			}(),
+			entry: blockIndexEntry{
+				header:         baseHeader,
+				status:         statusDataStored | statusValid,
+				voteInfo:       nil,
+				ticketsVoted:   nil,
+				ticketsRevoked: nil,
+			},
 			serialized: hexToBytes("040000001f733757b25d804863dbcad599c931e15e3a3425e21a6716690100000000000066c664d887c6e2c0c132b3c5c8c82f9931470d6ecbc5ccc003755d7979bbf25edec2d752551f38a2bd4bb0d06ff9a1ed06f833a5aa8dc12bdc27759b056529020100313e16e64c0b0400030274a10000986f011aee686fbd010000000f4b02001f2c000037c4665904f85df58f01ed92645e0a6b11ee3b3c000000000000000000000000000000000000000004000000030000"),
 		},
 		{
 			name: "1 vote, no revokes",
-			node: func() blockNode {
-				node := baseNode
-				node.ticketsVoted = node.ticketsVoted[:1]
-				node.votes = node.votes[:1]
-				node.ticketsRevoked = nil
-				return node
-			}(),
+			entry: blockIndexEntry{
+				header:         baseHeader,
+				status:         statusDataStored | statusValid,
+				voteInfo:       baseVoteInfo[:1],
+				ticketsVoted:   baseTicketsVoted[:1],
+				ticketsRevoked: nil,
+			},
 			serialized: hexToBytes("040000001f733757b25d804863dbcad599c931e15e3a3425e21a6716690100000000000066c664d887c6e2c0c132b3c5c8c82f9931470d6ecbc5ccc003755d7979bbf25edec2d752551f38a2bd4bb0d06ff9a1ed06f833a5aa8dc12bdc27759b056529020100313e16e64c0b0400030274a10000986f011aee686fbd010000000f4b02001f2c000037c4665904f85df58f01ed92645e0a6b11ee3b3c00000000000000000000000000000000000000000400000003012e9b0f3f37c74ba8e8a9211d38e9706106ec482a1422a880ea53475477a8628b040100"),
 		},
 		{
 			name: "no votes, 1 revoke",
-			node: func() blockNode {
-				node := baseNode
-				node.ticketsVoted = nil
-				node.ticketsRevoked = node.ticketsRevoked[:1]
-				node.votes = nil
-				return node
-			}(),
+			entry: blockIndexEntry{
+				header:         baseHeader,
+				status:         statusDataStored | statusValid,
+				voteInfo:       nil,
+				ticketsVoted:   nil,
+				ticketsRevoked: baseTicketsRevoked[:1],
+			},
 			serialized: hexToBytes("040000001f733757b25d804863dbcad599c931e15e3a3425e21a6716690100000000000066c664d887c6e2c0c132b3c5c8c82f9931470d6ecbc5ccc003755d7979bbf25edec2d752551f38a2bd4bb0d06ff9a1ed06f833a5aa8dc12bdc27759b056529020100313e16e64c0b0400030274a10000986f011aee686fbd010000000f4b02001f2c000037c4665904f85df58f01ed92645e0a6b11ee3b3c000000000000000000000000000000000000000004000000030001ebe895e6b1a9397b3ea756c4a5ff1d3bd678293d2980bc8e00a8fc8f1bf04681"),
 		},
 		{
-			name:       "4 votes, same vote versions, different vote bits, 2 revokes",
-			node:       baseNode,
+			name: "4 votes, same vote versions, different vote bits, 2 revokes",
+			entry: blockIndexEntry{
+				header:         baseHeader,
+				status:         statusDataStored | statusValid,
+				voteInfo:       baseVoteInfo,
+				ticketsVoted:   baseTicketsVoted,
+				ticketsRevoked: baseTicketsRevoked,
+			},
 			serialized: hexToBytes("040000001f733757b25d804863dbcad599c931e15e3a3425e21a6716690100000000000066c664d887c6e2c0c132b3c5c8c82f9931470d6ecbc5ccc003755d7979bbf25edec2d752551f38a2bd4bb0d06ff9a1ed06f833a5aa8dc12bdc27759b056529020100313e16e64c0b0400030274a10000986f011aee686fbd010000000f4b02001f2c000037c4665904f85df58f01ed92645e0a6b11ee3b3c00000000000000000000000000000000000000000400000003042e9b0f3f37c74ba8e8a9211d38e9706106ec482a1422a880ea53475477a8628b0401b79d388a66910e033233543a33248a121eff9a2e07d9ff0414ebaca703a0274404150b11a2f3ae3484641b5fe9552dc91ccd575246df415db1b6d78148c78ab8154404157ab8e5b30822e7ec6ae514da760af332c8764bb069a0d30988085273b521269d040102ebe895e6b1a9397b3ea756c4a5ff1d3bd678293d2980bc8e00a8fc8f1bf046810cbe94fb96a1b776d67e32621f6deee6102aac1e05e2c68cc525e76124ff9222"),
 		},
 	}
@@ -215,165 +219,169 @@ func TestBlockNodeSerialization(t *testing.T) {
 	for _, test := range tests {
 		// Ensure the function to calculate the serialized size without
 		// actually serializing it is calculated properly.
-		gotSize := blockNodeSerializeSize(&test.node)
+		gotSize := blockIndexEntrySerializeSize(&test.entry)
 		if gotSize != len(test.serialized) {
-			t.Errorf("blockNodeSerializeSize (%s): did not get "+
-				"expected size - got %d, want %d", test.name,
+			t.Errorf("blockIndexEntrySerializeSize (%s): did not "+
+				"get expected size - got %d, want %d", test.name,
 				gotSize, len(test.serialized))
 		}
 
-		// Ensure the block node serializes to the expected value.
-		gotSerialized, err := serializeBlockNode(&test.node)
+		// Ensure the block index entry serializes to the expected value.
+		gotSerialized, err := serializeBlockIndexEntry(&test.entry)
 		if err != nil {
-			t.Errorf("serializeBlockNode (%s): unexpected error: %v",
-				test.name, err)
+			t.Errorf("serializeBlockIndexEntry (%s): unexpected "+
+				"error: %v", test.name, err)
 			continue
 		}
 		if !bytes.Equal(gotSerialized, test.serialized) {
-			t.Errorf("serializeBlockNode (%s): did not get expected "+
-				"bytes - got %x, want %x", test.name,
+			t.Errorf("serializeBlockIndexEntry (%s): did not get "+
+				"expected bytes - got %x, want %x", test.name,
 				gotSerialized, test.serialized)
 			continue
 		}
 
-		// Ensure the block node serializes to the expected value and
-		// produces the expected number of bytes written via a direct
-		// put.
+		// Ensure the block index entry serializes to the expected value
+		// and produces the expected number of bytes written via a
+		// direct put.
 		gotSerialized2 := make([]byte, gotSize)
-		gotBytesWritten, err := putBlockNode(gotSerialized2, &test.node)
+		gotBytesWritten, err := putBlockIndexEntry(gotSerialized2,
+			&test.entry)
 		if err != nil {
-			t.Errorf("putBlockNode (%s): unexpected error: %v",
+			t.Errorf("putBlockIndexEntry (%s): unexpected error: %v",
 				test.name, err)
 			continue
 		}
 		if !bytes.Equal(gotSerialized2, test.serialized) {
-			t.Errorf("putBlockNode (%s): did not get expected "+
-				"bytes - got %x, want %x", test.name,
+			t.Errorf("putBlockIndexEntry (%s): did not get "+
+				"expected bytes - got %x, want %x", test.name,
 				gotSerialized2, test.serialized)
 			continue
 		}
 		if gotBytesWritten != len(test.serialized) {
-			t.Errorf("putBlockNode (%s): did not get expected "+
-				"number of bytes written - got %d, want %d",
-				test.name, gotBytesWritten,
+			t.Errorf("putBlockIndexEntry (%s): did not get "+
+				"expected number of bytes written - got %d, "+
+				"want %d", test.name, gotBytesWritten,
 				len(test.serialized))
 			continue
 		}
 
 		// Ensure the serialized bytes are decoded back to the expected
-		// block node.
-		gotNode, err := deserializeBlockNode(test.serialized)
+		// block index entry.
+		gotEntry, err := deserializeBlockIndexEntry(test.serialized)
 		if err != nil {
-			t.Errorf("deserializeBlockNode (%s): unexpected error: %v",
-				test.name, err)
+			t.Errorf("deserializeBlockIndexEntry (%s): unexpected "+
+				"error: %v", test.name, err)
 			continue
 		}
-		if !reflect.DeepEqual(*gotNode, test.node) {
-			t.Errorf("deserializeBlockNode (%s): mismatched entries\ngot "+
-				"%+v\nwant %+v", test.name, gotNode, test.node)
+		if !reflect.DeepEqual(*gotEntry, test.entry) {
+			t.Errorf("deserializeBlockIndexEntry (%s): mismatched "+
+				"entries\ngot %+v\nwant %+v", test.name,
+				gotEntry, test.entry)
 			continue
 		}
 
 		// Ensure the serialized bytes are decoded back to the expected
-		// block node.
-		var gotNode2 blockNode
-		bytesRead, err := decodeBlockNode(test.serialized, &gotNode2)
+		// block index entry.
+		var gotEntry2 blockIndexEntry
+		bytesRead, err := decodeBlockIndexEntry(test.serialized, &gotEntry2)
 		if err != nil {
-			t.Errorf("decodeBlockNode (%s): unexpected error: %v",
-				test.name, err)
+			t.Errorf("decodeBlockIndexEntry (%s): unexpected "+
+				"error: %v", test.name, err)
 			continue
 		}
-		if !reflect.DeepEqual(gotNode2, test.node) {
-			t.Errorf("decodeBlockNode (%s): mismatched entries\ngot "+
-				"%+v\nwant %+v", test.name, gotNode2, test.node)
+		if !reflect.DeepEqual(gotEntry2, test.entry) {
+			t.Errorf("decodeBlockIndexEntry (%s): mismatched "+
+				"entries\ngot %+v\nwant %+v", test.name,
+				gotEntry2, test.entry)
 			continue
 		}
 		if bytesRead != len(test.serialized) {
-			t.Errorf("decodeBlockNode (%s): did not get expected "+
-				"number of bytes read - got %d, want %d",
-				test.name, bytesRead, len(test.serialized))
+			t.Errorf("decodeBlockIndexEntry (%s): did not get "+
+				"expected number of bytes read - got %d, "+
+				"want %d", test.name, bytesRead,
+				len(test.serialized))
 			continue
 		}
 	}
 }
 
-// TestBlockNodeDecodeErrors performs negative tests against decoding block
-// nodes to ensure error paths work as expected.
-func TestBlockNodeDecodeErrors(t *testing.T) {
+// TestBlockIndexDecodeErrors performs negative tests against decoding block
+// index entries to ensure error paths work as expected.
+func TestBlockIndexDecodeErrors(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name       string
-		node       blockNode
+		entry      blockIndexEntry
 		serialized []byte
 		bytesRead  int // Expected number of bytes read.
 		errType    error
 	}{
 		{
 			name:       "nothing serialized",
-			node:       blockNode{},
+			entry:      blockIndexEntry{},
 			serialized: hexToBytes(""),
 			errType:    errDeserialize(""),
 			bytesRead:  0,
 		},
 		{
 			name:       "no data after block header",
-			node:       blockNode{},
+			entry:      blockIndexEntry{},
 			serialized: hexToBytes("040000001f733757b25d804863dbcad599c931e15e3a3425e21a6716690100000000000066c664d887c6e2c0c132b3c5c8c82f9931470d6ecbc5ccc003755d7979bbf25edec2d752551f38a2bd4bb0d06ff9a1ed06f833a5aa8dc12bdc27759b056529020100313e16e64c0b0400030274a10000986f011aee686fbd010000000f4b02001f2c000037c4665904f85df58f01ed92645e0a6b11ee3b3c000000000000000000000000000000000000000004000000"),
 			errType:    errDeserialize(""),
 			bytesRead:  180,
 		},
 		{
 			name:       "no data after status",
-			node:       blockNode{},
+			entry:      blockIndexEntry{},
 			serialized: hexToBytes("040000001f733757b25d804863dbcad599c931e15e3a3425e21a6716690100000000000066c664d887c6e2c0c132b3c5c8c82f9931470d6ecbc5ccc003755d7979bbf25edec2d752551f38a2bd4bb0d06ff9a1ed06f833a5aa8dc12bdc27759b056529020100313e16e64c0b0400030274a10000986f011aee686fbd010000000f4b02001f2c000037c4665904f85df58f01ed92645e0a6b11ee3b3c00000000000000000000000000000000000000000400000003"),
 			errType:    errDeserialize(""),
 			bytesRead:  181,
 		},
 		{
 			name:       "no data after num votes with no votes",
-			node:       blockNode{},
+			entry:      blockIndexEntry{},
 			serialized: hexToBytes("040000001f733757b25d804863dbcad599c931e15e3a3425e21a6716690100000000000066c664d887c6e2c0c132b3c5c8c82f9931470d6ecbc5ccc003755d7979bbf25edec2d752551f38a2bd4bb0d06ff9a1ed06f833a5aa8dc12bdc27759b056529020100313e16e64c0b0400030274a10000986f011aee686fbd010000000f4b02001f2c000037c4665904f85df58f01ed92645e0a6b11ee3b3c0000000000000000000000000000000000000000040000000300"),
 			errType:    errDeserialize(""),
 			bytesRead:  182,
 		},
 		{
 			name:       "no data after num votes with votes",
-			node:       blockNode{},
+			entry:      blockIndexEntry{},
 			serialized: hexToBytes("040000001f733757b25d804863dbcad599c931e15e3a3425e21a6716690100000000000066c664d887c6e2c0c132b3c5c8c82f9931470d6ecbc5ccc003755d7979bbf25edec2d752551f38a2bd4bb0d06ff9a1ed06f833a5aa8dc12bdc27759b056529020100313e16e64c0b0400030274a10000986f011aee686fbd010000000f4b02001f2c000037c4665904f85df58f01ed92645e0a6b11ee3b3c0000000000000000000000000000000000000000040000000301"),
 			errType:    errDeserialize(""),
 			bytesRead:  182,
 		},
 		{
 			name:       "short data in vote ticket hash",
-			node:       blockNode{},
+			entry:      blockIndexEntry{},
 			serialized: hexToBytes("040000001f733757b25d804863dbcad599c931e15e3a3425e21a6716690100000000000066c664d887c6e2c0c132b3c5c8c82f9931470d6ecbc5ccc003755d7979bbf25edec2d752551f38a2bd4bb0d06ff9a1ed06f833a5aa8dc12bdc27759b056529020100313e16e64c0b0400030274a10000986f011aee686fbd010000000f4b02001f2c000037c4665904f85df58f01ed92645e0a6b11ee3b3c00000000000000000000000000000000000000000400000003012e9b0f3f37c74ba8e8a9211d38e9706106ec482a1422a880ea53475477a862"),
 			errType:    errDeserialize(""),
 			bytesRead:  182,
 		},
 		{
 			name:       "no data after vote ticket hash",
-			node:       blockNode{},
+			entry:      blockIndexEntry{},
 			serialized: hexToBytes("040000001f733757b25d804863dbcad599c931e15e3a3425e21a6716690100000000000066c664d887c6e2c0c132b3c5c8c82f9931470d6ecbc5ccc003755d7979bbf25edec2d752551f38a2bd4bb0d06ff9a1ed06f833a5aa8dc12bdc27759b056529020100313e16e64c0b0400030274a10000986f011aee686fbd010000000f4b02001f2c000037c4665904f85df58f01ed92645e0a6b11ee3b3c00000000000000000000000000000000000000000400000003012e9b0f3f37c74ba8e8a9211d38e9706106ec482a1422a880ea53475477a8628b"),
 			errType:    errDeserialize(""),
 			bytesRead:  214,
 		},
 		{
 			name:       "no data after vote version",
-			node:       blockNode{},
+			entry:      blockIndexEntry{},
 			serialized: hexToBytes("040000001f733757b25d804863dbcad599c931e15e3a3425e21a6716690100000000000066c664d887c6e2c0c132b3c5c8c82f9931470d6ecbc5ccc003755d7979bbf25edec2d752551f38a2bd4bb0d06ff9a1ed06f833a5aa8dc12bdc27759b056529020100313e16e64c0b0400030274a10000986f011aee686fbd010000000f4b02001f2c000037c4665904f85df58f01ed92645e0a6b11ee3b3c00000000000000000000000000000000000000000400000003012e9b0f3f37c74ba8e8a9211d38e9706106ec482a1422a880ea53475477a8628b04"),
 			errType:    errDeserialize(""),
 			bytesRead:  215,
 		},
 		{
 			name:       "no data after votes",
-			node:       blockNode{},
+			entry:      blockIndexEntry{},
 			serialized: hexToBytes("040000001f733757b25d804863dbcad599c931e15e3a3425e21a6716690100000000000066c664d887c6e2c0c132b3c5c8c82f9931470d6ecbc5ccc003755d7979bbf25edec2d752551f38a2bd4bb0d06ff9a1ed06f833a5aa8dc12bdc27759b056529020100313e16e64c0b0400030274a10000986f011aee686fbd010000000f4b02001f2c000037c4665904f85df58f01ed92645e0a6b11ee3b3c00000000000000000000000000000000000000000400000003012e9b0f3f37c74ba8e8a9211d38e9706106ec482a1422a880ea53475477a8628b0401"),
 			errType:    errDeserialize(""),
 			bytesRead:  216,
 		},
 		{
 			name:       "no data after num revokes with revokes",
-			node:       blockNode{},
+			entry:      blockIndexEntry{},
 			serialized: hexToBytes("040000001f733757b25d804863dbcad599c931e15e3a3425e21a6716690100000000000066c664d887c6e2c0c132b3c5c8c82f9931470d6ecbc5ccc003755d7979bbf25edec2d752551f38a2bd4bb0d06ff9a1ed06f833a5aa8dc12bdc27759b056529020100313e16e64c0b0400030274a10000986f011aee686fbd010000000f4b02001f2c000037c4665904f85df58f01ed92645e0a6b11ee3b3c000000000000000000000000000000000000000004000000030001"),
 			errType:    errDeserialize(""),
 			bytesRead:  183,
@@ -382,19 +390,20 @@ func TestBlockNodeDecodeErrors(t *testing.T) {
 
 	for _, test := range tests {
 		// Ensure the expected error type is returned.
-		gotBytesRead, err := decodeBlockNode(test.serialized, &test.node)
+		gotBytesRead, err := decodeBlockIndexEntry(test.serialized,
+			&test.entry)
 		if reflect.TypeOf(err) != reflect.TypeOf(test.errType) {
-			t.Errorf("decodeBlockNode (%s): expected error type "+
-				"does not match - got %T, want %T", test.name,
-				err, test.errType)
+			t.Errorf("decodeBlockIndexEntry (%s): expected error "+
+				"type does not match - got %T, want %T",
+				test.name, err, test.errType)
 			continue
 		}
 
 		// Ensure the expected number of bytes read is returned.
 		if gotBytesRead != test.bytesRead {
-			t.Errorf("decodeBlockNode (%s): unexpected number of "+
-				"bytes read - got %d, want %d", test.name,
-				gotBytesRead, test.bytesRead)
+			t.Errorf("decodeBlockIndexEntry (%s): unexpected "+
+				"number of bytes read - got %d, want %d",
+				test.name, gotBytesRead, test.bytesRead)
 			continue
 		}
 	}


### PR DESCRIPTION
This modifies the newly added block index serialization code to use a separate structure as opposed to working with block nodes directly.

This approach is more desirable because it provides better separation and more robust code against changes to the block node structure itself and it avoids complications dealing with non-serialized fields such as
parent and child pointers.