### PR TITLE
txscript: Cleanup and add tests for right opcode.

### DIFF
--- a/txscript/data/script_invalid.json
+++ b/txscript/data/script_invalid.json
@@ -53,6 +53,16 @@
 ["'abc' 4", "LEFT NOT", "P2SH,STRICTENC", "LEFT must fail with index too large"],
 ["'' 2147483648", "LEFT NOT", "P2SH,STRICTENC", "LEFT with empty string must fail with index >4 bytes"],
 
+["Right substring related test coverage"],
+["", "RIGHT NOT", "P2SH,STRICTENC", "RIGHT requires a string to operate on"],
+["'abcd'", "RIGHT NOT", "P2SH,STRICTENC", "RIGHT requires an index"],
+["NOP 0", "RIGHT NOT", "P2SH,STRICTENC", "RIGHT must only operate on byte pushes"],
+["'abcd' NOP", "RIGHT NOT", "P2SH,STRICTENC", "RIGHT index must be numeric"],
+["'abcd' 4", "RIGHT", "P2SH,STRICTENC", "RIGHT index of same length must produce empty byte push which is equivalent to FALSE"],
+["'abcd' -1", "RIGHT NOT", "P2SH,STRICTENC", "RIGHT must fail with negative index"],
+["'abc' 4", "RIGHT NOT", "P2SH,STRICTENC", "RIGHT must fail with index too large"],
+["'' 2147483648", "RIGHT NOT", "P2SH,STRICTENC", "RIGHT with empty string must fail with index >4 bytes"],
+
 ["1", "IF 0x50 ENDIF 1", "P2SH,STRICTENC", "0x50 is reserved"],
 ["0x52", "0x5f ADD 0x60 EQUAL", "P2SH,STRICTENC", "0x51 through 0x60 push 1 through 16 onto stack"],
 ["0","NOP", "P2SH,STRICTENC"],

--- a/txscript/data/script_valid.json
+++ b/txscript/data/script_valid.json
@@ -53,6 +53,14 @@
 ["'abcd' 0 0", "IF LEFT ELSE 1 ENDIF", "P2SH,STRICTENC", "LEFT must not modify the stack if in an unexecuted branch"],
 ["'' 2147483647", "LEFT '' EQUAL", "P2SH,STRICTENC", "LEFT of an empty string produces an empty byte push regardless of out of bounds index <=4 bytes"],
 
+["Right substring related test coverage"],
+["'abcd' 4", "RIGHT NOT", "P2SH,STRICTENC", "RIGHT index equal to length must produce empty byte push which is equivalent to FALSE"],
+["'abcd' 3", "RIGHT 'd' EQUAL", "P2SH,STRICTENC", "RIGHT uses 0-based start index"],
+["'abcd' 0", "RIGHT 'abcd' EQUAL", "P2SH,STRICTENC", "RIGHT produces entire string when start index is zero"],
+["'abcd' 2 1", "IF RIGHT ELSE 0 ENDIF 'cd' EQUAL", "P2SH,STRICTENC", "RIGHT works in a conditional branch"],
+["'abcd' 4 0", "IF RIGHT ELSE 1 ENDIF", "P2SH,STRICTENC", "RIGHT must not modify the stack if in an unexecuted branch"],
+["'' 2147483647", "RIGHT '' EQUAL", "P2SH,STRICTENC", "RIGHT of an empty string produces an empty byte push regardless of out of bounds index <=4 bytes"],
+
 ["1 2 0 IF AND ELSE 1 ENDIF", "NOP", "P2SH,STRICTENC"],
 ["1 2 0 IF OR ELSE 1 ENDIF", "NOP", "P2SH,STRICTENC"],
 ["1 2 0 IF XOR ELSE 1 ENDIF", "NOP", "P2SH,STRICTENC"],


### PR DESCRIPTION
**This is rebased on top of #1281.**

This cleans up the code for handling the right opcode to explicitly call out its semantics which are likely not otherwise obvious as well as improve its readability.

It also adds several tests to the reference script tests which exercise the semantics of the right opcode including both positive and negative tests.
