### PR TITLE
rpcserver: Correct rebroadcastwinners handler.

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4477,7 +4477,7 @@ func handleRebroadcastMissed(s *rpcServer, cmd interface{}, closeChan <-chan str
 
 // handleRebroadcastWinners implements the rebroadcastwinners command.
 func handleRebroadcastWinners(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
-	hash, height := s.server.blockManager.chainState.Best()
+	_, height := s.server.blockManager.chainState.Best()
 	blocks, err := s.server.blockManager.TipGeneration()
 	if err != nil {
 		return nil, rpcInternalError("Could not get generation "+
@@ -4492,7 +4492,7 @@ func handleRebroadcastWinners(s *rpcServer, cmd interface{}, closeChan <-chan st
 				"failed: "+err.Error(), "")
 		}
 		ntfnData := &WinningTicketsNtfnData{
-			BlockHash:   *hash,
+			BlockHash:   blocks[i],
 			BlockHeight: height,
 			Tickets:     winningTickets,
 		}


### PR DESCRIPTION
This corrects the handler for the `rebroadcastwinners` RPC to return the hash of the block the tickets are voting on when there are multiple candidates at the current tip as opposed to all claiming to vote on the current best block.