### PR TITLE
wire: Update go build module support.

### DIFF
--- a/wire/go.mod
+++ b/wire/go.mod
@@ -1,3 +1,6 @@
 module github.com/decred/dcrd/wire
 
-require github.com/decred/dcrd/chaincfg/chainhash v1.0.0
+require (
+	github.com/davecgh/go-spew v1.1.0
+	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
+)

--- a/wire/go.modverify
+++ b/wire/go.modverify
@@ -1,3 +1,0 @@
-github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
-github.com/decred/dcrd v1.3.0 h1:Y/3k/RY3UU70ELNuu/X8aAG6gaa/sba283/o3iS58E8=
-github.com/decred/dcrd/chaincfg/chainhash v1.0.0 h1:aglSvKIb7PHMnQ0wODb9JC6tkGzvsNKaVoeHqHuERNg=

--- a/wire/go.sum
+++ b/wire/go.sum
@@ -1,0 +1,6 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
+github.com/dchest/blake256 v1.0.0/go.mod h1:xXNWCE1jsAP8DAjP+rKw2MbeqLczjI3TRx2VK+9OEYY=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.1 h1:0vG7U9+dSjSCaHQKdoSKURK2pOb47+b+8FK5q4+Je7M=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.1/go.mod h1:OVfvaOsNLS/A1y4Eod0Ip/Lf8qga7VXCQjUQLbkY0Go=


### PR DESCRIPTION
This updates the `wire` build module for the changes in the upcoming go1.11 release and to depend on the latest `chainhash` module version.