### PR TITLE
docs: Use unix line ending in mod hierarchy gv.

### DIFF
--- a/docs/assets/module_hierarchy.gv
+++ b/docs/assets/module_hierarchy.gv
@@ -28,8 +28,8 @@ digraph {
 	{rank=same connmgr addrmgr hdkeychain peer rpcclient mempool}
 
 	certgen
- 	chainhash -> dcrjson [dir=back color=aquamarine]
- 	chainhash -> wire [dir=back color=aquamarine]
+	chainhash -> dcrjson [dir=back color=aquamarine]
+	chainhash -> wire [dir=back color=aquamarine]
 	wire -> addrmgr [dir=back color=coral]
 	wire -> chaincfg [dir=back color=coral]
 	chaincfg -> connmgr [dir=back color=cadetblue]


### PR DESCRIPTION
This converts the module hierarchy graphviz file to use unix line endings so it is consistent with the rest of the code in the repository.