### PR TITLE
multi: Fast relay checked tip blocks.

### DIFF
--- a/blockchain/notifications.go
+++ b/blockchain/notifications.go
@@ -21,10 +21,31 @@ type NotificationCallback func(*Notification)
 
 // Constants for the type of a notification message.
 const (
+	// NTNewTipBlockChecked indicates the associated block intends to extend
+	// the current main chain and has passed all of the sanity and
+	// contextual checks such as having valid proof of work, valid merkle
+	// and stake roots, and only containing allowed votes and revocations.
+	//
+	// It should be noted that the block might still ultimately fail to
+	// become the new main chain tip if it contains invalid scripts, double
+	// spends, etc.  However, this is quite rare in practice because a lot
+	// of work was expended to create a block which satisifies the proof of
+	// work requirement.
+	//
+	// Finally, this notification is only sent if the the chain is believed
+	// to be current and the chain lock is NOT released, so consumers must
+	// take care to avoid calling blockchain functions to avoid potential
+	// deadlock.
+	//
+	// Typically, a caller would want to use this notification to relay the
+	// block to the rest of the network without needing to wait for the more
+	// time consuming full connection to take place.
+	NTNewTipBlockChecked NotificationType = iota
+
 	// NTBlockAccepted indicates the associated block was accepted into
 	// the block chain.  Note that this does not necessarily mean it was
 	// added to the main chain.  For that, use NTBlockConnected.
-	NTBlockAccepted NotificationType = iota
+	NTBlockAccepted
 
 	// NTBlockConnected indicates the associated block was connected to the
 	// main chain.
@@ -50,6 +71,7 @@ const (
 // notificationTypeStrings is a map of notification types back to their constant
 // names for pretty printing.
 var notificationTypeStrings = map[NotificationType]string{
+	NTNewTipBlockChecked:    "NTNewTipBlockChecked",
 	NTBlockAccepted:         "NTBlockAccepted",
 	NTBlockConnected:        "NTBlockConnected",
 	NTBlockDisconnected:     "NTBlockDisconnected",
@@ -111,6 +133,7 @@ type TicketNotificationsData struct {
 // Notification defines notification that is sent to the caller via the callback
 // function provided during the call to New and consists of a notification type
 // as well as associated data that depends on the type as follows:
+// 	- NTNewTipBlockChecked:    *dcrutil.Block
 // 	- NTBlockAccepted:         *BlockAcceptedNtfnsData
 // 	- NTBlockConnected:        []*dcrutil.Block of len 2
 // 	- NTBlockDisconnected:     []*dcrutil.Block of len 2

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1927,9 +1927,9 @@ func (b *blockManager) handleNotifyMsg(notification *blockchain.Notification) {
 			}
 		}
 
-		// Generate the inventory vector and relay it.
+		// Generate the inventory vector and relay it immediately.
 		iv := wire.NewInvVect(wire.InvTypeBlock, blockHash)
-		b.server.RelayInventory(iv, block.MsgBlock().Header)
+		b.server.RelayInventory(iv, block.MsgBlock().Header, true)
 
 	// A block has been connected to the main block chain.
 	case blockchain.NTBlockConnected:

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/decred/dcrd/hdkeychain v1.1.0
 	github.com/decred/dcrd/mempool v1.0.1
 	github.com/decred/dcrd/mining v1.0.1
-	github.com/decred/dcrd/peer v1.0.2
+	github.com/decred/dcrd/peer v1.1.0
 	github.com/decred/dcrd/rpcclient v1.0.1
 	github.com/decred/dcrd/txscript v1.0.1
 	github.com/decred/dcrd/wire v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/dchest/siphash v1.2.0
 	github.com/decred/base58 v1.0.0
 	github.com/decred/dcrd/addrmgr v1.0.2
-	github.com/decred/dcrd/blockchain v1.0.2
+	github.com/decred/dcrd/blockchain v1.1.0
 	github.com/decred/dcrd/blockchain/stake v1.0.2
 	github.com/decred/dcrd/certgen v1.0.1
 	github.com/decred/dcrd/chaincfg v1.1.1


### PR DESCRIPTION
This PR consists of several commits which ultimately immediately relays blocks that intend to extend the main chain to the rest of the network directly after they have passed all sanity and contextual checks rather than waiting for the more expensive connection code to complete.

This is acceptable because blocks that pass all of the aforementioned checks and then fail to connect are quite rare since it takes a significant amount of work to create a block which satisfies the proof of work requirement as well as all other checks up to that point.

The first commit adds a new function to `peer` named `QueueInventoryImmediate` which allows an inventory vector to be queued for immediate send versus the standard trickling batched inventory queue method while still respecting the functionality which filters attempts to notify peers about inventory that they are already known to have.

The second commit modifies the infrastructure for `server` inventory relay to allow the caller to specify the inventory should be announced immediately versus using the typical trickle mechanism, updates all callers in the repository accordingly, and changes the relay of accepted blocks use the new ability.

The third commit adds a new notification type to `blockchain` named `NTNewTipBlockChecked` which allows the caller to be notified when a block that intents to extend the main chain has passed all sanity and contextual checks such as having valid proof of work, valid merkle and stake roots, and only containing allowed votes and revocations.

Finally, the fourth commit makes use of the newly exposed notification from `blockchain` to relay the block the rest of the network at that point rather as previously described.