### PR TITLE
mining: Remove unnecessary notify goroutine.

### DIFF
--- a/mining.go
+++ b/mining.go
@@ -2112,10 +2112,8 @@ func (g *BgBlkTmplGenerator) notifySubscribersHandler(ctx context.Context) {
 		case t := <-g.notifyChan:
 			g.subscriptionMtx.Lock()
 			for c := range g.subscribers {
-				go func() {
-					c <- t
-					close(c)
-				}()
+				c <- t
+				close(c)
 
 				delete(g.subscribers, c)
 			}


### PR DESCRIPTION
This modifies the code which notifies subscribed clients about a new block template to avoid creating an unnecessary goroutine since the channel is single use and intentionally buffered to ensure the sender can't block.
