### PR TITLE
server: Minor function definition order cleanup.

### DIFF
--- a/server.go
+++ b/server.go
@@ -785,6 +785,36 @@ func (sp *serverPeer) OnGetHeaders(p *peer.Peer, msg *wire.MsgGetHeaders) {
 	p.QueueMessage(&wire.MsgHeaders{Headers: blockHeaders}, nil)
 }
 
+// enforceNodeCFFlag disconnects the peer if the server is not configured to
+// allow committed filters.  Additionally, if the peer has negotiated to a
+// protocol version that is high enough to observe the committed filter service
+// support bit, it will be banned since it is intentionally violating the
+// protocol.
+func (sp *serverPeer) enforceNodeCFFlag(cmd string) bool {
+	if sp.server.services&wire.SFNodeCF != wire.SFNodeCF {
+		// Ban the peer if the protocol version is high enough that the peer is
+		// knowingly violating the protocol and banning is enabled.
+		//
+		// NOTE: Even though the addBanScore function already examines whether
+		// or not banning is enabled, it is checked here as well to ensure the
+		// violation is logged and the peer is disconnected regardless.
+		if sp.ProtocolVersion() >= wire.NodeCFVersion && !cfg.DisableBanning {
+			// Disonnect the peer regardless of whether it was banned.
+			sp.addBanScore(100, 0, cmd)
+			sp.Disconnect()
+			return false
+		}
+
+		// Disconnect the peer regardless of protocol version or banning state.
+		peerLog.Debugf("%s sent an unsupported %s request -- disconnecting", sp,
+			cmd)
+		sp.Disconnect()
+		return false
+	}
+
+	return true
+}
+
 // OnGetCFilter is invoked when a peer receives a getcfilter wire message.
 func (sp *serverPeer) OnGetCFilter(p *peer.Peer, msg *wire.MsgGetCFilter) {
 	// Disconnect and/or ban depending on the node cf services flag and
@@ -1002,42 +1032,6 @@ func (sp *serverPeer) OnGetCFTypes(p *peer.Peer, msg *wire.MsgGetCFTypes) {
 	cfTypesMsg := wire.NewMsgCFTypes([]wire.FilterType{
 		wire.GCSFilterRegular, wire.GCSFilterExtended})
 	sp.QueueMessage(cfTypesMsg, nil)
-}
-
-// enforceNodeCFFlag disconnects the peer if the server is not configured to
-// allow committed filters.  Additionally, if the peer has negotiated to a
-// protocol version that is high enough to observe the committed filter service
-// support bit, it will be banned since it is intentionally violating the
-// protocol.
-func (sp *serverPeer) enforceNodeCFFlag(cmd string) bool {
-	if sp.server.services&wire.SFNodeCF != wire.SFNodeCF {
-		// Ban the peer if the protocol version is high enough that the
-		// peer is knowingly violating the protocol and banning is
-		// enabled.
-		//
-		// NOTE: Even though the addBanScore function already examines
-		// whether or not banning is enabled, it is checked here as well
-		// to ensure the violation is logged and the peer is
-		// disconnected regardless.
-		if sp.ProtocolVersion() >= wire.NodeCFVersion &&
-			!cfg.DisableBanning {
-
-			// Disonnect the peer regardless of whether it was
-			// banned.
-			sp.addBanScore(100, 0, cmd)
-			sp.Disconnect()
-			return false
-		}
-
-		// Disconnect the peer regardless of protocol version or banning
-		// state.
-		peerLog.Debugf("%s sent an unsupported %s request -- "+
-			"disconnecting", sp, cmd)
-		sp.Disconnect()
-		return false
-	}
-
-	return true
 }
 
 // OnGetAddr is invoked when a peer receives a getaddr wire message and is used


### PR DESCRIPTION
This moves the function definition for `enforceNodeCFFlag` so it are more consistent with the preferred order used throughout the codebase.  In particular, the functions are defined before they're first used and
generally as close as possible to the first use when they're defined in the same file.

While moving, it also reformats the code to match the same spacing as the other CF functions for consistency.

There are no functional changes.