### PR TITLE
txscript: Cleanup and add tests for mod opcode.

### DIFF
--- a/txscript/data/script_invalid.json
+++ b/txscript/data/script_invalid.json
@@ -97,6 +97,15 @@
 ["2147483648 1073741824", "DIV TRUE", "P2SH,STRICTENC", "DIV must fail with dividend >4 bytes"],
 ["1 2147483648", "DIV TRUE", "P2SH,STRICTENC", "DIV must fail with divisor >4 bytes"],
 
+["Modular division related test coverage"],
+["", "MOD TRUE", "P2SH,STRICTENC", "MOD requires a divisor"],
+["3", "MOD TRUE", "P2SH,STRICTENC", "MOD requires a dividend"],
+["NOP 3", "MOD TRUE", "P2SH,STRICTENC", "MOD dividend must be numeric"],
+["6 NOP", "MOD TRUE", "P2SH,STRICTENC", "MOD divisor must be numeric"],
+["6 0", "MOD TRUE", "P2SH,STRICTENC", "MOD must fail with zero divisor"],
+["2147483648 1073741824", "MOD TRUE", "P2SH,STRICTENC", "MOD must fail with dividend >4 bytes"],
+["1 2147483648", "MOD TRUE", "P2SH,STRICTENC", "MOD must fail with divisor >4 bytes"],
+
 ["Left bit shift related test coverage"],
 ["", "LSHIFT NOT", "P2SH,STRICTENC", "LSHIFT requires an input value"],
 ["1", "LSHIFT TRUE", "P2SH,STRICTENC", "LSHIFT requires a shift count"],

--- a/txscript/data/script_valid.json
+++ b/txscript/data/script_valid.json
@@ -162,7 +162,14 @@
 ["-2147483647 DUP", "DIV 1 EQUAL", "STRICTENC", "DIV must support 4-byte negative int32"],
 ["2 DUP DIV", "1 EQUAL", "P2SH,STRICTENC"],
 
-["7 3 MOD", "1 EQUAL", "P2SH,STRICTENC"],
+["Modular division related test coverage"],
+["7 3", "MOD 1 EQUAL", "STRICTENC", "MOD must produce expected result (7%3)"],
+["8 3", "MOD 2 EQUAL", "STRICTENC", "MOD must produce expected result (8%3)"],
+["6 3", "MOD 0 EQUAL", "STRICTENC", "MOD must support a positive dividend and divisor"],
+["-7 3", "MOD -1 EQUAL", "STRICTENC", "MOD must support a negative dividend with positive divisor with negative result"],
+["7 -3", "MOD 1 EQUAL", "STRICTENC", "MOD must support a positive dividend with negative divisor with positve result"],
+["-7 -3", "MOD -1 EQUAL", "STRICTENC", "MOD must support a negative dividend and divisor with negative result"],
+["-2147483647 1073741823", "MOD -1 EQUAL", "STRICTENC", "MOD must support 4-byte negative int32"],
 
 ["Left bit shift related test coverage"],
 ["1 1", "LSHIFT 2 EQUAL", "P2SH,STRICTENC", "LSHIFT 0x1 << 1"],


### PR DESCRIPTION
This cleans up the code for handling the mod opcode to explicitly call out its semantics which are likely not otherwise obvious as well as improve its readability.

It also adds several tests to the reference script tests which exercise the semantics of the div opcode including both positive and negative tests.
