### PR TITLE
dcrjson: Ready GetStakeInfoResult for SPV wallets.

### DIFF
--- a/dcrjson/walletsvrresults.go
+++ b/dcrjson/walletsvrresults.go
@@ -61,20 +61,25 @@ type GetMultisigOutInfoResult struct {
 // GetStakeInfoResult models the data returned from the getstakeinfo
 // command.
 type GetStakeInfoResult struct {
-	BlockHeight      int64   `json:"blockheight"`
-	PoolSize         uint32  `json:"poolsize"`
-	Difficulty       float64 `json:"difficulty"`
-	AllMempoolTix    uint32  `json:"allmempooltix"`
-	OwnMempoolTix    uint32  `json:"ownmempooltix"`
-	Immature         uint32  `json:"immature"`
-	Live             uint32  `json:"live"`
-	ProportionLive   float64 `json:"proportionlive"`
-	Voted            uint32  `json:"voted"`
-	TotalSubsidy     float64 `json:"totalsubsidy"`
-	Missed           uint32  `json:"missed"`
-	ProportionMissed float64 `json:"proportionmissed"`
-	Revoked          uint32  `json:"revoked"`
-	Expired          uint32  `json:"expired"`
+	BlockHeight  int64   `json:"blockheight"`
+	Difficulty   float64 `json:"difficulty"`
+	TotalSubsidy float64 `json:"totalsubsidy"`
+
+	OwnMempoolTix  uint32 `json:"ownmempooltix"`
+	Immature       uint32 `json:"immature"`
+	Unspent        uint32 `json:"unspent"`
+	Voted          uint32 `json:"voted"`
+	Revoked        uint32 `json:"revoked"`
+	UnspentExpired uint32 `json:"unspentexpired"`
+
+	// Not available to SPV wallets
+	PoolSize         uint32  `json:"poolsize,omitempty"`
+	AllMempoolTix    uint32  `json:"allmempooltix,omitempty"`
+	Live             uint32  `json:"live,omitempty"`
+	ProportionLive   float64 `json:"proportionlive,omitempty"`
+	Missed           uint32  `json:"missed,omitempty"`
+	ProportionMissed float64 `json:"proportionmissed,omitempty"`
+	Expired          uint32  `json:"expired,omitempty"`
 }
 
 // GetTicketsResult models the data returned from the gettickets


### PR DESCRIPTION
This change makes the following fields omitempty so they can be
ignored by SPV wallets:

 * poolsize
 * allmempooltix
 * live
 * proportionlive
 * missed
 * proportionmissed
 * expired

As a side-effect, non-SPV wallets will also omit these fields from the
result if the value is zero.

The following counts remain:

 * ownmempooltix
 * immature
 * voted
 * revoked

And two new fields have been added to allow SPV wallets to provide a
fuller picture of the wallet's ticket state counts:

 * unspent
 * unspentexpired

The `unspent` field describes the number of tickets that have gone
live and have not been spent by a vote or revocation.  The
`unspentexpired` field describes the number of unspent tickets that
must certainly be revoked as they have not been spent by a vote and
have passed the expiry period.  These tickets may have been called and
missed, or actually expired, but a SPV wallet is aware that they must
be revoked as they cannot possibly be live.

These changes are being made due to SPV wallets being unaware of what
state a matured ticket is in (whether live, picked, or missed) and
because SPV wallets do not know the ticket pool size or the number of
all unmined tickets.