### PR TITLE
dcrutil: Remove not used AtomsPerCent constant

### DIFF
--- a/dcrutil/const.go
+++ b/dcrutil/const.go
@@ -1,18 +1,14 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package dcrutil
 
 const (
-	// AtomsPerCent is the number of atomic units in one coin cent.
-	AtomsPerCent = 1e6
-
 	// AtomsPerCoin is the number of atomic units in one coin.
 	AtomsPerCoin = 1e8
 
 	// MaxAmount is the maximum transaction amount allowed in atoms.
-	// Decred - Changeme for release
 	MaxAmount = 21e6 * AtomsPerCoin
 )


### PR DESCRIPTION
This removes `AtomsPerCent` constant which has never been used in any Decred projects, so it's safe to remove.
This commit also removes an old todo comment.