### PR TITLE
blockchain: remove impossible to hit ErrInvalidSSRtxInput.

### DIFF
--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -348,10 +348,6 @@ const (
 	// be OP_SS* tagged, but it must be P2PKH or P2SH.
 	ErrSStxInScrType
 
-	// ErrInvalidSSRtxInput indicates that the input for the SSRtx was not from
-	// an SStx.
-	ErrInvalidSSRtxInput
-
 	// ErrSSRtxPayeesMismatch means that the number of payees in an SSRtx was
 	// not the same as the number of payees in the outputs of the input SStx.
 	ErrSSRtxPayeesMismatch
@@ -532,7 +528,6 @@ var errorCodeStrings = map[ErrorCode]string{
 	ErrSSGenSubsidy:           "ErrSSGenSubsidy",
 	ErrSStxInImmature:         "ErrSStxInImmature",
 	ErrSStxInScrType:          "ErrSStxInScrType",
-	ErrInvalidSSRtxInput:      "ErrInvalidSSRtxInput",
 	ErrSSRtxPayeesMismatch:    "ErrSSRtxPayeesMismatch",
 	ErrSSRtxPayees:            "ErrSSRtxPayees",
 	ErrTxSStxOutSpend:         "ErrTxSStxOutSpend",

--- a/blockchain/error_test.go
+++ b/blockchain/error_test.go
@@ -84,7 +84,6 @@ func TestErrorCodeStringer(t *testing.T) {
 		{ErrSSGenSubsidy, "ErrSSGenSubsidy"},
 		{ErrSStxInImmature, "ErrSStxInImmature"},
 		{ErrSStxInScrType, "ErrSStxInScrType"},
-		{ErrInvalidSSRtxInput, "ErrInvalidSSRtxInput"},
 		{ErrSSRtxPayeesMismatch, "ErrSSRtxPayeesMismatch"},
 		{ErrSSRtxPayees, "ErrSSRtxPayees"},
 		{ErrTxSStxOutSpend, "ErrTxSStxOutSpend"},


### PR DESCRIPTION
`ErrInvalidSSRtxInput`'s triggering condition is a subset of the checks IsSSRtx performs on a transaction. Since `IsSSRtx` is the first to evaluate a tx in `CheckTransactionInputs` that should be enough.

This is work towards #1182