### PR TITLE
server: Remove instead of disconnect node

### DIFF
--- a/server.go
+++ b/server.go
@@ -1549,6 +1549,15 @@ func (s *server) handleQuery(state *peerState, querymsg interface{}) {
 			// Keep group counts ok since we remove from
 			// the list now.
 			state.outboundGroups[addrmgr.GroupKey(sp.NA())]--
+
+			peerLog.Debugf("Removing persistent peer %s:%d (reqid %d)",
+				sp.NA().IP, sp.NA().Port, sp.connReq.ID())
+			connReq := sp.connReq
+
+			// Mark the peer's connReq as nil to prevent it from scheduling a
+			// re-connect attempt.
+			sp.connReq = nil
+			s.connManager.Remove(connReq.ID())
 		})
 
 		if found {


### PR DESCRIPTION
This changes the behavior of peer disconnection logic, such that
permanent peers are actually removed from the connection manager when
requested, instead of just being disconnected and therefore triggering a
future retry.

Previously, this prevented the addnode [addr] remove from correctly
removing permanent peers. A connection retry attempt would always be
performed.

The easiest way to test this behavior is to run two nodes disconnected from any other public nodes (either in testnet or on a private simnet), connect them via `dcrctl addnode [othernode] add` then disconnect via `dcrctl addnode [othernode] remove`. Without this patch the nodes will reconnect, even though the previous `remove` command should have removed the peer from the permanent list.