### PR TITLE
txscript: Make PeekInt consistent with PopInt.

### DIFF
--- a/txscript/opcode.go
+++ b/txscript/opcode.go
@@ -1098,14 +1098,7 @@ func opcodeCheckLockTimeVerify(op *parsedOpcode, vm *Engine) error {
 	// maximum of 2^31-1 (the year 2038).  Thus, a 5-byte scriptNum is used
 	// here since it will support up to 2^39-1 which allows dates beyond the
 	// current locktime limit.
-	//
-	// PeekByteArray is used here instead of PeekInt because we do not want
-	// to be limited to a 4-byte integer for reasons specified above.
-	so, err := vm.dstack.PeekByteArray(0)
-	if err != nil {
-		return err
-	}
-	lockTime, err := makeScriptNum(so, 5)
+	lockTime, err := vm.dstack.PeekInt(0, 5)
 	if err != nil {
 		return err
 	}
@@ -1172,14 +1165,7 @@ func opcodeCheckSequenceVerify(op *parsedOpcode, vm *Engine) error {
 	// 2^31-1.  Thus, a 5-byte scriptNum is used here since it will support
 	// up to 2^39-1 which allows sequences beyond the current sequence
 	// limit.
-	//
-	// PeekByteArray is used here instead of PeekInt because we do not want
-	// to be limited to a 4-byte integer for reasons specified above.
-	so, err := vm.dstack.PeekByteArray(0)
-	if err != nil {
-		return err
-	}
-	stackSequence, err := makeScriptNum(so, 5)
+	stackSequence, err := vm.dstack.PeekInt(0, 5)
 	if err != nil {
 		return err
 	}

--- a/txscript/stack.go
+++ b/txscript/stack.go
@@ -80,13 +80,13 @@ func (s *stack) PopByteArray() ([]byte, error) {
 // consensus rules imposed on data interpreted as numbers.
 //
 // Stack transformation: [... x1 x2 x3] -> [... x1 x2]
-func (s *stack) PopInt(maxLen int) (scriptNum, error) {
+func (s *stack) PopInt(maxScriptNumLen int) (scriptNum, error) {
 	so, err := s.PopByteArray()
 	if err != nil {
 		return 0, err
 	}
 
-	return makeScriptNum(so, maxLen)
+	return makeScriptNum(so, maxScriptNumLen)
 }
 
 // PopBool pops the value off the top of the stack, converts it into a bool, and
@@ -117,13 +117,13 @@ func (s *stack) PeekByteArray(idx int32) ([]byte, error) {
 // PeekInt returns the Nth item on the stack as a script num without removing
 // it.  The act of converting to a script num enforces the consensus rules
 // imposed on data interpreted as numbers.
-func (s *stack) PeekInt(idx int32) (scriptNum, error) {
+func (s *stack) PeekInt(idx int32, maxScriptNumLen int) (scriptNum, error) {
 	so, err := s.PeekByteArray(idx)
 	if err != nil {
 		return 0, err
 	}
 
-	return makeScriptNum(so, mathOpCodeMaxScriptNumLen)
+	return makeScriptNum(so, maxScriptNumLen)
 }
 
 // PeekBool returns the Nth item on the stack as a bool without removing it.


### PR DESCRIPTION
**This requires PR #1328**.

This modifies the `PeekInt` function of the stack to accept a maximum script number length to mirror `PopInt` for consistency.  It also updates the two callers `CLTV` and `CSV`) which were manually performing the same task with 5 bytes due to `PeekInt` enforcing 4-byte script nums to use the modified version accordingly.

It also adds some stack tests for 5-byte encodings on both `PopInt` and `PeekInt`.
