### PR TITLE
chaincfg, blockchain: refactor difficulty constants

### DIFF
--- a/blockchain/difficulty.go
+++ b/blockchain/difficulty.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/decred/dcrd/blockchainutil"
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/wire"
@@ -47,99 +48,6 @@ func HashToBig(hash *chainhash.Hash) *big.Int {
 	return new(big.Int).SetBytes(buf[:])
 }
 
-// CompactToBig converts a compact representation of a whole number N to an
-// unsigned 32-bit number.  The representation is similar to IEEE754 floating
-// point numbers.
-//
-// Like IEEE754 floating point, there are three basic components: the sign,
-// the exponent, and the mantissa.  They are broken out as follows:
-//
-//	* the most significant 8 bits represent the unsigned base 256 exponent
-// 	* bit 23 (the 24th bit) represents the sign bit
-//	* the least significant 23 bits represent the mantissa
-//
-//	-------------------------------------------------
-//	|   Exponent     |    Sign    |    Mantissa     |
-//	-------------------------------------------------
-//	| 8 bits [31-24] | 1 bit [23] | 23 bits [22-00] |
-//	-------------------------------------------------
-//
-// The formula to calculate N is:
-// 	N = (-1^sign) * mantissa * 256^(exponent-3)
-//
-// This compact form is only used in Decred to encode unsigned 256-bit numbers
-// which represent difficulty targets, thus there really is not a need for a
-// sign bit, but it is implemented here to stay consistent with bitcoind.
-func CompactToBig(compact uint32) *big.Int {
-	// Extract the mantissa, sign bit, and exponent.
-	mantissa := compact & 0x007fffff
-	isNegative := compact&0x00800000 != 0
-	exponent := uint(compact >> 24)
-
-	// Since the base for the exponent is 256, the exponent can be treated
-	// as the number of bytes to represent the full 256-bit number.  So,
-	// treat the exponent as the number of bytes and shift the mantissa
-	// right or left accordingly.  This is equivalent to:
-	// N = mantissa * 256^(exponent-3)
-	var bn *big.Int
-	if exponent <= 3 {
-		mantissa >>= 8 * (3 - exponent)
-		bn = big.NewInt(int64(mantissa))
-	} else {
-		bn = big.NewInt(int64(mantissa))
-		bn.Lsh(bn, 8*(exponent-3))
-	}
-
-	// Make it negative if the sign bit is set.
-	if isNegative {
-		bn = bn.Neg(bn)
-	}
-
-	return bn
-}
-
-// BigToCompact converts a whole number N to a compact representation using
-// an unsigned 32-bit number.  The compact representation only provides 23 bits
-// of precision, so values larger than (2^23 - 1) only encode the most
-// significant digits of the number.  See CompactToBig for details.
-func BigToCompact(n *big.Int) uint32 {
-	// No need to do any work if it's zero.
-	if n.Sign() == 0 {
-		return 0
-	}
-
-	// Since the base for the exponent is 256, the exponent can be treated
-	// as the number of bytes.  So, shift the number right or left
-	// accordingly.  This is equivalent to:
-	// mantissa = mantissa / 256^(exponent-3)
-	var mantissa uint32
-	exponent := uint(len(n.Bytes()))
-	if exponent <= 3 {
-		mantissa = uint32(n.Bits()[0])
-		mantissa <<= 8 * (3 - exponent)
-	} else {
-		// Use a copy to avoid modifying the caller's original number.
-		tn := new(big.Int).Set(n)
-		mantissa = uint32(tn.Rsh(tn, 8*(exponent-3)).Bits()[0])
-	}
-
-	// When the mantissa already has the sign bit set, the number is too
-	// large to fit into the available 23-bits, so divide the number by 256
-	// and increment the exponent accordingly.
-	if mantissa&0x00800000 != 0 {
-		mantissa >>= 8
-		exponent++
-	}
-
-	// Pack the exponent, sign bit, and mantissa into an unsigned 32-bit
-	// int and return it.
-	compact := uint32(exponent<<24) | mantissa
-	if n.Sign() < 0 {
-		compact |= 0x00800000
-	}
-	return compact
-}
-
 // CalcWork calculates a work value from difficulty bits.  Decred increases
 // the difficulty for generating a block by decreasing the value which the
 // generated hash must be less than.  This difficulty target is stored in each
