### PR TITLE
release: Freeze version 1 mempool module.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/decred/dcrd/fees v1.0.0
 	github.com/decred/dcrd/gcs v1.0.2
 	github.com/decred/dcrd/hdkeychain v1.1.1
-	github.com/decred/dcrd/mempool v1.1.0
+	github.com/decred/dcrd/mempool v1.2.0
 	github.com/decred/dcrd/mining v1.1.0
 	github.com/decred/dcrd/peer v1.1.0
 	github.com/decred/dcrd/rpcclient/v2 v2.0.0
@@ -60,7 +60,6 @@ replace (
 	github.com/decred/dcrd/gcs => ./gcs
 	github.com/decred/dcrd/hdkeychain => ./hdkeychain
 	github.com/decred/dcrd/limits => ./limits
-	github.com/decred/dcrd/mempool => ./mempool
 	github.com/decred/dcrd/mining => ./mining
 	github.com/decred/dcrd/peer => ./peer
 	github.com/decred/dcrd/rpcclient/v2 => ./rpcclient


### PR DESCRIPTION
This serves as the final release of version 1 of the `mempool` module.  All future releases will be moving to version 2 of the module.

Consequently, it bumps the module version as follows:

- github.com/decred/dcrd/mempool@v1.2.0

It also removes the `mempool` override in the root module and updates it so building the software will still produce binaries based on the v1 module until the v2 module is fully released.