### PR TITLE
blockchain: Allow named blocks in chaingen harness.

### DIFF
--- a/blockchain/agendas_test.go
+++ b/blockchain/agendas_test.go
@@ -379,7 +379,7 @@ func TestFixedSequenceLocks(t *testing.T) {
 			enableSeqLocks(tx, 0)
 		})
 	g.SaveTipCoinbaseOuts()
-	g.Accepted()
+	g.AcceptTipBlock()
 
 	// ---------------------------------------------------------------------
 	// Create block that spends from an output created in the previous
@@ -396,7 +396,7 @@ func TestFixedSequenceLocks(t *testing.T) {
 			enableSeqLocks(tx, 0)
 			b.AddTransaction(tx)
 		})
-	g.Accepted()
+	g.AcceptTipBlock()
 
 	// ---------------------------------------------------------------------
 	// Create block that involves reorganize to a sequence lock spending
@@ -420,7 +420,7 @@ func TestFixedSequenceLocks(t *testing.T) {
 			b.AddTransaction(tx)
 		})
 	g.SaveTipCoinbaseOuts()
-	g.Accepted()
+	g.AcceptTipBlock()
 	g.ExpectTip("b2")
 
 	// ---------------------------------------------------------------------
@@ -435,7 +435,7 @@ func TestFixedSequenceLocks(t *testing.T) {
 			enableSeqLocks(b.STransactions[0], 0)
 		})
 	g.SaveTipCoinbaseOuts()
-	g.Accepted()
+	g.AcceptTipBlock()
 
 	// ---------------------------------------------------------------------
 	// Create block that involves a sequence lock on a ticket.
@@ -449,7 +449,7 @@ func TestFixedSequenceLocks(t *testing.T) {
 			enableSeqLocks(b.STransactions[5], 0)
 		})
 	g.SaveTipCoinbaseOuts()
-	g.Accepted()
+	g.AcceptTipBlock()
 
 	// ---------------------------------------------------------------------
 	// Create two blocks such that the tip block involves a sequence lock
@@ -467,7 +467,7 @@ func TestFixedSequenceLocks(t *testing.T) {
 			b.AddTransaction(tx)
 		})
 	g.SaveTipCoinbaseOuts()
-	g.Accepted()
+	g.AcceptTipBlock()
 
 	outs = g.OldestCoinbaseOuts()
 	g.NextBlock("b6", nil, outs[1:], replaceFixSeqLocksVersions,
@@ -478,7 +478,7 @@ func TestFixedSequenceLocks(t *testing.T) {
 			b.AddTransaction(tx)
 		})
 	g.SaveTipCoinbaseOuts()
-	g.Accepted()
+	g.AcceptTipBlock()
 
 	// ---------------------------------------------------------------------
 	// Create block that involves a sequence lock spending from a regular
@@ -498,7 +498,7 @@ func TestFixedSequenceLocks(t *testing.T) {
 			b.AddTransaction(tx)
 		})
 	g.SaveTipCoinbaseOuts()
-	g.Accepted()
+	g.AcceptTipBlock()
 
 	// ---------------------------------------------------------------------
 	// Create block that involves a sequence lock spending from a block
@@ -512,7 +512,7 @@ func TestFixedSequenceLocks(t *testing.T) {
 	outs = g.OldestCoinbaseOuts()
 	g.NextBlock("b8", nil, outs[1:], replaceFixSeqLocksVersions)
 	g.SaveTipCoinbaseOuts()
-	g.Accepted()
+	g.AcceptTipBlock()
 
 	outs = g.OldestCoinbaseOuts()
 	g.NextBlock("b9", nil, outs[1:], replaceFixSeqLocksVersions,
@@ -523,7 +523,7 @@ func TestFixedSequenceLocks(t *testing.T) {
 			b.AddTransaction(tx)
 		})
 	g.SaveTipCoinbaseOuts()
-	g.Accepted()
+	g.AcceptTipBlock()
 
 	// ---------------------------------------------------------------------
 	// Create two blocks such that the tip block involves a sequence lock
@@ -550,7 +550,7 @@ func TestFixedSequenceLocks(t *testing.T) {
 			b.AddTransaction(tx)
 		})
 	g.SaveTipCoinbaseOuts()
