### PR TITLE
multi: Rename ThresholdState to NextThresholdState.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -323,7 +323,7 @@ func (b *BlockChain) GetVoteInfo(hash *chainhash.Hash, version uint32) (*VoteInf
 	}
 	for _, deployment := range deployments {
 		vi.Agendas = append(vi.Agendas, deployment)
-		status, err := b.ThresholdState(hash, version, deployment.Vote.Id)
+		status, err := b.NextThresholdState(hash, version, deployment.Vote.Id)
 		if err != nil {
 			return nil, err
 		}

--- a/blockchain/thresholdstate_test.go
+++ b/blockchain/thresholdstate_test.go
@@ -189,7 +189,7 @@ func TestThresholdState(t *testing.T) {
 	// state and choice to match the provided values.
 	testThresholdState := func(id string, state ThresholdState, choice uint32) {
 		tipHash := g.Tip().BlockHash()
-		s, err := chain.ThresholdState(&tipHash, posVersion, id)
+		s, err := chain.NextThresholdState(&tipHash, posVersion, id)
 		if err != nil {
 			t.Fatalf("block %q (hash %s, height %d) unexpected "+
 				"error when retrieving threshold state: %v",

--- a/blockchain/votebits_test.go
+++ b/blockchain/votebits_test.go
@@ -128,9 +128,9 @@ func TestNoQuorum(t *testing.T) {
 		bc.index.AddNode(node)
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
-	ts, err := bc.ThresholdState(&node.hash, posVersion, pedro.Id)
+	ts, err := bc.NextThresholdState(&node.hash, posVersion, pedro.Id)
 	if err != nil {
-		t.Fatalf("ThresholdState(SVI): %v", err)
+		t.Fatalf("NextThresholdState(SVI): %v", err)
 	}
 	tse := ThresholdStateTuple{
 		State:  ThresholdDefined,
@@ -150,9 +150,9 @@ func TestNoQuorum(t *testing.T) {
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
 
-	ts, err = bc.ThresholdState(&node.hash, posVersion, pedro.Id)
+	ts, err = bc.NextThresholdState(&node.hash, posVersion, pedro.Id)
 	if err != nil {
-		t.Fatalf("ThresholdState(started): %v", err)
+		t.Fatalf("NextThresholdState(started): %v", err)
 	}
 	tse = ThresholdStateTuple{
 		State:  ThresholdStarted,
@@ -181,9 +181,9 @@ func TestNoQuorum(t *testing.T) {
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
 
-	ts, err = bc.ThresholdState(&node.hash, posVersion, pedro.Id)
+	ts, err = bc.NextThresholdState(&node.hash, posVersion, pedro.Id)
 	if err != nil {
-		t.Fatalf("ThresholdState(quorum-1): %v", err)
+		t.Fatalf("NextThresholdState(quorum-1): %v", err)
 	}
 	tse = ThresholdStateTuple{
 		State:  ThresholdStarted,
@@ -218,9 +218,9 @@ func TestNoQuorum(t *testing.T) {
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
 
-	ts, err = bc.ThresholdState(&node.hash, posVersion, pedro.Id)
+	ts, err = bc.NextThresholdState(&node.hash, posVersion, pedro.Id)
 	if err != nil {
-		t.Fatalf("ThresholdState(quorum 75%%-1): %v", err)
+		t.Fatalf("NextThresholdState(quorum 75%%-1): %v", err)
 	}
 	tse = ThresholdStateTuple{
 		State:  ThresholdStarted,
@@ -255,9 +255,9 @@ func TestNoQuorum(t *testing.T) {
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
 
-	ts, err = bc.ThresholdState(&node.hash, posVersion, pedro.Id)
+	ts, err = bc.NextThresholdState(&node.hash, posVersion, pedro.Id)
 	if err != nil {
-		t.Fatalf("ThresholdState(quorum 75%%): %v", err)
+		t.Fatalf("NextThresholdState(quorum 75%%): %v", err)
 	}
 	tse = ThresholdStateTuple{
 		State:  ThresholdFailed,
@@ -285,9 +285,9 @@ func TestYesQuorum(t *testing.T) {
 		bc.index.AddNode(node)
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
-	ts, err := bc.ThresholdState(&node.hash, posVersion, pedro.Id)
+	ts, err := bc.NextThresholdState(&node.hash, posVersion, pedro.Id)
 	if err != nil {
-		t.Fatalf("ThresholdState(SVI): %v", err)
+		t.Fatalf("NextThresholdState(SVI): %v", err)
 	}
 	tse := ThresholdStateTuple{
 		State:  ThresholdDefined,
@@ -307,9 +307,9 @@ func TestYesQuorum(t *testing.T) {
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
 
-	ts, err = bc.ThresholdState(&node.hash, posVersion, pedro.Id)
+	ts, err = bc.NextThresholdState(&node.hash, posVersion, pedro.Id)
 	if err != nil {
-		t.Fatalf("ThresholdState(started): %v", err)
+		t.Fatalf("NextThresholdState(started): %v", err)
 	}
 	tse = ThresholdStateTuple{
 		State:  ThresholdStarted,
@@ -338,9 +338,9 @@ func TestYesQuorum(t *testing.T) {
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
 
-	ts, err = bc.ThresholdState(&node.hash, posVersion, pedro.Id)
+	ts, err = bc.NextThresholdState(&node.hash, posVersion, pedro.Id)
 	if err != nil {
-		t.Fatalf("ThresholdState(quorum-1): %v", err)
+		t.Fatalf("NextThresholdState(quorum-1): %v", err)
 	}
 	tse = ThresholdStateTuple{
 		State:  ThresholdStarted,
@@ -375,9 +375,9 @@ func TestYesQuorum(t *testing.T) {
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
 
-	ts, err = bc.ThresholdState(&node.hash, posVersion, pedro.Id)
+	ts, err = bc.NextThresholdState(&node.hash, posVersion, pedro.Id)
 	if err != nil {
-		t.Fatalf("ThresholdState(quorum 75%%-1): %v", err)
+		t.Fatalf("NextThresholdState(quorum 75%%-1): %v", err)
 	}
 	tse = ThresholdStateTuple{
 		State:  ThresholdStarted,
@@ -412,9 +412,9 @@ func TestYesQuorum(t *testing.T) {
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
 
-	ts, err = bc.ThresholdState(&node.hash, posVersion, pedro.Id)
+	ts, err = bc.NextThresholdState(&node.hash, posVersion, pedro.Id)
 	if err != nil {
-		t.Fatalf("ThresholdState(quorum 75%%): %v", err)
+		t.Fatalf("NextThresholdState(quorum 75%%): %v", err)
 	}
 	tse = ThresholdStateTuple{
 		State:  ThresholdLockedIn,
@@ -1484,10 +1484,10 @@ func TestVoting(t *testing.T) {
 				node.height, params.Deployments[4][0].StartTime,
 				node.timestamp, node.timestamp-
 					int64(params.Deployments[4][0].StartTime))
-			ts, err := bc.ThresholdState(&node.hash, posVersion,
+			ts, err := bc.NextThresholdState(&node.hash, posVersion,
 				test.vote.Id)
 			if err != nil {
-				t.Fatalf("ThresholdState(%v): %v", k, err)
+				t.Fatalf("NextThresholdState(%v): %v", k, err)
 			}
 			if ts != test.expectedState[k] {
 				t.Fatalf("%v.%v (%v) got state %+v wanted "+
@@ -1649,10 +1649,10 @@ func TestParallelVoting(t *testing.T) {
 				curTimestamp = curTimestamp.Add(time.Second)
 			}
 			for i := range test.vote {
-				ts, err := bc.ThresholdState(&node.hash,
+				ts, err := bc.NextThresholdState(&node.hash,
 					posVersion, test.vote[i].Id)
 				if err != nil {
-					t.Fatalf("ThresholdState(%v): %v", k, err)
+					t.Fatalf("NextThresholdState(%v): %v", k, err)
 				}
 
 				if ts != test.expectedState[i][k] {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1939,7 +1939,7 @@ func handleGetBlockchainInfo(s *rpcServer, cmd interface{}, closeChan <-chan str
 				ExpireTime: agenda.ExpireTime,
 			}
 
-			state, err := s.chain.ThresholdState(&best.PrevHash, version,
+			state, err := s.chain.NextThresholdState(&best.PrevHash, version,
 				agenda.Vote.Id)
 			if err != nil {
 				return nil, rpcInternalError(err.Error(),
@@ -3775,7 +3775,7 @@ func handleGetVoteInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{})
 		}
 
 		// Obtain status of agenda.
-		state, err := s.chain.ThresholdState(&snapshot.Hash, c.Version,
+		state, err := s.chain.NextThresholdState(&snapshot.Hash, c.Version,
 			agenda.Vote.Id)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This renames the unexported and exported versions of `ThresholdState` to `NextThresholdState` as well as related test helpers. `NextThresholdState` better describes the function because the threshold state being returned is for the block after the provided block hash.