### PR TITLE
stake: Remove unnecessary language in comment.

### DIFF
--- a/blockchain/stake/staketx.go
+++ b/blockchain/stake/staketx.go
@@ -26,8 +26,7 @@ import (
 // TxType indicates the type of tx (regular or stake type).
 type TxType int
 
-// Possible TxTypes.  Statically declare these so that they might be used in
-// consensus code.
+// Possible TxTypes.
 const (
 	TxTypeRegular TxType = iota
 	TxTypeSStx


### PR DESCRIPTION
This sentence read like a directive rather than a definition and all Go types
are statically declared anyways.