### PR TITLE
peer: Deprecate dependency on chaincfg.

### DIFF
--- a/peer/example_test.go
+++ b/peer/example_test.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"time"
 
-	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/peer"
 	"github.com/decred/dcrd/wire"
 )
@@ -23,7 +22,7 @@ func mockRemotePeer() error {
 	peerCfg := &peer.Config{
 		UserAgentName:    "peer",  // User agent name to advertise.
 		UserAgentVersion: "1.0.0", // User agent version to advertise.
-		ChainParams:      &chaincfg.SimNetParams,
+		Net:              wire.SimNet,
 	}
 
 	// Accept connections on the simnet port.
@@ -68,7 +67,7 @@ func Example_newOutboundPeer() {
 	peerCfg := &peer.Config{
 		UserAgentName:    "peer",  // User agent name to advertise.
 		UserAgentVersion: "1.0.0", // User agent version to advertise.
-		ChainParams:      &chaincfg.SimNetParams,
+		Net:              wire.SimNet,
 		Services:         0,
 		Listeners: peer.MessageListeners{
 			OnVersion: func(p *peer.Peer, msg *wire.MsgVersion) *wire.MsgReject {

--- a/server.go
+++ b/server.go
@@ -1670,7 +1670,7 @@ func newPeerConfig(sp *serverPeer) *peer.Config {
 		UserAgentName:     userAgentName,
 		UserAgentVersion:  userAgentVersion,
 		UserAgentComments: userAgentComments,
-		ChainParams:       sp.server.chainParams,
+		Net:               sp.server.chainParams.Net,
 		Services:          sp.server.services,
 		DisableRelayTx:    cfg.BlocksOnly,
 		ProtocolVersion:   maxProtocolVersion,


### PR DESCRIPTION
**This requires #1670**.

The only way the chain params are used by the peer is to ascertain the network magic to use on the wire (the Net field), so rather than requiring an entire chain params instance, it is desirable to reduce the scope such that the caller only needs to specify the specific value the module peer needs.

To that end, this introduces a new field named Net on the config struct which the caller can optionally specify in the same vain as the chain params could previously optionally be specified.

The ultimate goal is to remove the `chaincfg` dependency altogether, however, since removing the public `ChainParams` field is a breaking API change, the field is deprecated and, in order to maintain API compatibility, some additional semantics around handling of the optionality of the new `Net` field are introduced.

In particular, the `Net` field is chosen as follows:

- Use the value specified by the caller directly when set
- Fallback to the network associated with the chain params when set
- Fallback to the test network if neither are set

It also updates the example and tests to specify the network directly and adds a new test which explicitly tests the new fallback semantics.

---

Finally, a second commit updates `peer.Config` in the `server` to set the new `Net` parameter instead of the now deprecated `ChainParams` parameter.