### PR TITLE
database: Use module-scoped data in iface tests.

### DIFF
--- a/database/ffldb/interface_test.go
+++ b/database/ffldb/interface_test.go
@@ -37,7 +37,7 @@ var (
 
 	// blockDataFile is the path to a file containing the first 168 blocks
 	// of the simulation network.
-	blockDataFile = filepath.Join("..", "..", "blockchain", "testdata", "blocks0to168.bz2")
+	blockDataFile = filepath.Join("..", "testdata", "blocks0to168.bz2")
 
 	// errSubTestFail is used to signal that a sub test returned false.
 	errSubTestFail = fmt.Errorf("sub test failure")


### PR DESCRIPTION
This updates the interface tests in `database/ffldb`to reference the block tests within the same module as opposed to escaping the module to find it in the blockchain module.

This should have been a part of the previous commit that performs the same, but was missed.
