### PR TITLE
multi: Latest consensus active from simnet genesis.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1766,8 +1766,8 @@ func (b *BlockChain) BestSnapshot() *BestState {
 // This function MUST be called with the chain state lock held (for reads).
 func (b *BlockChain) maxBlockSize(prevNode *blockNode) (int64, error) {
 	// Hard fork voting on block size is only enabled on testnet v1 (removed
-	// from code), simnet, and regnet.
-	if b.chainParams.Net != wire.SimNet && b.chainParams.Net != wire.RegNet {
+	// from code) and regnet.
+	if b.chainParams.Net != wire.RegNet {
 		return int64(b.chainParams.MaximumBlockSizes[0]), nil
 	}
 

--- a/blockchain/difficulty.go
+++ b/blockchain/difficulty.go
@@ -883,10 +883,9 @@ func sdiffAlgoDeploymentVersion(network wire.CurrencyNet) uint32 {
 // This function MUST be called with the chain state lock held (for writes).
 func (b *BlockChain) calcNextRequiredStakeDifficulty(curNode *blockNode) (int64, error) {
 	// Consensus voting on the new stake difficulty algorithm is only
-	// enabled on mainnet, testnet v2 (removed from code), simnet, and
-	// regnet.
+	// enabled on mainnet, testnet v2 (removed from code), and regnet.
 	net := b.chainParams.Net
-	if net != wire.MainNet && net != wire.SimNet && net != wire.RegNet {
+	if net != wire.MainNet && net != wire.RegNet {
 		return b.calcNextRequiredStakeDifficultyV2(curNode)
 	}
 
@@ -1374,10 +1373,9 @@ func (b *BlockChain) estimateNextStakeDifficultyV2(curNode *blockNode, newTicket
 // This function MUST be called with the chain state lock held (for writes).
 func (b *BlockChain) estimateNextStakeDifficulty(curNode *blockNode, newTickets int64, useMaxTickets bool) (int64, error) {
 	// Consensus voting on the new stake difficulty algorithm is only
-	// enabled on mainnet, testnet v2 (removed from code), simnet, and
-	// regnet.
+	// enabled on mainnet, testnet v2 (removed from code), and regnet.
 	net := b.chainParams.Net
-	if net != wire.MainNet && net != wire.SimNet && net != wire.RegNet {
+	if net != wire.MainNet && net != wire.RegNet {
 		return b.calcNextRequiredStakeDifficultyV2(curNode)
 	}
 

--- a/blockchain/thresholdstate.go
+++ b/blockchain/thresholdstate.go
@@ -604,9 +604,9 @@ func (b *BlockChain) ThresholdState(hash *chainhash.Hash, version uint32, deploy
 // This function MUST be called with the chain state lock held (for writes).
 func (b *BlockChain) isLNFeaturesAgendaActive(prevNode *blockNode) (bool, error) {
 	// Consensus voting on LN features is only enabled on mainnet, testnet
-	// v2 (removed from code), simnet, and regnet.
+	// v2 (removed from code), and regnet.
 	net := b.chainParams.Net
-	if net != wire.MainNet && net != wire.SimNet && net != wire.RegNet {
+	if net != wire.MainNet && net != wire.RegNet {
 		return true, nil
 	}
 

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -1005,8 +1005,7 @@ func (b *BlockChain) checkBlockHeaderContext(header *wire.BlockHeader, prevNode 
 		// Reject version 5 blocks for networks other than the main
 		// network once a majority of the network has upgraded.
 		if b.chainParams.Net != wire.MainNet && header.Version < 6 &&
-			b.isMajorityVersion(6, prevNode,
-				b.chainParams.BlockRejectNumRequired) {
+			b.isMajorityVersion(6, prevNode, b.chainParams.BlockRejectNumRequired) {
 
 			str := "new blocks with version %d are no longer valid"
 			str = fmt.Sprintf(str, header.Version)

--- a/chaincfg/simnetparams.go
+++ b/chaincfg/simnetparams.go
@@ -6,7 +6,6 @@
 package chaincfg
 
 import (
-	"math"
 	"time"
 
 	"github.com/decred/dcrd/wire"
@@ -37,7 +36,7 @@ var SimNetParams = Params{
 	ReduceMinDifficulty:      false,
 	MinDiffReductionTime:     0, // Does not apply since ReduceMinDifficulty false
 	GenerateSupported:        true,
-	MaximumBlockSizes:        []int{1000000, 1310720},
+	MaximumBlockSizes:        []int{1310720},
 	MaxTxSize:                1000000,
 	TargetTimePerBlock:       time.Second,
 	WorkDiffAlpha:            1,
@@ -66,92 +65,6 @@ var SimNetParams = Params{
 	RuleChangeActivationMultiplier: 3,   // 75%
 	RuleChangeActivationDivisor:    4,
 	RuleChangeActivationInterval:   320, // 320 seconds
-	Deployments: map[uint32][]ConsensusDeployment{
-		4: {{
-			Vote: Vote{
-				Id:          VoteIDMaxBlockSize,
-				Description: "Change maximum allowed block size from 1MiB to 1.25MB",
-				Mask:        0x0006, // Bits 1 and 2
-				Choices: []Choice{{
-					Id:          "abstain",
-					Description: "abstain voting for change",
-					Bits:        0x0000,
-					IsAbstain:   true,
-					IsNo:        false,
-				}, {
-					Id:          "no",
-					Description: "reject changing max allowed block size",
-					Bits:        0x0002, // Bit 1
-					IsAbstain:   false,
-					IsNo:        true,
-				}, {
-					Id:          "yes",
-					Description: "accept changing max allowed block size",
-					Bits:        0x0004, // Bit 2
-					IsAbstain:   false,
-					IsNo:        false,
-				}},
-			},
-			StartTime:  0,             // Always available for vote
-			ExpireTime: math.MaxInt64, // Never expires
-		}},
-		5: {{
-			Vote: Vote{
-				Id:          VoteIDSDiffAlgorithm,
-				Description: "Change stake difficulty algorithm as defined in DCP0001",
-				Mask:        0x0006, // Bits 1 and 2
-				Choices: []Choice{{
-					Id:          "abstain",
-					Description: "abstain voting for change",
-					Bits:        0x0000,
-					IsAbstain:   true,
-					IsNo:        false,
-				}, {
-					Id:          "no",
-					Description: "keep the existing algorithm",
-					Bits:        0x0002, // Bit 1
-					IsAbstain:   false,
-					IsNo:        true,
-				}, {
-					Id:          "yes",
-					Description: "change to the new algorithm",
-					Bits:        0x0004, // Bit 2
-					IsAbstain:   false,
-					IsNo:        false,
-				}},
-			},
-			StartTime:  0,             // Always available for vote
-			ExpireTime: math.MaxInt64, // Never expires
-		}},
-		6: {{
-			Vote: Vote{
-				Id:          VoteIDLNFeatures,
-				Description: "Enable features defined in DCP0002 and DCP0003 necessary to support Lightning Network (LN)",
-				Mask:        0x0006, // Bits 1 and 2
-				Choices: []Choice{{
-					Id:          "abstain",
-					Description: "abstain voting for change",
-					Bits:        0x0000,
-					IsAbstain:   true,
-					IsNo:        false,
-				}, {
-					Id:          "no",
-					Description: "keep the existing consensus rules",
-					Bits:        0x0002, // Bit 1
-					IsAbstain:   false,
-					IsNo:        true,
-				}, {
-					Id:          "yes",
-					Description: "change to the new consensus rules",
-					Bits:        0x0004, // Bit 2
-					IsAbstain:   false,
-					IsNo:        false,
-				}},
-			},
-			StartTime:  0,             // Always available for vote
-			ExpireTime: math.MaxInt64, // Never expires
-		}},
-	},
 
 	// Enforce current block version once majority of the network has
 	// upgraded.

--- a/mining.go
+++ b/mining.go
@@ -33,7 +33,7 @@ const (
 	generatedBlockVersion = 5
 
 	// generatedBlockVersionTest is the version of the block being generated
-	// for networks other than the main network.
+	// for networks other than the main and simulation networks.
 	generatedBlockVersionTest = 6
 
 	// blockHeaderOverhead is the max number of bytes it takes to serialize
@@ -1950,7 +1950,7 @@ mempoolLoop:
 
 	// Choose the block version to generate based on the network.
 	blockVersion := int32(generatedBlockVersion)
-	if g.chainParams.Net != wire.MainNet {
+	if g.chainParams.Net != wire.MainNet && g.chainParams.Net != wire.SimNet {
 		blockVersion = generatedBlockVersionTest
 	}
 


### PR DESCRIPTION
**This requires PRs #1480 and #1481**.

This modifies `simnet` to include the latest consensus changes that have been successfully voted into mainnet to date starting from its genesis block.  This means it is no longer necessary to vote those changes in to `simnet` first before making use of them.

The changes entail removing the deployment entries for those votes, updating the mining templates to start from version 5, which matches the current `mainnet` version, and modifying the various sections in `blockchain` which make decisions accordingly.

The `chaincfg` and `blockchain` modules are affected, but since their version has already been bumped since their last release tags, they are not bumped again.
