### PR TITLE
blockchain: Remove dry run flag.

### DIFF
--- a/blockchain/process.go
+++ b/blockchain/process.go
@@ -30,11 +30,6 @@ const (
 	// not be performed.
 	BFNoPoWCheck
 
-	// BFDryRun may be set to indicate the block should not modify the chain
-	// or memory chain index.  This is useful to test that a block is valid
-	// without modifying the current state.
-	BFDryRun
-
 	// BFNone is a convenience value to specifically indicate no flags.
 	BFNone BehaviorFlags = 0
 )
@@ -149,7 +144,6 @@ func (b *BlockChain) ProcessBlock(block *dcrutil.Block, flags BehaviorFlags) (bo
 	defer b.chainLock.Unlock()
 
 	fastAdd := flags&BFFastAdd == BFFastAdd
-	dryRun := flags&BFDryRun == BFDryRun
 
 	blockHash := block.Hash()
 	log.Tracef("Processing block %v", blockHash)
@@ -231,11 +225,9 @@ func (b *BlockChain) ProcessBlock(block *dcrutil.Block, flags BehaviorFlags) (bo
 		return false, false, err
 	}
 	if !prevHashExists {
-		if !dryRun {
-			log.Infof("Adding orphan block %v with parent %v",
-				blockHash, prevHash)
-			b.addOrphanBlock(block)
-		}
+		log.Infof("Adding orphan block %v with parent %v", blockHash,
+			prevHash)
+		b.addOrphanBlock(block)
 
 		return false, true, nil
 	}
@@ -247,18 +239,15 @@ func (b *BlockChain) ProcessBlock(block *dcrutil.Block, flags BehaviorFlags) (bo
 		return false, false, err
 	}
 
-	// Don't process any orphans or log when the dry run flag is set.
-	if !dryRun {
-		// Accept any orphan blocks that depend on this block (they are
-		// no longer orphans) and repeat for those accepted blocks until
-		// there are no more.
-		err := b.processOrphans(blockHash, flags)
-		if err != nil {
-			return false, false, err
-		}
-
-		log.Debugf("Accepted block %v", blockHash)
+	// Accept any orphan blocks that depend on this block (they are no
+	// longer orphans) and repeat for those accepted blocks until there are
+	// no more.
+	err = b.processOrphans(blockHash, flags)
+	if err != nil {
+		return false, false, err
 	}
+
+	log.Debugf("Accepted block %v", blockHash)
 
 	return isMainChain, false, nil
 }

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2967,8 +2967,8 @@ func handleGetBlockTemplateProposal(s *rpcServer, request *dcrjson.TemplateReque
 		return "bad-prevblk", nil
 	}
 
-	flags := blockchain.BFDryRun | blockchain.BFNoPoWCheck
-	isOrphan, err := s.server.blockManager.ProcessBlock(block, flags)
+	flags := blockchain.BFNoPoWCheck
+	err = s.server.blockManager.chain.CheckConnectBlock(block, flags)
 	if err != nil {
 		if _, ok := err.(blockchain.RuleError); !ok {
 			errStr := fmt.Sprintf("Failed to process block "+
@@ -2980,9 +2980,6 @@ func handleGetBlockTemplateProposal(s *rpcServer, request *dcrjson.TemplateReque
 
 		rpcsLog.Infof("Rejected block proposal: %v", err)
 		return chainErrToGBTErrString(err), nil
-	}
-	if isOrphan {
-		return "orphan", nil
 	}
 
 	return nil, nil


### PR DESCRIPTION
This switches block template proposal checks over to use `CheckConnectBlock` now that all of the core checks needed for block templates is included there, and, more importantly, removes the the `BFDryRun` flag since it was only used to test block template proposals and it is much simpler to allow the main chain processing paths to run without the complication of selectively processing code for dry run behavior.