### PR TITLE
chainhash: Update go build module support.

### DIFF
--- a/chaincfg/chainhash/go.modverify
+++ b/chaincfg/chainhash/go.modverify
@@ -1,1 +1,0 @@
-github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=

--- a/chaincfg/chainhash/go.sum
+++ b/chaincfg/chainhash/go.sum
@@ -1,0 +1,2 @@
+github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
+github.com/dchest/blake256 v1.0.0/go.mod h1:xXNWCE1jsAP8DAjP+rKw2MbeqLczjI3TRx2VK+9OEYY=


### PR DESCRIPTION
This updates the `chainhash` build module for the changes in the upcoming go1.11 release.