### PR TITLE
mining: fix scheduled template regen.

### DIFF
--- a/mining.go
+++ b/mining.go
@@ -2313,9 +2313,10 @@ func (g *BgBlkTmplGenerator) onVoteReceivedHandler(ctx context.Context) {
 
 				// Schedule a block template regeneration if the new vote received
 				// is voting on the current chain tip with at least the minimum
-				// required number of votes by the network.
-				if currTipVotes >=
-					int((g.tg.chainParams.TicketsPerBlock/2)+1) {
+				// required number of votes by the network but less than the
+				// maximum number of votes possible for a block.
+				if currTipVotes < int(g.tg.chainParams.TicketsPerBlock) &&
+					currTipVotes >= int((g.tg.chainParams.TicketsPerBlock/2)+1) {
 					g.scheduleRegen(time.Second)
 				}
 			}


### PR DESCRIPTION
This fixes a case where a block with five votes immediately triggers a regen (as it should) but also
schedules another regen in a second.

This was first observed [here](https://github.com/decred/dcrd/pull/1424#pullrequestreview-2208376890)