### PR TITLE
blockmanager: remove serverPeer from blockmanager completely.

### DIFF
--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -253,12 +253,12 @@ func (b *rpcSyncMgr) SubmitBlock(block *dcrutil.Block, flags blockchain.Behavior
 	return b.blockMgr.ProcessBlock(block, flags)
 }
 
-// SyncPeer returns the peer that is currently the peer being used to sync from.
+// SyncPeer returns the id of the current peer being synced with.
 //
 // This function is safe for concurrent access and is part of the
 // rpcserverSyncManager interface implementation.
-func (b *rpcSyncMgr) SyncPeer() rpcserverPeer {
-	return (*rpcPeer)(b.blockMgr.SyncPeer())
+func (b *rpcSyncMgr) SyncPeerID() int32 {
+	return b.blockMgr.SyncPeerID()
 }
 
 // LocateBlocks returns the hashes of the blocks after the first known block in

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2539,7 +2539,7 @@ func handleGetNetworkInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct
 // handleGetPeerInfo implements the getpeerinfo command.
 func handleGetPeerInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
 	peers := s.cfg.ConnMgr.ConnectedPeers()
-	syncPeer := s.cfg.SyncMgr.SyncPeer().ToPeer()
+	syncPeerID := s.cfg.SyncMgr.SyncPeerID()
 	infos := make([]*types.GetPeerInfoResult, 0, len(peers))
 	for _, p := range peers {
 		peer := p.ToPeer()
@@ -2563,7 +2563,7 @@ func handleGetPeerInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{})
 			StartingHeight: statsSnap.StartingHeight,
 			CurrentHeight:  statsSnap.LastBlock,
 			BanScore:       int32(p.BanScore()),
-			SyncNode:       peer == syncPeer,
+			SyncNode:       peer.ID() == syncPeerID,
 		}
 		if peer.LastPingNonce() != 0 {
 			wait := float64(time.Since(statsSnap.LastPingTime).Nanoseconds())
@@ -5562,9 +5562,8 @@ type rpcserverSyncManager interface {
 	// processing it locally.
 	SubmitBlock(block *dcrutil.Block, flags blockchain.BehaviorFlags) (bool, error)
 
-	// SyncPeer returns the peer that is currently the peer being used to
-	// sync from.
-	SyncPeer() rpcserverPeer
+	// SyncPeerID returns the id of the current peer being synced with.
+	SyncPeerID() int32
 
 	// LocateBlocks returns the hashes of the blocks after the first known block in
 	// the locator until the provided stop hash is reached, or up to the provided


### PR DESCRIPTION
This is a port of btcd [989](https://github.com/btcsuite/btcd/pull/989)

The purpose is to remove the dependency of blockmanager on serverPeer, which is defined in the main package. Instead, we split out some of the fields from serverPeer into a separate struct called peerSyncState in blockmanager.go. While they are in the same package now, this change makes it easier to move blockManager into its own package along with peerSyncState. The blockManager tracks a map of Peer pointers to the peer state and keeps it updated as peers connect and disconnect.

