### PR TITLE
chaincfg: Add checkpoints for upcoming release.

### DIFF
--- a/chaincfg/mainnetparams.go
+++ b/chaincfg/mainnetparams.go
@@ -68,6 +68,7 @@ var MainNetParams = Params{
 		{189950, newHashFromStr("000000000000007341d8ae2ea7e41f25cee00e1a70a4a3dc1cb055d14ecb2e11")},
 		{214672, newHashFromStr("0000000000000021d5cbeead55cb7fd659f07e8127358929ffc34cd362209758")},
 		{259810, newHashFromStr("0000000000000000ee0fbf469a9f32477ffbb46ebd7a280a53c842ab4243f97c")},
+		{295940, newHashFromStr("0000000000000000148852c8a919addf4043f9f267b13c08df051d359f1622ca")},
 	},
 
 	// The miner confirmation window is defined as:

--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -51,7 +51,9 @@ var TestNet3Params = Params{
 	BlockTaxProportion:       1,
 
 	// Checkpoints ordered from oldest to newest.
-	Checkpoints: []Checkpoint{},
+	Checkpoints: []Checkpoint{
+		{83520, newHashFromStr("0000000001e6244d95feae8b598e854905158c7bc781daf874afff88675ef0c8")},
+	},
 
 	// Consensus rule change deployments.
 	//

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/decred/dcrd/blockchain v1.1.1
 	github.com/decred/dcrd/blockchain/stake v1.1.0
 	github.com/decred/dcrd/certgen v1.0.2
-	github.com/decred/dcrd/chaincfg v1.2.0
+	github.com/decred/dcrd/chaincfg v1.2.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
 	github.com/decred/dcrd/connmgr v1.0.2
 	github.com/decred/dcrd/database v1.0.3


### PR DESCRIPTION
This adds a checkpoint to mainnet at height 295940 and testnet at height 83520.

Also, bump the chaincfg module to v1.2.1 so the new checkpoint are available to consumers.