### PR TITLE
release: Bump module versions and deps.

### DIFF
--- a/addrmgr/go.mod
+++ b/addrmgr/go.mod
@@ -2,7 +2,7 @@ module github.com/decred/dcrd/addrmgr
 
 require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
-	github.com/decred/dcrd/wire v1.0.1
+	github.com/decred/dcrd/wire v1.1.0
 	github.com/decred/slog v1.0.0
 )
 

--- a/blockchain/go.mod
+++ b/blockchain/go.mod
@@ -1,18 +1,18 @@
 module github.com/decred/dcrd/blockchain
 
 require (
-	github.com/decred/dcrd/blockchain/stake v1.0.0
-	github.com/decred/dcrd/chaincfg v1.0.1
+	github.com/decred/dcrd/blockchain/stake v1.0.1
+	github.com/decred/dcrd/chaincfg v1.1.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
-	github.com/decred/dcrd/database v1.0.0
+	github.com/decred/dcrd/database v1.0.1
 	github.com/decred/dcrd/dcrec v0.0.0-20180801202239-0761de129164
 	github.com/decred/dcrd/dcrec/edwards v0.0.0-20180721031028-5369a485acf6
 	github.com/decred/dcrd/dcrec/secp256k1 v1.0.0
 	github.com/decred/dcrd/dcrjson v1.0.0
-	github.com/decred/dcrd/dcrutil v1.0.0
-	github.com/decred/dcrd/gcs v1.0.0
-	github.com/decred/dcrd/txscript v1.0.0
-	github.com/decred/dcrd/wire v1.0.1
+	github.com/decred/dcrd/dcrutil v1.1.1
+	github.com/decred/dcrd/gcs v1.0.1
+	github.com/decred/dcrd/txscript v1.0.1
+	github.com/decred/dcrd/wire v1.1.0
 	github.com/decred/slog v1.0.0
 )
 

--- a/blockchain/go.sum
+++ b/blockchain/go.sum
@@ -2,7 +2,9 @@ github.com/aead/siphash v0.0.0-20170329201724-e404fcfc8885 h1:bBmEG9/q1xH07CqeeF
 github.com/aead/siphash v0.0.0-20170329201724-e404fcfc8885/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
+github.com/btcsuite/goleveldb v1.0.0 h1:Tvd0BfvqX9o823q1j2UZ/epQo09eJh6dTcRp79ilIN4=
 github.com/btcsuite/goleveldb v1.0.0/go.mod h1:QiK9vBlgftBg6rWQIj6wFzbPfRjiykIEhBH4obrXJ/I=
+github.com/btcsuite/snappy-go v1.0.0 h1:ZxaA6lo2EpxGddsA8JwWOcxlzRybb444sgmeJQMJGQE=
 github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
@@ -38,6 +40,8 @@ github.com/onsi/gomega v1.4.1/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5
 golang.org/x/crypto v0.0.0-20180718160520-a2144134853f h1:lRy+hhwk7YT7MsKejxuz0C5Q1gk6p/QoPQYEmKmGFb8=
 golang.org/x/crypto v0.0.0-20180718160520-a2144134853f/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20180719180050-a680a1efc54d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20180808004115-f9ce57c11b24/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/blockchain/stake/go.mod
+++ b/blockchain/stake/go.mod
@@ -1,13 +1,13 @@
 module github.com/decred/dcrd/blockchain/stake
 
 require (
-	github.com/decred/dcrd/chaincfg v1.0.1
+	github.com/decred/dcrd/chaincfg v1.1.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
-	github.com/decred/dcrd/database v1.0.0
+	github.com/decred/dcrd/database v1.0.1
 	github.com/decred/dcrd/dcrec v0.0.0-20180801202239-0761de129164
-	github.com/decred/dcrd/dcrutil v1.0.0
-	github.com/decred/dcrd/txscript v1.0.0
-	github.com/decred/dcrd/wire v1.0.1
+	github.com/decred/dcrd/dcrutil v1.1.1
+	github.com/decred/dcrd/txscript v1.0.1
+	github.com/decred/dcrd/wire v1.1.0
 	github.com/decred/slog v1.0.0
 )
 

