### PR TITLE
rpcserver: fix nil deference if connection went away

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3377,10 +3377,15 @@ func handleGetPeerInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{})
 	infos := make([]*dcrjson.GetPeerInfoResult, 0, len(peers))
 	for _, p := range peers {
 		statsSnap := p.StatsSnapshot()
+		localAddr := p.LocalAddr()
+		if localAddr == nil {
+			// Currently not connected
+			continue
+		}
 		info := &dcrjson.GetPeerInfoResult{
 			ID:             statsSnap.ID,
 			Addr:           statsSnap.Addr,
-			AddrLocal:      p.LocalAddr().String(),
+			AddrLocal:      localAddr.String(),
 			Services:       fmt.Sprintf("%08d", uint64(statsSnap.Services)),
 			RelayTxes:      !p.disableRelayTx,
 			LastSend:       statsSnap.LastSend.Unix(),


### PR DESCRIPTION
A peer could have disconnected between fetching and reporting the peers,
which would result in LocalAddr() returning nil.
Cache the local address on peer association to prevent the LocalAddr method from ever returning nil.
Fixes #1603 