### PR TITLE
multi: Implement getchaintips JSON-RPC.

### DIFF
--- a/blockchain/chainquery.go
+++ b/blockchain/chainquery.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2018 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package blockchain
+
+import (
+	"bytes"
+	"sort"
+
+	"github.com/decred/dcrd/dcrjson"
+)
+
+// nodeHeightSorter implements sort.Interface to allow a slice of nodes to
+// be sorted by height in ascending order.
+type nodeHeightSorter []*blockNode
+
+// Len returns the number of nodes in the slice.  It is part of the
+// sort.Interface implementation.
+func (s nodeHeightSorter) Len() int {
+	return len(s)
+}
+
+// Swap swaps the nodes at the passed indices.  It is part of the
+// sort.Interface implementation.
+func (s nodeHeightSorter) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// Less returns whether the node with index i should sort before the node with
+// index j.  It is part of the sort.Interface implementation.
+func (s nodeHeightSorter) Less(i, j int) bool {
+	// To ensure stable order when the heights are the same, fall back to
+	// sorting based on hash.
+	if s[i].height == s[j].height {
+		return bytes.Compare(s[i].hash[:], s[j].hash[:]) < 0
+	}
+	return s[i].height < s[j].height
+}
+
+// ChainTips returns information, in JSON-RPC format, about all of the currently
+// known chain tips in the block index.
+func (b *BlockChain) ChainTips() []dcrjson.GetChainTipsResult {
+	b.index.RLock()
+	var chainTips []*blockNode
+	for _, nodes := range b.index.chainTips {
+		chainTips = append(chainTips, nodes...)
+	}
+	b.index.RUnlock()
+
+	b.chainLock.Lock()
+	bestTip := b.bestNode
+	b.chainLock.Unlock()
+
+	// Generate the results sorted by descending height.
+	sort.Sort(sort.Reverse(nodeHeightSorter(chainTips)))
+	results := make([]dcrjson.GetChainTipsResult, len(chainTips))
+	for i, tip := range chainTips {
+		// Find the fork point in order calculate the branch length later.
+		fork := tip
+		for fork != nil && !fork.inMainChain {
+			fork = fork.parent
+		}
+
+		result := &results[i]
+		result.Height = tip.height
+		result.Hash = tip.hash.String()
+		result.BranchLen = tip.height - fork.height
+
+		// Determine the status of the chain tip.
+		//
+		// active:
+		//   The current best chain tip.
+		//
+		// invalid:
+		//   The block or one of its ancestors is invalid.
+		//
+		// headers-only:
+		//   The block or one of its ancestors does not have the full block data
+		//   available which also means the block can't be validated or
+		//   connected.
+		//
+		// valid-fork:
+		//   The block is fully validated which implies it was probably part of
+		//   main chain at one point and was reorganized.
+		//
+		// valid-headers:
+		//   The full block data is available and the header is valid, but the
+		//   block was never validated which implies it was probably never part
+		//   of the main chain.
+		tipStatus := b.index.NodeStatus(tip)
+		if tip == bestTip {
+			result.Status = "active"
+		} else if tipStatus.KnownInvalid() {
+			result.Status = "invalid"
+		} else if !tipStatus.HaveData() {
+			result.Status = "headers-only"
+		} else if tipStatus.KnownValid() {
+			result.Status = "valid-fork"
+		} else {
+			result.Status = "valid-headers"
+		}
+	}
+	return results
+}

--- a/dcrjson/chainsvrresults.go
+++ b/dcrjson/chainsvrresults.go
@@ -172,6 +172,14 @@ type GetBlockTemplateResult struct {
 	RejectReasion string   `json:"reject-reason,omitempty"`
 }
 
