### PR TITLE
addrmgr: Improve isBad() performance.

### DIFF
--- a/addrmgr/knownaddress.go
+++ b/addrmgr/knownaddress.go
@@ -79,17 +79,18 @@ func (ka *KnownAddress) chance() float64 {
 func (ka *KnownAddress) isBad() bool {
 	ka.mtx.Lock()
 	defer ka.mtx.Unlock()
-	if ka.lastattempt.After(time.Now().Add(-1 * time.Minute)) {
+	now := time.Now()
+	if ka.lastattempt.After(now.Add(-1 * time.Minute)) {
 		return false
 	}
 
 	// From the future?
-	if ka.na.Timestamp.After(time.Now().Add(10 * time.Minute)) {
+	if ka.na.Timestamp.After(now.Add(10 * time.Minute)) {
 		return true
 	}
 
 	// Over a month old?
-	if ka.na.Timestamp.Before(time.Now().Add(-1 * numMissingDays * time.Hour * 24)) {
+	if ka.na.Timestamp.Before(now.Add(-1 * numMissingDays * time.Hour * 24)) {
 		return true
 	}
 
@@ -99,7 +100,7 @@ func (ka *KnownAddress) isBad() bool {
 	}
 
 	// Hasn't succeeded in too long?
-	if !ka.lastsuccess.After(time.Now().Add(-1*minBadDays*time.Hour*24)) &&
+	if !ka.lastsuccess.After(now.Add(-1*minBadDays*time.Hour*24)) &&
 		ka.attempts >= maxFailures {
 		return true
 	}


### PR DESCRIPTION
Caching the result of time.Now() increases performance by around 50%
in the happy case (measured for last return statement).