### PR TITLE
comment: RCI on testnet is 2.5 weeks.

### DIFF
--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -62,7 +62,7 @@ var TestNet3Params = Params{
 	RuleChangeActivationQuorum:     2520, // 10 % of RuleChangeActivationInterval * TicketsPerBlock
 	RuleChangeActivationMultiplier: 3,    // 75%
 	RuleChangeActivationDivisor:    4,
-	RuleChangeActivationInterval:   5040, // 1 week
+	RuleChangeActivationInterval:   5040, // 2.5 weeks
 	Deployments: map[uint32][]ConsensusDeployment{
 		7: {{
 			Vote: Vote{


### PR DESCRIPTION
Fix a comment in testnetparams.go which stated that a single rule change interval is one week. It is actually two and a half weeks (17.5 days).