### PR TITLE
rpcclient: support getchaintips RPC

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/decred/dcrd/mempool v1.0.1
 	github.com/decred/dcrd/mining v1.0.1
 	github.com/decred/dcrd/peer v1.1.0
-	github.com/decred/dcrd/rpcclient v1.0.1
+	github.com/decred/dcrd/rpcclient v1.0.2
 	github.com/decred/dcrd/txscript v1.0.1
 	github.com/decred/dcrd/wire v1.1.0
 	github.com/decred/slog v1.0.0


### PR DESCRIPTION
This adds support for the getchaintips node RPC to rpcclient,
adding asynchronous and blocking functions to rpcclient.Client.