### PR TITLE
wire: Rename extended errors to malformed errors.

### DIFF
--- a/wire/msgcftypes_test.go
+++ b/wire/msgcftypes_test.go
@@ -247,9 +247,9 @@ func TestCFTypesWireErrors(t *testing.T) {
 	}
 }
 
-// TestCFTypesExtendedErrors performs negative tests against decode
+// TestCFTypesMalformedErrors performs negative tests against decode
 // of CFTypes to confirm malformed encoded data doesn't pass through.
-func TestCFTypesExtendedErrors(t *testing.T) {
+func TestCFTypesMalformedErrors(t *testing.T) {
 	pver := ProtocolVersion
 	wireErr := &MessageError{}
 


### PR DESCRIPTION
This changes a test's name from `*ExtendedErrors` to `*MalformedErrors` to makes it naming convention consistent with the other tests of this type.
