### PR TITLE
multi: add valueIn parameter to wire.NewTxIn.

### DIFF
--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -326,7 +326,7 @@ func TestTxValidationErrors(t *testing.T) {
 	// Create a transaction that is too large
 	tx := wire.NewMsgTx()
 	prevOut := wire.NewOutPoint(&chainhash.Hash{0x01}, 0, wire.TxTreeRegular)
-	tx.AddTxIn(wire.NewTxIn(prevOut, nil))
+	tx.AddTxIn(wire.NewTxIn(prevOut, 0, nil))
 	pkScript := bytes.Repeat([]byte{0x00}, wire.MaxBlockPayload)
 	tx.AddTxOut(wire.NewTxOut(0, pkScript))
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -649,7 +649,7 @@ func handleCreateRawTransaction(s *rpcServer, cmd interface{}, closeChan <-chan 
 		}
 
 		prevOut := wire.NewOutPoint(txHash, input.Vout, input.Tree)
-		txIn := wire.NewTxIn(prevOut, []byte{})
+		txIn := wire.NewTxIn(prevOut, wire.NullValueIn, []byte{})
 		if c.LockTime != nil && *c.LockTime != 0 {
 			txIn.Sequence = wire.MaxTxInSequenceNum - 1
 		}
@@ -759,7 +759,7 @@ func handleCreateRawSStx(s *rpcServer, cmd interface{}, closeChan <-chan struct{
 		}
 
 		prevOut := wire.NewOutPoint(txHash, input.Vout, input.Tree)
-		txIn := wire.NewTxIn(prevOut, []byte{})
+		txIn := wire.NewTxIn(prevOut, wire.NullValueIn, []byte{})
 		mtx.AddTxIn(txIn)
 	}
 
@@ -985,7 +985,7 @@ func handleCreateRawSSGenTx(s *rpcServer, cmd interface{}, closeChan <-chan stru
 
 	stakeBaseOutPoint := wire.NewOutPoint(&chainhash.Hash{},
 		uint32(0xFFFFFFFF), int8(0x01))
-	txInStakeBase := wire.NewTxIn(stakeBaseOutPoint, []byte{})
+	txInStakeBase := wire.NewTxIn(stakeBaseOutPoint, stakeVoteSubsidy, []byte{})
 	mtx.AddTxIn(txInStakeBase)
 
 	for _, input := range c.Inputs {
@@ -1004,7 +1004,7 @@ func handleCreateRawSSGenTx(s *rpcServer, cmd interface{}, closeChan <-chan stru
 		}
 
 		prevOut := wire.NewOutPoint(txHash, input.Vout, input.Tree)
-		txIn := wire.NewTxIn(prevOut, []byte{})
+		txIn := wire.NewTxIn(prevOut, wire.NullValueIn, []byte{})
 		mtx.AddTxIn(txIn)
 	}
 
@@ -1145,7 +1145,7 @@ func handleCreateRawSSRtx(s *rpcServer, cmd interface{}, closeChan <-chan struct
 		}
 
 		prevOut := wire.NewOutPoint(txHash, input.Vout, input.Tree)
-		txIn := wire.NewTxIn(prevOut, []byte{})
+		txIn := wire.NewTxIn(prevOut, wire.NullValueIn, []byte{})
 		mtx.AddTxIn(txIn)
 	}
 

--- a/rpctest/memwallet.go
+++ b/rpctest/memwallet.go
@@ -396,7 +396,7 @@ func (m *memWallet) fundTx(tx *wire.MsgTx, amt dcrutil.Amount, feeRate dcrutil.A
 		// Add the selected output to the transaction, updating the
 		// current tx size while accounting for the size of the future
 		// sigScript.
-		tx.AddTxIn(wire.NewTxIn(&outPoint, nil))
+		tx.AddTxIn(wire.NewTxIn(&outPoint, int64(utxo.value), nil))
 		txSize = tx.SerializeSize() + spendSize*len(tx.TxIn)
 
 		// Calculate the fee required for the txn at this point

--- a/txscript/example_test.go
+++ b/txscript/example_test.go
@@ -104,7 +104,7 @@ func ExampleSignTxOutput() {
 	// contains a single output that pays to address in the amount of 1 DCR.
 	originTx := wire.NewMsgTx()
 	prevOut := wire.NewOutPoint(&chainhash.Hash{}, ^uint32(0), wire.TxTreeRegular)
-	txIn := wire.NewTxIn(prevOut, []byte{txscript.OP_0, txscript.OP_0})
+	txIn := wire.NewTxIn(prevOut, 100000000, []byte{txscript.OP_0, txscript.OP_0})
 	originTx.AddTxIn(txIn)
 	pkScript, err := txscript.PayToAddrScript(addr)
 	if err != nil {
@@ -122,7 +122,7 @@ func ExampleSignTxOutput() {
 	// signature script at this point since it hasn't been created or signed
 	// yet, hence nil is provided for it.
 	prevOut = wire.NewOutPoint(&originTxHash, 0, wire.TxTreeRegular)
-	txIn = wire.NewTxIn(prevOut, nil)
+	txIn = wire.NewTxIn(prevOut, 100000000, nil)
 	redeemTx.AddTxIn(txIn)
 
 	// Ordinarily this would contain that actual destination of the funds,

--- a/txscript/reference_test.go
+++ b/txscript/reference_test.go
@@ -169,7 +169,7 @@ func createSpendingTx(sigScript, pkScript []byte) *wire.MsgTx {
 
 	outPoint := wire.NewOutPoint(&chainhash.Hash{}, ^uint32(0),
 		wire.TxTreeRegular)
-	txIn := wire.NewTxIn(outPoint, []byte{OP_0, OP_0})
+	txIn := wire.NewTxIn(outPoint, 0, []byte{OP_0, OP_0})
 	txOut := wire.NewTxOut(0, pkScript)
 	coinbaseTx.AddTxIn(txIn)
 	coinbaseTx.AddTxOut(txOut)
@@ -177,7 +177,7 @@ func createSpendingTx(sigScript, pkScript []byte) *wire.MsgTx {
 	spendingTx := wire.NewMsgTx()
 	coinbaseTxHash := coinbaseTx.TxHash()
 	outPoint = wire.NewOutPoint(&coinbaseTxHash, 0, wire.TxTreeRegular)
-	txIn = wire.NewTxIn(outPoint, sigScript)
+	txIn = wire.NewTxIn(outPoint, 0, sigScript)
 	txOut = wire.NewTxOut(0, nil)
 
 	spendingTx.AddTxIn(txIn)

--- a/txscript/sign_test.go
+++ b/txscript/sign_test.go
@@ -2259,7 +2259,7 @@ nexttest:
 		tx.AddTxOut(output)
 
 		for range sigScriptTests[i].inputs {
-			txin := wire.NewTxIn(coinbaseOutPoint, nil)
+			txin := wire.NewTxIn(coinbaseOutPoint, 500, nil)
 			tx.AddTxIn(txin)
 		}
 

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -305,12 +305,12 @@ func (t *TxIn) SerializeSizeWitness() int {
 // NewTxIn returns a new Decred transaction input with the provided
 // previous outpoint point and signature script with a default sequence of
 // MaxTxInSequenceNum.
-func NewTxIn(prevOut *OutPoint, signatureScript []byte) *TxIn {
+func NewTxIn(prevOut *OutPoint, valueIn int64, signatureScript []byte) *TxIn {
 	return &TxIn{
 		PreviousOutPoint: *prevOut,
 		Sequence:         MaxTxInSequenceNum,
 		SignatureScript:  signatureScript,
-		ValueIn:          NullValueIn,
+		ValueIn:          valueIn,
 		BlockHeight:      NullBlockHeight,
 		BlockIndex:       NullBlockIndex,
 	}

--- a/wire/msgtx_test.go
+++ b/wire/msgtx_test.go
@@ -75,7 +75,7 @@ func TestTx(t *testing.T) {
 
 	// Ensure we get the same transaction input back out.
 	sigScript := []byte{0x04, 0x31, 0xdc, 0x00, 0x1b, 0x01, 0x62}
-	txIn := NewTxIn(prevOut, sigScript)
+	txIn := NewTxIn(prevOut, 5000000000, sigScript)
 	if !reflect.DeepEqual(&txIn.PreviousOutPoint, prevOut) {
 		t.Errorf("NewTxIn: wrong prev outpoint - got %v, want %v",
 			spew.Sprint(&txIn.PreviousOutPoint),
@@ -88,7 +88,7 @@ func TestTx(t *testing.T) {
 	}
 
 	// Ensure we get the same transaction output back out.
-	txValue := int64(5000000000)
+	txValue := txIn.ValueIn - 1000
 	pkScript := []byte{
 		0x41, // OP_DATA_65
 		0x04, 0xd6, 0x4b, 0xdf, 0xd0, 0x9e, 0xb1, 0xc5,


### PR DESCRIPTION
This adds the valueIn parameter to wire.NewTxIn. Call sites and associated tests have also been updated.

Resolves #1279