@@ -154,7 +62,7 @@ func CalcWork(bits uint32) *big.Int {
 	// Return a work value of zero if the passed difficulty bits represent
 	// a negative number. Note this should not happen in practice with valid
 	// blocks, but an invalid block could trigger it.
-	difficultyNum := CompactToBig(bits)
+	difficultyNum := blockchainutil.CompactToBig(bits)
 	if difficultyNum.Sign() <= 0 {
 		return big.NewInt(0)
 	}
@@ -187,7 +95,7 @@ func (b *BlockChain) calcEasiestDifficulty(bits uint32, duration time.Duration) 
 	// difficulty for a given duration is the largest value possible given
 	// the number of retargets for the duration and starting difficulty
 	// multiplied by the max adjustment factor.
-	newTarget := CompactToBig(bits)
+	newTarget := blockchainutil.CompactToBig(bits)
 	for durationVal > 0 && newTarget.Cmp(b.chainParams.PowLimit) < 0 {
 		newTarget.Mul(newTarget, adjustmentFactor)
 		durationVal -= maxRetargetTimespan
@@ -198,7 +106,7 @@ func (b *BlockChain) calcEasiestDifficulty(bits uint32, duration time.Duration) 
 		newTarget.Set(b.chainParams.PowLimit)
 	}
 
-	return BigToCompact(newTarget)
+	return blockchainutil.BigToCompact(newTarget)
 }
 
 // findPrevTestNetDifficulty returns the difficulty of the previous block which
@@ -240,7 +148,7 @@ func (b *BlockChain) calcNextRequiredDifficulty(curNode *blockNode, newBlockTime
 	// Get the old difficulty; if we aren't at a block height where it changes,
 	// just return this.
 	oldDiff := curNode.bits
-	oldDiffBig := CompactToBig(curNode.bits)
+	oldDiffBig := blockchainutil.CompactToBig(curNode.bits)
 
 	// We're not at a retarget point, return the oldDiff.
 	if (curNode.height+1)%b.chainParams.WorkDiffWindowSize != 0 {
@@ -263,7 +171,7 @@ func (b *BlockChain) calcNextRequiredDifficulty(curNode *blockNode, newBlockTime
 					time.Second)) + 1)
 
 				// Scale the difficulty with time passed.
-				oldTarget := CompactToBig(curNode.bits)
+				oldTarget := blockchainutil.CompactToBig(curNode.bits)
 				newTarget := new(big.Int)
 				if shifts < maxShift {
 					newTarget.Lsh(oldTarget, shifts)
@@ -276,7 +184,7 @@ func (b *BlockChain) calcNextRequiredDifficulty(curNode *blockNode, newBlockTime
 					newTarget.Set(b.chainParams.PowLimit)
 				}
 
-				return BigToCompact(newTarget), nil
+				return blockchainutil.BigToCompact(newTarget), nil
 			}
 
 			// The block was mined within the desired timeframe, so
