### PR TITLE
txscript: Prepare v1.1.0.

### DIFF
--- a/txscript/go.mod
+++ b/txscript/go.mod
@@ -7,9 +7,9 @@ require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
 	github.com/decred/dcrd/dcrec v1.0.0
 	github.com/decred/dcrd/dcrec/edwards v1.0.0
-	github.com/decred/dcrd/dcrec/secp256k1 v1.0.1
-	github.com/decred/dcrd/dcrutil v1.2.0
+	github.com/decred/dcrd/dcrec/secp256k1 v1.0.2
+	github.com/decred/dcrd/dcrutil v1.3.0
 	github.com/decred/dcrd/wire v1.2.0
 	github.com/decred/slog v1.0.0
-	golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613
+	golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8
 )


### PR DESCRIPTION
This updates the `txscript` dependencies and serves as a base for `txscript/v1.1.0`.

The updated direct dependencies in this commit are as follows:

- github.com/decred/dcrd/dcrec/secp256k1@v1.0.2
- github.com/decred/dcrd/dcrutil@v1.3.0
- golang.org/x/crypto@v0.0.0-20190611184440-5c40567a22f8

The full list of updated direct dependencies since the previous `txscripti/v1.0.2` release are as follows:

- github.com/decred/dcrd/chaincfg@v1.5.1
- github.com/decred/dcrd/dcrec@v1.0.0
- github.com/decred/dcrd/dcrec/edwards@v1.0.0
- github.com/decred/dcrd/dcrec/secp256k1@v1.0.2
- github.com/decred/dcrd/dcrutil@v1.3.0
- golang.org/x/crypto@v0.0.0-20190611184440-5c40567a22f8