### PR TITLE
docs: Revamp main README.md and update docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,83 +5,157 @@ dcrd
 [![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
 [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/decred/dcrd)
 
-dcrd is a Decred full node implementation written in Go (golang).
+## Decred Overview
 
-This acts as a chain daemon for the [Decred](https://decred.org) cryptocurrency.
-dcrd maintains the entire past transactional ledger of Decred and allows
- relaying of transactions to other Decred nodes across the world.  To read more
-about Decred please see the
-[project documentation](https://docs.decred.org/#overview).
+Decred is a blockchain-based cryptocurrency with a strong focus on community
+input, open governance, and sustainable funding for development. It utilizes a
+hybrid proof-of-work and proof-of-stake mining system to ensure that a small
+group cannot dominate the flow of transactions or make changes to Decred without
+the input of the community.  A unit of the currency is called a `decred` (DCR).
 
-Note: To send or receive funds and join Proof-of-Stake mining, you will also 
-need [dcrwallet](https://github.com/decred/dcrwallet).
+https://decred.org
 
-This project is currently under active development and is in a Beta state.  It
-is extremely stable and has been in production use since February 2016.
+## Latest Downloads
 
-It is forked from [btcd](https://github.com/btcsuite/btcd) which is a bitcoin
-full node implementation written in Go.  btcd is a ongoing project under active
-development.  Because dcrd is constantly synced with btcd codebase, it will
-get the benefit of btcd's ongoing upgrades to peer and connection handling,
-database optimization and other blockchain related technology improvements.
+https://decred.org/downloads
 
-## Requirements
+## What is dcrd?
 
-[Go](http://golang.org) 1.9 or newer.
+dcrd is a full node implementation of Decred written in Go (golang).
+
+It acts as a fully-validating chain daemon for the Decred cryptocurrency.  dcrd
+maintains the entire past transactional ledger of Decred and allows relaying of
+transactions to other Decred nodes around the world.
+
+This software is currently under active development.  It is extremely stable and
+has been in production use since February 2016.
+
+The sofware was originally forked from [btcd](https://github.com/btcsuite/btcd),
+which is a bitcoin full node implementation that is still under active
+development.  To gain the benefit of btcd's ongoing upgrades, including improved
+peer and connection handling, database optimization, and other blockchain
+related technology improvements, dcrd is continuously synced with the btcd
+codebase.
+
+## What is a full node?
+
+The term 'full node' is short for 'fully-validating node' and refers to software
+that fully validates all transactions and blocks, as opposed to trusting a 3rd
+party.  In addition to validating transactions and blocks, nearly all full nodes
+also participate in relaying transactions and blocks to other full nodes around
+the world, thus forming the peer-to-peer network that is the backbone of the
+Decred cryptocurrency.
+
+The full node distinction is important, since full nodes are not the only type
+of software participating in the Decred peer network. For instance, there are
+'lightweight nodes' which rely on full nodes to serve the transactions, blocks,
+and cryptographic proofs they require to function, as well as relay their
+transactions to the rest of the global network.
+
+## Why run dcrd?
+
+As described in the previous section, the Decred cryptocurrency relies on having
+a peer-to-peer network of nodes that fully validate all transactions and blocks
+and then relay them to other full nodes.
+
+Running a full node with dcrd contributes to the overall security of the
+network, increases the available paths for transactions and blocks to relay,
+and helps ensure there are an adequate number of nodes available to serve
+lightweight clients, such as Simplified Payment Verification (SPV) wallets.
+
+Without enough full nodes, the network could be unable to expediently serve
+users of lightweight clients which could force them to have to rely on
+centralized services that significantly reduce privacy and are vulernable to
+censorship.
+
+In terms of individual benefits, since dcrd fully validates every block and
+transaction, it provides the highest security and privacy possible when used in
+conjunction with a wallet that also supports directly connecting to it in full
+validation mode, such as [dcrwallet (CLI)](https://github.com/decred/dcrwallet)
+and [Decrediton (GUI)](https://github.com/decred/decrediton).
+
+## Minimum Recommended Specifications (dcrd only)
+
+* 10 GB disk space (as of September 2018, increases over time)
+* 1GB memory (RAM)
+* ~150MB/day download, ~1.5GB/day upload
+  * Plus one-time initial download of the entire block chain
+* Windows 7/8.x/10 (server preferred), macOS, Linux
+* High uptime
 
 ## Getting Started
 
-- dcrd (and utilities) will now be installed in either ```$GOROOT/bin``` or
-  ```$GOPATH/bin``` depending on your configuration.  If you did not already
-  add the bin directory to your system path during Go installation, we
-  recommend you do so now.
+So, you've decided to help the network by running a full node.  Great!  Running
+dcrd is simple.  All you need to do is install dcrd on a machine that is
+connected to the internet and meets the minimum recommended specifications, and
+launch it.
 
-## Updating
+Also, make sure your firewall is configured to allow inbound connections to port
+9108.
 
-#### Windows
+<a name="Installation" />
 
-Install a newer MSI
+## Installing and updating
 
-#### Linux/BSD/MacOSX/POSIX - Build from Source
+### Binaries (Windows/Linux/macOS)
 
-- **Dep**
+Binary releases are provided for common operating systems and architectures:
 
-  Dep is used to manage project dependencies and provide reproducible builds.
-  To install:
+https://decred.org/downloads
 
-  `go get -u github.com/golang/dep/cmd/dep`
+### Build from source (all platforms)
 
-Unfortunately, the use of `dep` prevents a handy tool such as `go get` from
-automatically downloading, building, and installing the source in a single
-command.  Instead, the latest project and dependency sources must be first
-obtained manually with `git` and `dep`, and then `go` is used to build and
-install the project.
+Building or updating from source requires the following build dependencies:
 
-**Getting the source**:
+- **Go 1.10 or 1.11**
 
-For a first time installation, the project and dependency sources can be
-obtained manually with `git` and `dep` (create directories as needed):
+  Installation instructions can be found here: https://golang.org/doc/install.
+  It is recommended to add `$GOPATH/bin` to your `PATH` at this point.
+
+- **Vgo (Go 1.10 only)**
+
+  The `GO111MODULE` experiment is used to manage project dependencies and
+  provide reproducible builds.  The module experiment is provided by the Go 1.11
+  toolchain, but the Go 1.10 toolchain does not provide any module support.  To
+  perform module-aware builds with Go 1.10,
+  [vgo](https://godoc.org/golang.org/x/vgo) (a drop-in replacement for the go
+  command) must be used instead.
+
+- **Git**
+
+  Installation instructions can be found at https://git-scm.com or
+  https://gitforwindows.org.
+
+To build and install from a checked-out repo, run `go install . ./cmd/...` in
+the repo's root directory.  Some notes:
+
+* Set the `GO111MODULE=on` environment variable if using Go 1.11 and building
+  from within `GOPATH`.
+
+* Replace `go` with `vgo` when using Go 1.10.
+
+* The `dcrwallet` executable will be installed to `$GOPATH/bin`.  `GOPATH`
+  defaults to `$HOME/go` (or `%USERPROFILE%\go` on Windows) if unset.
+
+
+### Example of obtaining and building from source on Windows 10 with Go 1.11:
+
+```PowerShell
+PS> git clone https://github.com/decred/dcrd $env:USERPROFILE\src\dcrd
+PS> cd $env:USERPROFILE\src\dcrd
+PS> go install . .\cmd\...
+PS> & "$(go env GOPATH)\bin\dcrd" -V
 
 ```
-git clone https://github.com/decred/dcrd $GOPATH/src/github.com/decred/dcrd
-cd $GOPATH/src/github.com/decred/dcrd
-dep ensure
-go install . ./cmd/...
-```
 
-To update an existing source tree, pull the latest changes and install the
-matching dependencies:
+### Example of obtaining and building from source on Linux with Go 1.10:
 
+```bash
+$ git clone https://github.com/decred/dcrd ~/src/dcrd
+$ cd ~/src/dcrd
+$ vgo install . ./cmd/...
+$ $(vgo env GOPATH)/bin/dcrd -V
 ```
-cd $GOPATH/src/github.com/decred/dcrd
-git pull
-dep ensure
-go install . ./cmd/...
-```
-
-For more information about Decred and how to set up your software please go to
-our docs page at
-[docs.decred.org](https://docs.decred.org/getting-started/beginner-guide/).
 
 ## Docker
 
@@ -130,33 +204,36 @@ And then run dcrctl commands against it.  For example:
 docker exec -ti dcrd-1 dcrctl getbestblock
 ```
 
-
 ### Running Tests
 
-All tests and linters may be run in a docker container using the script
-`run_tests.sh`.  This script defaults to using the current supported version of
-go.  You can run it with the major version of Go you would like to use as the
-only arguement to test a previous on a previous version of Go (generally Decred
-supports the current version of Go and the previous one).
+All tests and linters may be run in a docker (or podman) container using the
+script `run_tests.sh` by specifying either `docker` or `podman` as the first
+parameter.  This script defaults to using the current latest supported version
+of Go, but it also respects the `GOVERSION` environment variable set to the
+major version of Go to allow testing on a previous version of Go.  Generally,
+Decred only supports the current and previous major versions of Go.
 
 ```
-./run_tests.sh 1.9
+./run_tests.sh docker
 ```
 
-To run the tests locally without docker:
+To run the tests locally without docker on the latest supported version of Go:
 
 ```
-./run_tests.sh local
+./run_tests.sh
+```
+
+To run the tests locally without docker on Go 1.10:
+
+```
+GOVERSION=1.10 ./run_tests.sh
 ```
 
 ## Contact
 
 If you have any further questions you can find us at:
 
-- irc.freenode.net (channel #decred)
-- [webchat](https://webchat.freenode.net/?channels=decred)
-- forum.decred.org
-- decred.slack.com
+https://decred.org/community
 
 ## Issue Tracker
 
@@ -165,7 +242,7 @@ is used for this project.
 
 ## Documentation
 
-The documentation is a work-in-progress.  It is located in the
+The documentation for dcrd is a work-in-progress.  It is located in the
 [docs](https://github.com/decred/dcrd/tree/master/docs) folder.
 
 ## License

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,19 +2,14 @@
 1. [About](#About)
 2. [Getting Started](#GettingStarted)
     1. [Installation](#Installation)
-        1. [Windows](#WindowsInstallation)
-        2. [Linux/BSD/MacOSX/POSIX](#PosixInstallation)
     2. [Configuration](#Configuration)
     3. [Controlling and Querying dcrd via dcrctl](#DcrctlConfig)
     4. [Mining](#Mining)
 3. [Help](#Help)
-    1. [Startup](#Startup)
-        1. [Using bootstrap.dat](#BootstrapDat)
-    2. [Network Configuration](#NetworkConfig)
-    3. [Wallet](#Wallet)
+    1. [Network Configuration](#NetworkConfig)
+    2. [Wallet](#Wallet)
 4. [Contact](#Contact)
-    1. [IRC](#ContactIRC)
-    2. [Mailing Lists](#MailingLists)
+    1. [Community](#ContactCommunity)
 5. [Developer Resources](#DeveloperResources)
     1. [Code Contribution Guidelines](#ContributionGuidelines)
     2. [JSON-RPC Reference](#JSONRPCReference)
@@ -24,14 +19,15 @@
 <a name="About" />
 
 ### 1. About
-dcrd is a full node Decred implementation written in [Go](http://golang.org),
-licensed under the [copyfree](http://www.copyfree.org) ISC License.
 
-This project is currently under active development and is in a Beta state. It is
-extremely stable and has been in production use since February 2016.
+dcrd is a full node Decred implementation written in [Go](http://golang.org),
+and is licensed under the [copyfree](http://www.copyfree.org) ISC License.
+
+This software is currently under active development.  It is extremely stable and
+has been in production use since February 2016.
 
 It also properly relays newly mined blocks, maintains a transaction pool, and
-relays individual transactions that have not yet made it into a block. It
+relays individual transactions that have not yet made it into a block.  It
 ensures all individual transactions admitted to the pool follow the rules
 required into the block chain and also includes the vast majority of the more
 strict checks which filter transactions based on miner requirements ("standard"
@@ -45,25 +41,8 @@ transactions).
 
 **2.1 Installation**<br />
 
-The first step is to install dcrd.  See one of the following sections for
-details on how to install on the supported operating systems.
-
-<a name="WindowsInstallation" />
-
-**2.1.1 Windows Installation**<br />
-
-* Install the MSI available at: https://github.com/decred/dcrd/releases
-* Launch dcrd from the Start Menu
-
-<a name="PosixInstallation" />
-
-**2.1.2 Linux/BSD/MacOSX/POSIX Installation**<br />
-
-* Install Go according to the installation instructions here: http://golang.org/doc/install
-* Run the following command to ensure your Go version is at least version 1.2: `$ go version`
-* Run the following command to obtain dcrd, its dependencies, and install it: `$ go get github.com/decred/dcrd/...`<br />
-  * To upgrade, run the following command: `$ go get -u github.com/decred/dcrd/...`
-* Run dcrd: `$ dcrd`
+The first step is to install dcrd.  The installation instructions can be found
+[here](https://github.com/decred/dcrd/tree/master/README.md#Installation).
 
 <a name="Configuration" />
 
@@ -106,9 +85,8 @@ For a list of available options, run: `$ dcrctl --help`
 <a name="Mining" />
 
 **2.4 Mining**<br />
-dcrd supports both the `getwork` and `getblocktemplate` RPCs although the
-`getwork` RPC is deprecated and will likely be removed in a future release.
-The limited user cannot access these RPCs.<br />
+dcrd supports the [getwork](https://github.com/decred/dcrd/tree/master/docs/json_rpc_api.md#getwork)
+RPC.  The limited user cannot access this RPC.<br />
 
 **1. Add the payment addresses with the `miningaddr` option.**<br />
 
@@ -116,8 +94,8 @@ The limited user cannot access these RPCs.<br />
 [Application Options]
 rpcuser=myuser
 rpcpass=SomeDecentp4ssw0rd
-miningaddr=12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX
-miningaddr=1M83ju3EChKYyysmM2FXtLNftbacagd8FR
+miningaddr=DsExampleAddress1
+miningaddr=DsExampleAddress2
 ```
 
 **2. Add dcrd's RPC TLS certificate to system Certificate Authority list.**<br />
@@ -140,22 +118,9 @@ certificate into the default system Certificate Authority list.
 
 ### 3. Help
 
-<a name="Startup" />
-
-**3.1 Startup**<br />
-
-Typically dcrd will run and start downloading the block chain with no extra
-configuration necessary, however, there is an optional method to use a
-`bootstrap.dat` file that may speed up the initial block chain download process.
-
-<a name="BootstrapDat" />
-
-**3.1.1 bootstrap.dat**<br />
-* [Using bootstrap.dat](https://github.com/decred/dcrd/tree/master/docs/using_bootstrap_dat.md)
-
 <a name="NetworkConfig" />
 
-**3.1.2 Network Configuration**<br />
+**3.1 Network Configuration**<br />
 * [What Ports Are Used by Default?](https://github.com/decred/dcrd/tree/master/docs/default_ports.md)
 * [How To Listen on Specific Interfaces](https://github.com/decred/dcrd/tree/master/docs/configure_peer_server_listen_interfaces.md)
 * [How To Configure RPC Server to Listen on Specific Interfaces](https://github.com/decred/dcrd/tree/master/docs/configure_rpc_server_listen_interfaces.md)
@@ -163,7 +128,7 @@ configuration necessary, however, there is an optional method to use a
 
 <a name="Wallet" />
 
-**3.1 Wallet**<br />
+**3.2 Wallet**<br />
 
 dcrd was intentionally developed without an integrated wallet for security
 reasons.  Please see [dcrwallet](https://github.com/decred/dcrwallet) for more
@@ -173,18 +138,13 @@ information.
 
 ### 4. Contact
 
-<a name="ContactIRC" />
+<a name="ContactCommunity" />
 
-**4.1 IRC**<br />
-* [irc.freenode.net](irc://irc.freenode.net), channel #dcrd
+**4.1 Community**<br />
 
-<a name="MailingLists" />
+If you have any further questions you can find us at:
 
-**4.2 Mailing Lists**<br />
-* <a href="mailto:dcrd+subscribe@opensource.conformal.com">dcrd</a>: discussion
-  of dcrd and its packages.
-* <a href="mailto:dcrd-commits+subscribe@opensource.conformal.com">dcrd-commits</a>:
-  readonly mail-out of source code changes.
+https://decred.org/community
 
 <a name="DeveloperResources" />
 


### PR DESCRIPTION
This revamps the main `README.md` file in an attempt to provide a more user-friendly introduction to the software and why someone would want to run it and also updates the `docs/README.md` to remove some sections that do not apply to Decred and update some others to reflect reality.

It also adds minimum recommended specifications for `dcrd` to the main `README.md` and updates the build instruction for module-aware builds and the recent changes the `run_test.sh` script.

Finally, it updates the contact information to point to the decred.org/community page.