### PR TITLE
txscript: Cleanup and add tests for div opcode.

### DIFF
--- a/txscript/data/script_invalid.json
+++ b/txscript/data/script_invalid.json
@@ -88,6 +88,15 @@
 ["2147483648 1", "ROTL 1 EQUAL", "P2SH,STRICTENC", "ROTL must fail with input value >4 bytes"],
 ["1 2147483648", "ROTL TRUE", "P2SH,STRICTENC", "ROTL must fail with rotation count >4 bytes"],
 
+["Division related test coverage"],
+["", "DIV TRUE", "P2SH,STRICTENC", "DIV requires a divisor"],
+["3", "DIV TRUE", "P2SH,STRICTENC", "DIV requires a dividend"],
+["NOP 3", "DIV TRUE", "P2SH,STRICTENC", "DIV dividend must be numeric"],
+["6 NOP", "DIV TRUE", "P2SH,STRICTENC", "DIV divisor must be numeric"],
+["6 0", "DIV TRUE", "P2SH,STRICTENC", "DIV must fail with zero divisor"],
+["2147483648 1073741824", "DIV TRUE", "P2SH,STRICTENC", "DIV must fail with dividend >4 bytes"],
+["1 2147483648", "DIV TRUE", "P2SH,STRICTENC", "DIV must fail with divisor >4 bytes"],
+
 ["Left bit shift related test coverage"],
 ["", "LSHIFT NOT", "P2SH,STRICTENC", "LSHIFT requires an input value"],
 ["1", "LSHIFT TRUE", "P2SH,STRICTENC", "LSHIFT requires a shift count"],

--- a/txscript/data/script_valid.json
+++ b/txscript/data/script_valid.json
@@ -151,7 +151,17 @@
 ["2 2 0 IF RSHIFT ELSE 1 ENDIF", "NOP", "P2SH,STRICTENC"],
 
 ["2 DUP MUL", "4 EQUAL", "P2SH,STRICTENC"],
+
+["Division related test coverage"],
+["7 3", "DIV 2 EQUAL", "STRICTENC", "DIV must perform integer division (7 / 3)"],
+["8 3", "DIV 2 EQUAL", "STRICTENC", "DIV must perform integer division (8 / 3)"],
+["6 3", "DIV 2 EQUAL", "STRICTENC", "DIV must support a positive dividend and divisor"],
+["-6 3", "DIV -2 EQUAL", "STRICTENC", "DIV must support a negative dividend with positive divisor"],
+["6 -3", "DIV -2 EQUAL", "STRICTENC", "DIV must support a positive dividend with negative divisor"],
+["-6 -3", "DIV 2 EQUAL", "STRICTENC", "DIV must support a negative dividend and divisor"],
+["-2147483647 DUP", "DIV 1 EQUAL", "STRICTENC", "DIV must support 4-byte negative int32"],
 ["2 DUP DIV", "1 EQUAL", "P2SH,STRICTENC"],
+
 ["7 3 MOD", "1 EQUAL", "P2SH,STRICTENC"],
 
 ["Left bit shift related test coverage"],

--- a/txscript/opcode.go
+++ b/txscript/opcode.go
@@ -1952,19 +1952,21 @@ func opcodeDiv(op *parsedOpcode, vm *Engine) error {
 	if err != nil {
 		return err
 	}
-
 	v1, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
 
-	if v0.Int32() == 0 {
+	// The dividend and divisor are limited to int32 via the above, so it is
+	// safe to cast them.
+	divisor := v0.Int32()
+	dividend := v1.Int32()
+
+	if divisor == 0 {
 		return ErrDivideByZero
 	}
 
-	v2 := v1.Int32() / v0.Int32()
-
-	vm.dstack.PushInt(scriptNum(v2))
+	vm.dstack.PushInt(scriptNum(dividend / divisor))
 	return nil
 }
 


### PR DESCRIPTION
This cleans up the code for handling the div opcode to explicitly call out its semantics which are likely not otherwise obvious as well as improve its readability.

It also adds several tests to the reference script tests which exercise the semantics of the div opcode including both positive and negative tests.
