### PR TITLE
txscript: Remove DER signature verification flag.

### DIFF
--- a/blockchain/agendas_test.go
+++ b/blockchain/agendas_test.go
@@ -19,8 +19,7 @@ import (
 func testLNFeaturesDeployment(t *testing.T, params *chaincfg.Params, deploymentVer uint32) {
 	// baseConsensusScriptVerifyFlags are the expected script flags when the
 	// agenda is not active.
-	const baseConsensusScriptVerifyFlags = txscript.ScriptVerifyDERSignatures |
-		txscript.ScriptVerifyMinimalData |
+	const baseConsensusScriptVerifyFlags = txscript.ScriptVerifyMinimalData |
 		txscript.ScriptVerifyCleanStack |
 		txscript.ScriptVerifyCheckLockTimeVerify
 

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -2286,8 +2286,7 @@ func (b *BlockChain) checkTransactionsAndConnect(subsidyCache *SubsidyCache, inp
 // any flags required as the result of any agendas that have passed and become
 // active.
 func (b *BlockChain) consensusScriptVerifyFlags(node *blockNode) (txscript.ScriptFlags, error) {
-	scriptFlags := txscript.ScriptVerifyDERSignatures |
-		txscript.ScriptVerifyMinimalData |
+	scriptFlags := txscript.ScriptVerifyMinimalData |
 		txscript.ScriptVerifyCleanStack |
 		txscript.ScriptVerifyCheckLockTimeVerify
 

--- a/mempool/policy.go
+++ b/mempool/policy.go
@@ -63,8 +63,7 @@ const (
 	// the state of any agenda votes.  The full set of standard verification
 	// flags must include these flags as well as any additional flags that
 	// are conditionally enabled depending on the result of agenda votes.
-	BaseStandardVerifyFlags = txscript.ScriptVerifyDERSignatures |
-		txscript.ScriptVerifyMinimalData |
+	BaseStandardVerifyFlags = txscript.ScriptVerifyMinimalData |
 		txscript.ScriptDiscourageUpgradableNops |
 		txscript.ScriptVerifyCleanStack |
 		txscript.ScriptVerifyCheckLockTimeVerify |

--- a/txscript/data/script_tests.json
+++ b/txscript/data/script_tests.json
@@ -1030,24 +1030,6 @@
     "DERSIG", "OK",
     "CHECKSIG must push false with invalid non-null DER-compliant sig with DERSIG (P2PK NOT min sig)"
 ],
-[
-    "1",
-    "0x21 0x03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556 CHECKSIG NOT",
-    "NONE", "OK",
-    "CHECKSIG must push false with invalid non-DER-compliant sig without DERSIG"
-],
-[
-    "0x48 0x304402204de4b86166781ffbd4375650776a338d53a0eabcc61f371ce256364f058f88ba0220597090d34c536b727fb555d61b100703a3f63b7a6ad7aa0164138c6ab3c63f880101",
-    "0x21 0x0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798 CHECKSIG",
-    "NONE", "OK",
-    "CHECKSIG must push true for otherwise valid sig with multi-byte hash type without DERSIG"
-],
-[
-    "0x48 0x304502204fc10344934662ca0a93a84d14d650d8a21cf2ab91f608e8783d2999c95544320221008441aacd6b17038ff3f6700b042934f9a6fea0cec2051b51dc709e52a5bb7d6101",
-    "0x21 0x0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798 CHECKSIG",
-    "NONE", "OK",
-    "CHECKSIG must push true when S is greater than the curve half order and sig is valid without DERSIG"
-],
 ["", "CHECKSIG NOT", "", "ERR_INVALID_STACK_OPERATION", "CHECKSIG must error when there are no stack items"],
 ["0", "CHECKSIG NOT", "", "ERR_INVALID_STACK_OPERATION","CHECKSIG must error when there are not 2 stack items"],
 ["''", "0x21 0x0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798 CHECKSIG", "", "ERR_EVAL_FALSE", "CHECKSIG must evaluate 0-length signatures to false"],
@@ -1282,20 +1264,8 @@
 [
     "0",
     "0x21 0x03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556 CHECKSIG",
-    "", "ERR_EVAL_FALSE",
-    "CHECKSIG must evaluate 0 sig to false without DERSIG"
-],
-[
-    "0",
-    "0x21 0x03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556 CHECKSIG",
     "DERSIG", "ERR_EVAL_FALSE",
-    "CHECKSIG must consider 0 sig value and evaluate to false with DERSIG"
-],
-[
-    "1",
-    "0x21 0x03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556 CHECKSIG",
-    "", "ERR_EVAL_FALSE",
-    "CHECKSIG must evaluate non-DER-compliant sig to false without DERSIG"
+    "CHECKSIG must consider 0 sig valid and evaluate to false with DERSIG"
 ],
 
 ["Additional test coverage with standard payment forms involving CHECKSIG"],
@@ -1416,16 +1386,10 @@
     "CHECKMULTISIG must work in a P2SH redeem script (2-of-3, 2 valid sigs)"
 ],
 [
-    "0 0x47 0x30440220ea377dcb8630e68da3a0eeb57e96e195b4d9c437381f76912c0e6fc28bae6e3502204096da36de10b7261bfa6ae0fddbe11428c1d13160bcb1110ed04f3f7d2f389f01",
-    "2 0x21 0x0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798 0x21 0x02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9 2 CHECKMULTISIG NOT",
-    "NONE", "OK",
-    "CHECKMULTISIG must not error with sigs where R is negative without DERSIG (2-of-2, first sig valid non-DER, second sig invalid but DER compliant)"
-],
-[
     "0x47 0x30440220eb8231fbc543176e5ee8b80591b7db91d4dab835daada515d95f3532eb54b86102203e76890b026b24030a99a2ae5957d573b7a9ecbc382d613b18c25c124d0fac9a01 0",
     "2 0x21 0x0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798 0x21 0x02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9 2 CHECKMULTISIG NOT",
     "NONE", "OK",
-    "CHECKMULTISIG must not error with sigs where R is negative without DERSIG (2-of-2, first sig invalid but DER compliant, second sig valid non-DER)"
+    "CHECKMULTISIG must not error with sigs where R is negative in unparsed signature (2-of-2, first sig invalid but DER compliant, second sig valid non-DER)"
 ],
 ["", "CHECKMULTISIG NOT", "", "ERR_INVALID_STACK_OPERATION", "CHECKMULTISIG must error when there are no stack items"],
 ["", "-1 CHECKMULTISIG NOT", "", "ERR_PUBKEY_COUNT", "CHECKMULTISIG must error when the specified number of pubkeys is negative"],

--- a/txscript/engine.go
+++ b/txscript/engine.go
@@ -42,10 +42,6 @@ const (
 	// This flag should never be used without the ScriptBip16 flag.
 	ScriptVerifyCleanStack
 
-	// ScriptVerifyDERSignatures defines that signatures are required
-	// to compily with the DER format.
-	ScriptVerifyDERSignatures
-
 	// ScriptVerifyMinimalData defines that signatures must use the smallest
 	// push operator. This is both rules 3 and 4 of BIP0062.
 	ScriptVerifyMinimalData
@@ -398,7 +394,7 @@ func (vm *Engine) subScript() []parsedOpcode {
 }
 
 // checkHashTypeEncoding returns whether or not the passed hashtype adheres to
-// the strict encoding requirements if enabled.
+// the strict encoding requirements.
 func (vm *Engine) checkHashTypeEncoding(hashType SigHashType) error {
 	sigHashType := hashType & ^SigHashAnyOneCanPay
 	if sigHashType < SigHashAll || sigHashType > SigHashSingle {
@@ -409,7 +405,7 @@ func (vm *Engine) checkHashTypeEncoding(hashType SigHashType) error {
 }
 
 // checkPubKeyEncoding returns whether or not the passed public key adheres to
-// the strict encoding requirements if enabled.
+// the strict encoding requirements.
 func (vm *Engine) checkPubKeyEncoding(pubKey []byte) error {
 	if len(pubKey) == 33 && (pubKey[0] == 0x02 || pubKey[0] == 0x03) {
 		// Compressed
@@ -423,12 +419,8 @@ func (vm *Engine) checkPubKeyEncoding(pubKey []byte) error {
 }
 
 // checkSignatureEncoding returns whether or not the passed signature adheres to
-// the strict encoding requirements if enabled.
+// the strict encoding requirements.
 func (vm *Engine) checkSignatureEncoding(sig []byte) error {
-	if !vm.hasFlag(ScriptVerifyDERSignatures) {
-		return nil
-	}
-
 	// The format of a DER encoded signature is as follows:
 	//
 	// 0x30 <total length> 0x02 <length of R> <R> 0x02 <length of S> <S>

--- a/txscript/engine_test.go
+++ b/txscript/engine_test.go
@@ -194,7 +194,7 @@ func TestCheckPubKeyEncoding(t *testing.T) {
 		},
 	}
 
-	vm := Engine{flags: ScriptVerifyDERSignatures}
+	var vm Engine
 	for _, test := range tests {
 		err := vm.checkPubKeyEncoding(test.key)
 		if err != nil && test.isValid {
@@ -365,7 +365,7 @@ func TestCheckSignatureEncoding(t *testing.T) {
 		},
 	}
 
-	vm := Engine{flags: ScriptVerifyDERSignatures}
+	var vm Engine
 	for _, test := range tests {
 		err := vm.checkSignatureEncoding(test.sig)
 		if err != nil && test.isValid {

--- a/txscript/example_test.go
+++ b/txscript/example_test.go
@@ -164,8 +164,8 @@ func ExampleSignTxOutput() {
 
 	// Prove that the transaction has been validly signed by executing the
 	// script pair.
-	flags := txscript.ScriptVerifyDERSignatures |
-		txscript.ScriptDiscourageUpgradableNops
+
+	flags := txscript.ScriptDiscourageUpgradableNops
 	vm, err := txscript.NewEngine(originTx.TxOut[0].PkScript, redeemTx, 0,
 		flags, 0, nil)
 	if err != nil {

--- a/txscript/opcode_test.go
+++ b/txscript/opcode_test.go
@@ -20,8 +20,7 @@ import (
 // executing transaction scripts to enforce additional checks.  Note these flags
 // are different than what is required for the consensus rules in that they are
 // more strict.
-const testScriptFlags = ScriptVerifyDERSignatures |
-	ScriptVerifyMinimalData |
+const testScriptFlags = ScriptVerifyMinimalData |
 	ScriptDiscourageUpgradableNops |
 	ScriptVerifyCleanStack |
 	ScriptVerifyCheckLockTimeVerify |

--- a/txscript/reference_test.go
+++ b/txscript/reference_test.go
@@ -234,7 +234,7 @@ func parseScriptFlags(flagStr string) (ScriptFlags, error) {
 		case "CLEANSTACK":
 			flags |= ScriptVerifyCleanStack
 		case "DERSIG":
-			flags |= ScriptVerifyDERSignatures
+			// Always active in Decred.
 		case "DISCOURAGE_UPGRADABLE_NOPS":
 			flags |= ScriptDiscourageUpgradableNops
 		case "MINIMALDATA":

--- a/txscript/sign_test.go
+++ b/txscript/sign_test.go
@@ -83,8 +83,8 @@ func mkGetScript(scripts map[string][]byte) ScriptDB {
 
 func checkScripts(msg string, tx *wire.MsgTx, idx int, sigScript, pkScript []byte) error {
 	tx.TxIn[idx].SignatureScript = sigScript
-	vm, err := NewEngine(pkScript, tx, idx, ScriptVerifyDERSignatures, 0,
-		nil)
+	var scriptFlags ScriptFlags
+	vm, err := NewEngine(pkScript, tx, idx, scriptFlags, 0, nil)
 	if err != nil {
 		return fmt.Errorf("failed to make script engine for %s: %v",
 			msg, err)
@@ -2304,7 +2304,7 @@ nexttest:
 		}
 
 		// Validate tx input scripts
-		scriptFlags := ScriptVerifyDERSignatures
+		var scriptFlags ScriptFlags
 		for j := range tx.TxIn {
 			vm, err := NewEngine(sigScriptTests[i].inputs[j].txout.
 				PkScript, tx, j, scriptFlags, 0,


### PR DESCRIPTION
**This is rebased on PR #1322**.

This removes the `ScriptVerifyDERSignatures` flag from the `txscript` package, changes the default semantics to always enforce its behavior and updates all callers in the repository accordingly.

This change is being made to simplify the script engine code since the flag has always been active and required by consensus in Decred, so there is no need to require a flag to conditionally toggle it.

It should be noted that the tests removed from `script_tests.json` specifically dealt with ensuring non-DER-compliant signatures were handled properly when the `ScriptVerifyDERSignatures` flag was not set.  Therefore, they are no longer necessary.

Finally, the `DERSIG` indicator to enable the flag in the test data has been retained for now in order to keep the logic changes separate.