### PR TITLE
addrmgr: Improve test coverage.

### DIFF
--- a/addrmgr/addrmanager.go
+++ b/addrmgr/addrmanager.go
@@ -27,6 +27,9 @@ import (
 	"github.com/decred/dcrd/wire"
 )
 
+// PeersFilename is the default filename to store serialized peers.
+const PeersFilename = "peers.json"
+
 // AddrManager provides a concurrency safe address manager for caching potential
 // peers on the Decred network.
 type AddrManager struct {
@@ -363,8 +366,7 @@ func (a *AddrManager) savePeers() {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
 
-	// First we make a serialisable datastructure so we can encode it to
-	// json.
+	// First we make a serialisable datastructure so we can encode it to JSON.
 	sam := new(serializedAddrManager)
 	sam.Version = serialisationVersion
 	copy(sam.Key[:], a.key[:])
@@ -687,14 +689,14 @@ func (a *AddrManager) reset() {
 }
 
 // HostToNetAddress returns a netaddress given a host address. If the address is
-// a tor .onion address this will be taken care of. else if the host is not an
-// IP address it will be resolved (via tor if required).
+// a Tor .onion address this will be taken care of. Else if the host is not an
+// IP address it will be resolved (via Tor if required).
 func (a *AddrManager) HostToNetAddress(host string, port uint16, services wire.ServiceFlag) (*wire.NetAddress, error) {
-	// tor address is 16 char base32 + ".onion"
+	// Tor address is 16 char base32 + ".onion"
 	var ip net.IP
 	if len(host) == 22 && host[16:] == ".onion" {
 		// go base32 encoding uses capitals (as does the rfc
-		// but tor and bitcoind tend to user lowercase, so we switch
+		// but Tor and bitcoind tend to user lowercase, so we switch
 		// case here.
 		data, err := base32.StdEncoding.DecodeString(
 			strings.ToUpper(host[:16]))
@@ -718,7 +720,7 @@ func (a *AddrManager) HostToNetAddress(host string, port uint16, services wire.S
 }
 
 // ipString returns a string for the ip from the provided NetAddress. If the
-// ip is in the range used for tor addresses then it will be transformed into
+// ip is in the range used for Tor addresses then it will be transformed into
 // the relevant .onion address.
 func ipString(na *wire.NetAddress) string {
 	if IsOnionCatTor(na) {
@@ -1091,7 +1093,7 @@ func (a *AddrManager) GetBestLocalAddress(remoteAddr *wire.NetAddress) *wire.Net
 // Use Start to begin processing asynchronous address updates.
 func New(dataDir string, lookupFunc func(string) ([]net.IP, error)) *AddrManager {
 	am := AddrManager{
-		peersFile:      filepath.Join(dataDir, "peers.json"),
+		peersFile:      filepath.Join(dataDir, PeersFilename),
 		lookupFunc:     lookupFunc,
 		rand:           rand.New(rand.NewSource(time.Now().UnixNano())),
 		quit:           make(chan struct{}),

--- a/addrmgr/doc.go
+++ b/addrmgr/doc.go
@@ -29,7 +29,7 @@ generally helps provide greater peer diversity, and perhaps more importantly,
 drastically reduces the chances an attacker is able to coerce your peer into
 only connecting to nodes they control.
 
-The address manager also understands routability and tor addresses and tries
+The address manager also understands routability and Tor addresses and tries
 hard to only return routable addresses.  In addition, it uses the information
 provided by the caller about connected, known good, and attempted addresses to
 periodically purge peers which no longer appear to be good peers as well as

--- a/addrmgr/network.go
+++ b/addrmgr/network.go
@@ -233,7 +233,7 @@ func IsRoutable(na *wire.NetAddress) bool {
 // GroupKey returns a string representing the network group an address is part
 // of.  This is the /16 for IPv4, the /32 (/36 for he.net) for IPv6, the string
 // "local" for a local address, the string "tor:key" where key is the /4 of the
-// onion address for tor address, and the string "unroutable" for an unroutable
+// onion address for Tor address, and the string "unroutable" for an unroutable
 // address.
 func GroupKey(na *wire.NetAddress) string {
 	if IsLocal(na) {


### PR DESCRIPTION
Make sure the peers.json file is actually written and read in unit test.

Also some minor edits:

- Capitalize Tor.
- Capitalize JSON.
- Proper capitalization at the beginning of a sentence.

This PR increases the test coverage for the `addrmgr` package from 70.1% to 78.9%.