### PR TITLE
txscript: Remove unused old sig hash type.

### DIFF
--- a/txscript/sighash.go
+++ b/txscript/sighash.go
@@ -19,7 +19,6 @@ type SigHashType byte
 
 // Hash type bits from the end of a signature.
 const (
-	SigHashOld          SigHashType = 0x0
 	SigHashAll          SigHashType = 0x1
 	SigHashNone         SigHashType = 0x2
 	SigHashSingle       SigHashType = 0x3
@@ -329,8 +328,6 @@ func calcSignatureHash(prevOutScript []parsedOpcode, hashType SigHashType, tx *w
 		case SigHashSingle:
 			txOuts = tx.TxOut[:idx+1]
 		default:
-			fallthrough
-		case SigHashOld:
 			fallthrough
 		case SigHashAll:
 			// Nothing special here.

--- a/txscript/sign_test.go
+++ b/txscript/sign_test.go
@@ -144,7 +144,6 @@ func TestSignTxOutput(t *testing.T) {
 	// make script based on key.
 	// sign with magic pixie dust.
 	hashTypes := []SigHashType{
-		SigHashOld, // no longer used but should act like all
 		SigHashAll,
 		SigHashNone,
 		SigHashSingle,


### PR DESCRIPTION
**This is currently rebase on #1308**.

This removes the `SigHashOld` definition from the `txscript` package since it both has never been used in Decred and it has also always been invalid to use due to the fact that strict encoding has always been
active and required by consensus in Decred.