### PR TITLE
hdkeychain: Satisfy fmt.Stringer interface.

### DIFF
--- a/hdkeychain/example_test.go
+++ b/hdkeychain/example_test.go
@@ -176,11 +176,7 @@ func Example_audits() {
 	}
 
 	// Share the master public extended key with the auditor.
-	mpks, err := masterPubKey.String()
-	if err != nil {
-		panic("unexpected error creating string of extended public key")
-	}
-	fmt.Println("Audit key N(m/*):", mpks)
+	fmt.Println("Audit key N(m/*):", masterPubKey)
 
 	// Output:
 	// Audit key N(m/*): dpubZ9169KDAEUnypHbWCe2Vu5TxGEcqJeNeX6XCYFU1fqw2iQZK7fsMhzsEFArbLmyUdprUw9aXHneUNd92bjc31TqC6sUduMY6PK2z4JXDS8j

--- a/hdkeychain/extendedkey.go
+++ b/hdkeychain/extendedkey.go
@@ -372,9 +372,9 @@ func paddedAppend(size uint, dst, src []byte) []byte {
 }
 
 // String returns the extended key as a human-readable base58-encoded string.
-func (k *ExtendedKey) String() (string, error) {
+func (k *ExtendedKey) String() string {
 	if len(k.key) == 0 {
-		return "", fmt.Errorf("zeroed extended key")
+		return "zeroed extended key"
 	}
 
 	var childNumBytes [4]byte
@@ -399,7 +399,7 @@ func (k *ExtendedKey) String() (string, error) {
 
 	checkSum := chainhash.HashB(chainhash.HashB(serializedBytes))[:4]
 	serializedBytes = append(serializedBytes, checkSum...)
-	return base58.Encode(serializedBytes), nil
+	return base58.Encode(serializedBytes)
 }
 
 // IsForNet returns whether or not the extended key is associated with the

--- a/hdkeychain/extendedkey_test.go
+++ b/hdkeychain/extendedkey_test.go
@@ -213,7 +213,7 @@ tests:
 			}
 		}
 
-		privStr, _ := extKey.String()
+		privStr := extKey.String()
 		if privStr != test.wantPriv {
 			t.Errorf("Serialize #%d (%s): mismatched serialized "+
 				"private extended key -- got: %s, want: %s", i,
@@ -236,7 +236,7 @@ tests:
 			return
 		}
 
-		pubStr, _ := pubKey.String()
+		pubStr := pubKey.String()
 		if pubStr != test.wantPub {
 			t.Errorf("Neuter #%d (%s): mismatched serialized "+
 				"public extended key -- got: %s, want: %s", i,
@@ -364,7 +364,7 @@ tests:
 			}
 		}
 
-		privStr, _ := extKey.String()
+		privStr := extKey.String()
 		if privStr != test.wantPriv {
 			t.Errorf("Child #%d (%s): mismatched serialized "+
 				"private extended key -- got: %s, want: %s", i,
@@ -483,7 +483,7 @@ tests:
 			}
 		}
 
-		pubStr, _ := extKey.String()
+		pubStr := extKey.String()
 		if pubStr != test.wantPub {
 			t.Errorf("Child #%d (%s): mismatched serialized "+
 				"public extended key -- got: %s, want: %s", i,
@@ -586,7 +586,7 @@ func TestExtendedKeyAPI(t *testing.T) {
 			continue
 		}
 
-		serializedKey, _ := key.String()
+		serializedKey := key.String()
 		if serializedKey != test.extKey {
 			t.Errorf("String #%d (%s): mismatched serialized key "+
 				"-- want %s, got %s", i, test.name, test.extKey,
@@ -713,7 +713,7 @@ func TestNet(t *testing.T) {
 		}
 
 		if test.isPrivate {
-			privStr, _ := extKey.String()
+			privStr := extKey.String()
 			if privStr != test.newPriv {
 				t.Errorf("Serialize #%d (%s): mismatched serialized "+
 					"private extended key -- got: %s, want: %s", i,
@@ -729,7 +729,7 @@ func TestNet(t *testing.T) {
 			}
 		}
 
-		pubStr, _ := extKey.String()
+		pubStr := extKey.String()
 		if pubStr != test.newPub {
 			t.Errorf("Neuter #%d (%s): mismatched serialized "+
 				"public extended key -- got: %s, want: %s", i,
@@ -880,11 +880,11 @@ func TestZero(t *testing.T) {
 		}
 
 		wantKey := "zeroed extended key"
-		_, errZeroed := key.String()
-		if errZeroed.Error() != wantKey {
+		serializedKey := key.String()
+		if serializedKey != wantKey {
 			t.Errorf("String #%d (%s): mismatched serialized key "+
 				"-- want %s, got %s", i, testName, wantKey,
-				errZeroed)
+				serializedKey)
 			return false
 		}
 


### PR DESCRIPTION
This reverts changes to the `String` function on `ExtendedKey` to match the upstream code so that it satisfies the `fmt.Stringer` interface as intended.

For an additional bit of context, the condition was never intended to be an error to begin with because it's perfectly acceptable to work with zeroed keys and there is even a `Zero` function which serves precisely that purpose.