### PR TITLE
chaincfg: Rename extended key accessor funcs.

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -481,15 +481,15 @@ type Params struct {
 	BlockOneLedger []*TokenPayout
 }
 
-// XPrivKeyID returns the hierarchical deterministic extended private key magic
-// version bytes for the network the parameters define.
-func (p *Params) XPrivKeyID() [4]byte {
+// HDPrivKeyVersion returns the hierarchical deterministic extended private key
+// magic version bytes for the network the parameters define.
+func (p *Params) HDPrivKeyVersion() [4]byte {
 	return p.HDPrivateKeyID
 }
 
-// XPubKeyID returns the hierarchical deterministic extended public key magic
-// version bytes for the network the parameters define.
-func (p *Params) XPubKeyID() [4]byte {
+// HDPubKeyVersion returns the hierarchical deterministic extended public key
+// magic version bytes for the network the parameters define.
+func (p *Params) HDPubKeyVersion() [4]byte {
 	return p.HDPublicKeyID
 }
 


### PR DESCRIPTION
This renames the recently introduced accessor functions for obtaining the hierarchical deterministic extended private and public key magic version bytes based on feedback.

Ordinarily this would require a major module version bump, however, since a new version with the functions has not been released yet, it is acceptable to rename them without breaking callers.