### PR TITLE
blockchain: Optimize reorg to use known status.

### DIFF
--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -587,6 +587,19 @@ func TestForceHeadReorg(t *testing.T) {
 	expectTip("b3")
 
 	// Attempt to force tip reorganization to an invalid block that has an
+	// entry in the block index and is already known to be invalid.
+	//
+	//   ... -> b1(0) -> b3(1)
+	//               \-> b2(1)
+	//               \-> b4(1)
+	//               \-> b5(1)
+	//               \-> b2bad0(1)
+	//               \-> b2bad1(1)
+	//               \-> b2bad2(1)
+	rejectForceTipReorg("b3", "b2bad1", ErrKnownInvalidBlock)
+	expectTip("b3")
+
+	// Attempt to force tip reorganization to an invalid block that has an
 	// entry in the block index, but is not already known to be invalid.
 	//
 	//

--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -449,6 +449,10 @@ const (
 	// height had a non-zero final state.
 	ErrInvalidEarlyFinalState
 
+	// ErrKnownInvalidBlock indicates that this block has previously failed
+	// validation.
+	ErrKnownInvalidBlock
+
 	// ErrInvalidAncestorBlock indicates that an ancestor of this block has
 	// failed validation.
 	ErrInvalidAncestorBlock
@@ -558,6 +562,7 @@ var errorCodeStrings = map[ErrorCode]string{
 	ErrZeroValueOutputSpend:   "ErrZeroValueOutputSpend",
 	ErrInvalidEarlyVoteBits:   "ErrInvalidEarlyVoteBits",
 	ErrInvalidEarlyFinalState: "ErrInvalidEarlyFinalState",
+	ErrKnownInvalidBlock:      "ErrKnownInvalidBlock",
 	ErrInvalidAncestorBlock:   "ErrInvalidAncestorBlock",
 	ErrInvalidTemplateParent:  "ErrInvalidTemplateParent",
 }

--- a/blockchain/error_test.go
+++ b/blockchain/error_test.go
@@ -110,6 +110,7 @@ func TestErrorCodeStringer(t *testing.T) {
 		{ErrZeroValueOutputSpend, "ErrZeroValueOutputSpend"},
 		{ErrInvalidEarlyVoteBits, "ErrInvalidEarlyVoteBits"},
 		{ErrInvalidEarlyFinalState, "ErrInvalidEarlyFinalState"},
+		{ErrKnownInvalidBlock, "ErrKnownInvalidBlock"},
 		{ErrInvalidAncestorBlock, "ErrInvalidAncestorBlock"},
 		{ErrInvalidTemplateParent, "ErrInvalidTemplateParent"},
 		{0xffff, "Unknown ErrorCode (65535)"},


### PR DESCRIPTION
This optimizes the chain reorganization logic by making use of the block index status flags for known valid and invalid blocks.

In particular, validation is now skipped for blocks that are either already known valid or invalid.  When validating blocks, the result is stored into the block index for the block accordingly, and in the case of blocks that fail validation, all of the descendants of the invalid block are marked as having an invalid ancestor.

It also introduces a new error named `ErrKnownInvalidBlock` which is returned in the case a forced reorg is attempted to an invalid block and adds a test to ensure it works as intended.

This is work towards #1145.