### PR TITLE
mining: Remove superfluous error check.

### DIFF
--- a/mining.go
+++ b/mining.go
@@ -1773,9 +1773,7 @@ mempoolLoop:
 	}
 
 	coinbaseTx.SetTree(wire.TxTreeRegular) // Coinbase only in regular tx tree
-	if err != nil {
-		return nil, err
-	}
+
 	numCoinbaseSigOps := int64(blockchain.CountSigOps(coinbaseTx, true, false))
 	blockSize += uint32(coinbaseTx.MsgTx().SerializeSize())
 	blockSigOps += numCoinbaseSigOps


### PR DESCRIPTION
This removes a superfluous error check in the `NewBlockTemplate` function.