### PR TITLE
blockchain: Only mark nodes modified when modified.

### DIFF
--- a/blockchain/blockindex.go
+++ b/blockchain/blockindex.go
@@ -447,8 +447,11 @@ func (bi *blockIndex) NodeStatus(node *blockNode) blockStatus {
 // This function is safe for concurrent access.
 func (bi *blockIndex) SetStatusFlags(node *blockNode, flags blockStatus) {
 	bi.Lock()
+	origStatus := node.status
 	node.status |= flags
-	bi.modified[node] = struct{}{}
+	if node.status != origStatus {
+		bi.modified[node] = struct{}{}
+	}
 	bi.Unlock()
 }
 
@@ -458,8 +461,11 @@ func (bi *blockIndex) SetStatusFlags(node *blockNode, flags blockStatus) {
 // This function is safe for concurrent access.
 func (bi *blockIndex) UnsetStatusFlags(node *blockNode, flags blockStatus) {
 	bi.Lock()
+	origStatus := node.status
 	node.status &^= flags
-	bi.modified[node] = struct{}{}
+	if node.status != origStatus {
+		bi.modified[node] = struct{}{}
+	}
 	bi.Unlock()
 }
 


### PR DESCRIPTION
This updates the code which deals with marking block nodes modified when setting and clearing status flags to only mark them modified if the status flags actually change.

This is more efficient as it prevents the need to write nodes that haven't actually changed to the database.