### PR TITLE
server: Always allow whitelisted inbound peers.

### DIFF
--- a/server.go
+++ b/server.go
@@ -1279,8 +1279,9 @@ func (s *server) handleAddPeerMsg(state *peerState, sp *serverPeer) bool {
 
 	// TODO: Check for max peers from a single IP.
 
-	// Limit max number of total peers.
-	if state.Count() >= cfg.MaxPeers {
+	// Limit max number of total peers.  However, allow whitelisted inbound
+	// peers regardless.
+	if state.Count() >= cfg.MaxPeers && !(sp.Inbound() && sp.isWhitelisted) {
 		srvrLog.Infof("Max peers reached [%d] - disconnecting peer %s",
 			cfg.MaxPeers, sp)
 		sp.Disconnect()


### PR DESCRIPTION
This modifies the code which enforces a maximum number of peers to always allow whitelisted inbound peers even when they would exceed the maximum number of peers to ensure that operators can always allow their own clients.