-	g.Accepted()
+	g.AcceptTipBlock()
 
 	outs = g.OldestCoinbaseOuts()
 	g.NextBlock("b11", nil, outs[1:], replaceFixSeqLocksVersions,
@@ -563,5 +563,5 @@ func TestFixedSequenceLocks(t *testing.T) {
 			b.AddTransaction(tx)
 		})
 	g.SaveTipCoinbaseOuts()
-	g.Accepted()
+	g.AcceptTipBlock()
 }

--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -205,7 +205,7 @@ func TestForceHeadReorg(t *testing.T) {
 		blockName := fmt.Sprintf("bbm%d", i)
 		g.NextBlock(blockName, nil, outs[1:])
 		g.SaveTipCoinbaseOuts()
-		g.Accepted()
+		g.AcceptTipBlock()
 	}
 	g.AssertTipHeight(uint32(stakeValidationHeight) + uint32(coinbaseMaturity))
 
@@ -230,7 +230,7 @@ func TestForceHeadReorg(t *testing.T) {
 	//
 	//   ... -> b1(0)
 	g.NextBlock("b1", outs[0], ticketOuts[0])
-	g.Accepted()
+	g.AcceptTipBlock()
 
 	// Create a fork from b1 with an invalid block due to committing to an
 	// invalid number of votes.  Since verifying the header commitment is a
@@ -242,7 +242,7 @@ func TestForceHeadReorg(t *testing.T) {
 	g.NextBlock("b2bad0", outs[1], ticketOuts[1], func(b *wire.MsgBlock) {
 		b.Header.Voters++
 	})
-	g.Rejected(ErrTooManyVotes)
+	g.RejectTipBlock(ErrTooManyVotes)
 
 	// Create a fork from b1 with an invalid block due to committing to an
 	// invalid input amount.  Since verifying the fraud proof necessarily
@@ -257,7 +257,7 @@ func TestForceHeadReorg(t *testing.T) {
 	g.NextBlock("b2bad1", outs[1], ticketOuts[1], func(b *wire.MsgBlock) {
 		b.Transactions[1].TxIn[0].ValueIn--
 	})
-	g.Rejected(ErrFraudAmountIn)
+	g.RejectTipBlock(ErrFraudAmountIn)
 
 	// Create some forks from b1.  There should not be a reorg since b1 is
 	// the current tip and b2 is seen first.
@@ -270,7 +270,7 @@ func TestForceHeadReorg(t *testing.T) {
 	//               \-> b2bad1(1)
 	g.SetTip("b1")
 	g.NextBlock("b2", outs[1], ticketOuts[1])
-	g.Accepted()
+	g.AcceptTipBlock()
 
 	g.SetTip("b1")
 	g.NextBlock("b3", outs[1], ticketOuts[1])

--- a/blockchain/fullblocksstakeversion_test.go
+++ b/blockchain/fullblocksstakeversion_test.go
@@ -51,7 +51,7 @@ func TestStakeVersion(t *testing.T) {
 			chaingen.ReplaceStakeVersion(0),
 			chaingen.ReplaceVoteVersions(3))
 		g.SaveTipCoinbaseOuts()
-		g.Accepted()
+		g.AcceptTipBlock()
 	}
 	g.AssertTipHeight(uint32(stakeValidationHeight + stakeVerInterval - 1))
 	g.AssertBlockVersion(2)
@@ -73,7 +73,7 @@ func TestStakeVersion(t *testing.T) {
 		chaingen.ReplaceStakeVersion(42),
 		chaingen.ReplaceVoteVersions(41))
 	g.SaveTipCoinbaseOuts()
-	g.Accepted()
+	g.AcceptTipBlock()
 	g.AssertTipHeight(uint32(stakeValidationHeight + stakeVerInterval))
 	g.AssertBlockVersion(3)
 	g.AssertStakeVersion(42) // expected bogus
@@ -98,7 +98,7 @@ func TestStakeVersion(t *testing.T) {
 			chaingen.ReplaceStakeVersion(0),
 			chaingen.ReplaceVoteVersions(2))
 		g.SaveTipCoinbaseOuts()
-		g.Accepted()
+		g.AcceptTipBlock()
 	}
 	g.AssertTipHeight(uint32(stakeValidationHeight + 2*stakeVerInterval - 1))
 	g.AssertBlockVersion(3)
@@ -121,7 +121,7 @@ func TestStakeVersion(t *testing.T) {
 	g.AssertTipHeight(uint32(stakeValidationHeight + 2*stakeVerInterval))
 	g.AssertBlockVersion(3)
 	g.AssertStakeVersion(2)
-	g.Rejected(ErrBadStakeVersion)
+	g.RejectTipBlock(ErrBadStakeVersion)
 
 	// ---------------------------------------------------------------------
 	// Generate a single block with block version 3, stake version 1, and
@@ -141,7 +141,7 @@ func TestStakeVersion(t *testing.T) {
 	g.AssertTipHeight(uint32(stakeValidationHeight + 2*stakeVerInterval))
 	g.AssertBlockVersion(3)
 	g.AssertStakeVersion(1)
-	g.Rejected(ErrBadStakeVersion)
+	g.RejectTipBlock(ErrBadStakeVersion)
 
 	// ---------------------------------------------------------------------
 	// Generate enough blocks to reach one block before the next stake
@@ -161,7 +161,7 @@ func TestStakeVersion(t *testing.T) {
 			chaingen.ReplaceStakeVersion(0),
 			chaingen.ReplaceVoteVersions(3))
 		g.SaveTipCoinbaseOuts()
-		g.Accepted()
+		g.AcceptTipBlock()
 	}
 	g.AssertTipHeight(uint32(stakeValidationHeight + 3*stakeVerInterval - 1))
 	g.AssertBlockVersion(3)
@@ -182,7 +182,7 @@ func TestStakeVersion(t *testing.T) {
 	g.AssertTipHeight(uint32(stakeValidationHeight + 3*stakeVerInterval))
 	g.AssertBlockVersion(3)
 	g.AssertStakeVersion(2)
-	g.Rejected(ErrBadStakeVersion)
+	g.RejectTipBlock(ErrBadStakeVersion)
 
 	// ---------------------------------------------------------------------
 	// Generate a single block with block version 3, stake version 4, and
@@ -200,7 +200,7 @@ func TestStakeVersion(t *testing.T) {
 	g.AssertTipHeight(uint32(stakeValidationHeight + 3*stakeVerInterval))
 	g.AssertBlockVersion(3)
 	g.AssertStakeVersion(4)
-	g.Rejected(ErrBadStakeVersion)
+	g.RejectTipBlock(ErrBadStakeVersion)
 
 	// ---------------------------------------------------------------------
 	// Generate enough blocks to reach one block before the next stake
@@ -220,7 +220,7 @@ func TestStakeVersion(t *testing.T) {
 			chaingen.ReplaceStakeVersion(3),
 			chaingen.ReplaceVoteVersions(2))
 		g.SaveTipCoinbaseOuts()
-		g.Accepted()
+		g.AcceptTipBlock()
 	}
 	g.AssertTipHeight(uint32(stakeValidationHeight + 4*stakeVerInterval - 1))
 	g.AssertBlockVersion(3)
@@ -242,7 +242,7 @@ func TestStakeVersion(t *testing.T) {
 	g.AssertTipHeight(uint32(stakeValidationHeight + 4*stakeVerInterval))
 	g.AssertBlockVersion(3)
 	g.AssertStakeVersion(2)
-	g.Rejected(ErrBadStakeVersion)
+	g.RejectTipBlock(ErrBadStakeVersion)
 
 	// ---------------------------------------------------------------------
 	// Generate a single block with block version 3, stake version 4, and
@@ -260,7 +260,7 @@ func TestStakeVersion(t *testing.T) {
 	g.AssertTipHeight(uint32(stakeValidationHeight + 4*stakeVerInterval))
 	g.AssertBlockVersion(3)
 	g.AssertStakeVersion(4)
-	g.Rejected(ErrBadStakeVersion)
+	g.RejectTipBlock(ErrBadStakeVersion)
 
 	// ---------------------------------------------------------------------
 	// Generate enough blocks to reach one block before the next stake
@@ -285,7 +285,7 @@ func TestStakeVersion(t *testing.T) {
 		g.SaveTipCoinbaseOuts()
 		g.AssertBlockVersion(3)
 		g.AssertStakeVersion(3)
-		g.Accepted()
+		g.AcceptTipBlock()
 	}
 	for i := int64(0); i < stakeVerInterval-(targetBlocks-1); i++ {
 		outs := g.OldestCoinbaseOuts()
@@ -297,7 +297,7 @@ func TestStakeVersion(t *testing.T) {
 		g.SaveTipCoinbaseOuts()
 		g.AssertBlockVersion(3)
 		g.AssertStakeVersion(3)
-		g.Accepted()
+		g.AcceptTipBlock()
 	}
 	g.AssertTipHeight(uint32(stakeValidationHeight + 5*stakeVerInterval - 1))
 
@@ -317,7 +317,7 @@ func TestStakeVersion(t *testing.T) {
 	g.AssertTipHeight(uint32(stakeValidationHeight + 5*stakeVerInterval))
 	g.AssertBlockVersion(3)
 	g.AssertStakeVersion(4)
-	g.Rejected(ErrBadStakeVersion)
+	g.RejectTipBlock(ErrBadStakeVersion)
 
 	// ---------------------------------------------------------------------
 	// Generate enough blocks to reach one block before the next stake
@@ -339,7 +339,7 @@ func TestStakeVersion(t *testing.T) {
 		g.SaveTipCoinbaseOuts()
 		g.AssertBlockVersion(3)
 		g.AssertStakeVersion(3)
-		g.Accepted()
+		g.AcceptTipBlock()
 	}
 	for i := int64(0); i < stakeVerInterval-targetBlocks; i++ {
 		outs := g.OldestCoinbaseOuts()
@@ -351,7 +351,7 @@ func TestStakeVersion(t *testing.T) {
 		g.SaveTipCoinbaseOuts()
 		g.AssertBlockVersion(3)
 		g.AssertStakeVersion(3)
-		g.Accepted()
+		g.AcceptTipBlock()
 	}
 	g.AssertTipHeight(uint32(stakeValidationHeight + 6*stakeVerInterval - 1))
 
@@ -370,7 +370,7 @@ func TestStakeVersion(t *testing.T) {
 	g.AssertTipHeight(uint32(stakeValidationHeight + 6*stakeVerInterval))
 	g.AssertBlockVersion(3)
 	g.AssertStakeVersion(3)
-	g.Rejected(ErrBadStakeVersion)
+	g.RejectTipBlock(ErrBadStakeVersion)
 
 	// ---------------------------------------------------------------------
 	// Generate a single block with block version 3, stake version 4, and
@@ -388,5 +388,5 @@ func TestStakeVersion(t *testing.T) {
 	g.AssertTipHeight(uint32(stakeValidationHeight + 6*stakeVerInterval))
 	g.AssertBlockVersion(3)
 	g.AssertStakeVersion(4)
-	g.Accepted()
+	g.AcceptTipBlock()
 }

--- a/blockchain/thresholdstate_test.go
+++ b/blockchain/thresholdstate_test.go
@@ -167,7 +167,7 @@ func TestThresholdState(t *testing.T) {
 	//   genesis -> bfb
 	g.CreatePremineBlock("bfb", 0)
 	g.AssertTipHeight(1)
-	g.Accepted()
+	g.AcceptTipBlock()
 	g.TestThresholdStateChoice(testDummy1ID, ThresholdDefined, invalidChoice)
 	g.TestThresholdStateChoice(testDummy2ID, ThresholdDefined, invalidChoice)
 
@@ -181,7 +181,7 @@ func TestThresholdState(t *testing.T) {
 		blockName := fmt.Sprintf("bm%d", i)
 		g.NextBlock(blockName, nil, nil)
 		g.SaveTipCoinbaseOuts()
-		g.Accepted()
+		g.AcceptTipBlock()
 	}
 	g.AssertTipHeight(uint32(coinbaseMaturity) + 1)
 	g.TestThresholdStateChoice(testDummy1ID, ThresholdDefined, invalidChoice)
@@ -203,7 +203,7 @@ func TestThresholdState(t *testing.T) {
 		blockName := fmt.Sprintf("bse%d", i)
 		g.NextBlock(blockName, nil, ticketOuts)
 		g.SaveTipCoinbaseOuts()
-		g.Accepted()
+		g.AcceptTipBlock()
 	}
 	g.AssertTipHeight(uint32(stakeEnabledHeight))
 	g.TestThresholdStateChoice(testDummy1ID, ThresholdDefined, invalidChoice)
@@ -238,7 +238,7 @@ func TestThresholdState(t *testing.T) {
 		g.NextBlock(blockName, nil, ticketOuts,
 			chaingen.ReplaceBlockVersion(3))
 		g.SaveTipCoinbaseOuts()
-		g.Accepted()
+		g.AcceptTipBlock()
 	}
 	g.AssertTipHeight(uint32(stakeValidationHeight))
 	g.TestThresholdStateChoice(testDummy1ID, ThresholdDefined, invalidChoice)
@@ -265,7 +265,7 @@ func TestThresholdState(t *testing.T) {
 			chaingen.ReplaceStakeVersion(0),
 			chaingen.ReplaceVoteVersions(3))
 		g.SaveTipCoinbaseOuts()
-		g.Accepted()
+		g.AcceptTipBlock()
 	}
 	g.AssertTipHeight(uint32(stakeValidationHeight + stakeVerInterval - 1))
 	g.AssertBlockVersion(3)
@@ -293,7 +293,7 @@ func TestThresholdState(t *testing.T) {
 			chaingen.ReplaceStakeVersion(3),
 			chaingen.ReplaceVoteVersions(3))
 		g.SaveTipCoinbaseOuts()
-		g.Accepted()
+		g.AcceptTipBlock()
 	}
 	g.AssertTipHeight(uint32(stakeValidationHeight + ruleChangeInterval - 2))
 	g.AssertBlockVersion(3)
@@ -324,7 +324,7 @@ func TestThresholdState(t *testing.T) {
 			chaingen.ReplaceStakeVersion(3),
 			chaingen.ReplaceVoteVersions(4))
 		g.SaveTipCoinbaseOuts()
-		g.Accepted()
+		g.AcceptTipBlock()
 	}
 	g.AssertTipHeight(uint32(stakeValidationHeight + stakeVerInterval*4 - 1))
 	g.AssertBlockVersion(3)
@@ -357,7 +357,7 @@ func TestThresholdState(t *testing.T) {
 			chaingen.ReplaceStakeVersion(4),
 			chaingen.ReplaceVoteVersions(4))
 		g.SaveTipCoinbaseOuts()
-		g.Accepted()
+		g.AcceptTipBlock()
 	}
 	g.AssertTipHeight(uint32(stakeValidationHeight + ruleChangeInterval*2 - 1))
 	g.AssertBlockVersion(4)
@@ -390,7 +390,7 @@ func TestThresholdState(t *testing.T) {
 			chaingen.ReplaceVotes(vbPrevBlockValid|vbTestDummy1Yes|
 				vbTestDummy2No, 4))
 		g.SaveTipCoinbaseOuts()
-		g.Accepted()
+		g.AcceptTipBlock()
 	}
 	g.AssertTipHeight(uint32(stakeValidationHeight + ruleChangeInterval*2 -
 		1 + powNumToCheck))
@@ -423,7 +423,7 @@ func TestThresholdState(t *testing.T) {
 			chaingen.ReplaceVotes(vbPrevBlockValid|vbTestDummy1Yes|
 				vbTestDummy2No, 4))
 		g.SaveTipCoinbaseOuts()
-		g.Accepted()
+		g.AcceptTipBlock()
 	}
 	g.AssertTipHeight(uint32(stakeValidationHeight + ruleChangeInterval*3 - 1))
 	g.AssertBlockVersion(4)
@@ -453,7 +453,7 @@ func TestThresholdState(t *testing.T) {
 			chaingen.ReplaceVotes(vbPrevBlockValid|vbTestDummy1Yes|
 				vbTestDummy2No, 3))
 		g.SaveTipCoinbaseOuts()
-		g.Accepted()
+		g.AcceptTipBlock()
 	}
 	g.AssertTipHeight(uint32(stakeValidationHeight + ruleChangeInterval*4 - 1))
 	g.AssertBlockVersion(4)
@@ -489,7 +489,7 @@ func TestThresholdState(t *testing.T) {
 			chaingen.ReplaceVotes(voteBits, 4))
 		totalVotes += ticketsPerBlock
 		g.SaveTipCoinbaseOuts()
-		g.Accepted()
+		g.AcceptTipBlock()
 	}
 	g.AssertTipHeight(uint32(stakeValidationHeight + ruleChangeInterval*5 - 1))
 	g.AssertBlockVersion(4)
@@ -533,7 +533,7 @@ func TestThresholdState(t *testing.T) {
 			chaingen.ReplaceVotes(voteBits, 4))
 		totalVotes += ticketsPerBlock
 		g.SaveTipCoinbaseOuts()
-		g.Accepted()
+		g.AcceptTipBlock()
 	}
 	g.AssertTipHeight(uint32(stakeValidationHeight + ruleChangeInterval*6 - 1))
 	g.AssertBlockVersion(4)
@@ -564,7 +564,7 @@ func TestThresholdState(t *testing.T) {
 			chaingen.ReplaceVotes(vbPrevBlockValid|vbTestDummy1Yes|
 				vbTestDummy2No, 4))
 		g.SaveTipCoinbaseOuts()
-		g.Accepted()
+		g.AcceptTipBlock()
 	}
 	g.AssertTipHeight(uint32(stakeValidationHeight + ruleChangeInterval*7 - 1))
 	g.AssertBlockVersion(4)
@@ -597,7 +597,7 @@ func TestThresholdState(t *testing.T) {
 			chaingen.ReplaceVotes(vbPrevBlockValid|vbTestDummy1No|
 				vbTestDummy2Yes, 4))
 		g.SaveTipCoinbaseOuts()
-		g.Accepted()
+		g.AcceptTipBlock()
 	}
 	g.AssertTipHeight(uint32(stakeValidationHeight + ruleChangeInterval*8 - 1))
 	g.AssertBlockVersion(4)

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -333,7 +333,7 @@ func TestLegacySequenceLocks(t *testing.T) {
 			enableSeqLocks(tx, 0)
 		})
 	g.SaveTipCoinbaseOuts()
