### PR TITLE
blockchain: Explicit script ver in coinbase checks.

### DIFF
--- a/blockchain/subsidy.go
+++ b/blockchain/subsidy.go
@@ -236,11 +236,12 @@ func blockOneCoinbasePaysTokens(tx *dcrutil.Tx, params *chaincfg.Params) error {
 	}
 
 	// Check the addresses and output amounts against those in the ledger.
+	const consensusScriptVersion = 0
 	for i, txout := range tx.MsgTx().TxOut {
-		if txout.Version != txscript.DefaultScriptVersion {
-			errStr := fmt.Sprintf("bad block one output version; want %v, got %v",
-				txscript.DefaultScriptVersion, txout.Version)
-			return ruleError(ErrBlockOneOutputs, errStr)
+		if txout.Version != consensusScriptVersion {
+			str := fmt.Sprintf("block one output %d script version %d is not %d",
+				i, txout.Version, consensusScriptVersion)
+			return ruleError(ErrBlockOneOutputs, str)
 		}
 
 		// There should only be one address.


### PR DESCRIPTION
This modifies the function which ensures the first block coinbase pays to the outputs required by the chain params to explicitly require script version 0 rather than using the `DefaultScriptVersion` from `txscript` which is subject to change and could therefore easily inadvertently cause an unintentional consensus break.

It also improves the error message while here.