### PR TITLE
txscript: Introduce constant for max CSV bytes.

### DIFF
--- a/txscript/opcode.go
+++ b/txscript/opcode.go
@@ -1169,7 +1169,7 @@ func opcodeCheckSequenceVerify(op *parsedOpcode, vm *Engine) error {
 	// 2^31-1.  Thus, a 5-byte scriptNum is used here since it will support
 	// up to 2^39-1 which allows sequences beyond the current sequence
 	// limit.
-	stackSequence, err := vm.dstack.PeekInt(0, 5)
+	stackSequence, err := vm.dstack.PeekInt(0, csvMaxScriptNumLen)
 	if err != nil {
 		return err
 	}

--- a/txscript/scriptnum.go
+++ b/txscript/scriptnum.go
@@ -29,6 +29,18 @@ const (
 	// up to 2^39-1 which allows dates beyond the current locktime limit.
 	cltvMaxScriptNumLen = 5
 
+	// csvMaxScriptNumLen is the maximum number of bytes data being interpreted
+	// as an integer may be for by-time and by-height locks as interpreted by
+	// CHECKSEQUENCEVERIFY.
+	//
+	// The value comes from the fact that the current transaction sequence
+	// is a uint32 resulting in a maximum sequence of 2^32-1.  However,
+	// scriptNums are signed and therefore a standard 4-byte scriptNum would
+	// only support up to a maximum of 2^31-1.  Thus, a 5-byte scriptNum is
+	// needed since it will support up to 2^39-1 which allows sequences
+	// beyond the current sequence limit.
+	csvMaxScriptNumLen = 5
+
 	// altSigSuitesMaxscriptNumLen is the maximum number of bytes for the
 	// type of alternative signature suite
 	altSigSuitesMaxscriptNumLen = 1


### PR DESCRIPTION
**This is rebased on top of #1650**.

As is already well commented in the code, the sequence number parameter of the `CHECKSEQUENCEVERIFY` opcode requires 5 bytes instead of the standard 4 bytes allowed by math opcodes.  This introduces a constant for the value instead of hardcoding 5 to increase readability and potentially allow the value to be exported in the future.