### PR TITLE
multi: Simplify invalid proof of work tests

### DIFF
--- a/blockchain/chaingen/generator.go
+++ b/blockchain/chaingen/generator.go
@@ -1324,6 +1324,14 @@ func compactToBig(compact uint32) *big.Int {
 	return bn
 }
 
+// IsSolved returns whether or not the header hashes to a value that is less
+// than or equal to the target difficulty as specified by its bits field.
+func IsSolved(header *wire.BlockHeader) bool {
+	targetDifficulty := compactToBig(header.Bits)
+	hash := header.BlockHash()
+	return hashToBig(&hash).Cmp(targetDifficulty) <= 0
+}
+
 // solveBlock attempts to find a nonce which makes the passed block header hash
 // to a value less than the target difficulty.  When a successful solution is
 // found, true is returned and the nonce field of the passed header is updated

--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -1533,18 +1533,12 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	bmf3 := g.NextBlock("bmf3", outs[15], ticketOuts[15])
 	// This can't be done inside a munge function passed to NextBlock
 	// because the block is solved after the function returns and this test
-	// requires an unsolved block.
+	// requires an unsolved block.  Thus, just increment the nonce until
+	// it's not solved and then replace it in the generator's state.
 	{
 		origHash := bmf3.BlockHash()
-		for {
-			// Keep incrementing the nonce until the hash treated as
-			// a uint256 is higher than the limit.
-			bmf3.Header.Nonce += 1
-			hash := bmf3.BlockHash()
-			hashNum := blockchain.HashToBig(&hash)
-			if hashNum.Cmp(g.Params().PowLimit) >= 0 {
-				break
-			}
+		for chaingen.IsSolved(&bmf3.Header) {
+			bmf3.Header.Nonce++
 		}
 		g.UpdateBlockState("bmf3", origHash, "bmf3", bmf3)
 	}


### PR DESCRIPTION
This adds a new exported function named `IsSolved` to the `chaingen` package which allows consumers
to easily check if a block is solved according to the target difficulty specified by the bits in its header and updates `fullblocktests` to use it.
