### PR TITLE
rpcserver: bump version to 5.0.0

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -53,10 +53,10 @@ import (
 
 // API version constants
 const (
-	jsonrpcSemverString = "4.0.1"
-	jsonrpcSemverMajor  = 4
+	jsonrpcSemverString = "5.0.0"
+	jsonrpcSemverMajor  = 5
 	jsonrpcSemverMinor  = 0
-	jsonrpcSemverPatch  = 1
+	jsonrpcSemverPatch  = 0
 )
 
 const (


### PR DESCRIPTION
This bumps the major version of the JSON RPC server to reflect the
breaking change of reordering the reorg and block connected
notifications.  The reorg notification now indicates a successful reorg
was completed rather than initiated.

Ref: dcrd PR https://github.com/decred/dcrd/pull/1500