### PR TITLE
dcrctl: Make version string consistent.

### DIFF
--- a/cmd/dcrctl/config.go
+++ b/cmd/dcrctl/config.go
@@ -264,7 +264,8 @@ func loadConfig() (*config, []string, error) {
 	appName = strings.TrimSuffix(appName, filepath.Ext(appName))
 	usageMessage := fmt.Sprintf("Use %s -h to show options", appName)
 	if preCfg.ShowVersion {
-		fmt.Println(appName, "version", version.String())
+		fmt.Printf("%s version %s (Go version %s %s/%s)\n", appName,
+			version.String(), runtime.Version(), runtime.GOOS, runtime.GOARCH)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
This makes the version string printed by the `-V`/`--version` flag consistent with `dcrd`.  In particular it will now include the runtime version, OS, and architecture.

Before: `dcrctl version 1.5.0-pre+dev`
After: `dcrctl version 1.5.0-pre+dev (Go version go1.11.5 linux/amd64)`