### PR TITLE
multi: Replace btclog with slog.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,12 +18,6 @@
 
 [[projects]]
   branch = "master"
-  name = "github.com/btcsuite/btclog"
-  packages = ["."]
-  revision = "84c8d2346e9fc8c7b947e243b9c24e6df9fd206a"
-
-[[projects]]
-  branch = "master"
   name = "github.com/btcsuite/go-socks"
   packages = ["socks"]
   revision = "4720035b7bfd2a9bb130b1c184f8bbe41b6f0d0f"
@@ -90,6 +84,12 @@
   revision = "56c501706f00d9e1cfacee19a27117e12da24734"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/decred/slog"
+  packages = ["."]
+  revision = "fbd821ef791ba2b8ae945f5d44f4e49396d230c5"
+
+[[projects]]
   name = "github.com/jessevdk/go-flags"
   packages = ["."]
   revision = "96dc06278ce32a0e9d957d590bb987c81ee66407"
@@ -128,6 +128,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d190067efa8c61778ef133b4f695f26aa8e0333625b7f0172788009b68567f3d"
+  inputs-digest = "7e35e404b5345ce203e720970beeeb83e0c38ac93e0437b0a4c1f1c1f2ce0254"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -5,10 +5,6 @@
 
 [[constraint]]
   branch = "master"
-  name = "github.com/btcsuite/btclog"
-
-[[constraint]]
-  branch = "master"
   name = "github.com/btcsuite/go-socks"
 
 [[constraint]]
@@ -34,6 +30,10 @@
 [[constraint]]
   branch = "master"
   name = "github.com/decred/base58"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/decred/slog"
 
 [[constraint]]
   name = "github.com/jessevdk/go-flags"

--- a/addrmgr/log.go
+++ b/addrmgr/log.go
@@ -1,18 +1,18 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package addrmgr
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/decred/slog"
 )
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
 // requests it.
