### PR TITLE
dcrutil: Block does not cache for BlockHeaderBytes

### DIFF
--- a/dcrutil/block.go
+++ b/dcrutil/block.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -75,26 +75,19 @@ func (b *Block) Bytes() ([]byte, error) {
 	return serializedBlock, nil
 }
 
-// BlockHeaderBytes returns the serialized bytes for the Block's header.  This is
-// equivalent to calling Serialize on the underlying wire.MsgBlock, but it
-// returns a byte slice.
+// BlockHeaderBytes returns the serialized bytes for the Block's header.  This
+// is equivalent to calling Serialize on the underlying wire.MsgBlock.Header,
+// but it returns a byte slice.
 func (b *Block) BlockHeaderBytes() ([]byte, error) {
-	// Return the cached serialized bytes if it has already been generated.
-	if len(b.serializedBlock) != 0 {
-		return b.serializedBlock, nil
-	}
-
-	// Serialize the MsgBlock.
+	// Serialize the BlockHeader.
 	var w bytes.Buffer
 	w.Grow(wire.MaxBlockHeaderPayload)
 	err := b.msgBlock.Header.Serialize(&w)
 	if err != nil {
 		return nil, err
 	}
-	serializedBlockHeader := w.Bytes()
 
-	// Cache the serialized bytes and return them.
-	return serializedBlockHeader, nil
+	return w.Bytes(), nil
 }
 
 // Hash returns the block identifier hash for the Block.  This is equivalent to

--- a/dcrutil/block_test.go
+++ b/dcrutil/block_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -142,6 +142,28 @@ func TestBlock(t *testing.T) {
 				spew.Sdump(block100000Bytes))
 			continue
 		}
+	}
+
+	// Serialize the test block's header.
+	var block100000HeaderBuf bytes.Buffer
+	block100000HeaderBuf.Grow(wire.MaxBlockHeaderPayload)
+	err = Block100000.Header.Serialize(&block100000HeaderBuf)
+	if err != nil {
+		t.Errorf("Serialize: %v", err)
+	}
+	block100000HeaderBytes := block100000HeaderBuf.Bytes()
+
+	// Request serialized header bytes after the previous calls to block.Bytes
+	// to ensure the correct bytes are returned (not the cached copy of the full
+	// serialized block).
+	serializedHeaderBytes, err := b.BlockHeaderBytes()
+	if err != nil {
+		t.Errorf("Bytes: %v", err)
+	}
+	if !bytes.Equal(serializedHeaderBytes, block100000HeaderBytes) {
+		t.Errorf("BlockHeaderBytes wrong bytes - got %v, want %v",
+			spew.Sdump(serializedHeaderBytes),
+			spew.Sdump(block100000HeaderBytes))
 	}
 
 	// Transaction offsets and length for the transaction in Block100000.


### PR DESCRIPTION
This fixes a bug in dcrutil where `(*Block).BlockHeaderBytes` would incorrectly return a cached byte slice of the serialized block instead of just the header.  This would only happen after the cache had been set, such through a call to `block.Bytes()`, or construction via `NewBlockFromBytes` or `NewBlockFromBlockAndBytes`.

The comments are also changed accordingly and wrapped after 80 columns.

`TestBlock` is updated with a test for `(*Block).BlockHeaderBytes` that follows `(*Block).Bytes`.  When the test is run without the patch for `BlockHeaderBytes`:

