### PR TITLE
dcrutil: Fix NewTxDeepTxIns implementation.

### DIFF
--- a/dcrutil/tx_test.go
+++ b/dcrutil/tx_test.go
@@ -171,3 +171,50 @@ func TestNewTxDeep(t *testing.T) {
 		}
 	}
 }
+
+// TestNewTxDeepTxIns tests the API for creation of a Tx with deep TxIn copy.
+func TestNewTxDeepTxIns(t *testing.T) {
+	tx := Block100000.Transactions[0]
+	copyTxDeep := NewTxDeepTxIns(tx)
+	cpTx := copyTxDeep.MsgTx()
+
+	// Ensure original and copied transactions has equal values.
+	if !reflect.DeepEqual(tx, cpTx) {
+		t.Fatalf("MsgTx is not equal - got %v, want %v",
+			spew.Sdump(cpTx), spew.Sdump(&tx))
+	}
+
+	// Ensure original and copied transactions refer to different allocations.
+	if tx == cpTx {
+		t.Fatal("MsgTx is referring to the same allocation")
+	}
+
+	// Compare each original and copied input transaction allocations.
+	for i := 0; i < len(tx.TxIn); i++ {
+		// Ensure input transactions refer to different allocations.
+		if tx.TxIn[i] == cpTx.TxIn[i] {
+			t.Errorf("TxIn #%d is referring to the same allocation", i)
+		}
+
+		// Ensure previous transaction output points refer to different
+		// allocations.
+		if &tx.TxIn[i].PreviousOutPoint == &cpTx.TxIn[i].PreviousOutPoint {
+			t.Errorf("PreviousOutPoint #%d is referring to the same"+
+				" allocation", i)
+		}
+
+		// Ensure signature scripts refer to different allocations.
+		if &tx.TxIn[i].SignatureScript[0] == &cpTx.TxIn[i].SignatureScript[0] {
+			t.Errorf("SignatureScript #%d is referring to the same"+
+				" allocation", i)
+		}
+	}
+
+	// Compare each original and copied output transaction allocations.
+	for i := 0; i < len(tx.TxOut); i++ {
+		// Ensure output transactions refer to same allocation.
+		if tx.TxOut[i] != cpTx.TxOut[i] {
+			t.Errorf("TxOut #%d is not referring to same allocation", i)
+		}
+	}
+}


### PR DESCRIPTION
This fixes `NewTxDeepTxIns` implementation. The current implementation of `NewTxDeepTxIns` is wrong and has many issues. This commit fixes this and adds tests for ensuring the API works correctly.