### PR TITLE
wire: Fix MsgCFTypes maximum payload length.

### DIFF
--- a/wire/msgcftypes.go
+++ b/wire/msgcftypes.go
@@ -120,8 +120,9 @@ func (msg *MsgCFTypes) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver. This is part of the Message interface implementation.
 func (msg *MsgCFTypes) MaxPayloadLength(pver uint32) uint32 {
-	// 2 bytes for filter count, and 1 byte for up to 256 filter types.
-	return 258
+	// 3 bytes for filter count, 1 byte up to 256 bytes filter types.
+	return uint32(VarIntSerializeSize(MaxFilterTypesPerMsg)) +
+		MaxFilterTypesPerMsg
 }
 
 // NewMsgCFTypes returns a new cftypes message that conforms to the Message

--- a/wire/msgcftypes_test.go
+++ b/wire/msgcftypes_test.go
@@ -31,8 +31,9 @@ func TestCFTypes(t *testing.T) {
 	}
 
 	// Ensure max payload is expected value for latest protocol version.
-	// Filters count 2 bytes + 1 byte up to 256 bytes for each filter type.
-	wantPayload := uint32(258)
+	// Filters count (varInt) 3 bytes + 1 byte up to 256 bytes for each
+	// filter type.
+	wantPayload := uint32(259)
 	maxPayload := msg.MaxPayloadLength(pver)
 	if maxPayload != wantPayload {
 		t.Errorf("MaxPayloadLength: wrong max payload length for "+


### PR DESCRIPTION
Unlike #1672 which is an improvement this PR is fixing a potential bug, this is why it is in a separate PR