### PR TITLE
mempool: Make expiry pruning self contained.

### DIFF
--- a/blockchain/chainview_test.go
+++ b/blockchain/chainview_test.go
@@ -27,7 +27,7 @@ func zipLocators(locators ...BlockLocator) BlockLocator {
 }
 
 // TestChainView ensures all of the exported functionality of chain views works
-// as intended with the expection of some special cases which are handled in
+// as intended with the execption of some special cases which are handled in
 // other tests.
 func TestChainView(t *testing.T) {
 	// Construct a synthetic block index consisting of the following

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1112,7 +1112,7 @@ func (b *blockManager) handleBlockMsg(bmsg *blockMsg) {
 				}
 				b.server.txMemPool.PruneStakeTx(nextStakeDiff,
 					best.Height)
-				b.server.txMemPool.PruneExpiredTx(best.Height)
+				b.server.txMemPool.PruneExpiredTx()
 			}
 
 			winningTickets, poolSize, finalState, err :=
@@ -1678,7 +1678,7 @@ out:
 						}
 						b.server.txMemPool.PruneStakeTx(nextStakeDiff,
 							best.Height)
-						b.server.txMemPool.PruneExpiredTx(best.Height)
+						b.server.txMemPool.PruneExpiredTx()
 					}
 
 					missedTickets, err := b.chain.MissedTickets()
@@ -1753,8 +1753,7 @@ out:
 						}
 						b.server.txMemPool.PruneStakeTx(nextStakeDiff,
 							best.Height)
-						b.server.txMemPool.PruneExpiredTx(
-							best.Height)
+						b.server.txMemPool.PruneExpiredTx()
 					}
 
 					missedTickets, err := b.chain.MissedTickets()

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -1322,13 +1322,15 @@ func (mp *TxPool) pruneStakeTx(requiredStakeDifficulty, height int64) {
 	}
 }
 
-// pruneExpiredTx prunes expired transactions from the mempool that may no longer
-// be able to be included into a block.
+// pruneExpiredTx prunes expired transactions from the mempool that are no
+// longer able to be included into a block.
 //
 // This function MUST be called with the mempool lock held (for writes).
-func (mp *TxPool) pruneExpiredTx(height int64) {
+func (mp *TxPool) pruneExpiredTx() {
+	nextBlockHeight := mp.cfg.BestHeight() + 1
+
 	for _, tx := range mp.pool {
-		if blockchain.IsExpired(tx.Tx, height) {
+		if blockchain.IsExpired(tx.Tx, nextBlockHeight) {
 			log.Debugf("Pruning expired transaction %v from the mempool",
 				tx.Tx.Hash())
 			mp.removeTransaction(tx.Tx, true)
@@ -1340,10 +1342,10 @@ func (mp *TxPool) pruneExpiredTx(height int64) {
 // be able to be included into a block.
 //
 // This function is safe for concurrent access.
-func (mp *TxPool) PruneExpiredTx(height int64) {
+func (mp *TxPool) PruneExpiredTx() {
 	// Protect concurrent access.
 	mp.mtx.Lock()
-	mp.pruneExpiredTx(height)
+	mp.pruneExpiredTx()
 	mp.mtx.Unlock()
 }
 


### PR DESCRIPTION
This modifies the `mempool` to handle pruning of expired transactions in a self-contained way so that the caller is not responsible for worrying about the specific semantics of height and expiration interplay and updates all callers in the repository accordingly.

It also adds a test which ensures the behavior is correct by creating a series of transactions with expirations, adding them just before the point at which they will expire, and then advancing the chain so that each transaction expires and thus should be pruned.