### PR TITLE
chaingen: Prevent dup block names in NextBlock.

### DIFF
--- a/blockchain/chaingen/generator.go
+++ b/blockchain/chaingen/generator.go
@@ -1701,6 +1701,11 @@ func updateVoteCommitments(block *wire.MsgBlock) {
 // - The size of the block will be recalculated unless it was manually changed
 // - The block will be solved unless the nonce was changed
 func (g *Generator) NextBlock(blockName string, spend *SpendableOut, ticketSpends []SpendableOut, mungers ...func(*wire.MsgBlock)) *wire.MsgBlock {
+	// Prevent block name collisions.
+	if g.blocksByName[blockName] != nil {
+		panic(fmt.Sprintf("block name %s already exists", blockName))
+	}
+
 	// Calculate the next required stake difficulty (aka ticket price).
 	ticketPrice := dcrutil.Amount(g.calcNextRequiredStakeDifficulty())
 

--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -382,11 +382,11 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	//
 	// rejectNonCanonicalBlock creates a test instance that encodes the
 	// provided block using a non-canonical encoded as described by the
-	// encodeNonCanonicalBlock function and expected it to be rejected.
+	// encodeNonCanonicalBlock function and expects it to be rejected.
 	//
-	// orphanOrRejectBlock creates a test instance that expected the
-	// provided block to either by accepted as an orphan or rejected by the
-	// consensus rules.
+	// orphanOrRejectBlock creates a test instance that expects the provided
+	// block to either be accepted as an orphan or rejected by the consensus
+	// rules.
 	//
 	// expectTipBlock creates a test instance that expects the provided
 	// block to be the current tip of the block chain.
@@ -1464,7 +1464,6 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 		coinbaseOuts := g.OldestCoinbaseOuts()
 		outs = append(outs, &coinbaseOuts[0])
 		ticketOuts = append(ticketOuts, coinbaseOuts[1:])
-
 	}
 
 	// ---------------------------------------------------------------------


### PR DESCRIPTION
This modifies the `chaingen` test harness to error when a duplicate block name is provided to `NextBlock` to help prevent misuse.

It also corrects a couple of comment typos.