### PR TITLE
wire: Refine vgo deps.

### DIFF
--- a/wire/go.mod
+++ b/wire/go.mod
@@ -1,3 +1,3 @@
 module github.com/decred/dcrd/wire
 
-require github.com/decred/dcrd v1.3.0
+require github.com/decred/dcrd/chaincfg/chainhash v1.0.0

--- a/wire/go.modverify
+++ b/wire/go.modverify
@@ -1,2 +1,3 @@
 github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
 github.com/decred/dcrd v1.3.0 h1:Y/3k/RY3UU70ELNuu/X8aAG6gaa/sba283/o3iS58E8=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.0 h1:aglSvKIb7PHMnQ0wODb9JC6tkGzvsNKaVoeHqHuERNg=


### PR DESCRIPTION
Now that `chainhash` has been defined, update the `wire` module to only depend on it instead of the entire `dcrd` module.