### PR TITLE
mempool: Optimize pool double spend check.

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -706,7 +706,7 @@ func (mp *TxPool) addTransaction(utxoView *blockchain.UtxoViewpoint,
 func (mp *TxPool) checkPoolDoubleSpend(tx *dcrutil.Tx, txType stake.TxType) error {
 	for i, txIn := range tx.MsgTx().TxIn {
 		// We don't care about double spends of stake bases.
-		if (i == 0) && (txType == stake.TxTypeSSGen || txType == stake.TxTypeSSRtx) {
+		if i == 0 && (txType == stake.TxTypeSSGen || txType == stake.TxTypeSSRtx) {
 			continue
 		}
 


### PR DESCRIPTION
This optimizes `checkPoolDoubleSpend` to check the traversal position first since it is more likely.
