### PR TITLE
blockchain: Ensure no stake opcodes in tx sanity.

### DIFF
--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -2176,7 +2176,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 		b.AddSTransaction(ticket)
 		b.Header.FreshStake++
 	})
-	rejected(blockchain.ErrRegTxInStakeTree)
+	rejected(blockchain.ErrRegTxCreateStakeOut)
 
 	// Create block with scripts that do not involve p2pkh or
 	// p2sh addresses for a ticket purchase.
@@ -2193,7 +2193,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 		b.AddSTransaction(ticket)
 		b.Header.FreshStake++
 	})
-	rejected(blockchain.ErrRegTxInStakeTree)
+	rejected(blockchain.ErrRegTxCreateStakeOut)
 
 	// ---------------------------------------------------------------------
 	// Block header median time tests.
@@ -2708,7 +2708,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	g.NextBlock("bsc2", outs[19], ticketOuts[19],
 		replaceSpendScript(tooManySigOps))
 	g.AssertTipBlockSigOpsCount(maxBlockSigOps + 1)
-	rejected(blockchain.ErrTooManySigOps)
+	rejected(blockchain.ErrScriptMalformed)
 
 	// ---------------------------------------------------------------------
 	// Dead execution path tests.


### PR DESCRIPTION
**This requires PR #1452**.

This moves the check for validating that output scripts in non-stake transactions do not contain any of the opcodes only allowed in the stake tree to the `CheckTransactionSanity` function where it more naturally belongs since it does not require access to transaction inputs as its location in `CheckTransactionInputs` would otherwise indicate.

It should be noted that the check just before the one being moved in this change is removed because it checked that specific patterns involving stake opcodes where not being used in non-stake transactions which is a strict subset of the more general check which ensures there are no stake opcodes at all in the output scripts.

Also, to improve efficiency, the check is added to the existing loop which already iterates the outputs and the entire block is moved after some other faster checks.

Finally, since the transaction sanity code previously did not determine if the transaction is a stake transaction which is required for the check in question, this adds code to relatively efficiently determine that.

This is work towards #1145.