### PR TITLE
addrmgr: Update go build module support.

### DIFF
--- a/addrmgr/go.mod
+++ b/addrmgr/go.mod
@@ -1,6 +1,7 @@
 module github.com/decred/dcrd/addrmgr
 
 require (
-	github.com/decred/dcrd/wire v1.0.0
+	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
+	github.com/decred/dcrd/wire v1.0.1
 	github.com/decred/slog v1.0.0
 )

--- a/addrmgr/go.modverify
+++ b/addrmgr/go.modverify
@@ -1,4 +1,0 @@
-github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
-github.com/decred/dcrd/chaincfg/chainhash v1.0.0 h1:aglSvKIb7PHMnQ0wODb9JC6tkGzvsNKaVoeHqHuERNg=
-github.com/decred/dcrd/wire v1.0.0 h1:2h07YfuN8O2zxXiUGTrpdilYhIt9LMNBnIlAoa8SMfw=
-github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=

--- a/addrmgr/go.sum
+++ b/addrmgr/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
+github.com/dchest/blake256 v1.0.0/go.mod h1:xXNWCE1jsAP8DAjP+rKw2MbeqLczjI3TRx2VK+9OEYY=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.0 h1:aglSvKIb7PHMnQ0wODb9JC6tkGzvsNKaVoeHqHuERNg=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.0/go.mod h1:OVfvaOsNLS/A1y4Eod0Ip/Lf8qga7VXCQjUQLbkY0Go=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.1 h1:0vG7U9+dSjSCaHQKdoSKURK2pOb47+b+8FK5q4+Je7M=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.1/go.mod h1:OVfvaOsNLS/A1y4Eod0Ip/Lf8qga7VXCQjUQLbkY0Go=
+github.com/decred/dcrd/wire v1.0.0 h1:2h07YfuN8O2zxXiUGTrpdilYhIt9LMNBnIlAoa8SMfw=
+github.com/decred/dcrd/wire v1.0.0/go.mod h1:tC9h/4pnjuvD32xMNcFSifByV9IeBVPdB+dPCP0PuZ4=
+github.com/decred/dcrd/wire v1.0.1 h1:yhLSapj1ZF3LT/7cu7Ur9+chEuIV8gnrf6DqWDrFaVY=
+github.com/decred/dcrd/wire v1.0.1/go.mod h1:zpKZnBiN59CrzfXFigwgXmUDVYf34OLbEr8xwAwriHc=
+github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
+github.com/decred/slog v1.0.0/go.mod h1:zR98rEZHSnbZ4WHZtO0iqmSZjDLKhkXfrPTZQKtAonQ=


### PR DESCRIPTION
This updates the `addrmgr` build module for the changes in the upcoming go1.11 release and to depend on the latest `chainhash` and `wire` module versions.