### PR TITLE
mempool: tweak trace logs

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -301,13 +301,14 @@ var _ mining.TxSource = (*TxPool)(nil)
 // This function MUST be called with the mempool lock held (for writes).
 func (mp *TxPool) removeOrphan(tx *dcrutil.Tx, removeRedeemers bool) {
 	txHash := tx.Hash()
-	log.Tracef("Removing orphan transaction %v", txHash)
 
 	// Nothing to do if passed tx is not an orphan.
 	tx, exists := mp.orphans[*txHash]
 	if !exists {
 		return
 	}
+
+	log.Tracef("Removing orphan transaction %v", txHash)
 
 	// Remove the reference from the previous orphan index.
 	for _, txIn := range tx.MsgTx().TxIn {
@@ -584,6 +585,8 @@ func (mp *TxPool) removeTransaction(tx *dcrutil.Tx, removeRedeemers bool) {
 
 	// Remove the transaction if needed.
 	if txDesc, exists := mp.pool[*txHash]; exists {
+		log.Tracef("Removing transaction %v", txHash)
+
 		// Remove unconfirmed address index entries associated with the
 		// transaction if enabled.
 		if mp.cfg.AddrIndex != nil {


### PR DESCRIPTION
This improves trace logs related to transaction removal from the
mempool. During some debugging, they were found to be slightly
misleading in their current form.