### PR TITLE
blockchain: rename ErrRegTxSpendStakeOut to ErrRegTxCreateStakeOut.

### DIFF
--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -364,9 +364,9 @@ const (
 	// an OP_SSTX tagged output from an SStx.
 	ErrTxSStxOutSpend
 
-	// ErrRegTxSpendStakeOut indicates that a regular tx attempted to spend to
-	// outputs tagged with stake tags, e.g. OP_SSTX.
-	ErrRegTxSpendStakeOut
+	// ErrRegTxCreateStakeOut indicates that a regular tx attempted to create
+	// a stake tagged output.
+	ErrRegTxCreateStakeOut
 
 	// ErrInvalidFinalState indicates that the final state of the PRNG included
 	// in the the block differed from the calculated final state.
@@ -536,7 +536,7 @@ var errorCodeStrings = map[ErrorCode]string{
 	ErrSSRtxPayeesMismatch:    "ErrSSRtxPayeesMismatch",
 	ErrSSRtxPayees:            "ErrSSRtxPayees",
 	ErrTxSStxOutSpend:         "ErrTxSStxOutSpend",
-	ErrRegTxSpendStakeOut:     "ErrRegTxSpendStakeOut",
+	ErrRegTxCreateStakeOut:    "ErrRegTxCreateStakeOut",
 	ErrInvalidFinalState:      "ErrInvalidFinalState",
 	ErrPoolSize:               "ErrPoolSize",
 	ErrForceReorgWrongChain:   "ErrForceReorgWrongChain",

--- a/blockchain/error_test.go
+++ b/blockchain/error_test.go
@@ -88,7 +88,7 @@ func TestErrorCodeStringer(t *testing.T) {
 		{ErrSSRtxPayeesMismatch, "ErrSSRtxPayeesMismatch"},
 		{ErrSSRtxPayees, "ErrSSRtxPayees"},
 		{ErrTxSStxOutSpend, "ErrTxSStxOutSpend"},
-		{ErrRegTxSpendStakeOut, "ErrRegTxSpendStakeOut"},
+		{ErrRegTxCreateStakeOut, "ErrRegTxCreateStakeOut"},
 		{ErrInvalidFinalState, "ErrInvalidFinalState"},
 		{ErrPoolSize, "ErrPoolSize"},
 		{ErrForceReorgWrongChain, "ErrForceReorgWrongChain"},

--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -2381,7 +2381,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 		tx.AddTxOut(b.STransactions[5].TxOut[0])
 		b.AddTransaction(tx)
 	})
-	rejected(blockchain.ErrRegTxSpendStakeOut)
+	rejected(blockchain.ErrRegTxCreateStakeOut)
 
 	// ---------------------------------------------------------------------
 	// Extra subsidy tests.

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -1823,7 +1823,7 @@ func CheckTransactionInputs(subsidyCache *SubsidyCache, tx *dcrutil.Tx, txHeight
 					"included stake output type %v at in "+
 					"txout at position %v", txHash,
 					scriptClass, i)
-				return 0, ruleError(ErrRegTxSpendStakeOut, errStr)
+				return 0, ruleError(ErrRegTxCreateStakeOut, errStr)
 			}
 
 			// Check to make sure that non-stake transactions also


### PR DESCRIPTION
`ErrRegTxCreateStakeOut` better describes the error condition which is when a regular transaction tries to create a stake output. 

Thanks to @davecgh for pointing it out.