### PR TITLE
mempool/mining: TxSource separation.

### DIFF
--- a/mining/mining.go
+++ b/mining/mining.go
@@ -33,6 +33,14 @@ type TxDesc struct {
 	Fee int64
 }
 
+// VoteDesc is a descriptor about a vote transaction in a transaction source
+// along with additional metadata.
+type VoteDesc struct {
+	VoteHash       chainhash.Hash
+	TicketHash     chainhash.Hash
+	ApprovesParent bool
+}
+
 // TxSource represents a source of transactions to consider for inclusion in
 // new blocks.
 //
@@ -50,4 +58,22 @@ type TxSource interface {
 	// HaveTransaction returns whether or not the passed transaction hash
 	// exists in the source pool.
 	HaveTransaction(hash *chainhash.Hash) bool
+
+	// HaveAllTransactions returns whether or not all of the passed
+	// transaction hashes exist in the source pool.
+	HaveAllTransactions(hashes []chainhash.Hash) bool
+
+	// VoteHashesForBlock returns the hashes for all votes on the provided
+	// block hash that are currently available in the source pool.
+	VoteHashesForBlock(hash *chainhash.Hash) []chainhash.Hash
+
+	// VotesForBlocks returns a slice of vote descriptors for all votes on
+	// the provided block hashes that are currently available in the source
+	// pool.
+	VotesForBlocks(hashes []chainhash.Hash) [][]VoteDesc
+
+	// IsTxTreeKnownInvalid returns whether or not the transaction tree of
+	// the provided hash is known to be invalid according to the votes
+	// currently in the memory pool.
+	IsTxTreeKnownInvalid(hash *chainhash.Hash) bool
 }

--- a/server.go
+++ b/server.go
@@ -486,8 +486,9 @@ func (sp *serverPeer) OnGetMiningState(p *peer.Peer, msg *wire.MsgGetMiningState
 
 	// Construct the set of votes to send.
 	voteHashes := make([]chainhash.Hash, 0, wire.MaxMSVotesAtHeadPerMsg)
-	for _, bh := range blockHashes {
+	for i := range blockHashes {
 		// Fetch the vote hashes themselves and append them.
+		bh := &blockHashes[i]
 		vhsForBlock := mp.VoteHashesForBlock(bh)
 		if len(vhsForBlock) == 0 {
 			peerLog.Warnf("unexpected error while fetching vote hashes "+


### PR DESCRIPTION
**This requires PR #1118**.

This finishes separating the mining code from the `mempool` that was partially done in commit 9031d8574e857b5deefad4793ad5ba7eec6a72e3 by extending the `TxSource` interface to include the new functionality required by Decred.

The following is an overview of the changes to accomplish this:
- Move the `VoteTx` struct out of the `mempool` package in the mining package and rename it to `VoteDesc` instead to signify it is a vote descriptor and be consistent with the naming of `TxDesc`
- Update `mempool` to use the new `mining.VoteDesc` struct
- Rename `CheckIfTxsExist` to `HaveAllTransactions` to be more consistent with `HaveTransaction` in the `TxSource` interface as it now lives alongside it
- Add `VoteHashesForBlock`, `VotesForBlocks`, and `IsTxTreeKnownInvalid` to the `TxSource` interface
- Switch the mining code to call the functions on the `TxSource` interface instead and remove the reference to the concrete `mempool`
