### PR TITLE
stake: add ExpiredByBlock

### DIFF
--- a/blockchain/stake/tickets.go
+++ b/blockchain/stake/tickets.go
@@ -97,6 +97,18 @@ func (sn *Node) MissedByBlock() []chainhash.Hash {
 	return missed
 }
 
+// ExpiredByBlock returns the tickets that expired in this block.
+func (sn *Node) ExpiredByBlock() []chainhash.Hash {
+	var expired []chainhash.Hash
+	for _, undo := range sn.databaseUndoUpdate {
+		if undo.Expired {
+			expired = append(expired, undo.TicketHash)
+		}
+	}
+
+	return expired
+}
+
 // ExistsLiveTicket returns whether or not a ticket exists in the live ticket
 // treap for this stake node.
 func (sn *Node) ExistsLiveTicket(ticket chainhash.Hash) bool {

--- a/blockchain/stake/tickets.go
+++ b/blockchain/stake/tickets.go
@@ -85,7 +85,10 @@ func (sn *Node) SpentByBlock() []chainhash.Hash {
 	return spent
 }
 
-// MissedByBlock returns the tickets that were missed in this block.
+// MissedByBlock returns the tickets that were missed in this block. This
+// includes expired tickets and winning tickets that were not spent by a vote.
+// Also note that when a miss is later revoked, that ticket hash will also
+// appear in the output of this function for the block with the revocation.
 func (sn *Node) MissedByBlock() []chainhash.Hash {
 	var missed []chainhash.Hash
 	for _, undo := range sn.databaseUndoUpdate {
@@ -97,11 +100,14 @@ func (sn *Node) MissedByBlock() []chainhash.Hash {
 	return missed
 }
 
-// ExpiredByBlock returns the tickets that expired in this block.
+// ExpiredByBlock returns the tickets that expired in this block. This is a
+// subset of the missed tickets returned by MissedByBlock. The output only
+// includes the initial expiration of the ticket, not when an expired ticket is
+// revoked. This is unlike MissedByBlock that includes the revocation as well.
 func (sn *Node) ExpiredByBlock() []chainhash.Hash {
 	var expired []chainhash.Hash
 	for _, undo := range sn.databaseUndoUpdate {
-		if undo.Expired {
+		if undo.Expired && !undo.Revoked {
 			expired = append(expired, undo.TicketHash)
 		}
 	}

--- a/blockchain/stake/tickets_test.go
+++ b/blockchain/stake/tickets_test.go
@@ -200,6 +200,10 @@ func nodesEqual(a *Node, b *Node) error {
 		return fmt.Errorf("missedbyblock were not equal between nodes; "+
 			"a: %x, b: %x", a.MissedByBlock(), b.MissedByBlock())
 	}
+	if !reflect.DeepEqual(a.ExpiredByBlock(), b.ExpiredByBlock()) {
+		return fmt.Errorf("expiredbyblock were not equal between nodes; "+
+			"a: %x, b: %x", a.ExpiredByBlock(), b.ExpiredByBlock())
+	}
 
 	return nil
 }

--- a/blockchain/stake/tickets_test.go
+++ b/blockchain/stake/tickets_test.go
@@ -275,6 +275,57 @@ func TestTicketDBLongChain(t *testing.T) {
 			t.Fatalf("couldn't connect node: %v", err.Error())
 		}
 
+		// UndoTicketDataSlice tests
+
+		// Check that spent tickets in undo data are not in the live, missed, or
+		// revoked treaps. Spent only refers to votes, not revocations.
+		voted := bestNode.SpentByBlock()
+		for ie := range voted {
+			if exists := bestNode.ExistsLiveTicket(voted[ie]); exists {
+				t.Errorf("voted ticket in undo data in live treap")
+			}
+			if exists := bestNode.ExistsMissedTicket(voted[ie]); exists {
+				t.Errorf("voted ticket in undo data in missed treap")
+			}
+			if exists := bestNode.ExistsRevokedTicket(voted[ie]); exists {
+				t.Errorf("voted ticket in undo data in revoked treap")
+			}
+		}
+
+		// Check that expired tickets in undo data are in both the expired and
+		// missed treaps. Expired is a subset of missed.
+		expired := bestNode.ExpiredByBlock()
+		for ie := range expired {
+			if exists := bestNode.ExistsExpiredTicket(expired[ie]); !exists {
+				t.Errorf("expired ticket in undo data not in expired treap")
+			}
+			if exists := bestNode.ExistsMissedTicket(expired[ie]); !exists {
+				t.Errorf("expired ticket in undo data not in missed treap")
+			}
+		}
+
+		// Check that missed tickets in undo data are in either the missed or
+		// revoked treap. This is because tickets in undo data flagged as
+		// Revoked are removed from the missed treap and added to the revoked
+		// treap despite still being flagged as Missed.
+		missed := bestNode.MissedByBlock()
+		for ie := range missed {
+			exists := bestNode.ExistsMissedTicket(missed[ie]) ||
+				bestNode.ExistsRevokedTicket(missed[ie])
+			if !exists {
+				t.Errorf("missed ticket in undo data not in missed or revoked treap")
+			}
+		}
+
+		// Verify that each expired ticket is also in missed undo data. The
+		// UndoTicketData for an expired ticket will always have both Missed and
+		// Expired set to true.
+		for ie := range expired {
+			if !hashInSlice(expired[ie], missed) {
+				t.Errorf("expired ticket not found in missed undo data")
+			}
+		}
+
 		nodesForward[i] = bestNode
 	}
 


### PR DESCRIPTION
`MissedByBlock` includes both missed (a winner with no vote) and expired. It also includes revocations of either miss or expire.
`ExpiredByBlock` gives only tickets that expired, and only the actual expiry, not the revocation of an expired ticket.