-var log btclog.Logger
+var log slog.Logger
 
 // The default amount of logging is none.
 func init() {
@@ -22,12 +22,12 @@ func init() {
 // DisableLog disables all library log output.  Logging output is disabled
 // by default until either UseLogger or SetLogWriter are called.
 func DisableLog() {
-	log = btclog.Disabled
+	log = slog.Disabled
 }
 
 // UseLogger uses a specified Logger to output package logging info.
 // This should be used in preference to SetLogWriter if the caller is also
-// using btclog.
-func UseLogger(logger btclog.Logger) {
+// using slog.
+func UseLogger(logger slog.Logger) {
 	log = logger
 }

--- a/blockchain/indexers/log.go
+++ b/blockchain/indexers/log.go
@@ -1,16 +1,16 @@
 // Copyright (c) 2016 The btcsuite developers
-// Copyright (c) 2016 The Decred developers
+// Copyright (c) 2016-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package indexers
 
-import "github.com/btcsuite/btclog"
+import "github.com/decred/slog"
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
 // requests it.
-var log btclog.Logger
+var log slog.Logger
 
 // The default amount of logging is none.
 func init() {
@@ -20,12 +20,12 @@ func init() {
 // DisableLog disables all library log output.  Logging output is disabled
 // by default until either UseLogger or SetLogWriter are called.
 func DisableLog() {
-	log = btclog.Disabled
+	log = slog.Disabled
 }
 
 // UseLogger uses a specified Logger to output package logging info.
 // This should be used in preference to SetLogWriter if the caller is also
-// using btclog.
-func UseLogger(logger btclog.Logger) {
+// using slog.
+func UseLogger(logger slog.Logger) {
 	log = logger
 }

--- a/blockchain/internal/progresslog/blocklogger.go
+++ b/blockchain/internal/progresslog/blocklogger.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2016 The btcsuite developers
-// Copyright (c) 2016 The Decred developers
+// Copyright (c) 2016-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/btcsuite/btclog"
+	"github.com/decred/slog"
 
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrd/wire"
@@ -23,7 +23,7 @@ type BlockProgressLogger struct {
 	receivedLogTx     int64
 	lastBlockLogTime  time.Time
 
-	subsystemLogger btclog.Logger
+	subsystemLogger slog.Logger
 	progressAction  string
 	sync.Mutex
 }
@@ -32,7 +32,7 @@ type BlockProgressLogger struct {
 // The progress message is templated as follows:
 //  {progressAction} {numProcessed} {blocks|block} in the last {timePeriod}
 //  ({numTxs}, height {lastBlockHeight}, {lastBlockTimeStamp})
-func NewBlockProgressLogger(progressMessage string, logger btclog.Logger) *BlockProgressLogger {
+func NewBlockProgressLogger(progressMessage string, logger slog.Logger) *BlockProgressLogger {
 	return &BlockProgressLogger{
 		lastBlockLogTime: time.Now(),
 		progressAction:   progressMessage,

--- a/blockchain/log.go
+++ b/blockchain/log.go
@@ -1,18 +1,18 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package blockchain
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/decred/slog"
 )
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
 // requests it.
-var log btclog.Logger
+var log slog.Logger
 
 // The default amount of logging is none.
 func init() {
@@ -22,10 +22,10 @@ func init() {
 // DisableLog disables all library log output.  Logging output is disabled
 // by default until UseLogger is called.
 func DisableLog() {
-	log = btclog.Disabled
+	log = slog.Disabled
 }
 
 // UseLogger uses a specified Logger to output package logging info.
-func UseLogger(logger btclog.Logger) {
+func UseLogger(logger slog.Logger) {
 	log = logger
 }

--- a/blockchain/stake/log.go
+++ b/blockchain/stake/log.go
@@ -1,18 +1,18 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package stake
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/decred/slog"
 )
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
 // requests it.
-var log btclog.Logger
+var log slog.Logger
 
 // The default amount of logging is none.
 func init() {
@@ -22,10 +22,10 @@ func init() {
 // DisableLog disables all library log output.  Logging output is disabled
 // by default until UseLogger is called.
 func DisableLog() {
-	log = btclog.Disabled
+	log = slog.Disabled
 }
 
 // UseLogger uses a specified Logger to output package logging info.
-func UseLogger(logger btclog.Logger) {
+func UseLogger(logger slog.Logger) {
 	log = logger
 }

--- a/blocklogger.go
+++ b/blocklogger.go
@@ -1,11 +1,15 @@
+// Copyright (c) 2015-2018 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
 package main
 
 import (
 	"sync"
 	"time"
 
-	"github.com/btcsuite/btclog"
 	"github.com/decred/dcrd/dcrutil"
+	"github.com/decred/slog"
 )
 
 // blockProgressLogger provides periodic logging for other services in order
@@ -19,7 +23,7 @@ type blockProgressLogger struct {
 	receivedLogTickets     int64
 	lastBlockLogTime       time.Time
 
-	subsystemLogger btclog.Logger
+	subsystemLogger slog.Logger
 	progressAction  string
 	sync.Mutex
 }
@@ -28,7 +32,7 @@ type blockProgressLogger struct {
 // The progress message is templated as follows:
 //  {progressAction} {numProcessed} {blocks|block} in the last {timePeriod}
 //  ({numTxs}, height {lastBlockHeight}, {lastBlockTimeStamp})
-func newBlockProgressLogger(progressMessage string, logger btclog.Logger) *blockProgressLogger {
+func newBlockProgressLogger(progressMessage string, logger slog.Logger) *blockProgressLogger {
 	return &blockProgressLogger{
 		lastBlockLogTime: time.Now(),
 		progressAction:   progressMessage,

--- a/cmd/addblock/addblock.go
+++ b/cmd/addblock/addblock.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -10,11 +10,11 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/btcsuite/btclog"
 	"github.com/decred/dcrd/blockchain"
 	"github.com/decred/dcrd/blockchain/indexers"
 	"github.com/decred/dcrd/database"
 	"github.com/decred/dcrd/limits"
+	"github.com/decred/slog"
 )
 
 const (
@@ -24,7 +24,7 @@ const (
 
 var (
 	cfg *config
-	log btclog.Logger
+	log slog.Logger
 )
 
 // loadBlockDB opens the block database and returns a handle to it.
@@ -70,7 +70,7 @@ func realMain() error {
 	cfg = tcfg
 
 	// Setup logging.
-	backendLogger := btclog.NewBackend(os.Stdout)
+	backendLogger := slog.NewBackend(os.Stdout)
 	defer os.Stdout.Sync()
 	log = backendLogger.Logger("MAIN")
 	database.UseLogger(backendLogger.Logger("BCDB"))

--- a/config.go
+++ b/config.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2017 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/btcsuite/btclog"
 	"github.com/btcsuite/go-socks/socks"
 	"github.com/decred/dcrd/connmgr"
 	"github.com/decred/dcrd/database"
@@ -29,6 +28,7 @@ import (
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrd/mempool"
 	"github.com/decred/dcrd/sampleconfig"
+	"github.com/decred/slog"
 	flags "github.com/jessevdk/go-flags"
 )
 
@@ -235,7 +235,7 @@ func cleanAndExpandPath(path string) string {
 
 // validLogLevel returns whether or not logLevel is a valid debug log level.
 func validLogLevel(logLevel string) bool {
-	_, ok := btclog.LevelFromString(logLevel)
+	_, ok := slog.LevelFromString(logLevel)
 	return ok
 }
 

--- a/connmgr/log.go
+++ b/connmgr/log.go
@@ -1,15 +1,16 @@
 // Copyright (c) 2016 The btcsuite developers
+// Copyright (c) 2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package connmgr
 
-import "github.com/btcsuite/btclog"
+import "github.com/decred/slog"
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
 // requests it.
-var log btclog.Logger
+var log slog.Logger
 
 // The default amount of logging is none.
 func init() {
@@ -19,12 +20,12 @@ func init() {
 // DisableLog disables all library log output.  Logging output is disabled
 // by default until either UseLogger or SetLogWriter are called.
 func DisableLog() {
-	log = btclog.Disabled
+	log = slog.Disabled
 }
 
 // UseLogger uses a specified Logger to output package logging info.
 // This should be used in preference to SetLogWriter if the caller is also
-// using btclog.
-func UseLogger(logger btclog.Logger) {
+// using slog.
+func UseLogger(logger slog.Logger) {
 	log = logger
 }

--- a/database/cmd/dbtool/main.go
+++ b/database/cmd/dbtool/main.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2015-2016 The btcsuite developers
-// Copyright (c) 2016 The Decred developers
+// Copyright (c) 2016-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -11,8 +11,8 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/btcsuite/btclog"
 	"github.com/decred/dcrd/database"
+	"github.com/decred/slog"
 	flags "github.com/jessevdk/go-flags"
 )
 
@@ -22,7 +22,7 @@ const (
 )
 
 var (
-	log             btclog.Logger
+	log             slog.Logger
 	shutdownChannel = make(chan error)
 )
 
@@ -62,11 +62,11 @@ func loadBlockDB() (database.DB, error) {
 // around the fact that deferred functions do not run when os.Exit() is called.
 func realMain() error {
 	// Setup logging.
-	backendLogger := btclog.NewBackend(os.Stdout)
+	backendLogger := slog.NewBackend(os.Stdout)
 	defer os.Stdout.Sync()
 	log = backendLogger.Logger("MAIN")
 	dbLog := backendLogger.Logger("BCDB")
-	dbLog.SetLevel(btclog.LevelDebug)
+	dbLog.SetLevel(slog.LevelDebug)
 	database.UseLogger(dbLog)
 
 	// Setup the parser options and commands.

--- a/database/driver.go
+++ b/database/driver.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2015-2016 The btcsuite developers
-// Copyright (c) 2016 The Decred developers
+// Copyright (c) 2016-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -8,7 +8,7 @@ package database
 import (
 	"fmt"
 
-	"github.com/btcsuite/btclog"
+	"github.com/decred/slog"
 )
 
 // Driver defines a structure for backend drivers to use when they register
@@ -29,7 +29,7 @@ type Driver struct {
 	Open func(args ...interface{}) (DB, error)
 
 	// UseLogger uses a specified Logger to output package logging info.
-	UseLogger func(logger btclog.Logger)
+	UseLogger func(logger slog.Logger)
 }
 
 // driverList holds all of the registered database backends.

--- a/database/ffldb/driver.go
+++ b/database/ffldb/driver.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2015-2016 The btcsuite developers
-// Copyright (c) 2016 The Decred developers
+// Copyright (c) 2016-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -8,12 +8,12 @@ package ffldb
 import (
 	"fmt"
 
-	"github.com/btcsuite/btclog"
 	"github.com/decred/dcrd/database"
 	"github.com/decred/dcrd/wire"
+	"github.com/decred/slog"
 )
 
-var log = btclog.Disabled
+var log = slog.Disabled
 
 const (
 	dbType = "ffldb"
@@ -66,7 +66,7 @@ func createDBDriver(args ...interface{}) (database.DB, error) {
 
 // useLogger is the callback provided during driver registration that sets the
 // current logger to the provided one.
-func useLogger(logger btclog.Logger) {
+func useLogger(logger slog.Logger) {
 	log = logger
 }
 

--- a/database/log.go
+++ b/database/log.go
@@ -1,18 +1,18 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2016 The Decred developers
+// Copyright (c) 2016-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package database
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/decred/slog"
 )
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
 // requests it.
-var log btclog.Logger
+var log slog.Logger
 
 // The default amount of logging is none.
 func init() {
@@ -22,11 +22,11 @@ func init() {
 // DisableLog disables all library log output.  Logging output is disabled
 // by default until UseLogger is called.
 func DisableLog() {
-	log = btclog.Disabled
+	log = slog.Disabled
 }
 
 // UseLogger uses a specified Logger to output package logging info.
-func UseLogger(logger btclog.Logger) {
+func UseLogger(logger slog.Logger) {
 	log = logger
 
 	// Update the logger for the registered drivers.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/decred/dcrd
 require (
 	github.com/aead/siphash v0.0.0-20170329201724-e404fcfc8885
 	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412
-	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd
 	github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd
 	github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723
@@ -12,6 +11,7 @@ require (
 	github.com/davecgh/go-spew v1.1.0
 	github.com/dchest/blake256 v0.0.0-20150903101604-dee3fe6eb0e9
 	github.com/decred/base58 v0.0.0-20180302003706-56c501706f00
+	github.com/decred/slog v1.0.0
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/jrick/bitset v1.0.0
 	github.com/jrick/logrotate v0.0.0-20170628183752-a93b200c26cb

--- a/go.modverify
+++ b/go.modverify
@@ -9,6 +9,7 @@ github.com/btcsuite/winsvc v0.0.0-20150117052343-f8fb11f83f7e h1:Yf0qH7/DA25s5wO
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/dchest/blake256 v0.0.0-20150903101604-dee3fe6eb0e9 h1:R1zSOsHbPX/UQdOJzWPonBFMFa8BJpd3BIfK9nRXF70=
 github.com/decred/base58 v0.0.0-20180302003706-56c501706f00 h1:ejXqeY7P4O22qIxzhsWOq9N3An1kEmWcTjFfM6QGkyg=
+github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
 github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
 github.com/jrick/bitset v1.0.0 h1:Ws0PXV3PwXqWK2n7Vz6idCdrV/9OrBXgHEJi27ZB9Dw=
 github.com/jrick/logrotate v0.0.0-20170628183752-a93b200c26cb h1:rP491SxtBTd8SPgOu8fii6f1/pX+AfEu7bPHTegdRYc=

--- a/log.go
+++ b/log.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2017 The btcsuite developers
-// Copyright (c) 2015-2017 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/btcsuite/btclog"
 	"github.com/decred/dcrd/addrmgr"
 	"github.com/decred/dcrd/blockchain"
 	"github.com/decred/dcrd/blockchain/indexers"
@@ -20,6 +19,7 @@ import (
 	"github.com/decred/dcrd/mempool"
 	"github.com/decred/dcrd/peer"
 	"github.com/decred/dcrd/txscript"
+	"github.com/decred/slog"
 	"github.com/jrick/logrotate/rotator"
 )
 
@@ -47,7 +47,7 @@ var (
 	// backendLog is the logging backend used to create all subsystem loggers.
 	// The backend must not be used before the log rotator has been initialized,
 	// or data races and/or nil pointer dereferences will occur.
-	backendLog = btclog.NewBackend(logWriter{})
+	backendLog = slog.NewBackend(logWriter{})
 
 	// logRotator is one of the logging outputs.  It should be closed on
 	// application shutdown.
@@ -85,7 +85,7 @@ func init() {
 }
 
 // subsystemLoggers maps each subsystem identifier to its associated logger.
-var subsystemLoggers = map[string]btclog.Logger{
+var subsystemLoggers = map[string]slog.Logger{
 	"ADXR": adxrLog,
 	"AMGR": amgrLog,
 	"CMGR": cmgrLog,
@@ -134,7 +134,7 @@ func setLogLevel(subsystemID string, logLevel string) {
 	}
 
 	// Defaults to info if the log level is invalid.
-	level, _ := btclog.LevelFromString(logLevel)
+	level, _ := slog.LevelFromString(logLevel)
 	logger.SetLevel(level)
 }
 

--- a/mempool/log.go
+++ b/mempool/log.go
@@ -1,18 +1,18 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2016 The Decred developers
+// Copyright (c) 2016-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package mempool
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/decred/slog"
 )
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
 // requests it.
-var log btclog.Logger
+var log slog.Logger
 
 // The default amount of logging is none.
 func init() {
@@ -22,12 +22,12 @@ func init() {
 // DisableLog disables all library log output.  Logging output is disabled
 // by default until either UseLogger or SetLogWriter are called.
 func DisableLog() {
-	log = btclog.Disabled
+	log = slog.Disabled
 }
 
 // UseLogger uses a specified Logger to output package logging info.
 // This should be used in preference to SetLogWriter if the caller is also
-// using btclog.
-func UseLogger(logger btclog.Logger) {
+// using slog.
+func UseLogger(logger slog.Logger) {
 	log = logger
 }

--- a/peer/doc.go
+++ b/peer/doc.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2015-2016 The btcsuite developers
-// Copyright (c) 2016 The Decred developers
+// Copyright (c) 2016-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -134,7 +134,7 @@ written, the remote address, user agent, and negotiated protocol version.
 Logging
 
 This package provides extensive logging capabilities through the UseLogger
-function which allows a btclog.Logger to be specified.  For example, logging at
+function which allows a slog.Logger to be specified.  For example, logging at
 the debug level provides summaries of every message sent and received, and
 logging at the trace level provides full dumps of parsed messages as well as the
 raw message bytes using a format similar to hexdump -C.

--- a/peer/log.go
+++ b/peer/log.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/btcsuite/btclog"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/txscript"
 	"github.com/decred/dcrd/wire"
+	"github.com/decred/slog"
 )
 
 const (
@@ -25,7 +25,7 @@ const (
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
 // requests it.
-var log btclog.Logger
+var log slog.Logger
 
 // The default amount of logging is none.
 func init() {
@@ -35,11 +35,11 @@ func init() {
 // DisableLog disables all library log output.  Logging output is disabled
 // by default until UseLogger is called.
 func DisableLog() {
-	log = btclog.Disabled
+	log = slog.Disabled
 }
 
 // UseLogger uses a specified Logger to output package logging info.
-func UseLogger(logger btclog.Logger) {
+func UseLogger(logger slog.Logger) {
 	log = logger
 }
 

--- a/rpcclient/log.go
+++ b/rpcclient/log.go
@@ -1,18 +1,18 @@
 // Copyright (c) 2014-2015 The btcsuite developers
-// Copyright (c) 2015-2017 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package rpcclient
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/decred/slog"
 )
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
 // requests it.
-var log btclog.Logger
+var log slog.Logger
 
 // The default amount of logging is none.
 func init() {
@@ -22,10 +22,10 @@ func init() {
 // DisableLog disables all library log output.  Logging output is disabled
 // by default until UseLogger is called.
 func DisableLog() {
-	log = btclog.Disabled
+	log = slog.Disabled
 }
 
 // UseLogger uses a specified Logger to output package logging info.
-func UseLogger(logger btclog.Logger) {
+func UseLogger(logger slog.Logger) {
 	log = logger
 }

--- a/txscript/log.go
+++ b/txscript/log.go
@@ -1,18 +1,18 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package txscript
 
 import (
-	"github.com/btcsuite/btclog"
+	"github.com/decred/slog"
 )
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
 // requests it.
-var log btclog.Logger
+var log slog.Logger
 
 // The default amount of logging is none.
 func init() {
@@ -22,11 +22,11 @@ func init() {
 // DisableLog disables all library log output.  Logging output is disabled
 // by default until UseLogger is called.
 func DisableLog() {
-	log = btclog.Disabled
+	log = slog.Disabled
 }
 
 // UseLogger uses a specified Logger to output package logging info.
-func UseLogger(logger btclog.Logger) {
+func UseLogger(logger slog.Logger) {
 	log = logger
 }
 


### PR DESCRIPTION
This modifies all packages within the repository to the use the Decred fork of `btclog` which has been renamed to `slog` and updates the dependency files accordingly.