### PR TITLE
blockchain: Validate tx expiry in block context.

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -808,6 +808,13 @@ func (mp *TxPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit, allow
 	bestHeight := mp.cfg.BestHeight()
 	nextBlockHeight := bestHeight + 1
 
+	// Don't accept transactions that will be expired as of the next block.
+	if blockchain.IsExpired(tx, nextBlockHeight) {
+		str := fmt.Sprintf("transaction %v expired at height %d",
+			txHash, msgTx.Expiry)
+		return nil, txRuleError(wire.RejectInvalid, str)
+	}
+
 	// Determine what type of transaction we're dealing with (regular or stake).
 	// Then, be sure to set the tx tree correctly as it's possible a use submitted
 	// it to the network with TxTreeUnknown.


### PR DESCRIPTION
The `CheckTransactionInputs` function, as it name suggested, is only intended to perform validation that requires the inputs to transactions.

Consequently, this moves the check for validating the transactions in the block are not expired into the `checkBlockContext` function where it more naturally belongs since it is only dependent on the block and its contextual position within the chain.

Since this check is also needed by the `mempool`, it refactors the check into separate functions named `IsExpired` and `IsExpiredTx`, which work with both `dcrutil` transactions and raw `wire` transactions, respectively, and updates `mempool` to perform the necessary check by making use of them.