### PR TITLE
txscript: Cleanup P2SH and stake opcode handling.

### DIFF
--- a/txscript/script.go
+++ b/txscript/script.go
@@ -65,6 +65,37 @@ func IsPushOnlyScript(script []byte) bool {
 	return isPushOnly(pops)
 }
 
+// isStakeOpcode returns whether or not the opcode is one of the stake tagging
+// opcodes.
+func isStakeOpcode(op *opcode) bool {
+	return op.value >= OP_SSTX && op.value <= OP_SSTXCHANGE
+}
+
+// isScriptHash returns whether or not the passed script is a regular
+// pay-to-script-hash script.
+func isScriptHash(pops []parsedOpcode) bool {
+	return len(pops) == 3 &&
+		pops[0].opcode.value == OP_HASH160 &&
+		pops[1].opcode.value == OP_DATA_20 &&
+		pops[2].opcode.value == OP_EQUAL
+}
+
+// isStakeScriptHash returns whether or not the passed script is a stake
+// pay-to-script-hash script.
+func isStakeScriptHash(pops []parsedOpcode) bool {
+	return len(pops) == 4 &&
+		isStakeOpcode(pops[0].opcode) &&
+		pops[1].opcode.value == OP_HASH160 &&
+		pops[2].opcode.value == OP_DATA_20 &&
+		pops[3].opcode.value == OP_EQUAL
+}
+
+// isAnyKindOfScriptHash returns whether or not the passed script is either a
+// regular pay-to-script-hash script or a stake pay-to-script-hash script.
+func isAnyKindOfScriptHash(pops []parsedOpcode) bool {
+	return isScriptHash(pops) || isStakeScriptHash(pops)
+}
+
 // HasP2SHScriptSigStakeOpCodes returns an error is the p2sh script has either
 // stake opcodes or if the pkscript cannot be retrieved.
 func HasP2SHScriptSigStakeOpCodes(version uint16, scriptSig,

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -131,34 +131,6 @@ func isPubkeyHashAlt(pops []parsedOpcode) bool {
 		pops[5].opcode.value == OP_CHECKSIGALT
 }
 
-// isScriptHash returns true if the script passed is a pay-to-script-hash
-// transaction, false otherwise.
-func isScriptHash(pops []parsedOpcode) bool {
-	return len(pops) == 3 &&
-		pops[0].opcode.value == OP_HASH160 &&
-		pops[1].opcode.value == OP_DATA_20 &&
-		pops[2].opcode.value == OP_EQUAL
-}
-
-// isAnyKindOfScriptHash returns true if the script passed is a pay-to-script-hash
-// or stake pay-to-script-hash transaction, false otherwise. Used to make the
-// engine have the correct behaviour.
-func isAnyKindOfScriptHash(pops []parsedOpcode) bool {
-	standardP2SH := len(pops) == 3 &&
-		pops[0].opcode.value == OP_HASH160 &&
-		pops[1].opcode.value == OP_DATA_20 &&
-		pops[2].opcode.value == OP_EQUAL
-	if standardP2SH {
-		return true
-	}
-
-	return len(pops) == 4 &&
-		(pops[0].opcode.value >= 186 && pops[0].opcode.value <= 189) &&
-		pops[1].opcode.value == OP_HASH160 &&
-		pops[2].opcode.value == OP_DATA_20 &&
-		pops[3].opcode.value == OP_EQUAL
-}
-
 // isMultiSig returns true if the passed script is a multisig transaction, false
 // otherwise.
 func isMultiSig(pops []parsedOpcode) bool {
@@ -493,7 +465,7 @@ func GetStakeOutSubclass(pkScript []byte) (ScriptClass, error) {
 	if isStake {
 		var stakeSubscript []parsedOpcode
 		for _, pop := range pkPops {
-			if pop.opcode.value >= 186 && pop.opcode.value <= 189 {
+			if isStakeOpcode(pop.opcode) {
 				continue
 			}
 			stakeSubscript = append(stakeSubscript, pop)
@@ -522,7 +494,7 @@ func ContainsStakeOpCodes(pkScript []byte) (bool, error) {
 	}
 
 	for _, pop := range shPops {
-		if pop.opcode.value >= 186 && pop.opcode.value <= 189 {
+		if isStakeOpcode(pop.opcode) {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
This slightly cleans up the handling for pay-to-script-hash scripts and related stake opcode checking as follows:

- Move the `isScriptHash` and `isAnyKindOfScriptHash` functions to `script.go` since they are required by consensus and therefore do not belong in `standard.go` which is reserved for standardness only rules
- Introduce a new function named `isStakeOpcode` and use it throughout versus repeating the specific logic in multiple places
- Use the stake opcode constants instead of magic numbers in the aforementioned new function
- Introduce a new function named `isStakeScriptHash` which specifically determines if a script is of the special stake p2sh form
- Update `isAnyKindOfScriptHash` to make use of the original `isScriptHash` function instead of repeating the logic and the newly introduced `isStakeScriptHash` function