### PR TITLE
rpcclient: pass default value for NewPurchaseTicketCmd's comment param.

### DIFF
--- a/rpcclient/wallet.go
+++ b/rpcclient/wallet.go
@@ -810,7 +810,7 @@ func (c *Client) PurchaseTicketAsync(fromAccount string,
 
 	cmd := dcrjson.NewPurchaseTicketCmd(fromAccount, spendLimit.ToCoin(),
 		&minConfVal, &ticketAddrStr, &numTicketsVal, &poolAddrStr,
-		&poolFeesFloat, &expiryVal, nil, &splitTxVal, &ticketFeeFloat)
+		&poolFeesFloat, &expiryVal, dcrjson.String(""), &splitTxVal, &ticketFeeFloat)
 
 	return c.sendCmd(cmd)
 }


### PR DESCRIPTION
This avoids a dcrjson marshaling bug referenced in [dcrrpcclient 89](https://github.com/decred/dcrrpcclient/pull/89) and [dcrwallet 963](https://github.com/decred/dcrwallet/pull/963).

Thanks to @chappjc for pointing it out.