### PR TITLE
multi: Cleanup recent alt DNS names additions.

### DIFF
--- a/config.go
+++ b/config.go
@@ -70,7 +70,7 @@ var (
 	defaultRPCKeyFile  = filepath.Join(defaultHomeDir, "rpc.key")
 	defaultRPCCertFile = filepath.Join(defaultHomeDir, "rpc.cert")
 	defaultLogDir      = filepath.Join(defaultHomeDir, defaultLogDirname)
-	defaultAltDNSNames = []string{}
+	defaultAltDNSNames = []string(nil)
 )
 
 // runServiceCommand is only set to a real function on Windows.  It is used

--- a/config_test.go
+++ b/config_test.go
@@ -6,63 +6,76 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
 )
 
-// in order to test command line arguments and environment variables
-// you will need to append the flags to the os.Args variable like so
-// os.Args = append(os.Args, "--altdnsnames=\"hostname1,hostname2\"")
-// For environment variables you can use the
-// os.Setenv("DCRD_ALT_DNSNAMES", "hostname1,hostname2") to set the variable
-// before loadConfig() is called
-// These args and env variables will then get parsed by loadConfig()
+// In order to test command line arguments and environment variables, append
+// the flags to the os.Args variable like so:
+//   os.Args = append(os.Args, "--altdnsnames=\"hostname1,hostname2\"")
+//
+// For environment variables, use the following to set the variable before the
+// func that loads the configuration is called:
+//   os.Setenv("DCRD_ALT_DNSNAMES", "hostname1,hostname2")
+//
+// These args and env variables will then get parsed during configuration load.
 
-func setup() {
-	// Temp config file is used to ensure there are no external influences
-	// from previously set env variables or default config files.
-	file, _ := ioutil.TempFile("", "dcrd_test_file.cfg")
-	defer os.Remove(file.Name())
-
-	// Parse the -test.* flags before removing them from the command line
-	// arguments list, which we do to allow go-flags to succeed.
-	flag.Parse()
-	os.Args = os.Args[:1]
-}
-
+// TestLoadConfig ensures that basic configuration loading succeeds.
 func TestLoadConfig(t *testing.T) {
 	_, _, err := loadConfig()
 	if err != nil {
-		t.Errorf("Failed to load dcrd config: %s\n", err.Error())
+		t.Fatalf("Failed to load dcrd config: %s", err)
 	}
 }
 
+// TestDefaultAltDNSNames ensures that there are no additional hostnames added
+// by default during the configuration load phase.
 func TestDefaultAltDNSNames(t *testing.T) {
-	cfg, _, _ := loadConfig()
+	cfg, _, err := loadConfig()
+	if err != nil {
+		t.Fatalf("Failed to load dcrd config: %s", err)
+	}
 	if len(cfg.AltDNSNames) != 0 {
-		t.Errorf("Invalid default value for altdnsnames: %s\n", cfg.AltDNSNames)
+		t.Fatalf("Invalid default value for altdnsnames: %s", cfg.AltDNSNames)
 	}
 }
 
+// TestAltDNSNamesWithEnv ensures the DCRD_ALT_DNSNAMES environment variable is
+// parsed into a slice of additional hostnames as intended.
 func TestAltDNSNamesWithEnv(t *testing.T) {
 	os.Setenv("DCRD_ALT_DNSNAMES", "hostname1,hostname2")
-	cfg, _, _ := loadConfig()
+	cfg, _, err := loadConfig()
+	if err != nil {
+		t.Fatalf("Failed to load dcrd config: %s", err)
+	}
 	hostnames := strings.Join(cfg.AltDNSNames, ",")
 	if hostnames != "hostname1,hostname2" {
-		t.Errorf("altDNSNames should be %s but was %s", "hostname1,hostname2", hostnames)
+		t.Fatalf("altDNSNames should be %s but was %s", "hostname1,hostname2",
+			hostnames)
 	}
 }
 
+// TestAltDNSNamesWithArg ensures the altdnsnames configuration option parses
+// additional hostnames into a slice of hostnames as intended.
 func TestAltDNSNamesWithArg(t *testing.T) {
-	setup()
 	old := os.Args
 	os.Args = append(os.Args, "--altdnsnames=\"hostname1,hostname2\"")
-	cfg, _, _ := loadConfig()
+	cfg, _, err := loadConfig()
+	if err != nil {
+		t.Fatalf("Failed to load dcrd config: %s", err)
+	}
 	hostnames := strings.Join(cfg.AltDNSNames, ",")
 	if hostnames != "hostname1,hostname2" {
-		t.Errorf("altDNSNames should be %s but was %s", "hostname1,hostname2", hostnames)
+		t.Fatalf("altDNSNames should be %s but was %s", "hostname1,hostname2",
+			hostnames)
 	}
 	os.Args = old
+}
+
+// init parses the -test.* flags from the command line arguments list and then
+// removes them to allow go-flags tests to succeed.
+func init() {
+	flag.Parse()
+	os.Args = os.Args[:1]
 }

--- a/doc.go
+++ b/doc.go
@@ -126,6 +126,9 @@ Application Options:
                             for the active network.
       --rejectnonstd        Reject non-standard transactions regardless of the
                             default settings for the active network.
+      --altdnsnames:        Specify additional dns names to use when
+                            generating the rpc server certificate
+                            [supports DCRD_ALT_DNSNAMES environment variable]
 
 Help Options:
   -h, --help           Show this help message


### PR DESCRIPTION
This cleans up code recently added to support the `--altdnsnames` flag and `DCRD_ALT_DNSNAMES` environment variable to match the project standards, simplify it, and correct some issues with standalone test binaries.

- Gets rid of the setup func which had several issues:
  - It was creating a file that was not needed (and without even checking the error)
  - Since it was parsing flags and missing with `os.Args` in a func, it was not possible to individual run the test funcs without failure due to the additional flags
- Performs the flag parsing and removal in an `init` func that only runs once when the tests are run (and before `TestMain`)
- Avoids creating empty objects when nil will suffice
- Uses full sentences and periods in the comment and properly spaces them out so they are consistent with the rest of the code
- Adds comments to all of the added test functions as required by the code contribution guidelines
- Closes the create temp files before trying to write to them in the cert generation
- Defers the removal of the temp files directly after they are created so they are removed properly if the next one fails to create
- Uses consistent camel case in the variable names