### PR TITLE
blockchain: Make version 5 update atomic.

### DIFF
--- a/blockchain/upgrade.go
+++ b/blockchain/upgrade.go
@@ -611,7 +611,14 @@ func upgradeToVersion5(db database.DB, chainParams *chaincfg.Params, dbInfo *dat
 			totalSubsidy: 0,
 			workSum:      CalcWork(genesisBlock.Header.Bits),
 		})
-		return meta.Put(chainStateKeyName, serializedData)
+		err = meta.Put(chainStateKeyName, serializedData)
+		if err != nil {
+			return err
+		}
+
+		// Update and persist the updated database versions.
+		dbInfo.version = 5
+		return dbPutDatabaseInfo(dbTx, dbInfo)
 	})
 	if err != nil {
 		return err
@@ -619,13 +626,6 @@ func upgradeToVersion5(db database.DB, chainParams *chaincfg.Params, dbInfo *dat
 
 	elapsed := time.Since(start).Round(time.Millisecond)
 	log.Infof("Done upgrading database in %v.", elapsed)
-
-	// Update and persist the updated database versions.
-	dbInfo.version = 5
-	return db.Update(func(dbTx database.Tx) error {
-		return dbPutDatabaseInfo(dbTx, dbInfo)
-	})
-
 	return nil
 }
 


### PR DESCRIPTION
This modifies the version 5 migration code to update the database version atomically with setting a reindex tip and resetting the best chain tip back to the genesis block so the chain can be reindexed.

This is necessary because, unlike the modifications that come before it, storing the current chain tip and resetting it is not idempotent, so lack of atomicity in those updates can lead to failure to recover in unclean shutdown circumstances.

Thanks to @alexlyp for providing the logs which triggered the condition and helping test the resolution.