### PR TITLE
indexers: Provide interface for index removal.

### DIFF
--- a/blockchain/indexers/addrindex.go
+++ b/blockchain/indexers/addrindex.go
@@ -1091,5 +1091,10 @@ func NewAddrIndex(db database.DB, chainParams *chaincfg.Params) *AddrIndex {
 // DropAddrIndex drops the address index from the provided database if it
 // exists.
 func DropAddrIndex(db database.DB, interrupt <-chan struct{}) error {
-	return dropIndex(db, addrIndexKey, addrIndexName, interrupt)
+	return dropFlatIndex(db, addrIndexKey, addrIndexName, interrupt)
+}
+
+// DropIndex drops the address index from the provided database if it exists.
+func (*AddrIndex) DropIndex(db database.DB, interrupt <-chan struct{}) error {
+	return DropAddrIndex(db, interrupt)
 }

--- a/blockchain/indexers/common.go
+++ b/blockchain/indexers/common.go
@@ -60,6 +60,13 @@ type Indexer interface {
 	DisconnectBlock(dbTx database.Tx, block, parent *dcrutil.Block, view *blockchain.UtxoViewpoint) error
 }
 
+// IndexDropper provides a method to remove an index from the database. Indexers
+// may implement this for a more efficient way of deleting themselves from the
+// database rather than simply dropping a bucket.
+type IndexDropper interface {
+	DropIndex(db database.DB, interrupt <-chan struct{}) error
+}
+
 // AssertError identifies an error that indicates an internal code consistency
 // issue and should be treated as a critical and unrecoverable error.
 type AssertError string

--- a/blockchain/indexers/existsaddrindex.go
+++ b/blockchain/indexers/existsaddrindex.go
@@ -411,6 +411,12 @@ func (idx *ExistsAddrIndex) AddUnconfirmedTx(tx *wire.MsgTx) {
 // DropExistsAddrIndex drops the exists address index from the provided
 // database if it exists.
 func DropExistsAddrIndex(db database.DB, interrupt <-chan struct{}) error {
-	return dropIndex(db, existsAddrIndexKey, existsAddressIndexName,
+	return dropFlatIndex(db, existsAddrIndexKey, existsAddressIndexName,
 		interrupt)
+}
+
+// DropIndex drops the exists address index from the provided database if it
+// exists.
+func (*ExistsAddrIndex) DropIndex(db database.DB, interrupt <-chan struct{}) error {
+	return DropExistsAddrIndex(db, interrupt)
 }

--- a/database/error.go
+++ b/database/error.go
@@ -196,3 +196,9 @@ func (e Error) Error() string {
 func makeError(c ErrorCode, desc string, err error) Error {
 	return Error{ErrorCode: c, Description: desc, Err: err}
 }
+
+// IsError returns whether err is an Error with a matching error code.
+func IsError(err error, code ErrorCode) bool {
+	e, ok := err.(Error)
+	return ok && e.ErrorCode == code
+}


### PR DESCRIPTION
Indexes may now optionally provide their own implementation for
dropping the index, with a fallback to simply removing the index
bucket and metadata if not implemented.

Using an interface and dynamically dispatching to the correct drop
implementation also allowed removing a special case for deletion of
the transaction index from the common drop code.