### PR TITLE
blockchain: Add chain tip tracking.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -930,6 +930,9 @@ func (b *BlockChain) connectBlock(node *blockNode, block, parent *dcrutil.Block,
 	// This node is now the end of the best chain.
 	b.bestNode = node
 
+	// Update the chain tips by replacing the node that was just extended.
+	b.index.UpdateChainTips(node.parent, node)
+
 	// Update the state for the best block.  Notice how this replaces the
 	// entire struct instead of updating the existing one.  This effectively
 	// allows the old version to act as a snapshot which callers can use
@@ -1117,6 +1120,10 @@ func (b *BlockChain) disconnectBlock(node *blockNode, block, parent *dcrutil.Blo
 
 	// This node's parent is now the end of the best chain.
 	b.bestNode = node.parent
+
+	// Update the chain tips by replacing the node that was just
+	// disconnected.
+	b.index.UpdateChainTips(node, node.parent)
 
 	// Update the state for the best block.  Notice how this replaces the
 	// entire struct instead of updating the existing one.  This effectively
@@ -1691,6 +1698,10 @@ func (b *BlockChain) connectBestChain(node *blockNode, block, parent *dcrutil.Bl
 				fork.height,
 				fork.hash)
 		}
+
+		// The node is a new chain tip since it was connected without
+		// becoming the main chain.
+		b.index.AddChainTip(node)
 
 		return false, nil
 	}

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1819,6 +1819,7 @@ func (b *BlockChain) initChainState(interrupt <-chan struct{}) error {
 
 		// Add the new node to the indices for faster lookups.
 		b.index.AddNode(node)
+		b.index.AddChainTip(node)
 
 		// Calculate the median time for the block.
 		medianTime, err := b.index.CalcPastMedianTime(node)


### PR DESCRIPTION
This adds logic to keep track of all known chain tips.  Currently, this will only work with chain tips that have been seen since the daemon was loaded, however, when moving to the full block index in memory, it will end up tracking all chain tips in the block index.

Also, note that nothing makes use of the functionality as of this commit yet.  It will be useful in the future to allow things such as removal of the more expensive per-node children tracking, mining code improvements, and enhanced fork-related interrogation ability.