### PR TITLE
rpcserver: Improve JSON-RPC compatibility

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -6224,6 +6224,11 @@ func (s *rpcServer) jsonRPCRead(w http.ResponseWriter, r *http.Request, isAdmin 
 	if _, err := buf.Write(msg); err != nil {
 		rpcsLog.Errorf("Failed to write marshalled reply: %v", err)
 	}
+
+	// Terminate with newline to maintain compatibility with Bitcoin Core.
+	if err := buf.WriteByte('\n'); err != nil {
+		rpcsLog.Errorf("Failed to append terminating newline to reply: %v", err)
+	}
 }
 
 // jsonAuthFail sends a message back to the client if the http auth is rejected.


### PR DESCRIPTION
This PR has the following upstream commits:
 - [9799f0e](https://github.com/btcsuite/btcd/commit/9799f0e547c59ff7090bfd0a718ff345334adbb4)
 - [6b8a249](https://github.com/btcsuite/btcd/commit/6b8a24918e53e3c928df3eef0fd06f1c94e7e1cd)
    - NOOP

---
In order to avoid compatibility issues with software relying on 
Core's behavior, terminate HTTP POST JSON-RPC responses with a newline.