### PR TITLE
multi: add BgBlkTmplGenerator.

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -125,6 +125,10 @@ type Config struct {
 	// whenever a transaction is removed from the mempool in order to track fee
 	// estimation.
 	RemoveTxFromFeeEstimation func(txHash *chainhash.Hash)
+
+	// OnVoteReceived defines the function used to signal receiving a new
+	// vote in the mempool.
+	OnVoteReceived func(voteTx *wire.MsgTx)
 }
 
 // Policy houses the policy (configuration parameters) which is used to
@@ -676,6 +680,9 @@ func (mp *TxPool) RemoveDoubleSpends(tx *dcrutil.Tx) {
 // This function MUST be called with the mempool lock held (for writes).
 func (mp *TxPool) addTransaction(utxoView *blockchain.UtxoViewpoint,
 	tx *dcrutil.Tx, txType stake.TxType, height int64, fee int64) {
+	if mp.cfg.OnVoteReceived != nil && txType == stake.TxTypeSSGen {
+		mp.cfg.OnVoteReceived(tx.MsgTx())
+	}
 
 	// Add the transaction to the pool and mark the referenced outpoints
 	// as spent by the pool.

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -752,6 +752,7 @@ func newPoolHarness(chainParams *chaincfg.Params) (*poolHarness, []spendableOutp
 			SigCache:            nil,
 			AddrIndex:           nil,
 			ExistsAddrIndex:     nil,
+			OnVoteReceived:      nil,
 		}),
 	}
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -99,9 +99,6 @@ const (
 	// in the memory pool.
 	gbtRegenerateSeconds = 60
 
-	// merkleRootPairSize
-	merkleRootPairSize = 64
-
 	// sstxCommitmentString is the string to insert when a verbose
 	// transaction output's pkscript type is a ticket commitment.
 	sstxCommitmentString = "sstxcommitment"

--- a/rpcserver_test.go
+++ b/rpcserver_test.go
@@ -39,7 +39,7 @@ func testGetBestBlock(r *rpctest.Harness, t *testing.T) {
 	// Hash should be the same as the newly submitted block.
 	if !bytes.Equal(bestHash[:], generatedBlockHashes[0][:]) {
 		t.Fatalf("Block hashes do not match. Returned hash %v, wanted "+
-			"hash %v", bestHash, generatedBlockHashes[0][:])
+			"hash %v", bestHash, generatedBlockHashes[0])
 	}
 
 	// Block height should now reflect newest height.
@@ -91,7 +91,7 @@ func testGetBlockHash(r *rpctest.Harness, t *testing.T) {
 	// Block hashes should match newly created block.
 	if !bytes.Equal(generatedBlockHashes[0][:], blockHash[:]) {
 		t.Fatalf("Block hashes do not match. Returned hash %v, wanted "+
-			"hash %v", blockHash, generatedBlockHashes[0][:])
+			"hash %v", blockHash, generatedBlockHashes[0])
 	}
 }
 


### PR DESCRIPTION
**This PR requires #1417, #1418, #1419, #1420, #1421, #1422 and #1423**

`BgBlkTmplGenerator` represents the background process that generates block templates and notifies all subscribed clients on template regeneration. It generates new templates based on mempool activity for vote and non-vote transactions and the time elapsed since last template regeneration.