### PR TITLE
Update seed.go

### DIFF
--- a/connmgr/seed.go
+++ b/connmgr/seed.go
@@ -59,7 +59,7 @@ func SeedFromDNS(chainParams *chaincfg.Params, reqServices wire.ServiceFlag, loo
 			intPort, _ := strconv.Atoi(chainParams.DefaultPort)
 			for i, peer := range seedpeers {
 				addresses[i] = wire.NewNetAddressTimestamp(
-					// bitcoind seeds with addresses from
+					// Dcrd seeds with addresses from
 					// a time randomly selected between 3
 					// and 7 days ago.
 					time.Now().Add(-1*time.Second*time.Duration(secondsIn3Days+


### PR DESCRIPTION
connmgr/seed.go: This corrects the comment for the SeedFromDNS constant to correctly refer to Dcrd instead of bitcoind.