### PR TITLE
mining: Run vote ntfn in a separate goroutine.

### DIFF
--- a/mining.go
+++ b/mining.go
@@ -2362,7 +2362,9 @@ func (g *BgBlkTmplGenerator) onVoteReceivedHandler(ctx context.Context) {
 
 // OnVoteReceived signals a new vote received by the mempool.
 func (g *BgBlkTmplGenerator) OnVoteReceived(tx *wire.MsgTx) {
-	g.voteChan <- tx
+	go func() {
+		g.voteChan <- tx
+	}()
 }
 
 // generator generates new templates based on mempool activity for vote


### PR DESCRIPTION
This ensures the vote handling for the new background miner template happens in a goroutine in order to prevent blocking more transactions being added to the `mempool` and the vote itself from being immediately relayed to the rest of the network.

It also prevents a potential deadlock that can occur due to the cycle created by being called under the `mempool` lock and in turn generating a template which itself attempts to grab the `mempool` lock to get the list of transactions.

This really should be handled better overall, but this serves as a quick solution until the rest of the mining updates are made.