### PR TITLE
multi: Return fork len from ProcessBlock.

### DIFF
--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -158,7 +158,7 @@ func TestForceHeadReorg(t *testing.T) {
 		t.Logf("Testing block %s (hash %s, height %d)",
 			g.TipName(), block.Hash(), blockHeight)
 
-		isMainChain, isOrphan, err := chain.ProcessBlock(block, BFNone)
+		forkLen, isOrphan, err := chain.ProcessBlock(block, BFNone)
 		if err != nil {
 			t.Fatalf("block %q (hash %s, height %d) should "+
 				"have been accepted: %v", g.TipName(),
@@ -167,6 +167,7 @@ func TestForceHeadReorg(t *testing.T) {
 
 		// Ensure the main chain and orphan flags match the values
 		// specified in the test.
+		isMainChain := !isOrphan && forkLen == 0
 		if !isMainChain {
 			t.Fatalf("block %q (hash %s, height %d) unexpected main "+
 				"chain flag -- got %v, want true", g.TipName(),
@@ -197,7 +198,7 @@ func TestForceHeadReorg(t *testing.T) {
 		t.Logf("Testing block %s (hash %s, height %d)",
 			g.TipName(), block.Hash(), blockHeight)
 
-		isMainChain, isOrphan, err := chain.ProcessBlock(block, BFNone)
+		forkLen, isOrphan, err := chain.ProcessBlock(block, BFNone)
 		if err != nil {
 			t.Fatalf("block %q (hash %s, height %d) should "+
 				"have been accepted: %v", g.TipName(),
@@ -206,6 +207,7 @@ func TestForceHeadReorg(t *testing.T) {
 
 		// Ensure the main chain and orphan flags match the values
 		// specified in the test.
+		isMainChain := !isOrphan && forkLen == 0
 		if isMainChain {
 			t.Fatalf("block %q (hash %s, height %d) unexpected main "+
 				"chain flag -- got %v, want false", g.TipName(),

--- a/blockchain/example_test.go
+++ b/blockchain/example_test.go
@@ -60,12 +60,13 @@ func ExampleBlockChain_ProcessBlock() {
 	// cause an error by trying to process the genesis block which already
 	// exists.
 	genesisBlock := dcrutil.NewBlock(chaincfg.MainNetParams.GenesisBlock)
-	isMainChain, isOrphan, err := chain.ProcessBlock(genesisBlock,
+	forkLen, isOrphan, err := chain.ProcessBlock(genesisBlock,
 		blockchain.BFNone)
 	if err != nil {
 		fmt.Printf("Failed to create chain instance: %v\n", err)
 		return
 	}
+	isMainChain := !isOrphan && forkLen == 0
 	fmt.Printf("Block accepted. Is it on the main chain?: %v", isMainChain)
 	fmt.Printf("Block accepted. Is it an orphan?: %v", isOrphan)
 

--- a/blockchain/fullblocks_test.go
+++ b/blockchain/fullblocks_test.go
@@ -154,7 +154,7 @@ func TestFullBlocks(t *testing.T) {
 		t.Logf("Testing block %s (hash %s, height %d)",
 			item.Name, block.Hash(), blockHeight)
 
-		isMainChain, isOrphan, err := chain.ProcessBlock(block,
+		forkLen, isOrphan, err := chain.ProcessBlock(block,
 			blockchain.BFNone)
 		if err != nil {
 			t.Fatalf("block %q (hash %s, height %d) should "+
@@ -164,6 +164,7 @@ func TestFullBlocks(t *testing.T) {
 
 		// Ensure the main chain and orphan flags match the values
 		// specified in the test.
+		isMainChain := !isOrphan && forkLen == 0
 		if isMainChain != item.IsMainChain {
 			t.Fatalf("block %q (hash %s, height %d) unexpected main "+
 				"chain flag -- got %v, want %v", item.Name,

--- a/blockchain/fullblocksstakeversion_test.go
+++ b/blockchain/fullblocksstakeversion_test.go
@@ -46,7 +46,7 @@ func TestStakeVersion(t *testing.T) {
 		t.Logf("Testing block %s (hash %s, height %d)",
 			g.TipName(), block.Hash(), blockHeight)
 
-		isMainChain, isOrphan, err := chain.ProcessBlock(block, BFNone)
+		forkLen, isOrphan, err := chain.ProcessBlock(block, BFNone)
 		if err != nil {
 			t.Fatalf("block %q (hash %s, height %d) should "+
 				"have been accepted: %v", g.TipName(),
@@ -55,6 +55,7 @@ func TestStakeVersion(t *testing.T) {
 
 		// Ensure the main chain and orphan flags match the values
 		// specified in the test.
+		isMainChain := !isOrphan && forkLen == 0
 		if !isMainChain {
 			t.Fatalf("block %q (hash %s, height %d) unexpected main "+
 				"chain flag -- got %v, want true", g.TipName(),

--- a/blockchain/notifications.go
+++ b/blockchain/notifications.go
@@ -69,8 +69,8 @@ func (n NotificationType) String() string {
 // BlockAcceptedNtfnsData is the structure for data indicating information
 // about a block being accepted.
 type BlockAcceptedNtfnsData struct {
-	OnMainChain bool
-	Block       *dcrutil.Block
+	ForkLen int64
+	Block   *dcrutil.Block
 }
 
 // ReorganizationNtfnsData is the structure for data indicating information

--- a/blockchain/thresholdstate_test.go
+++ b/blockchain/thresholdstate_test.go
@@ -162,7 +162,7 @@ func TestThresholdState(t *testing.T) {
 		t.Logf("Testing block %s (hash %s, height %d)",
 			g.TipName(), block.Hash(), blockHeight)
 
-		isMainChain, isOrphan, err := chain.ProcessBlock(block, BFNone)
+		forkLen, isOrphan, err := chain.ProcessBlock(block, BFNone)
 		if err != nil {
 			t.Fatalf("block %q (hash %s, height %d) should "+
 				"have been accepted: %v", g.TipName(),
@@ -171,6 +171,7 @@ func TestThresholdState(t *testing.T) {
 
 		// Ensure the main chain and orphan flags match the values
 		// specified in the test.
+		isMainChain := !isOrphan && forkLen == 0
 		if !isMainChain {
 			t.Fatalf("block %q (hash %s, height %d) unexpected main "+
 				"chain flag -- got %v, want true", g.TipName(),

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -372,7 +372,7 @@ func TestCheckConnectBlockTemplate(t *testing.T) {
 		t.Logf("Testing block %s (hash %s, height %d)",
 			g.TipName(), block.Hash(), blockHeight)
 
-		isMainChain, isOrphan, err := chain.ProcessBlock(block, BFNone)
+		forkLen, isOrphan, err := chain.ProcessBlock(block, BFNone)
 		if err != nil {
 			t.Fatalf("block %q (hash %s, height %d) should "+
 				"have been accepted: %v", g.TipName(),
@@ -381,6 +381,7 @@ func TestCheckConnectBlockTemplate(t *testing.T) {
 
 		// Ensure the main chain and orphan flags match the values
 		// specified in the test.
+		isMainChain := !isOrphan && forkLen == 0
 		if !isMainChain {
 			t.Fatalf("block %q (hash %s, height %d) unexpected main "+
 				"chain flag -- got %v, want true", g.TipName(),
@@ -441,7 +442,7 @@ func TestCheckConnectBlockTemplate(t *testing.T) {
 		t.Logf("Testing block %s (hash %s, height %d)",
 			g.TipName(), block.Hash(), blockHeight)
 
-		isMainChain, isOrphan, err := chain.ProcessBlock(block, BFNone)
+		forkLen, isOrphan, err := chain.ProcessBlock(block, BFNone)
 		if err != nil {
 			t.Fatalf("block %q (hash %s, height %d) should "+
 				"have been accepted: %v", g.TipName(),
@@ -450,6 +451,7 @@ func TestCheckConnectBlockTemplate(t *testing.T) {
 
 		// Ensure the main chain and orphan flags match the values
 		// specified in the test.
+		isMainChain := !isOrphan && forkLen == 0
 		if isMainChain {
 			t.Fatalf("block %q (hash %s, height %d) unexpected main "+
 				"chain flag -- got %v, want false", g.TipName(),

--- a/cmd/addblock/import.go
+++ b/cmd/addblock/import.go
@@ -132,11 +132,12 @@ func (bi *blockImporter) processBlock(serializedBlock []byte) (bool, error) {
 
 	// Ensure the blocks follows all of the chain rules and match up to the
 	// known checkpoints.
-	isMainChain, isOrphan, err := bi.chain.ProcessBlock(block,
+	forkLen, isOrphan, err := bi.chain.ProcessBlock(block,
 		blockchain.BFFastAdd)
 	if err != nil {
 		return false, err
 	}
+	isMainChain := !isOrphan && forkLen == 0
 	if !isMainChain {
 		return false, fmt.Errorf("import file contains an block that "+
 			"does not extend the main chain: %v", blockHash)


### PR DESCRIPTION
This modifies the `ProcessBlock` function in the `blockchain` package to return the fork length for the connected block and updates all callers and tests accordingly.  Several of the internal functions which `ProcessBlock` calls are also updated in order to bubble the necessary information back up so it can be returned.  It does not make any behavioral changes.

This is being done to better expose information about the position of the block within the chain to callers without them having to make additional queries.