### PR TITLE
addrmgr: skip never-successful addresses

### DIFF
--- a/addrmgr/addrmanager.go
+++ b/addrmgr/addrmanager.go
@@ -143,14 +143,14 @@ const (
 
 	// maxFailures is the maximum number of failures we will accept without
 	// a success before considering an address bad.
-	maxFailures = 10
+	maxFailures = 5
 
 	// minBadDays is the number of days since the last success before we
 	// will consider evicting an address.
 	minBadDays = 7
 
 	// getAddrMax is the most addresses that we will send in response
-	// to a getAddr (in practise the most addresses we will return from a
+	// to a getAddr (in practice the most addresses we will return from a
 	// call to AddressCache()).
 	getAddrMax = 2500
 
@@ -666,6 +666,10 @@ func (a *AddrManager) AddressCache() []*wire.NetAddress {
 	for _, v := range a.addrIndex {
 		// Skip low quality addresses.
 		if v.isBad() {
+			continue
+		}
+		// Skip addresses that never succeeded.
+		if v.lastsuccess.IsZero() {
 			continue
 		}
 		allAddr = append(allAddr, v.na)

--- a/addrmgr/knownaddress.go
+++ b/addrmgr/knownaddress.go
@@ -73,7 +73,7 @@ func (ka *KnownAddress) chance() float64 {
 // 1) It claims to be from the future
 // 2) It hasn't been seen in over a month
 // 3) It has failed at least three times and never succeeded
-// 4) It has failed ten times in the last week
+// 4) It has failed a total of maxFailures in the last week
 // All addresses that meet these criteria are assumed to be worthless and not
 // worth keeping hold of.
 func (ka *KnownAddress) isBad() bool {

--- a/server.go
+++ b/server.go
@@ -1018,6 +1018,7 @@ func (sp *serverPeer) OnAddr(p *peer.Peer, msg *wire.MsgAddr) {
 		return
 	}
 
+	now := time.Now()
 	for _, na := range msg.AddrList {
 		// Don't add more address if we're disconnecting.
 		if !p.Connected() {
@@ -1027,7 +1028,6 @@ func (sp *serverPeer) OnAddr(p *peer.Peer, msg *wire.MsgAddr) {
 		// Set the timestamp to 5 days ago if it's more than 24 hours
 		// in the future so this address is one of the first to be
 		// removed when space is needed.
-		now := time.Now()
 		if na.Timestamp.After(now.Add(time.Minute * 10)) {
 			na.Timestamp = now.Add(-1 * time.Hour * 24 * 5)
 		}


### PR DESCRIPTION
A node that has never been successfully connected should not be
announced.