### PR TITLE
TravisCI: Disable race detector.

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -18,7 +18,6 @@ set -ex
 # 4. ineffassign   (https://github.com/gordonklaus/ineffassign)
 # 5. go vet        (https://golang.org/cmd/vet)
 # 6. misspell      (https://github.com/client9/misspell)
-# 7. race detector (https://blog.golang.org/race-detector)
 
 # golangci-lint (github.com/golangci/golangci-lint) is used to run each each
 # static checker.
@@ -49,8 +48,7 @@ testrepo () {
   MODPATHS=". $MODPATHS"
   for module in $MODPATHS; do
     echo "==> ${module}"
-    env GORACE='halt_on_error=1' CC=gcc $GO test -short -race \
-      -tags rpctest ./${module}/...
+    env CC=gcc $GO test -short -tags rpctest ./${module}/...
 
     # check linters
     golangci-lint run --build-tags rpctest --disable-all --deadline=10m \


### PR DESCRIPTION
Race-enabled testing is an order of magnitude slower. This causes issues for pull requests which add more tests, due to elapsed timeouts on the CI infrastructure, and it is more desirable to have a comprehensive test suite running without -race than few tests with it.

To test with -race locally, just run go test -race as usual, or (better) build and run a race-enabled binary.