### PR TITLE
blockchain: Combine block by hash functions.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -498,7 +498,8 @@ func (b *BlockChain) fetchMainChainBlockByHash(hash *chainhash.Hash) (*dcrutil.B
 }
 
 // fetchBlockByHash returns the block with the given hash from all known sources
-// such as the internal caches and the database.
+// such as the internal caches and the database.  This function returns blocks
+// regardless or whether or not they are part of the main chain.
 //
 // This function is safe for concurrent access.
 func (b *BlockChain) fetchBlockByHash(hash *chainhash.Hash) (*dcrutil.Block, error) {
@@ -535,17 +536,6 @@ func (b *BlockChain) fetchBlockByHash(hash *chainhash.Hash) (*dcrutil.Block, err
 	}
 
 	return nil, fmt.Errorf("unable to find block %v in cache or db", hash)
-}
-
-// FetchBlockByHash searches the internal chain block stores and the database
-// in an attempt to find the requested block.
-//
-// This function differs from BlockByHash in that this one also returns blocks
-// that are not part of the main chain (if they are known).
-//
-// This function is safe for concurrent access.
-func (b *BlockChain) FetchBlockByHash(hash *chainhash.Hash) (*dcrutil.Block, error) {
-	return b.fetchBlockByHash(hash)
 }
 
 // pruneStakeNodes removes references to old stake nodes which should no

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -2052,14 +2052,16 @@ func (b *BlockChain) BlockByHeight(blockHeight int64) (*dcrutil.Block, error) {
 	return block, err
 }
 
-// BlockByHash returns the block from the main chain with the given hash.
+// BlockByHash searches the internal chain block stores and the database in an
+// attempt to find the requested block and returns it.  This function returns
+// blocks regardless of whether or not they are part of the main chain.
 //
 // This function is safe for concurrent access.
 func (b *BlockChain) BlockByHash(hash *chainhash.Hash) (*dcrutil.Block, error) {
 	b.chainLock.RLock()
-	defer b.chainLock.RUnlock()
-
-	return b.fetchMainChainBlockByHash(hash)
+	block, err := b.fetchBlockByHash(hash)
+	b.chainLock.RUnlock()
+	return block, err
 }
 
 // HeightRange returns a range of block hashes for the given start and end

--- a/mining.go
+++ b/mining.go
@@ -848,7 +848,7 @@ func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache, nextHeight int64,
 				// we should have the option of readding some
 				// transactions from this block, too.
 				bestHash, _ := chainState.Best()
-				topBlock, err := bm.chain.FetchBlockByHash(bestHash)
+				topBlock, err := bm.chain.BlockByHash(bestHash)
 				if err != nil {
 					str := fmt.Sprintf("unable to get tip block %s",
 						prevBlockHash)
@@ -1659,7 +1659,7 @@ mempoolLoop:
 
 			// Retrieve the current top block, whose TxTreeRegular was voted
 			// out.
-			topBlock, err := blockManager.chain.FetchBlockByHash(prevHash)
+			topBlock, err := blockManager.chain.BlockByHash(prevHash)
 			if err != nil {
 				str := fmt.Sprintf("unable to get tip block %s", prevHash)
 				return nil, miningRuleError(ErrGetTopBlock, str)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1947,7 +1947,7 @@ func handleGetBlock(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (i
 	if err != nil {
 		return nil, rpcDecodeHexError(c.Hash)
 	}
-	blk, err := s.server.blockManager.chain.FetchBlockByHash(hash)
+	blk, err := s.server.blockManager.chain.BlockByHash(hash)
 	if err != nil {
 		return nil, &dcrjson.RPCError{
 			Code:    dcrjson.ErrRPCBlockNotFound,

--- a/server.go
+++ b/server.go
@@ -844,8 +844,7 @@ func (sp *serverPeer) OnGetCFilter(p *peer.Peer, msg *wire.MsgGetCFilter) {
 	// block was disconnected, or this has always been a sidechain block) build
 	// the filter on the spot.
 	if len(filterBytes) == 0 {
-		block, err := sp.server.blockManager.chain.FetchBlockByHash(
-			&msg.BlockHash)
+		block, err := sp.server.blockManager.chain.BlockByHash(&msg.BlockHash)
 		if err != nil {
 			peerLog.Errorf("OnGetCFilter: failed to fetch non-mainchain "+
 				"block %v: %v", &msg.BlockHash, err)
@@ -1154,7 +1153,7 @@ func (s *server) pushTxMsg(sp *serverPeer, hash *chainhash.Hash, doneChan chan<-
 // pushBlockMsg sends a block message for the provided block hash to the
 // connected peer.  An error is returned if the block hash is not known.
 func (s *server) pushBlockMsg(sp *serverPeer, hash *chainhash.Hash, doneChan chan<- struct{}, waitChan <-chan struct{}) error {
-	block, err := sp.server.blockManager.chain.FetchBlockByHash(hash)
+	block, err := sp.server.blockManager.chain.BlockByHash(hash)
 	if err != nil {
 		peerLog.Tracef("Unable to fetch requested block hash %v: %v",
 			hash, err)


### PR DESCRIPTION
This modifies the `BlockByHash` function to return blocks regardless of whether or not the block is on a side chain and removes the `FetchBlockByHash` function since this change makes it redundant.

This is being changed to simplify the API and because there are no current cases where calls into chain to retrieve a block need to be limited to the main chain and if the need should ever arise, the caller can simply make use of the `MainChainHasBlock` function to verify.