### PR TITLE
txscript: Remove SigHashAllValue.

### DIFF
--- a/txscript/sign_test.go
+++ b/txscript/sign_test.go
@@ -120,12 +120,6 @@ func signBadAndCheck(msg string, tx *wire.MsgTx, idx int, pkScript []byte,
 	randScriptHash := chainhash.HashB(pkScript)
 	tRand := mrand.New(mrand.NewSource(int64(randScriptHash[0])))
 
-	// Test SigHashAllValue by corrupting the transaction's ValueIn so that
-	// the signature becomes invalid.
-	if hashType == txscript.SigHashAllValue {
-		tx.TxIn[0].ValueIn = 1
-	}
-
 	sigScript, err := txscript.SignTxOutput(testingParams, tx,
 		idx, pkScript, hashType, kdb, sdb, nil, suite)
 	if err != nil {
@@ -137,11 +131,9 @@ func signBadAndCheck(msg string, tx *wire.MsgTx, idx int, pkScript []byte,
 	tx.TxIn[0].ValueIn = testValueIn
 
 	// Corrupt a random bit in the signature.
-	if hashType != txscript.SigHashAllValue {
-		pos := tRand.Intn(len(sigScript) - 1)
-		bitPos := tRand.Intn(7)
-		sigScript[pos] ^= 1 << uint8(bitPos)
-	}
+	pos := tRand.Intn(len(sigScript) - 1)
+	bitPos := tRand.Intn(7)
+	sigScript[pos] ^= 1 << uint8(bitPos)
 
 	return checkScripts(msg, tx, idx, sigScript, pkScript)
 }
@@ -157,11 +149,9 @@ func TestSignTxOutput(t *testing.T) {
 		txscript.SigHashAll,
 		txscript.SigHashNone,
 		txscript.SigHashSingle,
-		txscript.SigHashAllValue,
 		txscript.SigHashAll | txscript.SigHashAnyOneCanPay,
 		txscript.SigHashNone | txscript.SigHashAnyOneCanPay,
 		txscript.SigHashSingle | txscript.SigHashAnyOneCanPay,
-		txscript.SigHashAllValue | txscript.SigHashAnyOneCanPay,
 	}
 	signatureSuites := []int{
 		secp,


### PR DESCRIPTION
**This requires PR #1174**.

This removes the `SigHashAllValue` signature hash type.  This is being done because it is not currently usable without a consensus change due to a consensus rule which enforces strict signature encoding disallowing the hash type.

While it would be possible to change the consensus rule in question to include `SigHashAllValue`, that would obviously require a consensus vote since it constitutes a change to the consensus rules.  Given that a vote is required to make any changes in regards to this, it is ideal to completely change the algorithm altogether to not only address this issue, but also to address other shortcomings in regards to efficiency and complexity of the current algorithm in addition to committing to all input amounts per the aforementioned description.
