### PR TITLE
blockchain: Cleanup and optimize stake node logic.

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -80,7 +80,7 @@ func (b *BlockChain) maybeAcceptBlock(block *dcrutil.Block, flags BehaviorFlags)
 	b.index.AddNode(newNode)
 
 	// Ensure the new block index entry is written to the database.
-	err = b.index.flush()
+	err = b.flushBlockIndex()
 	if err != nil {
 		return 0, err
 	}
@@ -111,7 +111,6 @@ func (b *BlockChain) maybeAcceptBlock(block *dcrutil.Block, flags BehaviorFlags)
 		if err != nil {
 			return 0, err
 		}
-		newNode.stakeUndoData = newNode.stakeNode.UndoData()
 	}
 
 	// Grab the parent block since it is required throughout the block

--- a/blockchain/blockindex.go
+++ b/blockchain/blockindex.go
@@ -121,7 +121,6 @@ type blockNode struct {
 	// evaluation of sidechains.
 	stakeNode      *stake.Node
 	newTickets     []chainhash.Hash
-	stakeUndoData  stake.UndoTicketDataSlice
 	ticketsVoted   []chainhash.Hash
 	ticketsRevoked []chainhash.Hash
 
@@ -227,7 +226,7 @@ func (node *blockNode) lotteryIV() chainhash.Hash {
 // node.
 //
 // This function is NOT safe for concurrent access.  It must only be called when
-// initially creating a node.
+// initially creating a node or when protected by the chain lock.
 func (node *blockNode) populateTicketInfo(spentTickets *stake.SpentTicketsInBlock) {
 	node.ticketsVoted = spentTickets.VotedTickets
 	node.ticketsRevoked = spentTickets.RevokedTickets

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1749,7 +1749,6 @@ func (b *BlockChain) initChainState() error {
 			if err != nil {
 				return err
 			}
-			tip.stakeUndoData = tip.stakeNode.UndoData()
 			tip.newTickets = tip.stakeNode.NewTickets()
 		}
 

--- a/blockchain/stakeext.go
+++ b/blockchain/stakeext.go
@@ -35,11 +35,11 @@ func (b *BlockChain) NextLotteryData() ([]chainhash.Hash, int, [6]byte, error) {
 // with the chainLock held for writes.
 func (b *BlockChain) lotteryDataForNode(node *blockNode) ([]chainhash.Hash, int, [6]byte, error) {
 	if node.height < b.chainParams.StakeEnabledHeight {
-		return []chainhash.Hash{}, 0, [6]byte{}, nil
+		return nil, 0, [6]byte{}, nil
 	}
 	stakeNode, err := b.fetchStakeNode(node)
 	if err != nil {
-		return []chainhash.Hash{}, 0, [6]byte{}, err
+		return nil, 0, [6]byte{}, err
 	}
 
 	return stakeNode.Winners(), stakeNode.PoolSize(), stakeNode.FinalState(), nil

--- a/blockchain/stakenode.go
+++ b/blockchain/stakenode.go
@@ -13,187 +13,193 @@ import (
 	"github.com/decred/dcrd/database"
 )
 
-// fetchNewTicketsForNode fetches the list of newly maturing tickets for a
-// given node by traversing backwards through its parents until it finds the
-// block that contains the original tickets to mature.
+// maybeFetchNewTickets loads the list of newly maturing tickets for a given
+// node by traversing backwards through its parents until it finds the block
+// that contains the original tickets to mature if needed.
 //
-// This function is NOT safe for concurrent access and must be called with
-// the chainLock held for writes.
-func (b *BlockChain) fetchNewTicketsForNode(node *blockNode) ([]chainhash.Hash, error) {
-	// If we're before the stake enabled height, there can be no
-	// tickets in the live ticket pool.
-	if node.height < b.chainParams.StakeEnabledHeight {
-		return []chainhash.Hash{}, nil
+// This function MUST be called with the chain state lock held (for writes).
+func (b *BlockChain) maybeFetchNewTickets(node *blockNode) error {
+	// Nothing to do if the tickets are already loaded.  It's important to make
+	// the distinction here that nil means the value was never looked up, while
+	// an empty slice means that there are no new tickets at this height.
+	if node.newTickets != nil {
+		return nil
 	}
 
-	// If we already cached the tickets, simply return the cached list.
-	// It's important to make the distinction here that nil means the
-	// value was never looked up, while an empty slice of pointers means
-	// that there were no new tickets at this height.
-	if node.newTickets != nil {
-		return node.newTickets, nil
+	// No tickets in the live ticket pool are possible before stake enabled
+	// height.
+	if node.height < b.chainParams.StakeEnabledHeight {
+		node.newTickets = []chainhash.Hash{}
+		return nil
 	}
 
 	// Calculate block number for where new tickets matured from and retrieve
-	// this block from DB or in memory if it's a sidechain.
+	// its block from DB.
 	matureNode := node.RelativeAncestor(int64(b.chainParams.TicketMaturity))
 	if matureNode == nil {
-		return nil, fmt.Errorf("unable to obtain previous node; " +
-			"ancestor is genesis block")
+		return fmt.Errorf("unable to obtain ancestor %d blocks prior to %s "+
+			"(height %d)", b.chainParams.TicketMaturity, node.hash, node.height)
+	}
+	matureBlock, err := b.fetchBlockByNode(matureNode)
+	if err != nil {
+		return err
 	}
 
-	matureBlock, errBlock := b.fetchBlockByNode(matureNode)
-	if errBlock != nil {
-		return nil, errBlock
-	}
-
+	// Extract any ticket purchases from the block and cache them.
 	tickets := []chainhash.Hash{}
 	for _, stx := range matureBlock.MsgBlock().STransactions {
 		if stake.IsSStx(stx) {
-			h := stx.TxHash()
-			tickets = append(tickets, h)
+			tickets = append(tickets, stx.TxHash())
 		}
 	}
-
-	// Set the new tickets in memory so that they exist for future
-	// reference in the node.
 	node.newTickets = tickets
-
-	return tickets, nil
+	return nil
 }
 
-// fetchStakeNode will scour the blockchain from the best block, for which we
-// know that there is valid stake node.  The first step is finding a path to the
-// ancestor, or, if on a side chain, the path to the common ancestor, followed
-// by the path to the sidechain node.  After this path is established, the
-// algorithm walks along the path, regenerating and storing intermediate nodes
-// as it does so, until the final stake node of interest is populated with the
-// correct data.
+// maybeFetchTicketInfo loads and populates prunable ticket information in the
+// provided block node if needed.
+//
+// This function MUST be called with the chain state lock held (for writes).
+func (b *BlockChain) maybeFetchTicketInfo(node *blockNode) error {
+	// Load and populate the tickets maturing in this block when they are not
+	// already loaded.
+	if err := b.maybeFetchNewTickets(node); err != nil {
+		return err
+	}
+
+	// Load and populate the vote and revocation information as needed.
+	if node.ticketsVoted == nil || node.ticketsRevoked == nil ||
+		node.votes == nil {
+
+		block, err := b.fetchBlockByNode(node)
+		if err != nil {
+			return err
+		}
+
+		node.populateTicketInfo(stake.FindSpentTicketsInBlock(block.MsgBlock()))
+	}
+
+	return nil
+}
+
+// fetchStakeNode returns the stake node associated with the requested node
+// while handling the logic to create the stake node if needed.  In the majority
+// of cases, the stake node either already exists and is simply returned, or it
+// can be quickly created when the parent stake node is already available.
+// However, it should be noted that, since old stake nodes are pruned, this
+// function can be quite expensive if a node deep in history or on a long side
+// chain is requested since that requires reconstructing all of the intermediate
+// nodes along the path from the existing tip to the requested node that have
+// not already been pruned.
 //
 // This function MUST be called with the chain state lock held (for writes).
 func (b *BlockChain) fetchStakeNode(node *blockNode) (*stake.Node, error) {
-	// If we already have the stake node fetched, returned the cached result.
-	// Stake nodes are immutable.
+	// Return the cached immutable stake node when it is already loaded.
 	if node.stakeNode != nil {
 		return node.stakeNode, nil
 	}
 
-	// If the parent stake node is cached, connect the stake node
-	// from there.
-	if node.parent != nil {
-		if node.stakeNode == nil && node.parent.stakeNode != nil {
-			var err error
-			if node.newTickets == nil {
-				node.newTickets, err = b.fetchNewTicketsForNode(node)
-				if err != nil {
-					return nil, err
-				}
-			}
-
-			node.stakeNode, err = node.parent.stakeNode.ConnectNode(
-				node.lotteryIV(), node.ticketsVoted, node.ticketsRevoked,
-				node.newTickets)
-			if err != nil {
-				return nil, err
-			}
-
-			return node.stakeNode, nil
+	// Create the requested stake node from the parent stake node if it is
+	// already loaded as an optimization.
+	if node.parent.stakeNode != nil {
+		// Populate the prunable ticket information as needed.
+		if err := b.maybeFetchTicketInfo(node); err != nil {
+			return nil, err
 		}
+
+		stakeNode, err := node.parent.stakeNode.ConnectNode(node.lotteryIV(),
+			node.ticketsVoted, node.ticketsRevoked, node.newTickets)
+		if err != nil {
+			return nil, err
+		}
+		node.stakeNode = stakeNode
+
+		return stakeNode, nil
 	}
 
-	// We need to generate a path to the stake node and restore it
-	// it through the entire path.  The bestNode stake node must
-	// always be filled in, so assume it is safe to begin working
-	// backwards from there.
-	detachNodes, attachNodes := b.getReorganizeNodes(node)
-	current := b.bestChain.Tip()
+	// -------------------------------------------------------------------------
+	// In order to create the stake node, it is necessary to generate a path to
+	// the stake node from the current tip, which always has the stake node
+	// loaded, and undo the effects of each block back to, and including, the
+	// fork point (which might be the requested node itself), and then, in the
+	// case the target node is on a side chain, replay the effects of each on
+	// the side chain.  In most cases, many of the stake nodes along the path
+	// will already be loaded, so, they are only regenerated and populated if
+	// they aren't.
+	//
+	// For example, consider the following scenario:
+	//   A -> B  -> C  -> D
+	//    \-> B' -> C'
+	//
+	// Further assume the requested stake node is for C'.  The code that follows
+	// will regenerate and populate (only for those not already loaded) the
+	// stake nodes for C, B, A, B', and finally, C'.
+	// -------------------------------------------------------------------------
 
-	// Flush any potential unsaved changes to the block index due to the
-	// call to get the reorganize nodes.  Since the best state is not being
-	// being modified, it is safe to ignore any errors here as the changes
-	// will be flushed at that point and those errors are not ignored.
-	b.flushBlockIndexWarnOnly()
-
-	// Move backwards through the main chain, undoing the ticket
-	// treaps for each block.  The database is passed because the
-	// undo data and new tickets data for each block may not yet
-	// be filled in and may require the database to look up.
+	// Start by undoing the effects from the current tip back to, and including
+	// the fork point per the above description.
+	tip := b.bestChain.Tip()
+	fork := b.bestChain.FindFork(node)
 	err := b.db.View(func(dbTx database.Tx) error {
-		for e := detachNodes.Front(); e != nil; e = e.Next() {
-			n := e.Value.(*blockNode)
-			if n.stakeNode == nil {
-				var errLocal error
-				n.stakeNode, errLocal =
-					current.stakeNode.DisconnectNode(n.lotteryIV(),
-						n.stakeUndoData, n.newTickets, dbTx)
-				if errLocal != nil {
-					return errLocal
-				}
-			}
-			current = n
-		}
-
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// Detach the final block and get the filled in node for the fork
-	// point.
-	err = b.db.View(func(dbTx database.Tx) error {
-		if current.parent.stakeNode == nil {
-			var errLocal error
-			current.parent.stakeNode, errLocal =
-				current.stakeNode.DisconnectNode(current.parent.lotteryIV(),
-					current.parent.stakeUndoData, current.parent.newTickets, dbTx)
-			if errLocal != nil {
-				return errLocal
-			}
-		}
-		current = current.parent
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// The node is at a fork point in the block chain, so just return
-	// this stake node.
-	if attachNodes.Len() == 0 {
-		if current.hash != node.hash ||
-			current.height != node.height {
-			return nil, AssertError("failed to restore stake node to " +
-				"fork point when fetching")
-		}
-
-		return current.stakeNode, nil
-	}
-
-	// The requested node is on a side chain, so we need to apply the
-	// transactions and spend information from each of the nodes to attach.
-	// Not that side chain ticket data and undo data is always stored
-	// in memory, so there is not need to use the database here.
-	for e := attachNodes.Front(); e != nil; e = e.Next() {
-		n := e.Value.(*blockNode)
-
-		if n.stakeNode == nil {
-			if n.newTickets == nil {
-				n.newTickets, err = b.fetchNewTicketsForNode(n)
-				if err != nil {
-					return nil, err
-				}
+		for n := tip; n != nil && n != fork; n = n.parent {
+			// No need to load nodes that are already loaded.
+			prev := n.parent
+			if prev == nil || prev.stakeNode != nil {
+				continue
 			}
 
-			n.stakeNode, err = current.stakeNode.ConnectNode(n.lotteryIV(),
-				n.ticketsVoted, n.ticketsRevoked, n.newTickets)
+			// Generate the previous stake node by starting with the child stake
+			// node and undoing the modifications caused by the stake details in
+			// the previous block.
+			stakeNode, err := n.stakeNode.DisconnectNode(prev.lotteryIV(), nil,
+				nil, dbTx)
 			if err != nil {
-				return nil, err
+				return err
 			}
+			prev.stakeNode = stakeNode
 		}
 
-		current = n
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
-	return current.stakeNode, nil
+	// Nothing more to do if the requested node is the fork point itself.
+	if node == fork {
+		return node.stakeNode, nil
+	}
+
+	// The requested node is on a side chain, so replay the effects of the
+	// blocks up to the requested node per the above description.
+	//
+	// Note that the blocks between the fork point and the requested node are
+	// added to the slice from back to front so that they are attached in the
+	// appropriate order when iterating the slice.
+	attachNodes := make([]*blockNode, node.height-fork.height)
+	for n := node; n != nil && n != fork; n = n.parent {
+		attachNodes[n.height-fork.height-1] = n
+	}
+	for _, n := range attachNodes {
+		// No need to load nodes that are already loaded.
+		if n.stakeNode != nil {
+			continue
+		}
+
+		// Populate the prunable ticket information as needed.
+		if err := b.maybeFetchTicketInfo(n); err != nil {
+			return nil, err
+		}
+
+		// Generate the stake node by applying the stake details in the current
+		// block to the previous stake node.
+		stakeNode, err := n.parent.stakeNode.ConnectNode(n.lotteryIV(),
+			n.ticketsVoted, n.ticketsRevoked, n.newTickets)
+		if err != nil {
+			return nil, err
+		}
+		n.stakeNode = stakeNode
+	}
+
+	return node.stakeNode, nil
 }


### PR DESCRIPTION
This reworks the stake node handling logic a bit to clean it up, slightly optimize it, and to make it easier to decouple the chain processing and connection code from the download logic in the future.

To accomplish this, the `fetchStakeNode` dependence on the `getReorganizeNodes` function is removed in favor of directly iterating the block nodes in the function as needed.  Not only is this more efficient, it also allows the function to return stake nodes for branches regardless of their validation status.  Currently, this is irrelevant due to the connection and download logic being tightly coupled.  However, it will be necessary in the future when those are separated.

Also, the flushing and pruning logic is modified to no longer rely on the download logic being tightly coupled to the the connection logic. In particular, a new function named `flushBlockIndex` is added as a wrapper to the index flush function which populates stake information in a node before flushing it to the database as needed, and all flushing invocations use the wrapper instead.

Finally, the `stakeUndoData` field is removed since it is only used to avoid some database loads on reorgs that are large enough to exceed the pruning depth, which never happens in practice anyway, so there is no point in using up extra memory for it.