### PR TITLE
TravisCI: Test and lint latest version modules.

### DIFF
--- a/chaincfg/mainnetparams.go
+++ b/chaincfg/mainnetparams.go
@@ -45,7 +45,7 @@ func MainNetParams() *Params {
 			Nonce:        0x00000000,
 			StakeVersion: 0,
 		},
-		Transactions: []*wire.MsgTx{&wire.MsgTx{
+		Transactions: []*wire.MsgTx{{
 			SerType: wire.TxSerializeFull,
 			Version: 1,
 			TxIn: []*wire.TxIn{{

--- a/chaincfg/regnetparams.go
+++ b/chaincfg/regnetparams.go
@@ -49,7 +49,7 @@ func RegNetParams() *Params {
 			StakeVersion: 0,
 			Height:       0,
 		},
-		Transactions: []*wire.MsgTx{&wire.MsgTx{
+		Transactions: []*wire.MsgTx{{
 			SerType: wire.TxSerializeFull,
 			Version: 1,
 			TxIn: []*wire.TxIn{{

--- a/chaincfg/simnetparams.go
+++ b/chaincfg/simnetparams.go
@@ -50,7 +50,7 @@ func SimNetParams() *Params {
 			StakeVersion: 0,
 			Height:       0,
 		},
-		Transactions: []*wire.MsgTx{&wire.MsgTx{
+		Transactions: []*wire.MsgTx{{
 			SerType: wire.TxSerializeFull,
 			Version: 1,
 			TxIn: []*wire.TxIn{{

--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -34,7 +34,7 @@ func TestNet3Params() *Params {
 			Nonce:        0x18aea41a,
 			StakeVersion: 6,
 		},
-		Transactions: []*wire.MsgTx{&wire.MsgTx{
+		Transactions: []*wire.MsgTx{{
 			SerType: wire.TxSerializeFull,
 			Version: 1,
 			TxIn: []*wire.TxIn{{

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/decred/dcrd/chaincfg v1.5.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
 	github.com/decred/dcrd/connmgr v1.0.2
-	github.com/decred/dcrd/database v1.0.3
+	github.com/decred/dcrd/database v1.1.0
 	github.com/decred/dcrd/dcrec v1.0.0
 	github.com/decred/dcrd/dcrec/secp256k1 v1.0.2
 	github.com/decred/dcrd/dcrjson/v2 v2.0.0
@@ -43,10 +43,12 @@ replace (
 	github.com/decred/dcrd/blockchain/stake => ./blockchain/stake
 	github.com/decred/dcrd/certgen => ./certgen
 	github.com/decred/dcrd/chaincfg/chainhash => ./chaincfg/chainhash
+	github.com/decred/dcrd/chaincfg/v2 => ./chaincfg
 	github.com/decred/dcrd/connmgr => ./connmgr
 	github.com/decred/dcrd/database => ./database
 	github.com/decred/dcrd/dcrec => ./dcrec
 	github.com/decred/dcrd/dcrjson/v2 => ./dcrjson
+	github.com/decred/dcrd/dcrutil/v2 => ./dcrutil
 	github.com/decred/dcrd/fees => ./fees
 	github.com/decred/dcrd/gcs => ./gcs
 	github.com/decred/dcrd/hdkeychain/v2 => ./hdkeychain
@@ -56,5 +58,6 @@ replace (
 	github.com/decred/dcrd/mining => ./mining
 	github.com/decred/dcrd/peer => ./peer
 	github.com/decred/dcrd/rpcclient/v2 => ./rpcclient
+	github.com/decred/dcrd/txscript/v2 => ./txscript
 	github.com/decred/dcrd/wire => ./wire
 )

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,6 @@ github.com/decred/dcrd/chaincfg v1.4.0 h1:dIJhXQooiVW5AVZ0c4brylsiwkc8KSawpZ3NPq
 github.com/decred/dcrd/chaincfg v1.4.0/go.mod h1:ypuM30F+XgZmZTFfAkWHWd0lwwkWWAOAQYNRkRDlYLc=
 github.com/decred/dcrd/chaincfg v1.5.1 h1:u1Xbq0VTnAXIHW5ECqrWe0VYSgf5vWHqpSiwoLBzxAQ=
 github.com/decred/dcrd/chaincfg v1.5.1/go.mod h1:FukMzTjkwzjPU+hK7CqDMQe3NMbSZAYU5PAcsx1wlv0=
-github.com/decred/dcrd/chaincfg/v2 v2.0.2 h1:VeGY52lHuYT01tIGbvYj+OO0GaGxGaJmnh+4vGca1+U=
-github.com/decred/dcrd/chaincfg/v2 v2.0.2/go.mod h1:hpKvhLCDAD/xDZ3V1Pqpv9fIKVYYi11DyxETguazyvg=
 github.com/decred/dcrd/dcrec/edwards v0.0.0-20180721005212-59fe2b293f69/go.mod h1:+ehP0Hk/mesyZXttxCtBbhPX23BMpZJ1pcVBqUfbmvU=
 github.com/decred/dcrd/dcrec/edwards v0.0.0-20181208004914-a0816cf4301f/go.mod h1:+ehP0Hk/mesyZXttxCtBbhPX23BMpZJ1pcVBqUfbmvU=
 github.com/decred/dcrd/dcrec/edwards v0.0.0-20190130161649-59ed4247a1d5/go.mod h1:+ehP0Hk/mesyZXttxCtBbhPX23BMpZJ1pcVBqUfbmvU=

--- a/require.go
+++ b/require.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+// +build ignore
+
+// This file exists to prevent go mod tidy from removing requires for newer
+// module versions that are not yet fully integrated and to allow them to be
+// automatically discovered by the testing infrastructure.
+//
+// It is excluded from the build to avoid including unused modules in the final
+// binary.
+
+package main
+
+import (
+	_ "github.com/decred/dcrd/chaincfg/v2"
+	_ "github.com/decred/dcrd/dcrutil/v2"
+	_ "github.com/decred/dcrd/txscript/v2"
+)


### PR DESCRIPTION
The current approach of the CI tests of specifying the path to the directory that contains the module only tests version 1 of the module despite there being newer version available.  The same is true for the lints.

This resolves the test portion by obtaining a list of all modules required by the root go.mod file and providing the entire module path, which includes the version, to the go test command instead of the
directory.

Unfortunately, the linter does not recognize full module paths, however it will lint the latest module version from within the module directory itself, so this resolves the linting case by stripping the full module path and version down to the directory and changing into the directory to perform the lint checks.

It also contains two additional commits which correct newly discovered lint errors discovered by running them against the new version modules and to add requires for newer module versions that are not yet fully integrated to the main `go.mod` file along with a new file with a build tag to ignore it which imports those modules to prevent `go mod tidy` from removing the otherwise unused entries.