### PR TITLE
txscript: Remove script num require minimal flag.

### DIFF
--- a/txscript/opcode.go
+++ b/txscript/opcode.go
@@ -1105,7 +1105,7 @@ func opcodeCheckLockTimeVerify(op *parsedOpcode, vm *Engine) error {
 	if err != nil {
 		return err
 	}
-	lockTime, err := makeScriptNum(so, true, 5)
+	lockTime, err := makeScriptNum(so, 5)
 	if err != nil {
 		return err
 	}
@@ -1179,7 +1179,7 @@ func opcodeCheckSequenceVerify(op *parsedOpcode, vm *Engine) error {
 	if err != nil {
 		return err
 	}
-	stackSequence, err := makeScriptNum(so, true, 5)
+	stackSequence, err := makeScriptNum(so, 5)
 	if err != nil {
 		return err
 	}

--- a/txscript/scriptnum.go
+++ b/txscript/scriptnum.go
@@ -187,7 +187,7 @@ func (n scriptNum) Int32() int32 {
 // overflows.
 //
 // See the Bytes function documentation for example encodings.
-func makeScriptNum(v []byte, requireMinimal bool, scriptNumLen int) (scriptNum, error) {
+func makeScriptNum(v []byte, scriptNumLen int) (scriptNum, error) {
 	// Interpreting data requires that it is not larger than
 	// the the passed scriptNumLen value.
 	if len(v) > scriptNumLen {
@@ -197,11 +197,9 @@ func makeScriptNum(v []byte, requireMinimal bool, scriptNumLen int) (scriptNum, 
 		return 0, scriptError(ErrNumOutOfRange, str)
 	}
 
-	// Enforce minimal encoded if requested.
-	if requireMinimal {
-		if err := checkMinimalDataEncoding(v); err != nil {
-			return 0, err
-		}
+	// Enforce minimal encoding.
+	if err := checkMinimalDataEncoding(v); err != nil {
+		return 0, err
 	}
 
 	// Zero is encoded as an empty byte slice.

--- a/txscript/scriptnum_test.go
+++ b/txscript/scriptnum_test.go
@@ -98,106 +98,87 @@ func TestMakeScriptNum(t *testing.T) {
 	errMinimalData := scriptError(ErrMinimalData, "")
 
 	tests := []struct {
-		serialized      []byte
-		num             scriptNum
-		numLen          int
-		minimalEncoding bool
-		err             error
+		serialized []byte
+		num        scriptNum
+		numLen     int
+		err        error
 	}{
 		// Minimal encoding must reject negative 0.
-		{hexToBytes("80"), 0, mathOpCodeMaxScriptNumLen, true, errMinimalData},
+		{hexToBytes("80"), 0, mathOpCodeMaxScriptNumLen, errMinimalData},
 
-		// Minimally encoded valid values with minimal encoding flag.
-		// Should not error and return expected integral number.
-		{nil, 0, mathOpCodeMaxScriptNumLen, true, nil},
-		{hexToBytes("01"), 1, mathOpCodeMaxScriptNumLen, true, nil},
-		{hexToBytes("81"), -1, mathOpCodeMaxScriptNumLen, true, nil},
-		{hexToBytes("7f"), 127, mathOpCodeMaxScriptNumLen, true, nil},
-		{hexToBytes("ff"), -127, mathOpCodeMaxScriptNumLen, true, nil},
-		{hexToBytes("8000"), 128, mathOpCodeMaxScriptNumLen, true, nil},
-		{hexToBytes("8080"), -128, mathOpCodeMaxScriptNumLen, true, nil},
-		{hexToBytes("8100"), 129, mathOpCodeMaxScriptNumLen, true, nil},
-		{hexToBytes("8180"), -129, mathOpCodeMaxScriptNumLen, true, nil},
-		{hexToBytes("0001"), 256, mathOpCodeMaxScriptNumLen, true, nil},
-		{hexToBytes("0081"), -256, mathOpCodeMaxScriptNumLen, true, nil},
-		{hexToBytes("ff7f"), 32767, mathOpCodeMaxScriptNumLen, true, nil},
-		{hexToBytes("ffff"), -32767, mathOpCodeMaxScriptNumLen, true, nil},
-		{hexToBytes("008000"), 32768, mathOpCodeMaxScriptNumLen, true, nil},
-		{hexToBytes("008080"), -32768, mathOpCodeMaxScriptNumLen, true, nil},
-		{hexToBytes("ffff00"), 65535, mathOpCodeMaxScriptNumLen, true, nil},
-		{hexToBytes("ffff80"), -65535, mathOpCodeMaxScriptNumLen, true, nil},
-		{hexToBytes("000008"), 524288, mathOpCodeMaxScriptNumLen, true, nil},
-		{hexToBytes("000088"), -524288, mathOpCodeMaxScriptNumLen, true, nil},
-		{hexToBytes("000070"), 7340032, mathOpCodeMaxScriptNumLen, true, nil},
-		{hexToBytes("0000f0"), -7340032, mathOpCodeMaxScriptNumLen, true, nil},
-		{hexToBytes("00008000"), 8388608, mathOpCodeMaxScriptNumLen, true, nil},
-		{hexToBytes("00008080"), -8388608, mathOpCodeMaxScriptNumLen, true, nil},
-		{hexToBytes("ffffff7f"), 2147483647, mathOpCodeMaxScriptNumLen, true, nil},
-		{hexToBytes("ffffffff"), -2147483647, mathOpCodeMaxScriptNumLen, true, nil},
-		{hexToBytes("ffffffff7f"), 549755813887, 5, true, nil},
-		{hexToBytes("ffffffffff"), -549755813887, 5, true, nil},
-		{hexToBytes("ffffffffffffff7f"), 9223372036854775807, 8, true, nil},
-		{hexToBytes("ffffffffffffffff"), -9223372036854775807, 8, true, nil},
-		{hexToBytes("ffffffffffffffff7f"), -1, 9, true, nil},
-		{hexToBytes("ffffffffffffffffff"), 1, 9, true, nil},
-		{hexToBytes("ffffffffffffffffff7f"), -1, 10, true, nil},
-		{hexToBytes("ffffffffffffffffffff"), 1, 10, true, nil},
+		// Minimally encoded valid values.  Should not error and return
+		// expected integral number.
+		{nil, 0, mathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("01"), 1, mathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("81"), -1, mathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("7f"), 127, mathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("ff"), -127, mathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("8000"), 128, mathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("8080"), -128, mathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("8100"), 129, mathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("8180"), -129, mathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("0001"), 256, mathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("0081"), -256, mathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("ff7f"), 32767, mathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("ffff"), -32767, mathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("008000"), 32768, mathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("008080"), -32768, mathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("ffff00"), 65535, mathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("ffff80"), -65535, mathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("000008"), 524288, mathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("000088"), -524288, mathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("000070"), 7340032, mathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("0000f0"), -7340032, mathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("00008000"), 8388608, mathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("00008080"), -8388608, mathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("ffffff7f"), 2147483647, mathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("ffffffff"), -2147483647, mathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("ffffffff7f"), 549755813887, 5, nil},
+		{hexToBytes("ffffffffff"), -549755813887, 5, nil},
+		{hexToBytes("ffffffffffffff7f"), 9223372036854775807, 8, nil},
+		{hexToBytes("ffffffffffffffff"), -9223372036854775807, 8, nil},
+		{hexToBytes("ffffffffffffffff7f"), -1, 9, nil},
+		{hexToBytes("ffffffffffffffffff"), 1, 9, nil},
+		{hexToBytes("ffffffffffffffffff7f"), -1, 10, nil},
+		{hexToBytes("ffffffffffffffffffff"), 1, 10, nil},
 
 		// Minimally encoded values that are out of range for data that
-		// is interpreted as script numbers with the minimal encoding
-		// flag set.  Should error and return 0.
-		{hexToBytes("0000008000"), 0, mathOpCodeMaxScriptNumLen, true, errOutOfRange},
-		{hexToBytes("0000008080"), 0, mathOpCodeMaxScriptNumLen, true, errOutOfRange},
-		{hexToBytes("0000009000"), 0, mathOpCodeMaxScriptNumLen, true, errOutOfRange},
-		{hexToBytes("0000009080"), 0, mathOpCodeMaxScriptNumLen, true, errOutOfRange},
-		{hexToBytes("ffffffff00"), 0, mathOpCodeMaxScriptNumLen, true, errOutOfRange},
-		{hexToBytes("ffffffff80"), 0, mathOpCodeMaxScriptNumLen, true, errOutOfRange},
-		{hexToBytes("0000000001"), 0, mathOpCodeMaxScriptNumLen, true, errOutOfRange},
-		{hexToBytes("0000000081"), 0, mathOpCodeMaxScriptNumLen, true, errOutOfRange},
-		{hexToBytes("ffffffffffff00"), 0, mathOpCodeMaxScriptNumLen, true, errOutOfRange},
-		{hexToBytes("ffffffffffff80"), 0, mathOpCodeMaxScriptNumLen, true, errOutOfRange},
-		{hexToBytes("ffffffffffffff00"), 0, mathOpCodeMaxScriptNumLen, true, errOutOfRange},
-		{hexToBytes("ffffffffffffff80"), 0, mathOpCodeMaxScriptNumLen, true, errOutOfRange},
-		{hexToBytes("ffffffffffffff7f"), 0, mathOpCodeMaxScriptNumLen, true, errOutOfRange},
-		{hexToBytes("ffffffffffffffff"), 0, mathOpCodeMaxScriptNumLen, true, errOutOfRange},
+		// is interpreted as script numbers.  Should error and return 0.
+		{hexToBytes("0000008000"), 0, mathOpCodeMaxScriptNumLen, errOutOfRange},
+		{hexToBytes("0000008080"), 0, mathOpCodeMaxScriptNumLen, errOutOfRange},
+		{hexToBytes("0000009000"), 0, mathOpCodeMaxScriptNumLen, errOutOfRange},
+		{hexToBytes("0000009080"), 0, mathOpCodeMaxScriptNumLen, errOutOfRange},
+		{hexToBytes("ffffffff00"), 0, mathOpCodeMaxScriptNumLen, errOutOfRange},
+		{hexToBytes("ffffffff80"), 0, mathOpCodeMaxScriptNumLen, errOutOfRange},
+		{hexToBytes("0000000001"), 0, mathOpCodeMaxScriptNumLen, errOutOfRange},
+		{hexToBytes("0000000081"), 0, mathOpCodeMaxScriptNumLen, errOutOfRange},
+		{hexToBytes("ffffffffffff00"), 0, mathOpCodeMaxScriptNumLen, errOutOfRange},
+		{hexToBytes("ffffffffffff80"), 0, mathOpCodeMaxScriptNumLen, errOutOfRange},
+		{hexToBytes("ffffffffffffff00"), 0, mathOpCodeMaxScriptNumLen, errOutOfRange},
+		{hexToBytes("ffffffffffffff80"), 0, mathOpCodeMaxScriptNumLen, errOutOfRange},
+		{hexToBytes("ffffffffffffff7f"), 0, mathOpCodeMaxScriptNumLen, errOutOfRange},
+		{hexToBytes("ffffffffffffffff"), 0, mathOpCodeMaxScriptNumLen, errOutOfRange},
 
-		// Non-minimally encoded, but otherwise valid values with
-		// minimal encoding flag.  Should error and return 0.
-		{hexToBytes("00"), 0, mathOpCodeMaxScriptNumLen, true, errMinimalData},       // 0
-		{hexToBytes("0100"), 0, mathOpCodeMaxScriptNumLen, true, errMinimalData},     // 1
-		{hexToBytes("7f00"), 0, mathOpCodeMaxScriptNumLen, true, errMinimalData},     // 127
-		{hexToBytes("800000"), 0, mathOpCodeMaxScriptNumLen, true, errMinimalData},   // 128
-		{hexToBytes("810000"), 0, mathOpCodeMaxScriptNumLen, true, errMinimalData},   // 129
-		{hexToBytes("000100"), 0, mathOpCodeMaxScriptNumLen, true, errMinimalData},   // 256
-		{hexToBytes("ff7f00"), 0, mathOpCodeMaxScriptNumLen, true, errMinimalData},   // 32767
-		{hexToBytes("00800000"), 0, mathOpCodeMaxScriptNumLen, true, errMinimalData}, // 32768
-		{hexToBytes("ffff0000"), 0, mathOpCodeMaxScriptNumLen, true, errMinimalData}, // 65535
-		{hexToBytes("00000800"), 0, mathOpCodeMaxScriptNumLen, true, errMinimalData}, // 524288
-		{hexToBytes("00007000"), 0, mathOpCodeMaxScriptNumLen, true, errMinimalData}, // 7340032
-		{hexToBytes("0009000100"), 0, 5, true, errMinimalData},                       // 16779520
-
-		// Non-minimally encoded, but otherwise valid values without
-		// minimal encoding flag.  Should not error and return expected
-		// integral number.
-		{hexToBytes("00"), 0, mathOpCodeMaxScriptNumLen, false, nil},
-		{hexToBytes("0100"), 1, mathOpCodeMaxScriptNumLen, false, nil},
-		{hexToBytes("7f00"), 127, mathOpCodeMaxScriptNumLen, false, nil},
-		{hexToBytes("800000"), 128, mathOpCodeMaxScriptNumLen, false, nil},
-		{hexToBytes("810000"), 129, mathOpCodeMaxScriptNumLen, false, nil},
-		{hexToBytes("000100"), 256, mathOpCodeMaxScriptNumLen, false, nil},
-		{hexToBytes("ff7f00"), 32767, mathOpCodeMaxScriptNumLen, false, nil},
-		{hexToBytes("00800000"), 32768, mathOpCodeMaxScriptNumLen, false, nil},
-		{hexToBytes("ffff0000"), 65535, mathOpCodeMaxScriptNumLen, false, nil},
-		{hexToBytes("00000800"), 524288, mathOpCodeMaxScriptNumLen, false, nil},
-		{hexToBytes("00007000"), 7340032, mathOpCodeMaxScriptNumLen, false, nil},
-		{hexToBytes("0009000100"), 16779520, 5, false, nil},
+		// Non-minimally encoded, but otherwise valid values.  Should
+		// error and return 0.
+		{hexToBytes("00"), 0, mathOpCodeMaxScriptNumLen, errMinimalData},       // 0
+		{hexToBytes("0100"), 0, mathOpCodeMaxScriptNumLen, errMinimalData},     // 1
+		{hexToBytes("7f00"), 0, mathOpCodeMaxScriptNumLen, errMinimalData},     // 127
+		{hexToBytes("800000"), 0, mathOpCodeMaxScriptNumLen, errMinimalData},   // 128
+		{hexToBytes("810000"), 0, mathOpCodeMaxScriptNumLen, errMinimalData},   // 129
+		{hexToBytes("000100"), 0, mathOpCodeMaxScriptNumLen, errMinimalData},   // 256
+		{hexToBytes("ff7f00"), 0, mathOpCodeMaxScriptNumLen, errMinimalData},   // 32767
+		{hexToBytes("00800000"), 0, mathOpCodeMaxScriptNumLen, errMinimalData}, // 32768
+		{hexToBytes("ffff0000"), 0, mathOpCodeMaxScriptNumLen, errMinimalData}, // 65535
+		{hexToBytes("00000800"), 0, mathOpCodeMaxScriptNumLen, errMinimalData}, // 524288
+		{hexToBytes("00007000"), 0, mathOpCodeMaxScriptNumLen, errMinimalData}, // 7340032
+		{hexToBytes("0009000100"), 0, 5, errMinimalData},                       // 16779520
 	}
 
 	for _, test := range tests {
 		// Ensure the error code is of the expected type and the error
 		// code matches the value specified in the test instance.
-		gotNum, err := makeScriptNum(test.serialized, test.minimalEncoding,
-			test.numLen)
+		gotNum, err := makeScriptNum(test.serialized, test.numLen)
 		if e := tstCheckScriptError(err, test.err); e != nil {
 			t.Errorf("makeScriptNum(%#x): %v", test.serialized, e)
 			continue

--- a/txscript/stack.go
+++ b/txscript/stack.go
@@ -86,7 +86,7 @@ func (s *stack) PopInt(maxLen int) (scriptNum, error) {
 		return 0, err
 	}
 
-	return makeScriptNum(so, true, maxLen)
+	return makeScriptNum(so, maxLen)
 }
 
 // PopBool pops the value off the top of the stack, converts it into a bool, and
@@ -123,7 +123,7 @@ func (s *stack) PeekInt(idx int32) (scriptNum, error) {
 		return 0, err
 	}
 
-	return makeScriptNum(so, true, mathOpCodeMaxScriptNumLen)
+	return makeScriptNum(so, mathOpCodeMaxScriptNumLen)
 }
 
 // PeekBool returns the Nth item on the stack as a bool without removing it.

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -1426,7 +1426,7 @@ func ExtractAtomicSwapDataPushes(version uint16, pkScript []byte) (*AtomicSwapDa
 	copy(pushes.RecipientHash160[:], pops[9].data)
 	copy(pushes.RefundHash160[:], pops[16].data)
 	if pops[2].data != nil {
-		locktime, err := makeScriptNum(pops[2].data, true, 5)
+		locktime, err := makeScriptNum(pops[2].data, 5)
 		if err != nil {
 			return nil, nil
 		}
@@ -1437,7 +1437,7 @@ func ExtractAtomicSwapDataPushes(version uint16, pkScript []byte) (*AtomicSwapDa
 		return nil, nil
 	}
 	if pops[11].data != nil {
-		locktime, err := makeScriptNum(pops[11].data, true, 5)
+		locktime, err := makeScriptNum(pops[11].data, 5)
 		if err != nil {
 			return nil, nil
 		}


### PR DESCRIPTION
**This requires #1326 and is rebased on #1327**.

This removes the flag to require minimal encoding when create script numbers since since all callers now call the function with true due to the recent removal of the minimal data script verification flag from the script engine and updates the tests accordingly.
