### PR TITLE
rpcclient: Add GetBlockChainInfo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/decred/dcrd/mempool v1.0.2
 	github.com/decred/dcrd/mining v1.0.1
 	github.com/decred/dcrd/peer v1.1.0
-	github.com/decred/dcrd/rpcclient v1.0.2
+	github.com/decred/dcrd/rpcclient v1.1.0
 	github.com/decred/dcrd/txscript v1.0.2
 	github.com/decred/dcrd/wire v1.2.0
 	github.com/decred/slog v1.0.0

--- a/rpcclient/chain.go
+++ b/rpcclient/chain.go
@@ -230,6 +230,44 @@ func (c *Client) GetDifficulty() (float64, error) {
 	return c.GetDifficultyAsync().Receive()
 }
 
+// FutureGetBlockChainInfoResult is a future promise to deliver the result of a
+// GetBlockChainInfoAsync RPC invocation (or an applicable error).
+type FutureGetBlockChainInfoResult chan *response
+
+// Receive waits for the response promised by the future and returns the info
+// provided by the server.
+func (r FutureGetBlockChainInfoResult) Receive() (*dcrjson.GetBlockChainInfoResult, error) {
+	res, err := receiveFuture(r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal result as a getblockchaininfo result object.
+	var blockchainInfoRes dcrjson.GetBlockChainInfoResult
+	err = json.Unmarshal(res, &blockchainInfoRes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &blockchainInfoRes, nil
+}
+
+// GetBlockChainInfoAsync returns an instance of a type that can be used to get
+// the result of the RPC at some future time by invoking the Receive function on
+// the returned instance.
+//
+// See GetBlockChainInfo for the blocking version and more details.
+func (c *Client) GetBlockChainInfoAsync() FutureGetBlockChainInfoResult {
+	cmd := dcrjson.NewGetBlockChainInfoCmd()
+	return c.sendCmd(cmd)
+}
+
+// GetBlockChainInfo returns information about the current state of the block
+// chain.
+func (c *Client) GetBlockChainInfo() (*dcrjson.GetBlockChainInfoResult, error) {
+	return c.GetBlockChainInfoAsync().Receive()
+}
+
 // FutureGetBlockHashResult is a future promise to deliver the result of a
 // GetBlockHashAsync RPC invocation (or an applicable error).
 type FutureGetBlockHashResult chan *response


### PR DESCRIPTION
This adds support for the `getblockchaininfo` RPC to `rpcclient`.

The main package's required `rpcclient` module version is bumped from v1.0.2 to v1.1.0.