### PR TITLE
Fix the ConnReq print out causing panic

### DIFF
--- a/connmgr/connmanager.go
+++ b/connmgr/connmanager.go
@@ -82,7 +82,7 @@ func (c *ConnReq) State() ConnState {
 
 // String returns a human-readable string for the connection request.
 func (c *ConnReq) String() string {
-	if c.Addr.String() == "" {
+	if c.Addr == nil || c.Addr.String() == "" {
 		return fmt.Sprintf("reqid %d", atomic.LoadUint64(&c.id))
 	}
 	return fmt.Sprintf("%s (reqid %d)", c.Addr, atomic.LoadUint64(&c.id))


### PR DESCRIPTION
In debug mode you can see some Panics when `ConnReq.Addr` is `nil`. 
This happens before the deamon get connected to any peer. That commit will fix it.

Before:

```
2018-07-11 12:39:30.081 [INF] CMGR: Server listening on [::]:9108
2018-07-11 12:39:30.081 [INF] CMGR: Server listening on 0.0.0.0:9108
2018-07-11 12:39:33.993 [INF] CMGR: 32 addresses found from DNS seed mainnet-seed.decred.org
2018-07-11 12:39:33.991 [DBG] CMGR: Failed to connect to %!v(PANIC=runtime error: invalid memory address or nil pointer dereference): no valid connect address
2018-07-11 12:39:35.715 [DBG] CMGR: Failed to connect to %!v(PANIC=runtime error: invalid memory address or nil pointer dereference): no valid connect address
2018-07-11 12:39:35.715 [INF] CMGR: 23 addresses found from DNS seed mainnet-seed.decred.netpurgatory.com
2018-07-11 12:39:35.716 [INF] CMGR: 37 addresses found from DNS seed mainnet-seed.decred.mindcry.org
2018-07-11 12:39:37.921 [DBG] CMGR: Attempting to connect to 139.99.100.191:9108 (reqid 8)
2018-07-11 12:39:37.921 [DBG] CMGR: Failed to connect to %!v(PANIC=runtime error: invalid memory address or nil pointer dereference): no valid connect address
2018-07-11 12:39:40.098 [DBG] CMGR: Failed to connect to %!v(PANIC=runtime error: invalid memory address or nil pointer dereference): no valid connect address
2018-07-11 12:39:40.908 [DBG] CMGR: Failed to connect to %!v(PANIC=runtime error: invalid memory address or nil pointer dereference): no valid connect address
2018-07-11 12:39:40.908 [DBG] CMGR: Attempting to connect to 54.37.84.214:9108 (reqid 9)
2018-07-11 12:39:40.908 [DBG] CMGR: Attempting to connect to 163.172.24.172:9108 (reqid 10)
```

After:

```
2018-07-11 12:47:36.096 [INF] CMGR: Server listening on 0.0.0.0:9108
2018-07-11 12:47:36.096 [INF] CMGR: Server listening on [::]:9108
2018-07-11 12:47:39.028 [DBG] CMGR: Failed to connect to reqid 1: no valid connect address
2018-07-11 12:47:40.108 [DBG] CMGR: Failed to connect to reqid 2: no valid connect address
2018-07-11 12:47:40.795 [INF] CMGR: 23 addresses found from DNS seed mainnet-seed.decred.netpurgatory.com
2018-07-11 12:47:40.795 [INF] CMGR: 32 addresses found from DNS seed mainnet-seed.decred.org
2018-07-11 12:47:40.797 [DBG] CMGR: Failed to connect to reqid 3: no valid connect address
2018-07-11 12:47:40.797 [INF] CMGR: 37 addresses found from DNS seed mainnet-seed.decred.mindcry.org
2018-07-11 12:47:47.899 [DBG] CMGR: Failed to connect to reqid 4: no valid connect address
2018-07-11 12:47:50.225 [DBG] CMGR: Failed to connect to reqid 5: no valid connect address
2018-07-11 12:47:51.121 [DBG] CMGR: Failed to connect to reqid 6: no valid connect address
2018-07-11 12:47:51.899 [DBG] CMGR: Failed to connect to reqid 7: no valid connect address
2018-07-11 12:47:52.560 [DBG] CMGR: Attempting to connect to 219.235.103.161:9108 (reqid 11)
2018-07-11 12:47:52.560 [DBG] CMGR: Attempting to connect to 46.166.161.145:9108 (reqid 12)
```