### PR TITLE
chaincfg: Refine vgo deps.

### DIFF
--- a/chaincfg/go.mod
+++ b/chaincfg/go.mod
@@ -1,3 +1,3 @@
 module github.com/decred/dcrd/chaincfg
 
-require github.com/decred/dcrd v1.3.0
+require github.com/decred/dcrd/wire v1.0.0

--- a/chaincfg/go.modverify
+++ b/chaincfg/go.modverify
@@ -1,2 +1,2 @@
 github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
-github.com/decred/dcrd v1.3.0 h1:Y/3k/RY3UU70ELNuu/X8aAG6gaa/sba283/o3iS58E8=
+github.com/decred/dcrd/wire v1.0.0 h1:2h07YfuN8O2zxXiUGTrpdilYhIt9LMNBnIlAoa8SMfw=


### PR DESCRIPTION
Now that `wire` has been defined, update the `chaincfg` module to only depend on it instead of the entire `dcrd` module.  The `chainhash` dependency is handled transitively via `wire`.