### PR TITLE
TravisCI: Set ./run_tests.sh executable perms.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ env:
   - GOVERSION=1.11
   - GOVERSION=1.12
 
+before_install:
+  - chmod +x ./run_tests.sh
+
 install: true
 
 cache:


### PR DESCRIPTION
Ensures CI will not fail with `./run_tests.sh: Permission denied`