### PR TITLE
addrmrg: Refine vgo deps.

### DIFF
--- a/addrmgr/go.mod
+++ b/addrmgr/go.mod
@@ -1,3 +1,6 @@
 module github.com/decred/dcrd/addrmgr
 
-require github.com/decred/dcrd v1.3.0
+require (
+	github.com/decred/dcrd/wire v1.0.0
+	github.com/decred/slog v1.0.0
+)

--- a/addrmgr/go.modverify
+++ b/addrmgr/go.modverify
@@ -1,3 +1,4 @@
 github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
-github.com/decred/dcrd v1.3.0 h1:Y/3k/RY3UU70ELNuu/X8aAG6gaa/sba283/o3iS58E8=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.0 h1:aglSvKIb7PHMnQ0wODb9JC6tkGzvsNKaVoeHqHuERNg=
+github.com/decred/dcrd/wire v1.0.0 h1:2h07YfuN8O2zxXiUGTrpdilYhIt9LMNBnIlAoa8SMfw=
 github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=


### PR DESCRIPTION
Now that `wire` has been defined, update the `addrmgr` module to only depend on it instead of the entire `dcrd` module.  Also, since there is no longer a dep on the entire `dcrd` module to pick it up transitively, add the `slog` dep as well.