### PR TITLE
blockchain: Move finalized tx func to validation.

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -8,8 +8,6 @@ package blockchain
 import (
 	"encoding/binary"
 	"fmt"
-	"math"
-	"time"
 
 	"github.com/decred/dcrd/blockchain/stake"
 	"github.com/decred/dcrd/database"
@@ -65,40 +63,6 @@ func checkCoinbaseUniqueHeight(blockHeight int64, block *dcrutil.Block) error {
 	}
 
 	return nil
-}
-
-// IsFinalizedTransaction determines whether or not a transaction is finalized.
-func IsFinalizedTransaction(tx *dcrutil.Tx, blockHeight int64, blockTime time.Time) bool {
-	// Lock time of zero means the transaction is finalized.
-	msgTx := tx.MsgTx()
-	lockTime := msgTx.LockTime
-	if lockTime == 0 {
-		return true
-	}
-
-	// The lock time field of a transaction is either a block height at
-	// which the transaction is finalized or a timestamp depending on if the
-	// value is before the txscript.LockTimeThreshold.  When it is under the
-	// threshold it is a block height.
-	var blockTimeOrHeight int64
-	if lockTime < txscript.LockTimeThreshold {
-		blockTimeOrHeight = blockHeight
-	} else {
-		blockTimeOrHeight = blockTime.Unix()
-	}
-	if int64(lockTime) < blockTimeOrHeight {
-		return true
-	}
-
-	// At this point, the transaction's lock time hasn't occurred yet, but
-	// the transaction might still be finalized if the sequence number
-	// for all transaction inputs is maxed out.
-	for _, txIn := range msgTx.TxIn {
-		if txIn.Sequence != math.MaxUint32 {
-			return false
-		}
-	}
-	return true
 }
 
 // maybeAcceptBlock potentially accepts a block into the block chain and, if


### PR DESCRIPTION
This moves the `IsFinalizedTransaction` function from `accept.go` to `validate.go` where it more naturally belongs as it is a validation function.  This is also evidenced by only being called from validation functions as well.