### PR TITLE
multi: Add go 1.11 directive to all modules.

### DIFF
--- a/addrmgr/go.mod
+++ b/addrmgr/go.mod
@@ -1,5 +1,7 @@
 module github.com/decred/dcrd/addrmgr
 
+go 1.11
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1

--- a/blockchain/go.mod
+++ b/blockchain/go.mod
@@ -1,5 +1,7 @@
 module github.com/decred/dcrd/blockchain
 
+go 1.11
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dchest/siphash v1.2.1 // indirect

--- a/blockchain/stake/go.mod
+++ b/blockchain/stake/go.mod
@@ -1,5 +1,7 @@
 module github.com/decred/dcrd/blockchain/stake
 
+go 1.11
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/chaincfg v1.3.0

--- a/certgen/go.mod
+++ b/certgen/go.mod
@@ -1,1 +1,3 @@
 module github.com/decred/dcrd/certgen
+
+go 1.11

--- a/chaincfg/chainhash/go.mod
+++ b/chaincfg/chainhash/go.mod
@@ -1,3 +1,5 @@
 module github.com/decred/dcrd/chaincfg/chainhash
 
+go 1.11
+
 require github.com/dchest/blake256 v1.0.0

--- a/chaincfg/go.mod
+++ b/chaincfg/go.mod
@@ -1,5 +1,7 @@
 module github.com/decred/dcrd/chaincfg
 
+go 1.11
+
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1

--- a/connmgr/go.mod
+++ b/connmgr/go.mod
@@ -1,5 +1,7 @@
 module github.com/decred/dcrd/connmgr
 
+go 1.11
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/chaincfg v1.3.0

--- a/database/go.mod
+++ b/database/go.mod
@@ -1,5 +1,7 @@
 module github.com/decred/dcrd/database
 
+go 1.11
+
 require (
 	github.com/btcsuite/goleveldb v1.0.0
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/dcrec/edwards/go.mod
+++ b/dcrec/edwards/go.mod
@@ -1,3 +1,5 @@
 module github.com/decred/dcrd/dcrec/edwards
 
+go 1.11
+
 require github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412

--- a/dcrec/go.mod
+++ b/dcrec/go.mod
@@ -1,1 +1,3 @@
 module github.com/decred/dcrd/dcrec
+
+go 1.11

--- a/dcrec/secp256k1/go.mod
+++ b/dcrec/secp256k1/go.mod
@@ -1,5 +1,7 @@
 module github.com/decred/dcrd/dcrec/secp256k1
 
+go 1.11
+
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1

--- a/dcrjson/go.mod
+++ b/dcrjson/go.mod
@@ -1,3 +1,5 @@
 module github.com/decred/dcrd/dcrjson/v2
 
+go 1.11
+
 require github.com/decred/dcrd/chaincfg/chainhash v1.0.1

--- a/dcrutil/go.mod
+++ b/dcrutil/go.mod
@@ -1,5 +1,7 @@
 module github.com/decred/dcrd/dcrutil
 
+go 1.11
+
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/base58 v1.0.0

--- a/fees/go.mod
+++ b/fees/go.mod
@@ -1,5 +1,7 @@
 module github.com/decred/dcrd/fees
 
+go 1.11
+
 require (
 	github.com/btcsuite/goleveldb v1.0.0
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/gcs/go.mod
+++ b/gcs/go.mod
@@ -1,5 +1,7 @@
 module github.com/decred/dcrd/gcs
 
+go 1.11
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dchest/blake256 v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/decred/dcrd
 
+go 1.11
+
 require (
 	github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd
 	github.com/btcsuite/winsvc v1.0.0

--- a/hdkeychain/go.mod
+++ b/hdkeychain/go.mod
@@ -1,5 +1,7 @@
 module github.com/decred/dcrd/hdkeychain
 
+go 1.11
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/base58 v1.0.0

--- a/mempool/go.mod
+++ b/mempool/go.mod
@@ -1,5 +1,7 @@
 module github.com/decred/dcrd/mempool/v2
 
+go 1.11
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dchest/siphash v1.2.1 // indirect

--- a/mining/go.mod
+++ b/mining/go.mod
@@ -1,5 +1,7 @@
 module github.com/decred/dcrd/mining
 
+go 1.11
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/blockchain v1.1.1

--- a/peer/go.mod
+++ b/peer/go.mod
@@ -1,5 +1,7 @@
 module github.com/decred/dcrd/peer
 
+go 1.11
+
 require (
 	github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd
 	github.com/davecgh/go-spew v1.1.1

--- a/rpcclient/go.mod
+++ b/rpcclient/go.mod
@@ -1,5 +1,7 @@
 module github.com/decred/dcrd/rpcclient/v2
 
+go 1.11
+
 require (
 	github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd
 	github.com/davecgh/go-spew v1.1.1

--- a/txscript/go.mod
+++ b/txscript/go.mod
@@ -1,5 +1,7 @@
 module github.com/decred/dcrd/txscript
 
+go 1.11
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/chaincfg v1.3.0

--- a/wire/go.mod
+++ b/wire/go.mod
@@ -1,5 +1,7 @@
 module github.com/decred/dcrd/wire
 
+go 1.11
+
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1


### PR DESCRIPTION
This adds the go 1.11 directive to all of the modules in order to clearly mark they build and work with that version.  Go 1.12 modified the tools such that tidy will automatically add the new version to modules that do not already have a directive and that would prevent builds on Go 1.11 through Go 1.11.3 which is not desirable.