### PR TITLE
txscript: Cleanup and add tests for left opcode.

### DIFF
--- a/txscript/data/script_invalid.json
+++ b/txscript/data/script_invalid.json
@@ -43,6 +43,16 @@
 ["'' 4 2147483648", "SUBSTR NOT", "P2SH,STRICTENC", "SUBSTR with empty string must fail with start index >4 bytes"],
 ["'' 2147483648 4", "SUBSTR NOT", "P2SH,STRICTENC", "SUBSTR with empty string must fail with end index >4 bytes"],
 
+["Left substring related test coverage"],
+["", "LEFT NOT", "P2SH,STRICTENC", "LEFT requires a string to operate on"],
+["'abcd'", "LEFT NOT", "P2SH,STRICTENC", "LEFT requires an index"],
+["NOP 0", "LEFT NOT", "P2SH,STRICTENC", "LEFT must only operate on byte pushes"],
+["'abcd' NOP", "LEFT NOT", "P2SH,STRICTENC", "LEFT index must be numeric"],
+["'abcd' 0", "LEFT", "P2SH,STRICTENC", "LEFT index of zero must produce empty byte push which is equivalent to FALSE"],
+["'abcd' -1", "LEFT NOT", "P2SH,STRICTENC", "LEFT must fail with negative index"],
+["'abc' 4", "LEFT NOT", "P2SH,STRICTENC", "LEFT must fail with index too large"],
+["'' 2147483648", "LEFT NOT", "P2SH,STRICTENC", "LEFT with empty string must fail with index >4 bytes"],
+
 ["1", "IF 0x50 ENDIF 1", "P2SH,STRICTENC", "0x50 is reserved"],
 ["0x52", "0x5f ADD 0x60 EQUAL", "P2SH,STRICTENC", "0x51 through 0x60 push 1 through 16 onto stack"],
 ["0","NOP", "P2SH,STRICTENC"],

--- a/txscript/data/script_valid.json
+++ b/txscript/data/script_valid.json
@@ -45,6 +45,14 @@
 ["'abc' 2 0", "IF LEFT ELSE 1 ENDIF", "P2SH,STRICTENC"],
 ["'abc' 2 0", "IF RIGHT ELSE 1 ENDIF", "P2SH,STRICTENC"],
 
+["Left substring related test coverage"],
+["'abcd' 0", "LEFT NOT", "P2SH,STRICTENC", "LEFT index of zero must produce empty byte push which is equivalent to FALSE"],
+["'abcd' 1", "LEFT 'a' EQUAL", "P2SH,STRICTENC", "LEFT uses 0-based end index"],
+["'abcd' 4", "LEFT 'abcd' EQUAL", "P2SH,STRICTENC", "LEFT produces entire string when end index equals string length"],
+["'abcd' 2 1", "IF LEFT ELSE 0 ENDIF 'ab' EQUAL", "P2SH,STRICTENC", "LEFT works in a conditional branch"],
+["'abcd' 0 0", "IF LEFT ELSE 1 ENDIF", "P2SH,STRICTENC", "LEFT must not modify the stack if in an unexecuted branch"],
+["'' 2147483647", "LEFT '' EQUAL", "P2SH,STRICTENC", "LEFT of an empty string produces an empty byte push regardless of out of bounds index <=4 bytes"],
+
 ["1 2 0 IF AND ELSE 1 ENDIF", "NOP", "P2SH,STRICTENC"],
 ["1 2 0 IF OR ELSE 1 ENDIF", "NOP", "P2SH,STRICTENC"],
 ["1 2 0 IF XOR ELSE 1 ENDIF", "NOP", "P2SH,STRICTENC"],


### PR DESCRIPTION
This cleans up the code for handling the left opcode to explicitly call out its semantics which are likely not otherwise obvious as well as improve its readability.

It also adds several tests to the reference script tests which exercise the semantics of the left opcode including both positive and negative tests.