### PR TITLE
txscript: Cleanup and add tests for the cat opcode.

### DIFF
--- a/txscript/data/script_invalid.json
+++ b/txscript/data/script_invalid.json
@@ -53,6 +53,16 @@
 ["'abc' 4", "LEFT NOT", "P2SH,STRICTENC", "LEFT must fail with index too large"],
 ["'' 2147483648", "LEFT NOT", "P2SH,STRICTENC", "LEFT with empty string must fail with index >4 bytes"],
 
+["Right substring related test coverage"],
+["", "RIGHT NOT", "P2SH,STRICTENC", "RIGHT requires a string to operate on"],
+["'abcd'", "RIGHT NOT", "P2SH,STRICTENC", "RIGHT requires an index"],
+["NOP 0", "RIGHT NOT", "P2SH,STRICTENC", "RIGHT must only operate on byte pushes"],
+["'abcd' NOP", "RIGHT NOT", "P2SH,STRICTENC", "RIGHT index must be numeric"],
+["'abcd' 4", "RIGHT", "P2SH,STRICTENC", "RIGHT index of same length must produce empty byte push which is equivalent to FALSE"],
+["'abcd' -1", "RIGHT NOT", "P2SH,STRICTENC", "RIGHT must fail with negative index"],
+["'abc' 4", "RIGHT NOT", "P2SH,STRICTENC", "RIGHT must fail with index too large"],
+["'' 2147483648", "RIGHT NOT", "P2SH,STRICTENC", "RIGHT with empty string must fail with index >4 bytes"],
+
 ["1", "IF 0x50 ENDIF 1", "P2SH,STRICTENC", "0x50 is reserved"],
 ["0x52", "0x5f ADD 0x60 EQUAL", "P2SH,STRICTENC", "0x51 through 0x60 push 1 through 16 onto stack"],
 ["0","NOP", "P2SH,STRICTENC"],

--- a/txscript/data/script_invalid.json
+++ b/txscript/data/script_invalid.json
@@ -25,6 +25,11 @@
 ["0x4d0200ff","0x01 NOP", "P2SH,STRICTENC", "PUSHDATA2 with not enough bytes"],
 ["0x4e03000000ffff","0x01 NOP", "P2SH,STRICTENC", "PUSHDATA4 with not enough bytes"],
 
+["Cat related test coverage"],
+["", "CAT TRUE", "P2SH,STRICTENC", "CAT requires an input arg"],
+["'ab'", "CAT TRUE", "P2SH,STRICTENC", "CAT requires a second input arg"],
+["'a' 'abcdefghijklmnop' DUP CAT DUP CAT DUP CAT DUP CAT DUP CAT DUP CAT DUP CAT", "CAT", "P2SH,STRICTENC", "CAT must fail if the result would exceed max allowed stack item size"],
+
 ["Substring related test coverage"],
 ["", "SUBSTR NOT", "P2SH,STRICTENC", "SUBSTR requires a string to operate on"],
 ["'abcd'", "SUBSTR NOT", "P2SH,STRICTENC", "SUBSTR requires an end index"],

--- a/txscript/data/script_valid.json
+++ b/txscript/data/script_valid.json
@@ -29,8 +29,14 @@
 ["0x4d 0x0100 0x08","8 EQUAL", "P2SH,STRICTENC", "0x4d is OP_PUSHDATA2"],
 ["0x4e 0x01000000 0x09","9 EQUAL", "P2SH,STRICTENC", "0x4e is OP_PUSHDATA4"],
 
-["'a' 'b'", "CAT", "P2SH,STRICTENC"],
-["'a' 'b' 0", "IF CAT ELSE 1 ENDIF", "P2SH,STRICTENC"],
+["Cat related test coverage"],
+["'a' 'b'", "CAT 'ab' EQUAL", "P2SH,STRICTENC", "CAT concatenates two input args"],
+["'a' 2147483648", "CAT 0x06 0x610000008000 EQUAL", "P2SH,STRICTENC", "CAT must treat arguments as bytes as opposed to numeric"],
+["'' ''", "CAT '' EQUAL", "P2SH,STRICTENC", "CAT with two empty args must result in a single empty item on the stack"],
+["'a' ''", "CAT 'a' EQUAL", "P2SH,STRICTENC", "CAT with empty right-hand side must return left-hand side"],
+["'' 'b'", "CAT 'b' EQUAL", "P2SH,STRICTENC", "CAT with empty left-hand side must return right-hand side"],
+["'a' 'b' 1", "IF CAT ELSE 1 ENDIF 'ab' EQUAL", "P2SH,STRICTENC", "CAT works in a conditional branch"],
+["'a' 'b' 0", "IF CAT ELSE 2DROP 1 ENDIF 1 EQUAL", "P2SH,STRICTENC", "CAT must not modify the stack if in an unexecuted branch"],
 
 ["Substring related test coverage"],
 ["'abcd' 1 0", "SUBSTR 'a' EQUAL", "P2SH,STRICTENC", "SUBSTR uses 0-based indices"],

--- a/txscript/data/script_valid.json
+++ b/txscript/data/script_valid.json
@@ -53,6 +53,14 @@
 ["'abcd' 0 0", "IF LEFT ELSE 1 ENDIF", "P2SH,STRICTENC", "LEFT must not modify the stack if in an unexecuted branch"],
 ["'' 2147483647", "LEFT '' EQUAL", "P2SH,STRICTENC", "LEFT of an empty string produces an empty byte push regardless of out of bounds index <=4 bytes"],
 
+["Right substring related test coverage"],
+["'abcd' 4", "RIGHT NOT", "P2SH,STRICTENC", "RIGHT index equal to length must produce empty byte push which is equivalent to FALSE"],
+["'abcd' 3", "RIGHT 'd' EQUAL", "P2SH,STRICTENC", "RIGHT uses 0-based start index"],
+["'abcd' 0", "RIGHT 'abcd' EQUAL", "P2SH,STRICTENC", "RIGHT produces entire string when start index is zero"],
+["'abcd' 2 1", "IF RIGHT ELSE 0 ENDIF 'cd' EQUAL", "P2SH,STRICTENC", "RIGHT works in a conditional branch"],
+["'abcd' 4 0", "IF RIGHT ELSE 1 ENDIF", "P2SH,STRICTENC", "RIGHT must not modify the stack if in an unexecuted branch"],
+["'' 2147483647", "RIGHT '' EQUAL", "P2SH,STRICTENC", "RIGHT of an empty string produces an empty byte push regardless of out of bounds index <=4 bytes"],
+
 ["1 2 0 IF AND ELSE 1 ENDIF", "NOP", "P2SH,STRICTENC"],
 ["1 2 0 IF OR ELSE 1 ENDIF", "NOP", "P2SH,STRICTENC"],
 ["1 2 0 IF XOR ELSE 1 ENDIF", "NOP", "P2SH,STRICTENC"],


### PR DESCRIPTION
**This is rebased on top of #1282**.

This cleans up the code for handling the cat opcode to more closely match the style used by the rest of the code and improves its test coverage by adding several tests to the reference script tests which exercise its semantics including both positive and negative tests.