### PR TITLE
multi: No stake height checks in check tx inputs.

### DIFF
--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -1257,7 +1257,6 @@ func CheckTransactionInputs(subsidyCache *SubsidyCache, tx *dcrutil.Tx, txHeight
 	msgTx := tx.MsgTx()
 
 	ticketMaturity := int64(chainParams.TicketMaturity)
-	stakeEnabledHeight := chainParams.StakeEnabledHeight
 	txHash := tx.Hash()
 	var totalAtomIn int64
 
@@ -1348,15 +1347,6 @@ func CheckTransactionInputs(subsidyCache *SubsidyCache, tx *dcrutil.Tx, txHeight
 	// OP_SSTX tagged output uses.
 	isSSGen := stake.IsSSGen(msgTx)
 	if isSSGen {
-		// Cursory check to see if we've even reached stake-enabled
-		// height.
-		if txHeight < stakeEnabledHeight {
-			errStr := fmt.Sprintf("SSGen tx appeared in block "+
-				"height %v before stake enabled height %v",
-				txHeight, stakeEnabledHeight)
-			return 0, ruleError(ErrInvalidEarlyStakeTx, errStr)
-		}
-
 		// Grab the input SStx hash from the inputs of the transaction.
 		nullIn := msgTx.TxIn[0]
 		sstxIn := msgTx.TxIn[1] // sstx input
@@ -1499,16 +1489,6 @@ func CheckTransactionInputs(subsidyCache *SubsidyCache, tx *dcrutil.Tx, txHeight
 	// this later input check for OP_SSTX outs.
 	isSSRtx := stake.IsSSRtx(msgTx)
 	if isSSRtx {
-		// Cursory check to see if we've even reach stake-enabled
-		// height.  Note for an SSRtx to be valid a vote must be
-		// missed, so for SSRtx the height of allowance is +1.
-		if txHeight < stakeEnabledHeight+1 {
-			errStr := fmt.Sprintf("SSRtx tx appeared in block "+
-				"height %v before stake enabled height+1 %v",
-				txHeight, stakeEnabledHeight+1)
-			return 0, ruleError(ErrInvalidEarlyStakeTx, errStr)
-		}
-
 		// Grab the input SStx hash from the inputs of the transaction.
 		sstxIn := msgTx.TxIn[0] // sstx input
 		sstxHash := sstxIn.PreviousOutPoint.Hash

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -815,7 +815,7 @@ func TestVoteOrphan(t *testing.T) {
 		t.Fatalf("unable to create ticket purchase transaction: %v", err)
 	}
 
-	harness.chain.SetHeight(harness.chainParams.StakeEnabledHeight)
+	harness.chain.SetHeight(harness.chainParams.StakeValidationHeight)
 
 	vote, err := harness.CreateVote(ticket)
 	if err != nil {
@@ -886,7 +886,7 @@ func TestRevocationOrphan(t *testing.T) {
 		t.Fatalf("unable to create ticket purchase transaction: %v", err)
 	}
 
-	harness.chain.SetHeight(harness.chainParams.StakeEnabledHeight + 1)
+	harness.chain.SetHeight(harness.chainParams.StakeValidationHeight + 1)
 
 	revocation, err := harness.CreateRevocation(ticket)
 	if err != nil {


### PR DESCRIPTION
**This relies on #1456.**

This removes a redundant check for validating that votes and revocations are not in a block before they are allowed from `CheckTransactionInputs` since it has nothing to do with validation of transaction inputs and it's an impossible condition to hit in the block validation path because the same check is done much earlier in the validation process.

It should also be noted that the checks this removes are also more permissive than they need to be because the first vote is not allowed until stake validation height, which is after stake enabled height. There is no effect on consensus because, as previously mentioned, the more restrictive checks earlier in the process prevent these checks from ever being exercised.

However, the `mempool` previously relied on this duplicate check to reject early votes and revocations, so this adds the checks, with the corrected heights, directly to the `mempool` early in the process where they more naturally belong.  It is more efficient to reject the transactions in that scenario earlier before doing more work as well.

This is work towards #1145.