### PR TITLE
blockchain: Remove unused CheckWorklessBlockSanity.

### DIFF
--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -902,13 +902,6 @@ func CheckBlockSanity(block *dcrutil.Block, timeSource MedianTimeSource, chainPa
 	return checkBlockSanity(block, timeSource, BFNone, chainParams)
 }
 
-// CheckWorklessBlockSanity performs some preliminary checks on a block to
-// ensure it is sane before continuing with block processing.  These checks are
-// context free.
-func CheckWorklessBlockSanity(block *dcrutil.Block, timeSource MedianTimeSource, chainParams *chaincfg.Params) error {
-	return checkBlockSanity(block, timeSource, BFNoPoWCheck, chainParams)
-}
-
 // checkBlockHeaderContext peforms several validation checks on the block
 // header which depend on its position within the block chain.
 //

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -240,18 +240,6 @@ func TestCheckBlockSanity(t *testing.T) {
 	}
 }
 
-// TestCheckWorklessBlockSanity tests the context free workless block sanity
-// checks with blocks not on a chain.
-func TestCheckWorklessBlockSanity(t *testing.T) {
-	params := &chaincfg.RegNetParams
-	timeSource := NewMedianTime()
-	block := dcrutil.NewBlock(&badBlock)
-	err := CheckWorklessBlockSanity(block, timeSource, params)
-	if err == nil {
-		t.Fatalf("block should fail.\n")
-	}
-}
-
 // TestCheckBlockHeaderContext tests that genesis block passes context headers
 // because its parent is nil.
 func TestCheckBlockHeaderContext(t *testing.T) {


### PR DESCRIPTION
This removes the `CheckWorklessBlockSanity` function since nothing uses it anymore.  It was used for testing templates and unit tests in the past, but the former is now handled by `CheckConnectBlockTemplate` and the latter is handled by the full block tests.

It should be noted that this is a breaking change to the API and thus will need a major version bump of the blockchain module to be published before the next release.