### PR TITLE
dcrjson: Remove API breaking change

### DIFF
--- a/dcrjson/chainsvrcmds.go
+++ b/dcrjson/chainsvrcmds.go
@@ -180,10 +180,9 @@ type DecodeScriptCmd struct {
 
 // NewDecodeScriptCmd returns a new instance which can be used to issue a
 // decodescript JSON-RPC command.
-func NewDecodeScriptCmd(hexScript string, version *uint16) *DecodeScriptCmd {
+func NewDecodeScriptCmd(hexScript string) *DecodeScriptCmd {
 	return &DecodeScriptCmd{
 		HexScript: hexScript,
-		Version:   version,
 	}
 }
 

--- a/dcrjson/chainsvrcmds_test.go
+++ b/dcrjson/chainsvrcmds_test.go
@@ -109,7 +109,7 @@ func TestChainSvrCmds(t *testing.T) {
 				return NewCmd("decodescript", "00")
 			},
 			staticCmd: func() interface{} {
-				return NewDecodeScriptCmd("00", nil)
+				return NewDecodeScriptCmd("00")
 			},
 			marshalled:   `{"jsonrpc":"1.0","method":"decodescript","params":["00"],"id":1}`,
 			unmarshalled: &DecodeScriptCmd{HexScript: "00"},
@@ -120,7 +120,9 @@ func TestChainSvrCmds(t *testing.T) {
 				return NewCmd("decodescript", "00", Uint16(1))
 			},
 			staticCmd: func() interface{} {
-				return NewDecodeScriptCmd("00", Uint16(1))
+				cmd := NewDecodeScriptCmd("00")
+				cmd.Version = Uint16(1)
+				return cmd
 			},
 			marshalled:   `{"jsonrpc":"1.0","method":"decodescript","params":["00",1],"id":1}`,
 			unmarshalled: &DecodeScriptCmd{HexScript: "00", Version: Uint16(1)},


### PR DESCRIPTION
dcrjson will require a minor bump before the next major.
Unfortunately, the master branch contains a breaking change since the
prior 2.0.0 tag.  This commit reverts that change and prepares the
module for a 2.1.0 release.