-	g.Accepted()
+	g.AcceptTipBlock()
 
 	// ---------------------------------------------------------------------
 	// Create block that spends from an output created in the previous
@@ -350,7 +350,7 @@ func TestLegacySequenceLocks(t *testing.T) {
 			enableSeqLocks(tx, 0)
 			b.AddTransaction(tx)
 		})
-	g.Accepted()
+	g.AcceptTipBlock()
 
 	// ---------------------------------------------------------------------
 	// Create block that involves reorganize to a sequence lock spending
@@ -374,7 +374,7 @@ func TestLegacySequenceLocks(t *testing.T) {
 			b.AddTransaction(tx)
 		})
 	g.SaveTipCoinbaseOuts()
-	g.Accepted()
+	g.AcceptTipBlock()
 	g.ExpectTip("b2")
 
 	// ---------------------------------------------------------------------
@@ -389,7 +389,7 @@ func TestLegacySequenceLocks(t *testing.T) {
 			enableSeqLocks(b.STransactions[0], 0)
 		})
 	g.SaveTipCoinbaseOuts()
-	g.Accepted()
+	g.AcceptTipBlock()
 
 	// ---------------------------------------------------------------------
 	// Create block that involves a sequence lock on a ticket.
@@ -403,7 +403,7 @@ func TestLegacySequenceLocks(t *testing.T) {
 			enableSeqLocks(b.STransactions[5], 0)
 		})
 	g.SaveTipCoinbaseOuts()
