### PR TITLE
rpcserver: Add dcrd version info to getversion RPC.

### DIFF
--- a/version.go
+++ b/version.go
@@ -11,8 +11,15 @@ import (
 	"strings"
 )
 
-// semanticAlphabet
-const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
+const (
+	// semanticAlphabet defines the allowed characters for the pre-release
+	// portion of a semantic version string.
+	semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
+
+	// semanticBuildAlphabet defines the allowed characters for the build
+	// portion of a semantic version string.
+	semanticBuildAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-."
+)
 
 // These constants define the application version and follow the semantic
 // versioning 2.0.0 spec (http://semver.org/).
@@ -28,7 +35,8 @@ const (
 
 // appBuild is defined as a variable so it can be overridden during the build
 // process with '-ldflags "-X main.appBuild=foo' if needed.  It MUST only
-// contain characters from semanticAlphabet per the semantic versioning spec.
+// contain characters from semanticBuildAlphabet per the semantic versioning
+// spec.
 var appBuild = "dev"
 
 // version returns the application version as a properly formed string per the
@@ -41,7 +49,7 @@ func version() string {
 	// by the semantic versioning spec is automatically appended and should
 	// not be contained in the pre-release string.  The pre-release version
 	// is not appended if it contains invalid characters.
-	preRelease := normalizeVerString(appPreRelease)
+	preRelease := normalizePreRelString(appPreRelease)
 	if preRelease != "" {
 		version = fmt.Sprintf("%s-%s", version, preRelease)
 	}
@@ -50,7 +58,7 @@ func version() string {
 	// by the semantic versioning spec is automatically appended and should
 	// not be contained in the build metadata string.  The build metadata
 	// string is not appended if it contains invalid characters.
-	build := normalizeVerString(appBuild)
+	build := normalizeBuildString(appBuild)
 	if build != "" {
 		version = fmt.Sprintf("%s+%s", version, build)
 	}
@@ -58,16 +66,30 @@ func version() string {
 	return version
 }
 
-// normalizeVerString returns the passed string stripped of all characters which
-// are not valid according to the semantic versioning guidelines for pre-release
-// version and build metadata strings.  In particular they MUST only contain
-// characters in semanticAlphabet.
-func normalizeVerString(str string) string {
+// normalizeSemString returns the passed string stripped of all characters
+// which are not valid according to the provided semantic versioning alphabet.
+func normalizeSemString(str, alphabet string) string {
 	var result bytes.Buffer
 	for _, r := range str {
-		if strings.ContainsRune(semanticAlphabet, r) {
+		if strings.ContainsRune(alphabet, r) {
 			result.WriteRune(r)
 		}
 	}
 	return result.String()
+}
+
+// normalizePreRelString returns the passed string stripped of all characters
+// which are not valid according to the semantic versioning guidelines for
+// pre-release strings.  In particular they MUST only contain characters in
+// semanticAlphabet.
+func normalizePreRelString(str string) string {
+	return normalizeSemString(str, semanticAlphabet)
+}
+
+// normalizeBuildString returns the passed string stripped of all characters
+// which are not valid according to the semantic versioning guidelines for build
+// metadata strings.  In particular they MUST only contain characters in
+// semanticBuildAlphabet.
+func normalizeBuildString(str string) string {
+	return normalizeSemString(str, semanticBuildAlphabet)
 }


### PR DESCRIPTION
This adds the dcrd version info as an additional key to the JSON-RPC getversion response to accompany the existing RPC API version information and bumps the JSON-RPC minor version to account for the backwards-compatible change.

Also, it corrects the semver build handling. The semver spec allow the build portion to contain multiple identifiers separated by periods, however, the current code is stripping periods.
