### PR TITLE
multi: Correct clean and expand path handling.

### DIFF
--- a/cmd/dcrctl/config.go
+++ b/cmd/dcrctl/config.go
@@ -151,6 +151,11 @@ func normalizeAddress(addr string, useTestNet, useSimNet, useWallet bool) string
 // cleanAndExpandPath expands environment variables and leading ~ in the
 // passed path, cleans the result, and returns it.
 func cleanAndExpandPath(path string) string {
+	// Nothing to do when no path is given.
+	if path == "" {
+		return path
+	}
+
 	// NOTE: The os.ExpandEnv doesn't work with Windows cmd.exe-style
 	// %VARIABLE%, but the variables can still be expanded via POSIX-style
 	// $VARIABLE.

--- a/cmd/gencerts/gencerts.go
+++ b/cmd/gencerts/gencerts.go
@@ -83,6 +83,11 @@ func main() {
 // cleanAndExpandPath expands environment variables and leading ~ in the
 // passed path, cleans the result, and returns it.
 func cleanAndExpandPath(path string) string {
+	// Nothing to do when no path is given.
+	if path == "" {
+		return path
+	}
+
 	// NOTE: The os.ExpandEnv doesn't work with Windows cmd.exe-style
 	// %VARIABLE%, but the variables can still be expanded via POSIX-style
 	// $VARIABLE.

--- a/config.go
+++ b/config.go
@@ -182,6 +182,11 @@ type serviceOptions struct {
 // cleanAndExpandPath expands environment variables and leading ~ in the
 // passed path, cleans the result, and returns it.
 func cleanAndExpandPath(path string) string {
+	// Nothing to do when no path is given.
+	if path == "" {
+		return path
+	}
+
 	// NOTE: The os.ExpandEnv doesn't work with Windows cmd.exe-style
 	// %VARIABLE%, but the variables can still be expanded via POSIX-style
 	// $VARIABLE.


### PR DESCRIPTION
This corrects an issue introduced by commit c6f9474348e8eb1488ae3d6cbcca461f0bb80c79 which resulted in empty paths that were cleaned and expanded being transformed into "." instead of having no effect as intended.