### PR TITLE
peer: Allow OnVersion callback to reject peer.

### DIFF
--- a/peer/example_test.go
+++ b/peer/example_test.go
@@ -71,8 +71,9 @@ func Example_newOutboundPeer() {
 		ChainParams:      &chaincfg.SimNetParams,
 		Services:         0,
 		Listeners: peer.MessageListeners{
-			OnVersion: func(p *peer.Peer, msg *wire.MsgVersion) {
+			OnVersion: func(p *peer.Peer, msg *wire.MsgVersion) *wire.MsgReject {
 				fmt.Println("outbound: received version")
+				return nil
 			},
 			OnVerAck: func(p *peer.Peer, msg *wire.MsgVerAck) {
 				verack <- struct{}{}

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -386,8 +386,9 @@ func TestPeerListeners(t *testing.T) {
 			OnFeeFilter: func(p *peer.Peer, msg *wire.MsgFeeFilter) {
 				ok <- msg
 			},
-			OnVersion: func(p *peer.Peer, msg *wire.MsgVersion) {
+			OnVersion: func(p *peer.Peer, msg *wire.MsgVersion) *wire.MsgReject {
 				ok <- msg
+				return nil
 			},
 			OnVerAck: func(p *peer.Peer, msg *wire.MsgVerAck) {
 				verack <- struct{}{}

--- a/server.go
+++ b/server.go
@@ -326,11 +326,11 @@ func (sp *serverPeer) addBanScore(persistent, transient uint32, reason string) {
 // OnVersion is invoked when a peer receives a version wire message and is used
 // to negotiate the protocol version details as well as kick start the
 // communications.
-func (sp *serverPeer) OnVersion(p *peer.Peer, msg *wire.MsgVersion) {
+func (sp *serverPeer) OnVersion(p *peer.Peer, msg *wire.MsgVersion) *wire.MsgReject {
 	// Ignore peers that have a protcol version that is too old.  The peer
 	// negotiation logic will disconnect it after this callback returns.
 	if msg.ProtocolVersion < int32(wire.InitialProcotolVersion) {
-		return
+		return nil
 	}
 
 	// Add the remote peer time as a sample for creating an offset against
@@ -377,6 +377,7 @@ func (sp *serverPeer) OnVersion(p *peer.Peer, msg *wire.MsgVersion) {
 
 	// Add valid peer to the server.
 	sp.server.AddPeer(sp)
+	return nil
 }
 
 // OnMemPool is invoked when a peer receives a mempool wire message.  It creates


### PR DESCRIPTION
**This requires PR #1250.**

This modifies the `OnVersion` callback to allow a reject message to be returned in which case the message will be sent to the peer and the peer will be disconnected.