### PR TITLE
multi: Define vgo modules.

### DIFF
--- a/addrmgr/go.mod
+++ b/addrmgr/go.mod
@@ -1,0 +1,3 @@
+module github.com/decred/dcrd/addrmgr
+
+require github.com/decred/dcrd v1.3.0

--- a/addrmgr/go.modverify
+++ b/addrmgr/go.modverify
@@ -1,0 +1,3 @@
+github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
+github.com/decred/dcrd v1.3.0 h1:Y/3k/RY3UU70ELNuu/X8aAG6gaa/sba283/o3iS58E8=
+github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=

--- a/blockchain/go.mod
+++ b/blockchain/go.mod
@@ -1,0 +1,3 @@
+module github.com/decred/dcrd/blockchain
+
+require github.com/decred/dcrd v1.3.0

--- a/blockchain/go.modverify
+++ b/blockchain/go.modverify
@@ -1,0 +1,6 @@
+github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
+github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
+github.com/decred/base58 v1.0.0 h1:BVi1FQCThIjZ0ehG+I99NJ51o0xcc9A/fDKhmJxY6+w=
+github.com/decred/dcrd v1.3.0 h1:Y/3k/RY3UU70ELNuu/X8aAG6gaa/sba283/o3iS58E8=
+github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
+golang.org/x/crypto v0.0.0-20180515001509-1a580b3eff78 h1:uJIReYEB1ZZLarzi83Pmig1HhZ/cwFCysx05l0PFBIk=

--- a/certgen/go.mod
+++ b/certgen/go.mod
@@ -1,0 +1,1 @@
+module github.com/decred/dcrd/certgen

--- a/chaincfg/go.mod
+++ b/chaincfg/go.mod
@@ -1,0 +1,3 @@
+module github.com/decred/dcrd/chaincfg
+
+require github.com/decred/dcrd v1.3.0

--- a/chaincfg/go.modverify
+++ b/chaincfg/go.modverify
@@ -1,0 +1,2 @@
+github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
+github.com/decred/dcrd v1.3.0 h1:Y/3k/RY3UU70ELNuu/X8aAG6gaa/sba283/o3iS58E8=

--- a/connmgr/go.mod
+++ b/connmgr/go.mod
@@ -1,0 +1,3 @@
+module github.com/decred/dcrd/connmgr
+
+require github.com/decred/dcrd v1.3.0

--- a/connmgr/go.modverify
+++ b/connmgr/go.modverify
@@ -1,0 +1,3 @@
+github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
+github.com/decred/dcrd v1.3.0 h1:Y/3k/RY3UU70ELNuu/X8aAG6gaa/sba283/o3iS58E8=
+github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=

--- a/database/go.mod
+++ b/database/go.mod
@@ -1,0 +1,3 @@
+module github.com/decred/dcrd/database
+
+require github.com/decred/dcrd v1.3.0

--- a/database/go.modverify
+++ b/database/go.modverify
@@ -1,0 +1,6 @@
+github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
+github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
+github.com/decred/base58 v1.0.0 h1:BVi1FQCThIjZ0ehG+I99NJ51o0xcc9A/fDKhmJxY6+w=
+github.com/decred/dcrd v1.3.0 h1:Y/3k/RY3UU70ELNuu/X8aAG6gaa/sba283/o3iS58E8=
+github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
+golang.org/x/crypto v0.0.0-20180515001509-1a580b3eff78 h1:uJIReYEB1ZZLarzi83Pmig1HhZ/cwFCysx05l0PFBIk=

--- a/dcrjson/go.mod
+++ b/dcrjson/go.mod
@@ -1,0 +1,3 @@
+module github.com/decred/dcrd/dcrjson
+
+require github.com/decred/dcrd v1.3.0

--- a/dcrjson/go.modverify
+++ b/dcrjson/go.modverify
@@ -1,0 +1,6 @@
+github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
+github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
+github.com/decred/base58 v1.0.0 h1:BVi1FQCThIjZ0ehG+I99NJ51o0xcc9A/fDKhmJxY6+w=
+github.com/decred/dcrd v1.3.0 h1:Y/3k/RY3UU70ELNuu/X8aAG6gaa/sba283/o3iS58E8=
+github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
+golang.org/x/crypto v0.0.0-20180515001509-1a580b3eff78 h1:uJIReYEB1ZZLarzi83Pmig1HhZ/cwFCysx05l0PFBIk=

