### PR TITLE
mempool: Limit max vote double spends exactly.

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -973,7 +973,7 @@ func (mp *TxPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit, allow
 					voteAlreadyFound++
 				}
 			}
-			if voteAlreadyFound > maxVoteDoubleSpends {
+			if voteAlreadyFound >= maxVoteDoubleSpends {
 				str := fmt.Sprintf("transaction %v in the pool with more than "+
 					"%v votes", msgTx.TxIn[1].PreviousOutPoint,
 					maxVoteDoubleSpends)


### PR DESCRIPTION
**This requires #1595**.

This modifies the check which limits the maximum allowed votes double spending the same ticket to exactly the specified constant instead of one more.

It also adds tests for the max vote double spend handling to both ensure they are accepted up until the max, rejected thereafter, and that removing votes allows them to be accepted again.