### PR TITLE
rpctest: Add new functions

### DIFF
--- a/rpctest/utils.go
+++ b/rpctest/utils.go
@@ -134,6 +134,38 @@ func ConnectNode(from *Harness, to *Harness) error {
 	return nil
 }
 
+// RemoveNode removes the peer-to-peer connection between the "from" harness and
+// the "to" harness. The connection is only removed in this direction, therefore
+// if the reverse connection exists, the nodes may still be connected.
+//
+// This function returns an error if the nodes were not previously connected.
+func RemoveNode(from *Harness, to *Harness) error {
+	targetAddr := to.node.config.listen
+	if err := from.Node.AddNode(targetAddr, rpcclient.ANRemove); err != nil {
+		// AddNode(..., ANRemove) returns an error if the peer is not found
+		return err
+	}
+
+	// Block until this particular connection has been dropped.
+	for {
+		peerInfo, err := from.Node.GetPeerInfo()
+		if err != nil {
+			return err
+		}
+		for _, p := range peerInfo {
+			if p.Addr == targetAddr {
+				// Nodes still connected. Skip and re-fetch the list of nodes.
+				continue
+			}
+		}
+
+		// If this point is reached, then the nodes are not connected anymore.
+		break
+	}
+
+	return nil
+}
+
 // TearDownAll tears down all active test harnesses.
 func TearDownAll() error {
 	harnessStateMtx.Lock()

--- a/rpctest/utils.go
+++ b/rpctest/utils.go
@@ -166,6 +166,42 @@ func RemoveNode(from *Harness, to *Harness) error {
 	return nil
 }
 
+// NodesConnected verifies whether there is a connection via the p2p interface
+// between the specified nodes. If allowReverse is true, connectivity is also
+// checked in the reverse direction (to->from).
+func NodesConnected(from, to *Harness, allowReverse bool) (bool, error) {
+	peerInfo, err := from.Node.GetPeerInfo()
+	if err != nil {
+		return false, err
+	}
+
+	targetAddr := to.node.config.listen
+	for _, p := range peerInfo {
+		if p.Addr == targetAddr {
+			return true, nil
+		}
+	}
+
+	if !allowReverse {
+		return false, nil
+	}
+
+	// Check in the reverse direction.
+	peerInfo, err = to.Node.GetPeerInfo()
+	if err != nil {
+		return false, err
+	}
+
+	targetAddr = from.node.config.listen
+	for _, p := range peerInfo {
+		if p.Addr == targetAddr {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 // TearDownAll tears down all active test harnesses.
 func TearDownAll() error {
 	harnessStateMtx.Lock()


### PR DESCRIPTION
This adds new functions for the rpctest package to allow users to check the connection status and disconnect test harnesses.

This is necessary for some outside tests that perform reorgs or other sync operations between nodes.

Given that rpctest is not currently an individual module, this will require a minor bump to the main module.