### PR TITLE
blockchain: Simplify chain tip tracking.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -912,9 +912,6 @@ func (b *BlockChain) connectBlock(node *blockNode, block, parent *dcrutil.Block,
 	// This node is now the end of the best chain.
 	b.bestNode = node
 
-	// Update the chain tips by replacing the node that was just extended.
-	b.index.UpdateChainTips(node.parent, node)
-
 	// Update the state for the best block.  Notice how this replaces the
 	// entire struct instead of updating the existing one.  This effectively
 	// allows the old version to act as a snapshot which callers can use
@@ -1102,10 +1099,6 @@ func (b *BlockChain) disconnectBlock(node *blockNode, block, parent *dcrutil.Blo
 
 	// This node's parent is now the end of the best chain.
 	b.bestNode = node.parent
-
-	// Update the chain tips by replacing the node that was just
-	// disconnected.
-	b.index.UpdateChainTips(node, node.parent)
 
 	// Update the state for the best block.  Notice how this replaces the
 	// entire struct instead of updating the existing one.  This effectively
@@ -1680,10 +1673,6 @@ func (b *BlockChain) connectBestChain(node *blockNode, block, parent *dcrutil.Bl
 				fork.height,
 				fork.hash)
 		}
-
-		// The node is a new chain tip since it was connected without
-		// becoming the main chain.
-		b.index.AddChainTip(node)
 
 		return false, nil
 	}

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1818,7 +1818,6 @@ func (b *BlockChain) initChainState(interrupt <-chan struct{}) error {
 
 		// Add the new node to the indices for faster lookups.
 		b.index.AddNode(node)
-		b.index.AddChainTip(node)
 
 		// Calculate the median time for the block.
 		medianTime, err := b.index.CalcPastMedianTime(node)


### PR DESCRIPTION
This simplifies the recently added chain tip tracking by allowing the block index to handle it when a node is added to it.

This is possible since the block index does not support nodes that do not connect to an existing node (with the exception of the genesis block), and thus all new nodes are either extending an existing chain or are on a side chain, but in either case, are a new chain tip.  In the case the node is extending a chain, the parent is no longer a tip so it can be removed.