### PR TITLE
blockchain: Mark fastadd block valid.

### DIFF
--- a/blockchain/upgrade.go
+++ b/blockchain/upgrade.go
@@ -536,5 +536,13 @@ func upgradeDB(db database.DB, chainParams *chaincfg.Params, dbInfo *databaseInf
 		}
 	}
 
+	// NOTE: The next time a new database version is needed, the code in
+	// initChainState which marks all ancestors of the current chain tip as
+	// valid should be converted to updgrade all nodes in the database in the
+	// upgrade path here and removed from the chain init.  The version was not
+	// bumped when applying the update since it is possible to perform very
+	// quickly at startup on the block nodes in memory without requiring a
+	// database version bump.
+
 	return nil
 }


### PR DESCRIPTION
This modifies the block connection logic to also mark the status of blocks that are not already known to be valid in the fast add code path as valid.

This change is being made because the intent of the fast add path is to skip expensive checks on blocks which are already assumed to be valid due to checkpoints and therefore should be marked accordingly.

Also, since the status for those blocks in the block index does not have them marked valid, mark them all ancestors of the current tip as valid init time.