### PR TITLE
blockchain: Make block index flushable.

### DIFF
--- a/blockchain/stakenode.go
+++ b/blockchain/stakenode.go
@@ -108,6 +108,12 @@ func (b *BlockChain) fetchStakeNode(node *blockNode) (*stake.Node, error) {
 	detachNodes, attachNodes := b.getReorganizeNodes(node)
 	current := b.bestChain.Tip()
 
+	// Flush any potential unsaved changes to the block index due to the
+	// call to get the reorganize nodes.  Since the best state is not being
+	// being modified, it is safe to ignore any errors here as the changes
+	// will be flushed at that point and those errors are not ignored.
+	b.flushBlockIndexWarnOnly()
+
 	// Move backwards through the main chain, undoing the ticket
 	// treaps for each block.  The database is passed because the
 	// undo data and new tickets data for each block may not yet

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -2615,6 +2615,12 @@ func (b *BlockChain) CheckConnectBlockTemplate(block *dcrutil.Block) error {
 	// just before the requested node.
 	detachNodes, attachNodes := b.getReorganizeNodes(prevNode)
 
+	// Flush any potential unsaved changes to the block index due to the
+	// call to get the reorganize nodes.  Since the best state is not being
+	// modified, it is safe to ignore any errors here as the changes will be
+	// flushed at that point and those errors are not ignored.
+	b.flushBlockIndexWarnOnly()
+
 	view := NewUtxoViewpoint()
 	view.SetBestHash(&tip.hash)
 	view.SetStakeViewpoint(ViewpointPrevValidInitial)


### PR DESCRIPTION
**This PR depends on #1367.**

This modifies the block index to support tracking modified nodes and flushing them to the database.  This ensures that validation states set on arbitrary nodes are persisted to the database and helps pave the way towards supporting decoupling the chain processing logic from the download logic.

In the immediate term, as of this commit, side chains which encounter an invalid block will no longer potentially have to be revalidated to discover they are invalid after restart.

A few comments are also improved while here.

This is work towards #1145.