### PR TITLE
server: Use local inbound var in version handler.

### DIFF
--- a/server.go
+++ b/server.go
@@ -343,8 +343,9 @@ func (sp *serverPeer) OnVersion(p *peer.Peer, msg *wire.MsgVersion) *wire.MsgRej
 	// NOTE: This is done before rejecting peers that are too old to ensure
 	// it is updated regardless in the case a new minimum protocol version is
 	// enforced and the remote node has not upgraded yet.
+	isInbound := sp.Inbound()
 	addrManager := sp.server.addrManager
-	if !cfg.SimNet && !sp.Inbound() {
+	if !cfg.SimNet && !isInbound {
 		addrManager.SetServices(sp.NA(), msg.Services)
 	}
 
@@ -356,7 +357,7 @@ func (sp *serverPeer) OnVersion(p *peer.Peer, msg *wire.MsgVersion) *wire.MsgRej
 
 	// Reject outbound peers that are not full nodes.
 	wantServices := wire.SFNodeNetwork
-	if !sp.Inbound() && !hasServices(msg.Services, wantServices) {
+	if !isInbound && !hasServices(msg.Services, wantServices) {
 		missingServices := wantServices & ^msg.Services
 		srvrLog.Debugf("Rejecting peer %s with services %v due to not "+
 			"providing desired services %v", sp.Peer, msg.Services,
@@ -366,46 +367,43 @@ func (sp *serverPeer) OnVersion(p *peer.Peer, msg *wire.MsgVersion) *wire.MsgRej
 		return wire.NewMsgReject(msg.Command(), wire.RejectNonstandard, reason)
 	}
 
+	// Update the address manager and request known addresses from the
+	// remote peer for outbound connections.  This is skipped when running
+	// on the simulation test network since it is only intended to connect
+	// to specified peers and actively avoids advertising and connecting to
+	// discovered peers.
+	if !cfg.SimNet && !isInbound {
+		// TODO(davec): Only do this if not doing the initial block
+		// download and the local address is routable.
+		if !cfg.DisableListen /* && isCurrent? */ {
+			// Get address that best matches.
+			lna := addrManager.GetBestLocalAddress(p.NA())
+			if addrmgr.IsRoutable(lna) {
+				// Filter addresses the peer already knows about.
+				addresses := []*wire.NetAddress{lna}
+				sp.pushAddrMsg(addresses)
+			}
+		}
+
+		// Request known addresses if the server address manager needs
+		// more.
+		if addrManager.NeedMoreAddresses() {
+			p.QueueMessage(wire.NewMsgGetAddr(), nil)
+		}
+
+		// Mark the address as a known good address.
+		addrManager.Good(p.NA())
+	}
+
+	// Choose whether or not to relay transactions.
+	sp.setDisableRelayTx(msg.DisableRelayTx)
+
 	// Add the remote peer time as a sample for creating an offset against
 	// the local clock to keep the network time in sync.
 	sp.server.timeSource.AddTimeSample(p.Addr(), msg.Timestamp)
 
 	// Signal the block manager this peer is a new sync candidate.
 	sp.server.blockManager.NewPeer(sp)
-
-	// Choose whether or not to relay transactions.
-	sp.setDisableRelayTx(msg.DisableRelayTx)
-
-	// Update the address manager and request known addresses from the
-	// remote peer for outbound connections.  This is skipped when running
-	// on the simulation test network since it is only intended to connect
-	// to specified peers and actively avoids advertising and connecting to
-	// discovered peers.
-	if !cfg.SimNet {
-		// Outbound connections.
-		if !p.Inbound() {
-			// TODO(davec): Only do this if not doing the initial block
-			// download and the local address is routable.
-			if !cfg.DisableListen /* && isCurrent? */ {
-				// Get address that best matches.
-				lna := addrManager.GetBestLocalAddress(p.NA())
-				if addrmgr.IsRoutable(lna) {
-					// Filter addresses the peer already knows about.
-					addresses := []*wire.NetAddress{lna}
-					sp.pushAddrMsg(addresses)
-				}
-			}
-
-			// Request known addresses if the server address manager
-			// needs more.
-			if addrManager.NeedMoreAddresses() {
-				p.QueueMessage(wire.NewMsgGetAddr(), nil)
-			}
-
-			// Mark the address as a known good address.
-			addrManager.Good(p.NA())
-		}
-	}
 
 	// Add valid peer to the server.
 	sp.server.AddPeer(sp)


### PR DESCRIPTION
**This requires PR #1254**.

This modifies the `OnVersion` handler for server peers to use a local variable for the inbound status of the peer in order to avoid grabbing the mutex multiple times.

While here, it also does some light cleanup.  There are no functional changes.