### PR TITLE
multi: No winning ticket ntfns for big reorg depth.

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -213,10 +213,12 @@ func (b *BlockChain) maybeAcceptBlock(block *dcrutil.Block, flags BehaviorFlags)
 	// Notify the caller that the new block was accepted into the block
 	// chain.  The caller would typically want to react by relaying the
 	// inventory to other peers.
+	bestHeight := b.bestNode.height
 	b.chainLock.Unlock()
 	b.sendNotification(NTBlockAccepted, &BlockAcceptedNtfnsData{
-		ForkLen: forkLen,
-		Block:   block,
+		BestHeight: bestHeight,
+		ForkLen:    forkLen,
+		Block:      block,
 	})
 	b.chainLock.Lock()
 

--- a/blockchain/notifications.go
+++ b/blockchain/notifications.go
@@ -67,10 +67,25 @@ func (n NotificationType) String() string {
 }
 
 // BlockAcceptedNtfnsData is the structure for data indicating information
-// about a block being accepted.
+// about an accepted block.  Note that this does not necessarily mean the block
+// that was accepted extended the best chain as it might have created or
+// extended a side chain.
 type BlockAcceptedNtfnsData struct {
+	// BestHeight is the height of the current best chain.  Since the accepted
+	// block might be on a side chain, this is not necessarily the same as the
+	// height of the accepted block.
+	BestHeight int64
+
+	// ForkLen is the length of the side chain the block extended or zero in the
+	// case the block extended the main chain.
+	//
+	// This can be used in conjunction with the height of the accepted block to
+	// determine the height at which the side chain the block created or
+	// extended forked from the best chain.
 	ForkLen int64
-	Block   *dcrutil.Block
+
+	// Block is the block that was accepted into the chain.
+	Block *dcrutil.Block
 }
 
 // ReorganizationNtfnsData is the structure for data indicating information


### PR DESCRIPTION
This modifies the logic which sends winning ticket notifications to RPC clients to consider the reorganization depth and refuse to send the notifications for blocks on side chains that would ultimately result in a reorg of 6 or more blocks.

Also, the code used to send the notifications was needlessly repeated in multiple places since any blocks accepted via `ProcessBlock` also result in an accepted notification and therefore the RPC notification only
needs to be sent from there.