### PR TITLE
release: Bump for 1.4 release cycle.

### DIFF
--- a/cmd/dcrctl/version.go
+++ b/cmd/dcrctl/version.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013 The btcsuite developers
-// Copyright (c) 2015-2017 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -18,12 +18,12 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 // versioning 2.0.0 spec (http://semver.org/).
 const (
 	appMajor uint = 1
-	appMinor uint = 3
+	appMinor uint = 4
 	appPatch uint = 0
 
 	// appPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.
-	appPreRelease = ""
+	appPreRelease = "pre"
 )
 
 // appBuild is defined as a variable so it can be overridden during the build

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/decred/dcrd/hdkeychain v1.1.0
 	github.com/decred/dcrd/mempool v1.0.1
 	github.com/decred/dcrd/mining v1.0.1
-	github.com/decred/dcrd/peer v1.0.1
+	github.com/decred/dcrd/peer v1.0.2
 	github.com/decred/dcrd/rpcclient v1.0.1
 	github.com/decred/dcrd/txscript v1.0.1
 	github.com/decred/dcrd/wire v1.1.0

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2017 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -25,7 +25,7 @@ const (
 // versioning 2.0.0 spec (http://semver.org/).
 const (
 	appMajor uint = 1
-	appMinor uint = 3
+	appMinor uint = 4
 	appPatch uint = 0
 )
 
@@ -34,7 +34,7 @@ var (
 	// the build process with '-ldflags "-X main.appPreRelease=foo"' if
 	// needed.  It MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.
-	appPreRelease = ""
+	appPreRelease = "pre"
 
 	// appBuild is defined as a variable so it can be overridden during the
 	// build process with '-ldflags "-X main.appBuild=foo"' if needed.  It


### PR DESCRIPTION
This marks the start of a new release process as compared to previous releases.

Instead of bumping the version just before a release and releasing from the master branch, as has been done up to this point, the minor (or major when necessary) will now be bumped on the master branch at the beginning of a release cycle.  In addition, the pre-release portion of the semantic version is now the string "pre" to help make it more obvious that the master branch represents a pre-release build of work leading up to the next release.

When a new release is prepared, a new release branch will be created that has a naming scheme of "release-vX.Y", where X is the major and Y is the minor.  Any additional commits needed to prepare the release leading up to a release candidate will be cherry-picked to the release branch, and all tags for releases and release candidates will be created against that.

This implies that should any additional patch releases be necessary, the relevant commits will also be cherry-picked to the release branch as needed, followed by a new release candidate for the patch release and the eventual patch release.