### PR TITLE
blockchain: Panic on fatal assertions.

### DIFF
--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -2654,9 +2654,9 @@ func (b *BlockChain) CheckConnectBlockTemplate(block *dcrutil.Block) error {
 			}
 		}
 		if n.hash != *block.Hash() {
-			return AssertError(fmt.Sprintf("detach block node hash %v (height "+
-				"%v) does not match previous parent block hash %v", &n.hash,
-				n.height, block.Hash()))
+			panicf("detach block node hash %v (height %v) does not match "+
+				"previous parent block hash %v", &n.hash, n.height,
+				block.Hash())
 		}
 
 		parent, err := b.fetchMainChainBlockByHash(&n.parentHash)
@@ -2720,9 +2720,9 @@ func (b *BlockChain) CheckConnectBlockTemplate(block *dcrutil.Block) error {
 			}
 		}
 		if n.parentHash != *parent.Hash() {
-			return AssertError(fmt.Sprintf("attach block node hash %v (height "+
-				"%v) parent hash %v does not match previous parent block "+
-				"hash %v", &n.hash, n.height, &n.parentHash, parent.Hash()))
+			panicf("attach block node hash %v (height %v) parent hash %v does "+
+				"not match previous parent block hash %v", &n.hash, n.height,
+				&n.parentHash, parent.Hash())
 		}
 
 		// Store the loaded block for the next iteration.


### PR DESCRIPTION
This modifies the code to panic under unrecoverable conditions which will very likely lead to worse things happening such as writing incorrect information to the database versus return an assertion error.

We generally prefer to avoid using panics in packages since it largely takes control away from the caller (although they can use recover to catch them) and they are often misused as a substitute for proper error
handling.  However, the particular cases this changes really need to be panics because they apply to algorithmic invariants that if violated can lead to consensus failure, corrupted state, and other disastrous
outcomes.

Note that there are still some other cases in the package that return assert errors, but they either really should be returning a different error as they are not unrecoverable situations or they're in code that will be removed.