### PR TITLE
blockchain: Cache tip and parent at init.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -556,6 +556,7 @@ func (b *BlockChain) fetchMainChainBlockByHash(hash *chainhash.Hash) (*dcrutil.B
 		return block, nil
 	}
 
+	// Load the block from the database.
 	err := b.db.View(func(dbTx database.Tx) error {
 		var err error
 		block, err = dbFetchBlockByHash(dbTx, hash)


### PR DESCRIPTION
This modifies the startup logic to cache the tip and parent blocks in the main chain block cache at initialization time which is desirable because all of the transactions which come in to the mempool need access to the these blocks to construct their utxo views due to the potential for invalidation of the outputs in the previous block through voting.

Without caching them, the blocks end up being loaded from the database again every time a new transaction enters the mempool until the blocks eventually get cached when a new block is connected which is majorly inefficient.