### PR TITLE
blockchain: Notify stake states after connected block

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -53,10 +53,10 @@ import (
 
 // API version constants
 const (
-	jsonrpcSemverString = "4.0.0"
+	jsonrpcSemverString = "4.0.1"
 	jsonrpcSemverMajor  = 4
 	jsonrpcSemverMinor  = 0
-	jsonrpcSemverPatch  = 0
+	jsonrpcSemverPatch  = 1
 )
 
 const (


### PR DESCRIPTION
When an accepted block is attached to the main chain, potentially
three notifications are emitted: NTBlockConnected,
NTSpentAndMissedTickets, and NTNewTickets.  This change moves
NTBlockConnected to being the first notification, followed by
NTSpentAndMissedTickets and NTNewTickets.

This is important for applications which react to the stake
notifications since they will have already been notified of the most
recently connected block.  For example, dcrwallet uses the
spentandmissedtickets JSON-RPC notification to create revocation
transactions for missed votes.  However, if the missed tickets are
notified before the connected block, a race is possible where the
revocations are rejected as they double spend a vote on what wallet
believes is still the main chain tip block.

This is considered a patch bump to the JSON-RPC API semantic version
due to affecting and improving the ordering of the blockconnected and
spentandmissedtickets notifications.