### PR TITLE
multi: fix recent govet findings

### DIFF
--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1576,7 +1576,7 @@ func (b *BlockChain) initChainState() error {
 		}
 
 		// The database bucket for the versioning information is missing.
-		if dbInfo == nil && err == nil {
+		if dbInfo == nil {
 			return nil
 		}
 

--- a/mining.go
+++ b/mining.go
@@ -849,107 +849,106 @@ func handleTooFewVoters(subsidyCache *blockchain.SubsidyCache, nextHeight int64,
 				return cptCopy, nil
 			}
 
-			// We may have just started mining and stored the current block
-			// template, so we don't have a parent.
-			if curTemplate == nil {
-				// Fetch the latest block and head and begin working
-				// off of it with an empty transaction tree regular
-				// and the contents of that stake tree. In the future
-				// we should have the option of readding some
-				// transactions from this block, too.
-				topBlock, err := bm.chain.BlockByHash(&best.Hash)
-				if err != nil {
-					str := fmt.Sprintf("unable to get tip block %s",
-						best.PrevHash)
-					return nil, miningRuleError(ErrGetTopBlock, str)
-				}
-				btMsgBlock := new(wire.MsgBlock)
-				rand, err := wire.RandomUint64()
-				if err != nil {
-					return nil, err
-				}
-				coinbaseScript := make([]byte, len(coinbaseFlags)+2)
-				copy(coinbaseScript[2:], coinbaseFlags)
-				opReturnPkScript, err :=
-					standardCoinbaseOpReturn(topBlock.MsgBlock().Header.Height,
-						rand)
-				if err != nil {
-					return nil, err
-				}
-				coinbaseTx, err := createCoinbaseTx(subsidyCache,
-					coinbaseScript,
-					opReturnPkScript,
-					topBlock.Height(),
-					miningAddress,
-					topBlock.MsgBlock().Header.Voters,
-					bm.server.chainParams)
-				if err != nil {
-					return nil, err
-				}
-				btMsgBlock.AddTransaction(coinbaseTx.MsgTx())
-
-				for _, stx := range topBlock.STransactions() {
-					btMsgBlock.AddSTransaction(stx.MsgTx())
-				}
-
-				// Copy the rest of the header.
-				btMsgBlock.Header = topBlock.MsgBlock().Header
-
-				// Set a fresh timestamp.
-				ts := medianAdjustedTime(best, timeSource)
-				btMsgBlock.Header.Timestamp = ts
-
-				// If we're on testnet, the time since this last block
-				// listed as the parent must be taken into consideration.
-				if bm.server.chainParams.ReduceMinDifficulty {
-					parentHash := topBlock.MsgBlock().Header.PrevBlock
-
-					requiredDifficulty, err :=
-						bm.CalcNextRequiredDiffNode(&parentHash, ts)
-					if err != nil {
-						return nil, miningRuleError(ErrGettingDifficulty,
-							err.Error())
-					}
-
-					btMsgBlock.Header.Bits = requiredDifficulty
-				}
-
-				// Recalculate the size.
-				btMsgBlock.Header.Size = uint32(btMsgBlock.SerializeSize())
-
-				bt := &BlockTemplate{
-					Block:           btMsgBlock,
-					Fees:            []int64{0},
-					SigOpCounts:     []int64{0},
-					Height:          int64(topBlock.MsgBlock().Header.Height),
-					ValidPayAddress: miningAddress != nil,
-				}
-
-				// Recalculate the merkle roots. Use a temporary 'immutable'
-				// block object as we're changing the header contents.
-				btBlockTemp := dcrutil.NewBlockDeepCopyCoinbase(btMsgBlock)
-				merkles :=
-					blockchain.BuildMerkleTreeStore(btBlockTemp.Transactions())
-				merklesStake :=
-					blockchain.BuildMerkleTreeStore(btBlockTemp.STransactions())
-				btMsgBlock.Header.MerkleRoot = *merkles[len(merkles)-1]
-				btMsgBlock.Header.StakeRoot = *merklesStake[len(merklesStake)-1]
-
-				// Make sure the block validates.
-				btBlock := dcrutil.NewBlockDeepCopyCoinbase(btMsgBlock)
-				err = bm.chain.CheckConnectBlockTemplate(btBlock)
-				if err != nil {
-					str := fmt.Sprintf("failed to check template: %v while "+
-						"constructing a new parent", err.Error())
-					return nil, miningRuleError(ErrCheckConnectBlock,
-						str)
-				}
-
-				// Make a copy to return.
-				cptCopy := deepCopyBlockTemplate(bt)
-
-				return cptCopy, nil
+			// We may have just started mining and stored the
+			// current block template, so we don't have a parent.
+			//
+			// Fetch the latest block and head and begin working
+			// off of it with an empty transaction tree regular
+			// and the contents of that stake tree. In the future
+			// we should have the option of readding some
+			// transactions from this block, too.
+			topBlock, err := bm.chain.BlockByHash(&best.Hash)
+			if err != nil {
+				str := fmt.Sprintf("unable to get tip block %s",
+					best.PrevHash)
+				return nil, miningRuleError(ErrGetTopBlock, str)
 			}
+			btMsgBlock := new(wire.MsgBlock)
+			rand, err := wire.RandomUint64()
+			if err != nil {
+				return nil, err
+			}
+			coinbaseScript := make([]byte, len(coinbaseFlags)+2)
+			copy(coinbaseScript[2:], coinbaseFlags)
+			opReturnPkScript, err :=
+				standardCoinbaseOpReturn(topBlock.MsgBlock().Header.Height,
+					rand)
+			if err != nil {
+				return nil, err
+			}
+			coinbaseTx, err := createCoinbaseTx(subsidyCache,
+				coinbaseScript,
+				opReturnPkScript,
+				topBlock.Height(),
+				miningAddress,
+				topBlock.MsgBlock().Header.Voters,
+				bm.server.chainParams)
+			if err != nil {
+				return nil, err
+			}
+			btMsgBlock.AddTransaction(coinbaseTx.MsgTx())
+
+			for _, stx := range topBlock.STransactions() {
+				btMsgBlock.AddSTransaction(stx.MsgTx())
+			}
+
+			// Copy the rest of the header.
+			btMsgBlock.Header = topBlock.MsgBlock().Header
+
+			// Set a fresh timestamp.
+			ts := medianAdjustedTime(best, timeSource)
+			btMsgBlock.Header.Timestamp = ts
+
+			// If we're on testnet, the time since this last block
+			// listed as the parent must be taken into consideration.
+			if bm.server.chainParams.ReduceMinDifficulty {
+				parentHash := topBlock.MsgBlock().Header.PrevBlock
+
+				requiredDifficulty, err :=
+					bm.CalcNextRequiredDiffNode(&parentHash, ts)
+				if err != nil {
+					return nil, miningRuleError(ErrGettingDifficulty,
+						err.Error())
+				}
+
+				btMsgBlock.Header.Bits = requiredDifficulty
+			}
+
+			// Recalculate the size.
+			btMsgBlock.Header.Size = uint32(btMsgBlock.SerializeSize())
+
+			bt := &BlockTemplate{
+				Block:           btMsgBlock,
+				Fees:            []int64{0},
+				SigOpCounts:     []int64{0},
+				Height:          int64(topBlock.MsgBlock().Header.Height),
+				ValidPayAddress: miningAddress != nil,
+			}
+
+			// Recalculate the merkle roots. Use a temporary 'immutable'
+			// block object as we're changing the header contents.
+			btBlockTemp := dcrutil.NewBlockDeepCopyCoinbase(btMsgBlock)
+			merkles :=
+				blockchain.BuildMerkleTreeStore(btBlockTemp.Transactions())
+			merklesStake :=
+				blockchain.BuildMerkleTreeStore(btBlockTemp.STransactions())
+			btMsgBlock.Header.MerkleRoot = *merkles[len(merkles)-1]
+			btMsgBlock.Header.StakeRoot = *merklesStake[len(merklesStake)-1]
+
+			// Make sure the block validates.
+			btBlock := dcrutil.NewBlockDeepCopyCoinbase(btMsgBlock)
+			err = bm.chain.CheckConnectBlockTemplate(btBlock)
+			if err != nil {
+				str := fmt.Sprintf("failed to check template: %v while "+
+					"constructing a new parent", err.Error())
+				return nil, miningRuleError(ErrCheckConnectBlock,
+					str)
+			}
+
+			// Make a copy to return.
+			cptCopy := deepCopyBlockTemplate(bt)
+
+			return cptCopy, nil
 		}
 	}
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2946,7 +2946,7 @@ func handleGetBlockTemplateProposal(s *rpcServer, request *dcrjson.TemplateReque
 	// Ensure the block is building from the expected previous block.
 	expectedPrevHash := &s.server.blockManager.chain.BestSnapshot().Hash
 	prevHash := &block.MsgBlock().Header.PrevBlock
-	if expectedPrevHash == nil || !expectedPrevHash.IsEqual(prevHash) {
+	if *expectedPrevHash != *prevHash {
 		return "bad-prevblk", nil
 	}
 
@@ -3233,7 +3233,7 @@ func handleGetMiningInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{
 	}
 	networkHashesPerSec, ok := networkHashesPerSecIface.(int64)
 	if !ok {
-		return nil, rpcInternalError(err.Error(),
+		return nil, rpcInternalError("invalid network hashes per sec",
 			fmt.Sprintf("Invalid type: %q",
 				networkHashesPerSecIface))
 	}
@@ -4098,12 +4098,6 @@ func handleGetWorkRequest(s *rpcServer) (interface{}, error) {
 			blockchain.CompactToBig(msgBlock.Header.Bits),
 			msgBlock.Header.MerkleRoot)
 	} else {
-		if msgBlock == nil {
-			context := "Failed to create new block template, " +
-				"no previous state"
-			return nil, rpcInternalError("internal error", context)
-		}
-
 		// At this point, there is a saved block template and a new
 		// request for work was made, but either the available
 		// transactions haven't change or it hasn't been long enough to

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -12,12 +12,13 @@ set -ex
 
 # The script does automatic checking on a Go package and its sub-packages,
 # including:
-# 1. gofmt         (http://golang.org/cmd/gofmt/)
+# 1. gofmt         (https://golang.org/cmd/gofmt/)
 # 2. gosimple      (https://github.com/dominikh/go-simple)
 # 3. unconvert     (https://github.com/mdempsky/unconvert)
 # 4. ineffassign   (https://github.com/gordonklaus/ineffassign)
-# 5. misspell      (https://github.com/client9/misspell)
-# 6. race detector (http://blog.golang.org/race-detector)
+# 5. go vet        (https://golang.org/cmd/vet)
+# 6. misspell      (https://github.com/client9/misspell)
+# 7. race detector (https://blog.golang.org/race-detector)
 
 # golangci-lint (github.com/golangci/golangci-lint) is used to run each each
 # static checker.
@@ -57,6 +58,7 @@ testrepo () {
       --enable=gosimple \
       --enable=unconvert \
       --enable=ineffassign \
+      --enable=govet \
       --enable=misspell ./${module}/...
   done
 

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -1224,7 +1224,7 @@ func writeTxInWitness(w io.Writer, pver uint32, version uint16, ti *TxIn) error 
 	}
 
 	// BlockIndex.
-	binarySerializer.PutUint32(w, littleEndian, ti.BlockIndex)
+	err = binarySerializer.PutUint32(w, littleEndian, ti.BlockIndex)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
```
blockmanager.go:736:14: nilness: tautological condition: non-nil != nil (govet)
        if template != nil {
                    ^
mining.go:854:19: nilness: tautological condition: nil == nil (govet)
                        if curTemplate == nil {
                                       ^
rpcserver.go:2949:22: nilness: impossible condition: non-nil == nil (govet)
        if expectedPrevHash == nil || !expectedPrevHash.IsEqual(prevHash) {
                            ^
rpcserver.go:3236:41: nilness: nil dereference in dynamic method call (govet)
                return nil, rpcInternalError(err.Error(),
                                                      ^
rpcserver.go:4101:15: nilness: impossible condition: non-nil == nil (govet)
                if msgBlock == nil {
                            ^
```