### PR TITLE
multi: Use temp directories for database tests.

### DIFF
--- a/blockchain/common_test.go
+++ b/blockchain/common_test.go
@@ -7,9 +7,9 @@ package blockchain
 
 import (
 	"fmt"
+	"io/ioutil"
 	mrand "math/rand"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/decred/dcrd/blockchain/stake"
@@ -24,9 +24,6 @@ import (
 const (
 	// testDbType is the database backend type to use for the tests.
 	testDbType = "ffldb"
-
-	// testDbRoot is the root directory used to create all test databases.
-	testDbRoot = "testdbs"
 
 	// blockDataNet is the expected network in the test block data.
 	blockDataNet = wire.MainNet
@@ -80,20 +77,18 @@ func chainSetup(dbName string, params *chaincfg.Params) (*BlockChain, func(), er
 			db.Close()
 		}
 	} else {
-		// Create the root directory for test databases.
-		if !fileExists(testDbRoot) {
-			if err := os.MkdirAll(testDbRoot, 0700); err != nil {
-				err := fmt.Errorf("unable to create test db "+
-					"root: %v", err)
-				return nil, nil, err
-			}
+		// Create the directory for test database.
+		dbPath, err := ioutil.TempDir("", dbName)
+		if err != nil {
+			err := fmt.Errorf("unable to create test db path: %v",
+				err)
+			return nil, nil, err
 		}
 
 		// Create a new database to store the accepted blocks into.
-		dbPath := filepath.Join(testDbRoot, dbName)
-		_ = os.RemoveAll(dbPath)
 		ndb, err := database.Create(testDbType, dbPath, blockDataNet)
 		if err != nil {
+			os.RemoveAll(dbPath)
 			return nil, nil, fmt.Errorf("error creating db: %v", err)
 		}
 		db = ndb
@@ -103,7 +98,6 @@ func chainSetup(dbName string, params *chaincfg.Params) (*BlockChain, func(), er
 		teardown = func() {
 			db.Close()
 			os.RemoveAll(dbPath)
-			os.RemoveAll(testDbRoot)
 		}
 	}
 

--- a/blockchain/stake/internal/ticketdb/chainio_test.go
+++ b/blockchain/stake/internal/ticketdb/chainio_test.go
@@ -7,8 +7,8 @@ package ticketdb
 import (
 	"bytes"
 	"encoding/hex"
+	"io/ioutil"
 	"os"
-	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -24,9 +24,6 @@ import (
 const (
 	// testDbType is the database backend type to use for the tests.
 	testDbType = "ffldb"
-
-	// testDbRoot is the root directory used to create all test databases.
-	testDbRoot = "testdbs"
 )
 
 // hexToBytes converts a hex string to bytes, without returning any errors.
@@ -423,16 +420,15 @@ func TestTicketHashesDeserializingErrors(t *testing.T) {
 func TestLiveDatabase(t *testing.T) {
 	// Create a new database to store the accepted stake node data into.
 	dbName := "ffldb_ticketdb_test"
-	dbPath := filepath.Join(testDbRoot, dbName)
-	_ = os.RemoveAll(dbPath)
+	dbPath, err := ioutil.TempDir("", dbName)
+	if err != nil {
+		t.Fatalf("unable to create test db path: %v", err)
+	}
+	defer os.RemoveAll(dbPath)
 	testDb, err := database.Create(testDbType, dbPath, chaincfg.SimNetParams.Net)
 	if err != nil {
 		t.Fatalf("error creating db: %v", err)
 	}
-
-	// Setup a teardown.
-	defer os.RemoveAll(dbPath)
-	defer os.RemoveAll(testDbRoot)
 	defer testDb.Close()
 
 	// Initialize the database, then try to read the version.

--- a/blockchain/stake/tickets_test.go
+++ b/blockchain/stake/tickets_test.go
@@ -9,6 +9,7 @@ import (
 	"compress/bzip2"
 	"encoding/gob"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -26,9 +27,6 @@ import (
 const (
 	// testDbType is the database backend type to use for the tests.
 	testDbType = "ffldb"
-
-	// testDbRoot is the root directory used to create all test databases.
-	testDbRoot = "testdbs"
 )
 
 // calcHash256PRNGIVFromHeader calculates the initialization vector for a
@@ -405,16 +403,15 @@ func TestTicketDBLongChain(t *testing.T) {
 	/*
 		// Create a new database to store the accepted stake node data into.
 		dbName := "ffldb_staketest"
-		dbPath := filepath.Join(testDbRoot, dbName)
-		_ = os.RemoveAll(dbPath)
+		dbPath, err := ioutil.TempDir("", dbName)
+		if err != nil {
+			t.Fatalf("unable to create test db path: %v", err)
+		}
+		defer os.RemoveAll(dbPath)
 		testDb, err := database.Create(testDbType, dbPath, params.Net)
 		if err != nil {
 			t.Fatalf("error creating db: %v", err)
 		}
-
-		// Setup a teardown.
-		defer os.RemoveAll(dbPath)
-		defer os.RemoveAll(testDbRoot)
 		defer testDb.Close()
 
 		// Load the genesis block and begin testing exported functions.
@@ -625,16 +622,15 @@ func TestTicketDBGeneral(t *testing.T) {
 
 	// Create a new database to store the accepted stake node data into.
 	dbName := "ffldb_staketest"
-	dbPath := filepath.Join(testDbRoot, dbName)
-	_ = os.RemoveAll(dbPath)
+	dbPath, err := ioutil.TempDir("", dbName)
+	if err != nil {
+		t.Fatalf("unable to create test db path: %v", err)
+	}
+	defer os.RemoveAll(dbPath)
 	testDb, err := database.Create(testDbType, dbPath, params.Net)
 	if err != nil {
 		t.Fatalf("error creating db: %v", err)
 	}
-
-	// Setup a teardown.
-	defer os.RemoveAll(dbPath)
-	defer os.RemoveAll(testDbRoot)
 	defer testDb.Close()
 
 	// Load the genesis block and begin testing exported functions.


### PR DESCRIPTION
This modifies the various tests that create temporary databases to make use of `ioutil.TempDir` instead of a relative directory path.  This allows the tests to be run from any path without failure.