-	g.Accepted()
+	g.AcceptTipBlock()
 
 	// ---------------------------------------------------------------------
 	// Create two blocks such that the tip block involves a sequence lock
@@ -421,7 +421,7 @@ func TestLegacySequenceLocks(t *testing.T) {
 			b.AddTransaction(tx)
 		})
 	g.SaveTipCoinbaseOuts()
-	g.Accepted()
+	g.AcceptTipBlock()
 
 	outs = g.OldestCoinbaseOuts()
 	g.NextBlock("b6", nil, outs[1:], replaceLNFeaturesVersions,
@@ -432,7 +432,7 @@ func TestLegacySequenceLocks(t *testing.T) {
 			b.AddTransaction(tx)
 		})
 	g.SaveTipCoinbaseOuts()
-	g.Accepted()
+	g.AcceptTipBlock()
 
 	// ---------------------------------------------------------------------
 	// Create block that involves a sequence lock spending from a regular
@@ -451,7 +451,7 @@ func TestLegacySequenceLocks(t *testing.T) {
 			enableSeqLocks(tx, 0)
 			b.AddTransaction(tx)
 		})
-	g.Rejected(ErrMissingTxOut)
+	g.RejectTipBlock(ErrMissingTxOut)
 
 	// ---------------------------------------------------------------------
 	// Create block that involves a sequence lock spending from a block
