### PR TITLE
chaincfg: Introduce agenda for fixlnseqlocks vote.

### DIFF
--- a/blockchain/fullblocktests/params.go
+++ b/blockchain/fullblocktests/params.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 The Decred developers
+// Copyright (c) 2016-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -203,6 +203,34 @@ var regNetParams = &chaincfg.Params{
 			Vote: chaincfg.Vote{
 				Id:          chaincfg.VoteIDLNFeatures,
 				Description: "Enable features defined in DCP0002 and DCP0003 necessary to support Lightning Network (LN)",
+				Mask:        0x0006, // Bits 1 and 2
+				Choices: []chaincfg.Choice{{
+					Id:          "abstain",
+					Description: "abstain voting for change",
+					Bits:        0x0000,
+					IsAbstain:   true,
+					IsNo:        false,
+				}, {
+					Id:          "no",
+					Description: "keep the existing consensus rules",
+					Bits:        0x0002, // Bit 1
+					IsAbstain:   false,
+					IsNo:        true,
+				}, {
+					Id:          "yes",
+					Description: "change to the new consensus rules",
+					Bits:        0x0004, // Bit 2
+					IsAbstain:   false,
+					IsNo:        false,
+				}},
+			},
+			StartTime:  0,             // Always available for vote
+			ExpireTime: math.MaxInt64, // Never expires
+		}},
+		7: {{
+			Vote: chaincfg.Vote{
+				Id:          chaincfg.VoteIDFixLNSeqLocks,
+				Description: "Modify sequence lock handling as defined in DCP0004",
 				Mask:        0x0006, // Bits 1 and 2
 				Choices: []chaincfg.Choice{{
 					Id:          "abstain",

--- a/chaincfg/mainnetparams.go
+++ b/chaincfg/mainnetparams.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2016 The btcsuite developers
-// Copyright (c) 2015-2017 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -160,6 +160,34 @@ var MainNetParams = Params{
 			},
 			StartTime:  1505260800, // Sep 13th, 2017
 			ExpireTime: 1536796800, // Sep 13th, 2018
+		}},
+		6: {{
+			Vote: Vote{
+				Id:          VoteIDFixLNSeqLocks,
+				Description: "Modify sequence lock handling as defined in DCP0004",
+				Mask:        0x0006, // Bits 1 and 2
+				Choices: []Choice{{
+					Id:          "abstain",
+					Description: "abstain voting for change",
+					Bits:        0x0000,
+					IsAbstain:   true,
+					IsNo:        false,
+				}, {
+					Id:          "no",
+					Description: "keep the existing consensus rules",
+					Bits:        0x0002, // Bit 1
+					IsAbstain:   false,
+					IsNo:        true,
+				}, {
+					Id:          "yes",
+					Description: "change to the new consensus rules",
+					Bits:        0x0004, // Bit 2
+					IsAbstain:   false,
+					IsNo:        false,
+				}},
+			},
+			StartTime:  1548633600, // Jan 28th, 2019
+			ExpireTime: 1580169600, // Jan 28th, 2020
 		}},
 	},
 

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2016 The btcsuite developers
-// Copyright (c) 2015-2018 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -173,6 +173,11 @@ const (
 	// features useful for the Lightning Network (among other uses) defined
 	// by DCP0002 and DCP0003.
 	VoteIDLNFeatures = "lnfeatures"
+
+	// VoteIDFixLNSeqLocks is the vote ID for the agenda that corrects the
+	// sequence lock functionality needed for Lightning Network (among other
+	// uses) defined by DCP0004.
+	VoteIDFixLNSeqLocks = "fixlnseqlocks"
 )
 
 // ConsensusDeployment defines details related to a specific consensus rule

--- a/chaincfg/regnetparams.go
+++ b/chaincfg/regnetparams.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Decred developers
+// Copyright (c) 2018-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -125,6 +125,34 @@ var RegNetParams = Params{
 			Vote: Vote{
 				Id:          VoteIDLNFeatures,
 				Description: "Enable features defined in DCP0002 and DCP0003 necessary to support Lightning Network (LN)",
+				Mask:        0x0006, // Bits 1 and 2
+				Choices: []Choice{{
+					Id:          "abstain",
+					Description: "abstain voting for change",
+					Bits:        0x0000,
+					IsAbstain:   true,
+					IsNo:        false,
+				}, {
+					Id:          "no",
+					Description: "keep the existing consensus rules",
+					Bits:        0x0002, // Bit 1
+					IsAbstain:   false,
+					IsNo:        true,
+				}, {
+					Id:          "yes",
+					Description: "change to the new consensus rules",
+					Bits:        0x0004, // Bit 2
+					IsAbstain:   false,
+					IsNo:        false,
+				}},
+			},
+			StartTime:  0,             // Always available for vote
+			ExpireTime: math.MaxInt64, // Never expires
+		}},
+		7: {{
+			Vote: Vote{
+				Id:          VoteIDFixLNSeqLocks,
+				Description: "Modify sequence lock handling as defined in DCP0004",
 				Mask:        0x0006, // Bits 1 and 2
 				Choices: []Choice{{
 					Id:          "abstain",

--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2016 The btcsuite developers
-// Copyright (c) 2015-2018 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -63,6 +63,36 @@ var TestNet3Params = Params{
 	RuleChangeActivationMultiplier: 3,    // 75%
 	RuleChangeActivationDivisor:    4,
 	RuleChangeActivationInterval:   5040, // 1 week
+	Deployments: map[uint32][]ConsensusDeployment{
+		7: {{
+			Vote: Vote{
+				Id:          VoteIDFixLNSeqLocks,
+				Description: "Modify sequence lock handling as defined in DCP0004",
+				Mask:        0x0006, // Bits 1 and 2
+				Choices: []Choice{{
+					Id:          "abstain",
+					Description: "abstain voting for change",
+					Bits:        0x0000,
+					IsAbstain:   true,
+					IsNo:        false,
+				}, {
+					Id:          "no",
+					Description: "keep the existing consensus rules",
+					Bits:        0x0002, // Bit 1
+					IsAbstain:   false,
+					IsNo:        true,
+				}, {
+					Id:          "yes",
+					Description: "change to the new consensus rules",
+					Bits:        0x0004, // Bit 2
+					IsAbstain:   false,
+					IsNo:        false,
+				}},
+			},
+			StartTime:  1548633600, // Jan 28th, 2019
+			ExpireTime: 1580169600, // Jan 28th, 2020
+		}},
+	},
 
 	// Enforce current block version once majority of the network has
 	// upgraded.

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/decred/dcrd/blockchain v1.1.1
 	github.com/decred/dcrd/blockchain/stake v1.1.0
 	github.com/decred/dcrd/certgen v1.0.2
-	github.com/decred/dcrd/chaincfg v1.2.1
+	github.com/decred/dcrd/chaincfg v1.3.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
 	github.com/decred/dcrd/connmgr v1.0.2
 	github.com/decred/dcrd/database v1.0.3


### PR DESCRIPTION
This adds a new definition for the upcoming agenda vote to enable the corrected sequence locks behavior as defined by DCP0004.  It does not include any code to make decisions or bump the versions.  It is only the definition.

Also, bump the `chaincfg` module to v1.3.0 so the new definitions are available to consumers.
