### PR TITLE
multi: remove cached templates from block manager.

### DIFF
--- a/blockchain/process.go
+++ b/blockchain/process.go
@@ -91,6 +91,12 @@ func (b *BlockChain) processOrphans(hash *chainhash.Hash, flags BehaviorFlags) e
 	return nil
 }
 
+// WaitForChain blocks if the chain is processing a block or handling a reorg.
+func (b *BlockChain) WaitForChain() {
+	b.chainLock.RLock()
+	b.chainLock.RUnlock()
+}
+
 // ProcessBlock is the main workhorse for handling insertion of new blocks into
 // the block chain.  It includes functionality such as rejecting duplicate
 // blocks, ensuring blocks follow all rules, orphan handling, and insertion into

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -300,6 +300,7 @@ type headerNode struct {
 // incoming blocks.
 type blockManager struct {
 	server              *server
+	g                   *BgBlkTmplGenerator
 	started             int32
 	shutdown            int32
 	chain               *blockchain.BlockChain
@@ -1909,6 +1910,10 @@ func (b *blockManager) handleNotifyMsg(notification *blockchain.Notification) {
 			r.ntfnMgr.NotifyBlockConnected(block)
 		}
 
+		if b.server.bg != nil {
+			b.server.bg.handleConnectedBlock(block.Height())
+		}
+
 	// Stake tickets are spent or missed from the most recently connected block.
 	case blockchain.NTSpentAndMissedTickets:
 		tnd, ok := notification.Data.(*blockchain.TicketNotificationsData)
@@ -2000,12 +2005,32 @@ func (b *blockManager) handleNotifyMsg(notification *blockchain.Notification) {
 		handleDisconnectedBlockTxns(block.Transactions()[1:])
 		handleDisconnectedBlockTxns(block.STransactions())
 
+		if b.server.bg != nil {
+			b.server.bg.handleDisconnectedBlock(block.Height())
+		}
+
+		// Filter and update the rebroadcast inventory.
+		b.server.PruneRebroadcastInventory()
+
+		// Notify registered websocket clients.
 		if r := b.server.rpcServer; r != nil {
 			// Filter and update the rebroadcast inventory.
 			b.server.PruneRebroadcastInventory()
 
 			// Notify registered websocket clients.
 			r.ntfnMgr.NotifyBlockDisconnected(block)
+		}
+
+	// Chain reorganization has commenced.
+	case blockchain.NTChainReorgStarted:
+		if b.server.bg != nil {
+			b.server.bg.handleChainReorgStarted()
+		}
+
+	// Chain reorganization has concluded.
+	case blockchain.NTChainReorgDone:
+		if b.server.bg != nil {
+			b.server.bg.handleChainReorgDone()
 		}
 
 	// The blockchain is reorganizing.

--- a/cpuminer.go
+++ b/cpuminer.go
@@ -8,7 +8,6 @@ package main
 import (
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"math/rand"
 	"sync"
 	"time"
@@ -65,9 +64,11 @@ type cpuminerConfig struct {
 	// PermitConnectionlessMining allows single node mining on simnet.
 	PermitConnectionlessMining bool
 
-	// BlockTemplateGenerator identifies the instance to use in order to
-	// generate block templates that the miner will attempt to solve.
-	BlockTemplateGenerator *BlkTmplGenerator
+	// bg is the background process responsible for generating block templates.
+	bg *BgBlkTmplGenerator
+
+	// tg is the main workhorse for block template regeneration.
+	tg *BlkTmplGenerator
 
 	// MiningAddrs is a list of payment addresses to use for the generated
 	// blocks.  Each generated block will randomly choose one of them.
@@ -103,7 +104,8 @@ type cpuminerConfig struct {
 // system which is typically sufficient.
 type CPUMiner struct {
 	sync.Mutex
-	g                 *BlkTmplGenerator
+	bg                *BgBlkTmplGenerator
+	tg                *BlkTmplGenerator
 	cfg               *cpuminerConfig
 	numWorkers        uint32
 	started           bool
@@ -229,7 +231,7 @@ func (m *CPUMiner) submitBlock(block *dcrutil.Block) bool {
 // This function will return early with false when conditions that trigger a
 // stale block such as a new block showing up or periodically when there are
 // new transactions and enough time has elapsed without finding a solution.
-func (m *CPUMiner) solveBlock(msgBlock *wire.MsgBlock, ticker *time.Ticker, quit chan struct{}) bool {
+func (m *CPUMiner) solveBlock(header *wire.BlockHeader, ticker *time.Ticker, quit chan struct{}) bool {
 	// Choose a random extra nonce offset for this block template and
 	// worker.
 	enOffset, err := wire.RandomUint64()
@@ -239,13 +241,11 @@ func (m *CPUMiner) solveBlock(msgBlock *wire.MsgBlock, ticker *time.Ticker, quit
 		enOffset = 0
 	}
 
-	// Create a couple of convenience variables.
-	header := &msgBlock.Header
 	targetDifficulty := blockchain.CompactToBig(header.Bits)
 
 	// Initial state.
 	lastGenerated := time.Now()
-	lastTxUpdate := m.g.txSource.LastUpdated()
+	lastTxUpdate := m.tg.txSource.LastUpdated()
 	hashesCompleted := uint64(0)
 
 	// Note that the entire extra nonce range is iterated and the offset is
@@ -272,13 +272,13 @@ func (m *CPUMiner) solveBlock(msgBlock *wire.MsgBlock, ticker *time.Ticker, quit
 				// generated and it has been at least 3 seconds,
 				// or if it's been one minute.
 				now := time.Now()
-				if (lastTxUpdate != m.g.txSource.LastUpdated() &&
+				if (lastTxUpdate != m.tg.txSource.LastUpdated() &&
 					now.After(lastGenerated.Add(3*time.Second))) ||
 					now.After(lastGenerated.Add(60*time.Second)) {
 					return false
 				}
 
-				err = m.g.UpdateBlockTime(header)
+				err = m.tg.UpdateBlockTime(header)
 				if err != nil {
 					minrLog.Warnf("CPU miner unable to update block template "+
 						"time: %v", err)
@@ -286,7 +286,7 @@ func (m *CPUMiner) solveBlock(msgBlock *wire.MsgBlock, ticker *time.Ticker, quit
 				}
 
 			default:
-				// Non-blocking select to fall through
+				// Non-blocking receive fallthrough.
 			}
 
 			// Update the nonce and hash the block header.
@@ -307,10 +307,9 @@ func (m *CPUMiner) solveBlock(msgBlock *wire.MsgBlock, ticker *time.Ticker, quit
 }
 
 // generateBlocks is a worker that is controlled by the miningWorkerController.
-// It is self contained in that it creates block templates and attempts to solve
-// them while detecting when it is performing stale work and reacting
-// accordingly by generating a new block template.  When a block is solved, it
-// is submitted.
+// It subscribes to block template updates and attempts to solve them while
+// detecting stale work. When a block is solved block it is relayed to
+// the network.
 //
 // It must be run as a goroutine.
 func (m *CPUMiner) generateBlocks(quit chan struct{}) {
@@ -321,79 +320,57 @@ func (m *CPUMiner) generateBlocks(quit chan struct{}) {
 	ticker := time.NewTicker(333 * time.Millisecond)
 	defer ticker.Stop()
 
+	// Subscribe for block template updates.
+	updateChan := m.bg.RequestTemplateUpdate()
+
 out:
 	for {
 		// Quit when the miner is stopped.
 		select {
 		case <-quit:
 			break out
-		default:
-			// Non-blocking select to fall through
-		}
+		case template := <-updateChan:
+			// Resubscribe for block template updates after receiving an
+			// update.
+			updateChan = m.bg.RequestTemplateUpdate()
 
-		// If not in connectionless mode, wait until there is a connection to
-		// at least one other peer since there is no way to relay a found
-		// block or receive transactions to work on when there are no
-		// connected peers.
-		if !m.cfg.PermitConnectionlessMining && m.cfg.ConnectedCount() == 0 {
-			time.Sleep(time.Second)
-			continue
-		}
-
-		// No point in searching for a solution before the chain is
-		// synced.  Also, grab the same lock as used for block
-		// submission, since the current block will be changing and
-		// this would otherwise end up building a new block template on
-		// a block that is in the process of becoming stale.
-		m.submitBlockLock.Lock()
-		curHeight := m.g.chain.BestSnapshot().Height
-		if curHeight != 0 && !m.cfg.IsCurrent() {
-			m.submitBlockLock.Unlock()
-			time.Sleep(time.Second)
-			continue
-		}
-
-		// Choose a payment address at random.
-		rand.Seed(time.Now().UnixNano())
-		payToAddr := m.cfg.MiningAddrs[rand.Intn(len(m.cfg.MiningAddrs))]
-
-		// Create a new block template using the available transactions
-		// in the memory pool as a source of transactions to potentially
-		// include in the block.
-		template, err := m.g.NewBlockTemplate(payToAddr)
-		m.submitBlockLock.Unlock()
-		if err != nil {
-			errStr := fmt.Sprintf("Failed to create new block "+
-				"template: %v", err)
-			minrLog.Errorf(errStr)
-			continue
-		}
-
-		// Not enough voters.
-		if template == nil {
-			continue
-		}
-
-		// This prevents you from causing memory exhaustion issues
-		// when mining aggressively in a simulation network.
-		if m.cfg.PermitConnectionlessMining {
-			if m.minedOnParents[template.Block.Header.PrevBlock] >=
-				maxSimnetToMine {
-				minrLog.Tracef("too many blocks mined on parent, stopping " +
-					"until there are enough votes on these to make a new " +
-					"block")
+			// If not in connectionless mode, wait until there is a connection
+			// to at least one other peer since there is no way to relay a
+			// found block or receive transactions to work on when there are
+			// no connected peers.
+			if !m.cfg.PermitConnectionlessMining && m.cfg.ConnectedCount() == 0 {
+				time.Sleep(time.Second)
 				continue
 			}
-		}
 
-		// Attempt to solve the block.  The function will exit early
-		// with false when conditions that trigger a stale block, so
-		// a new block template can be generated.  When the return is
-		// true a solution was found, so submit the solved block.
-		if m.solveBlock(template.Block, ticker, quit) {
-			block := dcrutil.NewBlock(template.Block)
-			m.submitBlock(block)
-			m.minedOnParents[template.Block.Header.PrevBlock]++
+			// This prevents memory exhaustion issues when mining aggressively
+			// on a simulation network.
+			if m.cfg.PermitConnectionlessMining {
+				if m.minedOnParents[template.Block.Header.PrevBlock] >=
+					maxSimnetToMine {
+					minrLog.Tracef("too many blocks mined on parent, " +
+						"stopping until there are enough votes on these to " +
+						"make a new block")
+					continue
+				}
+			}
+
+			minrLog.Debugf("new block template from background generator "+
+				"(height: %v, hash: %v)", template.Block.Header.Height,
+				template.Block.BlockHash())
+
+			// Attempt to solve the block.  The function will exit early
+			// with false when conditions that trigger a stale block, so
+			// a new block template can be generated.  When the return is
+			// true a solution was found, so submit the solved block.
+			if m.solveBlock(&template.Block.Header, ticker, quit) {
+				blk := dcrutil.NewBlock(template.Block)
+				m.submitBlock(blk)
+				m.minedOnParents[template.Block.Header.PrevBlock]++
+			}
+
+		default:
+			// Non-blocking receive fallthrough.
 		}
 	}
 
@@ -639,29 +616,31 @@ func (m *CPUMiner) GenerateNBlocks(n uint32) ([]*chainhash.Hash, error) {
 		// Create a new block template using the available transactions
 		// in the memory pool as a source of transactions to potentially
 		// include in the block.
-		template, err := m.g.NewBlockTemplate(payToAddr)
+		template, err := m.tg.NewBlockTemplate(payToAddr)
 		m.submitBlockLock.Unlock()
 		if err != nil {
-			errStr := fmt.Sprintf("Failed to create new block "+
-				"template: %v", err)
-			minrLog.Errorf(errStr)
+			minrLog.Errorf("Failed to create new block template: %v", err)
 			continue
 		}
+
 		if template == nil {
-			errStr := fmt.Sprintf("Not enough voters on parent block " +
+			minrLog.Debugf("Not enough voters on parent block " +
 				"and failed to pull parent template")
-			minrLog.Debugf(errStr)
 			continue
 		}
+
+		minrLog.Debugf("new block template from background generator "+
+			"(height: %v, hash: %v)", template.Block.Header.Height,
+			template.Block.BlockHash())
 
 		// Attempt to solve the block.  The function will exit early
 		// with false when conditions that trigger a stale block, so
 		// a new block template can be generated.  When the return is
 		// true a solution was found, so submit the solved block.
-		if m.solveBlock(template.Block, ticker, nil) {
-			block := dcrutil.NewBlock(template.Block)
-			m.submitBlock(block)
-			blockHashes[i] = block.Hash()
+		if m.solveBlock(&template.Block.Header, ticker, nil) {
+			blk := dcrutil.NewBlock(template.Block)
+			m.submitBlock(blk)
+			blockHashes[i] = blk.Hash()
 			i++
 			if i == n {
 				minrLog.Tracef("Generated %d blocks", i)
@@ -682,7 +661,8 @@ func (m *CPUMiner) GenerateNBlocks(n uint32) ([]*chainhash.Hash, error) {
 // type for more details.
 func newCPUMiner(cfg *cpuminerConfig) *CPUMiner {
 	return &CPUMiner{
-		g:                 cfg.BlockTemplateGenerator,
+		bg:                cfg.bg,
+		tg:                cfg.tg,
 		cfg:               cfg,
 		numWorkers:        defaultNumWorkers,
 		updateNumWorkers:  make(chan struct{}),

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -611,6 +611,7 @@ func newPoolHarness(chainParams *chaincfg.Params) (*poolHarness, []spendableOutp
 			SigCache:            nil,
 			AddrIndex:           nil,
 			ExistsAddrIndex:     nil,
+			OnVoteReceived:      nil,
 		}),
 	}
 

--- a/mining.go
+++ b/mining.go
@@ -2072,6 +2072,15 @@ func newBgBlkTmplGenerator(tg *BlkTmplGenerator, addrs []dcrutil.Address, permit
 	}
 }
 
+// fetchTemplate retrieves a block template from the template pool based on the
+// provided key.
+func (g *BgBlkTmplGenerator) fetchTemplate(key [merkleRootPairSize]byte) *wire.MsgBlock {
+	g.templatePoolMtx.Lock()
+	template := g.templatePool[key]
+	g.templatePoolMtx.Unlock()
+	return template
+}
+
 // scheduleRegen schedules a template regeneration by the provided duration
 // in the future.  If there is an existing schedule in play the sheduled time
 // reset to updated the provided duration.

--- a/mining.go
+++ b/mining.go
@@ -7,10 +7,14 @@ package main
 
 import (
 	"container/heap"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"math"
+	"math/rand"
 	"sort"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/decred/dcrd/blockchain"
@@ -46,6 +50,18 @@ const (
 
 	// kilobyte is the size of a kilobyte.
 	kilobyte = 1000
+
+	// templateRegenSecs is the required number of seconds elapsed with
+	// incoming non vote transactions before template regeneration
+	// is required.
+	templateRegenSecs = 30
+
+	// maxTemplateRegenSecs is the maximum number of seconds elapsed
+	// without incoming transactions before template regeneration is required.
+	maxTemplateRegenSecs = 60
+
+	// merkleRootPairSize
+	merkleRootPairSize = 64
 )
 
 // txPrioItem houses a transaction along with extra information that allows the
@@ -766,7 +782,7 @@ func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache, nextHeight int64,
 		if !best.PrevHash.IsEqual(
 			&curTemplate.Block.Header.PrevBlock) {
 			minrLog.Debugf("Cached mining templates are no longer current, " +
-				"resetting")
+				"resetting.")
 			bm.SetCurrentTemplate(nil)
 			bm.SetParentTemplate(nil)
 		}
@@ -935,42 +951,6 @@ func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache, nextHeight int64,
 		"new block template")
 
 	return nil, nil
-}
-
-// handleCreatedBlockTemplate stores a successfully created block template to
-// the appropriate cache if needed, then returns the template to the miner to
-// work on. The stored template is a copy of the template, to prevent races
-// from occurring in case the template is mined on by the CPUminer.
-func handleCreatedBlockTemplate(blockTemplate *BlockTemplate, bm *blockManager) (*BlockTemplate, error) {
-	curTemplate := bm.GetCurrentTemplate()
-	nextBlockHeight := blockTemplate.Height
-	stakeValidationHeight := bm.server.chainParams.StakeValidationHeight
-	// This is where we begin storing block templates, when either the
-	// program is freshly started or the chain is matured to stake
-	// validation height.
-	if curTemplate == nil && nextBlockHeight >= stakeValidationHeight-2 {
-		bm.SetCurrentTemplate(blockTemplate)
-	}
-
-	// We're at the height where the next block needs to include SSGens,
-	// so we check to if CachedCurrentTemplate is out of date. If it is,
-	// we store it as the cached parent template, and store the new block
-	// template as the currenct template.
-	if curTemplate != nil && nextBlockHeight >= stakeValidationHeight-1 {
-		if curTemplate.Height < nextBlockHeight {
-			bm.SetParentTemplate(curTemplate)
-			bm.SetCurrentTemplate(blockTemplate)
-		}
-	}
-
-	// Overwrite the old cached block if it's out of date.
-	if curTemplate != nil {
-		if curTemplate.Height == nextBlockHeight {
-			bm.SetCurrentTemplate(blockTemplate)
-		}
-	}
-
-	return blockTemplate, nil
 }
 
 // BlkTmplGenerator generates block templates based on a given mining policy
@@ -2052,4 +2032,375 @@ func (g *BlkTmplGenerator) UpdateBlockTime(header *wire.BlockHeader) error {
 	}
 
 	return nil
+}
+
+// BgBlkTmplGenerator represents the background process that generates block
+// templates and notifies all subscribed clients on template regeneration.
+// It generates new templates based on the time elapsed since last template
+// regeneration.
+type BgBlkTmplGenerator struct {
+	voteChan                   chan *wire.MsgTx
+	notifyChan                 chan *BlockTemplate
+	tg                         *BlkTmplGenerator
+	txSource                   mining.TxSource
+	lastRegen                  int64
+	subscribers                map[chan *BlockTemplate]struct{}
+	miningAddrs                []dcrutil.Address
+	templateMtx                sync.Mutex
+	subscriptionMtx            sync.Mutex
+	currentTemplate            *BlockTemplate
+	parentTemplate             *BlockTemplate
+	templatePool               map[[merkleRootPairSize]byte]*wire.MsgBlock
+	templatePoolMtx            sync.RWMutex
+	chainReorg                 bool
+	chainReorgMtx              sync.Mutex
+	permitConnectionlessMining bool
+	regenScheduler             *time.Timer
+}
+
+// newBgBlkTmplGenerator initializes a background block template generator.
+func newBgBlkTmplGenerator(tg *BlkTmplGenerator, addrs []dcrutil.Address, permitConnectionlessMining bool) *BgBlkTmplGenerator {
+	return &BgBlkTmplGenerator{
+		voteChan:                   make(chan *wire.MsgTx),
+		notifyChan:                 make(chan *BlockTemplate),
+		tg:                         tg,
+		txSource:                   tg.txSource,
+		miningAddrs:                addrs,
+		subscribers:                make(map[chan *BlockTemplate]struct{}),
+		templatePool:               make(map[[merkleRootPairSize]byte]*wire.MsgBlock),
+		permitConnectionlessMining: permitConnectionlessMining,
+	}
+}
+
+// scheduleRegen schedules a template regeneration by the provided duration
+// in the future.  If there is an existing schedule in play the sheduled time
+// reset to updated the provided duration.
+func (g *BgBlkTmplGenerator) scheduleRegen(dt time.Duration) {
+	if g.regenScheduler != nil {
+		if !g.regenScheduler.Reset(dt) {
+			minrLog.Errorf("failed to reset the template regen scheduler")
+			return
+		}
+	}
+
+	g.regenScheduler = time.AfterFunc(dt, func() {
+		go g.regenTemplate()
+		g.cancelScheduledRegen()
+	})
+}
+
+// cancelScheduledRegen terminates a scheduled template regeneration.
+func (g *BgBlkTmplGenerator) cancelScheduledRegen() {
+	if g.regenScheduler != nil {
+		g.regenScheduler.Stop()
+		g.regenScheduler = nil
+	}
+}
+
+// notifySubscribersHandler updates subscribers of newly created block
+// templates. All subscribers are unsubscribed after being updated and
+// required to resubscribe after a template update.
+func (g *BgBlkTmplGenerator) notifySubscribersHandler(ctx context.Context) {
+	minrLog.Debug("Starting notify subscribers handler.")
+	for {
+		select {
+		case t := <-g.notifyChan:
+			g.subscriptionMtx.Lock()
+			for c := range g.subscribers {
+				go func() {
+					c <- t
+					close(c)
+				}()
+
+				delete(g.subscribers, c)
+			}
+			g.subscriptionMtx.Unlock()
+		case <-ctx.Done():
+			minrLog.Debug("Notify Subscribers handler done.")
+			return
+		default:
+			// Non-blocking receive fallthrough
+		}
+	}
+}
+
+// RequestTemplateUpdate subscribes a client for a block template update.  The
+// client is unsubscribed after being updated and required to resubscribe
+// for the next block template update.
+func (g *BgBlkTmplGenerator) RequestTemplateUpdate() chan *BlockTemplate {
+	updateChan := make(chan *BlockTemplate, 1)
+	g.subscriptionMtx.Lock()
+	g.subscribers[updateChan] = struct{}{}
+	g.subscriptionMtx.Unlock()
+	return updateChan
+}
+
+// regenTemplate regenerates the block template.  This must be run as a
+// goroutine.
+func (g *BgBlkTmplGenerator) regenTemplate() {
+	// NOTE: If the blockchain package is updated to provide more
+	// fine grained locking, it will be necessary to add a call to
+	// WaitForChain here.
+
+	// Do not generate block templates if the chain is reorganizing.
+	g.chainReorgMtx.Lock()
+	if g.chainReorg {
+		g.chainReorgMtx.Unlock()
+		return
+	}
+	g.chainReorgMtx.Unlock()
+
+	// Regenerate block templates on mainnet only when the chain is synced.
+	if !g.tg.chain.IsCurrent() && !g.permitConnectionlessMining {
+		return
+	}
+
+	// Pick a mining address at random.
+	rand.Seed(time.Now().UnixNano())
+	payToAddr := g.miningAddrs[rand.Intn(len(g.miningAddrs))]
+
+	// Regenerate the block template.
+	template, err := g.tg.NewBlockTemplate(payToAddr)
+	if err != nil {
+		minrLog.Debugf("block template generation failed: %v", err)
+		return
+	}
+
+	msgBlock := *template.Block
+
+	// In order to efficiently store the variations of block templates that
+	// have been provided to callers, save a pointer to the block keyed by
+	// the merkle root + stake root.  This along with the data that is included
+	// in a work submission is used to rebuild the block before checking the
+	// submitted solution.
+	var merkleRootPair [merkleRootPairSize]byte
+	copy(merkleRootPair[:chainhash.HashSize], msgBlock.Header.MerkleRoot[:])
+	copy(merkleRootPair[chainhash.HashSize:], msgBlock.Header.StakeRoot[:])
+	g.templatePoolMtx.Lock()
+	g.templatePool[merkleRootPair] = &msgBlock
+	g.templatePoolMtx.Unlock()
+
+	t := *template
+	g.notifyChan <- &t
+
+	g.templateMtx.Lock()
+	g.currentTemplate = template
+	g.templateMtx.Unlock()
+
+	// Update the last template regen time.
+	atomic.StoreInt64(&g.lastRegen, time.Now().Unix())
+}
+
+// pruneOldBlockTemplates prunes all block templates with heights lower than
+// the height of the best block's parent from the template pool.
+func (g *BgBlkTmplGenerator) pruneOldBlockTemplates(bestHeight int64) {
+	g.templatePoolMtx.Lock()
+	for rootHash, block := range g.templatePool {
+		height := int64(block.Header.Height)
+		if height < bestHeight-1 {
+			delete(g.templatePool, rootHash)
+		}
+	}
+	g.templatePoolMtx.Unlock()
+}
+
+// updateParentTemplate updates the parent template with the the current
+// block template.  This must be called when a new block has been connected.
+func (g *BgBlkTmplGenerator) updateParentTemplate() {
+	stakeValidationHeight := g.tg.chainParams.StakeValidationHeight
+	g.templateMtx.Lock()
+	if g.currentTemplate != nil {
+		height := g.currentTemplate.Height
+
+		// Set the parent template if the chain is matured to SVH-1.
+		if height >= stakeValidationHeight-2 {
+			g.parentTemplate = g.currentTemplate
+			minrLog.Debugf("Parent template updated to height: %v",
+				g.parentTemplate.Height)
+		}
+		g.currentTemplate = nil
+
+		// Prune invalidated block templates.
+		g.pruneOldBlockTemplates(height)
+	}
+	g.templateMtx.Unlock()
+}
+
+// HandleChainReorgStarted updates the chain reorg state of the background
+// template generator when a chain reorganization commences.
+func (g *BgBlkTmplGenerator) handleChainReorgStarted() {
+	g.chainReorgMtx.Lock()
+	// Update the reorg flag.
+	g.chainReorg = true
+	g.chainReorgMtx.Unlock()
+}
+
+// handleChainReorgDone updates the chain reorg state of the background
+// template generator and immdiately regenerates the block template
+// when a chain reorganization concludes.
+func (g *BgBlkTmplGenerator) handleChainReorgDone() {
+	g.chainReorgMtx.Lock()
+	// Update the reorg flag.
+	g.chainReorg = false
+	g.chainReorgMtx.Unlock()
+
+	// Regenerate block template.
+	go g.regenTemplate()
+}
+
+// handleDisconnectedBlock empties the template pool and updates the cached
+// templates based on the disconnected block's height.
+func (g *BgBlkTmplGenerator) handleDisconnectedBlock(discHeight int64) {
+	// Remove all block templates in the template pool.
+	g.templatePoolMtx.Lock()
+	for rootHash := range g.templatePool {
+		delete(g.templatePool, rootHash)
+	}
+	g.templatePoolMtx.Unlock()
+
+	g.templateMtx.Lock()
+	// Unset the current template.
+	g.currentTemplate = nil
+
+	// Unset the parent template if it shares the same height as the
+	// disconnected block.
+	if g.parentTemplate != nil && g.parentTemplate.Height == discHeight {
+		g.parentTemplate = nil
+	}
+	g.templateMtx.Unlock()
+}
+
+// handleConnectedBlock updates the parent template and generates a new block
+// template if the connected block height is below SVH-1.
+func (g *BgBlkTmplGenerator) handleConnectedBlock(connHeight int64) {
+	// Update the cached parent template.
+	g.updateParentTemplate()
+
+	// Generate a new block template if the connected block height
+	// is below SVH-1.
+	if connHeight <= g.tg.chainParams.StakeValidationHeight-2 {
+		go g.regenTemplate()
+	}
+}
+
+// onVoteReceivedHandler triggers block template regeneration based on
+// votes received by the mempool.  This must be run as a goroutine.
+func (g *BgBlkTmplGenerator) onVoteReceivedHandler(ctx context.Context) {
+	minrLog.Debug("Starting vote received handler.")
+	for {
+		select {
+		case voteTx := <-g.voteChan:
+			// Fetch the block height and hash of the block being voted on by
+			// the new vote received.
+			votedOnHash, votedOnHeight := stake.SSGenBlockVotedOn(voteTx)
+			best := g.tg.chain.BestSnapshot()
+
+			if votedOnHash.IsEqual(&best.Hash) &&
+				votedOnHeight == uint32(best.Height) {
+				currTipVotes :=
+					len(g.tg.txSource.VoteHashesForBlock(&best.Hash))
+
+				// Regenerate the block template immediately if the block being
+				// voted on has the maximum number of votes possible.
+				if currTipVotes == int(g.tg.chainParams.TicketsPerBlock) {
+					g.cancelScheduledRegen()
+					g.regenTemplate()
+				}
+
+				// Schedule a block template regeneration if the new vote received
+				// is voting on the current chain tip with at least the minimum
+				// required number of votes by the network.
+				if currTipVotes >=
+					int((g.tg.chainParams.TicketsPerBlock/2)+1) {
+					g.scheduleRegen(time.Second)
+				}
+			}
+
+			if !votedOnHash.IsEqual(&best.Hash) &&
+				votedOnHeight != uint32(best.Height) {
+				currTipVotes :=
+					len(g.tg.txSource.VoteHashesForBlock(&best.Hash))
+				votedOnVotes :=
+					len(g.tg.txSource.VoteHashesForBlock(&votedOnHash))
+				if votedOnVotes > currTipVotes {
+					// Regenerate the block template immediately if the block being
+					// voted on has the maximum number of votes possible.
+					if votedOnVotes == int(g.tg.chainParams.TicketsPerBlock) {
+						g.cancelScheduledRegen()
+						g.regenTemplate()
+					}
+
+					// Schdule a block template if the new vote received is voting
+					// on a side chain tip with at least the minimum required number
+					// of votes by the network and more votes than the current chain
+					// tip.
+					if votedOnVotes >=
+						int((g.tg.chainParams.TicketsPerBlock/2)+1) {
+						g.scheduleRegen(time.Second)
+					}
+				}
+			}
+
+		case <-ctx.Done():
+			minrLog.Debug("Vote received handler done.")
+			return
+		}
+	}
+}
+
+// OnVoteReceived signals a new vote received by the mempool.
+func (g *BgBlkTmplGenerator) OnVoteReceived(tx *wire.MsgTx) {
+	g.voteChan <- tx
+}
+
+// generator generates new templates based on mempool activity for vote
+// and non-vote transactions and the time elapsed since the last template
+// regeneration. This must be run as a goroutine.
+func (g *BgBlkTmplGenerator) generator(ctx context.Context) {
+	var isTicking bool
+	ticker := time.NewTicker(time.Millisecond * 500)
+	defer ticker.Stop()
+
+	// Immediately generate a block template if the chain is below SVH-1.
+	if g.tg.chain.BestSnapshot().Height <=
+		g.tg.chainParams.StakeValidationHeight-2 {
+		g.regenTemplate()
+	}
+
+	for {
+		select {
+		case <-ticker.C:
+			lastRegen := atomic.LoadInt64(&g.lastRegen)
+			lastUpdated := g.tg.txSource.LastUpdated().Unix()
+			now := time.Now().Unix()
+			sinceLastRegen := now - lastRegen
+
+			if !isTicking {
+				atomic.StoreInt64(&g.lastRegen, now)
+				sinceLastRegen = 0
+				isTicking = true
+			}
+
+			// Regenerate the block template if the mempool was updated after
+			// last template regeneration and 30 seconds has elapsed or 60
+			// seconds has elapsed since the last template regeneration.
+			if (lastUpdated > lastRegen && sinceLastRegen >
+				templateRegenSecs) || sinceLastRegen > maxTemplateRegenSecs {
+				g.regenTemplate()
+			}
+
+		case <-ctx.Done():
+			minrLog.Debug("Background block template generator done")
+			return
+		}
+	}
+}
+
+// Start runs the background block template generator as a goroutine using
+// the provided context.
+func (g *BgBlkTmplGenerator) Start(ctx context.Context) {
+	minrLog.Trace("Starting background block template generator")
+	go g.generator(ctx)
+	go g.notifySubscribersHandler(ctx)
+	go g.onVoteReceivedHandler(ctx)
 }

--- a/mining.go
+++ b/mining.go
@@ -772,7 +772,7 @@ func deepCopyBlockTemplate(blockTemplate *BlockTemplate) *BlockTemplate {
 func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache, nextHeight int64, miningAddress dcrutil.Address, bm *blockManager) (*BlockTemplate, error) {
 	timeSource := bm.server.timeSource
 	stakeValidationHeight := bm.server.chainParams.StakeValidationHeight
-	curTemplate := bm.GetCurrentTemplate()
+	curTemplate := bm.server.bg.currentTemplate
 
 	// Check to see if we've fallen off the chain, for example if a
 	// reorganization had recently occurred. If this is the case,
@@ -783,8 +783,8 @@ func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache, nextHeight int64,
 			&curTemplate.Block.Header.PrevBlock) {
 			minrLog.Debugf("Cached mining templates are no longer current, " +
 				"resetting.")
-			bm.SetCurrentTemplate(nil)
-			bm.SetParentTemplate(nil)
+			bm.server.bg.currentTemplate = nil
+			bm.server.bg.parentTemplate = nil
 		}
 	}
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -99,9 +99,6 @@ const (
 	// in the memory pool.
 	gbtRegenerateSeconds = 60
 
-	// merkleRootPairSize
-	merkleRootPairSize = 64
-
 	// sstxCommitmentString is the string to insert when a verbose
 	// transaction output's pkscript type is a ticket commitment.
 	sstxCommitmentString = "sstxcommitment"

--- a/rpcserver_test.go
+++ b/rpcserver_test.go
@@ -39,7 +39,7 @@ func testGetBestBlock(r *rpctest.Harness, t *testing.T) {
 	// Hash should be the same as the newly submitted block.
 	if !bytes.Equal(bestHash[:], generatedBlockHashes[0][:]) {
 		t.Fatalf("Block hashes do not match. Returned hash %v, wanted "+
-			"hash %v", bestHash, generatedBlockHashes[0][:])
+			"hash %v", bestHash, generatedBlockHashes[0])
 	}
 
 	// Block height should now reflect newest height.
@@ -91,7 +91,7 @@ func testGetBlockHash(r *rpctest.Harness, t *testing.T) {
 	// Block hashes should match newly created block.
 	if !bytes.Equal(generatedBlockHashes[0][:], blockHash[:]) {
 		t.Fatalf("Block hashes do not match. Returned hash %v, wanted "+
-			"hash %v", blockHash, generatedBlockHashes[0][:])
+			"hash %v", blockHash, generatedBlockHashes[0])
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -2614,16 +2614,15 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 	tg := newBlkTmplGenerator(&policy, s.txMemPool, s.timeSource, s.sigCache,
 		s.chainParams, bm.chain, bm)
 
-	// Create the background block template generator if the config has a
-	// mining address.
 	if len(cfg.miningAddrs) > 0 {
 		s.bg = newBgBlkTmplGenerator(tg, cfg.miningAddrs, cfg.SimNet)
 	}
 
 	s.cpuMiner = newCPUMiner(&cpuminerConfig{
+		bg:                         s.bg,
+		tg:                         tg,
 		ChainParams:                s.chainParams,
 		PermitConnectionlessMining: cfg.SimNet,
-		BlockTemplateGenerator:     tg,
 		MiningAddrs:                cfg.miningAddrs,
 		ProcessBlock:               bm.ProcessBlock,
 		ConnectedCount:             s.ConnectedCount,


### PR DESCRIPTION
This removes the old cached template fields and functions from the block manager and updates `checkBlockForHiddenVotes` to use generated templates from the background template block generator.