### PR TITLE
multi: Simplify and optimize mining tip block retrieval.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -616,12 +616,6 @@ func (b *BlockChain) FetchBlockByHash(hash *chainhash.Hash) (*dcrutil.Block, err
 	return b.fetchBlockByHash(hash)
 }
 
-// GetTopBlock returns the current block at HEAD on the blockchain.  Needed
-// for mining in the daemon.
-func (b *BlockChain) GetTopBlock() (*dcrutil.Block, error) {
-	return b.fetchMainChainBlockByHash(&b.bestNode.hash)
-}
-
 // pruneStakeNodes removes references to old stake nodes which should no
 // longer be held in memory so as to keep the maximum memory usage down.
 // It proceeds from the bestNode back to the determined minimum height node,

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -192,20 +192,6 @@ type forceReorganizationMsg struct {
 	reply      chan forceReorganizationResponse
 }
 
-// getTopBlockResponse is a response to the request for the block at HEAD of the
-// blockchain. We need to be able to obtain this from blockChain for mining
-// purposes.
-type getTopBlockResponse struct {
-	block *dcrutil.Block
-	err   error
-}
-
-// getTopBlockMsg is a message type to be sent across the message
-// channel for requesting the required stake difficulty of the next block.
-type getTopBlockMsg struct {
-	reply chan getTopBlockResponse
-}
-
 // processBlockResponse is a response sent to the reply channel of a
 // processBlockMsg.
 type processBlockResponse struct {
@@ -1767,13 +1753,6 @@ out:
 					err:    err,
 				}
 
-			case getTopBlockMsg:
-				b, err := b.chain.GetTopBlock()
-				msg.reply <- getTopBlockResponse{
-					block: b,
-					err:   err,
-				}
-
 			case processBlockMsg:
 				onMainChain, isOrphan, err := b.chain.ProcessBlock(
 					msg.block, msg.flags)
@@ -2460,15 +2439,6 @@ func (b *blockManager) TipGeneration() ([]chainhash.Hash, error) {
 	b.msgChan <- tipGenerationMsg{reply: reply}
 	response := <-reply
 	return response.hashes, response.err
-}
-
-// GetTopBlockFromChain obtains the current top block from HEAD of the blockchain.
-// Returns a pointer to the cached copy of the block in memory.
-func (b *blockManager) GetTopBlockFromChain() (*dcrutil.Block, error) {
-	reply := make(chan getTopBlockResponse)
-	b.msgChan <- getTopBlockMsg{reply: reply}
-	response := <-reply
-	return response.block, response.err
 }
 
 // ProcessBlock makes use of ProcessBlock on an internal instance of a block


### PR DESCRIPTION
This modifies the mining code to request the desired blocks from chain by hash as opposed to using a separate function to get the top block and removes the now unused plumbing through block manager.

Not only is this faster because it avoids the need to go through block manager, it is also more robust since it does not rely on the tip of the chain not having changing for correctness.

Finally, it removes the `blockchain.GetTopBlock` function since nothing else made use of it.