### PR TITLE
txscript: Remove unused strict multisig flag.

### DIFF
--- a/txscript/engine.go
+++ b/txscript/engine.go
@@ -22,10 +22,6 @@ const (
 	// pay-to-script hash transactions will be fully validated.
 	ScriptBip16 ScriptFlags = 1 << iota
 
-	// ScriptStrictMultiSig defines whether to verify the stack item
-	// used by CHECKMULTISIG is zero length.
-	ScriptStrictMultiSig
-
 	// ScriptDiscourageUpgradableNops defines whether to verify that
 	// currently unused opcodes in the NOP and UNKNOWN families are reserved
 	// for future upgrades.  This flag must not be used for consensus


### PR DESCRIPTION
This removes the `ScriptStrictMultiSig` flag from the `txscript` package since it is not used or needed by Decred.

The flag is a holdover from the upstream code which was used to address a bug that does not exist in Decred.