### PR TITLE
secp256k1: Refine go build module support.

### DIFF
--- a/dcrec/secp256k1/go.mod
+++ b/dcrec/secp256k1/go.mod
@@ -1,0 +1,6 @@
+module github.com/decred/dcrd/dcrec/secp256k1
+
+require (
+	github.com/davecgh/go-spew v1.1.0
+	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
+)

--- a/dcrec/secp256k1/go.sum
+++ b/dcrec/secp256k1/go.sum
@@ -1,0 +1,6 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
+github.com/dchest/blake256 v1.0.0/go.mod h1:xXNWCE1jsAP8DAjP+rKw2MbeqLczjI3TRx2VK+9OEYY=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.1 h1:0vG7U9+dSjSCaHQKdoSKURK2pOb47+b+8FK5q4+Je7M=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.1/go.mod h1:OVfvaOsNLS/A1y4Eod0Ip/Lf8qga7VXCQjUQLbkY0Go=


### PR DESCRIPTION
Now that the `chainhash` module has been defined, update the `secp256k1` module to only depend on it instead of the entire `dcrd` module.