### PR TITLE
multi: Move update blk time to blk templ generator.

### DIFF
--- a/cpuminer.go
+++ b/cpuminer.go
@@ -278,7 +278,7 @@ func (m *CPUMiner) solveBlock(msgBlock *wire.MsgBlock, ticker *time.Ticker, quit
 					return false
 				}
 
-				err = UpdateBlockTime(msgBlock, m.g.blockManager)
+				err = m.g.UpdateBlockTime(header)
 				if err != nil {
 					minrLog.Warnf("CPU miner unable to update block template "+
 						"time: %v", err)

--- a/mining.go
+++ b/mining.go
@@ -2036,23 +2036,21 @@ mempoolLoop:
 // consensus rules.  Finally, it will update the target difficulty if needed
 // based on the new time for the test networks since their target difficulty can
 // change based upon time.
-func UpdateBlockTime(msgBlock *wire.MsgBlock, bManager *blockManager) error {
+func (g *BlkTmplGenerator) UpdateBlockTime(header *wire.BlockHeader) error {
 	// The new timestamp is potentially adjusted to ensure it comes after
 	// the median time of the last several blocks per the chain consensus
 	// rules.
-	newTimestamp := medianAdjustedTime(bManager.chain.BestSnapshot(),
-		bManager.server.timeSource)
-	msgBlock.Header.Timestamp = newTimestamp
+	newTimestamp := medianAdjustedTime(g.chain.BestSnapshot(), g.timeSource)
+	header.Timestamp = newTimestamp
 
 	// If running on a network that requires recalculating the difficulty,
 	// do so now.
 	if activeNetParams.ReduceMinDifficulty {
-		difficulty, err := bManager.chain.CalcNextRequiredDifficulty(
-			newTimestamp)
+		difficulty, err := g.chain.CalcNextRequiredDifficulty(newTimestamp)
 		if err != nil {
 			return miningRuleError(ErrGettingDifficulty, err.Error())
 		}
-		msgBlock.Header.Bits = difficulty
+		header.Bits = difficulty
 	}
 
 	return nil

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2300,7 +2300,7 @@ func (state *gbtWorkState) updateBlockTemplate(s *rpcServer, useCoinbaseValue bo
 		// Update the time of the block template to the current time
 		// while accounting for the median time of the past several
 		// blocks per the chain consensus rules.
-		err := UpdateBlockTime(msgBlock, s.server.blockManager)
+		err := s.generator.UpdateBlockTime(&msgBlock.Header)
 		if err != nil {
 			context := "Failed to update timestamp"
 			return rpcInternalError(err.Error(), context)
@@ -3970,7 +3970,7 @@ func handleGetWorkRequest(s *rpcServer) (interface{}, error) {
 		// Update the time of the block template to the current time
 		// while accounting for the median time of the past several
 		// blocks per the chain consensus rules.
-		err := UpdateBlockTime(msgBlock, s.server.blockManager)
+		err := s.generator.UpdateBlockTime(&msgBlock.Header)
 		if err != nil {
 			return nil, rpcInternalError(err.Error(),
 				"Failed to update block time")


### PR DESCRIPTION
This moves the `UpdateBlockTime` function to the recently introduced `BlkTmplGenerator` type in order to break its dependence on the block manager.