### PR TITLE
blockchain: Correct best pool size on disconnect.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -976,7 +976,7 @@ func (b *BlockChain) disconnectBlock(node *blockNode, block, parent *dcrutil.Blo
 	prevNode := node.parent
 	state := newBestState(prevNode, parentBlockSize, numTxns, newTotalTxns,
 		prevNode.CalcPastMedianTime(), newTotalSubsidy,
-		uint32(node.stakeNode.PoolSize()), node.sbits,
+		uint32(prevNode.stakeNode.PoolSize()), node.sbits,
 		prevNode.stakeNode.Winners(), prevNode.stakeNode.MissedTickets(),
 		prevNode.stakeNode.FinalState())
 


### PR DESCRIPTION
This corrects the `NextPoolSize` field that was recently added to the best state when a block is disconnected to calculate the next pool size relative to the previous block since it will become the new best state.