### PR TITLE
rpcserver: Remove createrawssgen RPC.

### DIFF
--- a/dcrjson/walletsvrcmds.go
+++ b/dcrjson/walletsvrcmds.go
@@ -162,12 +162,16 @@ func NewCreateRawSStxCmd(inputs []SStxInput, amount map[string]int64,
 
 // CreateRawSSGenTxCmd is a type handling custom marshaling and
 // unmarshaling of createrawssgentxcmd JSON RPC commands.
+//
+// DEPRECATED.  This will be removed in the next major version bump of dcrjson.
 type CreateRawSSGenTxCmd struct {
 	Inputs   []TransactionInput
 	VoteBits uint16
 }
 
 // NewCreateRawSSGenTxCmd creates a new CreateRawSSGenTxCmd.
+//
+// DEPRECATED.  This will be removed in the next major version bump of dcrjson.
 func NewCreateRawSSGenTxCmd(inputs []TransactionInput,
 	vb uint16) *CreateRawSSGenTxCmd {
 	return &CreateRawSSGenTxCmd{
@@ -1290,6 +1294,8 @@ func init() {
 	MustRegisterCmd("createmultisig", (*CreateMultisigCmd)(nil), flags)
 	MustRegisterCmd("createnewaccount", (*CreateNewAccountCmd)(nil), flags)
 	MustRegisterCmd("createrawsstx", (*CreateRawSStxCmd)(nil), flags)
+	// DEPRECATED.  createrawssgentx will be removed in the next major version
+	// bump of dcrjson.
 	MustRegisterCmd("createrawssgentx", (*CreateRawSSGenTxCmd)(nil), flags)
 	MustRegisterCmd("createrawssrtx", (*CreateRawSSRtxCmd)(nil), flags)
 	MustRegisterCmd("createvotingaccount", (*CreateVotingAccountCmd)(nil), flags)

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -67,14 +67,6 @@ var helpDescsEnUS = map[string]string{
 	"sstxcommitout-changeaddr":    "Address for change",
 
 	// CreateRawSSGenTxCmd help.
-	"createrawssgentx--synopsis": "Returns a new transaction spending the provided inputs and sending to the provided addresses.\n" +
-		"The transaction inputs are not signed in the created transaction.\n" +
-		"The signrawtransaction RPC command provided by wallet must be used to sign the resulting transaction.",
-	"createrawssgentx--result0": "Hex-encoded bytes of the serialized transaction",
-	"createrawssgentx-inputs":   "The inputs to the transaction of type sstxinput",
-	"createrawssgentx-votebits": "The inputs to the transaction of type sstxinput",
-
-	// CreateRawSSGenTxCmd help.
 	"createrawssrtx--synopsis": "Returns a new transaction spending the provided inputs and sending to the provided addresses.\n" +
 		"The transaction inputs are not signed in the created transaction.\n" +
 		"The signrawtransaction RPC command provided by wallet must be used to sign the resulting transaction.",
@@ -921,7 +913,6 @@ var helpDescsEnUS = map[string]string{
 var rpcResultTypes = map[string][]interface{}{
 	"addnode":               nil,
 	"createrawsstx":         {(*string)(nil)},
-	"createrawssgentx":      {(*string)(nil)},
 	"createrawssrtx":        {(*string)(nil)},
 	"createrawtransaction":  {(*string)(nil)},
 	"debuglevel":            {(*string)(nil), (*string)(nil)},


### PR DESCRIPTION
This removes the handler for the `createrawssgen` RPC and deprecates the associated `dcrjson` structures.

This is being done because it doesn't make any sense for votes to be created over the RPC interface.  In order for voting on the previous block to have any semblance of relevance, the software producing the
vote clearly must have code to deserialize and understand the relevant data structures.