### PR TITLE
rpcclient: Implement fmt.Stringer for Client

### DIFF
--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -161,6 +161,25 @@ type Client struct {
 	wg              sync.WaitGroup
 }
 
+// String implements fmt.Stringer by returning the URL of the RPC server the
+// client makes requests to.
+func (c *Client) String() string {
+	var u url.URL
+	switch {
+	case c.config.HTTPPostMode && c.config.DisableTLS:
+		u.Scheme = "http"
+	case c.config.HTTPPostMode:
+		u.Scheme = "https"
+	case c.config.DisableTLS:
+		u.Scheme = "ws"
+	default:
+		u.Scheme = "wss"
+	}
+	u.Host = c.config.Host
+	u.Path = c.config.Endpoint
+	return u.String()
+}
+
 // NextID returns the next id to be used when sending a JSON-RPC message.  This
 // ID allows responses to be associated with particular requests per the
 // JSON-RPC specification.  Typically the consumer of the client does not need

--- a/rpcclient/infrastructure_test.go
+++ b/rpcclient/infrastructure_test.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2018 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package rpcclient
+
+import "testing"
+
+func TestClientStringer(t *testing.T) {
+	type test struct {
+		url      string
+		host     string
+		endpoint string
+		post     bool
+	}
+	tests := []test{
+		{"https://localhost:9109", "localhost:9109", "", true},
+		{"wss://localhost:9109/ws", "localhost:9109", "ws", false},
+	}
+	for _, test := range tests {
+		cfg := &ConnConfig{
+			Host:                test.host,
+			Endpoint:            test.endpoint,
+			HTTPPostMode:        test.post,
+			DisableTLS:          false,
+			DisableConnectOnNew: true,
+		}
+		c, err := New(cfg, nil)
+		if err != nil {
+			t.Errorf("%v rpcclient.New: %v", test.url, err)
+			continue
+		}
+		s := c.String()
+		if s != test.url {
+			t.Errorf("Expected %q, got %q", test.url, s)
+		}
+	}
+}


### PR DESCRIPTION
This implements fmt.Stringer by returning the URL of the RPC server
that the client makes requests to.

Since the client config is not exported by Client, this is now the
only way to return the scheme, host, and endpoint the server.