### PR TITLE
blockchain: Reduce GetGeneration to TipGeneration.

### DIFF
--- a/mining.go
+++ b/mining.go
@@ -1193,7 +1193,7 @@ func NewBlockTemplate(policy *mining.Policy, server *server,
 
 	if nextBlockHeight >= stakeValidationHeight {
 		// Obtain the entire generation of blocks stemming from this parent.
-		children, err := blockManager.GetGeneration(*prevHash)
+		children, err := blockManager.TipGeneration()
 		if err != nil {
 			return nil, miningRuleError(ErrFailedToGetGeneration, err.Error())
 		}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4380,7 +4380,7 @@ func handleRebroadcastMissed(s *rpcServer, cmd interface{}, closeChan <-chan str
 // handleRebroadcastWinners implements the rebroadcastwinners command.
 func handleRebroadcastWinners(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
 	hash, height := s.server.blockManager.chainState.Best()
-	blocks, err := s.server.blockManager.GetGeneration(*hash)
+	blocks, err := s.server.blockManager.TipGeneration()
 	if err != nil {
 		return nil, rpcInternalError("Could not get generation "+
 			err.Error(), "")

--- a/server.go
+++ b/server.go
@@ -463,7 +463,7 @@ func (sp *serverPeer) OnGetMiningState(p *peer.Peer, msg *wire.MsgGetMiningState
 
 	// Obtain the entire generation of blocks stemming from the parent of
 	// the current tip.
-	children, err := bm.GetGeneration(*newest)
+	children, err := bm.TipGeneration()
 	if err != nil {
 		peerLog.Warnf("failed to access block manager to get the generation "+
 			"for a mining state request (block: %v): %v", newest, err)


### PR DESCRIPTION
This replaces the `GetGeneration` function which allowed getting the entire generation (all children stemming from the same parent) of an arbitrary bock with `TipGeneration` which only returns the same information for the tip block.

This is being done because the function is only used for mining purposes to get the generation of the current tip.  The code is simplified by reducing its scope to its actual purpose as an initial benefit.  It also provides much better optimization opportunities later.