### PR TITLE
blockchain: Reduce block availability assumptions.

### DIFF
--- a/blockchain/common_test.go
+++ b/blockchain/common_test.go
@@ -130,6 +130,7 @@ func newFakeChain(params *chaincfg.Params) *BlockChain {
 	// Create a genesis block node and block index populated with it for use
 	// when creating the fake chain below.
 	node := newBlockNode(&params.GenesisBlock.Header, nil)
+	node.status = statusDataStored | statusValid
 	index := newBlockIndex(nil, params)
 	index.AddNode(node)
 
@@ -170,7 +171,9 @@ func newFakeNode(parent *blockNode, blockVersion int32, stakeVersion uint32, bit
 		Nonce:        testNoncePrng.Uint32(),
 		StakeVersion: stakeVersion,
 	}
-	return newBlockNode(header, parent)
+	node := newBlockNode(header, parent)
+	node.status = statusDataStored | statusValid
+	return node
 }
 
 // chainedFakeNodes returns the specified number of nodes constructed such that

--- a/blockchain/stakeversion.go
+++ b/blockchain/stakeversion.go
@@ -365,7 +365,7 @@ func (b *BlockChain) calcStakeVersionByHash(hash *chainhash.Hash) (uint32, error
 // This function is safe for concurrent access.
 func (b *BlockChain) CalcStakeVersionByHash(hash *chainhash.Hash) (uint32, error) {
 	b.chainLock.Lock()
-	defer b.chainLock.Unlock()
-
-	return b.calcStakeVersionByHash(hash)
+	version, err := b.calcStakeVersionByHash(hash)
+	b.chainLock.Unlock()
+	return version, err
 }

--- a/blockchain/thresholdstate.go
+++ b/blockchain/thresholdstate.go
@@ -470,8 +470,13 @@ func (b *BlockChain) deploymentState(prevNode *blockNode, version uint32, deploy
 //
 // This function is safe for concurrent access.
 func (b *BlockChain) ThresholdState(hash *chainhash.Hash, version uint32, deploymentID string) (ThresholdStateTuple, error) {
+	// NOTE: The requirement for the node being fully validated here is strictly
+	// stronger than what is actually required.  In reality, all that is needed
+	// is for the block data for the node and all of its ancestors to be
+	// available, but there is not currently any tracking to be able to
+	// efficiently determine that state.
 	node := b.index.LookupNode(hash)
-	if node == nil {
+	if node == nil || !b.index.NodeStatus(node).KnownValid() {
 		invalidState := ThresholdStateTuple{
 			State:  ThresholdInvalid,
 			Choice: invalidChoice,


### PR DESCRIPTION
This modifies the code in `blockchain` to make less assumptions about the availability of the block data by checking the status flags to determine whether or not it is available.

While currently there aren't actually ever any nodes in the block index that don't have the full block data available, that will not always be true in the future.