--- a/blockchain/stake/go.sum
+++ b/blockchain/stake/go.sum
@@ -1,6 +1,8 @@
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
+github.com/btcsuite/goleveldb v1.0.0 h1:Tvd0BfvqX9o823q1j2UZ/epQo09eJh6dTcRp79ilIN4=
 github.com/btcsuite/goleveldb v1.0.0/go.mod h1:QiK9vBlgftBg6rWQIj6wFzbPfRjiykIEhBH4obrXJ/I=
+github.com/btcsuite/snappy-go v1.0.0 h1:ZxaA6lo2EpxGddsA8JwWOcxlzRybb444sgmeJQMJGQE=
 github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
@@ -20,6 +22,8 @@ github.com/onsi/gomega v1.4.1/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5
 golang.org/x/crypto v0.0.0-20180718160520-a2144134853f h1:lRy+hhwk7YT7MsKejxuz0C5Q1gk6p/QoPQYEmKmGFb8=
 golang.org/x/crypto v0.0.0-20180718160520-a2144134853f/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20180719180050-a680a1efc54d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20180808004115-f9ce57c11b24/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/chaincfg/go.mod
+++ b/chaincfg/go.mod
@@ -3,7 +3,7 @@ module github.com/decred/dcrd/chaincfg
 require (
 	github.com/davecgh/go-spew v1.1.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
-	github.com/decred/dcrd/wire v1.0.1
+	github.com/decred/dcrd/wire v1.1.0
 )
 
 replace (

--- a/connmgr/go.mod
+++ b/connmgr/go.mod
@@ -1,8 +1,8 @@
 module github.com/decred/dcrd/connmgr
 
 require (
-	github.com/decred/dcrd/chaincfg v1.0.1
-	github.com/decred/dcrd/wire v1.0.1
+	github.com/decred/dcrd/chaincfg v1.1.1
+	github.com/decred/dcrd/wire v1.1.0
 	github.com/decred/slog v1.0.0
 )
 

--- a/database/go.mod
+++ b/database/go.mod
@@ -2,12 +2,14 @@ module github.com/decred/dcrd/database
 
 require (
 	github.com/btcsuite/goleveldb v1.0.0
-	github.com/decred/dcrd/chaincfg v1.0.1
+	github.com/decred/dcrd/chaincfg v1.1.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
-	github.com/decred/dcrd/dcrutil v1.0.0
-	github.com/decred/dcrd/wire v1.0.1
+	github.com/decred/dcrd/dcrutil v1.1.1
+	github.com/decred/dcrd/wire v1.1.0
 	github.com/decred/slog v1.0.0
 	github.com/jessevdk/go-flags v1.4.0
+	golang.org/x/net v0.0.0-20180808004115-f9ce57c11b24 // indirect
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )
 
 replace (

--- a/database/go.sum
+++ b/database/go.sum
@@ -32,6 +32,8 @@ github.com/onsi/gomega v1.4.1/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5
 golang.org/x/crypto v0.0.0-20180718160520-a2144134853f h1:lRy+hhwk7YT7MsKejxuz0C5Q1gk6p/QoPQYEmKmGFb8=
 golang.org/x/crypto v0.0.0-20180718160520-a2144134853f/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20180719180050-a680a1efc54d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20180808004115-f9ce57c11b24/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/dcrutil/go.mod
+++ b/dcrutil/go.mod
@@ -3,12 +3,12 @@ module github.com/decred/dcrd/dcrutil
 require (
 	github.com/davecgh/go-spew v1.1.0
 	github.com/decred/base58 v1.0.0
-	github.com/decred/dcrd/chaincfg v1.0.1
+	github.com/decred/dcrd/chaincfg v1.1.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
 	github.com/decred/dcrd/dcrec v0.0.0-20180721005212-59fe2b293f69
 	github.com/decred/dcrd/dcrec/edwards v0.0.0-20180721005212-59fe2b293f69
 	github.com/decred/dcrd/dcrec/secp256k1 v1.0.0
-	github.com/decred/dcrd/wire v1.0.1
+	github.com/decred/dcrd/wire v1.1.0
 	golang.org/x/crypto v0.0.0-20180718160520-a2144134853f
 )
 

--- a/gcs/go.mod
+++ b/gcs/go.mod
@@ -3,10 +3,10 @@ module github.com/decred/dcrd/gcs
 require (
 	github.com/aead/siphash v0.0.0-20170329201724-e404fcfc8885
 	github.com/dchest/blake256 v1.0.0
-	github.com/decred/dcrd/blockchain/stake v1.0.0
+	github.com/decred/dcrd/blockchain/stake v1.0.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
-	github.com/decred/dcrd/txscript v1.0.0
-	github.com/decred/dcrd/wire v1.0.1
+	github.com/decred/dcrd/txscript v1.0.1
+	github.com/decred/dcrd/wire v1.1.0
 )
 
 replace (

--- a/gcs/go.sum
+++ b/gcs/go.sum
@@ -19,6 +19,8 @@ github.com/onsi/gomega v1.4.1/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5
 golang.org/x/crypto v0.0.0-20180718160520-a2144134853f h1:lRy+hhwk7YT7MsKejxuz0C5Q1gk6p/QoPQYEmKmGFb8=
 golang.org/x/crypto v0.0.0-20180718160520-a2144134853f/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20180719180050-a680a1efc54d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20180808004115-f9ce57c11b24/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.mod
+++ b/go.mod
@@ -10,26 +10,27 @@ require (
 	github.com/davecgh/go-spew v1.1.0
 	github.com/dchest/blake256 v1.0.0
 	github.com/decred/base58 v1.0.0
-	github.com/decred/dcrd/addrmgr v1.0.1
-	github.com/decred/dcrd/blockchain v1.0.0
-	github.com/decred/dcrd/blockchain/stake v1.0.0
+	github.com/decred/dcrd/addrmgr v1.0.2
+	github.com/decred/dcrd/blockchain v1.0.1
+	github.com/decred/dcrd/blockchain/stake v1.0.1
 	github.com/decred/dcrd/certgen v1.0.1
-	github.com/decred/dcrd/chaincfg v1.0.1
+	github.com/decred/dcrd/chaincfg v1.1.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
-	github.com/decred/dcrd/connmgr v1.0.0
-	github.com/decred/dcrd/database v1.0.0
+	github.com/decred/dcrd/connmgr v1.0.1
+	github.com/decred/dcrd/database v1.0.1
 	github.com/decred/dcrd/dcrec v0.0.0-20180801202239-0761de129164
+	github.com/decred/dcrd/dcrec/edwards v0.0.0-20180808153611-f0e65ec62f91 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1 v1.0.0
 	github.com/decred/dcrd/dcrjson v1.0.0
-	github.com/decred/dcrd/dcrutil v1.0.0
-	github.com/decred/dcrd/gcs v1.0.0
-	github.com/decred/dcrd/hdkeychain v1.0.0
-	github.com/decred/dcrd/mempool v1.0.0
-	github.com/decred/dcrd/mining v1.0.0
-	github.com/decred/dcrd/peer v1.0.0
-	github.com/decred/dcrd/rpcclient v1.0.0
-	github.com/decred/dcrd/txscript v1.0.0
-	github.com/decred/dcrd/wire v1.0.1
+	github.com/decred/dcrd/dcrutil v1.1.1
+	github.com/decred/dcrd/gcs v1.0.1
+	github.com/decred/dcrd/hdkeychain v1.1.0
+	github.com/decred/dcrd/mempool v1.0.1
+	github.com/decred/dcrd/mining v1.0.1
+	github.com/decred/dcrd/peer v1.0.1
+	github.com/decred/dcrd/rpcclient v1.0.1
+	github.com/decred/dcrd/txscript v1.0.1
+	github.com/decred/dcrd/wire v1.1.0
 	github.com/decred/slog v1.0.0
 	github.com/gorilla/websocket v1.2.0
 	github.com/jessevdk/go-flags v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,10 @@ github.com/onsi/gomega v1.4.1/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5
 golang.org/x/crypto v0.0.0-20180718160520-a2144134853f h1:lRy+hhwk7YT7MsKejxuz0C5Q1gk6p/QoPQYEmKmGFb8=
 golang.org/x/crypto v0.0.0-20180718160520-a2144134853f/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20180719180050-a680a1efc54d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20180808004115-f9ce57c11b24/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sys v0.0.0-20180522224204-88eb85aaee56/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/hdkeychain/go.mod
+++ b/hdkeychain/go.mod
@@ -2,11 +2,11 @@ module github.com/decred/dcrd/hdkeychain
 
 require (
 	github.com/decred/base58 v1.0.0
-	github.com/decred/dcrd/chaincfg v1.0.1
+	github.com/decred/dcrd/chaincfg v1.1.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
 	github.com/decred/dcrd/dcrec v0.0.0-20180721005914-d26200ec716b
 	github.com/decred/dcrd/dcrec/secp256k1 v1.0.0
-	github.com/decred/dcrd/dcrutil v1.0.0
+	github.com/decred/dcrd/dcrutil v1.1.1
 )
 
 replace (

--- a/mempool/go.mod
+++ b/mempool/go.mod
@@ -1,18 +1,18 @@
 module github.com/decred/dcrd/mempool
 
 require (
-	github.com/decred/dcrd/blockchain v1.0.0
-	github.com/decred/dcrd/blockchain/stake v1.0.0
-	github.com/decred/dcrd/chaincfg v1.0.1
+	github.com/decred/dcrd/blockchain v1.0.1
+	github.com/decred/dcrd/blockchain/stake v1.0.1
+	github.com/decred/dcrd/chaincfg v1.1.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
 	github.com/decred/dcrd/dcrec v0.0.0-20180801202239-0761de129164
 	github.com/decred/dcrd/dcrec/secp256k1 v1.0.0
 	github.com/decred/dcrd/dcrjson v1.0.0
-	github.com/decred/dcrd/dcrutil v1.0.0
-	github.com/decred/dcrd/gcs v1.0.0
+	github.com/decred/dcrd/dcrutil v1.1.1
+	github.com/decred/dcrd/gcs v1.0.1
 	github.com/decred/dcrd/mining v1.0.0
-	github.com/decred/dcrd/txscript v1.0.0
-	github.com/decred/dcrd/wire v1.0.1
+	github.com/decred/dcrd/txscript v1.0.1
+	github.com/decred/dcrd/wire v1.1.0
 	github.com/decred/slog v1.0.0
 )
 
@@ -21,6 +21,7 @@ replace (
 	github.com/decred/dcrd/blockchain/stake => ../blockchain/stake
 	github.com/decred/dcrd/chaincfg => ../chaincfg
 	github.com/decred/dcrd/chaincfg/chainhash => ../chaincfg/chainhash
+	github.com/decred/dcrd/database => ../database
 	github.com/decred/dcrd/dcrjson => ../dcrjson
 	github.com/decred/dcrd/dcrutil => ../dcrutil
 	github.com/decred/dcrd/gcs => ../gcs

--- a/mempool/go.sum
+++ b/mempool/go.sum
@@ -32,11 +32,14 @@ github.com/decred/dcrd/wire v1.0.1 h1:yhLSapj1ZF3LT/7cu7Ur9+chEuIV8gnrf6DqWDrFaV
 github.com/decred/dcrd/wire v1.0.1/go.mod h1:zpKZnBiN59CrzfXFigwgXmUDVYf34OLbEr8xwAwriHc=
 github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
 github.com/decred/slog v1.0.0/go.mod h1:zR98rEZHSnbZ4WHZtO0iqmSZjDLKhkXfrPTZQKtAonQ=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.1/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 golang.org/x/crypto v0.0.0-20180718160520-a2144134853f h1:lRy+hhwk7YT7MsKejxuz0C5Q1gk6p/QoPQYEmKmGFb8=
 golang.org/x/crypto v0.0.0-20180718160520-a2144134853f/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20180719180050-a680a1efc54d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20180808004115-f9ce57c11b24/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/mining/go.mod
+++ b/mining/go.mod
@@ -1,13 +1,13 @@
 module github.com/decred/dcrd/mining
 
 require (
-	github.com/decred/dcrd/blockchain v1.0.0
-	github.com/decred/dcrd/blockchain/stake v1.0.0
+	github.com/decred/dcrd/blockchain v1.0.1
+	github.com/decred/dcrd/blockchain/stake v1.0.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
 	github.com/decred/dcrd/dcrjson v1.0.0
-	github.com/decred/dcrd/dcrutil v1.0.0
-	github.com/decred/dcrd/gcs v1.0.0
-	github.com/decred/dcrd/wire v1.0.1
+	github.com/decred/dcrd/dcrutil v1.1.1
+	github.com/decred/dcrd/gcs v1.0.1
+	github.com/decred/dcrd/wire v1.1.0
 )
 
 replace (
@@ -15,11 +15,13 @@ replace (
 	github.com/decred/dcrd/blockchain/stake => ../blockchain/stake
 	github.com/decred/dcrd/chaincfg => ../chaincfg
 	github.com/decred/dcrd/chaincfg/chainhash => ../chaincfg/chainhash
+	github.com/decred/dcrd/database => ../database
 	github.com/decred/dcrd/dcrec => ../dcrec
 	github.com/decred/dcrd/dcrec/edwards => ../dcrec/edwards
 	github.com/decred/dcrd/dcrec/secp256k1 => ../dcrec/secp256k1
 	github.com/decred/dcrd/dcrjson => ../dcrjson
 	github.com/decred/dcrd/dcrutil => ../dcrutil
 	github.com/decred/dcrd/gcs => ../gcs
+	github.com/decred/dcrd/txscript => ../txscript
 	github.com/decred/dcrd/wire => ../wire
 )

--- a/mining/go.sum
+++ b/mining/go.sum
@@ -31,11 +31,14 @@ github.com/decred/dcrd/wire v1.0.1 h1:yhLSapj1ZF3LT/7cu7Ur9+chEuIV8gnrf6DqWDrFaV
 github.com/decred/dcrd/wire v1.0.1/go.mod h1:zpKZnBiN59CrzfXFigwgXmUDVYf34OLbEr8xwAwriHc=
 github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
 github.com/decred/slog v1.0.0/go.mod h1:zR98rEZHSnbZ4WHZtO0iqmSZjDLKhkXfrPTZQKtAonQ=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.1/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 golang.org/x/crypto v0.0.0-20180718160520-a2144134853f h1:lRy+hhwk7YT7MsKejxuz0C5Q1gk6p/QoPQYEmKmGFb8=
 golang.org/x/crypto v0.0.0-20180718160520-a2144134853f/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20180719180050-a680a1efc54d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20180808004115-f9ce57c11b24/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/peer/go.mod
+++ b/peer/go.mod
@@ -3,16 +3,17 @@ module github.com/decred/dcrd/peer
 require (
 	github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd
 	github.com/davecgh/go-spew v1.1.0
-	github.com/decred/dcrd/blockchain v1.0.0
-	github.com/decred/dcrd/chaincfg v1.0.1
+	github.com/decred/dcrd/blockchain v1.0.1
+	github.com/decred/dcrd/chaincfg v1.1.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
-	github.com/decred/dcrd/txscript v1.0.0
-	github.com/decred/dcrd/wire v1.0.1
+	github.com/decred/dcrd/txscript v1.0.1
+	github.com/decred/dcrd/wire v1.1.0
 	github.com/decred/slog v1.0.0
 )
 
 replace (
 	github.com/decred/dcrd/blockchain => ../blockchain
+	github.com/decred/dcrd/blockchain/stake => ../blockchain/stake
 	github.com/decred/dcrd/chaincfg => ../chaincfg
 	github.com/decred/dcrd/chaincfg/chainhash => ../chaincfg/chainhash
 	github.com/decred/dcrd/database => ../database
@@ -21,6 +22,7 @@ replace (
 	github.com/decred/dcrd/dcrec/secp256k1 => ../dcrec/secp256k1
 	github.com/decred/dcrd/dcrjson => ../dcrjson
 	github.com/decred/dcrd/dcrutil => ../dcrutil
+	github.com/decred/dcrd/gcs => ../gcs
 	github.com/decred/dcrd/txscript => ../txscript
 	github.com/decred/dcrd/wire => ../wire
 )

--- a/peer/go.sum
+++ b/peer/go.sum
@@ -1,3 +1,4 @@
+github.com/aead/siphash v0.0.0-20170329201724-e404fcfc8885/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd h1:R/opQEbFEy9JGkIguV40SvRY1uliPX8ifOvi6ICsFCw=
@@ -33,11 +34,14 @@ github.com/decred/dcrd/wire v1.0.1 h1:yhLSapj1ZF3LT/7cu7Ur9+chEuIV8gnrf6DqWDrFaV
 github.com/decred/dcrd/wire v1.0.1/go.mod h1:zpKZnBiN59CrzfXFigwgXmUDVYf34OLbEr8xwAwriHc=
 github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
 github.com/decred/slog v1.0.0/go.mod h1:zR98rEZHSnbZ4WHZtO0iqmSZjDLKhkXfrPTZQKtAonQ=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.1/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 golang.org/x/crypto v0.0.0-20180718160520-a2144134853f h1:lRy+hhwk7YT7MsKejxuz0C5Q1gk6p/QoPQYEmKmGFb8=
 golang.org/x/crypto v0.0.0-20180718160520-a2144134853f/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20180719180050-a680a1efc54d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20180808004115-f9ce57c11b24/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/rpcclient/go.mod
+++ b/rpcclient/go.mod
@@ -2,13 +2,13 @@ module github.com/decred/dcrd/rpcclient
 
 require (
 	github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd
-	github.com/decred/dcrd/blockchain v1.0.0
-	github.com/decred/dcrd/blockchain/stake v1.0.0
+	github.com/decred/dcrd/blockchain v1.0.1
+	github.com/decred/dcrd/blockchain/stake v1.0.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
 	github.com/decred/dcrd/dcrjson v1.0.0
-	github.com/decred/dcrd/dcrutil v1.0.0
-	github.com/decred/dcrd/gcs v1.0.0
-	github.com/decred/dcrd/wire v1.0.1
+	github.com/decred/dcrd/dcrutil v1.1.1
+	github.com/decred/dcrd/gcs v1.0.1
+	github.com/decred/dcrd/wire v1.1.0
 	github.com/decred/slog v1.0.0
 	github.com/gorilla/websocket v1.2.0
 )

--- a/rpcclient/go.sum
+++ b/rpcclient/go.sum
@@ -27,6 +27,8 @@ github.com/onsi/gomega v1.4.1/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5
 golang.org/x/crypto v0.0.0-20180718160520-a2144134853f h1:lRy+hhwk7YT7MsKejxuz0C5Q1gk6p/QoPQYEmKmGFb8=
 golang.org/x/crypto v0.0.0-20180718160520-a2144134853f/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20180719180050-a680a1efc54d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20180808004115-f9ce57c11b24/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/txscript/go.mod
+++ b/txscript/go.mod
@@ -1,13 +1,13 @@
 module github.com/decred/dcrd/txscript
 
 require (
-	github.com/decred/dcrd/chaincfg v1.0.1
+	github.com/decred/dcrd/chaincfg v1.1.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
 	github.com/decred/dcrd/dcrec v0.0.0-20180721031028-5369a485acf6
 	github.com/decred/dcrd/dcrec/edwards v0.0.0-20180721031028-5369a485acf6
 	github.com/decred/dcrd/dcrec/secp256k1 v1.0.0
-	github.com/decred/dcrd/dcrutil v1.0.0
-	github.com/decred/dcrd/wire v1.0.1
+	github.com/decred/dcrd/dcrutil v1.1.1
+	github.com/decred/dcrd/wire v1.1.0
 	github.com/decred/slog v1.0.0
 	golang.org/x/crypto v0.0.0-20180718160520-a2144134853f
 )


### PR DESCRIPTION
This bumps the various module versions as follows:

- github.com/decred/dcrd/addrmgr@v1.0.2
- github.com/decred/dcrd/wire@v1.1.0
- github.com/decred/dcrd/chaincfg@v1.1.1
- github.com/decred/dcrd/connmgr@v1.0.1
- github.com/decred/dcrd/dcrutil@v1.1.1
- github.com/decred/dcrd/database@v1.0.1
- github.com/decred/dcrd/hdkeychain@v1.1.0
- github.com/decred/dcrd/txscript@v1.0.1
- github.com/decred/dcrd/blockchain/stake@v1.0.1
- github.com/decred/dcrd/gcs@v1.0.1
- github.com/decred/dcrd/blockchain@v1.0.1
- github.com/decred/dcrd/mining@v1.0.1
- github.com/decred/dcrd/mempool@v1.0.1
- github.com/decred/dcrd/peer@v1.0.1
- github.com/decred/dcrd/rpcclient@v1.0.1

It also updates all of the dependencies for every module accordingly and adds a few missing overrides for transitive dependencies.