@@ -464,7 +464,7 @@ func TestLegacySequenceLocks(t *testing.T) {
 	g.SetTip("b6")
 	g.NextBlock("b8", nil, outs[1:], replaceLNFeaturesVersions)
 	g.SaveTipCoinbaseOuts()
-	g.Accepted()
+	g.AcceptTipBlock()
 
 	outs = g.OldestCoinbaseOuts()
 	g.NextBlock("b9", nil, outs[1:], replaceLNFeaturesVersions,
@@ -474,7 +474,7 @@ func TestLegacySequenceLocks(t *testing.T) {
 			enableSeqLocks(tx, 0)
 			b.AddTransaction(tx)
 		})
-	g.Rejected(ErrMissingTxOut)
+	g.RejectTipBlock(ErrMissingTxOut)
 
 	// ---------------------------------------------------------------------
 	// Create two blocks such that the tip block involves a sequence lock
@@ -501,7 +501,7 @@ func TestLegacySequenceLocks(t *testing.T) {
 			b.AddTransaction(tx)
 		})
 	g.SaveTipCoinbaseOuts()
-	g.Accepted()
+	g.AcceptTipBlock()
 
 	outs = g.OldestCoinbaseOuts()
 	g.NextBlock("b11", nil, outs[1:], replaceLNFeaturesVersions,
@@ -513,7 +513,7 @@ func TestLegacySequenceLocks(t *testing.T) {
 			enableSeqLocks(tx, 0)
 			b.AddTransaction(tx)
 		})
