### PR TITLE
main: move cert tests to a separated file

### DIFF
--- a/cert_test.go
+++ b/cert_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2018 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+// TestCertCreationWithHosts creates a certificate pair with extra hosts and
+// ensures the extra hosts are present in the generated files.
+func TestCertCreationWithHosts(t *testing.T) {
+	certFile, err := ioutil.TempFile("", "certfile")
+	if err != nil {
+		t.Fatalf("Unable to create temp certfile: %s", err)
+	}
+	certFile.Close()
+	defer os.Remove(certFile.Name())
+
+	keyFile, err := ioutil.TempFile("", "keyfile")
+	if err != nil {
+		t.Fatalf("Unable to create temp keyfile: %s", err)
+	}
+	keyFile.Close()
+	defer os.Remove(keyFile.Name())
+
+	// Generate cert pair with extra hosts.
+	hostnames := []string{"hostname1", "hostname2"}
+	err = genCertPair(certFile.Name(), keyFile.Name(), hostnames)
+	if err != nil {
+		t.Fatalf("Certificate was not created correctly: %s", err)
+	}
+	certBytes, err := ioutil.ReadFile(certFile.Name())
+	if err != nil {
+		t.Fatalf("Unable to read the certfile: %s", err)
+	}
+	pemCert, _ := pem.Decode(certBytes)
+	x509Cert, err := x509.ParseCertificate(pemCert.Bytes)
+	if err != nil {
+		t.Fatalf("Unable to parse the certificate: %s", err)
+	}
+
+	// Ensure the specified extra hosts are present.
+	for _, host := range hostnames {
+		err := x509Cert.VerifyHostname(host)
+		if err != nil {
+			t.Fatalf("failed to verify extra host '%s'", host)
+		}
+	}
+}
+
+// TestCertCreationWithOutHosts ensures the creating a certificate pair without
+// any hosts works as intended.
+func TestCertCreationWithOutHosts(t *testing.T) {
+	certFile, err := ioutil.TempFile("", "certfile")
+	if err != nil {
+		t.Fatalf("Unable to create temp certfile: %s", err)
+	}
+	certFile.Close()
+	defer os.Remove(certFile.Name())
+
+	keyFile, err := ioutil.TempFile("", "keyfile")
+	if err != nil {
+		t.Fatalf("Unable to create temp keyfile: %s", err)
+	}
+	keyFile.Close()
+	defer os.Remove(keyFile.Name())
+
+	// Generate cert pair with no extra hosts.
+	err = genCertPair(certFile.Name(), keyFile.Name(), nil)
+	if err != nil {
+		t.Fatalf("Certificate was not created correctly: %s", err)
+	}
+}

--- a/rpcserver_test.go
+++ b/rpcserver_test.go
@@ -10,10 +10,7 @@ package main
 
 import (
 	"bytes"
-	"crypto/x509"
-	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime/debug"
 	"testing"
@@ -165,71 +162,5 @@ func TestRpcServer(t *testing.T) {
 		testCase(primaryHarness, t)
 
 		currentTestNum++
-	}
-}
-
-// TestCertCreationWithHosts creates a certificate pair with extra hosts and
-// ensures the extra hosts are present in the generated files.
-func TestCertCreationWithHosts(t *testing.T) {
-	certFile, err := ioutil.TempFile("", "certfile")
-	if err != nil {
-		t.Fatalf("Unable to create temp certfile: %s", err)
-	}
-	certFile.Close()
-	defer os.Remove(certFile.Name())
-
-	keyFile, err := ioutil.TempFile("", "keyfile")
-	if err != nil {
-		t.Fatalf("Unable to create temp keyfile: %s", err)
-	}
-	keyFile.Close()
-	defer os.Remove(keyFile.Name())
-
-	// Generate cert pair with extra hosts.
-	hostnames := []string{"hostname1", "hostname2"}
-	err = genCertPair(certFile.Name(), keyFile.Name(), hostnames)
-	if err != nil {
-		t.Fatalf("Certificate was not created correctly: %s", err)
-	}
-	certBytes, err := ioutil.ReadFile(certFile.Name())
-	if err != nil {
-		t.Fatalf("Unable to read the certfile: %s", err)
-	}
-	pemCert, _ := pem.Decode(certBytes)
-	x509Cert, err := x509.ParseCertificate(pemCert.Bytes)
-	if err != nil {
-		t.Fatalf("Unable to parse the certificate: %s", err)
-	}
-
-	// Ensure the specified extra hosts are present.
-	for _, host := range hostnames {
-		err := x509Cert.VerifyHostname(host)
-		if err != nil {
-			t.Fatalf("failed to verify extra host '%s'", host)
-		}
-	}
-}
-
-// TestCertCreationWithOutHosts ensures the creating a certificate pair without
-// any hosts works as intended.
-func TestCertCreationWithOutHosts(t *testing.T) {
-	certFile, err := ioutil.TempFile("", "certfile")
-	if err != nil {
-		t.Fatalf("Unable to create temp certfile: %s", err)
-	}
-	certFile.Close()
-	defer os.Remove(certFile.Name())
-
-	keyFile, err := ioutil.TempFile("", "keyfile")
-	if err != nil {
-		t.Fatalf("Unable to create temp keyfile: %s", err)
-	}
-	keyFile.Close()
-	defer os.Remove(keyFile.Name())
-
-	// Generate cert pair with no extra hosts.
-	err = genCertPair(certFile.Name(), keyFile.Name(), nil)
-	if err != nil {
-		t.Fatalf("Certificate was not created correctly: %s", err)
 	}
 }


### PR DESCRIPTION
Move mistakenly gated cert tests to another file.