### PR TITLE
dcrjson: add cointype to WalletInfoResult

### DIFF
--- a/dcrjson/walletsvrresults.go
+++ b/dcrjson/walletsvrresults.go
@@ -412,11 +412,11 @@ type VerifySeedResult struct {
 	CoinType uint32 `json:"cointype"`
 }
 
-// WalletInfoResult models the data returned from the walletinfo
-// command.
+// WalletInfoResult models the data returned from the walletinfo command.
 type WalletInfoResult struct {
 	DaemonConnected  bool    `json:"daemonconnected"`
 	Unlocked         bool    `json:"unlocked"`
+	CoinType         uint32  `json:"cointype,omitempty"`
 	TxFee            float64 `json:"txfee"`
 	TicketFee        float64 `json:"ticketfee"`
 	TicketPurchasing bool    `json:"ticketpurchasing"`


### PR DESCRIPTION
This adds the active coin type to `dcrjson.WalletInfoResult`.
Since watching-only wallets do not store the coin type keys, the
`CoinType` field is tagged as `"cointype,omitempty"` so that it will be
omitted when the default value of 0 is set, as is the case when the
wallet has an error of kind (dcrwallet/)`errors.WatchingOnly`.

The location of `CoinType` in the struct is chosen in part because it will
not change the size of the struct because of the preceding `bool`s that
leave room in padding for a 32-bit value.

Supporting https://github.com/decred/dcrwallet/pull/1393