### PR TITLE
multi: Remove unused secp256k1 sig parse parameter.

### DIFF
--- a/chaincfg/chainec/secp256k1.go
+++ b/chaincfg/chainec/secp256k1.go
@@ -253,7 +253,7 @@ func newSecp256k1DSA() DSA {
 			return ts
 		},
 		parseDERSignature: func(sigStr []byte) (Signature, error) {
-			sig, err := secp256k1.ParseDERSignature(sigStr, secp256k1Curve)
+			sig, err := secp256k1.ParseDERSignature(sigStr)
 			if err != nil {
 				return nil, err
 			}
@@ -261,7 +261,7 @@ func newSecp256k1DSA() DSA {
 			return ts, err
 		},
 		parseSignature: func(sigStr []byte) (Signature, error) {
-			sig, err := secp256k1.ParseSignature(sigStr, secp256k1Curve)
+			sig, err := secp256k1.ParseSignature(sigStr)
 			if err != nil {
 				return nil, err
 			}

--- a/dcrec/secp256k1/example_test.go
+++ b/dcrec/secp256k1/example_test.go
@@ -72,7 +72,7 @@ func Example_verifySignature() {
 		fmt.Println(err)
 		return
 	}
-	signature, err := secp256k1.ParseSignature(sigBytes, secp256k1.S256())
+	signature, err := secp256k1.ParseDERSignature(sigBytes)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/dcrec/secp256k1/signature.go
+++ b/dcrec/secp256k1/signature.go
@@ -8,7 +8,6 @@ package secp256k1
 import (
 	"bytes"
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/hmac"
 	"crypto/sha256"
 	"errors"
@@ -213,14 +212,14 @@ func parseSig(sigStr []byte, der bool) (*Signature, error) {
 // ParseSignature parses a signature in BER format for the curve type `curve'
 // into a Signature type, perfoming some basic sanity checks.  If parsing
 // according to the more strict DER format is needed, use ParseDERSignature.
-func ParseSignature(sigStr []byte, curve elliptic.Curve) (*Signature, error) {
+func ParseSignature(sigStr []byte) (*Signature, error) {
 	return parseSig(sigStr, false)
 }
 
 // ParseDERSignature parses a signature in DER format for the curve type
 // `curve` into a Signature type.  If parsing according to the less strict
 // BER format is needed, use ParseSignature.
-func ParseDERSignature(sigStr []byte, curve elliptic.Curve) (*Signature, error) {
+func ParseDERSignature(sigStr []byte) (*Signature, error) {
 	return parseSig(sigStr, true)
 }
 

--- a/dcrec/secp256k1/signature_test.go
+++ b/dcrec/secp256k1/signature_test.go
@@ -331,9 +331,9 @@ func TestSignatures(t *testing.T) {
 	for _, test := range signatureTests {
 		var err error
 		if test.der {
-			_, err = ParseDERSignature(test.sig, S256())
+			_, err = ParseDERSignature(test.sig)
 		} else {
-			_, err = ParseSignature(test.sig, S256())
+			_, err = ParseSignature(test.sig)
 		}
 		if err != nil {
 			if test.isValid {

--- a/txscript/opcode.go
+++ b/txscript/opcode.go
@@ -2638,7 +2638,7 @@ func opcodeCheckSig(op *parsedOpcode, vm *Engine) error {
 		return nil
 	}
 
-	signature, err := secp256k1.ParseDERSignature(sigBytes, secp256k1.S256())
+	signature, err := secp256k1.ParseDERSignature(sigBytes)
 	if err != nil {
 		vm.dstack.PushBool(false)
 		return nil
@@ -2810,7 +2810,7 @@ func opcodeCheckMultiSig(op *parsedOpcode, vm *Engine) error {
 
 			// Parse the signature.
 			var err error
-			parsedSig, err = secp256k1.ParseDERSignature(signature, secp256k1.S256())
+			parsedSig, err = secp256k1.ParseDERSignature(signature)
 			sigInfo.parsed = true
 			if err != nil {
 				continue

--- a/txscript/sigcache_test.go
+++ b/txscript/sigcache_test.go
@@ -14,10 +14,6 @@ import (
 	"github.com/decred/dcrd/dcrec/secp256k1"
 )
 
-var (
-	curve = secp256k1.S256()
-)
-
 // genRandomSig returns a random message, a signature of the message under the
 // public key and the public key. This function is used to generate randomized
 // test data.
@@ -57,7 +53,7 @@ func TestSigCacheAddExists(t *testing.T) {
 	sigCache.Add(*msg1, sig1, key1)
 
 	// The previously added triplet should now be found within the sigcache.
-	sig1Copy, _ := secp256k1.ParseSignature(sig1.Serialize(), curve)
+	sig1Copy, _ := secp256k1.ParseSignature(sig1.Serialize())
 	key1Copy, _ := secp256k1.ParsePubKey(key1.SerializeCompressed())
 	if !sigCache.Exists(*msg1, sig1Copy, key1Copy) {
 		t.Errorf("previously added item not found in signature cache")
@@ -80,7 +76,7 @@ func TestSigCacheAddEvictEntry(t *testing.T) {
 		}
 
 		sigCache.Add(*msg, sig, key)
-		sigCopy, _ := secp256k1.ParseSignature(sig.Serialize(), curve)
+		sigCopy, _ := secp256k1.ParseSignature(sig.Serialize())
 		keyCopy, _ := secp256k1.ParsePubKey(key.SerializeCompressed())
 		if !sigCache.Exists(*msg, sigCopy, keyCopy) {
 			t.Errorf("previously added item not found in signature" +
@@ -109,7 +105,7 @@ func TestSigCacheAddEvictEntry(t *testing.T) {
 	}
 
 	// The entry added above should be found within the sigcache.
-	sigNewCopy, _ := secp256k1.ParseSignature(sigNew.Serialize(), curve)
+	sigNewCopy, _ := secp256k1.ParseSignature(sigNew.Serialize())
 	keyNewCopy, _ := secp256k1.ParsePubKey(keyNew.SerializeCompressed())
 	if !sigCache.Exists(*msgNew, sigNewCopy, keyNewCopy) {
 		t.Fatalf("previously added item not found in signature cache")
@@ -132,7 +128,7 @@ func TestSigCacheAddMaxEntriesZeroOrNegative(t *testing.T) {
 	sigCache.Add(*msg1, sig1, key1)
 
 	// The generated triplet should not be found.
-	sig1Copy, _ := secp256k1.ParseSignature(sig1.Serialize(), curve)
+	sig1Copy, _ := secp256k1.ParseSignature(sig1.Serialize())
 	key1Copy, _ := secp256k1.ParsePubKey(key1.SerializeCompressed())
 	if sigCache.Exists(*msg1, sig1Copy, key1Copy) {
 		t.Errorf("previously added signature found in sigcache, but" +


### PR DESCRIPTION
**This requires PR #1304**.

This removes the unused curve parameter from the `ParseSignature` and `ParseDERSignature` functions of the `secp256k1` package and updates all callers in the repository accordingly.
