### PR TITLE
multi: Change NoSplitTransaction param to SplitTx.

### DIFF
--- a/dcrjson/dcrwalletextcmds.go
+++ b/dcrjson/dcrwalletextcmds.go
@@ -285,35 +285,35 @@ func NewListScriptsCmd() *ListScriptsCmd {
 // PurchaseTicketCmd is a type handling custom marshaling and
 // unmarshaling of purchaseticket JSON RPC commands.
 type PurchaseTicketCmd struct {
-	FromAccount        string
-	SpendLimit         float64 // In Coins
-	MinConf            *int    `jsonrpcdefault:"1"`
-	TicketAddress      *string
-	NumTickets         *int
-	PoolAddress        *string
-	PoolFees           *float64
-	Expiry             *int
-	Comment            *string
-	NoSplitTransaction *bool
-	TicketFee          *float64
+	FromAccount   string
+	SpendLimit    float64 // In Coins
+	MinConf       *int    `jsonrpcdefault:"1"`
+	TicketAddress *string
+	NumTickets    *int
+	PoolAddress   *string
+	PoolFees      *float64
+	Expiry        *int
+	Comment       *string
+	SplitTx       *uint32
+	TicketFee     *float64
 }
 
 // NewPurchaseTicketCmd creates a new PurchaseTicketCmd.
 func NewPurchaseTicketCmd(fromAccount string, spendLimit float64, minConf *int,
 	ticketAddress *string, numTickets *int, poolAddress *string, poolFees *float64,
-	expiry *int, comment *string, noSplitTransaction *bool, ticketFee *float64) *PurchaseTicketCmd {
+	expiry *int, comment *string, splitTx *uint32, ticketFee *float64) *PurchaseTicketCmd {
 	return &PurchaseTicketCmd{
-		FromAccount:        fromAccount,
-		SpendLimit:         spendLimit,
-		MinConf:            minConf,
-		TicketAddress:      ticketAddress,
-		NumTickets:         numTickets,
-		PoolAddress:        poolAddress,
-		PoolFees:           poolFees,
-		Expiry:             expiry,
-		Comment:            comment,
-		NoSplitTransaction: noSplitTransaction,
-		TicketFee:          ticketFee,
+		FromAccount:   fromAccount,
+		SpendLimit:    spendLimit,
+		MinConf:       minConf,
+		TicketAddress: ticketAddress,
+		NumTickets:    numTickets,
+		PoolAddress:   poolAddress,
+		PoolFees:      poolFees,
+		Expiry:        expiry,
+		Comment:       comment,
+		SplitTx:       splitTx,
+		TicketFee:     ticketFee,
 	}
 }
 

--- a/rpcclient/wallet.go
+++ b/rpcclient/wallet.go
@@ -761,7 +761,7 @@ func (r FuturePurchaseTicketResult) Receive() ([]*chainhash.Hash, error) {
 func (c *Client) PurchaseTicketAsync(fromAccount string,
 	spendLimit dcrutil.Amount, minConf *int, ticketAddress dcrutil.Address,
 	numTickets *int, poolAddress dcrutil.Address, poolFees *dcrutil.Amount,
-	expiry *int, noSplitTransaction *bool, ticketFee *dcrutil.Amount) FuturePurchaseTicketResult {
+	expiry *int, splitTx *uint32, ticketFee *dcrutil.Amount) FuturePurchaseTicketResult {
 	// An empty string is used to keep the sendCmd
 	// passing of the command from accidentally
 	// removing certain fields. We fill in the
@@ -803,9 +803,14 @@ func (c *Client) PurchaseTicketAsync(fromAccount string,
 		ticketFeeFloat = ticketFee.ToCoin()
 	}
 
+	splitTxVal := uint32(1)
+	if splitTx != nil {
+		splitTxVal = *splitTx
+	}
+
 	cmd := dcrjson.NewPurchaseTicketCmd(fromAccount, spendLimit.ToCoin(),
 		&minConfVal, &ticketAddrStr, &numTicketsVal, &poolAddrStr,
-		&poolFeesFloat, &expiryVal, nil, noSplitTransaction, &ticketFeeFloat)
+		&poolFeesFloat, &expiryVal, nil, &splitTxVal, &ticketFeeFloat)
 
 	return c.sendCmd(cmd)
 }
@@ -815,10 +820,10 @@ func (c *Client) PurchaseTicketAsync(fromAccount string,
 func (c *Client) PurchaseTicket(fromAccount string,
 	spendLimit dcrutil.Amount, minConf *int, ticketAddress dcrutil.Address,
 	numTickets *int, poolAddress dcrutil.Address, poolFees *dcrutil.Amount,
-	expiry *int, noSplitTransaction *bool, ticketFee *dcrutil.Amount) ([]*chainhash.Hash, error) {
+	expiry *int, splitTx *uint32, ticketFee *dcrutil.Amount) ([]*chainhash.Hash, error) {
 
 	return c.PurchaseTicketAsync(fromAccount, spendLimit, minConf, ticketAddress,
-		numTickets, poolAddress, poolFees, expiry, noSplitTransaction, ticketFee).Receive()
+		numTickets, poolAddress, poolFees, expiry, splitTx, ticketFee).Receive()
 }
 
 // SStx generation RPC call handling


### PR DESCRIPTION
The SplitTx parameter for PurchaseTicketCmd specifies the minimum
number of inputs needed to use a split transaction for a ticket
purchase. The parameter options are 1 and 2. Ticket purchase inputs
less than the set SplitTx value are used directly in the transaction.