### PR TITLE
server: Only advertise local addr when current.

### DIFF
--- a/server.go
+++ b/server.go
@@ -373,9 +373,10 @@ func (sp *serverPeer) OnVersion(p *peer.Peer, msg *wire.MsgVersion) *wire.MsgRej
 	// to specified peers and actively avoids advertising and connecting to
 	// discovered peers.
 	if !cfg.SimNet && !isInbound {
-		// TODO(davec): Only do this if not doing the initial block
-		// download and the local address is routable.
-		if !cfg.DisableListen /* && isCurrent? */ {
+		// Advertise the local address when the server accepts incoming
+		// connections and it believes itself to be close to the best
+		// known tip.
+		if !cfg.DisableListen && sp.server.blockManager.IsCurrent() {
 			// Get address that best matches.
 			lna := addrManager.GetBestLocalAddress(p.NA())
 			if addrmgr.IsRoutable(lna) {


### PR DESCRIPTION
**This requires PR #1255**.

This changes the server peers `OnVersion` handler to only advertise the server as a viable target for inbound connections when the server believes it is close the best known tip.
