### PR TITLE
blockchain: CheckConnectBlockTemplate with tests.

### DIFF
--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2017 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -453,6 +453,10 @@ const (
 	// failed validation.
 	ErrInvalidAncestorBlock
 
+	// ErrInvalidTemplateParent indicates that a block template builds on a
+	// block that is either not the current best chain tip or its parent.
+	ErrInvalidTemplateParent
+
 	// numErrorCodes is the maximum error code number used in tests.
 	numErrorCodes
 )
@@ -555,6 +559,7 @@ var errorCodeStrings = map[ErrorCode]string{
 	ErrInvalidEarlyVoteBits:   "ErrInvalidEarlyVoteBits",
 	ErrInvalidEarlyFinalState: "ErrInvalidEarlyFinalState",
 	ErrInvalidAncestorBlock:   "ErrInvalidAncestorBlock",
+	ErrInvalidTemplateParent:  "ErrInvalidTemplateParent",
 }
 
 // String returns the ErrorCode as a human-readable name.

--- a/blockchain/error_test.go
+++ b/blockchain/error_test.go
@@ -111,6 +111,7 @@ func TestErrorCodeStringer(t *testing.T) {
 		{ErrInvalidEarlyVoteBits, "ErrInvalidEarlyVoteBits"},
 		{ErrInvalidEarlyFinalState, "ErrInvalidEarlyFinalState"},
 		{ErrInvalidAncestorBlock, "ErrInvalidAncestorBlock"},
+		{ErrInvalidTemplateParent, "ErrInvalidTemplateParent"},
 		{0xffff, "Unknown ErrorCode (65535)"},
 	}
 

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -2299,15 +2299,14 @@ func (b *BlockChain) consensusScriptVerifyFlags(node *blockNode) (txscript.Scrip
 // connected and consequently the best hash for the view is also updated to
 // passed block.
 //
-// The CheckConnectBlock function makes use of this function to perform the
-// bulk of its work.  The only difference is this function accepts a node which
-// may or may not require reorganization to connect it to the main chain
-// whereas CheckConnectBlock creates a new node which specifically connects to
-// the end of the current main chain and then calls this function with that
-// node.
+// An example of some of the checks performed are ensuring connecting the block
+// would not cause any duplicate transaction hashes for old transactions that
+// aren't already fully spent, double spends, exceeding the maximum allowed
+// signature operations per block, invalid values in relation to the expected
+// block subsidy, or fail transaction script validation.
 //
-// See the comments for CheckConnectBlock for some examples of the type of
-// checks performed by this function.
+// The CheckConnectBlockTemplate function makes use of this function to perform
+// the bulk of its work.
 //
 // This function MUST be called with the chain state lock held (for writes).
 func (b *BlockChain) checkConnectBlock(node *blockNode, block, parent *dcrutil.Block, utxoView *UtxoViewpoint, stxos *[]spentTxOut) error {
@@ -2542,33 +2541,38 @@ func (b *BlockChain) checkConnectBlock(node *blockNode, block, parent *dcrutil.B
 	return nil
 }
 
-// CheckConnectBlock performs several checks to confirm connecting the passed
-// block to the main chain does not violate any rules.  An example of some of
-// the checks performed are ensuring connecting the block would not cause any
-// duplicate transaction hashes for old transactions that aren't already fully
-// spent, double spends, exceeding the maximum allowed signature operations per
-// block, invalid values in relation to the expected block subsidy, or fail
-// transaction script validation.
-//
-// The flags modify the behavior of this function as follows:
-//  - BFNoPoWCheck: The check to ensure the block hash is less than the target
-//    difficulty is not performed.
-//  - BFFastAdd: The transactions are not checked to see if they are finalized
-//    and the somewhat expensive duplication transaction check is not performed.
+// CheckConnectBlockTemplate fully validates that connecting the passed block to
+// either the tip of the main chain or its parent does not violate any consensus
+// rules, aside from the proof of work requirement.  The block must connect to
+// the current tip of the main chain or its parent.
 //
 // This function is safe for concurrent access.
-func (b *BlockChain) CheckConnectBlock(block *dcrutil.Block, flags BehaviorFlags) error {
+func (b *BlockChain) CheckConnectBlockTemplate(block *dcrutil.Block) error {
 	b.chainLock.Lock()
 	defer b.chainLock.Unlock()
 
+	// Skip the proof of work check as this is just a block template.
+	flags := BFNoPoWCheck
+
+	// The block template must build off the current tip of the main chain
+	// or its parent.
+	tip := b.bestNode
+	var prevNode *blockNode
 	parentHash := block.MsgBlock().Header.PrevBlock
-	prevNode, err := b.findNode(&parentHash, maxSearchDepth)
-	if err != nil {
-		return ruleError(ErrMissingParent, err.Error())
+	if parentHash == tip.hash {
+		prevNode = tip
+	} else if tip.parent != nil && parentHash == tip.parent.hash {
+		prevNode = tip.parent
+	}
+	if prevNode == nil {
+		str := fmt.Sprintf("previous block must be the current chain "+
+			"tip %s or its parent %s, but got %s", tip.hash,
+			tip.parentHash, parentHash)
+		return ruleError(ErrInvalidTemplateParent, str)
 	}
 
 	// Perform context-free sanity checks on the block and its transactions.
-	err = checkBlockSanity(block, b.timeSource, flags, b.chainParams)
+	err := checkBlockSanity(block, b.timeSource, flags, b.chainParams)
 	if err != nil {
 		return err
 	}
@@ -2583,20 +2587,17 @@ func (b *BlockChain) CheckConnectBlock(block *dcrutil.Block, flags BehaviorFlags
 	newNode := newBlockNode(&block.MsgBlock().Header, prevNode)
 	newNode.populateTicketInfo(stake.FindSpentTicketsInBlock(block.MsgBlock()))
 
-	// If we are extending the main (best) chain with a new block, just use
-	// the ticket database we already have.
-	if b.bestNode == nil || (prevNode != nil &&
-		prevNode.hash == b.bestNode.hash) {
-
+	// Use the ticket database as is when extending the main (best) chain.
+	if prevNode.hash == tip.hash {
 		// Grab the parent block since it is required throughout the block
 		// connection process.
-		parent, err := b.fetchMainChainBlockByHash(&parentHash)
+		parent, err := b.fetchMainChainBlockByHash(&prevNode.hash)
 		if err != nil {
 			return ruleError(ErrMissingParent, err.Error())
 		}
 
 		view := NewUtxoViewpoint()
-		view.SetBestHash(&prevNode.hash)
+		view.SetBestHash(&tip.hash)
 		return b.checkConnectBlock(newNode, block, parent, view, nil)
 	}
 
@@ -2611,9 +2612,8 @@ func (b *BlockChain) CheckConnectBlock(block *dcrutil.Block, flags BehaviorFlags
 	}
 
 	view := NewUtxoViewpoint()
-	view.SetBestHash(&b.bestNode.hash)
+	view.SetBestHash(&tip.hash)
 	view.SetStakeViewpoint(ViewpointPrevValidInitial)
-	var stxos []spentTxOut
 	var nextBlockToDetach *dcrutil.Block
 	for e := detachNodes.Front(); e != nil; e = e.Next() {
 		// Grab the block to detach based on the node.  Use the fact that the
@@ -2641,6 +2641,7 @@ func (b *BlockChain) CheckConnectBlock(block *dcrutil.Block, flags BehaviorFlags
 		nextBlockToDetach = parent
 
 		// Load all of the spent txos for the block from the spend journal.
+		var stxos []spentTxOut
 		err = b.db.View(func(dbTx database.Tx) error {
 			stxos, err = dbFetchSpendJournalEntry(dbTx, block, parent)
 			return err
@@ -2664,12 +2665,11 @@ func (b *BlockChain) CheckConnectBlock(block *dcrutil.Block, flags BehaviorFlags
 	if attachNodes.Len() == 0 {
 		// Grab the parent block since it is required throughout the block
 		// connection process.
-		parent, err := b.fetchMainChainBlockByHash(&parentHash)
+		parent, err := b.fetchMainChainBlockByHash(&prevNode.hash)
 		if err != nil {
 			return ruleError(ErrMissingParent, err.Error())
 		}
 
-		view.SetBestHash(&parentHash)
 		return b.checkConnectBlock(newNode, block, parent, view, nil)
 	}
 
@@ -2703,7 +2703,7 @@ func (b *BlockChain) CheckConnectBlock(block *dcrutil.Block, flags BehaviorFlags
 		// Store the loaded block for the next iteration.
 		prevAttachBlock = block
 
-		err = b.connectTransactions(view, block, parent, &stxos)
+		err = b.connectTransactions(view, block, parent, nil)
 		if err != nil {
 			return err
 		}
@@ -2711,11 +2711,13 @@ func (b *BlockChain) CheckConnectBlock(block *dcrutil.Block, flags BehaviorFlags
 
 	// Grab the parent block since it is required throughout the block
 	// connection process.
-	parent, err := b.fetchBlockByHash(&parentHash)
+	parent, err := b.fetchBlockByHash(&prevNode.hash)
 	if err != nil {
 		return ruleError(ErrMissingParent, err.Error())
 	}
 
-	view.SetBestHash(&parentHash)
-	return b.checkConnectBlock(newNode, block, parent, view, &stxos)
+	// Notice the spent txout details are not requested here and thus will not
+	// be generated.  This is done because the state will not be written to the
+	// database, so it is not needed.
+	return b.checkConnectBlock(newNode, block, parent, view, nil)
 }

--- a/mining.go
+++ b/mining.go
@@ -828,7 +828,7 @@ func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache, nextHeight int64,
 
 				// Make sure the block validates.
 				block := dcrutil.NewBlockDeepCopyCoinbase(cptCopy.Block)
-				err = bm.chain.CheckConnectBlock(block, blockchain.BFNoPoWCheck)
+				err = bm.chain.CheckConnectBlockTemplate(block)
 				if err != nil {
 					minrLog.Errorf("failed to check template while "+
 						"duplicating a parent: %v", err.Error())
@@ -931,7 +931,7 @@ func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache, nextHeight int64,
 
 				// Make sure the block validates.
 				btBlock := dcrutil.NewBlockDeepCopyCoinbase(btMsgBlock)
-				err = bm.chain.CheckConnectBlock(btBlock, blockchain.BFNoPoWCheck)
+				err = bm.chain.CheckConnectBlockTemplate(btBlock)
 				if err != nil {
 					str := fmt.Sprintf("failed to check template: %v while "+
 						"constructing a new parent", err.Error())
@@ -2016,7 +2016,7 @@ mempoolLoop:
 	// consensus rules to ensure it properly connects to the current best
 	// chain with no issues.
 	block := dcrutil.NewBlockDeepCopyCoinbase(&msgBlock)
-	err = blockManager.chain.CheckConnectBlock(block, blockchain.BFNoPoWCheck)
+	err = blockManager.chain.CheckConnectBlockTemplate(block)
 	if err != nil {
 		str := fmt.Sprintf("failed to do final check for check connect "+
 			"block when making new block template: %v",

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2982,8 +2982,7 @@ func handleGetBlockTemplateProposal(s *rpcServer, request *dcrjson.TemplateReque
 		return "bad-prevblk", nil
 	}
 
-	flags := blockchain.BFNoPoWCheck
-	err = s.server.blockManager.chain.CheckConnectBlock(block, flags)
+	err = s.server.blockManager.chain.CheckConnectBlockTemplate(block)
 	if err != nil {
 		if _, ok := err.(blockchain.RuleError); !ok {
 			errStr := fmt.Sprintf("Failed to process block "+


### PR DESCRIPTION
~**This requires PRs #1076, #1077, #1084, and #1085**.~ (now merged)

This removes the `CheckConnectBlock` function in favor of a new function named `CheckConnectBlockTemplate` which more accurately reflects its purpose of testing block template proposals and uses this fact to be more restrictive about the allowed inputs and to avoid performing the proof of work check.

In particular, the provided block template must only build from the current tip or its parent or an error is returned.

All mining code has been updated to call the new function accordingly.

Finally, it also adds a full suite of tests for the new function using the `chaingen` framework in order to ensure proper functionality.