### PR TITLE
fullblocktests: Improve vote on wrong block tests.

### DIFF
--- a/blockchain/chaingen/generator.go
+++ b/blockchain/chaingen/generator.go
@@ -533,10 +533,10 @@ func isRevocationTx(tx *wire.MsgTx) bool {
 	return scriptClass == txscript.StakeRevocationTy
 }
 
-// voteBlockScript returns a standard provably-pruneable OP_RETURN script
+// VoteCommitmentScript returns a standard provably-pruneable OP_RETURN script
 // suitable for use in a vote tx (ssgen) given the block hash and height to vote
 // on.
-func voteCommitmentScript(hash chainhash.Hash, height uint32) []byte {
+func VoteCommitmentScript(hash chainhash.Hash, height uint32) []byte {
 	// The vote commitment consists of a 32-byte hash of the block it is
 	// voting on along with its expected height as a 4-byte little-endian
 	// uint32.  32-byte hash + 4-byte uint32 = 36 bytes.
@@ -554,7 +554,7 @@ func voteCommitmentScript(hash chainhash.Hash, height uint32) []byte {
 // voteBlockScript returns a standard provably-pruneable OP_RETURN script
 // suitable for use in a vote tx (ssgen) given the block to vote on.
 func voteBlockScript(parentBlock *wire.MsgBlock) []byte {
-	return voteCommitmentScript(parentBlock.BlockHash(),
+	return VoteCommitmentScript(parentBlock.BlockHash(),
 		parentBlock.Header.Height)
 }
 
@@ -1825,7 +1825,7 @@ func updateVoteCommitments(block *wire.MsgBlock) {
 			continue
 		}
 
-		stx.TxOut[0].PkScript = voteCommitmentScript(block.Header.PrevBlock,
+		stx.TxOut[0].PkScript = VoteCommitmentScript(block.Header.PrevBlock,
 			block.Header.Height-1)
 	}
 }


### PR DESCRIPTION
This exports the `VoteCommitmentScript` function from the `chaingen` package so callers can make use of it to create new vote commitment scripts and improves the test which checks for votes on the wrong block by creating a new commitment script and testing 3 different scenarios:

- Ticket that commits to the parent of the correct block to ensure that the code under test is not just failing due to a hash that doesn't exist
- Ticket that commits to the correct block hash and wrong block height
- Ticket the commits to the correct block height and wrong block hash
