### PR TITLE
blockchain: Refactor db main chain idx to blk idx.

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -189,7 +189,7 @@ func (b *BlockChain) maybeAcceptBlock(block *dcrutil.Block, flags BehaviorFlags)
 
 	// Grab the parent block since it is required throughout the block
 	// connection process.
-	parent, err := b.fetchBlockByHash(&newNode.parent.hash)
+	parent, err := b.fetchBlockByNode(newNode.parent)
 	if err != nil {
 		return 0, err
 	}

--- a/blockchain/chainquery.go
+++ b/blockchain/chainquery.go
@@ -48,13 +48,11 @@ func (b *BlockChain) ChainTips() []dcrjson.GetChainTipsResult {
 	}
 	b.index.RUnlock()
 
-	b.chainLock.Lock()
-	bestTip := b.bestNode
-	b.chainLock.Unlock()
-
 	// Generate the results sorted by descending height.
 	sort.Sort(sort.Reverse(nodeHeightSorter(chainTips)))
 	results := make([]dcrjson.GetChainTipsResult, len(chainTips))
+	b.chainLock.RLock()
+	bestTip := b.bestNode
 	for i, tip := range chainTips {
 		// Find the fork point in order calculate the branch length later.
 		fork := tip
@@ -101,5 +99,6 @@ func (b *BlockChain) ChainTips() []dcrjson.GetChainTipsResult {
 			result.Status = "valid-headers"
 		}
 	}
+	b.chainLock.RUnlock()
 	return results
 }

--- a/blockchain/stakenode.go
+++ b/blockchain/stakenode.go
@@ -42,7 +42,7 @@ func (b *BlockChain) fetchNewTicketsForNode(node *blockNode) ([]chainhash.Hash, 
 			"ancestor is genesis block")
 	}
 
-	matureBlock, errBlock := b.fetchBlockByHash(&matureNode.hash)
+	matureBlock, errBlock := b.fetchBlockByNode(matureNode)
 	if errBlock != nil {
 		return nil, errBlock
 	}

