### PR TITLE
blockchain: Convert to full block index in mem.

### DIFF
--- a/blockchain/blockindex.go
+++ b/blockchain/blockindex.go
@@ -7,7 +7,6 @@ package blockchain
 
 import (
 	"bytes"
-	"fmt"
 	"math/big"
 	"sort"
 	"sync"
@@ -17,7 +16,6 @@ import (
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/database"
-	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -69,51 +67,40 @@ func (status blockStatus) KnownInvalid() bool {
 // aid in selecting the best chain to be the main chain.  The main chain is
 // stored into the block database.
 type blockNode struct {
+	// NOTE: Additions, deletions, or modifications to the order of the
+	// definitions in this struct should not be changed without considering
+	// how it affects alignment on 64-bit platforms.  The current order is
+	// specifically crafted to result in minimal padding.  There will be
+	// hundreds of thousands of these in memory, so a few extra bytes of
+	// padding adds up.
+
 	// parent is the parent block for this node.
 	parent *blockNode
 
-	// children contains the child nodes for this node.  Typically there
-	// will only be one, but sometimes there can be more than one and that
-	// is when the best chain selection algorithm is used.
-	children []*blockNode
-
 	// hash is the hash of the block this node represents.
 	hash chainhash.Hash
-
-	// parentHash is the hash of the parent block of the block this node
-	// represents.  This is kept here over simply relying on parent.hash
-	// directly since block nodes are sparse and the parent node might not be
-	// in memory when its hash is needed.
-	parentHash chainhash.Hash
-
-	// height is the position in the block chain.
-	height int64
 
 	// workSum is the total amount of work in the chain up to and including
 	// this node.
 	workSum *big.Int
 
-	// inMainChain denotes whether the block node is currently on the
-	// the main chain or not.  This is used to help find the common
-	// ancestor when switching chains.
-	inMainChain bool
-
 	// Some fields from block headers to aid in best chain selection and
 	// reconstructing headers from memory.  These must be treated as
 	// immutable and are intentionally ordered to avoid padding on 64-bit
 	// platforms.
-	blockVersion int32
+	height       int64
 	voteBits     uint16
 	finalState   [6]byte
+	blockVersion int32
 	voters       uint16
 	freshStake   uint8
+	revocations  uint8
 	poolSize     uint32
 	bits         uint32
 	sbits        int64
 	timestamp    int64
 	merkleRoot   chainhash.Hash
 	stakeRoot    chainhash.Hash
-	revocations  uint8
 	blockSize    uint32
 	nonce        uint32
 	extraData    [32]byte
@@ -125,6 +112,11 @@ type blockNode struct {
 	// concurrent-safe NodeStatus, SetStatusFlags, and UnsetStatusFlags
 	// methods on blockIndex once the node has been added to the index.
 	status blockStatus
+
+	// inMainChain denotes whether the block node is currently on the
+	// the main chain or not.  This is used to help find the common
+	// ancestor when switching chains.
+	inMainChain bool
 
 	// stakeNode contains all the consensus information required for the
 	// staking system.  The node also caches information required to add or
@@ -151,7 +143,6 @@ type blockNode struct {
 func initBlockNode(node *blockNode, blockHeader *wire.BlockHeader, parent *blockNode) {
 	*node = blockNode{
 		hash:         blockHeader.BlockHash(),
-		parentHash:   blockHeader.PrevBlock,
 		workSum:      CalcWork(blockHeader.Bits),
 		height:       int64(blockHeader.Height),
 		blockVersion: blockHeader.Version,
@@ -191,9 +182,13 @@ func newBlockNode(blockHeader *wire.BlockHeader, parent *blockNode) *blockNode {
 // This function is safe for concurrent access.
 func (node *blockNode) Header() wire.BlockHeader {
 	// No lock is needed because all accessed fields are immutable.
+	prevHash := zeroHash
+	if node.parent != nil {
+		prevHash = &node.parent.hash
+	}
 	return wire.BlockHeader{
 		Version:      node.blockVersion,
-		PrevBlock:    node.parentHash,
+		PrevBlock:    *prevHash,
 		MerkleRoot:   node.merkleRoot,
 		StakeRoot:    node.stakeRoot,
 		VoteBits:     node.voteBits,
@@ -243,35 +238,78 @@ func (node *blockNode) populateTicketInfo(spentTickets *stake.SpentTicketsInBloc
 	node.votes = spentTickets.Votes
 }
 
-// removeChildNode deletes node from the provided slice of child block
-// nodes.  It ensures the final pointer reference is set to nil to prevent
-// potential memory leaks.  The original slice is returned unmodified if node
-// is invalid or not in the slice.
+// Ancestor returns the ancestor block node at the provided height by following
+// the chain backwards from this node.  The returned block will be nil when a
+// height is requested that is after the height of the passed node or is less
+// than zero.
 //
-// This function MUST be called with the chain state lock held (for writes).
-func removeChildNode(children []*blockNode, node *blockNode) []*blockNode {
-	if node == nil {
-		return children
+// This function is safe for concurrent access.
+func (node *blockNode) Ancestor(height int64) *blockNode {
+	if height < 0 || height > node.height {
+		return nil
 	}
 
-	// An indexing for loop is intentionally used over a range here as range
-	// does not reevaluate the slice on each iteration nor does it adjust
-	// the index for the modified slice.
-	for i := 0; i < len(children); i++ {
-		if children[i].hash == node.hash {
-			copy(children[i:], children[i+1:])
-			children[len(children)-1] = nil
-			return children[:len(children)-1]
-		}
+	n := node
+	for ; n != nil && n.height != height; n = n.parent {
+		// Intentionally left blank
 	}
-	return children
+
+	return n
+}
+
+// RelativeAncestor returns the ancestor block node a relative 'distance' blocks
+// before this node.  This is equivalent to calling Ancestor with the node's
+// height minus provided distance.
+//
+// This function is safe for concurrent access.
+func (node *blockNode) RelativeAncestor(distance int64) *blockNode {
+	return node.Ancestor(node.height - distance)
+}
+
+// CalcPastMedianTime calculates the median time of the previous few blocks
+// prior to, and including, the block node.
+//
+// This function is safe for concurrent access.
+func (node *blockNode) CalcPastMedianTime() time.Time {
+	// Create a slice of the previous few block timestamps used to calculate
+	// the median per the number defined by the constant medianTimeBlocks.
+	timestamps := make([]int64, medianTimeBlocks)
+	numNodes := 0
+	iterNode := node
+	for i := 0; i < medianTimeBlocks && iterNode != nil; i++ {
+		timestamps[i] = iterNode.timestamp
+		numNodes++
+
+		iterNode = iterNode.parent
+	}
+
+	// Prune the slice to the actual number of available timestamps which
+	// will be fewer than desired near the beginning of the block chain
+	// and sort them.
+	timestamps = timestamps[:numNodes]
+	sort.Sort(timeSorter(timestamps))
+
+	// NOTE: The consensus rules incorrectly calculate the median for even
+	// numbers of blocks.  A true median averages the middle two elements
+	// for a set with an even number of elements in it.   Since the constant
+	// for the previous number of blocks to be used is odd, this is only an
+	// issue for a few blocks near the beginning of the chain.  I suspect
+	// this is an optimization even though the result is slightly wrong for
+	// a few of the first blocks since after the first few blocks, there
+	// will always be an odd number of blocks in the set per the constant.
+	//
+	// This code follows suit to ensure the same rules are used, however, be
+	// aware that should the medianTimeBlocks constant ever be changed to an
+	// even number, this code will be wrong.
+	medianTimestamp := timestamps[numNodes/2]
+	return time.Unix(medianTimestamp, 0)
 }
 
 // blockIndex provides facilities for keeping track of an in-memory index of the
-// block chain.  Although the name block chain suggest a single chain of blocks,
-// it is actually a tree-shaped structure where any node can have multiple
-// children.  However, there can only be one active branch which does indeed
-// form a chain from the tip all the way back to the genesis block.
+// block chain.  Although the name block chain suggests a single chain of
+// blocks, it is actually a tree-shaped structure where any node can have
+// multiple children.  However, there can only be one active branch which does
+// indeed form a chain from the tip all the way back to the genesis block.
 type blockIndex struct {
 	// The following fields are set when the instance is created and can't
 	// be changed afterwards, so there is no need to protect them with a
@@ -281,7 +319,6 @@ type blockIndex struct {
 
 	sync.RWMutex
 	index     map[chainhash.Hash]*blockNode
-	depNodes  map[chainhash.Hash][]*blockNode
 	chainTips map[int64][]*blockNode
 }
 
@@ -293,7 +330,6 @@ func newBlockIndex(db database.DB, chainParams *chaincfg.Params) *blockIndex {
 		db:          db,
 		chainParams: chainParams,
 		index:       make(map[chainhash.Hash]*blockNode),
-		depNodes:    make(map[chainhash.Hash][]*blockNode),
 		chainTips:   make(map[int64][]*blockNode),
 	}
 }
@@ -308,205 +344,12 @@ func (bi *blockIndex) HaveBlock(hash *chainhash.Hash) bool {
 	return hasBlock
 }
 
-// loadBlockNode loads the block identified by hash from the block database,
-// creates a block node from it, and updates the memory block chain accordingly.
-// It is used mainly to dynamically load previous blocks from the database as
-// they are needed to avoid needing to put the entire block chain in memory.
-//
-// This function MUST be called with the block index lock held (for writes).
-// The database transaction may be read-only.
-func (bi *blockIndex) loadBlockNode(dbTx database.Tx, hash *chainhash.Hash) (*blockNode, error) {
-	// Try to look up the height for passed block hash in the main chain.
-	height, err := dbFetchHeightByHash(dbTx, hash)
-	if err != nil {
-		return nil, err
-	}
-
-	// Load the block node for the provided hash and height from the
-	// database.
-	entry, err := dbFetchBlockIndexEntry(dbTx, hash, uint32(height))
-	if err != nil {
-		return nil, err
-	}
-	node := new(blockNode)
-	initBlockNode(node, &entry.header, nil)
-	node.ticketsVoted = entry.ticketsVoted
-	node.ticketsRevoked = entry.ticketsRevoked
-	node.votes = entry.voteInfo
-	node.inMainChain = true
-
-	// Add the node to the chain.
-	// There are a few possibilities here:
-	//  1) This node is a child of an existing block node
-	//  2) This node is the parent of one or more nodes
-	//  3) Neither 1 or 2 is true which implies it's an orphan block and
-	//     therefore is an error to insert into the chain
-	prevHash := &node.parentHash
-	if parentNode, ok := bi.index[*prevHash]; ok {
-		// Case 1 -- This node is a child of an existing block node.
-		// Update the node's work sum with the sum of the parent node's
-		// work sum and this node's work, append the node as a child of
-		// the parent node and set this node's parent to the parent
-		// node.
-		node.workSum = node.workSum.Add(parentNode.workSum, node.workSum)
-		parentNode.children = append(parentNode.children, node)
-		node.parent = parentNode
-
-		// Also, since this node is extending an existing chain it is a
-		// new chain tip and the parent is no longer a tip.
-		bi.addChainTip(node)
-		bi.removeChainTip(parentNode)
-
-	} else if childNodes, ok := bi.depNodes[*hash]; ok {
-		// Case 2 -- This node is the parent of one or more nodes.
-		// Update the node's work sum by subtracting this node's work
-		// from the sum of its first child, and connect the node to all
-		// of its children.
-		node.workSum.Sub(childNodes[0].workSum, node.workSum)
-		for _, childNode := range childNodes {
-			childNode.parent = node
-			node.children = append(node.children, childNode)
-		}
-
-	} else {
-		// Case 3 -- The node doesn't have a parent in the node cache
-		// and is not the parent of another node.  This means an arbitrary
-		// orphan block is trying to be loaded which is not allowed.
-		str := "loadBlockNode: attempt to insert orphan block %v"
-		return nil, AssertError(fmt.Sprintf(str, hash))
-	}
-
-	// Add the new node to the indices for faster lookups.
-	bi.index[*hash] = node
-	bi.depNodes[*prevHash] = append(bi.depNodes[*prevHash], node)
-
-	return node, nil
-}
-
-// PrevNodeFromBlock returns a block node for the block previous to the
-// passed block (the passed block's parent).  When it is already in the block
-// index, it simply returns it.  Otherwise, it loads the previous block header
-// from the block database, creates a new block node from it, and returns it.
-// The returned node will be nil if the genesis block is passed.
-//
-// This function is safe for concurrent access.
-func (bi *blockIndex) PrevNodeFromBlock(block *dcrutil.Block) (*blockNode, error) {
-	// Genesis block.
-	prevHash := &block.MsgBlock().Header.PrevBlock
-	if prevHash.IsEqual(zeroHash) {
-		return nil, nil
-	}
-
-	bi.Lock()
-	defer bi.Unlock()
-
-	// Return the existing previous block node if it's already there.
-	if bn, ok := bi.index[*prevHash]; ok {
-		return bn, nil
-	}
-
-	// Dynamically load the previous block from the block database, create
-	// a new block node for it, and update the memory chain accordingly.
-	var prevBlockNode *blockNode
-	err := bi.db.View(func(dbTx database.Tx) error {
-		var err error
-		prevBlockNode, err = bi.loadBlockNode(dbTx, prevHash)
-		return err
-	})
-	return prevBlockNode, err
-}
-
-// prevNodeFromNode returns a block node for the block previous to the passed
-// block node (the passed block node's parent).  When the node is already
-// connected to a parent, it simply returns it.  Otherwise, it loads the
-// associated block from the database to obtain the previous hash and uses that
-// to dynamically create a new block node and return it.  The memory block
-// chain is updated accordingly.  The returned node will be nil if the genesis
-// block is passed.
-//
-// This function MUST be called with the block index lock held (for writes).
-func (bi *blockIndex) prevNodeFromNode(node *blockNode) (*blockNode, error) {
-	// Return the existing previous block node if it's already there.
-	if node.parent != nil {
-		return node.parent, nil
-	}
-
-	// Genesis block.
-	if node.hash.IsEqual(bi.chainParams.GenesisHash) {
-		return nil, nil
-	}
-
-	// Dynamically load the previous block from the block database, create
-	// a new block node for it, and update the memory chain accordingly.
-	var prevBlockNode *blockNode
-	err := bi.db.View(func(dbTx database.Tx) error {
-		var err error
-		prevBlockNode, err = bi.loadBlockNode(dbTx, &node.parentHash)
-		return err
-	})
-	return prevBlockNode, err
-}
-
-// PrevNodeFromNode returns a block node for the block previous to the
-// passed block node (the passed block node's parent).  When the node is already
-// connected to a parent, it simply returns it.  Otherwise, it loads the
-// associated block from the database to obtain the previous hash and uses that
-// to dynamically create a new block node and return it.  The memory block
-// chain is updated accordingly.  The returned node will be nil if the genesis
-// block is passed.
-//
-// This function is safe for concurrent access.
-func (bi *blockIndex) PrevNodeFromNode(node *blockNode) (*blockNode, error) {
-	bi.Lock()
-	node, err := bi.prevNodeFromNode(node)
-	bi.Unlock()
-	return node, err
-}
-
-// AncestorNode returns the ancestor block node at the provided height by
-// following the chain backwards from the given node while dynamically loading
-// any pruned nodes from the database and updating the memory block chain as
-// needed.  The returned block will be nil when a height is requested that is
-// after the height of the passed node or is less than zero.
-//
-// This function is safe for concurrent access.
-func (bi *blockIndex) AncestorNode(node *blockNode, height int64) (*blockNode, error) {
-	// Nothing to do if the requested height is outside of the valid range.
-	if height > node.height || height < 0 {
-		return nil, nil
-	}
-
-	// Iterate backwards until the requested height is reached.
-	bi.Lock()
-	iterNode := node
-	for iterNode != nil && iterNode.height > height {
-		// Get the previous block node.  This function is used over
-		// simply accessing iterNode.parent directly as it will
-		// dynamically create previous block nodes as needed.  This
-		// helps allow only the pieces of the chain that are needed
-		// to remain in memory.
-		var err error
-		iterNode, err = bi.prevNodeFromNode(iterNode)
-		if err != nil {
-			log.Errorf("prevNodeFromNode: %v", err)
-			return nil, err
-		}
-	}
-	bi.Unlock()
-
-	return iterNode, nil
-}
-
-// AddNode adds the provided node to the block index.  Duplicate entries are not
+// addNode adds the provided node to the block index.  Duplicate entries are not
 // checked so it is up to caller to avoid adding them.
 //
-// This function is safe for concurrent access.
-func (bi *blockIndex) AddNode(node *blockNode) {
-	bi.Lock()
+// This function MUST be called with the block index lock held (for writes).
+func (bi *blockIndex) addNode(node *blockNode) {
 	bi.index[node.hash] = node
-	if prevHash := node.parentHash; prevHash != *zeroHash {
-		bi.depNodes[prevHash] = append(bi.depNodes[prevHash], node)
-	}
 
 	// Since the block index does not support nodes that do not connect to
 	// an existing node (except the genesis block), all new nodes are either
@@ -515,32 +358,17 @@ func (bi *blockIndex) AddNode(node *blockNode) {
 	// chain, the parent is no longer a tip.
 	bi.addChainTip(node)
 	if node.parent != nil {
-		node.parent.children = append(node.parent.children, node)
 		bi.removeChainTip(node.parent)
 	}
-	bi.Unlock()
 }
 
-// RemoveNode removes the provided node from the block index.  No checks are
-// performed to ensure the node already exists, so it's up to the caller to
-// avoid removing them.
+// AddNode adds the provided node to the block index.  Duplicate entries are not
+// checked so it is up to caller to avoid adding them.
 //
 // This function is safe for concurrent access.
-func (bi *blockIndex) RemoveNode(node *blockNode) {
+func (bi *blockIndex) AddNode(node *blockNode) {
 	bi.Lock()
-	if parent := node.parent; parent != nil {
-		parent.children = removeChildNode(parent.children, node)
-	}
-	if prevHash := node.parentHash; prevHash != *zeroHash {
-		depNodes := bi.depNodes[prevHash]
-		depNodes = removeChildNode(depNodes, node)
-		if len(depNodes) == 0 {
-			delete(bi.depNodes, prevHash)
-		} else {
-			bi.depNodes[prevHash] = depNodes
-		}
-	}
-	delete(bi.index, node.hash)
+	bi.addNode(node)
 	bi.Unlock()
 }
 
@@ -574,13 +402,21 @@ func (bi *blockIndex) removeChainTip(tip *blockNode) {
 	}
 }
 
+// lookupNode returns the block node identified by the provided hash.  It will
+// return nil if there is no entry for the hash.
+//
+// This function MUST be called with the block index lock held (for reads).
+func (bi *blockIndex) lookupNode(hash *chainhash.Hash) *blockNode {
+	return bi.index[*hash]
+}
+
 // LookupNode returns the block node identified by the provided hash.  It will
 // return nil if there is no entry for the hash.
 //
 // This function is safe for concurrent access.
 func (bi *blockIndex) LookupNode(hash *chainhash.Hash) *blockNode {
 	bi.RLock()
-	node := bi.index[*hash]
+	node := bi.lookupNode(hash)
 	bi.RUnlock()
 	return node
 }
@@ -613,61 +449,4 @@ func (bi *blockIndex) UnsetStatusFlags(node *blockNode, flags blockStatus) {
 	bi.Lock()
 	node.status &^= flags
 	bi.Unlock()
-}
-
-// CalcPastMedianTime calculates the median time of the previous few blocks
-// prior to, and including, the passed block node.
-//
-// This function is safe for concurrent access.
-func (bi *blockIndex) CalcPastMedianTime(startNode *blockNode) (time.Time, error) {
-	// Genesis block.
-	if startNode == nil {
-		return bi.chainParams.GenesisBlock.Header.Timestamp, nil
-	}
-
-	// Create a slice of the previous few block timestamps used to calculate
-	// the median per the number defined by the constant medianTimeBlocks.
-	timestamps := make([]int64, medianTimeBlocks)
-	numNodes := 0
-	iterNode := startNode
-	bi.Lock()
-	for i := 0; i < medianTimeBlocks && iterNode != nil; i++ {
-		timestamps[i] = iterNode.timestamp
-		numNodes++
-
-		// Get the previous block node.  This function is used over
-		// simply accessing iterNode.parent directly as it will
-		// dynamically create previous block nodes as needed.  This
-		// helps allow only the pieces of the chain that are needed
-		// to remain in memory.
-		var err error
-		iterNode, err = bi.prevNodeFromNode(iterNode)
-		if err != nil {
-			bi.Unlock()
-			log.Errorf("prevNodeFromNode failed to find node: %v", err)
-			return time.Time{}, err
-		}
-	}
-	bi.Unlock()
-
-	// Prune the slice to the actual number of available timestamps which
-	// will be fewer than desired near the beginning of the block chain
-	// and sort them.
-	timestamps = timestamps[:numNodes]
-	sort.Sort(timeSorter(timestamps))
-
-	// NOTE: bitcoind incorrectly calculates the median for even numbers of
-	// blocks.  A true median averages the middle two elements for a set
-	// with an even number of elements in it.   Since the constant for the
-	// previous number of blocks to be used is odd, this is only an issue
-	// for a few blocks near the beginning of the chain.  I suspect this is
-	// an optimization even though the result is slightly wrong for a few
-	// of the first blocks since after the first few blocks, there will
-	// always be an odd number of blocks in the set per the constant.
-	//
-	// This code follows suit to ensure the same rules are used as bitcoind
-	// however, be aware that should the medianTimeBlocks constant ever be
-	// changed to an even number, this code will be wrong.
-	medianTimestamp := timestamps[numNodes/2]
-	return time.Unix(medianTimestamp, 0), nil
 }

--- a/blockchain/blockindex_test.go
+++ b/blockchain/blockindex_test.go
@@ -162,11 +162,7 @@ func TestCalcPastMedianTime(t *testing.T) {
 		}
 
 		// Ensure the median time is the expected value.
-		gotTime, err := bc.index.CalcPastMedianTime(node)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.name, err)
-			continue
-		}
+		gotTime := node.CalcPastMedianTime()
 		wantTime := time.Unix(test.expected, 0)
 		if !gotTime.Equal(wantTime) {
 			t.Errorf("%s: mismatched timestamps -- got: %v, want: %v",

--- a/blockchain/blocklocator.go
+++ b/blockchain/blocklocator.go
@@ -112,12 +112,6 @@ func (bi *blockIndex) blockLocatorFromHash(hash *chainhash.Hash) BlockLocator {
 			// backwards along the side chain nodes to each block
 			// height.
 			if forkHeight != -1 && blockHeight > forkHeight {
-				// Intentionally use parent field instead of the
-				// PrevNodeFromNode function since we don't
-				// want to dynamically load nodes when building
-				// block locators.  Side chain blocks should
-				// always be in memory already, and if they
-				// aren't for some reason it's ok to skip them.
 				for iterNode != nil && blockHeight > iterNode.height {
 					iterNode = iterNode.parent
 				}

--- a/blockchain/sequencelock.go
+++ b/blockchain/sequencelock.go
@@ -39,8 +39,6 @@ func isStakeBaseTx(tx *wire.MsgTx) bool {
 // from the point of view of the block node passed in as the first argument.
 //
 // See the CalcSequenceLock comments for more details.
-//
-// This function MUST be called with the chain state lock held (for writes).
 func (b *BlockChain) calcSequenceLock(node *blockNode, tx *dcrutil.Tx, view *UtxoViewpoint, isActive bool) (*SequenceLock, error) {
 	// A value of -1 for each lock type allows a transaction to be included
 	// in a block at any given height or time.
@@ -102,17 +100,8 @@ func (b *BlockChain) calcSequenceLock(node *blockNode, tx *dcrutil.Tx, view *Utx
 			if prevInputHeight < 0 {
 				prevInputHeight = 0
 			}
-			blockNode, err := b.index.AncestorNode(node, prevInputHeight)
-			if err != nil {
-				return sequenceLock, err
-			}
-
-			// Calculate the past median time of the block prior to
-			// the one which included the output being spent.
-			medianTime, err := b.index.CalcPastMedianTime(blockNode)
-			if err != nil {
-				return sequenceLock, err
-			}
+			blockNode := node.Ancestor(prevInputHeight)
+			medianTime := blockNode.CalcPastMedianTime()
 
 			// Calculate the minimum required timestamp based on the
 			// sum of the aforementioned past median time and

--- a/blockchain/sequencelock_test.go
+++ b/blockchain/sequencelock_test.go
@@ -74,25 +74,13 @@ func TestCalcSequenceLock(t *testing.T) {
 	// Obtain the median time past from the PoV of the input created above.
 	// The median time for the input is the median time from the PoV of the
 	// block *prior* to the one that included it.
-	medianNode, err := bc.index.AncestorNode(node, node.height-5)
-	if err != nil {
-		t.Fatalf("Unable to obtain median node: %v", err)
-	}
-	medianT, err := bc.index.CalcPastMedianTime(medianNode)
-	if err != nil {
-		t.Fatalf("Unable to obtain median node time: %v", err)
-	}
-	medianTime := medianT.Unix()
+	medianTime := node.RelativeAncestor(5).CalcPastMedianTime().Unix()
 
 	// The median time calculated from the PoV of the best block in the
 	// test chain.  For unconfirmed inputs, this value will be used since
 	// the median time will be calculated from the PoV of the
 	// yet-to-be-mined block.
-	nextMedianT, err := bc.index.CalcPastMedianTime(node)
-	if err != nil {
-		t.Fatalf("Unable to obtain next median node time: %v", err)
-	}
-	nextMedianTime := nextMedianT.Unix()
+	nextMedianTime := node.CalcPastMedianTime().Unix()
 	nextBlockHeight := int64(numBlocks) + 1
 
 	// Add an additional transaction which will serve as our unconfirmed

--- a/blockchain/stakeversion_test.go
+++ b/blockchain/stakeversion_test.go
@@ -254,9 +254,9 @@ func TestCalcStakeVersionCorners(t *testing.T) {
 	}
 }
 
-// TestCalcStakeVersionByNode ensures that stake version calculation works as
+// TestCalcStakeVersion ensures that stake version calculation works as
 // intended when
-func TestCalcStakeVersionByNode(t *testing.T) {
+func TestCalcStakeVersion(t *testing.T) {
 	params := &chaincfg.SimNetParams
 	svh := params.StakeValidationHeight
 	svi := params.StakeVersionInterval
@@ -718,7 +718,7 @@ func TestLarge(t *testing.T) {
 			// validate calcStakeVersion
 			version := bc.calcStakeVersion(node)
 			if version != test.expectedCalcVersion {
-				t.Fatalf("%v calcStakeVersionByNode got %v expected %v",
+				t.Fatalf("%v calcStakeVersion got %v expected %v",
 					test.name, version, test.expectedCalcVersion)
 			}
 			end := time.Now()

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -881,11 +881,7 @@ func (b *BlockChain) checkBlockHeaderContext(header *wire.BlockHeader, prevNode 
 
 		// Ensure the timestamp for the block header is after the
 		// median time of the last several blocks (medianTimeBlocks).
-		medianTime, err := b.index.CalcPastMedianTime(prevNode)
-		if err != nil {
-			log.Errorf("CalcPastMedianTime: %v", err)
-			return err
-		}
+		medianTime := prevNode.CalcPastMedianTime()
 		if !header.Timestamp.After(medianTime) {
 			str := "block timestamp of %v is not after expected %v"
 			str = fmt.Sprintf(str, header.Timestamp, medianTime)
@@ -1131,12 +1127,7 @@ func (b *BlockChain) checkBlockContext(block *dcrutil.Block, prevNode *blockNode
 			return err
 		}
 		if lnFeaturesActive {
-			medianTime, err := b.index.CalcPastMedianTime(prevNode)
-			if err != nil {
-				return err
-			}
-
-			blockTime = medianTime
+			blockTime = prevNode.CalcPastMedianTime()
 		}
 
 		// The height of this block is one more than the referenced
@@ -2349,11 +2340,11 @@ func (b *BlockChain) checkConnectBlock(node *blockNode, block, parent *dcrutil.B
 	}
 
 	// Ensure the view is for the node being checked.
-	if !utxoView.BestHash().IsEqual(&node.parentHash) {
+	parentHash := &block.MsgBlock().Header.PrevBlock
+	if !utxoView.BestHash().IsEqual(parentHash) {
 		return AssertError(fmt.Sprintf("inconsistent view when "+
 			"checking block connection: best hash is %v instead "+
-			"of expected %v", utxoView.BestHash(),
-			node.parentHash))
+			"of expected %v", utxoView.BestHash(), parentHash))
 	}
 
 	// Check that the coinbase pays the tax, if applicable.
@@ -2451,10 +2442,7 @@ func (b *BlockChain) checkConnectBlock(node *blockNode, block, parent *dcrutil.B
 		// Use the past median time of the *previous* block in order
 		// to determine if the transactions in the current block are
 		// final.
-		prevMedianTime, err = b.index.CalcPastMedianTime(node.parent)
-		if err != nil {
-			return err
-		}
+		prevMedianTime = node.parent.CalcPastMedianTime()
 
 		// Skip the coinbase since it does not have any inputs and thus
 		// lock times do not apply.
@@ -2590,9 +2578,15 @@ func (b *BlockChain) CheckConnectBlockTemplate(block *dcrutil.Block) error {
 		prevNode = tip.parent
 	}
 	if prevNode == nil {
-		str := fmt.Sprintf("previous block must be the current chain "+
-			"tip %s or its parent %s, but got %s", tip.hash,
-			tip.parentHash, parentHash)
+		var str string
+		if tip.parent != nil {
+			str = fmt.Sprintf("previous block must be the current chain tip "+
+				"%s or its parent %s, but got %s", tip.hash, tip.parent.hash,
+				parentHash)
+		} else {
+			str = fmt.Sprintf("previous block must be the current chain tip "+
+				"%s, but got %s", tip.hash, parentHash)
+		}
 		return ruleError(ErrInvalidTemplateParent, str)
 	}
 
@@ -2631,10 +2625,7 @@ func (b *BlockChain) CheckConnectBlockTemplate(block *dcrutil.Block) error {
 	// the transactions and spend information for the blocks which would be
 	// disconnected during a reorganize to the point of view of the node
 	// just before the requested node.
-	detachNodes, attachNodes, err := b.getReorganizeNodes(prevNode)
-	if err != nil {
-		return err
-	}
+	detachNodes, attachNodes := b.getReorganizeNodes(prevNode)
 
 	view := NewUtxoViewpoint()
 	view.SetBestHash(&tip.hash)
@@ -2659,7 +2650,7 @@ func (b *BlockChain) CheckConnectBlockTemplate(block *dcrutil.Block) error {
 				block.Hash())
 		}
 
-		parent, err := b.fetchMainChainBlockByHash(&n.parentHash)
+		parent, err := b.fetchMainChainBlockByHash(&n.parent.hash)
 		if err != nil {
 			return err
 		}
@@ -2714,15 +2705,15 @@ func (b *BlockChain) CheckConnectBlockTemplate(block *dcrutil.Block) error {
 		parent := prevAttachBlock
 		if parent == nil {
 			var err error
-			parent, err = b.fetchMainChainBlockByHash(&n.parentHash)
+			parent, err = b.fetchMainChainBlockByHash(&n.parent.hash)
 			if err != nil {
 				return err
 			}
 		}
-		if n.parentHash != *parent.Hash() {
+		if n.parent.hash != *parent.Hash() {
 			panicf("attach block node hash %v (height %v) parent hash %v does "+
 				"not match previous parent block hash %v", &n.hash, n.height,
-				&n.parentHash, parent.Hash())
+				&n.parent.hash, parent.Hash())
 		}
 
 		// Store the loaded block for the next iteration.


### PR DESCRIPTION
This reworks the block index code such that it loads all of the headers in the main chain at startup and constructs the full block index accordingly.

Since the full index from the current best tip all the way back to the genesis block is now guaranteed to be in memory, this also removes all code related to dynamically loading the nodes and updates some of the logic to take advantage of the fact traversing the block index can no longer potentially fail.  There are also many more optimizations and simplifications that can be made in the future as a result of this.

Due to removing all of the extra overhead of tracking the dynamic state, and ensuring the block node structs are aligned to eliminate extra padding, the end result of a fully populated block index now takes quite a bit less memory than the previous dynamically loaded version.

It also speeds up the initial startup process by roughly 2x since it is faster to bulk load the nodes in order as opposed to dynamically loading only the nodes near the tip in backwards order.

For example, here is some startup timing information before and after this commit on a node that contains roughly 238,000 blocks:

7200 RPM HDD:
-------------
Startup time before this commit: ~7.71s
Startup time after this commit: ~3.47s

SSD:
----
Startup time before this commit: ~6.34s
Startup time after this commit: ~3.51s

Some additional benefits are:

- Since every block node is in memory, the code which reconstructs headers from block nodes means that all headers can always be served from memory which will be important since the network will be moving to header-based semantics
- Several of the error paths can be removed since they are no longer necessary
- It is no longer expensive to calculate CSV sequence locks or median times of blocks way in the past
- It is much less expensive to calculate the initial states for the various intervals such as the stake and voter version
- It will be possible to create much more efficient iteration and simplified views of the overall index

An overview of the logic changes are as follows:

- Move `AncestorNode` from `blockIndex` to `blockNode` and greatly simplify since it no longer has to deal with the possibility of dynamically loading nodes and related failures
- Replace `nodeAtHeightFromTopNode` from `BlockChain` with `RelativeAncestor` on `blockNode` and define it in terms of `AncestorNode`
- Move `CalcPastMedianTime` from `blockIndex` to `blockNode` and remove no longer necessary test for nil
- Remove `findNode` and replace all of its uses with direct queries of the block index
- Remove `blockExists` and replace all of its uses with direct queries of the block index
- Remove all functions and fields related to dynamically loading nodes
  - `children` and `parentHash` fields from `blockNode`
  - `depNodes` from `blockIndex`
  - `loadBlockNode` from `blockIndex`
  - `PrevNodeFromBlock` from `blockIndex`
  - `{p,P}revNodeFromNode` from `blockIndex`
  - `RemoveNode`
- Replace all instances of iterating backwards through nodes to directly access the parent now that nodes don't potentially need to be dynamically loaded
- Introduce a `lookupNode` function on `blockIndex` which allows the initialization code to locklessly query the index
- No longer take the chain lock when only access to the block index, which has its own lock, is needed
- Remove the error paths from several functions that can no longer fail
  - `getReorganizeNodes`
  - `findPrevTestNetDifficulty`
  - `sumPurchasedTickets`
  - `findStakeVersionPriorNode`
- Remove all error paths related to node iteration that can no longer fail
- Modify `FetchUtxoView` to return an empty view for the genesis block

This is work towards #1145.