### PR TITLE
multi: Rename BIP0111Version to NodeBloomVersion.

### DIFF
--- a/sampleconfig/sampleconfig.go
+++ b/sampleconfig/sampleconfig.go
@@ -169,7 +169,7 @@ const FileContents = `[Application Options]
 ; Disable listening for incoming connections.  This will override all listeners.
 ; nolisten=1
 
-; Disable peer bloom filtering.  See BIP0111.
+; Disable peer bloom filtering.
 ; nopeerbloomfilters=1
 
 

--- a/server.go
+++ b/server.go
@@ -866,7 +866,7 @@ func (sp *serverPeer) enforceNodeBloomFlag(cmd string) bool {
 		// whether or not banning is enabled, it is checked here as well
 		// to ensure the violation is logged and the peer is
 		// disconnected regardless.
-		if sp.ProtocolVersion() >= wire.BIP0111Version &&
+		if sp.ProtocolVersion() >= wire.NodeBloomVersion &&
 			!cfg.DisableBanning {
 
 			// Disonnect the peer regardless of whether it was

--- a/wire/protocol.go
+++ b/wire/protocol.go
@@ -19,9 +19,9 @@ const (
 	// ProtocolVersion is the latest protocol version this package supports.
 	ProtocolVersion uint32 = 5
 
-	// BIP0111Version is the protocol version which added the SFNodeBloom
+	// Node BloomVersion is the protocol version which added the SFNodeBloom
 	// service flag.
-	BIP0111Version uint32 = 2
+	NodeBloomVersion uint32 = 2
 
 	// SendHeadersVersion is the protocol version which added a new
 	// sendheaders message.


### PR DESCRIPTION
This renames the `BIP0111Version` constant to `NodeBloomVersion` to better describe its purpose.

Closes #196.