@@ -290,9 +198,9 @@ func (b *BlockChain) calcNextRequiredDifficulty(curNode *blockNode, newBlockTime
 
 	// Declare some useful variables.
 	RAFBig := big.NewInt(b.chainParams.RetargetAdjustmentFactor)
-	nextDiffBigMin := CompactToBig(curNode.bits)
+	nextDiffBigMin := blockchainutil.CompactToBig(curNode.bits)
 	nextDiffBigMin.Div(nextDiffBigMin, RAFBig)
-	nextDiffBigMax := CompactToBig(curNode.bits)
+	nextDiffBigMax := blockchainutil.CompactToBig(curNode.bits)
 	nextDiffBigMax.Mul(nextDiffBigMax, RAFBig)
 
 	alpha := b.chainParams.WorkDiffAlpha
@@ -398,10 +306,10 @@ func (b *BlockChain) calcNextRequiredDifficulty(curNode *blockNode, newBlockTime
 	// intentionally converting the bits back to a number instead of using
 	// newTarget since conversion to the compact representation loses
 	// precision.
-	nextDiffBits := BigToCompact(nextDiffBig)
+	nextDiffBits := blockchainutil.BigToCompact(nextDiffBig)
 	log.Debugf("Difficulty retarget at block height %d", curNode.height+1)
 	log.Debugf("Old target %08x (%064x)", curNode.bits, oldDiffBig)
-	log.Debugf("New target %08x (%064x)", nextDiffBits, CompactToBig(nextDiffBits))
+	log.Debugf("New target %08x (%064x)", nextDiffBits, blockchainutil.CompactToBig(nextDiffBits))
 
 	return nextDiffBits, nil
 }

--- a/blockchain/difficulty_test.go
+++ b/blockchain/difficulty_test.go
@@ -6,52 +6,12 @@
 package blockchain
 
 import (
-	"math/big"
 	"runtime"
 	"testing"
 
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/wire"
 )
-
-func TestBigToCompact(t *testing.T) {
-	tests := []struct {
-		in  int64
-		out uint32
-	}{
-		{0, 0},
-		{-1, 25231360},
-	}
-
-	for x, test := range tests {
-		n := big.NewInt(test.in)
-		r := BigToCompact(n)
-		if r != test.out {
-			t.Errorf("TestBigToCompact test #%d failed: got %d want %d\n",
-				x, r, test.out)
-			return
-		}
-	}
-}
-
-func TestCompactToBig(t *testing.T) {
-	tests := []struct {
-		in  uint32
-		out int64
-	}{
-		{10000000, 0},
-	}
-
-	for x, test := range tests {
-		n := CompactToBig(test.in)
-		want := big.NewInt(test.out)
-		if n.Cmp(want) != 0 {
-			t.Errorf("TestCompactToBig test #%d failed: got %d want %d\n",
-				x, n.Int64(), want.Int64())
-			return
-		}
-	}
-}
 
 func TestCalcWork(t *testing.T) {
 	tests := []struct {

--- a/blockchain/example_test.go
+++ b/blockchain/example_test.go
@@ -7,7 +7,6 @@ package blockchain_test
 
 import (
 	"fmt"
-	"math/big"
 	"os"
 	"path/filepath"
 
@@ -74,38 +73,4 @@ func ExampleBlockChain_ProcessBlock() {
 	// updated if the mainnet genesis block is updated.
 	// Output:
 	// Failed to process block: already have block 267a53b5ee86c24a48ec37aee4f4e7c0c4004892b7259e695e9f5b321f1ab9d2
-}
-
-// This example demonstrates how to convert the compact "bits" in a block header
-// which represent the target difficulty to a big integer and display it using
-// the typical hex notation.
-func ExampleCompactToBig() {
-	// Convert the bits from block 300000 in the main Decred block chain.
-	bits := uint32(419465580)
-	targetDifficulty := blockchain.CompactToBig(bits)
-
-	// Display it in hex.
-	fmt.Printf("%064x\n", targetDifficulty.Bytes())
-
-	// Output:
-	// 0000000000000000896c00000000000000000000000000000000000000000000
-}
-
-// This example demonstrates how to convert a target difficulty into the compact
-// "bits" in a block header which represent that target difficulty .
-func ExampleBigToCompact() {
-	// Convert the target difficulty from block 300000 in the main block
-	// chain to compact form.
-	t := "0000000000000000896c00000000000000000000000000000000000000000000"
-	targetDifficulty, success := new(big.Int).SetString(t, 16)
-	if !success {
-		fmt.Println("invalid target difficulty")
-		return
-	}
-	bits := blockchain.BigToCompact(targetDifficulty)
-
-	fmt.Println(bits)
-
-	// Output:
-	// 419465580
 }

--- a/blockchain/process.go
+++ b/blockchain/process.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/decred/dcrd/blockchainutil"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil"
 )
@@ -167,9 +168,9 @@ func (b *BlockChain) ProcessBlock(block *dcrutil.Block, flags BehaviorFlags) (in
 			// expected based on elapsed time since the last checkpoint and
 			// maximum adjustment allowed by the retarget rules.
 			duration := blockHeader.Timestamp.Sub(checkpointTime)
-			requiredTarget := CompactToBig(b.calcEasiestDifficulty(
+			requiredTarget := blockchainutil.CompactToBig(b.calcEasiestDifficulty(
 				checkpointNode.bits, duration))
-			currentTarget := CompactToBig(blockHeader.Bits)
+			currentTarget := blockchainutil.CompactToBig(blockHeader.Bits)
 			if currentTarget.Cmp(requiredTarget) > 0 {
 				str := fmt.Sprintf("block target difficulty of %064x "+
 					"is too low when compared to the previous "+

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/decred/dcrd/blockchain/stake"
+	"github.com/decred/dcrd/blockchainutil"
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/database"
@@ -368,7 +369,7 @@ func CheckProofOfStake(block *dcrutil.Block, posLimit int64) error {
 //    difficulty is not performed.
 func checkProofOfWork(header *wire.BlockHeader, powLimit *big.Int, flags BehaviorFlags) error {
 	// The target difficulty must be larger than zero.
-	target := CompactToBig(header.Bits)
+	target := blockchainutil.CompactToBig(header.Bits)
 	if target.Sign() <= 0 {
 		str := fmt.Sprintf("block target difficulty of %064x is too "+
 			"low", target)

--- a/blockchainutil/compactint.go
+++ b/blockchainutil/compactint.go
@@ -1,0 +1,96 @@
+package blockchainutil
+
+import "math/big"
+
+// CompactToBig converts a compact representation of a whole number N to an
+// unsigned 32-bit number.  The representation is similar to IEEE754 floating
+// point numbers.
+//
+// Like IEEE754 floating point, there are three basic components: the sign,
+// the exponent, and the mantissa.  They are broken out as follows:
+//
+//	* the most significant 8 bits represent the unsigned base 256 exponent
+// 	* bit 23 (the 24th bit) represents the sign bit
+//	* the least significant 23 bits represent the mantissa
+//
+//	-------------------------------------------------
+//	|   Exponent     |    Sign    |    Mantissa     |
+//	-------------------------------------------------
+//	| 8 bits [31-24] | 1 bit [23] | 23 bits [22-00] |
+//	-------------------------------------------------
+//
+// The formula to calculate N is:
+// 	N = (-1^sign) * mantissa * 256^(exponent-3)
+//
+// This compact form is only used in PicFight to encode unsigned 256-bit numbers
+// which represent difficulty targets, thus there really is not a need for a
+// sign bit, but it is implemented here to stay consistent with bitcoind.
+func CompactToBig(compact uint32) *big.Int {
+	// Extract the mantissa, sign bit, and exponent.
+	mantissa := compact & 0x007fffff
+	isNegative := compact&0x00800000 != 0
+	exponent := uint(compact >> 24)
+
+	// Since the base for the exponent is 256, the exponent can be treated
+	// as the number of bytes to represent the full 256-bit number.  So,
+	// treat the exponent as the number of bytes and shift the mantissa
+	// right or left accordingly.  This is equivalent to:
+	// N = mantissa * 256^(exponent-3)
+	var bn *big.Int
+	if exponent <= 3 {
+		mantissa >>= 8 * (3 - exponent)
+		bn = big.NewInt(int64(mantissa))
+	} else {
+		bn = big.NewInt(int64(mantissa))
+		bn.Lsh(bn, 8*(exponent-3))
+	}
+
+	// Make it negative if the sign bit is set.
+	if isNegative {
+		bn = bn.Neg(bn)
+	}
+
+	return bn
+}
+
+// BigToCompact converts a whole number N to a compact representation using
+// an unsigned 32-bit number.  The compact representation only provides 23 bits
+// of precision, so values larger than (2^23 - 1) only encode the most
+// significant digits of the number.  See CompactToBig for details.
+func BigToCompact(n *big.Int) uint32 {
+	// No need to do any work if it's zero.
+	if n.Sign() == 0 {
+		return 0
+	}
+
+	// Since the base for the exponent is 256, the exponent can be treated
+	// as the number of bytes.  So, shift the number right or left
+	// accordingly.  This is equivalent to:
+	// mantissa = mantissa / 256^(exponent-3)
+	var mantissa uint32
+	exponent := uint(len(n.Bytes()))
+	if exponent <= 3 {
+		mantissa = uint32(n.Bits()[0])
+		mantissa <<= 8 * (3 - exponent)
+	} else {
+		// Use a copy to avoid modifying the caller's original number.
+		tn := new(big.Int).Set(n)
+		mantissa = uint32(tn.Rsh(tn, 8*(exponent-3)).Bits()[0])
+	}
+
+	// When the mantissa already has the sign bit set, the number is too
+	// large to fit into the available 23-bits, so divide the number by 256
+	// and increment the exponent accordingly.
+	if mantissa&0x00800000 != 0 {
+		mantissa >>= 8
+		exponent++
+	}
+
+	// Pack the exponent, sign bit, and mantissa into an unsigned 32-bit
+	// int and return it.
+	compact := uint32(exponent<<24) | mantissa
+	if n.Sign() < 0 {
+		compact |= 0x00800000
+	}
+	return compact
+}

--- a/blockchainutil/compactint_test.go
+++ b/blockchainutil/compactint_test.go
@@ -1,0 +1,80 @@
+package blockchainutil
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+)
+
+func TestBigToCompact(t *testing.T) {
+	tests := []struct {
+		in  int64
+		out uint32
+	}{
+		{0, 0},
+		{-1, 25231360},
+	}
+
+	for x, test := range tests {
+		n := big.NewInt(test.in)
+		r := BigToCompact(n)
+		if r != test.out {
+			t.Errorf("TestBigToCompact test #%d failed: got %d want %d\n",
+				x, r, test.out)
+			return
+		}
+	}
+}
+
+func TestCompactToBig(t *testing.T) {
+	tests := []struct {
+		in  uint32
+		out int64
+	}{
+		{10000000, 0},
+	}
+
+	for x, test := range tests {
+		n := CompactToBig(test.in)
+		want := big.NewInt(test.out)
+		if n.Cmp(want) != 0 {
+			t.Errorf("TestCompactToBig test #%d failed: got %d want %d\n",
+				x, n.Int64(), want.Int64())
+			return
+		}
+	}
+}
+
+// This example demonstrates how to convert the compact "bits" in a block header
+// which represent the target difficulty to a big integer and display it using
+// the typical hex notation.
+func ExampleCompactToBig() {
+	// Convert the bits from block 300000 in the main Decred block chain.
+	bits := uint32(419465580)
+	targetDifficulty := CompactToBig(bits)
+
+	// Display it in hex.
+	fmt.Printf("%064x\n", targetDifficulty.Bytes())
+
+	// Output:
+	// 0000000000000000896c00000000000000000000000000000000000000000000
+}
+
+// This example demonstrates how to convert a target difficulty into the compact
+// "bits" in a block header which represent that target difficulty .
+func ExampleBigToCompact() {
+	// Convert the target difficulty from block 300000 in the main block
+	// chain to compact form.
+	t := "0000000000000000896c00000000000000000000000000000000000000000000"
+	targetDifficulty, success := new(big.Int).SetString(t, 16)
+	if !success {
+		fmt.Println("invalid target difficulty")
+		return
+	}
+	bits := BigToCompact(targetDifficulty)
+
+	fmt.Println(bits)
+
+	// Output:
+	// 419465580
+}

--- a/blockchainutil/difficulty.go
+++ b/blockchainutil/difficulty.go
@@ -1,0 +1,76 @@
+package blockchainutil
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"strings"
+)
+
+// Difficulty is a struct modeling the concept of how difficult it
+//  is to find a hash below a given target (https://en.bitcoin.it/wiki/Difficulty)
+//
+//  Difficulty has at least three different representations:
+//  1) Hex string
+//       example: `00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff`
+//  2) big.Int
+//       example: `new(big.Int).Sub(new(big.Int).Lsh(bigOne, 256-32), bigOne)`
+//  3) Bits, or in a compact form
+//       example: `0x1d00ffff`
+//
+// All the examples above represent the same entity.
+//
+//  The purpose of this struct is to properly handle all the representations
+//  and to avoid creating multiple occurrences of the same constants in different forms
+type Difficulty struct {
+	bigInt big.Int
+}
+
+//Print outputs Difficulty in all representations for debug purposes
+func (dif *Difficulty) Print() *Difficulty {
+	fmt.Println("hexstring: ", dif.ToHexString())
+	fmt.Println("     Bits: ", dif.ToCompact())
+	fmt.Println("  BitsHex: ", fmt.Sprintf("%x", dif.ToCompact()))
+	fmt.Println("   bigInt: ", dif.ToBigInt())
+	fmt.Println("")
+	return dif
+}
+
+//ToCompact projects instance into compact representation
+func (dif *Difficulty) ToCompact() uint32 {
+	return BigToCompact(&dif.bigInt)
+}
+
+//ToBigInt projects instance into big integer representation
+func (dif *Difficulty) ToBigInt() *big.Int {
+	return &dif.bigInt
+}
+
+//ToHexString projects instance into hex string representation
+func (dif *Difficulty) ToHexString() string {
+	return fmt.Sprintf("%064x", &dif.bigInt)
+}
+
+//NewDifficultyFromHashString creates a new instance from 64-digits hex
+// string. Spaces are allowed for readability. Valid examples inclide:
+// 00 00 00 00 ffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+// 00 00 00 ff ffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+// 7f ff ff ff ffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+func NewDifficultyFromHashString(hexstring string) *Difficulty {
+	noSpaces := strings.Replace(hexstring, " ", "", -1) //remove spaces if any
+	bytes, e := hex.DecodeString(noSpaces)
+
+	if e != nil {
+		panic(e) //invalid input is unacceptable
+	}
+
+	bigInt := new(big.Int)
+	bigInt.SetBytes(bytes)
+	return &Difficulty{*bigInt}
+}
+
+//NewDifficultyFromCompact creates a new instance from compact form (Bits)
+func NewDifficultyFromCompact(compact uint32) *Difficulty {
+	bigInt := CompactToBig(compact)
+	return &Difficulty{*bigInt}
+}

--- a/blockchainutil/difficulty_test.go
+++ b/blockchainutil/difficulty_test.go
@@ -1,0 +1,61 @@
+package blockchainutil
+
+import (
+	"math/big"
+	"testing"
+)
+
+var (
+	// bigOne is 1 represented as a big.Int.  It is defined here to avoid
+	// the overhead of creating it multiple times.
+	bigOne = big.NewInt(1)
+)
+
+var testsArray = []struct {
+	hashString string
+	compact    uint32
+	bigInt     *big.Int
+}{
+	{
+		hashString: "00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+		compact:    0x1d00ffff,
+		bigInt:     new(big.Int).Sub(new(big.Int).Lsh(bigOne, 224), bigOne),
+	},
+	{
+		hashString: "00 00 00 00 ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff",
+		compact:    0x1d00ffff,
+		bigInt:     new(big.Int).Sub(new(big.Int).Lsh(bigOne, 224), bigOne),
+	},
+	{
+		hashString: "00 00 00 00 ffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+		compact:    0x1d00ffff,
+		bigInt:     new(big.Int).Sub(new(big.Int).Lsh(bigOne, 224), bigOne),
+	},
+	{
+		hashString: "000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+		compact:    0x1e00ffff,
+		bigInt:     new(big.Int).Sub(new(big.Int).Lsh(bigOne, 232), bigOne),
+	},
+	{
+		hashString: "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+		compact:    0x207fffff,
+		bigInt:     new(big.Int).Sub(new(big.Int).Lsh(bigOne, 255), bigOne),
+	},
+}
+
+func TestDifficulty(t *testing.T) {
+	for i, test := range testsArray {
+		diffFromHash := NewDifficultyFromHashString(test.hashString).Print()
+
+		bigInt := diffFromHash.ToBigInt()
+		if bigInt.Cmp(test.bigInt) != 0 {
+			t.Fatalf("TestDifficulty[%v] values mismatch: diffFromHash.ToBigInt()=%v is not equal to test.bigInt=%v", i, diffFromHash.ToBigInt(), test.bigInt)
+		}
+
+		compact := diffFromHash.ToCompact()
+		if compact != test.compact {
+			t.Fatalf("TestDifficulty[%v] values mismatch: diffFromHash.ToCompact()=%v is not equal to test.compact=%v", i, diffFromHash.ToCompact(), test.compact)
+		}
+	}
+
+}

--- a/chaincfg/mainnetparams.go
+++ b/chaincfg/mainnetparams.go
@@ -25,8 +25,8 @@ var MainNetParams = Params{
 	// Chain parameters
 	GenesisBlock:             &genesisBlock,
 	GenesisHash:              &genesisHash,
-	PowLimit:                 mainPowLimit,
-	PowLimitBits:             0x1d00ffff,
+	PowLimit:                 mainPowLimit.ToBigInt(),
+	PowLimitBits:             mainPowLimit.ToCompact(),
 	ReduceMinDifficulty:      false,
 	MinDiffReductionTime:     0, // Does not apply since ReduceMinDifficulty false
 	GenerateSupported:        false,

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -12,28 +12,35 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/decred/dcrd/blockchainutil"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/wire"
 )
 
 // These variables are the chain proof-of-work limit parameters for each default
-// network.
+// network. Network power limit is the highest proof of work value a Decred
+// block can have. params_test.go should cover this section to ensure validity
 var (
-	// bigOne is 1 represented as a big.Int.  It is defined here to avoid
-	// the overhead of creating it multiple times.
-	bigOne = big.NewInt(1)
+	//  mainPowLimit value for the main network.
+	//  First 4 bytes (32 bits) are zeroes and the big.Int value
+	//  is equal to 2^(256-4*8) - 1 = 2^(256-32) - 1 = 2^224 - 1
+	//  compact form (Bits) is 0x1d00ffff
+	mainPowLimit = blockchainutil.NewDifficultyFromHashString( //
+		"00 00 00 00 ffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
 
-	// mainPowLimit is the highest proof of work value a Decred block can
-	// have for the main network.  It is the value 2^224 - 1.
-	mainPowLimit = new(big.Int).Sub(new(big.Int).Lsh(bigOne, 224), bigOne)
+	// testNetPowLimit value for the test network.
+	// First 3 bytes (24 bits) are zeroes and the big.Int value
+	// is equal to 2^(256-3*8) - 1 = 2^(256-24) - 1 = 2^232 - 1
+	// compact form (Bits) is 0x1e00ffff
+	testNetPowLimit = blockchainutil.NewDifficultyFromHashString(
+		"00 00 00 ff ffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
 
-	// testNetPowLimit is the highest proof of work value a Decred block
-	// can have for the test network.  It is the value 2^232 - 1.
-	testNetPowLimit = new(big.Int).Sub(new(big.Int).Lsh(bigOne, 232), bigOne)
-
-	// simNetPowLimit is the highest proof of work value a Decred block
-	// can have for the simulation test network.  It is the value 2^255 - 1.
-	simNetPowLimit = new(big.Int).Sub(new(big.Int).Lsh(bigOne, 255), bigOne)
+	// simNetPowLimit value for the simulation test network.
+	// First bit is zero, 7f = 01111111 in binary form, so the big.Int value
+	// is equal to 2^(256-1) - 1 = 2^255 - 1
+	// compact form (Bits) is 0x207fffff
+	simNetPowLimit = blockchainutil.NewDifficultyFromHashString(
+		"7f ff ff ff ffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
 
 	VoteBitsNotFound = fmt.Errorf("vote bits not found")
 )

--- a/chaincfg/params_test.go
+++ b/chaincfg/params_test.go
@@ -5,7 +5,12 @@
 
 package chaincfg
 
-import "testing"
+import (
+	"math/big"
+	"testing"
+
+	"github.com/decred/dcrd/blockchainutil"
+)
 
 // TestMustRegisterPanic ensures the mustRegister function panics when used to
 // register an invalid network.
@@ -22,4 +27,38 @@ func TestMustRegisterPanic(t *testing.T) {
 
 	// Intentionally try to register duplicate params to force a panic.
 	mustRegister(&MainNetParams)
+}
+
+func TestCheckDifficulty(t *testing.T) {
+	bigOne := big.NewInt(1)
+
+	{ //Check proof-of-work limit parameter for the main network
+		testBigIntValue := new(big.Int).Sub(new(big.Int).Lsh(bigOne, 256-4*8), bigOne)
+		testCompactBitsValue := uint32(0x1d00ffff)
+		checkPowerLimit(t, mainPowLimit, testCompactBitsValue, testBigIntValue)
+	}
+	{ //Check proof-of-work limit parameter for the test network
+		testBigIntValue := new(big.Int).Sub(new(big.Int).Lsh(bigOne, 256-3*8), bigOne)
+		testCompactBitsValue := uint32(0x1e00ffff)
+		checkPowerLimit(t, testNetPowLimit, testCompactBitsValue, testBigIntValue)
+	}
+	{ //Check proof-of-work limit parameter for the sim network
+		testBigIntValue := new(big.Int).Sub(new(big.Int).Lsh(bigOne, 256-1), bigOne)
+		testCompactBitsValue := uint32(0x207fffff)
+		checkPowerLimit(t, simNetPowLimit, testCompactBitsValue, testBigIntValue)
+	}
+
+}
+
+func checkPowerLimit(t *testing.T, dif *blockchainutil.Difficulty, testCompactBitsValue uint32, testBigIntValue *big.Int) {
+	dif.Print() //for code coverage and tests debug
+
+	if dif.ToBigInt().Cmp(testBigIntValue) != 0 {
+		t.Fatalf("mainPowLimit values mismatch: testBigIntValue=%v is not equal to dif.ToBigInt()=%v", testBigIntValue, mainPowLimit.ToBigInt())
+	}
+
+	if dif.ToCompact() != testCompactBitsValue {
+		t.Fatalf("mainPowLimit values mismatch: testCompactBitsValue=%v is not equal to dif.ToCompact()=%v", testBigIntValue, mainPowLimit.ToBigInt())
+	}
+
 }

--- a/chaincfg/simnetparams.go
+++ b/chaincfg/simnetparams.go
@@ -28,8 +28,8 @@ var SimNetParams = Params{
 	// Chain parameters
 	GenesisBlock:             &simNetGenesisBlock,
 	GenesisHash:              &simNetGenesisHash,
-	PowLimit:                 simNetPowLimit,
-	PowLimitBits:             0x207fffff,
+	PowLimit:                 simNetPowLimit.ToBigInt(),
+	PowLimitBits:             simNetPowLimit.ToCompact(),
 	ReduceMinDifficulty:      false,
 	MinDiffReductionTime:     0, // Does not apply since ReduceMinDifficulty false
 	GenerateSupported:        true,

--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -27,8 +27,8 @@ var TestNet2Params = Params{
 	// Chain parameters
 	GenesisBlock:             &testNet2GenesisBlock,
 	GenesisHash:              &testNet2GenesisHash,
-	PowLimit:                 testNetPowLimit,
-	PowLimitBits:             0x1e00ffff,
+	PowLimit:                 testNetPowLimit.ToBigInt(),
+	PowLimitBits:             testNetPowLimit.ToCompact(),
 	ReduceMinDifficulty:      false,
 	MinDiffReductionTime:     0, // Does not apply since ReduceMinDifficulty false
 	GenerateSupported:        true,

--- a/cpuminer.go
+++ b/cpuminer.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/decred/dcrd/blockchain"
+	"github.com/decred/dcrd/blockchainutil"
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil"
@@ -204,7 +205,7 @@ func (m *CPUMiner) solveBlock(msgBlock *wire.MsgBlock, ticker *time.Ticker, quit
 
 	// Create a couple of convenience variables.
 	header := &msgBlock.Header
-	targetDifficulty := blockchain.CompactToBig(header.Bits)
+	targetDifficulty := blockchainutil.CompactToBig(header.Bits)
 
 	// Initial state.
 	lastGenerated := time.Now()

--- a/mining.go
+++ b/mining.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/decred/dcrd/blockchain"
 	"github.com/decred/dcrd/blockchain/stake"
+	"github.com/decred/dcrd/blockchainutil"
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil"
@@ -2029,7 +2030,7 @@ mempoolLoop:
 		"%d bytes, target difficulty %064x, stake difficulty %v)",
 		len(msgBlock.Transactions), len(msgBlock.STransactions),
 		totalFees, blockSigOps, blockSize,
-		blockchain.CompactToBig(msgBlock.Header.Bits),
+		blockchainutil.CompactToBig(msgBlock.Header.Bits),
 		dcrutil.Amount(msgBlock.Header.SBits).ToCoin())
 
 	blockTemplate := &BlockTemplate{

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -33,6 +33,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/decred/dcrd/blockchainutil"
+
 	"github.com/gorilla/websocket"
 
 	"github.com/decred/dcrd/blockchain"
@@ -1898,8 +1900,8 @@ func getDifficultyRatio(bits uint32) float64 {
 	// converted back to a number.  Note this is not the same as the proof
 	// of work limit directly because the block difficulty is encoded in a
 	// block with the compact form which loses precision.
-	max := blockchain.CompactToBig(activeNetParams.PowLimitBits)
-	target := blockchain.CompactToBig(bits)
+	max := blockchainutil.CompactToBig(activeNetParams.PowLimitBits)
+	target := blockchainutil.CompactToBig(bits)
 
 	difficulty := new(big.Rat).SetFrac(max, target)
 	outString := difficulty.FloatString(8)
@@ -2374,7 +2376,7 @@ func (state *gbtWorkState) updateBlockTemplate(s *rpcServer, useCoinbaseValue bo
 		template = blkTemplate
 		msgBlock = template.Block
 		targetDifficulty = fmt.Sprintf("%064x",
-			blockchain.CompactToBig(msgBlock.Header.Bits))
+			blockchainutil.CompactToBig(msgBlock.Header.Bits))
 
 		// Find the minimum allowed timestamp for the block based on the
 		// median timestamp of the last several blocks per the chain
@@ -2438,7 +2440,7 @@ func (state *gbtWorkState) updateBlockTemplate(s *rpcServer, useCoinbaseValue bo
 		// Set locals for convenience.
 		msgBlock = template.Block
 		targetDifficulty = fmt.Sprintf("%064x",
-			blockchain.CompactToBig(msgBlock.Header.Bits))
+			blockchainutil.CompactToBig(msgBlock.Header.Bits))
 
 		// Update the time of the block template to the current time
 		// while accounting for the median time of the past several
@@ -2625,7 +2627,7 @@ func (state *gbtWorkState) blockTemplateResult(bm *blockManager, useCoinbaseValu
 	// are implied by the included or omission of fields:
 	//  Including MinTime -> time/decrement
 	//  Omitting CoinbaseTxn -> coinbase, generation
-	targetDifficulty := fmt.Sprintf("%064x", blockchain.CompactToBig(header.Bits))
+	targetDifficulty := fmt.Sprintf("%064x", blockchainutil.CompactToBig(header.Bits))
 	templateID := encodeTemplateID(state.prevHash, state.lastGenerated)
 	reply := dcrjson.GetBlockTemplateResult{
 		Header:        hex.EncodeToString(headerBytes),
@@ -4080,7 +4082,7 @@ func handleGetWorkRequest(s *rpcServer) (interface{}, error) {
 		rpcsLog.Debugf("Generated block template (timestamp %v, extra "+
 			"nonce %d, target %064x, merkle root %s)",
 			msgBlock.Header.Timestamp, state.extraNonce,
-			blockchain.CompactToBig(msgBlock.Header.Bits),
+			blockchainutil.CompactToBig(msgBlock.Header.Bits),
 			msgBlock.Header.MerkleRoot)
 	} else {
 		if msgBlock == nil {
@@ -4128,7 +4130,7 @@ func handleGetWorkRequest(s *rpcServer) (interface{}, error) {
 			"nonce %d, target %064x, merkle root %s)",
 			msgBlock.Header.Timestamp,
 			state.extraNonce,
-			blockchain.CompactToBig(msgBlock.Header.Bits),
+			blockchainutil.CompactToBig(msgBlock.Header.Bits),
 			msgBlock.Header.MerkleRoot)
 	}
 
@@ -4187,7 +4189,7 @@ func handleGetWorkRequest(s *rpcServer) (interface{}, error) {
 	// The fact the fields are reversed in this way is rather odd and likey
 	// an artifact of some legacy internal state in the reference
 	// implementation, but it is required for compatibility.
-	target := bigToLEUint256(blockchain.CompactToBig(msgBlock.Header.Bits))
+	target := bigToLEUint256(blockchainutil.CompactToBig(msgBlock.Header.Bits))
 	reply := &dcrjson.GetWorkResult{
 		Data:   hex.EncodeToString(data),
 		Target: hex.EncodeToString(target[:]),


### PR DESCRIPTION
#### Motivation
Currently network parameters contain multiple [unnamed numerical constants](https://en.wikipedia.org/wiki/Magic_number_(programming)#Unnamed_numerical_constants) referring conceptually to the same entities.

Example:
```
mainnetparams.go:
...
PowLimit:         mainPowLimit,// big int
PowLimitBits:     0x1d00ffff,  //conceptually the same
                               //value, but in an obscure form
...
```

The purpose of this PR is to improve code readability and maintainability.

#### Proposed changes
1) Create a structure for Difficulty
2) Group network PoW limits in dedicated variables
3) Move the `CompactToBig()` and `BigToCompact()` functions from
the ```blockchain``` to an upper-level package


#### Commits:

#### Step 1: Create the structure ```Difficulty```

 ```Difficulty``` is a struct modeling the concept of how difficult it is to find a hash below a given target (https://en.bitcoin.it/wiki/Difficulty) ```Difficulty``` has at least three different representations:
 1) Hex string
      example: `00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff`
 2) big.Int
      example: `new(big.Int).Sub(new(big.Int).Lsh(bigOne, 256-32), bigOne)`
 3) Bits, or in a compact form
      example: `0x1d00ffff`

 The purpose of this struct is to properly handle all representations and to avoid creating multiple occurrences of the same constants in different forms.

All required tests are attached.

#### Step 2: Update ```mainnetparams.go```, ```simnetparams.go```, ```testnetparams.go```
Previously used `big.Int` constants are replaced to use the ```Difficulty```-struct. 

All required tests are attached.

#### Step 3: remove duplicated code from the ```blockchain``` package and update the related calls
Overall this PR moves `CompactToBig()` and `BigToCompact()` functions and related tests from the `blockchain`-package into the newly created `blockchainutil`. The reason for this is to avoid loop dependency when `chaincfg` is not able to use the functions producing the following error message:
```
go build
import cycle not allowed
package github.com/decred/dcrd
        imports github.com/decred/dcrd/blockchain
        imports github.com/decred/dcrd/blockchain/internal/progresslog
        imports github.com/decred/dcrd/dcrutil
        imports github.com/decred/dcrd/chaincfg
        imports github.com/decred/dcrd/blockchain
```
Keeping these basic functions separated improves overall code structure by making them accessible from any package in the repo, including  ```chaincfg``` and ```blockchain```.

Please let me know if additional changes are required.