### PR TITLE
addrmgr: Test removal of corrupt peers file.

### DIFF
--- a/addrmgr/addrmanager.go
+++ b/addrmgr/addrmanager.go
@@ -177,7 +177,7 @@ func (a *AddrManager) updateAddress(netAddr, srcAddr *wire.NetAddress) {
 		// TODO(oga) only update addresses periodically.
 		// Update the last seen time and services.
 		// note that to prevent causing excess garbage on getaddr
-		// messages the netaddresses in addrmaanger are *immutable*,
+		// messages the netaddresses in addrmanager are *immutable*,
 		// if we need to change them then we replace the pointer with a
 		// new copy so that we don't have to copy every na for getaddr.
 		if netAddr.Timestamp.After(ka.na.Timestamp) ||

--- a/addrmgr/addrmanager_test.go
+++ b/addrmgr/addrmanager_test.go
@@ -169,7 +169,7 @@ func TestAddAddressByIP(t *testing.T) {
 	// make sure the peers file has been written
 	peersFile := filepath.Join(dir, addrmgr.PeersFilename)
 	if _, err := os.Stat(peersFile); err != nil {
-		t.Fatalf("Peer file does not exist: %s", peersFile)
+		t.Fatalf("Peers file does not exist: %s", peersFile)
 	}
 
 	// start address manager again to read peers file
@@ -497,4 +497,27 @@ func TestNetAddressKey(t *testing.T) {
 		}
 	}
 
+}
+
+func TestCorruptPeersFile(t *testing.T) {
+	dir, err := ioutil.TempDir("", "testcorruptpeersfile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	peersFile := filepath.Join(dir, addrmgr.PeersFilename)
+	// create corrupt (empty) peers file
+	fp, err := os.Create(peersFile)
+	if err != nil {
+		t.Fatalf("Could not create empty peers file: %s", peersFile)
+	}
+	if err := fp.Close(); err != nil {
+		t.Fatalf("Could not write empty peers file: %s", peersFile)
+	}
+	amgr := addrmgr.New(dir, nil)
+	amgr.Start()
+	amgr.Stop()
+	if _, err := os.Stat(peersFile); err != nil {
+		t.Fatalf("Corrupt peers file has not been removed: %s", peersFile)
+	}
 }

--- a/addrmgr/doc.go
+++ b/addrmgr/doc.go
@@ -17,7 +17,7 @@ be trusted to send valid peers nor attempt to provide you with only peers they
 control with malicious intent.
 
 With that in mind, this package provides a concurrency safe address manager for
-caching and selecting peers in a non-determinstic manner.  The general idea is
+caching and selecting peers in a non-deterministic manner.  The general idea is
 the caller adds addresses to the address manager and notifies it when addresses
 are connected, known good, and attempted.  The caller also requests addresses as
 it needs them.
@@ -34,6 +34,6 @@ hard to only return routable addresses.  In addition, it uses the information
 provided by the caller about connected, known good, and attempted addresses to
 periodically purge peers which no longer appear to be good peers as well as
 bias the selection toward known good peers.  The general idea is to make a best
-effort at only providing usuable addresses.
+effort at only providing usable addresses.
 */
 package addrmgr


### PR DESCRIPTION
Add unit test to ensure the removal of corrupt peers files.

Also fix some typos.

Increases test coverage from 78.4% to 79.5%.