### PR TITLE
wire: Fix maximum payload length of MsgAddr.

### DIFF
--- a/wire/msgaddr.go
+++ b/wire/msgaddr.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -120,8 +120,11 @@ func (msg *MsgAddr) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgAddr) MaxPayloadLength(pver uint32) uint32 {
-	// Num addresses (varInt) + max allowed addresses.
-	return MaxVarIntPayload + (MaxAddrPerMsg * maxNetAddressPayload(pver))
+	// Num addresses (size of varInt for max address per message) + max allowed
+	// addresses * max address size.
+	return uint32(VarIntSerializeSize(MaxAddrPerMsg)) +
+		(MaxAddrPerMsg * maxNetAddressPayload(pver))
+
 }
 
 // NewMsgAddr returns a new bitcoin addr message that conforms to the

--- a/wire/msgaddr_test.go
+++ b/wire/msgaddr_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -29,8 +29,8 @@ func TestAddr(t *testing.T) {
 	}
 
 	// Ensure max payload is expected value for latest protocol version.
-	// Num addresses (varInt) + max allowed addresses.
-	wantPayload := uint32(30009)
+	// Num addresses (size of varInt for max address ) + max allowed addresses.
+	wantPayload := uint32(30003)
 	maxPayload := msg.MaxPayloadLength(pver)
 	if maxPayload != wantPayload {
 		t.Errorf("MaxPayloadLength: wrong max payload length for "+


### PR DESCRIPTION
This fixes the calculation of the maximum payload size of `MsgAddr`. The number of address in encoded `MsgAddr` is `varInt` which its size for the maximum size of allowed address is lower than `MaxVarIntPayload`.
