### PR TITLE
server: Always reply to getheaders with headers

### DIFF
--- a/server.go
+++ b/server.go
@@ -772,10 +772,6 @@ func (sp *serverPeer) OnGetHeaders(p *peer.Peer, msg *wire.MsgGetHeaders) {
 	// over with the genesis block if unknown block locators are provided.
 	chain := sp.server.blockManager.chain
 	headers := chain.LocateHeaders(msg.BlockLocatorHashes, &msg.HashStop)
-	if len(headers) == 0 {
-		// Nothing to send.
-		return
-	}
 
 	// Send found headers to the requesting peer.
 	blockHeaders := make([]*wire.BlockHeader, len(headers))


### PR DESCRIPTION
This reverts a change made in 4f6ed9afdbf4eed86055a5122780f405b48010d2
which resulted in a headers response to not be created for a
getheaders request if there were no more discovered headers.  This was
a deviation from the previous behavior of queueing a headers message
with an empty vector of headers.

This was a protocol change without a protocol bump, so the behavior
must be reverted.

I also cross referenced the Bitcoin Core source code and, just like
the now-restored behavior, headers messages were always sent even when
no new headers were discovered.  I don't see any reason why Decred
should deviate from this behavior.