### PR TITLE
peer: Improve net address service adverts.

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1772,6 +1772,7 @@ func (p *Peer) readRemoteVersionMsg() error {
 	p.protocolVersion = minUint32(p.protocolVersion, p.advertisedProtoVer)
 	p.versionKnown = true
 	p.services = msg.Services
+	p.na.Services = msg.Services
 	p.flagsMtx.Unlock()
 	log.Debugf("Negotiated protocol version %d for peer %s",
 		p.protocolVersion, p)
@@ -1839,7 +1840,8 @@ func (p *Peer) localVersionMsg() (*wire.MsgVersion, error) {
 		proxyaddress, _, err := net.SplitHostPort(p.cfg.Proxy)
 		// invalid proxy means poorly configured, be on the safe side.
 		if err != nil || p.na.IP.String() == proxyaddress {
-			theirNA = wire.NewNetAddressIPPort(net.IP([]byte{0, 0, 0, 0}), 0, 0)
+			theirNA = wire.NewNetAddressIPPort(net.IP([]byte{0, 0, 0, 0}), 0,
+				theirNA.Services)
 		}
 	}
 
@@ -1869,25 +1871,7 @@ func (p *Peer) localVersionMsg() (*wire.MsgVersion, error) {
 	msg := wire.NewMsgVersion(ourNA, theirNA, nonce, int32(blockNum))
 	msg.AddUserAgent(p.cfg.UserAgentName, p.cfg.UserAgentVersion)
 
-	// XXX: bitcoind appears to always enable the full node services flag
-	// of the remote peer netaddress field in the version message regardless
-	// of whether it knows it supports it or not.  Also, bitcoind sets
-	// the services field of the local peer to 0 regardless of support.
-	//
-	// Realistically, this should be set as follows:
-	// - For outgoing connections:
-	//    - Set the local netaddress services to what the local peer
-	//      actually supports
-	//    - Set the remote netaddress services to 0 to indicate no services
-	//      as they are still unknown
-	// - For incoming connections:
-	//    - Set the local netaddress services to what the local peer
-	//      actually supports
-	//    - Set the remote netaddress services to the what was advertised by
-	//      by the remote peer in its version message
-	msg.AddrYou.Services = wire.SFNodeNetwork
-
-	// Advertise the services flag
+	// Advertise local services.
 	msg.Services = p.cfg.Services
 
 	// Advertise our max supported protocol version.
@@ -2076,14 +2060,13 @@ func NewOutboundPeer(cfg *Config, addr string) (*Peer, error) {
 	}
 
 	if cfg.HostToNetAddress != nil {
-		na, err := cfg.HostToNetAddress(host, uint16(port), cfg.Services)
+		na, err := cfg.HostToNetAddress(host, uint16(port), 0)
 		if err != nil {
 			return nil, err
 		}
 		p.na = na
 	} else {
-		p.na = wire.NewNetAddressIPPort(net.ParseIP(host), uint16(port),
-			cfg.Services)
+		p.na = wire.NewNetAddressIPPort(net.ParseIP(host), uint16(port), 0)
 	}
 
 	return p, nil


### PR DESCRIPTION
**This requires PR #1250 and is currently rebased on top of #1252.**

This modifies the peer code which deals with advertising service flags via the net address fields of the version message as follows:

- For outgoing connections:
  - Set the local netaddress services to what the local peer supports
  - Set the remote netaddress services to 0 to indicate no services as they are still unknown
- For incoming connections:
  - Set the local netaddress services to what the local peer supports
  - Set the remote netaddress services to the what was advertised by the remote peer in its version message