--- a/dcrutil/go.mod
+++ b/dcrutil/go.mod
@@ -1,0 +1,6 @@
+module github.com/decred/dcrd/dcrutil
+
+require (
+	github.com/decred/dcrd v1.3.0
+	golang.org/x/crypto v0.0.0-20180525160159-a3beeb748656
+)

--- a/dcrutil/go.modverify
+++ b/dcrutil/go.modverify
@@ -1,0 +1,5 @@
+github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
+github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
+github.com/decred/base58 v1.0.0 h1:BVi1FQCThIjZ0ehG+I99NJ51o0xcc9A/fDKhmJxY6+w=
+github.com/decred/dcrd v1.3.0 h1:Y/3k/RY3UU70ELNuu/X8aAG6gaa/sba283/o3iS58E8=
+golang.org/x/crypto v0.0.0-20180525160159-a3beeb748656 h1:4aSCHfY5DFX3NMvHjnKshMxCsDvv5fMK5tI2JrWUzeg=

--- a/gcs/go.mod
+++ b/gcs/go.mod
@@ -1,0 +1,3 @@
+module github.com/decred/dcrd/gcs
+
+require github.com/decred/dcrd v1.3.0

--- a/gcs/go.modverify
+++ b/gcs/go.modverify
@@ -1,0 +1,3 @@
+github.com/aead/siphash v0.0.0-20170329201724-e404fcfc8885 h1:bBmEG9/q1xH07CqeeFw1ejup6Kw+/88WhhLHqIJ0ngQ=
+github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
+github.com/decred/dcrd v1.3.0 h1:Y/3k/RY3UU70ELNuu/X8aAG6gaa/sba283/o3iS58E8=

--- a/hdkeychain/go.mod
+++ b/hdkeychain/go.mod
@@ -1,0 +1,3 @@
+module github.com/decred/dcrd/hdkeychain
+
+require github.com/decred/dcrd v1.3.0

--- a/hdkeychain/go.modverify
+++ b/hdkeychain/go.modverify
@@ -1,0 +1,5 @@
+github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
+github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
+github.com/decred/base58 v1.0.0 h1:BVi1FQCThIjZ0ehG+I99NJ51o0xcc9A/fDKhmJxY6+w=
+github.com/decred/dcrd v1.3.0 h1:Y/3k/RY3UU70ELNuu/X8aAG6gaa/sba283/o3iS58E8=
+golang.org/x/crypto v0.0.0-20180515001509-1a580b3eff78 h1:uJIReYEB1ZZLarzi83Pmig1HhZ/cwFCysx05l0PFBIk=

--- a/mempool/go.mod
+++ b/mempool/go.mod
@@ -1,0 +1,3 @@
+module github.com/decred/dcrd/mempool
+
+require github.com/decred/dcrd v1.3.0

--- a/mempool/go.modverify
+++ b/mempool/go.modverify
@@ -1,0 +1,7 @@
+github.com/aead/siphash v0.0.0-20170329201724-e404fcfc8885 h1:bBmEG9/q1xH07CqeeFw1ejup6Kw+/88WhhLHqIJ0ngQ=
+github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
+github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
+github.com/decred/base58 v1.0.0 h1:BVi1FQCThIjZ0ehG+I99NJ51o0xcc9A/fDKhmJxY6+w=
+github.com/decred/dcrd v1.3.0 h1:Y/3k/RY3UU70ELNuu/X8aAG6gaa/sba283/o3iS58E8=
+github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
+golang.org/x/crypto v0.0.0-20180515001509-1a580b3eff78 h1:uJIReYEB1ZZLarzi83Pmig1HhZ/cwFCysx05l0PFBIk=

--- a/mining/go.mod
+++ b/mining/go.mod
@@ -1,0 +1,3 @@
+module github.com/decred/dcrd/mining
+
+require github.com/decred/dcrd v1.3.0

--- a/mining/go.modverify
+++ b/mining/go.modverify
@@ -1,0 +1,6 @@
+github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
+github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
+github.com/decred/base58 v1.0.0 h1:BVi1FQCThIjZ0ehG+I99NJ51o0xcc9A/fDKhmJxY6+w=
+github.com/decred/dcrd v1.3.0 h1:Y/3k/RY3UU70ELNuu/X8aAG6gaa/sba283/o3iS58E8=
+github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
+golang.org/x/crypto v0.0.0-20180515001509-1a580b3eff78 h1:uJIReYEB1ZZLarzi83Pmig1HhZ/cwFCysx05l0PFBIk=

