### PR TITLE
multi: Update addrmgr services on outbound conns.

### DIFF
--- a/addrmgr/addrmanager.go
+++ b/addrmgr/addrmanager.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -868,9 +868,11 @@ func (a *AddrManager) Connected(addr *wire.NetAddress) {
 	now := time.Now()
 	if now.After(ka.na.Timestamp.Add(time.Minute * 20)) {
 		// ka.na is immutable, so replace it.
+		ka.mtx.Lock()
 		naCopy := *ka.na
 		naCopy.Timestamp = time.Now()
 		ka.na = &naCopy
+		ka.mtx.Unlock()
 	}
 }
 
@@ -963,6 +965,27 @@ func (a *AddrManager) Good(addr *wire.NetAddress) {
 
 	// We made sure there is space here just above.
 	a.addrNew[newBucket][rmkey] = rmka
+}
+
+// SetServices sets the services for the giiven address to the provided value.
+func (a *AddrManager) SetServices(addr *wire.NetAddress, services wire.ServiceFlag) {
+	a.mtx.Lock()
+	defer a.mtx.Unlock()
+
+	ka := a.find(addr)
+	if ka == nil {
+		return
+	}
+
+	// Update the services if needed.
+	if ka.na.Services != services {
+		// ka.na is immutable, so replace it.
+		ka.mtx.Lock()
+		naCopy := *ka.na
+		naCopy.Services = services
+		ka.na = &naCopy
+		ka.mtx.Unlock()
+	}
 }
 
 // AddLocalAddress adds na to the list of known local addresses to advertise

--- a/server.go
+++ b/server.go
@@ -333,6 +333,21 @@ func hasServices(advertised, desired wire.ServiceFlag) bool {
 // to negotiate the protocol version details as well as kick start the
 // communications.
 func (sp *serverPeer) OnVersion(p *peer.Peer, msg *wire.MsgVersion) *wire.MsgReject {
+	// Update the address manager with the advertised services for outbound
+	// connections in case they have changed.  This is not done for inbound
+	// connections to help prevent malicious behavior and is skipped when
+	// running on the simulation test network since it is only intended to
+	// connect to specified peers and actively avoids advertising and
+	// connecting to discovered peers.
+	//
+	// NOTE: This is done before rejecting peers that are too old to ensure
+	// it is updated regardless in the case a new minimum protocol version is
+	// enforced and the remote node has not upgraded yet.
+	addrManager := sp.server.addrManager
+	if !cfg.SimNet && !sp.Inbound() {
+		addrManager.SetServices(sp.NA(), msg.Services)
+	}
+
 	// Ignore peers that have a protcol version that is too old.  The peer
 	// negotiation logic will disconnect it after this callback returns.
 	if msg.ProtocolVersion < int32(wire.InitialProcotolVersion) {
@@ -367,7 +382,6 @@ func (sp *serverPeer) OnVersion(p *peer.Peer, msg *wire.MsgVersion) *wire.MsgRej
 	// to specified peers and actively avoids advertising and connecting to
 	// discovered peers.
 	if !cfg.SimNet {
-		addrManager := sp.server.addrManager
 		// Outbound connections.
 		if !p.Inbound() {
 			// TODO(davec): Only do this if not doing the initial block


### PR DESCRIPTION
Date:   Sun Jun 3 03:29:22 2018 -0500

This consists of two commits.

The first commit exposes a new method named `SetServices` to the address manager which can be used to update the services for a known address.

The second updates server to add code which updates the address manager services for a known     address to the services advertised by peers when they are connected to via an outbound connection.  It is only done for outbound connections to help prevent malicious behavior from inbound connections.