### PR TITLE
multi: Replace several bitcoin references.

### DIFF
--- a/server.go
+++ b/server.go
@@ -1686,7 +1686,7 @@ func (s *server) peerHandler() {
 	if !cfg.DisableDNSSeed {
 		// Add peers discovered through DNS to the address manager.
 		connmgr.SeedFromDNS(activeNetParams.Params, defaultRequiredServices, dcrdLookup, func(addrs []*wire.NetAddress) {
-			// Bitcoind uses a lookup of the dns seeder here. This
+			// Dcrd uses a lookup of the dns seeder here. This
 			// is rather strange since the values looked up by the
 			// DNS seed lookups will vary quite a lot.
 			// to replicate this behaviour we put all addresses as


### PR DESCRIPTION
server.go: This corrects the comment for the SeedFromDNS constant to correctly refer to Dcrd instead of Bitcoind.