### PR TITLE
mining: Correct initial template generation.

### DIFF
--- a/mining.go
+++ b/mining.go
@@ -847,7 +847,8 @@ func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache, nextHeight int64,
 				// and the contents of that stake tree. In the future
 				// we should have the option of readding some
 				// transactions from this block, too.
-				topBlock, err := bm.chain.FetchBlockByHash(&prevBlockHash)
+				bestHash, _ := chainState.Best()
+				topBlock, err := bm.chain.FetchBlockByHash(bestHash)
 				if err != nil {
 					str := fmt.Sprintf("unable to get tip block %s",
 						prevBlockHash)
@@ -858,6 +859,8 @@ func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache, nextHeight int64,
 				if err != nil {
 					return nil, err
 				}
+				coinbaseScript := make([]byte, len(coinbaseFlags)+2)
+				copy(coinbaseScript[2:], coinbaseFlags)
 				opReturnPkScript, err :=
 					standardCoinbaseOpReturn(topBlock.MsgBlock().Header.Height,
 						rand)
@@ -865,7 +868,7 @@ func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache, nextHeight int64,
 					return nil, err
 				}
 				coinbaseTx, err := createCoinbaseTx(subsidyCache,
-					[]byte{0x01, 0x02},
+					coinbaseScript,
 					opReturnPkScript,
 					topBlock.Height(),
 					miningAddress,


### PR DESCRIPTION
This corrects the code to create a new template when first starting up with aggressive mining enable before votes on the most recent block are known.

First, the code is expecting the current best block, not its parent, and second, the coinbase script should match what is created in the normal path as well.