### PR TITLE
build: Support MacOS sed for obtaining module list.

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -46,7 +46,7 @@ testrepo () {
   ROOTPATH=$($GO list -m -f {{.Dir}} 2>/dev/null)
   ROOTPATHPATTERN=$(echo $ROOTPATH | sed 's/\\/\\\\/g' | sed 's/\//\\\//g')
   MODPATHS=$($GO list -m -f {{.Dir}} all 2>/dev/null | grep "^$ROOTPATHPATTERN"\
-    | sed -e "s/^$ROOTPATHPATTERN//" -e 's/^\\\|\///')
+    | sed -e "s/^$ROOTPATHPATTERN//" -e 's/^\\//' -e 's/^\///')
   MODPATHS=". $MODPATHS"
   for module in $MODPATHS; do
     echo "==> ${module}"


### PR DESCRIPTION
This modifies the code in `run_tests.sh` which obtains the stripped list of modules to test based on the output of the go list command to work with MacOS as well.  It seems that `sed` on MacOS does not like the "or" regexp syntax, so this modifies it to perform each branch separately.