### PR TITLE
multi: revert TicketChange addition to PurchaseTicketCmd

### DIFF
--- a/dcrjson/walletsvrcmds.go
+++ b/dcrjson/walletsvrcmds.go
@@ -731,14 +731,13 @@ type PurchaseTicketCmd struct {
 	PoolFees      *float64
 	Expiry        *int
 	Comment       *string
-	TicketChange  *bool
 	TicketFee     *float64
 }
 
 // NewPurchaseTicketCmd creates a new PurchaseTicketCmd.
 func NewPurchaseTicketCmd(fromAccount string, spendLimit float64, minConf *int,
 	ticketAddress *string, numTickets *int, poolAddress *string, poolFees *float64,
-	expiry *int, comment *string, ticketChange *bool, ticketFee *float64) *PurchaseTicketCmd {
+	expiry *int, comment *string, ticketFee *float64) *PurchaseTicketCmd {
 	return &PurchaseTicketCmd{
 		FromAccount:   fromAccount,
 		SpendLimit:    spendLimit,
@@ -749,7 +748,6 @@ func NewPurchaseTicketCmd(fromAccount string, spendLimit float64, minConf *int,
 		PoolFees:      poolFees,
 		Expiry:        expiry,
 		Comment:       comment,
-		TicketChange:  ticketChange,
 		TicketFee:     ticketFee,
 	}
 }

--- a/rpcclient/wallet.go
+++ b/rpcclient/wallet.go
@@ -761,7 +761,7 @@ func (r FuturePurchaseTicketResult) Receive() ([]*chainhash.Hash, error) {
 func (c *Client) PurchaseTicketAsync(fromAccount string,
 	spendLimit dcrutil.Amount, minConf *int, ticketAddress dcrutil.Address,
 	numTickets *int, poolAddress dcrutil.Address, poolFees *dcrutil.Amount,
-	expiry *int, ticketChange *bool, ticketFee *dcrutil.Amount) FuturePurchaseTicketResult {
+	expiry *int, ticketFee *dcrutil.Amount) FuturePurchaseTicketResult {
 	// An empty string is used to keep the sendCmd
 	// passing of the command from accidentally
 	// removing certain fields. We fill in the
@@ -805,7 +805,7 @@ func (c *Client) PurchaseTicketAsync(fromAccount string,
 
 	cmd := dcrjson.NewPurchaseTicketCmd(fromAccount, spendLimit.ToCoin(),
 		&minConfVal, &ticketAddrStr, &numTicketsVal, &poolAddrStr,
-		&poolFeesFloat, &expiryVal, dcrjson.String(""), ticketChange, &ticketFeeFloat)
+		&poolFeesFloat, &expiryVal, dcrjson.String(""), &ticketFeeFloat)
 
 	return c.sendCmd(cmd)
 }
@@ -818,7 +818,7 @@ func (c *Client) PurchaseTicket(fromAccount string,
 	expiry *int, ticketChange *bool, ticketFee *dcrutil.Amount) ([]*chainhash.Hash, error) {
 
 	return c.PurchaseTicketAsync(fromAccount, spendLimit, minConf, ticketAddress,
-		numTickets, poolAddress, poolFees, expiry, ticketChange, ticketFee).Receive()
+		numTickets, poolAddress, poolFees, expiry, ticketFee).Receive()
 }
 
 // SStx generation RPC call handling


### PR DESCRIPTION
This reverts the split_tx/ticket_change addition to PurchaseTickeCmd. From a discussion had with raedah and jrick on purchasing tickets we concluded that change created by direct ticket purchases will adhere to coinbase maturity before becoming available for spending. We will not be circumventing this by not setting the expiry for sstxchange.

The only ideal scenario currently for purchasing tickets directly is with inputs equal to the stake difficulty plus the fee.