### PR TITLE
blockchain: Improve spend journal tests.

### DIFF
--- a/blockchain/chainio_test.go
+++ b/blockchain/chainio_test.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"math/big"
 	"reflect"
 	"testing"
@@ -64,39 +63,6 @@ func hexToExtraData(s string) [32]byte {
 	}
 	copy(extraData[:], b)
 	return extraData
-}
-
-// DoStxoTest does a test on a simulated blockchain to ensure that the data
-// stored in the STXO buckets is not corrupt.
-func (b *BlockChain) DoStxoTest() error {
-	return b.db.View(func(dbTx database.Tx) error {
-		for i := int64(2); i <= b.bestNode.height; i++ {
-			block, err := dbFetchBlockByHeight(dbTx, i)
-			if err != nil {
-				return err
-			}
-
-			parent, err := dbFetchBlockByHeight(dbTx, i-1)
-			if err != nil {
-				return err
-			}
-
-			ntx := countSpentOutputs(block, parent)
-			stxos, err := dbFetchSpendJournalEntry(dbTx, block,
-				parent)
-			if err != nil {
-				return err
-			}
-
-			if ntx != len(stxos) {
-				return fmt.Errorf("bad number of stxos "+
-					"calculated at "+"height %v, got %v "+
-					"expected %v", i, len(stxos), ntx)
-			}
-		}
-
-		return nil
-	})
 }
 
 // TestErrNotInMainChain ensures the functions related to errNotInMainChain work


### PR DESCRIPTION
This cleans up and corrects the spend journal tests which deal with a live blockchain.

First, it updates the params used in the test to the legacy values so the blocks actually connect to the main chain instead of being added as orphans.

Second, it checks the return value from `ProcessBlock` for whether or not the block is on the main chain and fails if it is not to ensure it actually is on the main chain.

Finally, it moves the core logic which checks the number of spend outputs matches the serialized spend journal directly into the test instead of calling a separate `DoStxoTest` function on the `blockchain` instance for that purpose and removes that now unused function.