```
=== RUN   TestBlock
--- FAIL: TestBlock (0.00s)
    /home/jon/github/decred/dcrd/dcrutil/block_test.go:164: BlockHeaderBytes wrong bytes - got ([]uint8) (len=1158 cap=1158) {
         00000000  01 00 00 00 50 12 01 19  17 2a 61 04 21 a6 c3 01  |....P....*a.!...|
         00000010  1d d3 30 d9 df 07 b6 36  16 c2 cc 1f 1c d0 02 00  |..0....6........|
         00000020  00 00 00 00 66 57 a9 25  2a ac d5 c0 b2 94 09 96  |....fW.%*.......|
         00000030  ec ff 95 22 28 c3 06 7c  c3 8d 48 85 ef b5 a4 ac  |..."(..|..H.....|
         00000040  42 47 e9 f3 00 00 00 00  00 00 00 00 00 00 00 00  |BG..............|
         00000050  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
         00000060  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
         00000070  00 00 00 00 4c 86 04 1b  00 00 00 00 00 00 00 00  |....L...........|
         00000080  a0 86 01 00 00 00 00 00  37 22 1b 4d 0f 2b 57 10  |........7".M.+W.|
         00000090  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
         000000a0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
         000000b0  00 00 00 00 04 01 00 00  00 01 00 00 00 00 00 00  |................|
         000000c0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
         000000d0  00 00 00 00 00 00 00 00  00 00 ff ff ff ff 00 ff  |................|
         000000e0  ff ff ff 01 00 f2 05 2a  01 00 00 00 00 00 43 41  |.......*......CA|
         000000f0  04 1b 0e 8c 25 67 c1 25  36 aa 13 35 7b 79 a0 73  |....%g.%6..5{y.s|
         00000100  dc 44 44 ac b8 3c 4e c7  a0 e2 f9 9d d7 45 75 16  |.DD..<N......Eu.|
         00000110  c5 81 72 42 da 79 69 24  ca 4e 99 94 7d 08 7f ed  |..rB.yi$.N..}...|
         00000120  f9 ce 46 7c b9 f7 c6 28  70 78 f8 01 df 27 6f df  |..F|...(px...'o.|
         00000130  84 ac 00 00 00 00 00 00  00 00 01 00 00 00 00 00  |................|
         00000140  00 00 00 00 00 00 00 00  00 00 00 08 04 4c 86 04  |.............L..|
         00000150  1b 02 06 02 01 00 00 00  01 03 2e 38 e9 c0 a8 4c  |...........8...L|
         00000160  60 46 d6 87 d1 05 56 dc  ac c4 1d 27 5e c5 5f c0  |`F....V....'^._.|
         00000170  07 79 ac 88 fd f3 57 a1  87 00 00 00 00 00 ff ff  |.y....W.........|
         00000180  ff ff 02 00 e3 23 21 00  00 00 00 00 00 19 76 a9  |.....#!.......v.|
         00000190  14 c3 98 ef a9 c3 92 ba  60 13 c5 e0 4e e7 29 75  |........`...N.)u|
         000001a0  5e f7 f5 8b 32 88 ac 00  0f e2 08 01 00 00 00 00  |^...2...........|
         000001b0  00 19 76 a9 14 94 8c 76  5a 69 14 d4 3f 2a 7a c1  |..v....vZi..?*z.|
         000001c0  77 da 2c 2f 6b 52 de 3d  7c 88 ac 00 00 00 00 00  |w.,/kR.=|.......|
         000001d0  00 00 00 01 00 00 00 00  00 00 00 00 00 00 00 00  |................|
         000001e0  00 00 00 00 8c 49 30 46  02 21 00 c3 52 d3 dd 99  |.....I0F.!..R...|
         000001f0  3a 98 1b eb a4 a6 3a d1  5c 20 92 75 ca 94 70 ab  |:.....:.\ .u..p.|
         00000200  fc d5 7d a9 3b 58 e4 eb  5d ce 82 02 21 00 84 07  |..}.;X..]...!...|
         00000210  92 bc 1f 45 60 62 81 9f  15 d3 3e e7 05 5c f7 b5  |...E`b....>..\..|
         00000220  ee 1a f1 eb cc 60 28 d9  cd b1 c3 af 77 48 01 41  |.....`(.....wH.A|
         00000230  04 f4 6d b5 e9 d6 1a 9d  c2 7b 8d 64 ad 23 e7 38  |..m......{.d.#.8|
         00000240  3a 4e 6c a1 64 59 3c 25  27 c0 38 c0 85 7e b6 7e  |:Nl.dY<%'.8..~.~|
         00000250  e8 e8 25 dc a6 50 46 b8  2c 93 31 58 6c 82 e0 fd  |..%..PF.,.1Xl...|
         00000260  1f 63 3f 25 f8 7c 16 1b  c6 f8 a6 30 12 1d f2 b3  |.c?%.|.....0....|
         00000270  d3 01 00 00 00 01 c3 3e  bf f2 a7 09 f1 3d 9f 9a  |.......>.....=..|
         00000280  75 69 ab 16 a3 27 86 af  7d 7e 2d e0 92 65 e4 1c  |ui...'..}~-..e..|
         00000290  61 d0 78 29 4e cf 01 00  00 00 00 ff ff ff ff 02  |a.x)N...........|
         000002a0  40 42 0f 00 00 00 00 00  00 00 19 76 a9 14 b0 dc  |@B.........v....|
         000002b0  bf 97 ea bf 44 04 e3 1d  95 24 77 ce 82 2d ad be  |....D....$w..-..|
         000002c0  7e 10 88 ac c0 60 d2 11  00 00 00 00 00 00 19 76  |~....`.........v|
         000002d0  a9 14 6b 12 81 ee c2 5a  b4 e1 e0 79 3f f4 e0 8a  |..k....Z...y?...|
         000002e0  b1 ab b3 40 9c d9 88 ac  00 00 00 00 00 00 00 00  |...@............|
         000002f0  01 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
         00000300  00 8a 47 30 44 02 20 03  2d 30 df 5e e6 f5 7f a4  |..G0D. .-0.^....|
         00000310  6c dd b5 eb 8d 0d 9f e8  de 6b 34 2d 27 94 2a e9  |l........k4-'.*.|
         00000320  0a 32 31 e0 ba 33 3e 02  20 3d ee e8 06 0f dc 70  |.21..3>. =.....p|
         00000330  23 0a 7f 5b 4a d7 d7 bc  3e 62 8c be 21 9a 88 6b  |#..[J...>b..!..k|
         00000340  84 26 9e ae b8 1e 26 b4  fe 01 41 04 ae 31 c3 1b  |.&....&...A..1..|
         00000350  f9 12 78 d9 9b 83 77 a3  5b bc e5 b2 7d 9f ff 15  |..x...w.[...}...|
         00000360  45 68 39 e9 19 45 3f c7  b3 f7 21 f0 ba 40 3f f9  |Eh9..E?...!..@?.|
         00000370  6c 9d ee b6 80 e5 fd 34  1c 0f c3 a7 b9 0d a4 63  |l......4.......c|
         00000380  1e e3 95 60 63 9d b4 62  e9 cb 85 0f 01 00 00 00  |...`c..b........|
         00000390  01 0b 60 72 b3 86 d4 a7  73 23 52 37 f6 4c 11 26  |..`r....s#R7.L.&|
         000003a0  ac 3b 24 0c 84 b9 17 a3  90 9b a1 c4 3d ed 5f 51  |.;$.........=._Q|
         000003b0  f4 00 00 00 00 00 ff ff  ff ff 01 40 42 0f 00 00  |...........@B...|
         000003c0  00 00 00 00 00 19 76 a9  14 39 aa 3d 56 9e 06 a1  |......v..9.=V...|
         000003d0  d7 92 6d c4 be 11 93 c9  9b f2 eb 9e e0 88 ac 00  |..m.............|
         000003e0  00 00 00 00 00 00 00 01  00 00 00 00 00 00 00 00  |................|
         000003f0  00 00 00 00 00 00 00 00  8c 49 30 46 02 21 00 bb  |.........I0F.!..|
         00000400  1a d2 6d f9 30 a5 1c ce  11 0c f4 4f 7a 48 c3 c5  |..m.0......OzH..|
         00000410  61 fd 97 75 00 b1 ae 5d  6b 6f d1 3d 0b 3f 4a 02  |a..u...]ko.=.?J.|
         00000420  21 00 c5 b4 29 51 ac ed  ff 14 ab ba 27 36 fd 57  |!...)Q......'6.W|
         00000430  4b db 46 5f 3e 6f 8d a1  2e 2c 53 03 95 4a ca 7f  |K.F_>o...,S..J..|
         00000440  78 f3 01 41 04 a7 13 5b  fe 82 4c 97 ec c0 1e c7  |x..A...[..L.....|
         00000450  d7 e3 36 18 5c 81 e2 aa  2c 41 ab 17 54 07 c0 94  |..6.\...,A..T...|
         00000460  84 ce 96 94 b4 49 53 fc  b7 51 20 65 64 a9 c2 4d  |.....IS..Q ed..M|
         00000470  d0 94 d4 2f db fd d5 aa  d3 e0 63 ce 6a f4 cf aa  |.../......c.j...|
         00000480  ea 4e a1 4f bb 00                                 |.N.O..|
        }
        , want ([]uint8) (len=180 cap=180) {
         00000000  01 00 00 00 50 12 01 19  17 2a 61 04 21 a6 c3 01  |....P....*a.!...|
         00000010  1d d3 30 d9 df 07 b6 36  16 c2 cc 1f 1c d0 02 00  |..0....6........|
         00000020  00 00 00 00 66 57 a9 25  2a ac d5 c0 b2 94 09 96  |....fW.%*.......|
         00000030  ec ff 95 22 28 c3 06 7c  c3 8d 48 85 ef b5 a4 ac  |..."(..|..H.....|
         00000040  42 47 e9 f3 00 00 00 00  00 00 00 00 00 00 00 00  |BG..............|
         00000050  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
         00000060  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
         00000070  00 00 00 00 4c 86 04 1b  00 00 00 00 00 00 00 00  |....L...........|
         00000080  a0 86 01 00 00 00 00 00  37 22 1b 4d 0f 2b 57 10  |........7".M.+W.|
         00000090  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
         000000a0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
         000000b0  00 00 00 00                                       |....|
        }
FAIL
FAIL	github.com/decred/dcrd/dcrutil	0.018s
```

The same test with the patch for `BlockHeaderBytes`:
```
=== RUN   TestBlock
--- PASS: TestBlock (0.00s)
PASS
ok  	github.com/decred/dcrd/dcrutil	0.017s
```