### PR TITLE
multi: add optional version arg to decodescript rpc.

### DIFF
--- a/dcrjson/chainsvrcmds.go
+++ b/dcrjson/chainsvrcmds.go
@@ -175,13 +175,15 @@ func NewDecodeRawTransactionCmd(hexTx string) *DecodeRawTransactionCmd {
 // DecodeScriptCmd defines the decodescript JSON-RPC command.
 type DecodeScriptCmd struct {
 	HexScript string
+	Version   *uint16
 }
 
 // NewDecodeScriptCmd returns a new instance which can be used to issue a
 // decodescript JSON-RPC command.
-func NewDecodeScriptCmd(hexScript string) *DecodeScriptCmd {
+func NewDecodeScriptCmd(hexScript string, version *uint16) *DecodeScriptCmd {
 	return &DecodeScriptCmd{
 		HexScript: hexScript,
+		Version:   version,
 	}
 }
 

--- a/dcrjson/chainsvrcmds_test.go
+++ b/dcrjson/chainsvrcmds_test.go
@@ -109,10 +109,21 @@ func TestChainSvrCmds(t *testing.T) {
 				return NewCmd("decodescript", "00")
 			},
 			staticCmd: func() interface{} {
-				return NewDecodeScriptCmd("00")
+				return NewDecodeScriptCmd("00", nil)
 			},
 			marshalled:   `{"jsonrpc":"1.0","method":"decodescript","params":["00"],"id":1}`,
 			unmarshalled: &DecodeScriptCmd{HexScript: "00"},
+		},
+		{
+			name: "decodescript optional",
+			newCmd: func() (interface{}, error) {
+				return NewCmd("decodescript", "00", Uint16(1))
+			},
+			staticCmd: func() interface{} {
+				return NewDecodeScriptCmd("00", Uint16(1))
+			},
+			marshalled:   `{"jsonrpc":"1.0","method":"decodescript","params":["00",1],"id":1}`,
+			unmarshalled: &DecodeScriptCmd{HexScript: "00", Version: Uint16(1)},
 		},
 		{
 			name: "estimatefee",

--- a/dcrjson/helpers.go
+++ b/dcrjson/helpers.go
@@ -29,6 +29,14 @@ func Uint(v uint) *uint {
 	return p
 }
 
+// Uint16 is a helper routine that allocates a new uint16 value to store v and
+// returns a pointer to it.  This is useful when assigning optional parameters.
+func Uint16(v uint16) *uint16 {
+	p := new(uint16)
+	*p = v
+	return p
+}
+
 // Int32 is a helper routine that allocates a new int32 value to store v and
 // returns a pointer to it.  This is useful when assigning optional parameters.
 func Int32(v int32) *int32 {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1320,6 +1320,12 @@ func handleDecodeScript(s *rpcServer, cmd interface{}, closeChan <-chan struct{}
 		return nil, rpcDecodeHexError(hexStr)
 	}
 
+	// Fetch the script version if provided.
+	scriptVersion := uint16(0)
+	if c.Version != nil {
+		scriptVersion = *c.Version
+	}
+
 	// The disassembled string will contain [error] inline if the script
 	// doesn't fully parse, so ignore the error here.
 	disbuf, _ := txscript.DisasmString(script)
@@ -1327,9 +1333,8 @@ func handleDecodeScript(s *rpcServer, cmd interface{}, closeChan <-chan struct{}
 	// Get information about the script.
 	// Ignore the error here since an error means the script couldn't parse
 	// and there is no additinal information about it anyways.
-	// TODO Replace magic version with argument passed to RPC call
 	scriptClass, addrs, reqSigs, _ := txscript.ExtractPkScriptAddrs(
-		txscript.DefaultScriptVersion, script, s.server.chainParams)
+		scriptVersion, script, s.server.chainParams)
 	addresses := make([]string, len(addrs))
 	for i, addr := range addrs {
 		addresses[i] = addr.EncodeAddress()

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -156,6 +156,7 @@ var helpDescsEnUS = map[string]string{
 	// DecodeScriptCmd help.
 	"decodescript--synopsis": "Returns a JSON object with information about the provided hex-encoded script.",
 	"decodescript-hexscript": "Hex-encoded script",
+	"decodescript-version":   "The script version, defaults to version 0 if not set.",
 
 	// ExistsAddressCmd help.
 	"existsaddress--synopsis": "Test for the existence of the provided address",


### PR DESCRIPTION
This add an optional version parameter to the `decodescript` rpc. It defaults to version zero if not set.