### PR TITLE
dcrutil: Lookup params by addr prefix in chaincfg.

### DIFF
--- a/dcrutil/address.go
+++ b/dcrutil/address.go
@@ -205,19 +205,7 @@ func detectNetworkForAddress(addr string) (*chaincfg.Params, error) {
 		return nil, fmt.Errorf("empty string given for network detection")
 	}
 
-	networkChar := addr[0:1]
-	switch networkChar {
-	case chaincfg.MainNetParams.NetworkAddressPrefix:
-		return &chaincfg.MainNetParams, nil
-	case chaincfg.TestNet3Params.NetworkAddressPrefix:
-		return &chaincfg.TestNet3Params, nil
-	case chaincfg.SimNetParams.NetworkAddressPrefix:
-		return &chaincfg.SimNetParams, nil
-	case chaincfg.RegNetParams.NetworkAddressPrefix:
-		return &chaincfg.RegNetParams, nil
-	}
-
-	return nil, fmt.Errorf("unknown network type in string encoded address")
+	return chaincfg.ParamsByNetAddrPrefix(addr[0:1])
 }
 
 // AddressPubKeyHash is an Address for a pay-to-pubkey-hash (P2PKH)


### PR DESCRIPTION
**This requires #1664**.

This modifies the code that looks up the params by a given network prefix to make use of the new function provided by `chaincfg` in order to ensure that it works with all registered networks as the package was intended.

