### PR TITLE
build: Update some vgo dependencies to use tags.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -128,6 +128,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "449d7c8bffc532ba95de7b1ff1610a127446bc19afd8071dbc023bb8d978da13"
+  inputs-digest = "746f7a4be4e049bc47a6d29b4fdb85c908c7da9e1983f856b26b69a218bfae80"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -28,8 +28,8 @@
   name = "github.com/decred/base58"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/decred/slog"
+  version = "1.0.0"
 
 [[constraint]]
   name = "github.com/gorilla/websocket"

--- a/go.mod
+++ b/go.mod
@@ -6,15 +6,15 @@ require (
 	github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd
 	github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd
 	github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723
-	github.com/btcsuite/winsvc v0.0.0-20150117052343-f8fb11f83f7e
+	github.com/btcsuite/winsvc v1.0.0
 	github.com/davecgh/go-spew v1.1.0
-	github.com/dchest/blake256 v0.0.0-20150903101604-dee3fe6eb0e9
-	github.com/decred/base58 v0.0.0-20180302003706-56c501706f00
+	github.com/dchest/blake256 v1.0.0
+	github.com/decred/base58 v1.0.0
 	github.com/decred/slog v1.0.0
 	github.com/gorilla/websocket v1.2.0
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/jrick/bitset v1.0.0
-	github.com/jrick/logrotate v0.0.0-20170628183752-a93b200c26cb
+	github.com/jrick/logrotate v1.0.0
 	golang.org/x/crypto v0.0.0-20180515001509-1a580b3eff78
 	golang.org/x/sys v0.0.0-20180522224204-88eb85aaee56
 )

--- a/go.modverify
+++ b/go.modverify
@@ -6,13 +6,17 @@ github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd h1:qdGvebPBDuYD
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723 h1:ZA/jbKoGcVAnER6pCHPEkGdZOV7U1oLUedErBHCUMs0=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792 h1:R8vQdOQdZ9Y3SkEwmHoWBmX1DNXhXZqlTpq6s4tyJGc=
 github.com/btcsuite/winsvc v0.0.0-20150117052343-f8fb11f83f7e h1:Yf0qH7/DA25s5wOtKffIg9hGSyTj9dXCnbqXr2UugNk=
+github.com/btcsuite/winsvc v1.0.0 h1:J9B4L7e3oqhXOcm+2IuNApwzQec85lE+QaikUcCs+dk=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/dchest/blake256 v0.0.0-20150903101604-dee3fe6eb0e9 h1:R1zSOsHbPX/UQdOJzWPonBFMFa8BJpd3BIfK9nRXF70=
+github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
 github.com/decred/base58 v0.0.0-20180302003706-56c501706f00 h1:ejXqeY7P4O22qIxzhsWOq9N3An1kEmWcTjFfM6QGkyg=
+github.com/decred/base58 v1.0.0 h1:BVi1FQCThIjZ0ehG+I99NJ51o0xcc9A/fDKhmJxY6+w=
 github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
 github.com/gorilla/websocket v1.2.0 h1:VJtLvh6VQym50czpZzx07z/kw9EgAxI3x1ZB8taTMQQ=
 github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
 github.com/jrick/bitset v1.0.0 h1:Ws0PXV3PwXqWK2n7Vz6idCdrV/9OrBXgHEJi27ZB9Dw=
 github.com/jrick/logrotate v0.0.0-20170628183752-a93b200c26cb h1:rP491SxtBTd8SPgOu8fii6f1/pX+AfEu7bPHTegdRYc=
+github.com/jrick/logrotate v1.0.0 h1:lQ1bL/n9mBNeIXoTUoYRlK4dHuNJVofX9oWqBtPnSzI=
 golang.org/x/crypto v0.0.0-20180515001509-1a580b3eff78 h1:uJIReYEB1ZZLarzi83Pmig1HhZ/cwFCysx05l0PFBIk=
 golang.org/x/sys v0.0.0-20180522224204-88eb85aaee56 h1:ALdc3t+jAqSs6+pzVEioBeI8YtMICgYVFhEy6P69czc=


### PR DESCRIPTION
**This PR builds on #1218.**

Also, while here, constrain slog in Gopkg.toml to 1.0.0 and update the associated lock file accordingly.