### PR TITLE
main: Make func definition style consistent.

### DIFF
--- a/cpuminer.go
+++ b/cpuminer.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -187,9 +187,7 @@ func (m *CPUMiner) submitBlock(block *dcrutil.Block) bool {
 // This function will return early with false when conditions that trigger a
 // stale block such as a new block showing up or periodically when there are
 // new transactions and enough time has elapsed without finding a solution.
-func (m *CPUMiner) solveBlock(msgBlock *wire.MsgBlock, ticker *time.Ticker,
-	quit chan struct{}) bool {
-
+func (m *CPUMiner) solveBlock(msgBlock *wire.MsgBlock, ticker *time.Ticker, quit chan struct{}) bool {
 	blockHeight := int64(msgBlock.Header.Height)
 
 	// Choose a random extra nonce offset for this block template and

--- a/mining.go
+++ b/mining.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2016 The btcsuite developers
-// Copyright (c) 2015-2017 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -222,8 +222,7 @@ func txPQByStakeAndFeeAndThenPriority(pq *txPriorityQueue, i, j int) bool {
 // less than function lessFunc to sort the items in the min heap. The priority
 // queue can grow larger than the reserved space, but extra copies of the
 // underlying array can be avoided by reserving a sane value.
-func newTxPriorityQueue(reserve int, lessFunc func(*txPriorityQueue, int,
-	int) bool) *txPriorityQueue {
+func newTxPriorityQueue(reserve int, lessFunc func(*txPriorityQueue, int, int) bool) *txPriorityQueue {
 	pq := &txPriorityQueue{
 		items: make([]*txPrioItem, 0, reserve),
 	}
@@ -419,8 +418,7 @@ func txIndexFromTxList(hash chainhash.Hash, list []*dcrutil.Tx) int {
 
 // standardCoinbaseOpReturn creates a standard OP_RETURN output to insert into
 // coinbase to use as extranonces. The OP_RETURN pushes 32 bytes.
-func standardCoinbaseOpReturn(height uint32, extraNonces []uint64) ([]byte,
-	error) {
+func standardCoinbaseOpReturn(height uint32, extraNonces []uint64) ([]byte, error) {
 	if len(extraNonces) != 4 {
 		return nil, fmt.Errorf("extranonces has wrong num uint64s")
 	}
@@ -491,8 +489,7 @@ func getCoinbaseExtranonces(msgBlock *wire.MsgBlock) []uint64 {
 // block by regenerating the coinbase script with the passed value and block
 // height.  It also recalculates and updates the new merkle root that results
 // from changing the coinbase script.
-func UpdateExtraNonce(msgBlock *wire.MsgBlock, blockHeight int64,
-	extraNonces []uint64) error {
+func UpdateExtraNonce(msgBlock *wire.MsgBlock, blockHeight int64, extraNonces []uint64) error {
 	// First block has no extranonce.
 	if blockHeight == 1 {
 		return nil
@@ -525,14 +522,7 @@ func UpdateExtraNonce(msgBlock *wire.MsgBlock, blockHeight int64,
 //
 // See the comment for NewBlockTemplate for more information about why the nil
 // address handling is useful.
-func createCoinbaseTx(subsidyCache *blockchain.SubsidyCache,
-	coinbaseScript []byte,
-	opReturnPkScript []byte,
-	nextBlockHeight int64,
-	addr dcrutil.Address,
-	voters uint16,
-	params *chaincfg.Params) (*dcrutil.Tx, error) {
-
+func createCoinbaseTx(subsidyCache *blockchain.SubsidyCache, coinbaseScript []byte, opReturnPkScript []byte, nextBlockHeight int64, addr dcrutil.Address, voters uint16, params *chaincfg.Params) (*dcrutil.Tx, error) {
 	tx := wire.NewMsgTx()
 	tx.AddTxIn(&wire.TxIn{
 		// Coinbase transactions have no inputs, so previous outpoint is
@@ -640,8 +630,7 @@ func createCoinbaseTx(subsidyCache *blockchain.SubsidyCache,
 // spendTransaction updates the passed view by marking the inputs to the passed
 // transaction as spent.  It also adds all outputs in the passed transaction
 // which are not provably unspendable as available unspent transaction outputs.
-func spendTransaction(utxoView *blockchain.UtxoViewpoint, tx *dcrutil.Tx,
-	height int64) error {
+func spendTransaction(utxoView *blockchain.UtxoViewpoint, tx *dcrutil.Tx, height int64) error {
 	for _, txIn := range tx.MsgTx().TxIn {
 		originHash := &txIn.PreviousOutPoint.Hash
 		originIndex := txIn.PreviousOutPoint.Index
@@ -683,8 +672,7 @@ func minimumMedianTime(chainState *chainState) (time.Time, error) {
 // medianAdjustedTime returns the current time adjusted to ensure it is at least
 // one second after the median timestamp of the last several blocks per the
 // chain consensus rules.
-func medianAdjustedTime(chainState *chainState,
-	timeSource blockchain.MedianTimeSource) (time.Time, error) {
+func medianAdjustedTime(chainState *chainState, timeSource blockchain.MedianTimeSource) (time.Time, error) {
 	chainState.Lock()
 	defer chainState.Unlock()
 
@@ -998,8 +986,7 @@ func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache, nextHeight int64,
 // the appropriate cache if needed, then returns the template to the miner to
 // work on. The stored template is a copy of the template, to prevent races
 // from occurring in case the template is mined on by the CPUminer.
-func handleCreatedBlockTemplate(blockTemplate *BlockTemplate,
-	bm *blockManager) (*BlockTemplate, error) {
+func handleCreatedBlockTemplate(blockTemplate *BlockTemplate, bm *blockManager) (*BlockTemplate, error) {
 	curTemplate := bm.GetCurrentTemplate()
 
 	nextBlockHeight := blockTemplate.Height
@@ -1116,9 +1103,7 @@ func handleCreatedBlockTemplate(blockTemplate *BlockTemplate,
 //
 //  This function returns nil, nil if there are not enough voters on any of
 //  the current top blocks to create a new block template.
-func NewBlockTemplate(policy *mining.Policy, server *server,
-	payToAddress dcrutil.Address) (*BlockTemplate, error) {
-
+func NewBlockTemplate(policy *mining.Policy, server *server, payToAddress dcrutil.Address) (*BlockTemplate, error) {
 	// TODO: The mempool should be completely separated via the TxSource
 	// interface so this function is fully decoupled.
 	mp := server.txMemPool

--- a/rpcwebsocket.go
+++ b/rpcwebsocket.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -82,9 +82,7 @@ var wsHandlersBeforeInit = map[string]wsCommandHandler{
 // must be run in a separate goroutine.  It should be invoked from the websocket
 // server handler which runs each new connection in a new goroutine thereby
 // satisfying the requirement.
-func (s *rpcServer) WebsocketHandler(conn *websocket.Conn, remoteAddr string,
-	authenticated bool, isAdmin bool) {
-
+func (s *rpcServer) WebsocketHandler(conn *websocket.Conn, remoteAddr string, authenticated bool, isAdmin bool) {
 	// Clear the read deadline that was set before the websocket hijacked
 	// the connection.
 	conn.SetReadDeadline(timeZeroVal)
@@ -654,9 +652,7 @@ func (m *wsNotificationManager) UnregisterBlockUpdates(wsc *wsClient) {
 // spending a watched output or outputting to a watched address.  Matching
 // client's filters are updated based on this transaction's outputs and output
 // addresses that may be relevant for a client.
-func (m *wsNotificationManager) subscribedClients(tx *dcrutil.Tx,
-	clients map[chan struct{}]*wsClient) map[chan struct{}]struct{} {
-
+func (m *wsNotificationManager) subscribedClients(tx *dcrutil.Tx, clients map[chan struct{}]*wsClient) map[chan struct{}]struct{} {
 	// Use a map of client quit channels as keys to prevent duplicates when
 	// multiple inputs and/or outputs are relevant to the client.
 	subscribed := make(map[chan struct{}]struct{})
@@ -707,9 +703,7 @@ func (m *wsNotificationManager) subscribedClients(tx *dcrutil.Tx,
 
 // notifyBlockConnected notifies websocket clients that have registered for
 // block updates when a block is connected to the main chain.
-func (m *wsNotificationManager) notifyBlockConnected(clients map[chan struct{}]*wsClient,
-	block *dcrutil.Block) {
-
+func (m *wsNotificationManager) notifyBlockConnected(clients map[chan struct{}]*wsClient, block *dcrutil.Block) {
 	// Create the common portion of the notification that is the same for
 	// every client.
 	headerBytes, err := block.MsgBlock().Header.Bytes()
@@ -873,9 +867,7 @@ func (m *wsNotificationManager) UnregisterSpentAndMissedTickets(wsc *wsClient) {
 
 // notifySpentAndMissedTickets notifies websocket clients that have registered for
 // spent and missed ticket updates.
-func (*wsNotificationManager) notifySpentAndMissedTickets(
-	clients map[chan struct{}]*wsClient, tnd *blockchain.TicketNotificationsData) {
-
+func (*wsNotificationManager) notifySpentAndMissedTickets(clients map[chan struct{}]*wsClient, tnd *blockchain.TicketNotificationsData) {
 	// Create a ticket map to export as JSON.
 	ticketMap := make(map[string]string)
 	for _, ticket := range tnd.TicketsMissed {
@@ -927,9 +919,7 @@ func (m *wsNotificationManager) UnregisterStakeDifficulty(wsc *wsClient) {
 
 // notifyNewTickets notifies websocket clients that have registered for
 // maturing ticket updates.
-func (*wsNotificationManager) notifyNewTickets(clients map[chan struct{}]*wsClient,
-	tnd *blockchain.TicketNotificationsData) {
-
+func (*wsNotificationManager) notifyNewTickets(clients map[chan struct{}]*wsClient, tnd *blockchain.TicketNotificationsData) {
 	// Create a ticket map to export as JSON.
 	var tickets []string
 	for _, h := range tnd.TicketsNew {
@@ -953,10 +943,7 @@ func (*wsNotificationManager) notifyNewTickets(clients map[chan struct{}]*wsClie
 
 // notifyStakeDifficulty notifies websocket clients that have registered for
 // maturing ticket updates.
-func (*wsNotificationManager) notifyStakeDifficulty(
-	clients map[chan struct{}]*wsClient,
-	sdnd *StakeDifficultyNtfnData) {
-
+func (*wsNotificationManager) notifyStakeDifficulty(clients map[chan struct{}]*wsClient, sdnd *StakeDifficultyNtfnData) {
 	// Notify interested websocket clients about the connected block.
 	ntfn := dcrjson.NewStakeDifficultyNtfn(sdnd.BlockHash.String(),
 		int32(sdnd.BlockHeight),
@@ -2040,32 +2027,28 @@ func handleSession(wsc *wsClient, icmd interface{}) (interface{}, error) {
 
 // handleWinningTickets implements the notifywinningtickets command
 // extension for websocket connections.
-func handleWinningTickets(wsc *wsClient, icmd interface{}) (interface{},
-	error) {
+func handleWinningTickets(wsc *wsClient, icmd interface{}) (interface{}, error) {
 	wsc.server.ntfnMgr.RegisterWinningTickets(wsc)
 	return nil, nil
 }
 
 // handleSpentAndMissedTickets implements the notifyspentandmissedtickets command
 // extension for websocket connections.
-func handleSpentAndMissedTickets(wsc *wsClient, icmd interface{}) (interface{},
-	error) {
+func handleSpentAndMissedTickets(wsc *wsClient, icmd interface{}) (interface{}, error) {
 	wsc.server.ntfnMgr.RegisterSpentAndMissedTickets(wsc)
 	return nil, nil
 }
 
 // handleNewTickets implements the notifynewtickets command extension for
 // websocket connections.
-func handleNewTickets(wsc *wsClient, icmd interface{}) (interface{},
-	error) {
+func handleNewTickets(wsc *wsClient, icmd interface{}) (interface{}, error) {
 	wsc.server.ntfnMgr.RegisterNewTickets(wsc)
 	return nil, nil
 }
 
 // handleStakeDifficulty implements the notifystakedifficulty command extension
 // for websocket connections.
-func handleStakeDifficulty(wsc *wsClient, icmd interface{}) (interface{},
-	error) {
+func handleStakeDifficulty(wsc *wsClient, icmd interface{}) (interface{}, error) {
 	wsc.server.ntfnMgr.RegisterStakeDifficulty(wsc)
 	return nil, nil
 }


### PR DESCRIPTION
This modifies all files in the main package so that function definitions are on the a single line as is the style used in the upstream code as well as throughout its code base.  This helps minimize the differences between them and the upstream code in order to facilitate easier syncs due to less merge conflicts as a result of superfluous changes.