### PR TITLE
mining: Stop transactions losing their dependants.

### DIFF
--- a/mining.go
+++ b/mining.go
@@ -1435,12 +1435,8 @@ mempoolLoop:
 		// Store if this is an SSRtx or not.
 		isSSRtx := prioItem.txType == stake.TxTypeSSRtx
 
-		// Grab the list of transactions which depend on this one (if
-		// any) and remove the entry for this transaction as it will
-		// either be included or skipped, but in either case the deps
-		// are no longer needed.
+		// Grab the list of transactions which depend on this one (if any).
 		deps := dependers[*tx.Hash()]
-		delete(dependers, *tx.Hash())
 
 		// Skip if we already have too many SStx.
 		if isSStx && (numSStx >=


### PR DESCRIPTION
**This requires PR #1108**.

This fixes a bug where a transaction would lose reference to other transactions dependent on it when being considered for inclusion in a new block template. The issue only occurs when the transaction being considered triggers a change of priority queue ordering to ordering by fee. It results in none of the dependent transactions being considered for inclusion in the new block template.

Work towards #709.