### PR TITLE
txscript: Remove pay-to-script-hash flag.

### DIFF
--- a/blockchain/agendas_test.go
+++ b/blockchain/agendas_test.go
@@ -19,8 +19,7 @@ import (
 func testLNFeaturesDeployment(t *testing.T, params *chaincfg.Params, deploymentVer uint32) {
 	// baseConsensusScriptVerifyFlags are the expected script flags when the
 	// agenda is not active.
-	const baseConsensusScriptVerifyFlags = txscript.ScriptBip16 |
-		txscript.ScriptVerifyDERSignatures |
+	const baseConsensusScriptVerifyFlags = txscript.ScriptVerifyDERSignatures |
 		txscript.ScriptVerifyMinimalData |
 		txscript.ScriptVerifyCleanStack |
 		txscript.ScriptVerifyCheckLockTimeVerify

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -2286,8 +2286,7 @@ func (b *BlockChain) checkTransactionsAndConnect(subsidyCache *SubsidyCache, inp
 // any flags required as the result of any agendas that have passed and become
 // active.
 func (b *BlockChain) consensusScriptVerifyFlags(node *blockNode) (txscript.ScriptFlags, error) {
-	scriptFlags := txscript.ScriptBip16 |
-		txscript.ScriptVerifyDERSignatures |
+	scriptFlags := txscript.ScriptVerifyDERSignatures |
 		txscript.ScriptVerifyMinimalData |
 		txscript.ScriptVerifyCleanStack |
 		txscript.ScriptVerifyCheckLockTimeVerify

--- a/mempool/policy.go
+++ b/mempool/policy.go
@@ -63,8 +63,7 @@ const (
 	// the state of any agenda votes.  The full set of standard verification
 	// flags must include these flags as well as any additional flags that
 	// are conditionally enabled depending on the result of agenda votes.
-	BaseStandardVerifyFlags = txscript.ScriptBip16 |
-		txscript.ScriptVerifyDERSignatures |
+	BaseStandardVerifyFlags = txscript.ScriptVerifyDERSignatures |
 		txscript.ScriptVerifyMinimalData |
 		txscript.ScriptDiscourageUpgradableNops |
 		txscript.ScriptVerifyCleanStack |

--- a/txscript/data/script_tests.json
+++ b/txscript/data/script_tests.json
@@ -1312,12 +1312,6 @@
     "Execution must not error with non-push-only sig script with P2SH and without SIGPUSHONLY"
 ],
 [
-    "0x47 0x304402205550606a87650619f98b261adde6d343aad0c3fdd526c68d5ed718819ee59a7e0220335af6a47a18064681a77f8387c95934439bdf74b61e290a3353528311b8c99301 NOP 0x23 0x21 0x0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798 CHECKSIG",
-    "HASH160 0x14 0xe57d091fa806258280dc78a1d8544a47a5b16a19 EQUAL",
-    "", "OK",
-    "Unexecuted P2SH must not error with non-push-only sig script without P2SH or SIGPUSHONLY"
-],
-[
     "11 0x48 0x3045022100f5353150d31a63f4a0d06d1f5a01ac65f7267a719e49f2a1ac584fd546bef074022030e09575e7a1541aa018876a4003cefe1b061a90556b5140c63e0ef84813524801",
     "0x21 0x0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798 CHECKSIG",
     "P2SH", "OK",
@@ -1357,13 +1351,13 @@
     "0x47 0x304402205550606a87650619f98b261adde6d343aad0c3fdd526c68d5ed718819ee59a7e0220335af6a47a18064681a77f8387c95934439bdf74b61e290a3353528311b8c99301 NOP 0x23 0x21 0x0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798 CHECKSIG",
     "HASH160 0x14 0xe57d091fa806258280dc78a1d8544a47a5b16a19 EQUAL",
     "P2SH", "ERR_SIG_PUSHONLY",
-    "Execution must error when signature script contains non-push-only opcodes with P2SH and without SIGPUSHONLY (executed redeem script)"
+    "P2SH execution must error when signature script contains non-push-only opcodes without SIGPUSHONLY"
 ],
 [
     "0x47 0x304402205550606a87650619f98b261adde6d343aad0c3fdd526c68d5ed718819ee59a7e0220335af6a47a18064681a77f8387c95934439bdf74b61e290a3353528311b8c99301 NOP 0x23 0x21 0x0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798 CHECKSIG",
     "HASH160 0x14 0xe57d091fa806258280dc78a1d8544a47a5b16a19 EQUAL",
     "SIGPUSHONLY", "ERR_SIG_PUSHONLY",
-    "Execution must error when signature script contains non-push-only opcodes without P2SH and with SIGPUSHONLY (unexecuted redeem script)"
+    "P2SH execution must error when signature script contains non-push-only opcodes with SIGPUSHONLY"
 ],
 [
     "11 0x48 0x3045022100f5353150d31a63f4a0d06d1f5a01ac65f7267a719e49f2a1ac584fd546bef074022030e09575e7a1541aa018876a4003cefe1b061a90556b5140c63e0ef84813524801",

--- a/txscript/engine_test.go
+++ b/txscript/engine_test.go
@@ -149,53 +149,6 @@ func TestCheckErrorCondition(t *testing.T) {
 	}
 }
 
-// TestInvalidFlagCombinations ensures the script engine returns the expected
-// error when disallowed flag combinations are specified.
-func TestInvalidFlagCombinations(t *testing.T) {
-	t.Parallel()
-
-	tests := []ScriptFlags{
-		ScriptVerifyCleanStack,
-	}
-
-	// tx with almost empty scripts.
-	tx := &wire.MsgTx{
-		SerType: wire.TxSerializeFull,
-		Version: 1,
-		TxIn: []*wire.TxIn{{
-			PreviousOutPoint: wire.OutPoint{
-				Hash: chainhash.Hash([32]byte{
-					0xc9, 0x97, 0xa5, 0xe5,
-					0x6e, 0x10, 0x41, 0x02,
-					0xfa, 0x20, 0x9c, 0x6a,
-					0x85, 0x2d, 0xd9, 0x06,
-					0x60, 0xa2, 0x0b, 0x2d,
-					0x9c, 0x35, 0x24, 0x23,
-					0xed, 0xce, 0x25, 0x85,
-					0x7f, 0xcd, 0x37, 0x04,
-				}),
-				Index: 0,
-			},
-			SignatureScript: []uint8{OP_NOP},
-			Sequence:        4294967295,
-		}},
-		TxOut: []*wire.TxOut{{
-			Value:    1000000000,
-			PkScript: nil,
-		}},
-		LockTime: 0,
-	}
-	pkScript := []byte{OP_NOP}
-
-	for i, test := range tests {
-		_, err := NewEngine(pkScript, tx, 0, test, 0, nil)
-		if !IsErrorCode(err, ErrInvalidFlags) {
-			t.Fatalf("TestInvalidFlagCombinations #%d unexpected "+
-				"error: %v", i, err)
-		}
-	}
-}
-
 // TestCheckPubKeyEncoding ensures the internal checkPubKeyEncoding function
 // works as expected.
 func TestCheckPubKeyEncoding(t *testing.T) {

--- a/txscript/error.go
+++ b/txscript/error.go
@@ -23,10 +23,6 @@ const (
 	// Failures related to improper API usage.
 	// ---------------------------------------
 
-	// ErrInvalidFlags is returned when the passed flags to NewEngine
-	// contain an invalid combination.
-	ErrInvalidFlags
-
 	// ErrInvalidIndex is returned when an out-of-bounds index is passed to
 	// a function.
 	ErrInvalidIndex
@@ -345,7 +341,6 @@ const (
 // Map of ErrorCode values back to their constant names for pretty printing.
 var errorCodeStrings = map[ErrorCode]string{
 	ErrInternal:                  "ErrInternal",
-	ErrInvalidFlags:              "ErrInvalidFlags",
 	ErrInvalidIndex:              "ErrInvalidIndex",
 	ErrInvalidSigHashSingleIndex: "ErrInvalidSigHashSingleIndex",
 	ErrUnsupportedAddress:        "ErrUnsupportedAddress",

--- a/txscript/error_test.go
+++ b/txscript/error_test.go
@@ -17,7 +17,6 @@ func TestErrorCodeStringer(t *testing.T) {
 		want string
 	}{
 		{ErrInternal, "ErrInternal"},
-		{ErrInvalidFlags, "ErrInvalidFlags"},
 		{ErrInvalidIndex, "ErrInvalidIndex"},
 		{ErrInvalidSigHashSingleIndex, "ErrInvalidSigHashSingleIndex"},
 		{ErrUnsupportedAddress, "ErrUnsupportedAddress"},

--- a/txscript/example_test.go
+++ b/txscript/example_test.go
@@ -164,7 +164,7 @@ func ExampleSignTxOutput() {
 
 	// Prove that the transaction has been validly signed by executing the
 	// script pair.
-	flags := txscript.ScriptBip16 | txscript.ScriptVerifyDERSignatures |
+	flags := txscript.ScriptVerifyDERSignatures |
 		txscript.ScriptDiscourageUpgradableNops
 	vm, err := txscript.NewEngine(originTx.TxOut[0].PkScript, redeemTx, 0,
 		flags, 0, nil)

--- a/txscript/opcode_test.go
+++ b/txscript/opcode_test.go
@@ -20,8 +20,7 @@ import (
 // executing transaction scripts to enforce additional checks.  Note these flags
 // are different than what is required for the consensus rules in that they are
 // more strict.
-const testScriptFlags = ScriptBip16 |
-	ScriptVerifyDERSignatures |
+const testScriptFlags = ScriptVerifyDERSignatures |
 	ScriptVerifyMinimalData |
 	ScriptDiscourageUpgradableNops |
 	ScriptVerifyCleanStack |

--- a/txscript/reference_test.go
+++ b/txscript/reference_test.go
@@ -242,7 +242,7 @@ func parseScriptFlags(flagStr string) (ScriptFlags, error) {
 		case "NONE":
 			// Nothing.
 		case "P2SH":
-			flags |= ScriptBip16
+			// Always active in Decred.
 		case "SIGPUSHONLY":
 			flags |= ScriptVerifySigPushOnly
 		case "SHA256":

--- a/txscript/sign_test.go
+++ b/txscript/sign_test.go
@@ -83,8 +83,8 @@ func mkGetScript(scripts map[string][]byte) ScriptDB {
 
 func checkScripts(msg string, tx *wire.MsgTx, idx int, sigScript, pkScript []byte) error {
 	tx.TxIn[idx].SignatureScript = sigScript
-	vm, err := NewEngine(pkScript, tx, idx,
-		ScriptBip16|ScriptVerifyDERSignatures, 0, nil)
+	vm, err := NewEngine(pkScript, tx, idx, ScriptVerifyDERSignatures, 0,
+		nil)
 	if err != nil {
 		return fmt.Errorf("failed to make script engine for %s: %v",
 			msg, err)
@@ -2304,7 +2304,7 @@ nexttest:
 		}
 
 		// Validate tx input scripts
-		scriptFlags := ScriptBip16 | ScriptVerifyDERSignatures
+		scriptFlags := ScriptVerifyDERSignatures
 		for j := range tx.TxIn {
 			vm, err := NewEngine(sigScriptTests[i].inputs[j].txout.
 				PkScript, tx, j, scriptFlags, 0,


### PR DESCRIPTION
**This requires PR #1320**.

This removes the `ScriptBip16` flag from the `txscript` package, changes the default semantics to always enforce its behavior, and updates all callers in the repository accordingly.

This change is being made to simplify the script engine code since the flag has always been active and required by consensus in Decred, so there is no need to require a flag to conditionally toggle it.

Also, since it is no longer possible to invoke the script engine without the flag with the clean stack flag, it removes the now unused `ErrInvalidFlags` error and associated tests.

It should be noted that the test removed from `script_tests.json` specifically dealt with ensuring a signature script that contained non-data-pushing opcodes was successful when neither the `ScriptBip16` or `ScriptVerifySigPushOnly` flags were set.  Therefore, it is no longer necessary.

Finally, the P2SH indicator to enable the flag in the test data has been retained for now in order to keep the logic changes separate.