### PR TITLE
blockchain: Add test logic to find deployments.

### DIFF
--- a/blockchain/thresholdstate_test.go
+++ b/blockchain/thresholdstate_test.go
@@ -118,7 +118,7 @@ func TestThresholdState(t *testing.T) {
 	// size to a really large number so that the test chain can be generated
 	// more quickly.
 	posVersion := uint32(4)
-	params := chaincfg.RegNetParams
+	params := cloneParams(&chaincfg.RegNetParams)
 	params.WorkDiffWindowSize = 200000
 	params.WorkDiffWindows = 1
 	params.TargetTimespan = params.TargetTimePerBlock *
@@ -141,13 +141,13 @@ func TestThresholdState(t *testing.T) {
 
 	// Create a test generator instance initialized with the genesis block
 	// as the tip.
-	g, err := chaingen.MakeGenerator(&params)
+	g, err := chaingen.MakeGenerator(params)
 	if err != nil {
 		t.Fatalf("Failed to create generator: %v", err)
 	}
 
 	// Create a new database and chain instance to run tests against.
-	chain, teardownFunc, err := chainSetup("thresholdstatetest", &params)
+	chain, teardownFunc, err := chainSetup("thresholdstatetest", params)
 	if err != nil {
 		t.Fatalf("Failed to setup chain instance: %v", err)
 	}


### PR DESCRIPTION
**This requires #1579 and #1580**.

Several of the blockchain tests have similar code to find a specific agenda id for a given version within a given set of chain parameters. This is cumbersome to repeat and also requires hard coding the specific version for an agenda, which can make it more difficult to use different chain parameters since the version often differs between them.

This improves the tests accordingly by introducing common test infrastructure to more easily work with deployments within the tests and refactoring the tests to make use of them.

The following is an overview of the changes:
- Introduce a `findDeployment` function to search for a given agenda within a set of network parameters and return the resulting version and consensus deployment struct itself
- Add a `findDeploymentChoice` function to find and return a given choice within a consensus deployment
- Add a `removeDeploymentTimeConstraints` function to modify a given deployment such that it never expires to prevent false positives in the tests as time passes
- Update the feature deployment tests to make use of the aforementioned functions and thus no longer require the version to be specified
- Update the legacy and fixed sequence lock tests accordingly