--- a/blockchain/utxoviewpoint.go
+++ b/blockchain/utxoviewpoint.go
@@ -1095,11 +1095,11 @@ func (b *BlockChain) FetchUtxoView(tx *dcrutil.Tx, treeValid bool) (*UtxoViewpoi
 	// chain.
 	if treeValid {
 		view.SetStakeViewpoint(ViewpointPrevValidRegular)
-		block, err := b.fetchMainChainBlockByHash(&tip.hash)
+		block, err := b.fetchMainChainBlockByNode(tip)
 		if err != nil {
 			return nil, err
 		}
-		parent, err := b.fetchMainChainBlockByHash(&tip.parent.hash)
+		parent, err := b.fetchMainChainBlockByNode(tip.parent)
 		if err != nil {
 			return nil, err
 		}

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -2605,7 +2605,7 @@ func (b *BlockChain) CheckConnectBlockTemplate(block *dcrutil.Block) error {
 	if prevNode.hash == tip.hash {
 		// Grab the parent block since it is required throughout the block
 		// connection process.
-		parent, err := b.fetchMainChainBlockByHash(&prevNode.hash)
+		parent, err := b.fetchMainChainBlockByNode(prevNode)
 		if err != nil {
 			return ruleError(ErrMissingParent, err.Error())
 		}
@@ -2634,7 +2634,7 @@ func (b *BlockChain) CheckConnectBlockTemplate(block *dcrutil.Block) error {
 		block := nextBlockToDetach
 		if block == nil {
 			var err error
-			block, err = b.fetchMainChainBlockByHash(&n.hash)
+			block, err = b.fetchMainChainBlockByNode(n)
 			if err != nil {
 				return err
 			}
@@ -2645,7 +2645,7 @@ func (b *BlockChain) CheckConnectBlockTemplate(block *dcrutil.Block) error {
 				block.Hash())
 		}
 
-		parent, err := b.fetchMainChainBlockByHash(&n.parent.hash)
+		parent, err := b.fetchMainChainBlockByNode(n.parent)
 		if err != nil {
 			return err
 		}
@@ -2676,7 +2676,7 @@ func (b *BlockChain) CheckConnectBlockTemplate(block *dcrutil.Block) error {
 	if attachNodes.Len() == 0 {
 		// Grab the parent block since it is required throughout the block
 		// connection process.
-		parent, err := b.fetchMainChainBlockByHash(&prevNode.hash)
+		parent, err := b.fetchMainChainBlockByNode(prevNode)
 		if err != nil {
 			return ruleError(ErrMissingParent, err.Error())
 		}
@@ -2693,14 +2693,14 @@ func (b *BlockChain) CheckConnectBlockTemplate(block *dcrutil.Block) error {
 		// attached or the previous one that was attached for subsequent blocks
 		// to optimize.
 		n := e.Value.(*blockNode)
-		block, err := b.fetchBlockByHash(&n.hash)
+		block, err := b.fetchBlockByNode(n)
 		if err != nil {
 			return err
 		}
 		parent := prevAttachBlock
 		if parent == nil {
 			var err error
-			parent, err = b.fetchMainChainBlockByHash(&n.parent.hash)
+			parent, err = b.fetchMainChainBlockByNode(n.parent)
 			if err != nil {
 				return err
 			}
@@ -2722,7 +2722,7 @@ func (b *BlockChain) CheckConnectBlockTemplate(block *dcrutil.Block) error {
 
 	// Grab the parent block since it is required throughout the block
 	// connection process.
-	parent, err := b.fetchBlockByHash(&prevNode.hash)
+	parent, err := b.fetchBlockByNode(prevNode)
 	if err != nil {
 		return ruleError(ErrMissingParent, err.Error())
 	}

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -92,7 +92,7 @@ func TestBlockchainSpendJournal(t *testing.T) {
 			str := fmt.Sprintf("no block at height %d exists", 1)
 			return errNotInMainChain(str)
 		}
-		parent, err := dbFetchBlockByHash(dbTx, &parentNode.hash)
+		parent, err := dbFetchBlockByNode(dbTx, parentNode)
 		if err != nil {
 			return err
 		}
@@ -103,7 +103,7 @@ func TestBlockchainSpendJournal(t *testing.T) {
 				str := fmt.Sprintf("no block at height %d exists", i)
 				return errNotInMainChain(str)
 			}
-			block, err := dbFetchBlockByHash(dbTx, &node.hash)
+			block, err := dbFetchBlockByNode(dbTx, node)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This refactors the code that relies on the database main chain index to use the in-memory block index now that the full index is in memory.

This is a major optimization for several functions because they no longer have to first consult the database (which is incredibly slow in many cases due to the way `leveldb` splits all of the information across files) to perform lookups and determine if blocks are in the main chain.

It should also be noted that even though the main chain index is no longer used as of this commit, the code which writes the main chain index entries to the database in `connectBlock`, `disconnectBlock`, and
`createChainState` have not been removed because, once that is done, it will no longer be possible to downgrade and thus those changes must be performed along with a database migration and associated version bump.

An overview of the changes are as follows:

- Update all code which previously used the db to use the main chain by height map instead
- Update several internal functions which previously accepted the hash to instead accept the block node as the parameter
  - Rename `fetchMainChainBlockByHash` to `fetchMainChainBlockByNode`
  - Rename `fetchBlockByHash` to `fetchBlockByNode`
  - Rename `dbFetchBlockByHash` to `dbFetchBlockByNode`
  - Update all callers to use the new names and semantics
- Optimize `HeaderByHeight` to use block index/height map instead of db
  - Move to `chain.go` since it no longer involves database I/O
- Optimize `BlockByHash` to use block index instead of db
  - Move to `chain.go` since it no longer involves database I/O
- Optimize `BlockByHeight` to use block index/height map instead of db
  - Move to `chain.go` since it no longer involves database I/O
- Optimize `MainChainHasBlock` to use block index instead of db
  - Move to `chain.go` since it no longer involves database I/O
  - Removed error return since it can no longer fail
- Optimize `BlockHeightByHash` to use block index instead of db
  - Move to `chain.go` since it no longer involves database I/O
- Optimize `BlockHashByHeight` to use block index instead of db
  - Move to `chain.go` since it no longer involves database I/O
- Optimize `HeightRange` to use block index instead of db
  - Move to `chain.go` since it no longer involves database I/O
- Remove several unused functions related to the main chain index
  - `dbFetchHeaderByHash`
  - `DBFetchHeaderByHeight`
  - `dbFetchBlockByHeight`
  - `DBFetchBlockByHeight`
  - `dbMainChainHasBlock`
  - `DBMainChainHasBlock`
- Rework `IsCheckpointCandidate` to use block index
- Modify the upgrade code to expose the old `dbFetchBlockByHeight` function only in the local scope since upgrades require the ability to read the old format
- Update indexers to fetch the blocks themselves while only querying chain for chain-related details

This is work towards #1145.