### PR TITLE
chainhash: Remove dup code from hash funcs.

### DIFF
--- a/chaincfg/chainhash/hashfuncs.go
+++ b/chaincfg/chainhash/hashfuncs.go
@@ -13,14 +13,9 @@ import (
 // TODO(jcv) Should modify blake256 so it has the same interface as blake2
 // and sha256 so these function can look more like btcsuite.  Then should
 // try to get it to the upstream blake256 repo
-func HashFunc(data []byte) [blake256.Size]byte {
+func HashFunc(b []byte) [blake256.Size]byte {
 	var outB [blake256.Size]byte
-	a := blake256.New()
-	a.Write(data)
-	out := a.Sum(nil)
-	for i, el := range out {
-		outB[i] = el
-	}
+	copy(outB[:], HashB(b))
 
 	return outB
 }
@@ -35,15 +30,7 @@ func HashB(b []byte) []byte {
 
 // HashH calculates hash(b) and returns the resulting bytes as a Hash.
 func HashH(b []byte) Hash {
-	var outB [blake256.Size]byte
-	a := blake256.New()
-	a.Write(b)
-	out := a.Sum(nil)
-	for i, el := range out {
-		outB[i] = el
-	}
-
-	return Hash(outB)
+	return Hash(HashFunc(b))
 }
 
 // HashBlockSize is the block size of the hash algorithm in bytes.

--- a/chaincfg/chainhash/hashfuncs_test.go
+++ b/chaincfg/chainhash/hashfuncs_test.go
@@ -9,10 +9,9 @@ import (
 	"testing"
 )
 
-// TestHashFuncs ensures the hash functions which perform hash(b) work as
-// expected.
-func TestHashFuncs(t *testing.T) {
-	tests := []struct {
+var (
+	// hashTests provides sample inputs and outputs for hash function tests
+	hashTests = []struct {
 		out string
 		in  string
 	}{
@@ -48,24 +47,39 @@ func TestHashFuncs(t *testing.T) {
 		{"496f7063f8bd479bf54e9d87e9ba53e277839ac7fdaecc5105f2879b58ee562f", "The fugacity of a constituent in a mixture of gases at a given temperature is proportional to its mole fraction.  Lewis-Randall Rule"},
 		{"2e0eff918940b01eea9539a02212f33ee84f77fab201f4287aa6167e4a1ed043", "How can you write a big system without C++?  -Paul Glick"},
 	}
+)
 
-	// Ensure the hash function which returns a byte slice returns the
-	// expected result.
-	for _, test := range tests {
+// TestHashB ensure HashB returns the correct hashed bytes for given bytes
+func TestHashB(t *testing.T) {
+	for _, test := range hashTests {
 		h := fmt.Sprintf("%x", HashB([]byte(test.in)))
 		if h != test.out {
 			t.Errorf("HashB(%q) = %s, want %s", test.in, h, test.out)
 			continue
 		}
 	}
+}
 
-	// Ensure the hash function which returns a Hash returns the expected
-	// result.
-	for _, test := range tests {
+// TestHashH ensure HashH returns a hash with the correct hashed bytes for
+// given bytes
+func TestHashH(t *testing.T) {
+	for _, test := range hashTests {
 		hash := HashH([]byte(test.in))
 		h := fmt.Sprintf("%x", hash[:])
 		if h != test.out {
 			t.Errorf("HashH(%q) = %s, want %s", test.in, h, test.out)
+			continue
+		}
+	}
+}
+
+// TestHashFunc ensure HashFunc returns the correct hashed bytes for given
+// bytes
+func TestHashFunc(t *testing.T) {
+	for _, test := range hashTests {
+		h := fmt.Sprintf("%x", HashFunc([]byte(test.in)))
+		if h != test.out {
+			t.Errorf("HashFunc(%q) = %s, want %s", test.in, h, test.out)
 			continue
 		}
 	}


### PR DESCRIPTION
Removed some duplicate code by having HashH use HashB rather than duplicating its functionality.