--- a/peer/go.mod
+++ b/peer/go.mod
@@ -1,0 +1,3 @@
+module github.com/decred/dcrd/peer
+
+require github.com/decred/dcrd v1.3.0

--- a/peer/go.modverify
+++ b/peer/go.modverify
@@ -1,0 +1,8 @@
+github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
+github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd h1:R/opQEbFEy9JGkIguV40SvRY1uliPX8ifOvi6ICsFCw=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
+github.com/decred/base58 v1.0.0 h1:BVi1FQCThIjZ0ehG+I99NJ51o0xcc9A/fDKhmJxY6+w=
+github.com/decred/dcrd v1.3.0 h1:Y/3k/RY3UU70ELNuu/X8aAG6gaa/sba283/o3iS58E8=
+github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
+golang.org/x/crypto v0.0.0-20180515001509-1a580b3eff78 h1:uJIReYEB1ZZLarzi83Pmig1HhZ/cwFCysx05l0PFBIk=

--- a/rpcclient/go.mod
+++ b/rpcclient/go.mod
@@ -1,0 +1,3 @@
+module github.com/decred/dcrd/rpcclient
+
+require github.com/decred/dcrd v1.3.0

--- a/rpcclient/go.modverify
+++ b/rpcclient/go.modverify
@@ -1,0 +1,9 @@
+github.com/aead/siphash v0.0.0-20170329201724-e404fcfc8885 h1:bBmEG9/q1xH07CqeeFw1ejup6Kw+/88WhhLHqIJ0ngQ=
+github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
+github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd h1:R/opQEbFEy9JGkIguV40SvRY1uliPX8ifOvi6ICsFCw=
+github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
+github.com/decred/base58 v1.0.0 h1:BVi1FQCThIjZ0ehG+I99NJ51o0xcc9A/fDKhmJxY6+w=
+github.com/decred/dcrd v1.3.0 h1:Y/3k/RY3UU70ELNuu/X8aAG6gaa/sba283/o3iS58E8=
+github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
+github.com/gorilla/websocket v1.2.0 h1:VJtLvh6VQym50czpZzx07z/kw9EgAxI3x1ZB8taTMQQ=
+golang.org/x/crypto v0.0.0-20180515001509-1a580b3eff78 h1:uJIReYEB1ZZLarzi83Pmig1HhZ/cwFCysx05l0PFBIk=

--- a/txscript/go.mod
+++ b/txscript/go.mod
@@ -1,0 +1,6 @@
+module github.com/decred/dcrd/txscript
+
+require (
+	github.com/decred/dcrd v1.3.0
+	golang.org/x/crypto v0.0.0-20180525160159-a3beeb748656
+)

--- a/txscript/go.modverify
+++ b/txscript/go.modverify
@@ -1,0 +1,6 @@
+github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
+github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
+github.com/decred/base58 v1.0.0 h1:BVi1FQCThIjZ0ehG+I99NJ51o0xcc9A/fDKhmJxY6+w=
+github.com/decred/dcrd v1.3.0 h1:Y/3k/RY3UU70ELNuu/X8aAG6gaa/sba283/o3iS58E8=
+github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
+golang.org/x/crypto v0.0.0-20180525160159-a3beeb748656 h1:4aSCHfY5DFX3NMvHjnKshMxCsDvv5fMK5tI2JrWUzeg=

--- a/wire/go.mod
+++ b/wire/go.mod
@@ -1,0 +1,3 @@
+module github.com/decred/dcrd/wire
+
+require github.com/decred/dcrd v1.3.0

--- a/wire/go.modverify
+++ b/wire/go.modverify
@@ -1,0 +1,2 @@
+github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
+github.com/decred/dcrd v1.3.0 h1:Y/3k/RY3UU70ELNuu/X8aAG6gaa/sba283/o3iS58E8=


### PR DESCRIPTION
This adds module support for the versioned go toolchain.  In particular, the following packages are defined as modules:

* addrmgr
* blockchain
* certgen
* chaincfg
* connmgr
* database
* dcrjson
* dcrutil
* gcs
* hdkeychain
* mempool
* mining
* peer
* rpcclient
* txscript
* wire

It does not update the travis build environment or `README` since it is experimental at this point.

It should also be noted that these definitions are all currently defined in terms of dcrd, because the modules do not yet exist publicly in order for the vgo toolchain to be able to indepently reference them.  A future commit will refine the dependency graph accordingly.