### PR TITLE
blockchain: Use temp dirs for fullblocks test.

### DIFF
--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -56,7 +56,7 @@ func TestBlockchainFunctions(t *testing.T) {
 	defer teardownFunc()
 
 	// Load up the rest of the blocks up to HEAD~1.
-	filename := filepath.Join("testdata/", "blocks0to168.bz2")
+	filename := filepath.Join("testdata", "blocks0to168.bz2")
 	fi, err := os.Open(filename)
 	if err != nil {
 		t.Errorf("Unable to open %s: %v", filename, err)

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -43,7 +43,7 @@ func TestBlockchainSpendJournal(t *testing.T) {
 	defer teardownFunc()
 
 	// Load up the rest of the blocks up to HEAD.
-	filename := filepath.Join("testdata/", "reorgto179.bz2")
+	filename := filepath.Join("testdata", "reorgto179.bz2")
 	fi, err := os.Open(filename)
 	if err != nil {
 		t.Errorf("Failed to open %s: %v", filename, err)


### PR DESCRIPTION
This modifies the `fullblocktests` that create a temporary database to make use of `ioutil.TempDir` instead of a relative directory path.  This allows the tests to be run from any path without failure.