### PR TITLE
blockmanager: use local var for the request queue

### DIFF
--- a/server.go
+++ b/server.go
@@ -233,7 +233,6 @@ type serverPeer struct {
 	relayMtx        sync.Mutex
 	disableRelayTx  bool
 	isWhitelisted   bool
-	requestQueue    []*wire.InvVect
 	requestedTxns   map[chainhash.Hash]struct{}
 	requestedBlocks map[chainhash.Hash]struct{}
 	knownAddresses  lru.Cache


### PR DESCRIPTION
Instead of waiting for a second inv to process what the first inv
may have requested, just send it all at once.  This allows dropping
of a request queue for each server peer.