### PR TITLE
chaincfg: Add checkpoints for upcoming release.

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -523,6 +523,7 @@ var MainNetParams = Params{
 		{164300, newHashFromStr("000000000000009ed067ff51cd5e15f3c786222a5183b20a991a80ce535907a9")},
 		{181020, newHashFromStr("00000000000000b77d832cb2cbed02908d69323862a53e56345400ad81a6fb8f")},
 		{189950, newHashFromStr("000000000000007341d8ae2ea7e41f25cee00e1a70a4a3dc1cb055d14ecb2e11")},
+		{214672, newHashFromStr("0000000000000021d5cbeead55cb7fd659f07e8127358929ffc34cd362209758")},
 	},
 
 	// The miner confirmation window is defined as:

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -729,6 +729,7 @@ var TestNet2Params = Params{
 		{140000, newHashFromStr("00000000015736a13fb25ef414947a8a7a4359ef5a00e3a03d6089f38f16f2de")},
 		{157500, newHashFromStr("00000000052684525a3fedd619247b148eaa3ac38ab45781a1571099fd6036cf")},
 		{175000, newHashFromStr("0000000000320a623fcc6453986ef13423f455ddf0f788ad1f2bda43858ccb8d")},
+		{249802, newHashFromStr("0000000000153386623d86ce70cc9372fa000ac3b999eff11b9fc7a3ca0d072a")},
 	},
 
 	// Consensus rule change deployments.


### PR DESCRIPTION
This adds checkpoints for both the main and test networks as follows:

- Add mainnet checkpoint at height 214672.
- Add testnet checkpoint at height 249802.