### PR TITLE
blockchain: Remove unnecessary genesis block check.

### DIFF
--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -2327,13 +2327,6 @@ func (b *BlockChain) checkConnectBlock(node *blockNode, block, parent *dcrutil.B
 	// implementation only currently uses memory for the side chain blocks,
 	// it isn't currently necessary.
 
-	// The coinbase for the Genesis block is not spendable, so just return
-	// an error now.
-	if node.hash.IsEqual(b.chainParams.GenesisHash) {
-		str := "the coinbase for the genesis block is not spendable"
-		return ruleError(ErrMissingTxOut, str)
-	}
-
 	// Ensure the view is for the node being checked.
 	parentHash := &block.MsgBlock().Header.PrevBlock
 	if !utxoView.BestHash().IsEqual(parentHash) {


### PR DESCRIPTION
This modifies the `checkConnectBlock` function to remove the check which tests if the block is the genesis block and returns an error since it is no longer necessary due to other changes in the code since the function was originally written.

In particular, the genesis block is valid by definition as the root of the chain, so it does not make sense to try to connect it to a chain that doesn't exist yet.