### PR TITLE
multi: Switch default coin types to SLIP0044.

### DIFF
--- a/blockchain/fullblocktests/params.go
+++ b/blockchain/fullblocktests/params.go
@@ -264,7 +264,8 @@ var simNetParams = &chaincfg.Params{
 
 	// BIP44 coin type used in the hierarchical deterministic path for
 	// address generation.
-	HDCoinType: 115, // ASCII for s
+	SLIP0044CoinType: 1,   // SLIP0044, Testnet (all coins)
+	LegacyCoinType:   115, // ASCII for s, for backwards compatibility
 
 	// Decred PoS parameters
 	MinimumStakeDiff:      20000,

--- a/chaincfg/mainnetparams.go
+++ b/chaincfg/mainnetparams.go
@@ -190,7 +190,8 @@ var MainNetParams = Params{
 
 	// BIP44 coin type used in the hierarchical deterministic path for
 	// address generation.
-	HDCoinType: 20,
+	SLIP0044CoinType: 42, // SLIP0044, Decred
+	LegacyCoinType:   20, // for backwards compatibility
 
 	// Decred PoS parameters
 	MinimumStakeDiff:        2 * 1e8, // 2 Coin

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -378,9 +378,17 @@ type Params struct {
 	HDPrivateKeyID [4]byte
 	HDPublicKeyID  [4]byte
 
-	// BIP44 coin type used in the hierarchical deterministic path for
-	// address generation.
-	HDCoinType uint32
+	// SLIP-0044 registered coin type used for BIP44, used in the hierarchical
+	// deterministic path for address generation.
+	// All SLIP-0044 registered coin types are are defined here:
+	// https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+	SLIP0044CoinType uint32
+
+	// Legacy BIP44 coin type used in the hierarchical deterministic path for
+	// address generation. Previous name was HDCoinType, the LegacyCoinType
+	// was introduced for backwards compatibility. Usually, SLIP0044CoinType
+	// should be used instead.
+	LegacyCoinType uint32
 
 	// MinimumStakeDiff if the minimum amount of Atoms required to purchase a
 	// stake ticket.

--- a/chaincfg/simnetparams.go
+++ b/chaincfg/simnetparams.go
@@ -178,7 +178,8 @@ var SimNetParams = Params{
 
 	// BIP44 coin type used in the hierarchical deterministic path for
 	// address generation.
-	HDCoinType: 115, // ASCII for s
+	SLIP0044CoinType: 1,   // SLIP0044, Testnet (all coins)
+	LegacyCoinType:   115, // ASCII for s, for backwards compatibility
 
 	// Decred PoS parameters
 	MinimumStakeDiff:        20000,

--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -163,7 +163,8 @@ var TestNet2Params = Params{
 
 	// BIP44 coin type used in the hierarchical deterministic path for
 	// address generation.
-	HDCoinType: 11,
+	SLIP0044CoinType: 1,  // SLIP0044, Testnet (all coins)
+	LegacyCoinType:   11, // for backwards compatiblity
 
 	// Decred PoS parameters
 	MinimumStakeDiff:        20000000, // 0.2 Coin


### PR DESCRIPTION
Use the coin type numbers defined in SLIP0044:
https://github.com/satoshilabs/slips/blob/master/slip-0044.md

They are not going to change and dcrwallet already uses them.