### PR TITLE
main: add address encoding magic constants test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ dcrd.db
 _obj
 _test
 vendor
+.idea
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/networkparams_test.go
+++ b/networkparams_test.go
@@ -76,8 +76,7 @@ func checkGenesisBlockRespectsNetworkPowLimit(t *testing.T, params *chaincfg.Par
 func checkPrefix(t *testing.T, prefix string, targetString, networkName string) {
 	if strings.Index(targetString, prefix) != 0 {
 		t.Logf("Address prefix mismatch for <%s>: expected <%s> received <%s>",
-			networkName, prefix, targetString,
-		)
+			networkName, prefix, targetString)
 		t.FailNow()
 	}
 }

--- a/networkparams_test.go
+++ b/networkparams_test.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -50,8 +51,7 @@ func checkPowLimitsAreConsistent(t *testing.T, params *chaincfg.Params) {
 // Solved block shouldn't be rejected due to the PoW limit check.
 //
 // This test ensures these blocks will respect the network PoW limit.
-func checkGenesisBlockRespectsNetworkPowLimit(
-	t *testing.T, params *chaincfg.Params) {
+func checkGenesisBlockRespectsNetworkPowLimit(t *testing.T, params *chaincfg.Params) {
 	genesis := params.GenesisBlock
 	bits := genesis.Header.Bits
 
@@ -72,24 +72,14 @@ func checkGenesisBlockRespectsNetworkPowLimit(
 	}
 }
 
-func checkPrefix(t *testing.T, prefix string, encoded, networkName string) {
-	if strings.Index(encoded, prefix) != 0 {
-		t.Logf(
-			"Address prefix mismatch for <%s>: expected <%s> received <%s>",
-			networkName,
-			prefix,
-			encoded,
+// checkPrefix checks if targetString starts with the given prefix
+func checkPrefix(t *testing.T, prefix string, targetString, networkName string) {
+	if strings.Index(targetString, prefix) != 0 {
+		t.Logf("Address prefix mismatch for <%s>: expected <%s> received <%s>",
+			networkName, prefix, targetString,
 		)
 		t.FailNow()
 	}
-}
-
-func preFillArray(size int, value byte) []byte {
-	b := make([]byte, size)
-	for i := 0; i < size; i++ {
-		b[i] = value
-	}
-	return b
 }
 
 // checkInterval creates two corner cases defining interval
@@ -97,11 +87,12 @@ func preFillArray(size int, value byte) []byte {
 // where xxxx - is the encoding magic, and cccc is a checksum.
 // The interval is mapped to corresponding interval in base 58.
 // Then prefixes are checked for mismatch.
-func checkInterval(t *testing.T,
-	desiredPrefix string, keySize int, networkName string, magic [2]byte) {
+func checkInterval(t *testing.T, desiredPrefix string, keySize int, networkName string, magic [2]byte) {
 	// min and max possible keys
-	minKey := preFillArray(keySize, 0x00) // all zeroes
-	maxKey := preFillArray(keySize, 0xff) // all ones
+	// all zeroes
+	minKey := bytes.Repeat([]byte{0x00}, keySize)
+	// all ones
+	maxKey := bytes.Repeat([]byte{0xff}, keySize)
 
 	base58interval := [2]string{
 		base58.CheckEncode(minKey, magic),
@@ -114,8 +105,7 @@ func checkInterval(t *testing.T,
 // checkAddressPrefixesAreConsistent ensures address encoding magics and
 // NetworkAddressPrefix are consistent with each other.
 // This test will light red when a new network is started with incorrect values.
-func checkAddressPrefixesAreConsistent(t *testing.T,
-	privateKeyPrefix string, params *chaincfg.Params) {
+func checkAddressPrefixesAreConsistent(t *testing.T, privateKeyPrefix string, params *chaincfg.Params) {
 	P := params.NetworkAddressPrefix
 
 	// Desired prefixes

--- a/networkparams_test.go
+++ b/networkparams_test.go
@@ -5,8 +5,10 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/decred/base58"
 	"github.com/decred/dcrd/blockchain"
 	"github.com/decred/dcrd/chaincfg"
 )
@@ -16,7 +18,7 @@ import (
 // PowLimit:         mainPowLimit,// big int
 // PowLimitBits:     0x1d00ffff,  // conceptually the same
 //                                // value, but in an obscure form
-func checkPowLimitsAreConsistent(t *testing.T, params chaincfg.Params) {
+func checkPowLimitsAreConsistent(t *testing.T, params *chaincfg.Params) {
 	powLimitBigInt := params.PowLimit
 	powLimitCompact := params.PowLimitBits
 
@@ -49,7 +51,7 @@ func checkPowLimitsAreConsistent(t *testing.T, params chaincfg.Params) {
 //
 // This test ensures these blocks will respect the network PoW limit.
 func checkGenesisBlockRespectsNetworkPowLimit(
-	t *testing.T, params chaincfg.Params) {
+	t *testing.T, params *chaincfg.Params) {
 	genesis := params.GenesisBlock
 	bits := genesis.Header.Bits
 
@@ -70,13 +72,79 @@ func checkGenesisBlockRespectsNetworkPowLimit(
 	}
 }
 
+func checkPrefix(t *testing.T, prefix string, encoded, networkName string) {
+	if strings.Index(encoded, prefix) != 0 {
+		t.Logf(
+			"Address prefix mismatch for <%s>: expected <%s> received <%s>",
+			networkName,
+			prefix,
+			encoded,
+		)
+		t.FailNow()
+	}
+}
+
+func preFillArray(size int, value byte) []byte {
+	b := make([]byte, size)
+	for i := 0; i < size; i++ {
+		b[i] = value
+	}
+	return b
+}
+
+// checkInterval creates two corner cases defining interval
+// of all key values: [ xxxx000000000...0cccc , xxxx111111111...1cccc ],
+// where xxxx - is the encoding magic, and cccc is a checksum.
+// The interval is mapped to corresponding interval in base 58.
+// Then prefixes are checked for mismatch.
+func checkInterval(t *testing.T,
+	desiredPrefix string, keySize int, networkName string, magic [2]byte) {
+	// min and max possible keys
+	minKey := preFillArray(keySize, 0x00) // all zeroes
+	maxKey := preFillArray(keySize, 0xff) // all ones
+
+	base58interval := [2]string{
+		base58.CheckEncode(minKey, magic),
+		base58.CheckEncode(maxKey, magic),
+	}
+	checkPrefix(t, desiredPrefix, base58interval[0], networkName)
+	checkPrefix(t, desiredPrefix, base58interval[1], networkName)
+}
+
+// checkAddressPrefixesAreConsistent ensures address encoding magics and
+// NetworkAddressPrefix are consistent with each other.
+// This test will light red when a new network is started with incorrect values.
+func checkAddressPrefixesAreConsistent(t *testing.T,
+	privateKeyPrefix string, params *chaincfg.Params) {
+	P := params.NetworkAddressPrefix
+
+	// Desired prefixes
+	Pk := P + "k"
+	Ps := P + "s"
+	Pe := P + "e"
+	PS := P + "S"
+	Pc := P + "c"
+	pk := privateKeyPrefix
+
+	checkInterval(t, Pk, 33, params.Name, params.PubKeyAddrID)
+	checkInterval(t, Ps, 20, params.Name, params.PubKeyHashAddrID)
+	checkInterval(t, Pe, 20, params.Name, params.PKHEdwardsAddrID)
+	checkInterval(t, PS, 20, params.Name, params.PKHSchnorrAddrID)
+	checkInterval(t, Pc, 20, params.Name, params.ScriptHashAddrID)
+	checkInterval(t, pk, 33, params.Name, params.PrivateKeyID)
+}
+
 // TestDecredNetworkSettings checks Network-specific settings
 func TestDecredNetworkSettings(t *testing.T) {
-	checkPowLimitsAreConsistent(t, chaincfg.MainNetParams)
-	checkPowLimitsAreConsistent(t, chaincfg.TestNet3Params)
-	checkPowLimitsAreConsistent(t, chaincfg.SimNetParams)
+	checkPowLimitsAreConsistent(t, &chaincfg.MainNetParams)
+	checkPowLimitsAreConsistent(t, &chaincfg.TestNet3Params)
+	checkPowLimitsAreConsistent(t, &chaincfg.SimNetParams)
 
-	checkGenesisBlockRespectsNetworkPowLimit(t, chaincfg.MainNetParams)
-	checkGenesisBlockRespectsNetworkPowLimit(t, chaincfg.TestNet3Params)
-	checkGenesisBlockRespectsNetworkPowLimit(t, chaincfg.SimNetParams)
+	checkGenesisBlockRespectsNetworkPowLimit(t, &chaincfg.MainNetParams)
+	checkGenesisBlockRespectsNetworkPowLimit(t, &chaincfg.TestNet3Params)
+	checkGenesisBlockRespectsNetworkPowLimit(t, &chaincfg.SimNetParams)
+
+	checkAddressPrefixesAreConsistent(t, "Pm", &chaincfg.MainNetParams)
+	checkAddressPrefixesAreConsistent(t, "Pt", &chaincfg.TestNet3Params)
+	checkAddressPrefixesAreConsistent(t, "Ps", &chaincfg.SimNetParams)
 }


### PR DESCRIPTION
Ensures address encoding magics and `params.NetworkAddressPrefix` are consistent with each other. This test will light red when a new network is started with incorrect values.

Also there is a minor fix of *pointers for two other tests in this file.