### PR TITLE
txscript: Remove checks for impossible conditions.

### DIFF
--- a/txscript/engine.go
+++ b/txscript/engine.go
@@ -296,7 +296,7 @@ func (vm *Engine) executeOpcode(op *opcode, data []byte) error {
 	}
 
 	// Ensure all executed data push opcodes use the minimal encoding.
-	if vm.isBranchExecuting() && op.value >= 0 && op.value <= OP_PUSHDATA4 {
+	if vm.isBranchExecuting() && op.value <= OP_PUSHDATA4 {
 		if err := checkMinimalDataPush(op, data); err != nil {
 			return err
 		}

--- a/txscript/sigcache.go
+++ b/txscript/sigcache.go
@@ -79,7 +79,7 @@ func (s *SigCache) Add(sigHash chainhash.Hash, sig chainec.Signature, pubKey cha
 	s.Lock()
 	defer s.Unlock()
 
-	if s.maxEntries <= 0 {
+	if s.maxEntries == 0 {
 		return
 	}
 


### PR DESCRIPTION
This removes a couple of checks for impossible conditions found by the `staticcheck` linter.  In the case of `executeOpcode`, `bytes` are always `>= 0` and, similarly for `SigCache.Add`, `uints` are always `>= 0`.