### PR TITLE
wire: Accurate calculations of maximum length.

### DIFF
--- a/wire/msgcfheaders.go
+++ b/wire/msgcfheaders.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2017 The btcsuite developers
 // Copyright (c) 2017 The Lightning Network Developers
-// Copyright (c) 2018 The Decred developers
+// Copyright (c) 2018-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -166,9 +166,9 @@ func (msg *MsgCFHeaders) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver. This is part of the Message interface implementation.
 func (msg *MsgCFHeaders) MaxPayloadLength(pver uint32) uint32 {
-	// Hash size + filter type + num headers (varInt) +
+	// Hash size + filter type + num headers (varInt) 3 bytes +
 	// (header size * max headers).
-	return chainhash.HashSize + 1 + MaxVarIntPayload +
+	return chainhash.HashSize + 1 + uint32(VarIntSerializeSize(MaxCFHeadersPerMsg)) +
 		(MaxCFHeaderPayload * MaxCFHeadersPerMsg)
 }
 

--- a/wire/msggetblocks.go
+++ b/wire/msggetblocks.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -123,9 +123,10 @@ func (msg *MsgGetBlocks) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgGetBlocks) MaxPayloadLength(pver uint32) uint32 {
-	// Protocol version 4 bytes + num hashes (varInt) + max block locator
-	// hashes + hash stop.
-	return 4 + MaxVarIntPayload + (MaxBlockLocatorsPerMsg * chainhash.HashSize) + chainhash.HashSize
+	// Protocol version 4 bytes + num hashes (varInt) 3 bytes + max block
+	// locator hashes + hash stop.
+	return 4 + uint32(VarIntSerializeSize(MaxBlockLocatorsPerMsg)) +
+		(MaxBlockLocatorsPerMsg * chainhash.HashSize) + chainhash.HashSize
 }
 
 // NewMsgGetBlocks returns a new Decred getblocks message that conforms to the

--- a/wire/msggetblocks_test.go
+++ b/wire/msggetblocks_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -48,9 +48,9 @@ func TestGetBlocks(t *testing.T) {
 	}
 
 	// Ensure max payload is expected value for latest protocol version.
-	// Protocol version 4 bytes + num hashes (varInt) + max block locator
-	// hashes + hash stop.
-	wantPayload := uint32(16045)
+	// Protocol version 4 bytes + num hashes (varInt) 3 bytes + max block
+	// locator hashes + hash stop.
+	wantPayload := uint32(16039)
 	maxPayload := msg.MaxPayloadLength(pver)
 	if maxPayload != wantPayload {
 		t.Errorf("MaxPayloadLength: wrong max payload length for "+

--- a/wire/msggetcfheaders.go
+++ b/wire/msggetcfheaders.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2017 The btcsuite developers
 // Copyright (c) 2017 The Lightning Network Developers
-// Copyright (c) 2018 The Decred developers
+// Copyright (c) 2018-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -121,10 +121,10 @@ func (msg *MsgGetCFHeaders) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgGetCFHeaders) MaxPayloadLength(pver uint32) uint32 {
-	// Num block locator hashes (varInt) + max allowed
+	// Num block locator hashes (varInt) 3 bytes + max allowed
 	// block locators + hash stop + filter type 1 byte.
-	return MaxVarIntPayload + (MaxBlockLocatorsPerMsg *
-		chainhash.HashSize) + chainhash.HashSize + 1
+	return uint32(VarIntSerializeSize(MaxBlockLocatorsPerMsg)) +
+		(MaxBlockLocatorsPerMsg * chainhash.HashSize) + chainhash.HashSize + 1
 }
 
 // NewMsgGetCFHeaders returns a new getcfheader message that conforms to the

--- a/wire/msggetdata.go
+++ b/wire/msggetdata.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -100,8 +100,9 @@ func (msg *MsgGetData) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgGetData) MaxPayloadLength(pver uint32) uint32 {
-	// Num inventory vectors (varInt) + max allowed inventory vectors.
-	return MaxVarIntPayload + (MaxInvPerMsg * maxInvVectPayload)
+	// Num inventory vectors (varInt) 3 byte + max allowed inventory vectors.
+	return uint32(VarIntSerializeSize(MaxInvPerMsg)) +
+		(MaxInvPerMsg * maxInvVectPayload)
 }
 
 // NewMsgGetData returns a new Decred getdata message that conforms to the