+// GetChainTipsResult models the data returns from the getchaintips command.
+type GetChainTipsResult struct {
+	Height    int64  `json:"height"`
+	Hash      string `json:"hash"`
+	BranchLen int64  `json:"branchlen"`
+	Status    string `json:"status"`
+}
+
 // GetMempoolInfoResult models the data returned from the getmempoolinfo
 // command.
 type GetMempoolInfoResult struct {

--- a/docs/json_rpc_api.md
+++ b/docs/json_rpc_api.md
@@ -164,34 +164,35 @@ the method name for further details such as parameter and return information.
 |8|[getblockcount](#getblockcount)|Y|Returns the number of blocks in the longest block chain.|
 |9|[getblockhash](#getblockhash)|Y|Returns hash of the block in best block chain at the given height.|
 |10|[getblockheader](#getblockheader)|Y|Returns the block header of the block.|
-|11|[getconnectioncount](#getconnectioncount)|N|Returns the number of active connections to other peers.|
-|12|[getdifficulty](#getdifficulty)|Y|Returns the proof-of-work difficulty as a multiple of the minimum difficulty.|
-|13|[getgenerate](#getgenerate)|N|Return if the server is set to generate coins (mine) or not.|
-|14|[gethashespersec](#gethashespersec)|N|Returns a recent hashes per second performance measurement while generating coins (mining).|
-|15|[getinfo](#getinfo)|Y|Returns a JSON object containing various state info.|
-|16|[getmempoolinfo](#getmempoolinfo)|N|Returns a JSON object containing mempool-related information.|
-|17|[getmininginfo](#getmininginfo)|N|Returns a JSON object containing mining-related information.|
-|18|[getnettotals](#getnettotals)|Y|Returns a JSON object containing network traffic statistics.|
-|19|[getnetworkhashps](#getnetworkhashps)|Y|Returns the estimated network hashes per second for the block heights provided by the parameters.|
-|20|[getpeerinfo](#getpeerinfo)|N|Returns information about each connected network peer as an array of json objects.|
-|21|[getrawmempool](#getrawmempool)|Y|Returns an array of hashes for all of the transactions currently in the memory pool.|
-|22|[getrawtransaction](#getrawtransaction)|Y|Returns information about a transaction given its hash.|
-|23|[getwork](#getwork)|N|Returns formatted hash data to work on or checks and submits solved data.<br /><br />NOTE: Since dcrd does not have the wallet integrated to provide payment addresses, dcrd must be configured via the `--miningaddr` option to provide which payment addresses to pay created blocks to for this RPC to function.|
-|24|[help](#help)|Y|Returns a list of all commands or help for a specified command.|
-|25|[ping](#ping)|N|Queues a ping to be sent to each connected peer.|
-|26|[sendrawtransaction](#sendrawtransaction)|Y|Submits the serialized, hex-encoded transaction to the local peer and relays it to the network.<br /><br />NOTE: dcrd does not yet implement the `allowhighfees` parameter, so it has no effect|
-|27|[setgenerate](#setgenerate) |N|Set the server to generate coins (mine) or not.<br/>NOTE: Since dcrd does not have the wallet integrated to provide payment addresses, dcrd must be configured via the `--miningaddr` option to provide which payment addresses to pay created blocks to for this RPC to function.|
-|28|[stop](#stop)|N|Shutdown dcrd.|
-|29|[submitblock](#submitblock)|Y|Attempts to submit a new serialized, hex-encoded block to the network.|
-|30|[validateaddress](#validateaddress)|Y|Verifies the given address is valid.  NOTE: Since dcrd does not have a wallet integrated, dcrd will only return whether the address is valid or not.|
-|31|[verifychain](#verifychain)|N|Verifies the block chain database.|
-|32|[debuglevel](#debuglevel)|N|Dynamically changes the debug logging level.|
-|33|[getbestblock](#getbestblock)|Y|Get block height and hash of best block in the main chain.|
-|34|[getcurrentnet](#getcurrentnet)|Y|Get decred network dcrd is running on.|
-|35|[searchrawtransactions](#searchrawtransactions)|Y|Query for transactions related to a particular address.|
-|36|[node](#node)|N|Attempts to add or remove a peer. |
-|37|[generate](#generate)|N|When in simnet or regtest mode, generate a set number of blocks. |
-|38|[getstakeversions](#getstakeversions)|Y|Get stake versions per block. |
+|11|[getchaintips](#getchaintips)|Y|Returns information about all known chain tips the in the block tree.|
+|12|[getconnectioncount](#getconnectioncount)|N|Returns the number of active connections to other peers.|
+|13|[getdifficulty](#getdifficulty)|Y|Returns the proof-of-work difficulty as a multiple of the minimum difficulty.|
+|14|[getgenerate](#getgenerate)|N|Return if the server is set to generate coins (mine) or not.|
+|15|[gethashespersec](#gethashespersec)|N|Returns a recent hashes per second performance measurement while generating coins (mining).|
+|16|[getinfo](#getinfo)|Y|Returns a JSON object containing various state info.|
+|17|[getmempoolinfo](#getmempoolinfo)|N|Returns a JSON object containing mempool-related information.|
+|18|[getmininginfo](#getmininginfo)|N|Returns a JSON object containing mining-related information.|
+|19|[getnettotals](#getnettotals)|Y|Returns a JSON object containing network traffic statistics.|
+|20|[getnetworkhashps](#getnetworkhashps)|Y|Returns the estimated network hashes per second for the block heights provided by the parameters.|
+|21|[getpeerinfo](#getpeerinfo)|N|Returns information about each connected network peer as an array of json objects.|
+|22|[getrawmempool](#getrawmempool)|Y|Returns an array of hashes for all of the transactions currently in the memory pool.|
+|23|[getrawtransaction](#getrawtransaction)|Y|Returns information about a transaction given its hash.|
+|24|[getwork](#getwork)|N|Returns formatted hash data to work on or checks and submits solved data.<br /><br />NOTE: Since dcrd does not have the wallet integrated to provide payment addresses, dcrd must be configured via the `--miningaddr` option to provide which payment addresses to pay created blocks to for this RPC to function.|
+|25|[help](#help)|Y|Returns a list of all commands or help for a specified command.|
+|26|[ping](#ping)|N|Queues a ping to be sent to each connected peer.|
+|27|[sendrawtransaction](#sendrawtransaction)|Y|Submits the serialized, hex-encoded transaction to the local peer and relays it to the network.<br /><br />NOTE: dcrd does not yet implement the `allowhighfees` parameter, so it has no effect|
+|28|[setgenerate](#setgenerate) |N|Set the server to generate coins (mine) or not.<br/>NOTE: Since dcrd does not have the wallet integrated to provide payment addresses, dcrd must be configured via the `--miningaddr` option to provide which payment addresses to pay created blocks to for this RPC to function.|
+|29|[stop](#stop)|N|Shutdown dcrd.|
+|30|[submitblock](#submitblock)|Y|Attempts to submit a new serialized, hex-encoded block to the network.|
+|31|[validateaddress](#validateaddress)|Y|Verifies the given address is valid.  NOTE: Since dcrd does not have a wallet integrated, dcrd will only return whether the address is valid or not.|
+|32|[verifychain](#verifychain)|N|Verifies the block chain database.|
+|33|[debuglevel](#debuglevel)|N|Dynamically changes the debug logging level.|
+|34|[getbestblock](#getbestblock)|Y|Get block height and hash of best block in the main chain.|
+|35|[getcurrentnet](#getcurrentnet)|Y|Get decred network dcrd is running on.|
+|36|[searchrawtransactions](#searchrawtransactions)|Y|Query for transactions related to a particular address.|
+|37|[node](#node)|N|Attempts to add or remove a peer. |
+|38|[generate](#generate)|N|When in simnet or regtest mode, generate a set number of blocks. |
+|39|[getstakeversions](#getstakeversions)|Y|Get stake versions per block. |
 
 <a name="MethodDetails" />
 
@@ -320,6 +321,18 @@ the method name for further details such as parameter and return information.
 |Returns (verbose=true)|`(json object)`<br />`hash`: `(string)` the hash of the block (same as provided).<br />`confirmations`: `(numeric)` the number of confirmations.<br />`height`: `(numeric)` the height of the block in the block chain.<br />`version`: `(numeric)` the block version.<br />`merkleroot`:  `(string)` root hash of the merkle tree.<br />`stakeroot`:  `(string)` root hash of the stake tree.<br />`time`: `(numeric)` the block time in seconds since 1 Jan 1970 GMT<br />`nonce`: (numeric) the block nonce.<br />`bits`: `(numeric)` the bits which represent the block difficulty.<br />`sbits`: `(numeric)` the bits which represent the stake difficulty.<br />`difficulty`: `(numeric)` the proof-of-work difficulty as a multiple of the minimum difficulty.<br />`previousblockhash`: `(string)` the hash of the previous block.<br />`nextblockhash`: `(string)` the hash of the next block (only if there is one).<br /><br />`{"hash": "blockhash", "confirmations": n, "height": n, "version": n,  "merkleroot": "hash", "stakeroot": "hash", "time": n, "nonce": n, "bits": n, "sbits": n, "difficulty": n.nn,  "previousblockhash": "hash", "nextblockhash": "hash"}`|
 |Example Return (verbose=false)|Newlines added for display purposes.  The actual return does not contain newlines.<br />`"0200000035ab154183570282ce9afc0b494c9fc6a3cfea05aa8c1add2ecc564900000000`<br />`38ba3d78e4500a5a7570dbe61960398add4410d278b21cd9708e6d9743f374d544fc0552`<br />`27f1001c29c1ea3b"`|
 |Example Return (verbose=true)|`{"hash": "00000000009e2958c15ff9290d571bf9459e93b19765c6801ddeccadbb160a1e", "confirmations": 392076, "height": 100000, "version": 2, "merkleroot": "d574f343976d8e70d91cb278d21044dd8a396019e6db70755a0a50e4783dba38", "stakeroot":"b4765ae7d5bf4768ff7c4372d55abb7894b2bd9d3f48f7437115502b0bcc47e7", "time": 1376123972, "nonce": 1005240617, "bits": "1c00f127", "sbits": 68, "difficulty": 271.75767393, "previousblockhash": "000000004956cc2edd1a8caa05eacfa3c69f4c490bfc9ace820257834115ab35",  "nextblockhash": "0000000000629d100db387f37d0f37c51118f250fb0946310a8c37316cbc4028", ...}`|
+[Return to Overview](#MethodOverview)<br />
+
+***
+<a name="getchaintips"/>
+
+|   |   |
+|---|---|
+|Method|getchaintips|
+|Parameters|None|
+|Description|Returns about all known chain tips the in the block tree.<br /><br />The statuses in the result have the following meanings:<br /><br />`active`: The current best chain tip.<br />`invalid`: The block or one of its ancestors is invalid.<br />`headers-only`: The block or one of its ancestors does not have the full block data available which also means the block can't be validated or connected.<br />`valid-fork`: The block is fully validated which implies it was probably part of the main chain at one point and was reorganized.<br />`valid-headers`: The full block data is available and the header is valid, but the block was never validated which implies it was probably never part of the main chain.|
+|Returns|`(json array of objects)`<br />`height`: `(numeric)` The height of the chain tip.<br />`hash`: `(string)` The block hash of the chain tip.<br />`branchlen`: `(numeric)` The length of the branch that connects the tip to the main chain (0 for the main chain tip).<br />`status`: `(string)`  status of the chain (active, invalid, headers-only, valid-fork, valid-headers).<br /><br />`[{"height": n, "hash": "hash", "branchlen": n, "status": "status"}, ...]`|
+|Example Return|`[{"height": 217033, "hash": "00000000000000161bd5b120ef945faad60fc6e4c32b5caf1d4cabeae9a75346", "branchlen": 0, "status": "active"}, {"height": 213522, "hash": "0000000000000015e27658ce02ba8fa05d8d7ad9c587a5a472e3307773a9b36e", "branchlen": 1, "status": "valid-fork"}]"`|
 [Return to Overview](#MethodOverview)<br />
 
 ***

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -194,6 +194,7 @@ var rpcHandlersBeforeInit = map[string]commandHandler{
 	"getblockhash":          handleGetBlockHash,
 	"getblockheader":        handleGetBlockHeader,
 	"getblocksubsidy":       handleGetBlockSubsidy,
+	"getchaintips":          handleGetChainTips,
 	"getcoinsupply":         handleGetCoinSupply,
 	"getconnectioncount":    handleGetConnectionCount,
 	"getcurrentnet":         handleGetCurrentNet,
@@ -295,7 +296,6 @@ var rpcUnimplemented = map[string]struct{}{
 	"estimatepriority":  {},
 	"getblocktemplate":  {},
 	"getblockchaininfo": {},
-	"getchaintips":      {},
 	"getnetworkinfo":    {},
 }
 
@@ -321,6 +321,7 @@ var rpcLimited = map[string]struct{}{
 	"getblock":              {},
 	"getblockcount":         {},
 	"getblockhash":          {},
+	"getchaintips":          {},
 	"getcurrentnet":         {},
 	"getdifficulty":         {},
 	"getinfo":               {},
@@ -3020,6 +3021,11 @@ func handleGetBlockTemplate(s *rpcServer, cmd interface{}, closeChan <-chan stru
 	}
 
 	return nil, rpcInvalidError("Invalid mode: %v", mode)
+}
+
+// handleGetChainTips implements the getchaintips command.
+func handleGetChainTips(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
+	return s.chain.ChainTips(), nil
 }
 
 // handleGetCoinSupply implements the getcoinsupply command.

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -409,6 +409,22 @@ var helpDescsEnUS = map[string]string{
 	"getblocktemplate--condition2": "mode=proposal, accepted",
 	"getblocktemplate--result1":    "An error string which represents why the proposal was rejected or nothing if accepted",
 
+	// GetChainTips help.
+	"getchaintips--synopsis": "Returns information about all known chain tips the in the block tree.\n\n" +
+		"The statuses in the result have the following meanings:\n" +
+		"active: The current best chain tip.\n" +
+		"invalid: The block or one of its ancestors is invalid.\n" +
+		"headers-only: The block or one of its ancestors does not have the full block data available which also means the block can't be validated or connected.\n" +
+		"valid-fork: The block is fully validated which implies it was probably part of the main chain at one point and was reorganized.\n" +
+		"valid-headers: The full block data is available and the header is valid, but the block was never validated which implies it was probably never part of the main chain.",
+
+	// GetChainTipsResult help.
+	"getchaintipsresult-height":    "The height of the chain tip",
+	"getchaintipsresult-hash":      "The block hash of the chain tip",
+	"getchaintipsresult-branchlen": "The length of the branch that connects the tip to the main chain (0 for the main chain tip)",
+	"getchaintipsresult-status":    "The status of the chain (active, invalid, headers-only, valid-fork, valid-headers)",
+	"getchaintipsresults--result0": "test",
+
 	// GetConnectionCountCmd help.
 	"getconnectioncount--synopsis": "Returns the number of active connections to other peers.",
 	"getconnectioncount--result0":  "The number of connections",
@@ -913,6 +929,7 @@ var rpcResultTypes = map[string][]interface{}{
 	"getblockheader":        {(*string)(nil), (*dcrjson.GetBlockHeaderVerboseResult)(nil)},
 	"getblocksubsidy":       {(*dcrjson.GetBlockSubsidyResult)(nil)},
 	"getblocktemplate":      {(*dcrjson.GetBlockTemplateResult)(nil), (*string)(nil), nil},
+	"getchaintips":          {(*[]dcrjson.GetChainTipsResult)(nil)},
 	"getconnectioncount":    {(*int32)(nil)},
 	"getcurrentnet":         {(*uint32)(nil)},
 	"getdifficulty":         {(*float64)(nil)},


### PR DESCRIPTION
This implements the `getchaintips` JSON-RPC and updates the associated JSON-RPC API documentation accordingly.

It should be noted that until the entire block index is loaded into memory, the chain tips tracking currently only works with tips that have been seen since the daemon was started.
