### PR TITLE
certgen: Support Ed25519 cert generation on Go 1.13

### DIFF
--- a/certgen/README.md
+++ b/certgen/README.md
@@ -7,9 +7,12 @@ Certgen
 
 ## Overview
 
-This package currently contains a single function for creating
-a new TLS certificate key pair, typically used for encrypting
-RPC and websocket communications.
+This package contains functions for creating self-signed TLS certificate from
+random new key pairs, typically used for encrypting RPC and websocket
+communications.
+
+ECDSA certificates are supported on all Go versions.  Beginning with Go 1.13,
+this package additionally includes support for Ed25519 certificates.
 
 ## Installation and Updating
 

--- a/certgen/doc.go
+++ b/certgen/doc.go
@@ -8,9 +8,11 @@ new TLS certificate key pair.
 
 Overview
 
-This package currently contains a single function for creating
-a new TLS certificate key pair, typically used for encrypting
-RPC and websocket communications.
+This package contains functions for creating self-signed TLS certificate from
+random new key pairs, typically used for encrypting RPC and websocket
+communications.
 
+ECDSA certificates are supported on all Go versions.  Beginning with Go 1.13,
+this package additionally includes support for Ed25519 certificates.
 */
 package certgen


### PR DESCRIPTION
This adds the function NewEd25519TLSCertPair which uses Ed25519 keys
rather than ECDSA keys as required by NewTLSCertPair.

Conditional compilation is used to provide the function only on Go 1.13.

Closes #1756.