### PR TITLE
blockchain: Reverse utxo set semantics.

### DIFF
--- a/blockchain/indexers/addrindex_test.go
+++ b/blockchain/indexers/addrindex_test.go
@@ -222,7 +222,7 @@ nextTest:
 		for i := 0; i < test.numInsert; i++ {
 			txLoc := wire.TxLoc{TxStart: i * 2}
 			err := dbPutAddrIndexEntry(populatedBucket, test.key,
-				uint32(i), txLoc)
+				uint32(i), txLoc, uint32(i%100))
 			if err != nil {
 				t.Errorf("dbPutAddrIndexEntry #%d (%s) - "+
 					"unexpected error: %v", testNum,

--- a/blockchain/internal/progresslog/blocklogger.go
+++ b/blockchain/internal/progresslog/blocklogger.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/decred/slog"
 
-	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -46,12 +45,9 @@ func NewBlockProgressLogger(progressMessage string, logger slog.Logger) *BlockPr
 func (b *BlockProgressLogger) LogBlockHeight(block, parent *wire.MsgBlock) {
 	b.Lock()
 	defer b.Unlock()
+
 	b.receivedLogBlocks++
-	regularTxTreeValid := dcrutil.IsFlagSet16(block.Header.VoteBits,
-		dcrutil.BlockValid)
-	if regularTxTreeValid {
-		b.receivedLogTx += int64(len(parent.Transactions))
-	}
+	b.receivedLogTx += int64(len(block.Transactions))
 	b.receivedLogTx += int64(len(block.STransactions))
 
 	now := time.Now()

--- a/blockchain/upgrade.go
+++ b/blockchain/upgrade.go
@@ -544,5 +544,11 @@ func upgradeDB(db database.DB, chainParams *chaincfg.Params, dbInfo *databaseInf
 	// quickly at startup on the block nodes in memory without requiring a
 	// database version bump.
 
+	// TODO(davec): Replace with proper upgrade code for utxo set semantics
+	// reversal and index updates.
+	if dbInfo.version == 4 {
+		return errors.New("Upgrade from version 4 database not supported yet")
+	}
+
 	return nil
 }

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -96,16 +96,6 @@ func TestBlockchainSpendJournal(t *testing.T) {
 	// Loop through all of the blocks and ensure the number of spent outputs
 	// matches up with the information loaded from the spend journal.
 	err = chain.db.View(func(dbTx database.Tx) error {
-		parentNode := chain.bestChain.NodeByHeight(1)
-		if parentNode == nil {
-			str := fmt.Sprintf("no block at height %d exists", 1)
-			return errNotInMainChain(str)
-		}
-		parent, err := dbFetchBlockByNode(dbTx, parentNode)
-		if err != nil {
-			return err
-		}
-
 		for i := int64(2); i <= chain.bestChain.Tip().height; i++ {
 			node := chain.bestChain.NodeByHeight(i)
 			if node == nil {
@@ -117,9 +107,8 @@ func TestBlockchainSpendJournal(t *testing.T) {
 				return err
 			}
 
-			ntx := countSpentOutputs(block, parent)
-			stxos, err := dbFetchSpendJournalEntry(dbTx, block,
-				parent)
+			ntx := countSpentOutputs(block)
+			stxos, err := dbFetchSpendJournalEntry(dbTx, block)
 			if err != nil {
 				return err
 			}
@@ -129,8 +118,6 @@ func TestBlockchainSpendJournal(t *testing.T) {
 					"calculated at "+"height %v, got %v "+
 					"expected %v", i, len(stxos), ntx)
 			}
-
-			parent = block
 		}
 
 		return nil

--- a/mining/mining.go
+++ b/mining/mining.go
@@ -78,8 +78,9 @@ type TxSource interface {
 	// pool.
 	VotesForBlocks(hashes []chainhash.Hash) [][]VoteDesc
 
-	// IsTxTreeKnownInvalid returns whether or not the transaction tree of
-	// the provided hash is known to be invalid according to the votes
-	// currently in the memory pool.
-	IsTxTreeKnownInvalid(hash *chainhash.Hash) bool
+	// IsRegTxTreeKnownDisapproved returns whether or not the regular
+	// transaction tree of the block represented by the provided hash is
+	// known to be disapproved according to the votes currently in the
+	// source pool.
+	IsRegTxTreeKnownDisapproved(hash *chainhash.Hash) bool
 }

--- a/server.go
+++ b/server.go
@@ -1150,7 +1150,7 @@ func (s *server) pushTxMsg(sp *serverPeer, hash *chainhash.Hash, doneChan chan<-
 	// Do not allow peers to request transactions already in a block
 	// but are unconfirmed, as they may be expensive. Restrict that
 	// to the authenticated RPC only.
-	tx, err := s.txMemPool.FetchTransaction(hash, false)
+	tx, err := s.txMemPool.FetchTransaction(hash)
 	if err != nil {
 		peerLog.Tracef("Unable to fetch tx %v from transaction "+
 			"pool: %v", hash, err)


### PR DESCRIPTION
## NOTE: This PR currently requires a full chain download. If you plan to test it, please make a copy of your existing data directory first.

---

### Testing Notes

This PR does not yet have database migration code and is completely incompatible with the current v4 database format.  Thus a full chain download is required.  dcrd will exit with error in the case you attempt to run it against an existing v4 database and the new database it creates will be v5, so if you try to run an older software version against the new database, you will get an error message similar to `Unable to start server on [:9108]: the current blockchain database is no longer compatible with this version of the software (5 > 4).`

The migration code will be added via a separate PR.

This is the biggest change to dcrd to date and, as such, will need a significant amount of testing and careful review.

---

This modifies the way the unspent transaction output set is handled to reverse its current semantics so that it is optimized for the typical case, provides simpler handling, and resolves various issues with the previous approach.  In addition, it updates the `transaction`, `address`, and `existsaddress` indexes to no longer remove entries from blocks that have been disapproved as, in all cases, the data still exists in the blockchain and thus should be queryable via the indexes even though there is special handling applied which treats them as if they did not exist in certain regards.

Prior to this change, transactions in the regular tree were not applied to the utxo set until the next block was processed and did not vote against them.  However, that approach has several undesirable consequences such as temporarily "invisible" utxos that are actually spendable, disapproved transactions missing from indexes even though they are still in the blockchain, and poor performance characteristics.

In a certain sense, the previous approach could be viewed as the transactions not being valid until they were approved, however, that is not really true because it was (and still is) perfectly acceptable to spend utxos created by transactions in the regular tree of the same block so long as they come before the transactions that spend them. Further, utxos from a transaction in the regular tree of a block can be spent in the next block so long as that block does not disapprove them, which further illustrates that the utxos are actually valid unless they are disapproved.

Consequently, this modifies that behavior to instead make the utxo set always track the most recent block and remove the regular transactions in the parent when a block votes against them.  This approach is significantly more efficient for the normal case where the previous block is not disapproved by its successor.

Also, the terminology is changed in several places to refer to disapproved blocks and transaction trees as opposed to invalid, because invalid implies the tree/block is malformed or does not follow the consensus rules.  On the contrary, when a block votes against its parent, it is only voting against regular transaction tree of the parent.  Both the block and transaction tree are still valid in that case, only the regular transaction tree is treated as if it never existed in terms of effects on the utxo set and duplicate transaction semantics.

High level overview of changes:
- Modify the utxo viewpoint to reverse semantics as previously described
  - Remove all code related to stake viewpoints
  - Change all block connection code in the viewpoint to first undo all
    transactions in the regular tree of the parent block if the current
    one disapproves it then connect all of the stake txns followed by
    the regular transactions in the block
    - NOTE: The order here is important since stake transactions are not
      allowed to spend outputs from the regular transactions in the same
      block as the next block might disapprove them
  - Change all block disconnection code in the viewpoint to first undo
    all the transactions in the regular and stake trees of the block
    being disconnected, and then resurrect the regular transactions in
    the parent block if the block being disconnected disapproved of it
  - Introduce a new type named `viewFilteredSet` for handling sets
    filtered by transactions that already exist in a view
  - Introduce a function on the viewpoint for specifically fetching the
    inputs to the regular transactions
  - Update `mempool` block connection and disconnection code to match the
    new semantics
  - Update all tests to handle the new semantics
- Modify the best state number of transactions to include all
  transactions in all blocks regardless of disapproval because they
  still had to be processed and still exist in the blockchain
- Remove include recent block parameter from `mempool.FetchTransaction`
  since the utxoset now always includes the latest block
  - This also has the side effect of correcting some unexpected results
    such as coinbases in the most recent block being incorrectly
    reported as having zero confirmations
- Modify `mempool` utxo fetch logic to use a cached disapproved view, when
  needed, rather than recreating the view for every new transaction
  added to it
- Update spend journal to include all transactions in the block instead
  of only stake transactions from the current block and regular
  transactions from the parent block
- Modify tx and address indexes to store the block index of each tx
  along with its location within the files and update the query
  functions to return the information as well
- Change the `tx`, `address`, and `existsaddress` indexes to index all
  transactions regardless of their disapproval
  - This also corrects several issues such as the inability to query and
    retrieve transactions that exist in a disapproved block
- Update all RPC commands that return verbose transaction information
  to set that newly available block index information properly
- Rename `IsRegTxTreeKnownDisapproved` in the `mining.TxSource` interface to
  `IsRegTxTreeKnownDisapproved`
  - NOTE: This will require a major bump to the mining module before
    the next release
- Rename several `utxoView` instances to `view` for consistency
- Rename several variables that dealt with disapproved trees from
  names that contained `Invalid` to ones that contain `Disapproved`

---

This is work towards #1145.
Fixes #618.