### PR TITLE
rpc: Use upstream gorilla/websocket.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -49,12 +49,6 @@
 
 [[projects]]
   branch = "master"
-  name = "github.com/btcsuite/websocket"
-  packages = ["."]
-  revision = "31079b6807923eb23992c421b114992b95131b55"
-
-[[projects]]
-  branch = "master"
   name = "github.com/btcsuite/winsvc"
   packages = [
     "eventlog",
@@ -88,6 +82,12 @@
   name = "github.com/decred/slog"
   packages = ["."]
   revision = "fbd821ef791ba2b8ae945f5d44f4e49396d230c5"
+
+[[projects]]
+  name = "github.com/gorilla/websocket"
+  packages = ["."]
+  revision = "ea4d1f681babbce9545c9c5f3d5194a789c89f5b"
+  version = "v1.2.0"
 
 [[projects]]
   name = "github.com/jessevdk/go-flags"
@@ -128,6 +128,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7e35e404b5345ce203e720970beeeb83e0c38ac93e0437b0a4c1f1c1f2ce0254"
+  inputs-digest = "449d7c8bffc532ba95de7b1ff1610a127446bc19afd8071dbc023bb8d978da13"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -13,10 +13,6 @@
 
 [[constraint]]
   branch = "master"
-  name = "github.com/btcsuite/websocket"
-
-[[constraint]]
-  branch = "master"
   name = "github.com/btcsuite/winsvc"
 
 [[constraint]]
@@ -34,6 +30,10 @@
 [[constraint]]
   branch = "master"
   name = "github.com/decred/slog"
+
+[[constraint]]
+  name = "github.com/gorilla/websocket"
+  version = "1.2.0"
 
 [[constraint]]
   name = "github.com/jessevdk/go-flags"

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,12 @@ require (
 	github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd
 	github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd
 	github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723
-	github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792
 	github.com/btcsuite/winsvc v0.0.0-20150117052343-f8fb11f83f7e
 	github.com/davecgh/go-spew v1.1.0
 	github.com/dchest/blake256 v0.0.0-20150903101604-dee3fe6eb0e9
 	github.com/decred/base58 v0.0.0-20180302003706-56c501706f00
 	github.com/decred/slog v1.0.0
+	github.com/gorilla/websocket v1.2.0
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/jrick/bitset v1.0.0
 	github.com/jrick/logrotate v0.0.0-20170628183752-a93b200c26cb

--- a/go.modverify
+++ b/go.modverify
@@ -10,6 +10,7 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/dchest/blake256 v0.0.0-20150903101604-dee3fe6eb0e9 h1:R1zSOsHbPX/UQdOJzWPonBFMFa8BJpd3BIfK9nRXF70=
 github.com/decred/base58 v0.0.0-20180302003706-56c501706f00 h1:ejXqeY7P4O22qIxzhsWOq9N3An1kEmWcTjFfM6QGkyg=
 github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
+github.com/gorilla/websocket v1.2.0 h1:VJtLvh6VQym50czpZzx07z/kw9EgAxI3x1ZB8taTMQQ=
 github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
 github.com/jrick/bitset v1.0.0 h1:Ws0PXV3PwXqWK2n7Vz6idCdrV/9OrBXgHEJi27ZB9Dw=
 github.com/jrick/logrotate v0.0.0-20170628183752-a93b200c26cb h1:rP491SxtBTd8SPgOu8fii6f1/pX+AfEu7bPHTegdRYc=

--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2016 The btcsuite developers
-// Copyright (c) 2015-2017 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -25,10 +25,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/decred/dcrd/dcrjson"
-
 	"github.com/btcsuite/go-socks/socks"
-	"github.com/btcsuite/websocket"
+	"github.com/gorilla/websocket"
+
+	"github.com/decred/dcrd/dcrjson"
 )
 
 var (

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -33,7 +33,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/btcsuite/websocket"
+	"github.com/gorilla/websocket"
 
 	"github.com/decred/dcrd/blockchain"
 	"github.com/decred/dcrd/blockchain/stake"

--- a/rpcwebsocket.go
+++ b/rpcwebsocket.go
@@ -20,7 +20,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/btcsuite/websocket"
+	"github.com/gorilla/websocket"
 	"golang.org/x/crypto/ripemd160"
 
 	"github.com/decred/dcrd/blockchain"


### PR DESCRIPTION
This change is being made since no local changes exist and dependencies are pinned unlike when it was originally vendored.