### PR TITLE
[DO NOT MERGE] addrmgr: Properly scale up.

### DIFF
--- a/addrmgr/addrmanager.go
+++ b/addrmgr/addrmanager.go
@@ -107,11 +107,11 @@ const (
 
 	// triedBucketSize is the maximum number of addresses in each
 	// tried address bucket.
-	triedBucketSize = 256
+	triedBucketSize = 64
 
 	// triedBucketCount is the number of buckets we split tried
 	// addresses over.
-	triedBucketCount = 64
+	triedBucketCount = 256
 
 	// newBucketSize is the maximum number of addresses in each new address
 	// bucket.


### PR DESCRIPTION
Commit c80c8e7fe9000d887e1e7b9e22595f1b50d8de23 was supposed to mimic
Bitcoin Core commit https://github.com/bitcoin/bitcoin/commit/1d21ba2f5ecbf03086d0b65c4c4c80a39a94c2ee in order to implement the suggested Countermeasure 6 in
Eclipse Attacks on Bitcoin’s Peer-to-Peer Network, Ethan
Heilman, Alison Kendler, Aviv Zohar, Sharon Goldberg. ePrint Archive
Report 2015/263. March 2015.

However, erroneously the `triedBucketSize` was increased instead of the `triedBucketCount`.

This commit fixes this error in order to properly mimic the Bitcoin Core
commit referenced above.

This change in isolation is problematic, because after applying it old
peers.json files will still load, but with many empty new tried buckets and
potentially overfull old tried buckets.

See issue #1131 for discussion.