### PR TITLE
dcrec/secp256k1: Update README.md broken link.

### DIFF
--- a/dcrec/secp256k1/doc.go
+++ b/dcrec/secp256k1/doc.go
@@ -1,15 +1,14 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 /*
-Package secp256k1 implements support for the elliptic curves needed for decred.
+Package secp256k1 implements support for the elliptic curves needed for Decred.
 
 Decred uses elliptic curve cryptography using koblitz curves
 (specifically secp256k1) for cryptographic functions.  See
-http://www.secg.org/collateral/sec2_final.pdf for details on the
-standard.
+http://www.secg.org/sec2-v2.pdf for details on the standard.
 
 This package provides the data structures and functions implementing the
 crypto/elliptic Curve interface in order to permit using these curves


### PR DESCRIPTION
This updates the link to the document of secp256k1.