### PR TITLE
rpcserver: Allow scripthash addrs in createrawsstx.

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -798,6 +798,7 @@ func handleCreateRawSStx(s *rpcServer, cmd interface{}, closeChan <-chan struct{
 		// server is currently on.
 		switch addr.(type) {
 		case *dcrutil.AddressPubKeyHash:
+		case *dcrutil.AddressScriptHash:
 		default:
 			return nil, rpcAddressKeyError("Invalid address type: "+
 				"%T", addr)


### PR DESCRIPTION
This modifies the `createrawsstx` handler to accept pay-to-script-hash addresses for the voting address since they are also valid.