-	g.Rejected(ErrMissingTxOut)
+	g.RejectTipBlock(ErrMissingTxOut)
 }
 
 // TestCheckBlockSanity tests the context free block sanity checks with blocks
@@ -740,7 +740,7 @@ func TestCheckConnectBlockTemplate(t *testing.T) {
 	}
 	g.AssertTipHeight(1)
 	acceptedBlockTemplate()
-	g.Rejected(ErrHighHash)
+	g.RejectTipBlock(ErrHighHash)
 	g.ExpectTip("genesis")
 
 	// Produce a valid and solved initial block.
@@ -749,7 +749,7 @@ func TestCheckConnectBlockTemplate(t *testing.T) {
 	g.SetTip("genesis")
 	g.CreatePremineBlock("bfb", 0)
 	g.AssertTipHeight(1)
-	g.Accepted()
+	g.AcceptTipBlock()
 
 	// ---------------------------------------------------------------------
 	// Generate enough blocks to have mature coinbase outputs to work with.
@@ -766,7 +766,7 @@ func TestCheckConnectBlockTemplate(t *testing.T) {
 		g.NextBlock(blockName, nil, nil)
 		g.SaveTipCoinbaseOuts()
 		acceptedBlockTemplate()
-		g.Accepted()
+		g.AcceptTipBlock()
 		tipName = blockName
 	}
 	g.AssertTipHeight(uint32(coinbaseMaturity) + 1)
@@ -815,7 +815,7 @@ func TestCheckConnectBlockTemplate(t *testing.T) {
 	g.NextBlock("bse0", nil, tempTicketOuts)
 	g.SaveTipCoinbaseOuts()
 	acceptedBlockTemplate()
-	g.Accepted()
+	g.AcceptTipBlock()
 
 	var ticketsPurchased int
 	for i := int64(1); int64(g.Tip().Header.Height) < stakeEnabledHeight; i++ {
@@ -826,7 +826,7 @@ func TestCheckConnectBlockTemplate(t *testing.T) {
 		g.NextBlock(blockName, nil, ticketOuts)
 		g.SaveTipCoinbaseOuts()
 		acceptedBlockTemplate()
-		g.Accepted()
+		g.AcceptTipBlock()
 	}
 	g.AssertTipHeight(uint32(stakeEnabledHeight))
 
@@ -861,7 +861,7 @@ func TestCheckConnectBlockTemplate(t *testing.T) {
 		g.NextBlock(blockName, nil, ticketOuts)
 		g.SaveTipCoinbaseOuts()
 		acceptedBlockTemplate()
-		g.Accepted()
+		g.AcceptTipBlock()
 	}
 	g.AssertTipHeight(uint32(stakeValidationHeight))
 
@@ -882,7 +882,7 @@ func TestCheckConnectBlockTemplate(t *testing.T) {
 		g.NextBlock(blockName, nil, outs[1:])
 		g.SaveTipCoinbaseOuts()
 		acceptedBlockTemplate()
-		g.Accepted()
+		g.AcceptTipBlock()
 	}
 	g.AssertTipHeight(uint32(stakeValidationHeight) + uint32(coinbaseMaturity))
 
@@ -907,13 +907,13 @@ func TestCheckConnectBlockTemplate(t *testing.T) {
 	//
 	//   ... -> b1(0) -> b2(1) -> b3(2)
 	g.NextBlock("b1", outs[0], ticketOuts[0])
-	g.Accepted()
+	g.AcceptTipBlock()
 
 	g.NextBlock("b2", outs[1], ticketOuts[1])
-	g.Accepted()
+	g.AcceptTipBlock()
 
 	g.NextBlock("b3", outs[2], ticketOuts[2])
-	g.Accepted()
+	g.AcceptTipBlock()
 
 	// Create a block template that forks from b1.  It should not be allowed
 	// since it is not the current tip or its parent.


### PR DESCRIPTION
This introduces two new functions on the `chaingen` harness, named `AcceptBlock` and `RejectBlock`, which allow ensuring a named block is accepted or rejected, respectively, and redefines the existing `Accepted` and `Rejected` functions which only deal with the tip block in terms of the new functions.

It also renames `Accepted` and `Rejected` to `AcceptTipBlock` and `RejectTipBlock`, respectively.

The motivation for this change is to make it easier to test future code which will allow processing of headers and blocks independently as well as processing blocks out of order so long as their headers are already known.