### PR TITLE
multi: Resurrect regression network.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1765,9 +1765,9 @@ func (b *BlockChain) BestSnapshot() *BestState {
 //
 // This function MUST be called with the chain state lock held (for reads).
 func (b *BlockChain) maxBlockSize(prevNode *blockNode) (int64, error) {
-	// Hard fork voting on block size is only enabled on testnet v1 and
-	// simnet.
-	if b.chainParams.Net != wire.SimNet {
+	// Hard fork voting on block size is only enabled on testnet v1 (removed
+	// from code), simnet, and regnet.
+	if b.chainParams.Net != wire.SimNet && b.chainParams.Net != wire.RegNet {
 		return int64(b.chainParams.MaximumBlockSizes[0]), nil
 	}
 

--- a/blockchain/difficulty.go
+++ b/blockchain/difficulty.go
@@ -883,9 +883,10 @@ func sdiffAlgoDeploymentVersion(network wire.CurrencyNet) uint32 {
 // This function MUST be called with the chain state lock held (for writes).
 func (b *BlockChain) calcNextRequiredStakeDifficulty(curNode *blockNode) (int64, error) {
 	// Consensus voting on the new stake difficulty algorithm is only
-	// enabled on mainnet, testnet v2, and simnet.
+	// enabled on mainnet, testnet v2 (removed from code), simnet, and
+	// regnet.
 	net := b.chainParams.Net
-	if net != wire.MainNet && net != wire.SimNet {
+	if net != wire.MainNet && net != wire.SimNet && net != wire.RegNet {
 		return b.calcNextRequiredStakeDifficultyV2(curNode)
 	}
 
@@ -1373,9 +1374,10 @@ func (b *BlockChain) estimateNextStakeDifficultyV2(curNode *blockNode, newTicket
 // This function MUST be called with the chain state lock held (for writes).
 func (b *BlockChain) estimateNextStakeDifficulty(curNode *blockNode, newTickets int64, useMaxTickets bool) (int64, error) {
 	// Consensus voting on the new stake difficulty algorithm is only
-	// enabled on mainnet, testnet v2, and simnet.
+	// enabled on mainnet, testnet v2 (removed from code), simnet, and
+	// regnet.
 	net := b.chainParams.Net
-	if net != wire.MainNet && net != wire.SimNet {
+	if net != wire.MainNet && net != wire.SimNet && net != wire.RegNet {
 		return b.calcNextRequiredStakeDifficultyV2(curNode)
 	}
 

--- a/blockchain/go.mod
+++ b/blockchain/go.mod
@@ -2,7 +2,7 @@ module github.com/decred/dcrd/blockchain
 
 require (
 	github.com/decred/dcrd/blockchain/stake v1.0.1
-	github.com/decred/dcrd/chaincfg v1.1.1
+	github.com/decred/dcrd/chaincfg v1.2.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
 	github.com/decred/dcrd/database v1.0.1
 	github.com/decred/dcrd/dcrec v0.0.0-20180801202239-0761de129164
@@ -12,7 +12,7 @@ require (
 	github.com/decred/dcrd/dcrutil v1.1.1
 	github.com/decred/dcrd/gcs v1.0.1
 	github.com/decred/dcrd/txscript v1.0.1
-	github.com/decred/dcrd/wire v1.1.0
+	github.com/decred/dcrd/wire v1.2.0
 	github.com/decred/slog v1.0.0
 )
 

--- a/blockchain/stakeversion_test.go
+++ b/blockchain/stakeversion_test.go
@@ -56,6 +56,12 @@ func TestCalcWantHeight(t *testing.T) {
 			multiplier: 10000,
 		},
 		{
+			name:       "regnet params",
+			skip:       chaincfg.RegNetParams.StakeValidationHeight,
+			interval:   chaincfg.RegNetParams.StakeVersionInterval,
+			multiplier: 10000,
+		},
+		{
 			name:       "negative mainnet params",
 			skip:       chaincfg.MainNetParams.StakeValidationHeight,
 			interval:   chaincfg.MainNetParams.StakeVersionInterval,

--- a/blockchain/thresholdstate.go
+++ b/blockchain/thresholdstate.go
@@ -604,9 +604,9 @@ func (b *BlockChain) ThresholdState(hash *chainhash.Hash, version uint32, deploy
 // This function MUST be called with the chain state lock held (for writes).
 func (b *BlockChain) isLNFeaturesAgendaActive(prevNode *blockNode) (bool, error) {
 	// Consensus voting on LN features is only enabled on mainnet, testnet
-	// v2, and simnet.
+	// v2 (removed from code), simnet, and regnet.
 	net := b.chainParams.Net
-	if net != wire.MainNet && net != wire.SimNet {
+	if net != wire.MainNet && net != wire.SimNet && net != wire.RegNet {
 		return true, nil
 	}
 

--- a/chaincfg/genesis.go
+++ b/chaincfg/genesis.go
@@ -159,7 +159,7 @@ var testNet3GenesisHash = testNet3GenesisBlock.BlockHash()
 
 // SimNet -------------------------------------------------------------------------
 
-var regTestGenesisCoinbaseTx = wire.MsgTx{
+var simNetGenesisCoinbaseTx = wire.MsgTx{
 	SerType: wire.TxSerializeFull,
 	Version: 1,
 	TxIn: []*wire.TxIn{
@@ -239,10 +239,54 @@ var simNetGenesisBlock = wire.MsgBlock{
 		StakeVersion: 0,
 		Height:       0,
 	},
-	Transactions:  []*wire.MsgTx{&regTestGenesisCoinbaseTx},
-	STransactions: []*wire.MsgTx{},
+	Transactions: []*wire.MsgTx{&simNetGenesisCoinbaseTx},
 }
 
 // simNetGenesisHash is the hash of the first block in the block chain for the
 // simulation test network.
 var simNetGenesisHash = simNetGenesisBlock.BlockHash()
+
+// RegNet -------------------------------------------------------------------------
+
+// regNetGenesisMerkleRoot is the hash of the first transaction in the genesis
+// block for the regression test network.  It is the same as the merkle root for
+// the main network.
+var regNetGenesisMerkleRoot = genesisMerkleRoot
+
+// regNetGenesisBlock defines the genesis block of the block chain which serves
+// as the public transaction ledger for the regression test network.
+var regNetGenesisBlock = wire.MsgBlock{
+	Header: wire.BlockHeader{
+		Version: 1,
+		PrevBlock: chainhash.Hash([chainhash.HashSize]byte{ // Make go vet happy.
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		}),
+		MerkleRoot: simNetGenesisMerkleRoot,
+		StakeRoot: chainhash.Hash([chainhash.HashSize]byte{ // Make go vet happy.
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		}),
+		VoteBits:     0,
+		FinalState:   [6]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+		Voters:       0,
+		FreshStake:   0,
+		Revocations:  0,
+		Timestamp:    time.Unix(1538524800, 0), // 2018-10-03 00:00:00 +0000 UTC
+		PoolSize:     0,
+		Bits:         0x207fffff, // 545259519 [7fffff0000000000000000000000000000000000000000000000000000000000]
+		SBits:        0,
+		Nonce:        0,
+		StakeVersion: 0,
+		Height:       0,
+	},
+	Transactions: []*wire.MsgTx{&genesisCoinbaseTx},
+}
+
+// regNetGenesisHash is the hash of the first block in the block chain for the
+// simulation test network.
+var regNetGenesisHash = regNetGenesisBlock.BlockHash()

--- a/chaincfg/genesis_test.go
+++ b/chaincfg/genesis_test.go
@@ -130,3 +130,42 @@ func TestSimNetGenesisBlock(t *testing.T) {
 			spew.Sdump(SimNetParams.GenesisHash))
 	}
 }
+
+// TestRegNetGenesisBlock tests the genesis block of the regression test network
+// for validity by checking the encoded bytes and hashes.
+func TestRegNetGenesisBlock(t *testing.T) {
+	// Encode the genesis block to raw bytes.
+	var buf bytes.Buffer
+	err := RegNetParams.GenesisBlock.Serialize(&buf)
+	if err != nil {
+		t.Fatalf("TestSimNetGenesisBlock: %v", err)
+	}
+
+	regNetGenesisBlockBytes, _ := hex.DecodeString("0100000000000000000" +
+		"000000000000000000000000000000000000000000000000000000dc101dfc" +
+		"3c6a2eb10ca0c5374e10d28feb53f7eabcc850511ceadb99174aa660000000" +
+		"00000000000000000000000000000000000000000000000000000000000000" +
+		"000000000000000000000000000ffff7f20000000000000000000000000000" +
+		"000008006b45b0000000000000000000000000000000000000000000000000" +
+		"00000000000000000000000000000000101000000010000000000000000000" +
+		"000000000000000000000000000000000000000000000ffffffff00fffffff" +
+		"f010000000000000000000020801679e98561ada96caec2949a5d41c4cab38" +
+		"51eb740d951c10ecbcf265c1fd9000000000000000001ffffffffffffffff0" +
+		"0000000ffffffff02000000")
+
+	// Ensure the encoded block matches the expected bytes.
+	if !bytes.Equal(buf.Bytes(), regNetGenesisBlockBytes) {
+		t.Fatalf("TestRegNetGenesisBlock: Genesis block does not "+
+			"appear valid - got %v, want %v",
+			spew.Sdump(buf.Bytes()),
+			spew.Sdump(regNetGenesisBlockBytes))
+	}
+
+	// Check hash of the block against expected hash.
+	hash := RegNetParams.GenesisBlock.BlockHash()
+	if !RegNetParams.GenesisHash.IsEqual(&hash) {
+		t.Fatalf("TestRegNetGenesisBlock: Genesis block hash does "+
+			"not appear valid - got %v, want %v", spew.Sdump(hash),
+			spew.Sdump(RegNetParams.GenesisHash))
+	}
+}

--- a/chaincfg/go.mod
+++ b/chaincfg/go.mod
@@ -3,7 +3,7 @@ module github.com/decred/dcrd/chaincfg
 require (
 	github.com/davecgh/go-spew v1.1.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
-	github.com/decred/dcrd/wire v1.1.0
+	github.com/decred/dcrd/wire v1.2.0
 )
 
 replace (

--- a/chaincfg/init.go
+++ b/chaincfg/init.go
@@ -145,7 +145,8 @@ func validateDeployments(deployments []ConsensusDeployment) (int, error) {
 }
 
 func validateAgendas() {
-	allParams := []*Params{&MainNetParams, &TestNet3Params, &SimNetParams}
+	allParams := []*Params{&MainNetParams, &TestNet3Params, &SimNetParams,
+		&RegNetParams}
 	for _, params := range allParams {
 		for version, deployments := range params.Deployments {
 			index, err := validateDeployments(deployments)

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -35,6 +35,10 @@ var (
 	// can have for the simulation test network.  It is the value 2^255 - 1.
 	simNetPowLimit = new(big.Int).Sub(new(big.Int).Lsh(bigOne, 255), bigOne)
 
+	// regNetPowLimit is the highest proof of work value a Decred block
+	// can have for the regression test network.  It is the value 2^255 - 1.
+	regNetPowLimit = new(big.Int).Sub(new(big.Int).Lsh(bigOne, 255), bigOne)
+
 	VoteBitsNotFound = fmt.Errorf("vote bits not found")
 )
 
@@ -654,4 +658,5 @@ func init() {
 	mustRegister(&MainNetParams)
 	mustRegister(&TestNet3Params)
 	mustRegister(&SimNetParams)
+	mustRegister(&RegNetParams)
 }

--- a/chaincfg/premine.go
+++ b/chaincfg/premine.go
@@ -3163,10 +3163,19 @@ var BlockOneLedgerTestNet3 = []*TokenPayout{
 }
 
 // BlockOneLedgerSimNet is the block one output ledger for the simulation
-// network. See under "Decred organization related parameters" in params.go
-// for information on how to spend these outputs.
+// network.  See "Decred organization related parameters" in simnetparams.go for
+// information on how to spend these outputs.
 var BlockOneLedgerSimNet = []*TokenPayout{
 	{"Sshw6S86G2bV6W32cbc7EhtFy8f93rU6pae", 100000 * 1e8},
 	{"SsjXRK6Xz6CFuBt6PugBvrkdAa4xGbcZ18w", 100000 * 1e8},
 	{"SsfXiYkYkCoo31CuVQw428N6wWKus2ZEw5X", 100000 * 1e8},
+}
+
+// BlockOneLedgerRegNet is the block one output ledger for the regression test
+// network.  See "Decred organization related parameters" in regnetparams.go for
+// information on how to spend these outputs.
+var BlockOneLedgerRegNet = []*TokenPayout{
+	{"RsKrWb7Vny1jnzL1sDLgKTAteh9RZcRr5g6", 100000 * 1e8},
+	{"Rs8ca5cDALtsMVD4PV3xvFTC7dmuU1juvLv", 100000 * 1e8},
+	{"RsHzbGt6YajuHpurtpqXXHz57LmYZK8w9tX", 100000 * 1e8},
 }

--- a/chaincfg/register_test.go
+++ b/chaincfg/register_test.go
@@ -66,6 +66,11 @@ func TestRegister(t *testing.T) {
 					params: &SimNetParams,
 					err:    ErrDuplicateNet,
 				},
+				{
+					name:   "duplicate regnet",
+					params: &RegNetParams,
+					err:    ErrDuplicateNet,
+				},
 			},
 			p2pkhMagics: []magicTest{
 				{
@@ -78,6 +83,10 @@ func TestRegister(t *testing.T) {
 				},
 				{
 					magic: SimNetParams.PubKeyHashAddrID,
+					valid: true,
+				},
+				{
+					magic: RegNetParams.PubKeyHashAddrID,
 					valid: true,
 				},
 				{
@@ -103,6 +112,10 @@ func TestRegister(t *testing.T) {
 					valid: true,
 				},
 				{
+					magic: RegNetParams.ScriptHashAddrID,
+					valid: true,
+				},
+				{
 					magic: mockNetParams.ScriptHashAddrID,
 					valid: false,
 				},
@@ -125,6 +138,11 @@ func TestRegister(t *testing.T) {
 				{
 					priv: SimNetParams.HDPrivateKeyID[:],
 					want: SimNetParams.HDPublicKeyID[:],
+					err:  nil,
+				},
+				{
+					priv: RegNetParams.HDPrivateKeyID[:],
+					want: RegNetParams.HDPublicKeyID[:],
 					err:  nil,
 				},
 				{
@@ -164,6 +182,10 @@ func TestRegister(t *testing.T) {
 					valid: true,
 				},
 				{
+					magic: RegNetParams.PubKeyHashAddrID,
+					valid: true,
+				},
+				{
 					magic: mockNetParams.PubKeyHashAddrID,
 					valid: true,
 				},
@@ -183,6 +205,10 @@ func TestRegister(t *testing.T) {
 				},
 				{
 					magic: SimNetParams.ScriptHashAddrID,
+					valid: true,
+				},
+				{
+					magic: RegNetParams.ScriptHashAddrID,
 					valid: true,
 				},
 				{
@@ -221,6 +247,11 @@ func TestRegister(t *testing.T) {
 					err:    ErrDuplicateNet,
 				},
 				{
+					name:   "duplicate regnet",
+					params: &RegNetParams,
+					err:    ErrDuplicateNet,
+				},
+				{
 					name:   "duplicate mocknet",
 					params: &mockNetParams,
 					err:    ErrDuplicateNet,
@@ -237,6 +268,10 @@ func TestRegister(t *testing.T) {
 				},
 				{
 					magic: SimNetParams.PubKeyHashAddrID,
+					valid: true,
+				},
+				{
+					magic: RegNetParams.PubKeyHashAddrID,
 					valid: true,
 				},
 				{
@@ -262,6 +297,10 @@ func TestRegister(t *testing.T) {
 					valid: true,
 				},
 				{
+					magic: RegNetParams.ScriptHashAddrID,
+					valid: true,
+				},
+				{
 					magic: mockNetParams.ScriptHashAddrID,
 					valid: true,
 				},
@@ -284,6 +323,11 @@ func TestRegister(t *testing.T) {
 				{
 					priv: SimNetParams.HDPrivateKeyID[:],
 					want: SimNetParams.HDPublicKeyID[:],
+					err:  nil,
+				},
+				{
+					priv: RegNetParams.HDPrivateKeyID[:],
+					want: RegNetParams.HDPublicKeyID[:],
 					err:  nil,
 				},
 				{

--- a/chaincfg/regnetparams.go
+++ b/chaincfg/regnetparams.go
@@ -1,5 +1,4 @@
-// Copyright (c) 2014-2016 The btcsuite developers
-// Copyright (c) 2015-2017 The Decred developers
+// Copyright (c) 2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -12,27 +11,26 @@ import (
 	"github.com/decred/dcrd/wire"
 )
 
-// SimNetParams defines the network parameters for the simulation test network.
-// This network is similar to the normal test network except it is intended for
-// private use within a group of individuals doing simulation testing and full
-// integration tests between different applications such as wallets, voting
-// service providers, mining pools, block explorers, and other services that
-// build on Decred.
+// RegNetParams defines the network parameters for the regression test network.
+// This should not be confused with the public test network or the simulation
+// test network.  The purpose of this network is primarily for unit tests and
+// RPC server tests.  On the other hand, the simulation test network is intended
+// for full integration tests between different applications such as wallets,
+// voting service providers, mining pools, block explorers, and other services
+// that build on Decred.
 //
-// The functionality is intended to differ in that the only nodes which are
-// specifically specified are used to create the network rather than following
-// normal discovery rules.  This is important as otherwise it would just turn
-// into another public testnet.
-var SimNetParams = Params{
-	Name:        "simnet",
-	Net:         wire.SimNet,
-	DefaultPort: "18555",
+// Since this network is only intended for unit testing, its values are subject
+// to change even if it would cause a hard fork.
+var RegNetParams = Params{
+	Name:        "regnet",
+	Net:         wire.RegNet,
+	DefaultPort: "18655",
 	DNSSeeds:    nil, // NOTE: There must NOT be any seeds.
 
 	// Chain parameters
-	GenesisBlock:             &simNetGenesisBlock,
-	GenesisHash:              &simNetGenesisHash,
-	PowLimit:                 simNetPowLimit,
+	GenesisBlock:             &regNetGenesisBlock,
+	GenesisHash:              &regNetGenesisHash,
+	PowLimit:                 regNetPowLimit,
 	PowLimitBits:             0x207fffff,
 	ReduceMinDifficulty:      false,
 	MinDiffReductionTime:     0, // Does not apply since ReduceMinDifficulty false
@@ -65,7 +63,7 @@ var SimNetParams = Params{
 	RuleChangeActivationQuorum:     160, // 10 % of RuleChangeActivationInterval * TicketsPerBlock
 	RuleChangeActivationMultiplier: 3,   // 75%
 	RuleChangeActivationDivisor:    4,
-	RuleChangeActivationInterval:   320, // 320 seconds
+	RuleChangeActivationInterval:   320, // Full ticket pool -- 320 seconds
 	Deployments: map[uint32][]ConsensusDeployment{
 		4: {{
 			Vote: Vote{
@@ -168,22 +166,22 @@ var SimNetParams = Params{
 	AcceptNonStdTxs: true,
 
 	// Address encoding magics
-	NetworkAddressPrefix: "S",
-	PubKeyAddrID:         [2]byte{0x27, 0x6f}, // starts with Sk
-	PubKeyHashAddrID:     [2]byte{0x0e, 0x91}, // starts with Ss
-	PKHEdwardsAddrID:     [2]byte{0x0e, 0x71}, // starts with Se
-	PKHSchnorrAddrID:     [2]byte{0x0e, 0x53}, // starts with SS
-	ScriptHashAddrID:     [2]byte{0x0e, 0x6c}, // starts with Sc
-	PrivateKeyID:         [2]byte{0x23, 0x07}, // starts with Ps
+	NetworkAddressPrefix: "R",
+	PubKeyAddrID:         [2]byte{0x25, 0xe5}, // starts with Rk
+	PubKeyHashAddrID:     [2]byte{0x0e, 0x00}, // starts with Rs
+	PKHEdwardsAddrID:     [2]byte{0x0d, 0xe0}, // starts with Re
+	PKHSchnorrAddrID:     [2]byte{0x0d, 0xc2}, // starts with RS
+	ScriptHashAddrID:     [2]byte{0x0d, 0xdb}, // starts with Rc
+	PrivateKeyID:         [2]byte{0x22, 0xfe}, // starts with Pr
 
 	// BIP32 hierarchical deterministic extended key magics
-	HDPrivateKeyID: [4]byte{0x04, 0x20, 0xb9, 0x03}, // starts with sprv
-	HDPublicKeyID:  [4]byte{0x04, 0x20, 0xbd, 0x3d}, // starts with spub
+	HDPrivateKeyID: [4]byte{0xea, 0xb4, 0x04, 0x48}, // starts with rprv
+	HDPublicKeyID:  [4]byte{0xea, 0xb4, 0xf9, 0x87}, // starts with rpub
 
 	// BIP44 coin type used in the hierarchical deterministic path for
 	// address generation.
-	SLIP0044CoinType: 1,   // SLIP0044, Testnet (all coins)
-	LegacyCoinType:   115, // ASCII for s, for backwards compatibility
+	SLIP0044CoinType: 1, // SLIP0044, Testnet (all coins)
+	LegacyCoinType:   1,
 
 	// Decred PoS parameters
 	MinimumStakeDiff:        20000,
@@ -201,7 +199,7 @@ var SimNetParams = Params{
 	MaxFreshStakePerBlock:   20,            // 4*TicketsPerBlock
 	StakeEnabledHeight:      16 + 16,       // CoinbaseMaturity + TicketMaturity
 	StakeValidationHeight:   16 + (64 * 2), // CoinbaseMaturity + TicketPoolSize*2
-	StakeBaseSigScript:      []byte{0xDE, 0xAD, 0xBE, 0xEF},
+	StakeBaseSigScript:      []byte{0x73, 0x57},
 	StakeMajorityMultiplier: 3,
 	StakeMajorityDivisor:    4,
 
@@ -219,22 +217,22 @@ var SimNetParams = Params{
 	// briefcase
 	// (seed 0x0000000000000000000000000000000000000000000000000000000000000000)
 	//
-	// This same wallet owns the three ledger outputs for simnet.
+	// This same wallet owns the three ledger outputs for regnet.
 	//
-	// P2SH details for simnet treasury:
+	// P2SH details for regnet treasury:
 	//
-	// redeemScript: 532103e8c60c7336744c8dcc7b85c27789950fc52aa4e48f895ebbfb
-	// ac383ab893fc4c2103ff9afc246e0921e37d12e17d8296ca06a8f92a07fbe7857ed1d4
-	// f0f5d94e988f21033ed09c7fa8b83ed53e6f2c57c5fa99ed2230c0d38edf53c0340d0f
-	// c2e79c725a53ae
+	// redeemScript: 53210323c1b9aa4facca85df363fb4abd5c52fe2af4746fbb5f99a6d
+	// cc2edb633fe2a62103c2d8a61a2800092ddaf04ba30dfc7cf1ab4130ac1d2398ba15fc
+	// 795b11bc690621035fe97a7b2d6b98242f4bfc33d86a564158b44634b93cdefa155909
+	// 5d4bf6167853ae
 	//   (3-of-3 multisig)
 	// Pubkeys used:
-	//   SkQmxbeuEFDByPoTj41TtXat8tWySVuYUQpd4fuNNyUx51tF1csSs
-	//   SkQn8ervNvAUEX5Ua3Lwjc6BAuTXRznDoDzsyxgjYqX58znY7w9e4
-	//   SkQkfkHZeBbMW8129tZ3KspEh1XBFC1btbkgzs6cjSyPbrgxzsKqk
+	//   Rk8J2ZY5CkDLaBbAYqU7fb1Tr6nSwEACJ1j2oWAwuFZ26PyPeMXiB
+	//   Rk8KEdGMGJiF27CZ8rw2gDPD7MkVGSPjHinXjtTZhoH8ZQ6UhJvhV
+	//   Rk8JV484ePPX6vWZCfBX2Scme5XriXhzwmyaKSYQT64HTbkkfyzL3
 	//
-	// Organization address is ScuQxvveKGfpG1ypt6u27F99Anf7EW3cqhq
-	OrganizationPkScript:        hexDecode("a914cbb08d6ca783b533b2c7d24a51fbca92d937bf9987"),
+	// Organization address is RcQR65gasxuzf7mUeBXeAux6Z37joPuUwUN
+	OrganizationPkScript:        hexDecode("a9146913bcc838bd0087fb3f6b3c868423d5e300078d87"),
 	OrganizationPkScriptVersion: 0,
-	BlockOneLedger:              BlockOneLedgerSimNet,
+	BlockOneLedger:              BlockOneLedgerRegNet,
 }

--- a/dcrutil/address.go
+++ b/dcrutil/address.go
@@ -213,6 +213,8 @@ func detectNetworkForAddress(addr string) (*chaincfg.Params, error) {
 		return &chaincfg.TestNet3Params, nil
 	case chaincfg.SimNetParams.NetworkAddressPrefix:
 		return &chaincfg.SimNetParams, nil
+	case chaincfg.RegNetParams.NetworkAddressPrefix:
+		return &chaincfg.RegNetParams, nil
 	}
 
 	return nil, fmt.Errorf("unknown network type in string encoded address")

--- a/dcrutil/go.mod
+++ b/dcrutil/go.mod
@@ -3,12 +3,12 @@ module github.com/decred/dcrd/dcrutil
 require (
 	github.com/davecgh/go-spew v1.1.0
 	github.com/decred/base58 v1.0.0
-	github.com/decred/dcrd/chaincfg v1.1.1
+	github.com/decred/dcrd/chaincfg v1.2.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
 	github.com/decred/dcrd/dcrec v0.0.0-20180721005212-59fe2b293f69
 	github.com/decred/dcrd/dcrec/edwards v0.0.0-20180721005212-59fe2b293f69
 	github.com/decred/dcrd/dcrec/secp256k1 v1.0.0
-	github.com/decred/dcrd/wire v1.1.0
+	github.com/decred/dcrd/wire v1.2.0
 	golang.org/x/crypto v0.0.0-20180718160520-a2144134853f
 )
 

--- a/dcrutil/wif_test.go
+++ b/dcrutil/wif_test.go
@@ -77,6 +77,10 @@ func TestEncodeDecodeWIF(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		wif4, err := NewWIF(priv2, &chaincfg.RegNetParams, suite)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		var tests []struct {
 			wif     *WIF
@@ -101,6 +105,10 @@ func TestEncodeDecodeWIF(t *testing.T) {
 					wif3,
 					"PsURoUb7FMeJQdTYea8pkbUQFBZAsxtfDcfTLGja5sCLZvLZWRtjK",
 				},
+				{
+					wif4,
+					"Pr9D8L8s9nG4AroRjbTGiRuYrweN1T8Dg9grAEeTEStZAPMnjxwCT",
+				},
 			}
 		case dcrec.STEd25519:
 			tests = []struct {
@@ -119,6 +127,10 @@ func TestEncodeDecodeWIF(t *testing.T) {
 					wif3,
 					"PsUSAB97uSWqSr4jsnQNJMRC2Y33iD7FDymZuss9rM6PExexSPyTQ",
 				},
+				{
+					wif4,
+					"Pr9DV2gsos8bD5QcxoipGBrLeJ8EqhLogWnxjqn2zvnbqRg9fZMHs",
+				},
 			}
 		case dcrec.STSchnorrSecp256k1:
 			tests = []struct {
@@ -136,6 +148,10 @@ func TestEncodeDecodeWIF(t *testing.T) {
 				{
 					wif3,
 					"PsUVgxwa9RM9m5jBoywyzbP3SjPQ7QC4uNEjUVDsTfBeahKkmETvQ",
+				},
+				{
+					wif4,
+					"Pr9H1pVL3qxuXK54u1GRxRpC4VUbEtRdMuG8JT8kcEssBALyTRM7v",
 				},
 			}
 		}

--- a/doc.go
+++ b/doc.go
@@ -74,6 +74,7 @@ Application Options:
                             credentials for each connection.
       --testnet             Use the test network
       --simnet              Use the simulation test network
+      --regnet              Use the regression test network
       --nocheckpoints       Disable built-in checkpoints.  Don't do this unless
                             you know what you're doing.
       --dbtype=             Database backend to use for the Block Chain (ffldb)

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/decred/dcrd/blockchain v1.1.0
 	github.com/decred/dcrd/blockchain/stake v1.0.2
 	github.com/decred/dcrd/certgen v1.0.1
-	github.com/decred/dcrd/chaincfg v1.1.1
+	github.com/decred/dcrd/chaincfg v1.2.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
 	github.com/decred/dcrd/connmgr v1.0.1
 	github.com/decred/dcrd/database v1.0.2
@@ -22,15 +22,15 @@ require (
 	github.com/decred/dcrd/dcrec/edwards v0.0.0-20180808153611-f0e65ec62f91 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1 v1.0.0
 	github.com/decred/dcrd/dcrjson v1.0.0
-	github.com/decred/dcrd/dcrutil v1.1.1
+	github.com/decred/dcrd/dcrutil v1.2.0
 	github.com/decred/dcrd/gcs v1.0.2
-	github.com/decred/dcrd/hdkeychain v1.1.0
+	github.com/decred/dcrd/hdkeychain v1.1.1
 	github.com/decred/dcrd/mempool v1.0.1
 	github.com/decred/dcrd/mining v1.0.1
 	github.com/decred/dcrd/peer v1.1.0
 	github.com/decred/dcrd/rpcclient v1.0.2
 	github.com/decred/dcrd/txscript v1.0.1
-	github.com/decred/dcrd/wire v1.1.0
+	github.com/decred/dcrd/wire v1.2.0
 	github.com/decred/slog v1.0.0
 	github.com/gorilla/websocket v1.2.0
 	github.com/jessevdk/go-flags v1.4.0

--- a/hdkeychain/extendedkey_test.go
+++ b/hdkeychain/extendedkey_test.go
@@ -670,6 +670,24 @@ func TestNet(t *testing.T) {
 			newPub:    "dpubZ9169KDAEUnyoTzA7pDGtXbxpji5LuUk8johUPVGY2CDsz6S7hahGNL6QmyavE5fgonsepiACAa7FQPsCDeLFnoSSAGiQEQhimBGGK84nye",
 			isPrivate: true,
 		},
+		{
+			name:      "mainnet -> regnet",
+			key:       "dprv3hCznBesA6jBu46PsJ9vNJoiCj9ouxtfwCBNjUYuXwbbAS4oEkF6Bnp5G3QbBAjRXy4uWWZYmC5Y71s3ovCyPLrCjEkYGPErrueuPPjvNWh",
+			origNet:   &chaincfg.MainNetParams,
+			newNet:    &chaincfg.RegNetParams,
+			newPriv:   "rprv13NkrLvVJ4gKz3hZF4PR7Ck9pg4NZmcg26Mwq9Z6qp6WCdmoCNFUShNWMhod4dDSu3Bk9WxPf5kchK9VXFjiByNvB6RvcAAsexFdRHQN6zR6",
+			newPub:    "rpub18c3kpu3apJ4HgHn6KjxKQ19dAkDxeq7swTnWdWnxPtfEMguYAcP8aT5bgHPrQFJ9DT53H11YDsU4aA2NcjpXgMgqZgoGESmc9tw2j6E4jnG",
+			isPrivate: true,
+		},
+		{
+			name:      "regnet -> mainnet",
+			key:       "rprv13NkrLvVJ4gKz3hZF4PR7Ck9pg4NZmcg26Mwq9Z6qp6WCdmoCNFUShNWMhod4dDSu3Bk9WxPf5kchK9VXFjiByNvB6RvcAAsexFdRHQN6zR6",
+			origNet:   &chaincfg.RegNetParams,
+			newNet:    &chaincfg.MainNetParams,
+			newPriv:   "dprv3hCznBesA6jBu46PsJ9vNJoiCj9ouxtfwCBNjUYuXwbbAS4oEkF6Bnp5G3QbBAjRXy4uWWZYmC5Y71s3ovCyPLrCjEkYGPErrueuPPjvNWh",
+			newPub:    "dpubZ9169KDAEUnyoTzA7pDGtXbxpji5LuUk8johUPVGY2CDsz6S7hahGNL6QmyavE5fgonsepiACAa7FQPsCDeLFnoSSAGiQEQhimBGGK84nye",
+			isPrivate: true,
+		},
 
 		// Public extended keys.
 		{
@@ -684,6 +702,22 @@ func TestNet(t *testing.T) {
 			name:      "simnet -> mainnet",
 			key:       "spubVNx6fk6e22GL2diV1D6RmVDdDJ4tmitfkERbwnNyzBD8fha1a4PELZEeNoUfNofdyJS2Y19tFgHZQ62tzKwELiBA3xVeZowLr4DJQ7xGuao",
 			origNet:   &chaincfg.SimNetParams,
+			newNet:    &chaincfg.MainNetParams,
+			newPub:    "dpubZ9169KDAEUnyoTzA7pDGtXbxpji5LuUk8johUPVGY2CDsz6S7hahGNL6QmyavE5fgonsepiACAa7FQPsCDeLFnoSSAGiQEQhimBGGK84nye",
+			isPrivate: false,
+		},
+		{
+			name:      "mainnet -> regnet",
+			key:       "dpubZ9169KDAEUnyoTzA7pDGtXbxpji5LuUk8johUPVGY2CDsz6S7hahGNL6QmyavE5fgonsepiACAa7FQPsCDeLFnoSSAGiQEQhimBGGK84nye",
+			origNet:   &chaincfg.MainNetParams,
+			newNet:    &chaincfg.RegNetParams,
+			newPub:    "rpub18c3kpu3apJ4HgHn6KjxKQ19dAkDxeq7swTnWdWnxPtfEMguYAcP8aT5bgHPrQFJ9DT53H11YDsU4aA2NcjpXgMgqZgoGESmc9tw2j6E4jnG",
+			isPrivate: false,
+		},
+		{
+			name:      "regnet -> mainnet",
+			key:       "rpub18c3kpu3apJ4HgHn6KjxKQ19dAkDxeq7swTnWdWnxPtfEMguYAcP8aT5bgHPrQFJ9DT53H11YDsU4aA2NcjpXgMgqZgoGESmc9tw2j6E4jnG",
+			origNet:   &chaincfg.RegNetParams,
 			newNet:    &chaincfg.MainNetParams,
 			newPub:    "dpubZ9169KDAEUnyoTzA7pDGtXbxpji5LuUk8johUPVGY2CDsz6S7hahGNL6QmyavE5fgonsepiACAa7FQPsCDeLFnoSSAGiQEQhimBGGK84nye",
 			isPrivate: false,

--- a/hdkeychain/go.mod
+++ b/hdkeychain/go.mod
@@ -2,7 +2,7 @@ module github.com/decred/dcrd/hdkeychain
 
 require (
 	github.com/decred/base58 v1.0.0
-	github.com/decred/dcrd/chaincfg v1.1.1
+	github.com/decred/dcrd/chaincfg v1.2.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
 	github.com/decred/dcrd/dcrec v0.0.0-20180721005914-d26200ec716b
 	github.com/decred/dcrd/dcrec/secp256k1 v1.0.0

--- a/networkparams_test.go
+++ b/networkparams_test.go
@@ -128,12 +128,15 @@ func TestDecredNetworkSettings(t *testing.T) {
 	checkPowLimitsAreConsistent(t, &chaincfg.MainNetParams)
 	checkPowLimitsAreConsistent(t, &chaincfg.TestNet3Params)
 	checkPowLimitsAreConsistent(t, &chaincfg.SimNetParams)
+	checkPowLimitsAreConsistent(t, &chaincfg.RegNetParams)
 
 	checkGenesisBlockRespectsNetworkPowLimit(t, &chaincfg.MainNetParams)
 	checkGenesisBlockRespectsNetworkPowLimit(t, &chaincfg.TestNet3Params)
 	checkGenesisBlockRespectsNetworkPowLimit(t, &chaincfg.SimNetParams)
+	checkGenesisBlockRespectsNetworkPowLimit(t, &chaincfg.RegNetParams)
 
 	checkAddressPrefixesAreConsistent(t, "Pm", &chaincfg.MainNetParams)
 	checkAddressPrefixesAreConsistent(t, "Pt", &chaincfg.TestNet3Params)
 	checkAddressPrefixesAreConsistent(t, "Ps", &chaincfg.SimNetParams)
+	checkAddressPrefixesAreConsistent(t, "Pr", &chaincfg.RegNetParams)
 }

--- a/params.go
+++ b/params.go
@@ -44,3 +44,10 @@ var simNetParams = params{
 	Params:  &chaincfg.SimNetParams,
 	rpcPort: "19556",
 }
+
+// regNetParams contains parameters specific to the regression test
+// network (wire.RegNet).
+var regNetParams = params{
+	Params:  &chaincfg.RegNetParams,
+	rpcPort: "18656",
+}

--- a/rpctest/rpc_harness.go
+++ b/rpctest/rpc_harness.go
@@ -113,6 +113,8 @@ func New(activeNet *chaincfg.Params, handlers *rpcclient.NotificationHandlers, e
 		extraArgs = append(extraArgs, "--testnet")
 	case wire.SimNet:
 		extraArgs = append(extraArgs, "--simnet")
+	case wire.RegNet:
+		extraArgs = append(extraArgs, "--regnet")
 	default:
 		return nil, fmt.Errorf("rpctest.New must be called with one " +
 			"of the supported chain networks")

--- a/wire/doc.go
+++ b/wire/doc.go
@@ -85,8 +85,9 @@ message and which Decred network the message applies to.  This package provides
 the following constants:
 
 	wire.MainNet
-	wire.TestNet (Test network version 3)
+	wire.TestNet3 (Test network version 3)
 	wire.SimNet   (Simulation test network)
+	wire.RegNet   (Regression test network)
 
 Determining Message Type
 

--- a/wire/protocol.go
+++ b/wire/protocol.go
@@ -108,8 +108,14 @@ const (
 	// MainNet represents the main Decred network.
 	MainNet CurrencyNet = 0xd9b400f9
 
+	// RegNet represents the regression test network.
+	RegNet CurrencyNet = 0xdab500fa
+
 	// RegTest represents the regression test network.
-	RegTest CurrencyNet = 0xdab500fa
+	//
+	// DEPRECATED.  This will be removed in the next major version bump.
+	// Use Regnet instead.
+	RegTest CurrencyNet = RegNet
 
 	// TestNet3 represents the 3rd test network.
 	TestNet3 CurrencyNet = 0xb194aa75
@@ -123,7 +129,7 @@ const (
 var bnStrings = map[CurrencyNet]string{
 	MainNet:  "MainNet",
 	TestNet3: "TestNet3",
-	RegTest:  "RegNet",
+	RegNet:   "RegNet",
 	SimNet:   "SimNet",
 }
 


### PR DESCRIPTION
This resurrects the regression test network that was removed before initial launch although it really should not have been.  The simulation test network and the regression test network do not serve the same purpose.  Specifically, the regression test network is intended for unit tests, RPC server tests, and consensus tests.  On the other hand, the simulation test network is intended for private use within a group of individuals doing simulation testing and full integration tests between different applications such as wallets, voting service providers, mining pools, block explorers, and other services that build on Decred.

Keeping the concerns separate will allow the simulation test network to be modified in ways such as activating consensus changes that have been successfully voted into `mainnet` without also needing to vote them in on the simulation test network while still preserving the ability for the unit tests to properly test the voting semantics and handling to help prevent regressions.

In addition to resurrecting the regression test network, this also fully fleshes out new values for the various addresses prefixes (`Rk`, `Rs`, `Re`, etc), HD key prefixes (`rprv`, `rpub`), and treasury multisig details.

As a part of resurrecting the network, a new CLI flag `--regnet` is added to allow the RPC test harness connect to a running instance, the areas of the code which involve votes have been modified to allow the
votes to apply to the new network, and tests have been added to the relevant modules.

This bumps the affected module versions as follows:

- github.com/decred/dcrd/wire@v1.2.0
- github.com/decred/dcrd/chaincfg@v1.2.0
- github.com/decred/dcrd/dcrutil@v1.2.0
- github.com/decred/dcrd/hdkeychain@v1.1.1

The `blockchain` module is also affected, but since its version has already been bumped since the last release tag, it is not bumped again.

Finally, this does not include switching unit tests or the RPC test harness over the new network since that will be done in a separate commit.