### PR TITLE
dcrec: add Pubkey func to secp256k1 and edwards elliptic curves.

### DIFF
--- a/dcrec/edwards/privkey.go
+++ b/dcrec/edwards/privkey.go
@@ -158,6 +158,11 @@ func (p PrivateKey) Public() (*big.Int, *big.Int) {
 	return p.ecPk.PublicKey.X, p.ecPk.PublicKey.Y
 }
 
+// PubKey returns the PublicKey corresponding to this private key.
+func (p *PrivateKey) PubKey() *PublicKey {
+	return (*PublicKey)(&p.ecPk.PublicKey)
+}
+
 // ToECDSA returns the private key as a *ecdsa.PrivateKey.
 func (p PrivateKey) ToECDSA() *ecdsa.PrivateKey {
 	return p.ecPk

--- a/dcrec/secp256k1/privkey.go
+++ b/dcrec/secp256k1/privkey.go
@@ -78,6 +78,11 @@ func (p PrivateKey) Public() (*big.Int, *big.Int) {
 	return p.PublicKey.X, p.PublicKey.Y
 }
 
+// PubKey returns the PublicKey corresponding to this private key.
+func (p *PrivateKey) PubKey() *PublicKey {
+	return (*PublicKey)(&p.PublicKey)
+}
+
 // ToECDSA returns the private key as a *ecdsa.PrivateKey.
 func (p *PrivateKey) ToECDSA() *ecdsa.PrivateKey {
 	return (*ecdsa.PrivateKey)(p)


### PR DESCRIPTION
PubKey() returns the corresponding public key of the referenced private
key. This is preferred to Public() which returns the X and Y values
of the public key instead. Public() is scheduled to be removed after
the imposed chainec interface restrictions are removed.