### PR TITLE
mining: Use single uint64 coinbase extra nonce.

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -898,8 +898,7 @@ func (b *blockManager) checkBlockForHiddenVotes(block *dcrutil.Block) {
 		return
 	}
 	height := block.MsgBlock().Header.Height
-	opReturnPkScript, err := standardCoinbaseOpReturn(height,
-		[]uint64{0, 0, 0, random})
+	opReturnPkScript, err := standardCoinbaseOpReturn(height, random)
 	if err != nil {
 		// Stopping at this step will lead to a corrupted block template
 		// because the stake tree has already been manipulated, so throw

--- a/cpuminer.go
+++ b/cpuminer.go
@@ -212,14 +212,10 @@ func (m *CPUMiner) solveBlock(msgBlock *wire.MsgBlock, ticker *time.Ticker, quit
 	// added relying on the fact that overflow will wrap around 0 as
 	// provided by the Go spec.
 	for extraNonce := uint64(0); extraNonce < maxExtraNonce; extraNonce++ {
-		// Get the old nonce values.
-		ens := getCoinbaseExtranonces(msgBlock)
-		ens[2] = extraNonce + enOffset
-
 		// Update the extra nonce in the block template with the
 		// new value by regenerating the coinbase script and
-		// setting the merkle root to the new value.  The
-		err := UpdateExtraNonce(msgBlock, blockHeight, ens)
+		// setting the merkle root to the new value.
+		err := UpdateExtraNonce(msgBlock, blockHeight, extraNonce+enOffset)
 		if err != nil {
 			minrLog.Warnf("Unable to update CPU miner extranonce: %v",
 				err)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4033,10 +4033,9 @@ func handleGetWorkRequest(s *rpcServer) (interface{}, error) {
 			// Increment the extra nonce and update the block template
 			// with the new value by regenerating the coinbase script and
 			// setting the merkle root to the new value.
-			ens := getCoinbaseExtranonces(msgBlock)
+			en := extractCoinbaseExtraNonce(msgBlock) + 1
 			state.extraNonce++
-			ens[0]++
-			err := UpdateExtraNonce(msgBlock, latestHeight+1, ens)
+			err := UpdateExtraNonce(msgBlock, latestHeight+1, en)
 			if err != nil {
 				errStr := fmt.Sprintf("Failed to update extra nonce: "+
 					"%v", err)


### PR DESCRIPTION
**This requires PR #1114**.

The current code creates block templates with coinbase transactions that have 4 uint64 extra nonces, but only ever uses one of them.  Rather than wasting the extra space, this modifies the code so it only uses a single uint64 extra nonce.

It should be noted that realistically there isn't even a real need for an extra nonce in the coinbase at all because there is extra space in the header specifically for that purpose and miners can't modify the coinbase via `getwork` anyways.

However, it is still necessary to insert for the current code in order to ensure every block template has a unique merkle root since that is what is used to uniquely identify the block template.
