### PR TITLE
miner: Improve background generator lifecycle.

### DIFF
--- a/server.go
+++ b/server.go
@@ -2134,7 +2134,11 @@ func (s *server) Start() {
 	// Start the background block template generator if the config provides
 	// a mining address.
 	if len(cfg.MiningAddrs) > 0 {
-		s.bg.Start(s.context)
+		s.wg.Add(1)
+		go func(s *server) {
+			s.bg.Run(s.context)
+			s.wg.Done()
+		}(s)
 	}
 
 	// Start the CPU miner if generation is enabled.
@@ -2156,7 +2160,7 @@ func (s *server) Stop() error {
 
 	// Stop the background block template generator.
 	if len(cfg.miningAddrs) > 0 {
-		minrLog.Info("Shutting down background block template generator.")
+		minrLog.Info("Background block template generator shutting down")
 		s.cancel()
 	}
 


### PR DESCRIPTION
This modifies the lifecycle of the background generator to use the expected pattern for running subsystems based on contexts in the future.

In particular, this renames the `Start` function to `Run` and arranges for it to block until the provided context is cancelled.  This is more flexible for the caller since it can easily turn blocking code into async code while the reverse is not true.

Next, the server is modified to ensure it waits for the background template generator to shutdown before shutting down itself to help ensure an orderly shutdown.

While here, it also makes the various lifecycle debug messages more consistent with the rest of the code base.