### PR TITLE
policy: Lower default relay fee to 0.0001/kB.

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -37,9 +37,9 @@ const (
 	MinHighPriority = dcrutil.AtomsPerCoin * 144.0 / 250
 
 	// maxRelayFeeMultiplier is the factor that we disallow fees / kB above the
-	// minimum tx fee.  At the current default minimum relay fee of 0.001
+	// minimum tx fee.  At the current default minimum relay fee of 0.0001
 	// DCR/kB, this results in a maximum allowed high fee of 1 DCR/kB.
-	maxRelayFeeMultiplier = 1000
+	maxRelayFeeMultiplier = 1e4
 
 	// maxSSGensDoubleSpends is the maximum number of SSGen double spends
 	// allowed in the pool.

--- a/mempool/policy.go
+++ b/mempool/policy.go
@@ -50,7 +50,7 @@ const (
 	// It is also used to help determine if a transaction is considered dust
 	// and as a base for calculating minimum required fees for larger
 	// transactions.  This value is in Atoms/1000 bytes.
-	DefaultMinRelayTxFee = dcrutil.Amount(1e5)
+	DefaultMinRelayTxFee = dcrutil.Amount(1e4)
 
 	// maxStandardMultiSigKeys is the maximum number of public keys allowed
 	// in a multi-signature transaction output script for it to be
@@ -272,7 +272,7 @@ func isDust(txOut *wire.TxOut, minRelayTxFee dcrutil.Amount) bool {
 	//
 	// Using the typical values for a pay-to-pubkey-hash transaction from
 	// the breakdown above and the default minimum free transaction relay
-	// fee of 100000, this equates to values less than 60300 atoms being
+	// fee of 10000, this equates to values less than 6030 atoms being
 	// considered dust.
 	//
 	// The following is equivalent to (value/totalSize) * (1/3) * 1000

--- a/mempool/policy_test.go
+++ b/mempool/policy_test.go
@@ -41,13 +41,13 @@ func TestCalcMinRequiredTxRelayFee(t *testing.T) {
 			"1000 bytes with default minimum relay fee",
 			1000,
 			DefaultMinRelayTxFee,
-			1e5,
+			1e4,
 		},
 		{
 			"max standard tx size with default minimum relay fee",
 			maxStandardTxSize,
 			DefaultMinRelayTxFee,
-			1e7,
+			1e6,
 		},
 		{
 			"max standard tx size with max relay fee",
@@ -251,6 +251,18 @@ func TestDust(t *testing.T) {
 			"25 byte public key script with value 60300, relay fee 1e5",
 			wire.TxOut{Value: 60300, Version: 0, PkScript: pkScript},
 			1e5,
+			false,
+		},
+		{
+			"25 byte public key script with value 6029, relay fee 1e4",
+			wire.TxOut{Value: 6029, Version: 0, PkScript: pkScript},
+			1e4,
+			true,
+		},
+		{
+			"25 byte public key script with value 6030, relay fee 1e4",
+			wire.TxOut{Value: 6030, Version: 0, PkScript: pkScript},
+			1e4,
 			false,
 		},
 		{

--- a/sampleconfig/sampleconfig.go
+++ b/sampleconfig/sampleconfig.go
@@ -231,7 +231,7 @@ const FileContents = `[Application Options]
 ; ------------------------------------------------------------------------------
 
 ; Set the minimum transaction fee to be considered a non-zero fee,
-; minrelaytxfee=0.001
+; minrelaytxfee=0.0001
 
 ; Rate-limit free transactions to the value 15 * 1000 bytes per
 ; minute.


### PR DESCRIPTION
This lowers the default minimum relay fee to 0.0001 DCR/Kb from its previous value of 0.001 DCR/Kb and increases the high fee multiplier to keep the same default high fee threshold of 1 DCR/kB.

In order to keep the comments accurate, it also updates the comments in the `isDust` function and the sample config file to match the new default relay fee as it's nice to have the most recent values as a reference in the comments.

Finally, it updates the tests for the expected new values as a result of the reduced default relay fee and adds add a couple of dust tests just below and above the dust point for the new reduced default relay fee.

It should be noted that this is only a default node policy change and as such does not affect the consensus rules in any way.