### PR TITLE
blockchain: Separate full data context checks.

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -21,8 +21,9 @@ import (
 // extends the best chain or is now the tip of the best chain due to causing a
 // reorganize, the fork length will be 0.
 //
-// The flags are also passed to checkBlockContext and connectBestChain.  See
-// their documentation for how the flags modify their behavior.
+// The flags are also passed to checkBlockPositional, checkBlockContext and
+// connectBestChain.  See their documentation for how the flags modify their
+// behavior.
 //
 // This function MUST be called with the chain state lock held (for writes).
 func (b *BlockChain) maybeAcceptBlock(block *dcrutil.Block, flags BehaviorFlags) (int64, error) {
@@ -43,9 +44,17 @@ func (b *BlockChain) maybeAcceptBlock(block *dcrutil.Block, flags BehaviorFlags)
 		return 0, ruleError(ErrInvalidAncestorBlock, str)
 	}
 
-	// The block must pass all of the validation rules which depend on the
-	// position of the block within the block chain.
-	err := b.checkBlockContext(block, prevNode, flags)
+	// The block must pass all of the validation rules which depend on having
+	// the headers of all ancestors available, but do not rely on having the
+	// full block data of all ancestors available.
+	err := b.checkBlockPositional(block, prevNode, flags)
+	if err != nil {
+		return 0, err
+	}
+
+	// The block must pass all of the validation rules which depend on having
+	// the full block data for all of its ancestors available.
+	err = b.checkBlockContext(block, prevNode, flags)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
This separates the block and header context checks to make it more explicit exactly which checks require the availability of the full data for all ancestors and which checks do not.

Currently, all ancestor data is always available due to the way the download and block processing logic is implemented, however, ultimately, the plan is to decouple the chain processing and connection code from the download logic.  In order to help pave the way towards that goal, this more clearly delineates the checks by redefining the current meaning of the concept of contextual checks and creating a new concept of positional checks.

Positional checks are defined as those which depend on the position of a block or header within the block chain and have all of the ancestor block headers available, but do NOT have all of the full block data for
all of the ancestor blocks.

Contextual checks are now defined as those which depend on having the full block data for all of the ancestors available, which also implies all of the ancestor block headers are available too.

To that end, this introduces two new functions named `checkBlockHeaderPositional` and `checkBlockPositional`, moves all of the checks which adhere to the aforementioned semantics to the new
functions, and updates all call sites which invoke the contextual variants to call the positional variants first.