### PR TITLE
multi: Refactor and optimize inv discovery.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -135,6 +135,11 @@ type BlockChain struct {
 	bestNode *blockNode
 	index    *blockIndex
 
+	// This field allows efficient lookup of nodes in the main chain by
+	// height.  It is protected by the height lock.
+	heightLock        sync.RWMutex
+	mainNodesByHeight map[int64]*blockNode
+
 	// These fields are related to handling of orphan blocks.  They are
 	// protected by a combination of the chain lock and the orphan lock.
 	orphanLock   sync.RWMutex
@@ -814,6 +819,9 @@ func (b *BlockChain) connectBlock(node *blockNode, block, parent *dcrutil.Block,
 
 	// Mark block as being in the main chain.
 	node.inMainChain = true
+	b.heightLock.Lock()
+	b.mainNodesByHeight[node.height] = node
+	b.heightLock.Unlock()
 
 	// This node is now the end of the best chain.
 	b.bestNode = node
@@ -989,6 +997,9 @@ func (b *BlockChain) disconnectBlock(node *blockNode, block, parent *dcrutil.Blo
 
 	// Mark block as being in a side chain.
 	node.inMainChain = false
+	b.heightLock.Lock()
+	delete(b.mainNodesByHeight, node.height)
+	b.heightLock.Unlock()
 
 	// This node's parent is now the end of the best chain.
 	b.bestNode = node.parent
@@ -1693,6 +1704,169 @@ func (b *BlockChain) FetchHeader(hash *chainhash.Hash) (wire.BlockHeader, error)
 	return *header, nil
 }
 
+// locateInventory returns the node of the block after the first known block in
+// the locator along with the number of subsequent nodes needed to either reach
+// the provided stop hash or the provided max number of entries.
+//
+// In addition, there are two special cases:
+//
+// - When no locators are provided, the stop hash is treated as a request for
+//   that block, so it will either return the node associated with the stop hash
+//   if it is known, or nil if it is unknown
+// - When locators are provided, but none of them are known, nodes starting
+//   after the genesis block will be returned
+//
+// This is primarily a helper function for the locateBlocks and locateHeaders
+// functions.
+//
+// This function MUST be called with the chain state lock held (for reads).
+func (b *BlockChain) locateInventory(locator BlockLocator, hashStop *chainhash.Hash, maxEntries uint32) (*blockNode, uint32) {
+	// There are no block locators so a specific block is being requested
+	// as identified by the stop hash.
+	stopNode := b.index.LookupNode(hashStop)
+	if len(locator) == 0 {
+		if stopNode == nil {
+			// No blocks with the stop hash were found so there is
+			// nothing to do.
+			return nil, 0
+		}
+		return stopNode, 1
+	}
+
+	// Find the most recent locator block hash in the main chain.  In the
+	// case none of the hashes in the locator are in the main chain, fall
+	// back to the genesis block.
+	b.heightLock.RLock()
+	startNode := b.mainNodesByHeight[0]
+	b.heightLock.RUnlock()
+	for _, hash := range locator {
+		node := b.index.LookupNode(hash)
+		if node != nil && node.inMainChain {
+			startNode = node
+			break
+		}
+	}
+
+	// Start at the block after the most recently known block.  When there
+	// is no next block it means the most recently known block is the tip of
+	// the best chain, so there is nothing more to do.
+	if startNode != nil {
+		b.heightLock.RLock()
+		startNode = b.mainNodesByHeight[startNode.height+1]
+		b.heightLock.RUnlock()
+	}
+	if startNode == nil {
+		return nil, 0
+	}
+
+	// Calculate how many entries are needed.
+	total := uint32((b.bestNode.height - startNode.height) + 1)
+	if stopNode != nil && stopNode.inMainChain && stopNode.height >=
+		startNode.height {
+
+		total = uint32((stopNode.height - startNode.height) + 1)
+	}
+	if total > maxEntries {
+		total = maxEntries
+	}
+
+	return startNode, total
+}
+
+// locateBlocks returns the hashes of the blocks after the first known block in
+// the locator until the provided stop hash is reached, or up to the provided
+// max number of block hashes.
+//
+// See the comment on the exported function for more details on special cases.
+//
+// This function MUST be called with the chain state lock held (for reads).
+func (b *BlockChain) locateBlocks(locator BlockLocator, hashStop *chainhash.Hash, maxHashes uint32) []chainhash.Hash {
+	// Find the node after the first known block in the locator and the
+	// total number of nodes after it needed while respecting the stop hash
+	// and max entries.
+	node, total := b.locateInventory(locator, hashStop, maxHashes)
+	if total == 0 {
+		return nil
+	}
+
+	// Populate and return the found hashes.
+	hashes := make([]chainhash.Hash, 0, total)
+	b.heightLock.RLock()
+	for i := uint32(0); i < total; i++ {
+		hashes = append(hashes, node.hash)
+		node = b.mainNodesByHeight[node.height+1]
+	}
+	b.heightLock.RUnlock()
+	return hashes
+}
+
+// LocateBlocks returns the hashes of the blocks after the first known block in
+// the locator until the provided stop hash is reached, or up to the provided
+// max number of block hashes.
+//
+// In addition, there are two special cases:
+//
+// - When no locators are provided, the stop hash is treated as a request for
+//   that block, so it will either return the stop hash itself if it is known,
+//   or nil if it is unknown
+// - When locators are provided, but none of them are known, hashes starting
+//   after the genesis block will be returned
+//
+// This function is safe for concurrent access.
+func (b *BlockChain) LocateBlocks(locator BlockLocator, hashStop *chainhash.Hash, maxHashes uint32) []chainhash.Hash {
+	b.chainLock.RLock()
+	hashes := b.locateBlocks(locator, hashStop, maxHashes)
+	b.chainLock.RUnlock()
+	return hashes
+}
+
+// locateHeaders returns the headers of the blocks after the first known block
+// in the locator until the provided stop hash is reached, or up to the provided
+// max number of block headers.
+//
+// See the comment on the exported function for more details on special cases.
+//
+// This function MUST be called with the chain state lock held (for reads).
+func (b *BlockChain) locateHeaders(locator BlockLocator, hashStop *chainhash.Hash, maxHeaders uint32) []wire.BlockHeader {
+	// Find the node after the first known block in the locator and the
+	// total number of nodes after it needed while respecting the stop hash
+	// and max entries.
+	node, total := b.locateInventory(locator, hashStop, maxHeaders)
+	if total == 0 {
+		return nil
+	}
+
+	// Populate and return the found headers.
+	headers := make([]wire.BlockHeader, 0, total)
+	for i := uint32(0); i < total; i++ {
+		headers = append(headers, node.Header())
+		b.heightLock.RLock()
+		node = b.mainNodesByHeight[node.height+1]
+		b.heightLock.RUnlock()
+	}
+	return headers
+}
+
+// LocateHeaders returns the headers of the blocks after the first known block
+// in the locator until the provided stop hash is reached, or up to a max of
+// wire.MaxBlockHeadersPerMsg headers.
+//
+// In addition, there are two special cases:
+//
+// - When no locators are provided, the stop hash is treated as a request for
+//   that header, so it will either return the header for the stop hash itself
+//   if it is known, or nil if it is unknown
+// - When locators are provided, but none of them are known, headers starting
+//   after the genesis block will be returned
+//
+// This function is safe for concurrent access.
+func (b *BlockChain) LocateHeaders(locator BlockLocator, hashStop *chainhash.Hash) []wire.BlockHeader {
+	b.chainLock.RLock()
+	headers := b.locateHeaders(locator, hashStop, wire.MaxBlockHeadersPerMsg)
+	b.chainLock.RUnlock()
+	return headers
+}
+
 // IndexManager provides a generic interface that the is called when blocks are
 // connected and disconnected to and from the tip of the main chain for the
 // purpose of supporting optional indexes.
@@ -1798,6 +1972,7 @@ func New(config *Config) (*BlockChain, error) {
 		sigCache:                      config.SigCache,
 		indexManager:                  config.IndexManager,
 		index:                         newBlockIndex(config.DB, params),
+		mainNodesByHeight:             make(map[int64]*blockNode),
 		orphans:                       make(map[chainhash.Hash]*orphanBlock),
 		prevOrphans:                   make(map[chainhash.Hash][]*orphanBlock),
 		mainchainBlockCache:           make(map[chainhash.Hash]*dcrutil.Block),

--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -12,11 +12,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/decred/dcrd/blockchain/chaingen"
 	"github.com/decred/dcrd/chaincfg"
+	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil"
+	"github.com/decred/dcrd/wire"
 )
 
 // cloneParams returns a deep copy of the provided parameters so the caller is
@@ -402,4 +405,384 @@ func TestForceHeadReorg(t *testing.T) {
 	//               \-> b4(1)
 	forceTipReorg("b4", "b5")
 	expectTip("b5")
+}
+
+// locatorHashes is a convenience function that returns the hashes for all of
+// the passed indexes of the provided nodes.  It is used to construct expected
+// block locators in the tests.
+func locatorHashes(nodes []*blockNode, indexes ...int) BlockLocator {
+	hashes := make(BlockLocator, 0, len(indexes))
+	for _, idx := range indexes {
+		hashes = append(hashes, &nodes[idx].hash)
+	}
+	return hashes
+}
+
+// nodeHashes is a convenience function that returns the hashes for all of the
+// passed indexes of the provided nodes.  It is used to construct expected hash
+// slices in the tests.
+func nodeHashes(nodes []*blockNode, indexes ...int) []chainhash.Hash {
+	hashes := make([]chainhash.Hash, 0, len(indexes))
+	for _, idx := range indexes {
+		hashes = append(hashes, nodes[idx].hash)
+	}
+	return hashes
+}
+
+// nodeHeaders is a convenience function that returns the headers for all of
+// the passed indexes of the provided nodes.  It is used to construct expected
+// located headers in the tests.
+func nodeHeaders(nodes []*blockNode, indexes ...int) []wire.BlockHeader {
+	headers := make([]wire.BlockHeader, 0, len(indexes))
+	for _, idx := range indexes {
+		headers = append(headers, nodes[idx].Header())
+	}
+	return headers
+}
+
+// TestLocateInventory ensures that locating inventory via the LocateHeaders and
+// LocateBlocks functions behaves as expected.
+func TestLocateInventory(t *testing.T) {
+	// Construct a synthetic block chain with a block index consisting of
+	// the following structure.
+	// 	genesis -> 1 -> 2 -> ... -> 15 -> 16  -> 17  -> 18
+	// 	                              \-> 16a -> 17a
+	tip := branchTip
+	chain := newFakeChain(&chaincfg.MainNetParams)
+	branch0Nodes := chainedFakeNodes(chain.bestNode, 18)
+	branch1Nodes := chainedFakeNodes(branch0Nodes[14], 2)
+	for _, node := range branch0Nodes {
+		chain.index.AddNode(node)
+		node.inMainChain = true
+		chain.mainNodesByHeight[node.height] = node
+	}
+	for _, node := range branch1Nodes {
+		chain.index.AddNode(node)
+		node.inMainChain = false
+	}
+	chain.bestNode = tip(branch0Nodes)
+
+	// NOTE: These tests simulate a local and remote node on different parts of
+	// the chain by treating the branch0Nodes as the local node and the
+	// branch1Nodes as the remote node.
+
+	// Create a completely unrelated block chain to simulate a remote node on a
+	// totally different chain.
+	unrelatedChain := newFakeChain(&chaincfg.MainNetParams)
+	unrelatedBranchNodes := chainedFakeNodes(unrelatedChain.bestNode, 5)
+	for _, node := range unrelatedBranchNodes {
+		unrelatedChain.index.AddNode(node)
+		node.inMainChain = true
+		unrelatedChain.mainNodesByHeight[node.height] = node
+	}
+
+	tests := []struct {
+		name       string
+		locator    BlockLocator       // locator for requested inventory
+		hashStop   chainhash.Hash     // stop hash for locator
+		maxAllowed uint32             // max to locate, 0 = wire const
+		headers    []wire.BlockHeader // expected located headers
+		hashes     []chainhash.Hash   // expected located hashes
+	}{
+		{
+			// Empty block locators and unknown stop hash.  No
+			// inventory should be located.
+			name:     "no locators, no stop",
+			locator:  nil,
+			hashStop: chainhash.Hash{},
+			headers:  nil,
+			hashes:   nil,
+		},
+		{
+			// Empty block locators and stop hash in side chain.
+			// The expected result is the requested block.
+			name:     "no locators, stop in side",
+			locator:  nil,
+			hashStop: tip(branch1Nodes).hash,
+			headers:  nodeHeaders(branch1Nodes, 1),
+			hashes:   nodeHashes(branch1Nodes, 1),
+		},
+		{
+			// Empty block locators and stop hash in main chain.
+			// The expected result is the requested block.
+			name:     "no locators, stop in main",
+			locator:  nil,
+			hashStop: branch0Nodes[12].hash,
+			headers:  nodeHeaders(branch0Nodes, 12),
+			hashes:   nodeHashes(branch0Nodes, 12),
+		},
+		{
+			// Locators based on remote being on side chain and a
+			// stop hash local node doesn't know about.  The
+			// expected result is the blocks after the fork point in
+			// the main chain and the stop hash has no effect.
+			name:     "remote side chain, unknown stop",
+			locator:  blockLocator(tip(branch1Nodes)),
+			hashStop: chainhash.Hash{0x01},
+			headers:  nodeHeaders(branch0Nodes, 15, 16, 17),
+			hashes:   nodeHashes(branch0Nodes, 15, 16, 17),
+		},
+		{
+			// Locators based on remote being on side chain and a
+			// stop hash in side chain.  The expected result is the
+			// blocks after the fork point in the main chain and the
+			// stop hash has no effect.
+			name:     "remote side chain, stop in side",
+			locator:  blockLocator(tip(branch1Nodes)),
+			hashStop: tip(branch1Nodes).hash,
+			headers:  nodeHeaders(branch0Nodes, 15, 16, 17),
+			hashes:   nodeHashes(branch0Nodes, 15, 16, 17),
+		},
+		{
+			// Locators based on remote being on side chain and a
+			// stop hash in main chain, but before fork point.  The
+			// expected result is the blocks after the fork point in
+			// the main chain and the stop hash has no effect.
+			name:     "remote side chain, stop in main before",
+			locator:  blockLocator(tip(branch1Nodes)),
+			hashStop: branch0Nodes[13].hash,
+			headers:  nodeHeaders(branch0Nodes, 15, 16, 17),
+			hashes:   nodeHashes(branch0Nodes, 15, 16, 17),
+		},
+		{
+			// Locators based on remote being on side chain and a
+			// stop hash in main chain, but exactly at the fork
+			// point.  The expected result is the blocks after the
+			// fork point in the main chain and the stop hash has no
+			// effect.
+			name:     "remote side chain, stop in main exact",
+			locator:  blockLocator(tip(branch1Nodes)),
+			hashStop: branch0Nodes[14].hash,
+			headers:  nodeHeaders(branch0Nodes, 15, 16, 17),
+			hashes:   nodeHashes(branch0Nodes, 15, 16, 17),
+		},
+		{
+			// Locators based on remote being on side chain and a
+			// stop hash in main chain just after the fork point.
+			// The expected result is the blocks after the fork
+			// point in the main chain up to and including the stop
+			// hash.
+			name:     "remote side chain, stop in main after",
+			locator:  blockLocator(tip(branch1Nodes)),
+			hashStop: branch0Nodes[15].hash,
+			headers:  nodeHeaders(branch0Nodes, 15),
+			hashes:   nodeHashes(branch0Nodes, 15),
+		},
+		{
+			// Locators based on remote being on side chain and a
+			// stop hash in main chain some time after the fork
+			// point.  The expected result is the blocks after the
+			// fork point in the main chain up to and including the
+			// stop hash.
+			name:     "remote side chain, stop in main after more",
+			locator:  blockLocator(tip(branch1Nodes)),
+			hashStop: branch0Nodes[16].hash,
+			headers:  nodeHeaders(branch0Nodes, 15, 16),
+			hashes:   nodeHashes(branch0Nodes, 15, 16),
+		},
+		{
+			// Locators based on remote being on main chain in the
+			// past and a stop hash local node doesn't know about.
+			// The expected result is the blocks after the known
+			// point in the main chain and the stop hash has no
+			// effect.
+			name:     "remote main chain past, unknown stop",
+			locator:  blockLocator(branch0Nodes[12]),
+			hashStop: chainhash.Hash{0x01},
+			headers:  nodeHeaders(branch0Nodes, 13, 14, 15, 16, 17),
+			hashes:   nodeHashes(branch0Nodes, 13, 14, 15, 16, 17),
+		},
+		{
+			// Locators based on remote being on main chain in the
+			// past and a stop hash in a side chain.  The expected
+			// result is the blocks after the known point in the
+			// main chain and the stop hash has no effect.
+			name:     "remote main chain past, stop in side",
+			locator:  blockLocator(branch0Nodes[12]),
+			hashStop: tip(branch1Nodes).hash,
+			headers:  nodeHeaders(branch0Nodes, 13, 14, 15, 16, 17),
+			hashes:   nodeHashes(branch0Nodes, 13, 14, 15, 16, 17),
+		},
+		{
+			// Locators based on remote being on main chain in the
+			// past and a stop hash in the main chain before that
+			// point.  The expected result is the blocks after the
+			// known point in the main chain and the stop hash has
+			// no effect.
+			name:     "remote main chain past, stop in main before",
+			locator:  blockLocator(branch0Nodes[12]),
+			hashStop: branch0Nodes[11].hash,
+			headers:  nodeHeaders(branch0Nodes, 13, 14, 15, 16, 17),
+			hashes:   nodeHashes(branch0Nodes, 13, 14, 15, 16, 17),
+		},
+		{
+			// Locators based on remote being on main chain in the
+			// past and a stop hash in the main chain exactly at that
+			// point.  The expected result is the blocks after the
+			// known point in the main chain and the stop hash has
+			// no effect.
+			name:     "remote main chain past, stop in main exact",
+			locator:  blockLocator(branch0Nodes[12]),
+			hashStop: branch0Nodes[12].hash,
+			headers:  nodeHeaders(branch0Nodes, 13, 14, 15, 16, 17),
+			hashes:   nodeHashes(branch0Nodes, 13, 14, 15, 16, 17),
+		},
+		{
+			// Locators based on remote being on main chain in the
+			// past and a stop hash in the main chain just after
+			// that point.  The expected result is the blocks after
+			// the known point in the main chain and the stop hash
+			// has no effect.
+			name:     "remote main chain past, stop in main after",
+			locator:  blockLocator(branch0Nodes[12]),
+			hashStop: branch0Nodes[13].hash,
+			headers:  nodeHeaders(branch0Nodes, 13),
+			hashes:   nodeHashes(branch0Nodes, 13),
+		},
+		{
+			// Locators based on remote being on main chain in the
+			// past and a stop hash in the main chain some time
+			// after that point.  The expected result is the blocks
+			// after the known point in the main chain and the stop
+			// hash has no effect.
+			name:     "remote main chain past, stop in main after more",
+			locator:  blockLocator(branch0Nodes[12]),
+			hashStop: branch0Nodes[15].hash,
+			headers:  nodeHeaders(branch0Nodes, 13, 14, 15),
+			hashes:   nodeHashes(branch0Nodes, 13, 14, 15),
+		},
+		{
+			// Locators based on remote being at exactly the same
+			// point in the main chain and a stop hash local node
+			// doesn't know about.  The expected result is no
+			// located inventory.
+			name:     "remote main chain same, unknown stop",
+			locator:  blockLocator(tip(branch0Nodes)),
+			hashStop: chainhash.Hash{0x01},
+			headers:  nil,
+			hashes:   nil,
+		},
+		{
+			// Locators based on remote being at exactly the same
+			// point in the main chain and a stop hash at exactly
+			// the same point.  The expected result is no located
+			// inventory.
+			name:     "remote main chain same, stop same point",
+			locator:  blockLocator(tip(branch0Nodes)),
+			hashStop: tip(branch0Nodes).hash,
+			headers:  nil,
+			hashes:   nil,
+		},
+		{
+			// Locators from remote that don't include any blocks
+			// the local node knows.  This would happen if the
+			// remote node is on a completely separate chain that
+			// isn't rooted with the same genesis block.  The
+			// expected result is the blocks after the genesis
+			// block.
+			name:     "remote unrelated chain",
+			locator:  blockLocator(tip(unrelatedBranchNodes)),
+			hashStop: chainhash.Hash{},
+			headers: nodeHeaders(branch0Nodes, 0, 1, 2, 3, 4, 5, 6,
+				7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17),
+			hashes: nodeHashes(branch0Nodes, 0, 1, 2, 3, 4, 5, 6,
+				7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17),
+		},
+		{
+			// Locators from remote for second block in main chain
+			// and no stop hash, but with an overridden max limit.
+			// The expected result is the blocks after the second
+			// block limited by the max.
+			name:       "remote genesis",
+			locator:    locatorHashes(branch0Nodes, 0),
+			hashStop:   chainhash.Hash{},
+			maxAllowed: 3,
+			headers:    nodeHeaders(branch0Nodes, 1, 2, 3),
+			hashes:     nodeHashes(branch0Nodes, 1, 2, 3),
+		},
+		{
+			// Poorly formed locator.
+			//
+			// Locator from remote that only includes a single
+			// block on a side chain the local node knows.  The
+			// expected result is the blocks after the genesis
+			// block since even though the block is known, it is on
+			// a side chain and there are no more locators to find
+			// the fork point.
+			name:     "weak locator, single known side block",
+			locator:  locatorHashes(branch1Nodes, 1),
+			hashStop: chainhash.Hash{},
+			headers: nodeHeaders(branch0Nodes, 0, 1, 2, 3, 4, 5, 6,
+				7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17),
+			hashes: nodeHashes(branch0Nodes, 0, 1, 2, 3, 4, 5, 6,
+				7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17),
+		},
+		{
+			// Poorly formed locator.
+			//
+			// Locator from remote that only includes multiple
+			// blocks on a side chain the local node knows however
+			// none in the main chain.  The expected result is the
+			// blocks after the genesis block since even though the
+			// blocks are known, they are all on a side chain and
+			// there are no more locators to find the fork point.
+			name:     "weak locator, multiple known side blocks",
+			locator:  locatorHashes(branch1Nodes, 1),
+			hashStop: chainhash.Hash{},
+			headers: nodeHeaders(branch0Nodes, 0, 1, 2, 3, 4, 5, 6,
+				7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17),
+			hashes: nodeHashes(branch0Nodes, 0, 1, 2, 3, 4, 5, 6,
+				7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17),
+		},
+		{
+			// Poorly formed locator.
+			//
+			// Locator from remote that only includes multiple
+			// blocks on a side chain the local node knows however
+			// none in the main chain but includes a stop hash in
+			// the main chain.  The expected result is the blocks
+			// after the genesis block up to the stop hash since
+			// even though the blocks are known, they are all on a
+			// side chain and there are no more locators to find the
+			// fork point.
+			name:     "weak locator, multiple known side blocks, stop in main",
+			locator:  locatorHashes(branch1Nodes, 1),
+			hashStop: branch0Nodes[5].hash,
+			headers:  nodeHeaders(branch0Nodes, 0, 1, 2, 3, 4, 5),
+			hashes:   nodeHashes(branch0Nodes, 0, 1, 2, 3, 4, 5),
+		},
+	}
+	for _, test := range tests {
+		// Ensure the expected headers are located.
+		var headers []wire.BlockHeader
+		if test.maxAllowed != 0 {
+			// Need to use the unexported function to override the
+			// max allowed for headers.
+			chain.chainLock.RLock()
+			headers = chain.locateHeaders(test.locator,
+				&test.hashStop, test.maxAllowed)
+			chain.chainLock.RUnlock()
+		} else {
+			headers = chain.LocateHeaders(test.locator,
+				&test.hashStop)
+		}
+		if !reflect.DeepEqual(headers, test.headers) {
+			t.Errorf("%s: unxpected headers -- got %v, want %v",
+				test.name, headers, test.headers)
+			continue
+		}
+
+		// Ensure the expected block hashes are located.
+		maxAllowed := uint32(wire.MaxBlocksPerMsg)
+		if test.maxAllowed != 0 {
+			maxAllowed = test.maxAllowed
+		}
+		hashes := chain.LocateBlocks(test.locator, &test.hashStop,
+			maxAllowed)
+		if !reflect.DeepEqual(hashes, test.hashes) {
+			t.Errorf("%s: unxpected hashes -- got %v, want %v",
+				test.name, hashes, test.hashes)
+			continue
+		}
+	}
 }

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1840,9 +1840,10 @@ func (b *BlockChain) initChainState(interrupt <-chan struct{}) error {
 		b.bestNode = tip
 
 		// Mark all of the nodes from the tip back to the genesis block
-		// as part of the main chain.
+		// as part of the main chain and build the by height map.
 		for n := tip; n != nil; n = n.parent {
 			n.inMainChain = true
+			b.mainNodesByHeight[n.height] = n
 		}
 
 		log.Debugf("Block index loaded in %v", time.Since(bidxStart))

--- a/blockchain/common_test.go
+++ b/blockchain/common_test.go
@@ -139,12 +139,15 @@ func newFakeChain(params *chaincfg.Params) *BlockChain {
 	node.inMainChain = true
 	index := newBlockIndex(nil, params)
 	index.AddNode(node)
+	mainNodesByHeight := make(map[int64]*blockNode)
+	mainNodesByHeight[node.height] = node
 
 	return &BlockChain{
-		chainParams:      params,
-		deploymentCaches: newThresholdCaches(params),
-		bestNode:         node,
-		index:            index,
+		chainParams:                   params,
+		deploymentCaches:              newThresholdCaches(params),
+		bestNode:                      node,
+		index:                         index,
+		mainNodesByHeight:             mainNodesByHeight,
 		isVoterMajorityVersionCache:   make(map[[stakeMajorityCacheKeySize]byte]bool),
 		isStakeMajorityVersionCache:   make(map[[stakeMajorityCacheKeySize]byte]bool),
 		calcPriorStakeVersionCache:    make(map[[chainhash.HashSize]byte]uint32),
@@ -192,6 +195,12 @@ func chainedFakeNodes(parent *blockNode, numNodes int) []*blockNode {
 		nodes[i] = node
 	}
 	return nodes
+}
+
+// branchTip is a convenience function to grab the tip of a chain of block nodes
+// created via chainedFakeNodes.
+func branchTip(nodes []*blockNode) *blockNode {
+	return nodes[len(nodes)-1]
 }
 
 // appendFakeVotes appends the passed number of votes to the node with the


### PR DESCRIPTION
**This requires PRs #1229, #1230, and #1237.**

This refactors the code that locates blocks (inventory discovery) out of `server` and into `blockchain` where it can make use of the fact that all block nodes are now in memory and more easily be tested.  As an aside, it really belongs in blockchain anyways since it's purely dealing with the block index and best chain.

In order to do this reasonably efficiently, a new memory-only height to block node mapping for the main chain is introduced to allow efficient forward traversal of the main chain.  This is ultimately intended to be replaced by a chain view.

Since the network will be moving to header-based semantics, this also provides an additional optimization to allow headers to be located directly versus needing to first discover the hashes and then fetch the headers.

The new functions are named `LocateBlocks` and `LocateHeaders`. The former returns a slice of located hashes and the latter returns a slice of located headers.

Finally, it also updates the RPC server `getheaders` call and related plumbing to use the new `LocateHeaders` function.

A comprehensive suite of tests is provided to ensure both functions behave correctly for both correct and incorrect block locators.

This is work towards #1145 and fixes #427.