### PR TITLE
main: Update for mempool/v2.

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -22,7 +22,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/database"
 	"github.com/decred/dcrd/dcrutil"
-	"github.com/decred/dcrd/mempool"
+	"github.com/decred/dcrd/mempool/v2"
 	"github.com/decred/dcrd/wire"
 )
 

--- a/config.go
+++ b/config.go
@@ -27,7 +27,7 @@ import (
 	_ "github.com/decred/dcrd/database/ffldb"
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrd/internal/version"
-	"github.com/decred/dcrd/mempool"
+	"github.com/decred/dcrd/mempool/v2"
 	"github.com/decred/dcrd/sampleconfig"
 	"github.com/decred/slog"
 	flags "github.com/jessevdk/go-flags"

--- a/go.mod
+++ b/go.mod
@@ -13,13 +13,12 @@ require (
 	github.com/decred/dcrd/connmgr v1.0.2
 	github.com/decred/dcrd/database v1.0.3
 	github.com/decred/dcrd/dcrec/secp256k1 v1.0.1
-	github.com/decred/dcrd/dcrjson v1.2.0 // indirect
 	github.com/decred/dcrd/dcrjson/v2 v2.0.0
 	github.com/decred/dcrd/dcrutil v1.2.0
 	github.com/decred/dcrd/fees v1.0.0
 	github.com/decred/dcrd/gcs v1.0.2
 	github.com/decred/dcrd/hdkeychain v1.1.1
-	github.com/decred/dcrd/mempool v1.2.0
+	github.com/decred/dcrd/mempool/v2 v2.0.0
 	github.com/decred/dcrd/mining v1.1.0
 	github.com/decred/dcrd/peer v1.1.0
 	github.com/decred/dcrd/rpcclient/v2 v2.0.0
@@ -52,6 +51,7 @@ replace (
 	github.com/decred/dcrd/gcs => ./gcs
 	github.com/decred/dcrd/hdkeychain => ./hdkeychain
 	github.com/decred/dcrd/limits => ./limits
+	github.com/decred/dcrd/mempool/v2 => ./mempool
 	github.com/decred/dcrd/mining => ./mining
 	github.com/decred/dcrd/peer => ./peer
 	github.com/decred/dcrd/rpcclient/v2 => ./rpcclient

--- a/go.sum
+++ b/go.sum
@@ -38,10 +38,6 @@ github.com/decred/dcrd/dcrec/edwards v0.0.0-20190130161649-59ed4247a1d5 h1:qA+q5
 github.com/decred/dcrd/dcrec/edwards v0.0.0-20190130161649-59ed4247a1d5/go.mod h1:+ehP0Hk/mesyZXttxCtBbhPX23BMpZJ1pcVBqUfbmvU=
 github.com/decred/dcrd/dcrec/secp256k1 v1.0.1 h1:EFWVd1p0t0Y5tnsm/dJujgV0ORogRJ6vo7CMAjLseAc=
 github.com/decred/dcrd/dcrec/secp256k1 v1.0.1/go.mod h1:lhu4eZFSfTJWUnR3CFRcpD+Vta0KUAqnhTsTksHXgy0=
-github.com/decred/dcrd/dcrjson v1.1.0 h1:pFpbay3cWACkgloFxWjHBwlXWG2+S2QCJJzNxL40hwg=
-github.com/decred/dcrd/dcrjson v1.1.0/go.mod h1:ozddIaeF+EAvZZvFuB3zpfxhyxBGfvbt22crQh+PYuI=
-github.com/decred/dcrd/dcrjson v1.2.0 h1:3BFFQHq3/YO/zae9WLxQkXsX6AXKx3+M8H3yk4oXZi0=
-github.com/decred/dcrd/dcrjson v1.2.0/go.mod h1:ozddIaeF+EAvZZvFuB3zpfxhyxBGfvbt22crQh+PYuI=
 github.com/decred/dcrd/dcrjson/v2 v2.0.0 h1:W0q4Alh36c5N318eUpfmU8kXoCNgImMLI87NIXni9Us=
 github.com/decred/dcrd/dcrjson/v2 v2.0.0/go.mod h1:FYueNy8BREAFq04YNEwcTsmGFcNqY+ehUUO81w2igi4=
 github.com/decred/dcrd/dcrutil v1.2.0 h1:Pd5Wf650g6Xu6luYDfGkh1yiUoPUAgqzRu6K+BGyJGg=
@@ -52,8 +48,8 @@ github.com/decred/dcrd/gcs v1.0.2 h1:wZjxeC9WPBoRApaAQpBrzvN9NA0iS2KWrTJa9IiDgc8
 github.com/decred/dcrd/gcs v1.0.2/go.mod h1:eLCvrzUsWro48TlTyrmFcZAZqnllYFz0vEv5VZtufF4=
 github.com/decred/dcrd/hdkeychain v1.1.1 h1:6+BwOmPfEyw/Krm+91RXysc76F1jqCta3m45DyD5+s4=
 github.com/decred/dcrd/hdkeychain v1.1.1/go.mod h1:CLBVXLoO63fIiqkv38KR23zXGSgrfiAWOybOKTneLhA=
-github.com/decred/dcrd/mempool v1.2.0 h1:jFlofZOz9QPv7eXWYYyQ9gBq6roeV2SaYI1uDD4wbF0=
-github.com/decred/dcrd/mempool v1.2.0/go.mod h1:jbL4+jOVjTU/MfgYV8SptKVpOTFD+DeHC15DhdJsfAI=
+github.com/decred/dcrd/mempool/v2 v2.0.0 h1:QoQC5Lri311unqCr/PejBEwNERWMSWtnSa7bpBFZjbQ=
+github.com/decred/dcrd/mempool/v2 v2.0.0/go.mod h1:/AH0mFOKCglSdEDubF3oRDbWUmDj26gwnrIlFsr+lbM=
 github.com/decred/dcrd/mining v1.1.0 h1:9Wtla+i+pEjfYsNCfixsipmyyoB26DgL4LSXWAin/zw=
 github.com/decred/dcrd/mining v1.1.0/go.mod h1:NQEtX604XgNwKcPFId1hVTTiBqmVQDlnqV1yNqGl4oU=
 github.com/decred/dcrd/peer v1.1.0 h1:Il05Vzt2uW6cOCISJgT3rTtJ0BEs/09bSvivGMmQt8g=

--- a/log.go
+++ b/log.go
@@ -17,7 +17,7 @@ import (
 	"github.com/decred/dcrd/connmgr"
 	"github.com/decred/dcrd/database"
 	"github.com/decred/dcrd/fees"
-	"github.com/decred/dcrd/mempool"
+	"github.com/decred/dcrd/mempool/v2"
 	"github.com/decred/dcrd/peer"
 	"github.com/decred/dcrd/txscript"
 	"github.com/decred/slog"

--- a/server.go
+++ b/server.go
@@ -33,7 +33,7 @@ import (
 	"github.com/decred/dcrd/gcs"
 	"github.com/decred/dcrd/gcs/blockcf"
 	"github.com/decred/dcrd/internal/version"
-	"github.com/decred/dcrd/mempool"
+	"github.com/decred/dcrd/mempool/v2"
 	"github.com/decred/dcrd/mining"
 	"github.com/decred/dcrd/peer"
 	"github.com/decred/dcrd/txscript"


### PR DESCRIPTION
This updates the main module to use version 2 of the mempool module.

The following is a summary of changes:

- Update all imports to use mempool/v2
- Update module requirements to include new module and remove no longer needed old versions
- Add an override for the v2 module so CI is always builds with the latest code
- Update `rpcserver` `getrawmempool` handler to make use of new `mempool` `VerboseTxDescs` instead of the removed `RawMempoolVerbose`
- Update `rpcserver` `getrawmempool` handler to properly return the parameter  provided for the transaction type instead of the type of variable in the case an invalid type is provided
- Update `rpcserver` `getrawmempool` to return the supported transaction types in the error when an invalid type is provided