### PR TITLE
dcrec: Make function defs more consistent.

### DIFF
--- a/dcrec/edwards/ciphering.go
+++ b/dcrec/edwards/ciphering.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2015 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -64,8 +64,7 @@ func GenerateSharedSecret(privkey *PrivateKey, pubkey *PublicKey) []byte {
 // The primary aim is to ensure byte compatibility with Pyelliptic.
 // Additionally, refer to section 5.8.1 of ANSI X9.63 for rationale on this
 // format.
-func Encrypt(curve *TwistedEdwardsCurve, pubkey *PublicKey, in []byte) ([]byte,
-	error) {
+func Encrypt(curve *TwistedEdwardsCurve, pubkey *PublicKey, in []byte) ([]byte, error) {
 	ephemeral, err := GeneratePrivateKey(curve)
 	if err != nil {
 		return nil, err
@@ -112,8 +111,7 @@ func Encrypt(curve *TwistedEdwardsCurve, pubkey *PublicKey, in []byte) ([]byte,
 }
 
 // Decrypt decrypts data that was encrypted using the Encrypt function.
-func Decrypt(curve *TwistedEdwardsCurve, priv *PrivateKey, in []byte) ([]byte,
-	error) {
+func Decrypt(curve *TwistedEdwardsCurve, priv *PrivateKey, in []byte) ([]byte, error) {
 	// IV + Curve params/X/Y + 1 block + HMAC-256
 	if len(in) < aes.BlockSize+36+aes.BlockSize+sha256.Size {
 		return nil, errInputTooShort

--- a/dcrec/edwards/ciphering_test.go
+++ b/dcrec/edwards/ciphering_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2015 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/dcrec/edwards/curve.go
+++ b/dcrec/edwards/curve.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -47,8 +47,7 @@ func Unmarshal(curve *TwistedEdwardsCurve, data []byte) (x, y *big.Int) {
 
 // RecoverXBigInt recovers the X value for some Y value, for a coordinate
 // on the Ed25519 curve given as a big integer Y value.
-func (curve *TwistedEdwardsCurve) RecoverXBigInt(xIsNeg bool,
-	y *big.Int) *big.Int {
+func (curve *TwistedEdwardsCurve) RecoverXBigInt(xIsNeg bool, y *big.Int) *big.Int {
 	// (y^2 - 1)
 	l := new(big.Int).Mul(y, y)
 	l.Sub(l, one)
@@ -94,8 +93,7 @@ func (curve *TwistedEdwardsCurve) RecoverXBigInt(xIsNeg bool,
 // RecoverXFieldElement recovers the X value for some Y value, for a coordinate
 // on the Ed25519 curve given as a field element. Y value. Probably the fastest
 // way to get your respective X from Y.
-func (curve *TwistedEdwardsCurve) RecoverXFieldElement(xIsNeg bool,
-	y *edwards25519.FieldElement) *edwards25519.FieldElement {
+func (curve *TwistedEdwardsCurve) RecoverXFieldElement(xIsNeg bool, y *edwards25519.FieldElement) *edwards25519.FieldElement {
 	// (y^2 - 1)
 	l := new(edwards25519.FieldElement)
 	edwards25519.FeSquare(l, y)
@@ -284,8 +282,7 @@ func (curve *TwistedEdwardsCurve) Double(x1, y1 *big.Int) (x, y *big.Int) {
 // ScalarMult returns k*(Bx,By) where k is a number in big-endian form. This
 // uses the repeated doubling method, which is variable time.
 // TODO use a constant time method to prevent side channel attacks.
-func (curve *TwistedEdwardsCurve) ScalarMult(x1, y1 *big.Int,
-	k []byte) (x, y *big.Int) {
+func (curve *TwistedEdwardsCurve) ScalarMult(x1, y1 *big.Int, k []byte) (x, y *big.Int) {
 	// Convert the scalar to a big int.
 	s := new(big.Int).SetBytes(k)
 

--- a/dcrec/edwards/ecdsa.go
+++ b/dcrec/edwards/ecdsa.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -38,8 +38,7 @@ var (
 // GenerateKey generates a key using a random number generator, returning
 // the private scalar and the corresponding public key points from a
 // random secret.
-func GenerateKey(curve *TwistedEdwardsCurve, rand io.Reader) (priv []byte, x,
-	y *big.Int, err error) {
+func GenerateKey(curve *TwistedEdwardsCurve, rand io.Reader) (priv []byte, x, y *big.Int, err error) {
 	var pub *[PubKeyBytesLen]byte
 	var privArray *[PrivKeyBytesLen]byte
 	pub, privArray, err = ed25519.GenerateKey(rand)
@@ -58,8 +57,7 @@ func GenerateKey(curve *TwistedEdwardsCurve, rand io.Reader) (priv []byte, x,
 
 // SignFromSecret signs a message 'hash' using the given private key priv. It doesn't
 // actually user the random reader (the lib is maybe deterministic???).
-func SignFromSecret(rand io.Reader, priv *PrivateKey, hash []byte) (r, s *big.Int,
-	err error) {
+func SignFromSecret(rand io.Reader, priv *PrivateKey, hash []byte) (r, s *big.Int, err error) {
 	r, s, err = SignFromSecretNoReader(priv, hash)
 
 	return
@@ -67,8 +65,7 @@ func SignFromSecret(rand io.Reader, priv *PrivateKey, hash []byte) (r, s *big.In
 
 // SignFromSecretNoReader signs a message 'hash' using the given private key
 // priv. It doesn't actually user the random reader.
-func SignFromSecretNoReader(priv *PrivateKey, hash []byte) (r, s *big.Int,
-	err error) {
+func SignFromSecretNoReader(priv *PrivateKey, hash []byte) (r, s *big.Int, err error) {
 	privBytes := priv.SerializeSecret()
 	privArray := copyBytes64(privBytes)
 	sig := ed25519.Sign(privArray, hash)
@@ -87,8 +84,7 @@ func SignFromSecretNoReader(priv *PrivateKey, hash []byte) (r, s *big.Int,
 
 // nonceRFC6979 is a local instatiation of deterministic nonce generation
 // by the standards of RFC6979.
-func nonceRFC6979(curve *TwistedEdwardsCurve, privkey []byte, hash []byte,
-	extra []byte, version []byte) []byte {
+func nonceRFC6979(curve *TwistedEdwardsCurve, privkey []byte, hash []byte, extra []byte, version []byte) []byte {
 	pkD := new(big.Int).SetBytes(privkey)
 	defer pkD.SetInt64(0)
 	bigK := NonceRFC6979(curve, pkD, hash, extra, version)
@@ -100,8 +96,7 @@ func nonceRFC6979(curve *TwistedEdwardsCurve, privkey []byte, hash []byte,
 // NonceRFC6979 generates an ECDSA nonce (`k`) deterministically according to
 // RFC 6979. It takes a 32-byte hash as an input and returns 32-byte nonce to
 // be used in ECDSA algorithm.
-func NonceRFC6979(curve *TwistedEdwardsCurve, privkey *big.Int, hash []byte,
-	extra []byte, version []byte) *big.Int {
+func NonceRFC6979(curve *TwistedEdwardsCurve, privkey *big.Int, hash []byte, extra []byte, version []byte) *big.Int {
 	q := curve.Params().N
 	x := privkey
 	alg := sha256.New
@@ -224,8 +219,7 @@ func bits2octets(in []byte, curve *TwistedEdwardsCurve, rolen int) []byte {
 // It uses RFC6979 to generate a deterministic nonce. Considered experimental.
 // r = kG, where k is the RFC6979 nonce
 // s = r + hash512(k || A || M) * a
-func SignFromScalar(curve *TwistedEdwardsCurve, priv *PrivateKey,
-	nonce []byte, hash []byte) (r, s *big.Int, err error) {
+func SignFromScalar(curve *TwistedEdwardsCurve, priv *PrivateKey, nonce []byte, hash []byte) (r, s *big.Int, err error) {
 	publicKey := new([PubKeyBytesLen]byte)
 	var A edwards25519.ExtendedGroupElement
 	privateScalar := copyBytes(priv.Serialize())
@@ -278,9 +272,9 @@ func SignFromScalar(curve *TwistedEdwardsCurve, priv *PrivateKey,
 // the public nonce point with n-1 keys added.
 // r = K_Sum
 // s = r + hash512(k || A || M) * a
-func SignThreshold(curve *TwistedEdwardsCurve, priv *PrivateKey,
-	groupPub *PublicKey, hash []byte, privNonce *PrivateKey,
+func SignThreshold(curve *TwistedEdwardsCurve, priv *PrivateKey, groupPub *PublicKey, hash []byte, privNonce *PrivateKey,
 	pubNonceSum *PublicKey) (r, s *big.Int, err error) {
+
 	if priv == nil || hash == nil || privNonce == nil || pubNonceSum == nil {
 		return nil, nil, fmt.Errorf("nil input")
 	}
@@ -327,8 +321,7 @@ func SignThreshold(curve *TwistedEdwardsCurve, priv *PrivateKey,
 
 // Sign is the generalized and exported version of Ed25519 signing, that
 // handles both standard private secrets and non-standard scalars.
-func Sign(curve *TwistedEdwardsCurve, priv *PrivateKey, hash []byte) (r,
-	s *big.Int, err error) {
+func Sign(curve *TwistedEdwardsCurve, priv *PrivateKey, hash []byte) (r, s *big.Int, err error) {
 	if priv == nil {
 		return nil, nil, fmt.Errorf("private key is nil")
 	}

--- a/dcrec/edwards/primitives.go
+++ b/dcrec/edwards/primitives.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -227,8 +227,7 @@ func (curve *TwistedEdwardsCurve) extendedToBigAffine(xi, yi,
 // EncodedBytesToBigIntPoint converts a 32 byte representation of a point
 // on the elliptical curve into a big integer point. It returns an error
 // if the point does not fall on the curve.
-func (curve *TwistedEdwardsCurve) EncodedBytesToBigIntPoint(s *[32]byte) (*big.Int,
-	*big.Int, error) {
+func (curve *TwistedEdwardsCurve) EncodedBytesToBigIntPoint(s *[32]byte) (*big.Int, *big.Int, error) {
 	sCopy := new([32]byte)
 	for i := 0; i < fieldIntSize; i++ {
 		sCopy[i] = s[i]

--- a/dcrec/edwards/privkey.go
+++ b/dcrec/edwards/privkey.go
@@ -70,8 +70,7 @@ func computeScalar(privateKey *[PrivKeyBytesLen]byte) *[PrivScalarSize]byte {
 
 // PrivKeyFromBytes returns a private and public key for `curve' based on the
 // private key passed as an argument as a byte slice.
-func PrivKeyFromBytes(curve *TwistedEdwardsCurve,
-	pkBytes []byte) (*PrivateKey, *PublicKey) {
+func PrivKeyFromBytes(curve *TwistedEdwardsCurve, pkBytes []byte) (*PrivateKey, *PublicKey) {
 	if len(pkBytes) != PrivKeyBytesLen {
 		return nil, nil
 	}
@@ -101,8 +100,7 @@ func PrivKeyFromBytes(curve *TwistedEdwardsCurve,
 
 // PrivKeyFromSecret returns a private and public key for `curve' based on the
 // 32-byte private key secret passed as an argument as a byte slice.
-func PrivKeyFromSecret(curve *TwistedEdwardsCurve, s []byte) (*PrivateKey,
-	*PublicKey) {
+func PrivKeyFromSecret(curve *TwistedEdwardsCurve, s []byte) (*PrivateKey, *PublicKey) {
 	if len(s) != PrivKeyBytesLen/2 {
 		return nil, nil
 	}
@@ -121,8 +119,7 @@ func PrivKeyFromSecret(curve *TwistedEdwardsCurve, s []byte) (*PrivateKey,
 // PrivKeyFromScalar returns a private and public key for `curve' based on the
 // 32-byte private scalar passed as an argument as a byte slice (encoded big
 // endian int).
-func PrivKeyFromScalar(curve *TwistedEdwardsCurve, p []byte) (*PrivateKey,
-	*PublicKey, error) {
+func PrivKeyFromScalar(curve *TwistedEdwardsCurve, p []byte) (*PrivateKey, *PublicKey, error) {
 	if len(p) != PrivScalarSize {
 		return nil, nil, fmt.Errorf("bad private scalar size")
 	}

--- a/dcrec/edwards/pubkey.go
+++ b/dcrec/edwards/pubkey.go
@@ -28,8 +28,11 @@ func NewPublicKey(curve *TwistedEdwardsCurve, x *big.Int, y *big.Int) *PublicKey
 
 // ParsePubKey parses a public key for an edwards curve from a bytestring into a
 // ecdsa.Publickey, verifying that it is valid.
-func ParsePubKey(curve *TwistedEdwardsCurve, pubKeyStr []byte) (key *PublicKey,
-	err error) {
+func ParsePubKey(curve *TwistedEdwardsCurve, pubKeyStr []byte) (key *PublicKey, err error) {
+	if len(pubKeyStr) == 0 {
+		return nil, errors.New("pubkey string is empty")
+	}
+
 	pubkey := PublicKey{}
 	pubkey.Curve = curve
 	x, y, err := curve.EncodedBytesToBigIntPoint(copyBytes(pubKeyStr))
@@ -39,9 +42,6 @@ func ParsePubKey(curve *TwistedEdwardsCurve, pubKeyStr []byte) (key *PublicKey,
 	pubkey.X = x
 	pubkey.Y = y
 
-	if len(pubKeyStr) == 0 {
-		return nil, errors.New("pubkey string is empty")
-	}
 	if pubkey.X.Cmp(pubkey.Curve.Params().P) >= 0 {
 		return nil, fmt.Errorf("pubkey X parameter is >= to P")
 	}

--- a/dcrec/edwards/signature.go
+++ b/dcrec/edwards/signature.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -40,8 +40,7 @@ func (sig Signature) Serialize() []byte {
 }
 
 // parseSig is the default method of parsing a serialized Ed25519 signature.
-func parseSig(curve *TwistedEdwardsCurve, sigStr []byte, der bool) (*Signature,
-	error) {
+func parseSig(curve *TwistedEdwardsCurve, sigStr []byte, der bool) (*Signature, error) {
 	if der {
 		return nil, fmt.Errorf("DER signatures not allowed in ed25519")
 	}
@@ -73,15 +72,13 @@ func parseSig(curve *TwistedEdwardsCurve, sigStr []byte, der bool) (*Signature,
 
 // ParseSignature parses a signature in BER format for the curve type `curve'
 // into a Signature type, perfoming some basic sanity checks.
-func ParseSignature(curve *TwistedEdwardsCurve, sigStr []byte) (*Signature,
-	error) {
+func ParseSignature(curve *TwistedEdwardsCurve, sigStr []byte) (*Signature, error) {
 	return parseSig(curve, sigStr, false)
 }
 
 // ParseDERSignature offers a legacy function for plugging into Decred, which
 // is based off btcec.
-func ParseDERSignature(curve *TwistedEdwardsCurve, sigStr []byte) (*Signature,
-	error) {
+func ParseDERSignature(curve *TwistedEdwardsCurve, sigStr []byte) (*Signature, error) {
 	return parseSig(curve, sigStr, false)
 }
 

--- a/dcrec/edwards/threshold.go
+++ b/dcrec/edwards/threshold.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -15,8 +15,7 @@ var Sha512VersionStringRFC6979 = []byte("Edwards+SHA512  ")
 
 // CombinePubkeys combines a slice of public keys into a single public key
 // by adding them together with point addition.
-func CombinePubkeys(curve *TwistedEdwardsCurve,
-	pks []*PublicKey) *PublicKey {
+func CombinePubkeys(curve *TwistedEdwardsCurve, pks []*PublicKey) *PublicKey {
 	numPubKeys := len(pks)
 
 	// Have to have at least two pubkeys.
@@ -82,8 +81,10 @@ func generateNoncePair(curve *TwistedEdwardsCurve, msg []byte, priv []byte,
 func GenerateNoncePair(curve *TwistedEdwardsCurve, msg []byte,
 	privkey *PrivateKey, extra []byte,
 	version []byte) (*PrivateKey, *PublicKey, error) {
+
 	priv, pubNonce, err := generateNoncePair(curve, msg, privkey.Serialize(),
 		nonceRFC6979, extra, version)
+
 	if err != nil {
 		return nil, nil, err
 	}
@@ -98,6 +99,7 @@ func GenerateNoncePair(curve *TwistedEdwardsCurve, msg []byte,
 func schnorrPartialSign(curve *TwistedEdwardsCurve, msg []byte, priv []byte,
 	groupPublicKey []byte, privNonce []byte, pubNonceSum []byte) (*big.Int,
 	*big.Int, error) {
+
 	// Sanity checks.
 	if len(msg) != PrivScalarSize {
 		str := fmt.Sprintf("wrong size for message (got %v, want %v)",
@@ -182,6 +184,7 @@ func schnorrPartialSign(curve *TwistedEdwardsCurve, msg []byte, priv []byte,
 func SchnorrPartialSign(curve *TwistedEdwardsCurve, msg []byte,
 	priv *PrivateKey, groupPub *PublicKey, privNonce *PrivateKey,
 	pubSum *PublicKey) (*big.Int, *big.Int, error) {
+
 	privBytes := priv.Serialize()
 	defer zeroSlice(privBytes)
 	privNonceBytes := privNonce.Serialize()
@@ -194,8 +197,7 @@ func SchnorrPartialSign(curve *TwistedEdwardsCurve, msg []byte,
 // schnorrCombineSigs combines a list of partial Schnorr signatures s values
 // into a complete signature s for some group public key. This is achieved
 // by simply adding the s values of the partial signatures as scalars.
-func schnorrCombineSigs(curve *TwistedEdwardsCurve, sigss [][]byte) (*big.Int,
-	error) {
+func schnorrCombineSigs(curve *TwistedEdwardsCurve, sigss [][]byte) (*big.Int, error) {
 	combinedSigS := new(big.Int).SetInt64(0)
 	for i, sigs := range sigss {
 		sigsBI := EncodedBytesToBigInt(copyBytes(sigs))


### PR DESCRIPTION
This makes the style of the function definitions in the `dcrcec/edwards` package more consistent with the code throughout the rest of the code base.

Also, move the nil check for pubkey parsing to the top of the function before any more work is done.