### PR TITLE
chaingen/fullblocktests: Add disapproval tests.

### DIFF
--- a/blockchain/chaingen/generator.go
+++ b/blockchain/chaingen/generator.go
@@ -2597,3 +2597,12 @@ func (g *Generator) AssertTipNumRevocations(expected uint8) {
 			g.tip.Header.Height, numRevocations, expected))
 	}
 }
+
+// AssertTipDisapprovesPrevious panics if the current tip block associated with
+// the generator does not disapprove the previous block.
+func (g *Generator) AssertTipDisapprovesPrevious() {
+	if g.tip.Header.VoteBits&voteBitYes == 1 {
+		panic(fmt.Sprintf("block %q (height %d) does not disapprove prev block",
+			g.tipName, g.tip.Header.Height))
+	}
+}

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -779,7 +779,7 @@ func dbFetchSpendJournalEntry(dbTx database.Tx, block *dcrutil.Block, parent *dc
 	blockTxns = append(blockTxns, block.MsgBlock().STransactions...)
 
 	if len(blockTxns) > 0 && len(serialized) == 0 {
-		return nil, AssertError("missing spend journal data")
+		panicf("missing spend journal data for %s", block.Hash())
 	}
 
 	stxos, err := deserializeSpendJournalEntry(serialized, blockTxns)


### PR DESCRIPTION
**This requires PR #1484**.

This adds some tests to ensure blocks that disapprove the regular transaction tree of the parent as follows:

- Attempt to spend an output from a disapproved tree in the block that disapproves it is rejected
- Reorg to a side chain that contains two consecutive blocks that disapprove their parents is accepted without error
- Reorg back to the original chain which causes the disapproving blocks to be removed is accepted without error

 While here, it adds a new function named `AssertTipDisapprovesPrevious` which, as its name suggests, allows the caller to assert the vote bits in the header disapprove of the previous block.
