### PR TITLE
blockchain: Move unique coinbase func to validate.

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -8,8 +8,6 @@ package blockchain
 import (
 	"encoding/binary"
 	"fmt"
-	"math"
-	"time"
 
 	"github.com/decred/dcrd/blockchain/stake"
 	"github.com/decred/dcrd/database"
@@ -65,40 +63,6 @@ func checkCoinbaseUniqueHeight(blockHeight int64, block *dcrutil.Block) error {
 	}
 
 	return nil
-}
-
-// IsFinalizedTransaction determines whether or not a transaction is finalized.
-func IsFinalizedTransaction(tx *dcrutil.Tx, blockHeight int64, blockTime time.Time) bool {
-	// Lock time of zero means the transaction is finalized.
-	msgTx := tx.MsgTx()
-	lockTime := msgTx.LockTime
-	if lockTime == 0 {
-		return true
-	}
-
-	// The lock time field of a transaction is either a block height at
-	// which the transaction is finalized or a timestamp depending on if the
-	// value is before the txscript.LockTimeThreshold.  When it is under the
-	// threshold it is a block height.
-	var blockTimeOrHeight int64
-	if lockTime < txscript.LockTimeThreshold {
-		blockTimeOrHeight = blockHeight
-	} else {
-		blockTimeOrHeight = blockTime.Unix()
-	}
-	if int64(lockTime) < blockTimeOrHeight {
-		return true
-	}
-
-	// At this point, the transaction's lock time hasn't occurred yet, but
-	// the transaction might still be finalized if the sequence number
-	// for all transaction inputs is maxed out.
-	for _, txIn := range msgTx.TxIn {
-		if txIn.Sequence != math.MaxUint32 {
-			return false
-		}
-	}
-	return true
 }
 
 // maybeAcceptBlock potentially accepts a block into the block chain and, if

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -7,6 +7,7 @@ package blockchain
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"math"
 	"math/big"
@@ -1065,6 +1066,56 @@ func (b *BlockChain) checkBlockHeaderContext(header *wire.BlockHeader, prevNode 
 				calcFinalState)
 			return ruleError(ErrInvalidFinalState, errStr)
 		}
+	}
+
+	return nil
+}
+
+// checkCoinbaseUniqueHeight checks to ensure that for all blocks height > 1 the
+// coinbase contains the height encoding to make coinbase hash collisions
+// impossible.
+func checkCoinbaseUniqueHeight(blockHeight int64, block *dcrutil.Block) error {
+	// Coinbase TxOut[0] is always tax, TxOut[1] is always
+	// height + extranonce, so at least two outputs must
+	// exist.
+	if len(block.MsgBlock().Transactions[0].TxOut) < 2 {
+		str := fmt.Sprintf("block %v is missing necessary coinbase "+
+			"outputs", block.Hash())
+		return ruleError(ErrFirstTxNotCoinbase, str)
+	}
+
+	// Only version 0 scripts are currently valid.
+	nullDataOut := block.MsgBlock().Transactions[0].TxOut[1]
+	if nullDataOut.Version != 0 {
+		str := fmt.Sprintf("block %v output 1 has wrong script version",
+			block.Hash())
+		return ruleError(ErrFirstTxNotCoinbase, str)
+	}
+
+	// The first 4 bytes of the null data output must be the encoded height
+	// of the block, so that every coinbase created has a unique transaction
+	// hash.
+	nullData, err := txscript.ExtractCoinbaseNullData(nullDataOut.PkScript)
+	if err != nil {
+		str := fmt.Sprintf("block %v output 1 has wrong script type",
+			block.Hash())
+		return ruleError(ErrFirstTxNotCoinbase, str)
+	}
+	if len(nullData) < 4 {
+		str := fmt.Sprintf("block %v output 1 data push too short to "+
+			"contain height", block.Hash())
+		return ruleError(ErrFirstTxNotCoinbase, str)
+	}
+
+	// Check the height and ensure it is correct.
+	cbHeight := binary.LittleEndian.Uint32(nullData[0:4])
+	if cbHeight != uint32(blockHeight) {
+		prevBlock := block.MsgBlock().Header.PrevBlock
+		str := fmt.Sprintf("block %v output 1 has wrong height in "+
+			"coinbase; want %v, got %v; prevBlock %v, header height %v",
+			block.Hash(), blockHeight, cbHeight, prevBlock,
+			block.MsgBlock().Header.Height)
+		return ruleError(ErrCoinbaseHeight, str)
 	}
 
 	return nil


### PR DESCRIPTION
**This requires #1465**.

This moves the `checkCoinbaseUniqueHeight` function from `accept.go` to `validate.go` where it more naturally belongs as it is a validation function.  This is also evidenced by only being called from validation functions as well.