### PR TITLE
blockchain: Deprecate BlockOneCoinbasePaysTokens.

### DIFF
--- a/blockchain/subsidy.go
+++ b/blockchain/subsidy.go
@@ -200,9 +200,9 @@ func CalcBlockTaxSubsidy(subsidyCache *SubsidyCache, height int64, voters uint16
 	return adjusted
 }
 
-// BlockOneCoinbasePaysTokens checks to see if the first block coinbase pays
+// blockOneCoinbasePaysTokens checks to see if the first block coinbase pays
 // out to the network initial token ledger.
-func BlockOneCoinbasePaysTokens(tx *dcrutil.Tx, params *chaincfg.Params) error {
+func blockOneCoinbasePaysTokens(tx *dcrutil.Tx, params *chaincfg.Params) error {
 	// If no ledger is specified, just return true.
 	if len(params.BlockOneLedger) == 0 {
 		return nil
@@ -278,6 +278,14 @@ func BlockOneCoinbasePaysTokens(tx *dcrutil.Tx, params *chaincfg.Params) error {
 	}
 
 	return nil
+}
+
+// BlockOneCoinbasePaysTokens checks to see if the first block coinbase pays
+// out to the network initial token ledger.
+//
+// DEPRECATED.  This will be removed in the next major version bump.
+func BlockOneCoinbasePaysTokens(tx *dcrutil.Tx, params *chaincfg.Params) error {
+	return blockOneCoinbasePaysTokens(tx, params)
 }
 
 // CoinbasePaysTax checks to see if a given block's coinbase correctly pays

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -3047,7 +3047,7 @@ func (b *BlockChain) checkConnectBlock(node *blockNode, block, parent *dcrutil.B
 
 	// First block has special rules concerning the ledger.
 	if node.height == 1 {
-		err := BlockOneCoinbasePaysTokens(block.Transactions()[0],
+		err := blockOneCoinbasePaysTokens(block.Transactions()[0],
 			b.chainParams)
 		if err != nil {
 			return err


### PR DESCRIPTION
This deprecates the exported `BlockOneCoinbasePaysTokens` function in favor of an unexported variant.  This is being done since it is only intended to be an internal function and thus should not be exported.

However, since unexporting the function is a break to the API, it requires a major version bump to the `blockchain` module.  Therefore, the exported function is retained and simply redefined in terms of the now unexported definition.