--- a/wire/msggetdata_test.go
+++ b/wire/msggetdata_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -28,8 +28,8 @@ func TestGetData(t *testing.T) {
 	}
 
 	// Ensure max payload is expected value for latest protocol version.
-	// Num inventory vectors (varInt) + max allowed inventory vectors.
-	wantPayload := uint32(1800009)
+	// Num inventory vectors (varInt) 3 byte + max allowed inventory vectors.
+	wantPayload := uint32(1800003)
 	maxPayload := msg.MaxPayloadLength(pver)
 	if maxPayload != wantPayload {
 		t.Errorf("MaxPayloadLength: wrong max payload length for "+

--- a/wire/msggetheaders.go
+++ b/wire/msggetheaders.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -121,10 +121,10 @@ func (msg *MsgGetHeaders) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgGetHeaders) MaxPayloadLength(pver uint32) uint32 {
-	// Version 4 bytes + num block locator hashes (varInt) + max allowed block
-	// locators + hash stop.
-	return 4 + MaxVarIntPayload + (MaxBlockLocatorsPerMsg *
-		chainhash.HashSize) + chainhash.HashSize
+	// Version 4 bytes + num block locator hashes (varInt) 3 bytes + max allowed
+	// block locators + hash stop.
+	return 4 + uint32(VarIntSerializeSize(MaxBlockLocatorsPerMsg)) +
+		(MaxBlockLocatorsPerMsg * chainhash.HashSize) + chainhash.HashSize
 }
 
 // NewMsgGetHeaders returns a new Decred getheaders message that conforms to

--- a/wire/msggetheaders_test.go
+++ b/wire/msggetheaders_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -35,9 +35,9 @@ func TestGetHeaders(t *testing.T) {
 	}
 
 	// Ensure max payload is expected value for latest protocol version.
-	// Protocol version 4 bytes + num hashes (varInt) + max block locator
-	// hashes + hash stop.
-	wantPayload := uint32(16045)
+	// Protocol version 4 bytes + num hashes (varInt) 3 bytes + max block
+	// locator hashes + hash stop.
+	wantPayload := uint32(16039)
 	maxPayload := msg.MaxPayloadLength(pver)
 	if maxPayload != wantPayload {
 		t.Errorf("MaxPayloadLength: wrong max payload length for "+

--- a/wire/msgheaders.go
+++ b/wire/msgheaders.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -122,10 +122,10 @@ func (msg *MsgHeaders) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgHeaders) MaxPayloadLength(pver uint32) uint32 {
-	// Num headers (varInt) + max allowed headers (header length + 1 byte
-	// for the number of transactions which is always 0).
-	return MaxVarIntPayload + ((MaxBlockHeaderPayload + 1) *
-		MaxBlockHeadersPerMsg)
+	// Num headers (varInt) 3 bytes + max allowed headers (header length +
+	// 1 byte for the number of transactions which is always 0).
+	return uint32(VarIntSerializeSize(MaxBlockHeadersPerMsg)) +
+		((MaxBlockHeaderPayload + 1) * MaxBlockHeadersPerMsg)
 }
 
 // NewMsgHeaders returns a new Decred headers message that conforms to the

--- a/wire/msgheaders_test.go
+++ b/wire/msgheaders_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -28,9 +28,9 @@ func TestHeaders(t *testing.T) {
 	}
 
 	// Ensure max payload is expected value for latest protocol version.
-	// Num headers (varInt) + max allowed headers (header length + 1 byte
-	// for the number of transactions which is always 0).
-	wantPayload := uint32(362009)
+	// Num headers (varInt) 3 bytes + max allowed headers (header length +
+	// 1 byte for the number of transactions which is always 0).
+	wantPayload := uint32(362003)
 	maxPayload := msg.MaxPayloadLength(pver)
 	if maxPayload != wantPayload {
 		t.Errorf("MaxPayloadLength: wrong max payload length for "+

--- a/wire/msginv.go
+++ b/wire/msginv.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -108,8 +108,9 @@ func (msg *MsgInv) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgInv) MaxPayloadLength(pver uint32) uint32 {
-	// Num inventory vectors (varInt) + max allowed inventory vectors.
-	return MaxVarIntPayload + (MaxInvPerMsg * maxInvVectPayload)
+	// Num inventory vectors (varInt) 3 bytes + max allowed inventory vectors.
+	return uint32(VarIntSerializeSize(MaxInvPerMsg)) + (MaxInvPerMsg *
+		maxInvVectPayload)
 }
 
 // NewMsgInv returns a new Decred inv message that conforms to the Message

--- a/wire/msginv_test.go
+++ b/wire/msginv_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -28,8 +28,8 @@ func TestInv(t *testing.T) {
 	}
 
 	// Ensure max payload is expected value for latest protocol version.
-	// Num inventory vectors (varInt) + max allowed inventory vectors.
-	wantPayload := uint32(1800009)
+	// Num inventory vectors (varInt) 3 bytes + max allowed inventory vectors.
+	wantPayload := uint32(1800003)
 	maxPayload := msg.MaxPayloadLength(pver)
 	if maxPayload != wantPayload {
 		t.Errorf("MaxPayloadLength: wrong max payload length for "+

--- a/wire/msgminingstate.go
+++ b/wire/msgminingstate.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -181,11 +181,12 @@ func (msg *MsgMiningState) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgMiningState) MaxPayloadLength(pver uint32) uint32 {
-	// Protocol version 4 bytes + Height 4 bytes + num block hashes (varInt) +
-	// block hashes + num vote hashes (varInt) + vote hashes
-	return 4 + 4 + MaxVarIntPayload + (MaxMSBlocksAtHeadPerMsg *
-		chainhash.HashSize) + MaxVarIntPayload + (MaxMSVotesAtHeadPerMsg *
-		chainhash.HashSize)
+	// Protocol version 4 bytes + Height 4 bytes + num block hashes (varInt)
+	// 1 byte + block hashes + num vote hashes (varInt) 1 byte + vote hashes
+	return 4 + 4 + uint32(VarIntSerializeSize(MaxMSBlocksAtHeadPerMsg)) +
+		(MaxMSBlocksAtHeadPerMsg * chainhash.HashSize) +
+		uint32(VarIntSerializeSize(MaxMSVotesAtHeadPerMsg)) +
+		(MaxMSVotesAtHeadPerMsg * chainhash.HashSize)
 }
 
 // NewMsgMiningState returns a new Decred miningstate message that conforms to

--- a/wire/msgnotfound.go
+++ b/wire/msgnotfound.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -97,9 +97,10 @@ func (msg *MsgNotFound) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgNotFound) MaxPayloadLength(pver uint32) uint32 {
-	// Max var int 9 bytes + max InvVects at 36 bytes each.
-	// Num inventory vectors (varInt) + max allowed inventory vectors.
-	return MaxVarIntPayload + (MaxInvPerMsg * maxInvVectPayload)
+	// Num inventory vectors (varInt) 3 bytes + max allowed inventory vectors (
+	// 36 bytes each).
+	return uint32(VarIntSerializeSize(MaxInvPerMsg)) + (MaxInvPerMsg *
+		maxInvVectPayload)
 }
 
 // NewMsgNotFound returns a new Decred notfound message that conforms to the

--- a/wire/msgnotfound_test.go
+++ b/wire/msgnotfound_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -28,8 +28,8 @@ func TestNotFound(t *testing.T) {
 	}
 
 	// Ensure max payload is expected value for latest protocol version.
-	// Num inventory vectors (varInt) + max allowed inventory vectors.
-	wantPayload := uint32(1800009)
+	// Num inventory vectors (varInt) 3 bytes + max allowed inventory vectors.
+	wantPayload := uint32(1800003)
 	maxPayload := msg.MaxPayloadLength(pver)
 	if maxPayload != wantPayload {
 		t.Errorf("MaxPayloadLength: wrong max payload length for "+


### PR DESCRIPTION
This makes messages maximum payload length calculations accurate.
In wire messages which contain arrays, the array items counter is variable integer (`varInt`). Since we limit items count in the arrays, the maximum size of these counters is limited, this causes these counters encoded size in all cases be lower than maximum integer encoded size (`MaxVarIntPayload`).
This PR makes this calculation accurate and makes them consistent with the rest of the codebase.