### PR TITLE
txscript: Consistent checksigaltverify handling.

### DIFF
--- a/txscript/error.go
+++ b/txscript/error.go
@@ -143,6 +143,11 @@ const (
 	// evaluate to true.
 	ErrCheckMultiSigVerify
 
+	// ErrCheckSigAltVerify is returned when OP_CHECKSIGALTVERIFY is
+	// encountered in a script and the top item on the data stack does not
+	// evaluate to true.
+	ErrCheckSigAltVerify
+
 	// --------------------------------------------
 	// Failures related to improper use of opcodes.
 	// --------------------------------------------
@@ -352,6 +357,7 @@ var errorCodeStrings = map[ErrorCode]string{
 	ErrNumEqualVerify:            "ErrNumEqualVerify",
 	ErrCheckSigVerify:            "ErrCheckSigVerify",
 	ErrCheckMultiSigVerify:       "ErrCheckMultiSigVerify",
+	ErrCheckSigAltVerify:         "ErrCheckSigAltVerify",
 	ErrP2SHStakeOpCodes:          "ErrP2SHStakeOpCodes",
 	ErrDisabledOpcode:            "ErrDisabledOpcode",
 	ErrReservedOpcode:            "ErrReservedOpcode",

--- a/txscript/error_test.go
+++ b/txscript/error_test.go
@@ -41,6 +41,7 @@ func TestErrorCodeStringer(t *testing.T) {
 		{ErrNumEqualVerify, "ErrNumEqualVerify"},
 		{ErrCheckSigVerify, "ErrCheckSigVerify"},
 		{ErrCheckMultiSigVerify, "ErrCheckMultiSigVerify"},
+		{ErrCheckSigAltVerify, "ErrCheckSigAltVerify"},
 		{ErrP2SHStakeOpCodes, "ErrP2SHStakeOpCodes"},
 		{ErrDisabledOpcode, "ErrDisabledOpcode"},
 		{ErrReservedOpcode, "ErrReservedOpcode"},

--- a/txscript/opcode.go
+++ b/txscript/opcode.go
@@ -3043,7 +3043,7 @@ func opcodeCheckSigAlt(op *parsedOpcode, vm *Engine) error {
 func opcodeCheckSigAltVerify(op *parsedOpcode, vm *Engine) error {
 	err := opcodeCheckSigAlt(op, vm)
 	if err == nil {
-		err = opcodeVerify(op, vm)
+		err = abstractVerify(op, vm, ErrCheckSigAltVerify)
 	}
 	return err
 }


### PR DESCRIPTION
This introduces a new error named `ErrCheckSigAltVerify` and modifies the `opcodeCheckSigAltVerify` handler to use the `abstractVerify` function along with the new error.  This makes the handling consistent with all other signature checking verification opcode handlers and ensures the error both can be programmatically detected as well as be uniquely identified as compared to a generic verify failure.