### PR TITLE
multi: modify PurchaseTicketCmd.

### DIFF
--- a/dcrjson/dcrwalletextcmds.go
+++ b/dcrjson/dcrwalletextcmds.go
@@ -294,14 +294,14 @@ type PurchaseTicketCmd struct {
 	PoolFees      *float64
 	Expiry        *int
 	Comment       *string
-	SplitTx       *uint32
+	TicketChange  *bool
 	TicketFee     *float64
 }
 
 // NewPurchaseTicketCmd creates a new PurchaseTicketCmd.
 func NewPurchaseTicketCmd(fromAccount string, spendLimit float64, minConf *int,
 	ticketAddress *string, numTickets *int, poolAddress *string, poolFees *float64,
-	expiry *int, comment *string, splitTx *uint32, ticketFee *float64) *PurchaseTicketCmd {
+	expiry *int, comment *string, ticketChange *bool, ticketFee *float64) *PurchaseTicketCmd {
 	return &PurchaseTicketCmd{
 		FromAccount:   fromAccount,
 		SpendLimit:    spendLimit,
@@ -312,7 +312,7 @@ func NewPurchaseTicketCmd(fromAccount string, spendLimit float64, minConf *int,
 		PoolFees:      poolFees,
 		Expiry:        expiry,
 		Comment:       comment,
-		SplitTx:       splitTx,
+		TicketChange:  ticketChange,
 		TicketFee:     ticketFee,
 	}
 }

--- a/rpcclient/wallet.go
+++ b/rpcclient/wallet.go
@@ -761,7 +761,7 @@ func (r FuturePurchaseTicketResult) Receive() ([]*chainhash.Hash, error) {
 func (c *Client) PurchaseTicketAsync(fromAccount string,
 	spendLimit dcrutil.Amount, minConf *int, ticketAddress dcrutil.Address,
 	numTickets *int, poolAddress dcrutil.Address, poolFees *dcrutil.Amount,
-	expiry *int, splitTx *uint32, ticketFee *dcrutil.Amount) FuturePurchaseTicketResult {
+	expiry *int, ticketChange *bool, ticketFee *dcrutil.Amount) FuturePurchaseTicketResult {
 	// An empty string is used to keep the sendCmd
 	// passing of the command from accidentally
 	// removing certain fields. We fill in the
@@ -803,14 +803,9 @@ func (c *Client) PurchaseTicketAsync(fromAccount string,
 		ticketFeeFloat = ticketFee.ToCoin()
 	}
 
-	splitTxVal := uint32(1)
-	if splitTx != nil {
-		splitTxVal = *splitTx
-	}
-
 	cmd := dcrjson.NewPurchaseTicketCmd(fromAccount, spendLimit.ToCoin(),
 		&minConfVal, &ticketAddrStr, &numTicketsVal, &poolAddrStr,
-		&poolFeesFloat, &expiryVal, dcrjson.String(""), &splitTxVal, &ticketFeeFloat)
+		&poolFeesFloat, &expiryVal, dcrjson.String(""), ticketChange, &ticketFeeFloat)
 
 	return c.sendCmd(cmd)
 }
@@ -820,10 +815,10 @@ func (c *Client) PurchaseTicketAsync(fromAccount string,
 func (c *Client) PurchaseTicket(fromAccount string,
 	spendLimit dcrutil.Amount, minConf *int, ticketAddress dcrutil.Address,
 	numTickets *int, poolAddress dcrutil.Address, poolFees *dcrutil.Amount,
-	expiry *int, splitTx *uint32, ticketFee *dcrutil.Amount) ([]*chainhash.Hash, error) {
+	expiry *int, ticketChange *bool, ticketFee *dcrutil.Amount) ([]*chainhash.Hash, error) {
 
 	return c.PurchaseTicketAsync(fromAccount, spendLimit, minConf, ticketAddress,
-		numTickets, poolAddress, poolFees, expiry, splitTx, ticketFee).Receive()
+		numTickets, poolAddress, poolFees, expiry, ticketChange, ticketFee).Receive()
 }
 
 // SStx generation RPC call handling


### PR DESCRIPTION
This renames the SplitTx field to TicketChange since it better describes
the feature being opted into. The field type was also changed to a bool
pointer.