### PR TITLE
chainhash: Define vgo module.

### DIFF
--- a/chaincfg/chainhash/go.mod
+++ b/chaincfg/chainhash/go.mod
@@ -1,0 +1,3 @@
+module github.com/decred/dcrd/chaincfg/chainhash
+
+require github.com/dchest/blake256 v1.0.0

--- a/chaincfg/chainhash/go.modverify
+++ b/chaincfg/chainhash/go.modverify
@@ -1,0 +1,1 @@
+github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=


### PR DESCRIPTION
This adds module support for the versioned go toolchain to the `chainhash` package.

It does not update the travis build environment or README since it is
experimental at this point.