### PR TITLE
dcrjson: Introduce v3 and move types to module.

### DIFF
--- a/cmd/dcrctl/dcrctl.go
+++ b/cmd/dcrctl/dcrctl.go
@@ -15,7 +15,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/decred/dcrd/dcrjson/v2"
+	"github.com/decred/dcrd/dcrjson/v3"
+	dcrdtypes "github.com/decred/dcrd/rpc/jsonrpc/types"
+	wallettypes "github.com/decred/dcrwallet/rpc/jsonrpc/types"
 )
 
 const (
@@ -24,7 +26,7 @@ const (
 )
 
 // commandUsage display the usage for a specific command.
-func commandUsage(method string) {
+func commandUsage(method interface{}) {
 	usage, err := dcrjson.MethodUsageText(method)
 	if err != nil {
 		// This should never happen since the method was already checked
@@ -64,10 +66,15 @@ func main() {
 
 	// Ensure the specified method identifies a valid registered command and
 	// is one of the usable types.
-	method := args[0]
+	methodStr := args[0]
+	var method interface{} = dcrdtypes.Method(methodStr)
 	usageFlags, err := dcrjson.MethodUsageFlags(method)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Unrecognized command '%s'\n", method)
+		method = wallettypes.Method(methodStr)
+		usageFlags, err = dcrjson.MethodUsageFlags(method)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unrecognized command %q\n", methodStr)
 		fmt.Fprintln(os.Stderr, listCmdMessage)
 		os.Exit(1)
 	}

--- a/config.go
+++ b/config.go
@@ -25,10 +25,10 @@ import (
 	"github.com/decred/dcrd/connmgr"
 	"github.com/decred/dcrd/database"
 	_ "github.com/decred/dcrd/database/ffldb"
-	"github.com/decred/dcrd/dcrjson/v2"
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrd/internal/version"
 	"github.com/decred/dcrd/mempool/v2"
+	"github.com/decred/dcrd/rpc/jsonrpc/types"
 	"github.com/decred/dcrd/sampleconfig"
 	"github.com/decred/slog"
 	flags "github.com/jessevdk/go-flags"
@@ -177,9 +177,9 @@ type config struct {
 	miningAddrs          []dcrutil.Address
 	minRelayTxFee        dcrutil.Amount
 	whitelists           []*net.IPNet
-	ipv4NetInfo          dcrjson.NetworksResult
-	ipv6NetInfo          dcrjson.NetworksResult
-	onionNetInfo         dcrjson.NetworksResult
+	ipv4NetInfo          types.NetworksResult
+	ipv6NetInfo          types.NetworksResult
+	onionNetInfo         types.NetworksResult
 }
 
 // serviceOptions defines the configuration options for the daemon as a service on
@@ -423,8 +423,8 @@ func createDefaultConfigFile(destPath string) error {
 
 // generateNetworkInfo is a convenience function that creates a slice from the
 // available networks.
-func (cfg *config) generateNetworkInfo() []dcrjson.NetworksResult {
-	return []dcrjson.NetworksResult{cfg.ipv4NetInfo, cfg.ipv6NetInfo,
+func (cfg *config) generateNetworkInfo() []types.NetworksResult {
+	return []types.NetworksResult{cfg.ipv4NetInfo, cfg.ipv6NetInfo,
 		cfg.onionNetInfo}
 }
 
@@ -512,9 +512,9 @@ func loadConfig() (*config, []string, error) {
 		NoExistsAddrIndex:    defaultNoExistsAddrIndex,
 		NoCFilters:           defaultNoCFilters,
 		AltDNSNames:          defaultAltDNSNames,
-		ipv4NetInfo:          dcrjson.NetworksResult{Name: "IPV4"},
-		ipv6NetInfo:          dcrjson.NetworksResult{Name: "IPV6"},
-		onionNetInfo:         dcrjson.NetworksResult{Name: "Onion"},
+		ipv4NetInfo:          types.NetworksResult{Name: "IPV4"},
+		ipv6NetInfo:          types.NetworksResult{Name: "IPV6"},
+		onionNetInfo:         types.NetworksResult{Name: "Onion"},
 	}
 
 	// Service options which are only added on Windows.

--- a/dcrjson/cmdinfo.go
+++ b/dcrjson/cmdinfo.go
@@ -21,17 +21,17 @@ func CmdMethod(cmd interface{}) (string, error) {
 	method, ok := concreteTypeToMethod[rt]
 	registerLock.RUnlock()
 	if !ok {
-		str := fmt.Sprintf("%q is not registered", method)
+		str := fmt.Sprintf("%T is not registered", cmd)
 		return "", makeError(ErrUnregisteredMethod, str)
 	}
 
-	return method, nil
+	return reflect.ValueOf(method).String(), nil
 }
 
 // MethodUsageFlags returns the usage flags for the passed command method.  The
 // provided method must be associated with a registered type.  All commands
 // provided by this package are registered by default.
-func MethodUsageFlags(method string) (UsageFlag, error) {
+func MethodUsageFlags(method interface{}) (UsageFlag, error) {
 	// Look up details about the provided method and error out if not
 	// registered.
 	registerLock.RLock()
@@ -178,7 +178,7 @@ func fieldUsage(structField reflect.StructField, defaultVal *reflect.Value) stri
 // methodUsageText returns a one-line usage string for the provided command and
 // method info.  This is the main work horse for the exported MethodUsageText
 // function.
-func methodUsageText(rtp reflect.Type, defaults map[int]reflect.Value, method string) string {
+func methodUsageText(rtp reflect.Type, defaults map[int]reflect.Value, method interface{}) string {
 	// Generate the individual usage for each field in the command.  Several
 	// simplifying assumptions are made here because the RegisterCmd
 	// function has already rigorously enforced the layout.
@@ -209,7 +209,7 @@ func methodUsageText(rtp reflect.Type, defaults map[int]reflect.Value, method st
 	}
 
 	// Generate and return the one-line usage string.
-	usageStr := method
+	usageStr := reflect.ValueOf(method).String()
 	if len(reqFieldUsages) > 0 {
 		usageStr += " " + strings.Join(reqFieldUsages, " ")
 	}
@@ -222,7 +222,7 @@ func methodUsageText(rtp reflect.Type, defaults map[int]reflect.Value, method st
 // MethodUsageText returns a one-line usage string for the provided method.  The
 // provided method must be associated with a registered type.  All commands
 // provided by this package are registered by default.
-func MethodUsageText(method string) (string, error) {
+func MethodUsageText(method interface{}) (string, error) {
 	// Look up details about the provided method and error out if not
 	// registered.
 	registerLock.RLock()

--- a/dcrjson/cmdinfo_test.go
+++ b/dcrjson/cmdinfo_test.go
@@ -28,12 +28,12 @@ func TestCmdMethod(t *testing.T) {
 		},
 		{
 			name:   "nil pointer of registered type",
-			cmd:    (*GetBlockCmd)(nil),
+			cmd:    (*testGetBlockCmd)(nil),
 			method: "getblock",
 		},
 		{
-			name:   "nil instance of registered type",
-			cmd:    &GetBlockCountCmd{},
+			name:   "zero instance of registered type",
+			cmd:    &testGetBlockCountCmd{},
 			method: "getblockcount",
 		},
 	}

--- a/dcrjson/example_test.go
+++ b/dcrjson/example_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -19,8 +19,10 @@ func ExampleMarshalCmd() {
 	// optional fields.  Also, notice the call to Bool which is a
 	// convenience function for creating a pointer out of a primitive for
 	// optional parameters.
+	//
+	// testGetBlockCmd was registered at init by the test.
 	blockHash := "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
-	gbCmd := NewGetBlockCmd(blockHash, Bool(false), nil)
+	gbCmd := &testGetBlockCmd{Hash: blockHash, Verbose: Bool(false), VerboseTx: nil}
 
 	// Marshal the command to the format suitable for sending to the RPC
 	// server.  Typically the client would increment the id here which is
@@ -41,8 +43,8 @@ func ExampleMarshalCmd() {
 }
 
 // This example demonstrates how to unmarshal a JSON-RPC request and then
-// unmarshal the concrete request into a concrete command.
-func ExampleUnmarshalCmd() {
+// parse the parameters into a concrete type.
+func ExampleParseParams() {
 	// Ordinarily this would be read from the wire, but for this example,
 	// it is hard coded here for clarity.
 	data := []byte(`{"jsonrpc":"1.0","method":"getblock","params":["000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",false],"id":1}`)
@@ -67,17 +69,17 @@ func ExampleUnmarshalCmd() {
 		return
 	}
 
-	// Unmarshal the request into a concrete command.
-	cmd, err := UnmarshalCmd(&request)
+	// Unmarshal the request into concrete params.
+	params, err := ParseParams(request.Method, request.Params)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 
-	// Type assert the command to the appropriate type.
-	gbCmd, ok := cmd.(*GetBlockCmd)
+	// Type assert the params to the appropriate type.
+	gbCmd, ok := params.(*testGetBlockCmd)
 	if !ok {
-		fmt.Printf("Incorrect command type: %T\n", cmd)
+		fmt.Printf("Incorrect params type: %T\n", params)
 		return
 	}
 

--- a/dcrjson/go.mod
+++ b/dcrjson/go.mod
@@ -1,4 +1,4 @@
-module github.com/decred/dcrd/dcrjson/v2
+module github.com/decred/dcrd/dcrjson/v3
 
 go 1.11
 

--- a/dcrjson/help.go
+++ b/dcrjson/help.go
@@ -503,7 +503,7 @@ func isValidResultType(kind reflect.Kind) bool {
 //   "help--condition1": "command specified"
 //   "help--result0":    "List of commands"
 //   "help--result1":    "Help for specified command"
-func GenerateHelp(method string, descs map[string]string, resultTypes ...interface{}) (string, error) {
+func GenerateHelp(method interface{}, descs map[string]string, resultTypes ...interface{}) (string, error) {
 	// Look up details about the provided method and error out if not
 	// registered.
 	registerLock.RLock()
@@ -511,7 +511,7 @@ func GenerateHelp(method string, descs map[string]string, resultTypes ...interfa
 	info := methodToInfo[method]
 	registerLock.RUnlock()
 	if !ok {
-		str := fmt.Sprintf("%q is not registered", method)
+		str := fmt.Sprintf("%#v is not registered", method)
 		return "", makeError(ErrUnregisteredMethod, str)
 	}
 
@@ -553,7 +553,8 @@ func GenerateHelp(method string, descs map[string]string, resultTypes ...interfa
 	}
 
 	// Generate and return the help for the method.
-	help := methodHelp(xT, rtp, info.defaults, method, resultTypes)
+	methodStr := reflect.ValueOf(method).String()
+	help := methodHelp(xT, rtp, info.defaults, methodStr, resultTypes)
 	if missingKey != "" {
 		return help, makeError(ErrMissingDescription, missingKey)
 	}

--- a/dcrjson/helpers.go
+++ b/dcrjson/helpers.go
@@ -84,12 +84,3 @@ func String(v string) *string {
 	*p = v
 	return p
 }
-
-// EstimateSmartFeeModeAddr is a helper routine that allocates a new
-// EstimateSmartFeeMode value to store v and returns a pointer to it. This is
-// useful when assigning optional parameters.
-func EstimateSmartFeeModeAddr(v EstimateSmartFeeMode) *EstimateSmartFeeMode {
-	p := new(EstimateSmartFeeMode)
-	*p = v
-	return p
-}

--- a/dcrjson/helpers_test.go
+++ b/dcrjson/helpers_test.go
@@ -100,16 +100,6 @@ func TestHelpers(t *testing.T) {
 				return &val
 			}(),
 		},
-		{
-			name: "estimatesmartfeemode",
-			f: func() interface{} {
-				return EstimateSmartFeeModeAddr("abc")
-			},
-			expected: func() interface{} {
-				val := EstimateSmartFeeMode("abc")
-				return &val
-			}(),
-		},
 	}
 
 	t.Logf("Running %d tests", len(tests))

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,8 @@ require (
 	github.com/decred/dcrd/database v1.1.0
 	github.com/decred/dcrd/dcrec v1.0.0
 	github.com/decred/dcrd/dcrec/secp256k1 v1.0.2
-	github.com/decred/dcrd/dcrjson/v2 v2.0.0
+	github.com/decred/dcrd/dcrjson/v2 v2.2.0
+	github.com/decred/dcrd/dcrjson/v3 v3.0.0
 	github.com/decred/dcrd/dcrutil v1.3.0
 	github.com/decred/dcrd/fees v1.0.0
 	github.com/decred/dcrd/gcs v1.0.2
@@ -25,10 +26,11 @@ require (
 	github.com/decred/dcrd/mempool/v2 v2.0.0
 	github.com/decred/dcrd/mining v1.1.0
 	github.com/decred/dcrd/peer v1.1.0
+	github.com/decred/dcrd/rpc/jsonrpc/types v0.0.0
 	github.com/decred/dcrd/rpcclient/v2 v2.0.0
 	github.com/decred/dcrd/txscript v1.1.0
 	github.com/decred/dcrd/wire v1.2.0
-	github.com/decred/dcrwallet/rpc/jsonrpc/types v1.0.0
+	github.com/decred/dcrwallet/rpc/jsonrpc/types v1.1.0
 	github.com/decred/slog v1.0.0
 	github.com/gorilla/websocket v1.4.0
 	github.com/jessevdk/go-flags v1.4.0
@@ -47,7 +49,7 @@ replace (
 	github.com/decred/dcrd/connmgr => ./connmgr
 	github.com/decred/dcrd/database => ./database
 	github.com/decred/dcrd/dcrec => ./dcrec
-	github.com/decred/dcrd/dcrjson/v2 => ./dcrjson
+	github.com/decred/dcrd/dcrjson/v3 => ./dcrjson
 	github.com/decred/dcrd/dcrutil/v2 => ./dcrutil
 	github.com/decred/dcrd/fees => ./fees
 	github.com/decred/dcrd/gcs => ./gcs
@@ -57,7 +59,12 @@ replace (
 	github.com/decred/dcrd/mempool/v2 => ./mempool
 	github.com/decred/dcrd/mining => ./mining
 	github.com/decred/dcrd/peer => ./peer
+	github.com/decred/dcrd/rpc/jsonrpc/types => ./rpc/jsonrpc/types
 	github.com/decred/dcrd/rpcclient/v2 => ./rpcclient
 	github.com/decred/dcrd/txscript/v2 => ./txscript
 	github.com/decred/dcrd/wire => ./wire
 )
+
+replace github.com/decred/dcrd/dcrjson/v2 v2.2.0 => github.com/jrick/btcd/dcrjson/v2 v2.0.0-20190715200557-9fffa6c80ab0
+
+replace github.com/decred/dcrwallet/rpc/jsonrpc/types v1.1.0 => github.com/jrick/btcwallet/rpc/jsonrpc/types v0.0.0-20190715193601-785bca9161e7

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,10 @@ github.com/decred/dcrd/dcrec/secp256k1 v1.0.0/go.mod h1:JPMFscGlgXTV684jxQNDijae
 github.com/decred/dcrd/dcrec/secp256k1 v1.0.1/go.mod h1:lhu4eZFSfTJWUnR3CFRcpD+Vta0KUAqnhTsTksHXgy0=
 github.com/decred/dcrd/dcrec/secp256k1 v1.0.2 h1:awk7sYJ4pGWmtkiGHFfctztJjHMKGLV8jctGQhAbKe0=
 github.com/decred/dcrd/dcrec/secp256k1 v1.0.2/go.mod h1:CHTUIVfmDDd0KFVFpNX1pFVCBUegxW387nN0IGwNKR0=
+github.com/decred/dcrd/dcrjson/v2 v2.0.0 h1:W0q4Alh36c5N318eUpfmU8kXoCNgImMLI87NIXni9Us=
+github.com/decred/dcrd/dcrjson/v2 v2.0.0/go.mod h1:FYueNy8BREAFq04YNEwcTsmGFcNqY+ehUUO81w2igi4=
+github.com/decred/dcrd/dcrjson/v2 v2.1.0-0.20190709184057-e4f5e3f84f39 h1:gRp7NXypQMNiK8MX4rxEgB7jWXZrpE9R3tqNYGoLeM0=
+github.com/decred/dcrd/dcrjson/v2 v2.1.0-0.20190709184057-e4f5e3f84f39/go.mod h1:x4dY9EiT+awLvXz4wNzGlVtzR9EXYkZglXlrnDoLI6g=
 github.com/decred/dcrd/dcrutil v1.1.1/go.mod h1:Jsttr0pEvzPAw+qay1kS1/PsbZYPyhluiNwwY6yBJS4=
 github.com/decred/dcrd/dcrutil v1.2.0/go.mod h1:tUNHS2gj7ApeEVS8gb6O+4wJW7w3O2MSRyRdcjW1JxU=
 github.com/decred/dcrd/dcrutil v1.3.0 h1:LtKIiDnq925yJT/4OpIKKiU9/WaxfD9LfhxrpLSi0Qs=
@@ -56,6 +60,12 @@ github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGAR
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jrick/bitset v1.0.0 h1:Ws0PXV3PwXqWK2n7Vz6idCdrV/9OrBXgHEJi27ZB9Dw=
 github.com/jrick/bitset v1.0.0/go.mod h1:ZOYB5Uvkla7wIEY4FEssPVi3IQXa02arznRaYaAEPe4=
+github.com/jrick/btcd/dcrjson/v2 v2.0.0-20190712210503-292c1e5e80ac h1:2vTh3IBLNrz5hsSpL8ADkxaIRSU8UW64wqUC0wmADtc=
+github.com/jrick/btcd/dcrjson/v2 v2.0.0-20190712210503-292c1e5e80ac/go.mod h1:JwKNPWI2B+oMTtj4zv5ale8682i99PF+ETEydAGdQIg=
+github.com/jrick/btcd/dcrjson/v2 v2.0.0-20190715200557-9fffa6c80ab0 h1:wgwsgxMRl8Z3MohHq+RxTxsZI8S3qHdJq88tZkX9Rv8=
+github.com/jrick/btcd/dcrjson/v2 v2.0.0-20190715200557-9fffa6c80ab0/go.mod h1:JwKNPWI2B+oMTtj4zv5ale8682i99PF+ETEydAGdQIg=
+github.com/jrick/btcwallet/rpc/jsonrpc/types v0.0.0-20190715193601-785bca9161e7 h1:mzBwESVcoOOQRdj+redewvo14ZY8o7FndeaNvMjYqss=
+github.com/jrick/btcwallet/rpc/jsonrpc/types v0.0.0-20190715193601-785bca9161e7/go.mod h1:3sSyqYX80jbLe3O/o3VgxHR82Up8lRLvhhbWZ26wCos=
 github.com/jrick/logrotate v1.0.0 h1:lQ1bL/n9mBNeIXoTUoYRlK4dHuNJVofX9oWqBtPnSzI=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/rpc/jsonrpc/types/chainsvrcmds.go
+++ b/rpc/jsonrpc/types/chainsvrcmds.go
@@ -6,11 +6,13 @@
 // NOTE: This file is intended to house the RPC commands that are supported by
 // a chain server.
 
-package dcrjson
+package types
 
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/decred/dcrd/dcrjson/v3"
 )
 
 // AddNodeSubCmd defines the type used in the addnode JSON-RPC command for the
@@ -268,27 +270,27 @@ func NewExistsAddressesCmd(addresses []string) *ExistsAddressesCmd {
 
 // ExistsMissedTicketsCmd defines the existsmissedtickets JSON-RPC command.
 type ExistsMissedTicketsCmd struct {
-	TxHashBlob string
+	TxHashes []string
 }
 
 // NewExistsMissedTicketsCmd returns a new instance which can be used to issue an
 // existsmissedtickets JSON-RPC command.
-func NewExistsMissedTicketsCmd(txHashBlob string) *ExistsMissedTicketsCmd {
+func NewExistsMissedTicketsCmd(txHashes []string) *ExistsMissedTicketsCmd {
 	return &ExistsMissedTicketsCmd{
-		TxHashBlob: txHashBlob,
+		TxHashes: txHashes,
 	}
 }
 
 // ExistsExpiredTicketsCmd defines the existsexpiredtickets JSON-RPC command.
 type ExistsExpiredTicketsCmd struct {
-	TxHashBlob string
+	TxHashes []string
 }
 
 // NewExistsExpiredTicketsCmd returns a new instance which can be used to issue an
 // existsexpiredtickets JSON-RPC command.
-func NewExistsExpiredTicketsCmd(txHashBlob string) *ExistsExpiredTicketsCmd {
+func NewExistsExpiredTicketsCmd(txHashes []string) *ExistsExpiredTicketsCmd {
 	return &ExistsExpiredTicketsCmd{
-		TxHashBlob: txHashBlob,
+		TxHashes: txHashes,
 	}
 }
 
@@ -307,27 +309,27 @@ func NewExistsLiveTicketCmd(txHash string) *ExistsLiveTicketCmd {
 
 // ExistsLiveTicketsCmd defines the existslivetickets JSON-RPC command.
 type ExistsLiveTicketsCmd struct {
-	TxHashBlob string
+	TxHashes []string
 }
 
 // NewExistsLiveTicketsCmd returns a new instance which can be used to issue an
 // existslivetickets JSON-RPC command.
-func NewExistsLiveTicketsCmd(txHashBlob string) *ExistsLiveTicketsCmd {
+func NewExistsLiveTicketsCmd(txHashes []string) *ExistsLiveTicketsCmd {
 	return &ExistsLiveTicketsCmd{
-		TxHashBlob: txHashBlob,
+		TxHashes: txHashes,
 	}
 }
 
 // ExistsMempoolTxsCmd defines the existsmempooltxs JSON-RPC command.
 type ExistsMempoolTxsCmd struct {
-	TxHashBlob string
+	TxHashes []string
 }
 
 // NewExistsMempoolTxsCmd returns a new instance which can be used to issue an
 // existslivetickets JSON-RPC command.
-func NewExistsMempoolTxsCmd(txHashBlob string) *ExistsMempoolTxsCmd {
+func NewExistsMempoolTxsCmd(txHashes []string) *ExistsMempoolTxsCmd {
 	return &ExistsMempoolTxsCmd{
-		TxHashBlob: txHashBlob,
+		TxHashes: txHashes,
 	}
 }
 
@@ -502,7 +504,7 @@ func convertTemplateRequestField(fieldName string, iface interface{}) (interface
 
 	str := fmt.Sprintf("the %s field must be unspecified, a boolean, or "+
 		"a 64-bit integer", fieldName)
-	return nil, makeError(ErrInvalidType, str)
+	return nil, dcrjson.Error{Code: dcrjson.ErrInvalidType, Message: str}
 }
 
 // UnmarshalJSON provides a custom Unmarshal method for TemplateRequest.  This
@@ -653,13 +655,13 @@ func NewGetInfoCmd() *GetInfoCmd {
 
 // GetHeadersCmd defines the getheaders JSON-RPC command.
 type GetHeadersCmd struct {
-	BlockLocators string `json:"blocklocators"`
-	HashStop      string `json:"hashstop"`
+	BlockLocators []string `json:"blocklocators"`
+	HashStop      string   `json:"hashstop"`
 }
 
 // NewGetHeadersCmd returns a new instance which can be used to issue a
 // getheaders JSON-RPC command.
-func NewGetHeadersCmd(blockLocators string, hashStop string) *GetHeadersCmd {
+func NewGetHeadersCmd(blockLocators []string, hashStop string) *GetHeadersCmd {
 	return &GetHeadersCmd{
 		BlockLocators: blockLocators,
 		HashStop:      hashStop,
@@ -1195,81 +1197,81 @@ func NewVersionCmd() *VersionCmd { return new(VersionCmd) }
 
 func init() {
 	// No special flags for commands in this file.
-	flags := UsageFlag(0)
+	flags := dcrjson.UsageFlag(0)
 
-	MustRegisterCmd("addnode", (*AddNodeCmd)(nil), flags)
-	MustRegisterCmd("createrawssrtx", (*CreateRawSSRtxCmd)(nil), flags)
-	MustRegisterCmd("createrawsstx", (*CreateRawSStxCmd)(nil), flags)
-	MustRegisterCmd("createrawtransaction", (*CreateRawTransactionCmd)(nil), flags)
-	MustRegisterCmd("debuglevel", (*DebugLevelCmd)(nil), flags)
-	MustRegisterCmd("decoderawtransaction", (*DecodeRawTransactionCmd)(nil), flags)
-	MustRegisterCmd("decodescript", (*DecodeScriptCmd)(nil), flags)
-	MustRegisterCmd("estimatefee", (*EstimateFeeCmd)(nil), flags)
-	MustRegisterCmd("estimatesmartfee", (*EstimateSmartFeeCmd)(nil), flags)
-	MustRegisterCmd("estimatestakediff", (*EstimateStakeDiffCmd)(nil), flags)
-	MustRegisterCmd("existsaddress", (*ExistsAddressCmd)(nil), flags)
-	MustRegisterCmd("existsaddresses", (*ExistsAddressesCmd)(nil), flags)
-	MustRegisterCmd("existsmissedtickets", (*ExistsMissedTicketsCmd)(nil), flags)
-	MustRegisterCmd("existsexpiredtickets", (*ExistsExpiredTicketsCmd)(nil), flags)
-	MustRegisterCmd("existsliveticket", (*ExistsLiveTicketCmd)(nil), flags)
-	MustRegisterCmd("existslivetickets", (*ExistsLiveTicketsCmd)(nil), flags)
-	MustRegisterCmd("existsmempooltxs", (*ExistsMempoolTxsCmd)(nil), flags)
-	MustRegisterCmd("generate", (*GenerateCmd)(nil), flags)
-	MustRegisterCmd("getaddednodeinfo", (*GetAddedNodeInfoCmd)(nil), flags)
-	MustRegisterCmd("getbestblock", (*GetBestBlockCmd)(nil), flags)
-	MustRegisterCmd("getbestblockhash", (*GetBestBlockHashCmd)(nil), flags)
-	MustRegisterCmd("getblock", (*GetBlockCmd)(nil), flags)
-	MustRegisterCmd("getblockchaininfo", (*GetBlockChainInfoCmd)(nil), flags)
-	MustRegisterCmd("getblockcount", (*GetBlockCountCmd)(nil), flags)
-	MustRegisterCmd("getblockhash", (*GetBlockHashCmd)(nil), flags)
-	MustRegisterCmd("getblockheader", (*GetBlockHeaderCmd)(nil), flags)
-	MustRegisterCmd("getblocksubsidy", (*GetBlockSubsidyCmd)(nil), flags)
-	MustRegisterCmd("getblocktemplate", (*GetBlockTemplateCmd)(nil), flags)
-	MustRegisterCmd("getcfilter", (*GetCFilterCmd)(nil), flags)
-	MustRegisterCmd("getcfilterheader", (*GetCFilterHeaderCmd)(nil), flags)
-	MustRegisterCmd("getchaintips", (*GetChainTipsCmd)(nil), flags)
-	MustRegisterCmd("getcoinsupply", (*GetCoinSupplyCmd)(nil), flags)
-	MustRegisterCmd("getconnectioncount", (*GetConnectionCountCmd)(nil), flags)
-	MustRegisterCmd("getcurrentnet", (*GetCurrentNetCmd)(nil), flags)
-	MustRegisterCmd("getdifficulty", (*GetDifficultyCmd)(nil), flags)
-	MustRegisterCmd("getgenerate", (*GetGenerateCmd)(nil), flags)
-	MustRegisterCmd("gethashespersec", (*GetHashesPerSecCmd)(nil), flags)
-	MustRegisterCmd("getheaders", (*GetHeadersCmd)(nil), flags)
-	MustRegisterCmd("getinfo", (*GetInfoCmd)(nil), flags)
-	MustRegisterCmd("getmempoolinfo", (*GetMempoolInfoCmd)(nil), flags)
-	MustRegisterCmd("getmininginfo", (*GetMiningInfoCmd)(nil), flags)
-	MustRegisterCmd("getnetworkinfo", (*GetNetworkInfoCmd)(nil), flags)
-	MustRegisterCmd("getnettotals", (*GetNetTotalsCmd)(nil), flags)
-	MustRegisterCmd("getnetworkhashps", (*GetNetworkHashPSCmd)(nil), flags)
-	MustRegisterCmd("getpeerinfo", (*GetPeerInfoCmd)(nil), flags)
-	MustRegisterCmd("getrawmempool", (*GetRawMempoolCmd)(nil), flags)
-	MustRegisterCmd("getrawtransaction", (*GetRawTransactionCmd)(nil), flags)
-	MustRegisterCmd("getstakedifficulty", (*GetStakeDifficultyCmd)(nil), flags)
-	MustRegisterCmd("getstakeversioninfo", (*GetStakeVersionInfoCmd)(nil), flags)
-	MustRegisterCmd("getstakeversions", (*GetStakeVersionsCmd)(nil), flags)
-	MustRegisterCmd("getticketpoolvalue", (*GetTicketPoolValueCmd)(nil), flags)
-	MustRegisterCmd("gettxout", (*GetTxOutCmd)(nil), flags)
-	MustRegisterCmd("gettxoutsetinfo", (*GetTxOutSetInfoCmd)(nil), flags)
-	MustRegisterCmd("getvoteinfo", (*GetVoteInfoCmd)(nil), flags)
-	MustRegisterCmd("getwork", (*GetWorkCmd)(nil), flags)
-	MustRegisterCmd("help", (*HelpCmd)(nil), flags)
-	MustRegisterCmd("livetickets", (*LiveTicketsCmd)(nil), flags)
-	MustRegisterCmd("missedtickets", (*MissedTicketsCmd)(nil), flags)
-	MustRegisterCmd("node", (*NodeCmd)(nil), flags)
-	MustRegisterCmd("ping", (*PingCmd)(nil), flags)
-	MustRegisterCmd("rebroadcastmissed", (*RebroadcastMissedCmd)(nil), flags)
-	MustRegisterCmd("rebroadcastwinners", (*RebroadcastWinnersCmd)(nil), flags)
-	MustRegisterCmd("searchrawtransactions", (*SearchRawTransactionsCmd)(nil), flags)
-	MustRegisterCmd("sendrawtransaction", (*SendRawTransactionCmd)(nil), flags)
-	MustRegisterCmd("setgenerate", (*SetGenerateCmd)(nil), flags)
-	MustRegisterCmd("stop", (*StopCmd)(nil), flags)
-	MustRegisterCmd("submitblock", (*SubmitBlockCmd)(nil), flags)
-	MustRegisterCmd("ticketfeeinfo", (*TicketFeeInfoCmd)(nil), flags)
-	MustRegisterCmd("ticketsforaddress", (*TicketsForAddressCmd)(nil), flags)
-	MustRegisterCmd("ticketvwap", (*TicketVWAPCmd)(nil), flags)
-	MustRegisterCmd("txfeeinfo", (*TxFeeInfoCmd)(nil), flags)
-	MustRegisterCmd("validateaddress", (*ValidateAddressCmd)(nil), flags)
-	MustRegisterCmd("verifychain", (*VerifyChainCmd)(nil), flags)
-	MustRegisterCmd("verifymessage", (*VerifyMessageCmd)(nil), flags)
-	MustRegisterCmd("version", (*VersionCmd)(nil), flags)
+	dcrjson.MustRegister(Method("addnode"), (*AddNodeCmd)(nil), flags)
+	dcrjson.MustRegister(Method("createrawssrtx"), (*CreateRawSSRtxCmd)(nil), flags)
+	dcrjson.MustRegister(Method("createrawsstx"), (*CreateRawSStxCmd)(nil), flags)
+	dcrjson.MustRegister(Method("createrawtransaction"), (*CreateRawTransactionCmd)(nil), flags)
+	dcrjson.MustRegister(Method("debuglevel"), (*DebugLevelCmd)(nil), flags)
+	dcrjson.MustRegister(Method("decoderawtransaction"), (*DecodeRawTransactionCmd)(nil), flags)
+	dcrjson.MustRegister(Method("decodescript"), (*DecodeScriptCmd)(nil), flags)
+	dcrjson.MustRegister(Method("estimatefee"), (*EstimateFeeCmd)(nil), flags)
+	dcrjson.MustRegister(Method("estimatesmartfee"), (*EstimateSmartFeeCmd)(nil), flags)
+	dcrjson.MustRegister(Method("estimatestakediff"), (*EstimateStakeDiffCmd)(nil), flags)
+	dcrjson.MustRegister(Method("existsaddress"), (*ExistsAddressCmd)(nil), flags)
+	dcrjson.MustRegister(Method("existsaddresses"), (*ExistsAddressesCmd)(nil), flags)
+	dcrjson.MustRegister(Method("existsmissedtickets"), (*ExistsMissedTicketsCmd)(nil), flags)
+	dcrjson.MustRegister(Method("existsexpiredtickets"), (*ExistsExpiredTicketsCmd)(nil), flags)
+	dcrjson.MustRegister(Method("existsliveticket"), (*ExistsLiveTicketCmd)(nil), flags)
+	dcrjson.MustRegister(Method("existslivetickets"), (*ExistsLiveTicketsCmd)(nil), flags)
+	dcrjson.MustRegister(Method("existsmempooltxs"), (*ExistsMempoolTxsCmd)(nil), flags)
+	dcrjson.MustRegister(Method("generate"), (*GenerateCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getaddednodeinfo"), (*GetAddedNodeInfoCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getbestblock"), (*GetBestBlockCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getbestblockhash"), (*GetBestBlockHashCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getblock"), (*GetBlockCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getblockchaininfo"), (*GetBlockChainInfoCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getblockcount"), (*GetBlockCountCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getblockhash"), (*GetBlockHashCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getblockheader"), (*GetBlockHeaderCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getblocksubsidy"), (*GetBlockSubsidyCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getblocktemplate"), (*GetBlockTemplateCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getcfilter"), (*GetCFilterCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getcfilterheader"), (*GetCFilterHeaderCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getchaintips"), (*GetChainTipsCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getcoinsupply"), (*GetCoinSupplyCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getconnectioncount"), (*GetConnectionCountCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getcurrentnet"), (*GetCurrentNetCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getdifficulty"), (*GetDifficultyCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getgenerate"), (*GetGenerateCmd)(nil), flags)
+	dcrjson.MustRegister(Method("gethashespersec"), (*GetHashesPerSecCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getheaders"), (*GetHeadersCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getinfo"), (*GetInfoCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getmempoolinfo"), (*GetMempoolInfoCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getmininginfo"), (*GetMiningInfoCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getnetworkinfo"), (*GetNetworkInfoCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getnettotals"), (*GetNetTotalsCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getnetworkhashps"), (*GetNetworkHashPSCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getpeerinfo"), (*GetPeerInfoCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getrawmempool"), (*GetRawMempoolCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getrawtransaction"), (*GetRawTransactionCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getstakedifficulty"), (*GetStakeDifficultyCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getstakeversioninfo"), (*GetStakeVersionInfoCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getstakeversions"), (*GetStakeVersionsCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getticketpoolvalue"), (*GetTicketPoolValueCmd)(nil), flags)
+	dcrjson.MustRegister(Method("gettxout"), (*GetTxOutCmd)(nil), flags)
+	dcrjson.MustRegister(Method("gettxoutsetinfo"), (*GetTxOutSetInfoCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getvoteinfo"), (*GetVoteInfoCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getwork"), (*GetWorkCmd)(nil), flags)
+	dcrjson.MustRegister(Method("help"), (*HelpCmd)(nil), flags)
+	dcrjson.MustRegister(Method("livetickets"), (*LiveTicketsCmd)(nil), flags)
+	dcrjson.MustRegister(Method("missedtickets"), (*MissedTicketsCmd)(nil), flags)
+	dcrjson.MustRegister(Method("node"), (*NodeCmd)(nil), flags)
+	dcrjson.MustRegister(Method("ping"), (*PingCmd)(nil), flags)
+	dcrjson.MustRegister(Method("rebroadcastmissed"), (*RebroadcastMissedCmd)(nil), flags)
+	dcrjson.MustRegister(Method("rebroadcastwinners"), (*RebroadcastWinnersCmd)(nil), flags)
+	dcrjson.MustRegister(Method("searchrawtransactions"), (*SearchRawTransactionsCmd)(nil), flags)
+	dcrjson.MustRegister(Method("sendrawtransaction"), (*SendRawTransactionCmd)(nil), flags)
+	dcrjson.MustRegister(Method("setgenerate"), (*SetGenerateCmd)(nil), flags)
+	dcrjson.MustRegister(Method("stop"), (*StopCmd)(nil), flags)
+	dcrjson.MustRegister(Method("submitblock"), (*SubmitBlockCmd)(nil), flags)
+	dcrjson.MustRegister(Method("ticketfeeinfo"), (*TicketFeeInfoCmd)(nil), flags)
+	dcrjson.MustRegister(Method("ticketsforaddress"), (*TicketsForAddressCmd)(nil), flags)
+	dcrjson.MustRegister(Method("ticketvwap"), (*TicketVWAPCmd)(nil), flags)
+	dcrjson.MustRegister(Method("txfeeinfo"), (*TxFeeInfoCmd)(nil), flags)
+	dcrjson.MustRegister(Method("validateaddress"), (*ValidateAddressCmd)(nil), flags)
+	dcrjson.MustRegister(Method("verifychain"), (*VerifyChainCmd)(nil), flags)
+	dcrjson.MustRegister(Method("verifymessage"), (*VerifyMessageCmd)(nil), flags)
+	dcrjson.MustRegister(Method("version"), (*VersionCmd)(nil), flags)
 }

--- a/rpc/jsonrpc/types/chainsvrcmds_test.go
+++ b/rpc/jsonrpc/types/chainsvrcmds_test.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package dcrjson
+package types
 
 import (
 	"bytes"
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/decred/dcrd/dcrjson/v3"
 )
 
 // TestChainSvrCmds tests all of the chain server commands marshal and unmarshal
@@ -31,7 +33,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "addnode",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("addnode", "127.0.0.1", ANRemove)
+				return dcrjson.NewCmd(Method("addnode"), "127.0.0.1", ANRemove)
 			},
 			staticCmd: func() interface{} {
 				return NewAddNodeCmd("127.0.0.1", ANRemove)
@@ -42,8 +44,9 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "createrawtransaction",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("createrawtransaction", `[{"amount":0.0123,"txid":"123","vout":1}]`,
+				return dcrjson.NewCmd(Method("createrawtransaction"), `[{"amount":0.0123,"txid":"123","vout":1}]`,
 					`{"456":0.0123}`)
+
 			},
 			staticCmd: func() interface{} {
 				txInputs := []TransactionInput{
@@ -61,28 +64,29 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "createrawtransaction optional",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("createrawtransaction", `[{"amount":0.0123,"txid":"123","vout":1,"tree":0}]`,
+				return dcrjson.NewCmd(Method("createrawtransaction"), `[{"amount":0.0123,"txid":"123","vout":1,"tree":0}]`,
 					`{"456":0.0123}`, int64(12312333333), int64(12312333333))
+
 			},
 			staticCmd: func() interface{} {
 				txInputs := []TransactionInput{
 					{Amount: 0.0123, Txid: "123", Vout: 1},
 				}
 				amounts := map[string]float64{"456": .0123}
-				return NewCreateRawTransactionCmd(txInputs, amounts, Int64(12312333333), Int64(12312333333))
+				return NewCreateRawTransactionCmd(txInputs, amounts, dcrjson.Int64(12312333333), dcrjson.Int64(12312333333))
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"createrawtransaction","params":[[{"amount":0.0123,"txid":"123","vout":1,"tree":0}],{"456":0.0123},12312333333,12312333333],"id":1}`,
 			unmarshalled: &CreateRawTransactionCmd{
 				Inputs:   []TransactionInput{{Amount: 0.0123, Txid: "123", Vout: 1}},
 				Amounts:  map[string]float64{"456": .0123},
-				LockTime: Int64(12312333333),
-				Expiry:   Int64(12312333333),
+				LockTime: dcrjson.Int64(12312333333),
+				Expiry:   dcrjson.Int64(12312333333),
 			},
 		},
 		{
 			name: "debuglevel",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("debuglevel", "trace")
+				return dcrjson.NewCmd(Method("debuglevel"), "trace")
 			},
 			staticCmd: func() interface{} {
 				return NewDebugLevelCmd("trace")
@@ -95,7 +99,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "decoderawtransaction",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("decoderawtransaction", "123")
+				return dcrjson.NewCmd(Method("decoderawtransaction"), "123")
 			},
 			staticCmd: func() interface{} {
 				return NewDecodeRawTransactionCmd("123")
@@ -106,7 +110,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "decodescript",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("decodescript", "00")
+				return dcrjson.NewCmd(Method("decodescript"), "00")
 			},
 			staticCmd: func() interface{} {
 				return NewDecodeScriptCmd("00")
@@ -117,20 +121,20 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "decodescript optional",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("decodescript", "00", Uint16(1))
+				return dcrjson.NewCmd(Method("decodescript"), "00", dcrjson.Uint16(1))
 			},
 			staticCmd: func() interface{} {
 				cmd := NewDecodeScriptCmd("00")
-				cmd.Version = Uint16(1)
+				cmd.Version = dcrjson.Uint16(1)
 				return cmd
 			},
 			marshalled:   `{"jsonrpc":"1.0","method":"decodescript","params":["00",1],"id":1}`,
-			unmarshalled: &DecodeScriptCmd{HexScript: "00", Version: Uint16(1)},
+			unmarshalled: &DecodeScriptCmd{HexScript: "00", Version: dcrjson.Uint16(1)},
 		},
 		{
 			name: "estimatefee",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("estimatefee", 6)
+				return dcrjson.NewCmd(Method("estimatefee"), 6)
 			},
 			staticCmd: func() interface{} {
 				return NewEstimateFeeCmd(6)
@@ -143,7 +147,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "estimatesmartfee",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("estimatesmartfee", 6)
+				return dcrjson.NewCmd(Method("estimatesmartfee"), 6)
 			},
 			staticCmd: func() interface{} {
 				return NewEstimateSmartFeeCmd(6, nil)
@@ -157,7 +161,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "estimatesmartfee optional",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("estimatesmartfee", 6, EstimateSmartFeeConservative)
+				return dcrjson.NewCmd(Method("estimatesmartfee"), 6, EstimateSmartFeeConservative)
 			},
 			staticCmd: func() interface{} {
 				mode := EstimateSmartFeeConservative
@@ -172,7 +176,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "generate",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("generate", 1)
+				return dcrjson.NewCmd(Method("generate"), 1)
 			},
 			staticCmd: func() interface{} {
 				return NewGenerateCmd(1)
@@ -185,7 +189,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getaddednodeinfo",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getaddednodeinfo", true)
+				return dcrjson.NewCmd(Method("getaddednodeinfo"), true)
 			},
 			staticCmd: func() interface{} {
 				return NewGetAddedNodeInfoCmd(true, nil)
@@ -196,21 +200,21 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getaddednodeinfo optional",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getaddednodeinfo", true, "127.0.0.1")
+				return dcrjson.NewCmd(Method("getaddednodeinfo"), true, "127.0.0.1")
 			},
 			staticCmd: func() interface{} {
-				return NewGetAddedNodeInfoCmd(true, String("127.0.0.1"))
+				return NewGetAddedNodeInfoCmd(true, dcrjson.String("127.0.0.1"))
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getaddednodeinfo","params":[true,"127.0.0.1"],"id":1}`,
 			unmarshalled: &GetAddedNodeInfoCmd{
 				DNS:  true,
-				Node: String("127.0.0.1"),
+				Node: dcrjson.String("127.0.0.1"),
 			},
 		},
 		{
 			name: "getbestblock",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getbestblock")
+				return dcrjson.NewCmd(Method("getbestblock"))
 			},
 			staticCmd: func() interface{} {
 				return NewGetBestBlockCmd()
@@ -221,7 +225,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getbestblockhash",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getbestblockhash")
+				return dcrjson.NewCmd(Method("getbestblockhash"))
 			},
 			staticCmd: func() interface{} {
 				return NewGetBestBlockHashCmd()
@@ -232,7 +236,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getblock",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getblock", "123")
+				return dcrjson.NewCmd(Method("getblock"), "123")
 			},
 			staticCmd: func() interface{} {
 				return NewGetBlockCmd("123", nil, nil)
@@ -240,8 +244,8 @@ func TestChainSvrCmds(t *testing.T) {
 			marshalled: `{"jsonrpc":"1.0","method":"getblock","params":["123"],"id":1}`,
 			unmarshalled: &GetBlockCmd{
 				Hash:      "123",
-				Verbose:   Bool(true),
-				VerboseTx: Bool(false),
+				Verbose:   dcrjson.Bool(true),
+				VerboseTx: dcrjson.Bool(false),
 			},
 		},
 		{
@@ -250,38 +254,38 @@ func TestChainSvrCmds(t *testing.T) {
 				// Intentionally use a source param that is
 				// more pointers than the destination to
 				// exercise that path.
-				verbosePtr := Bool(true)
-				return NewCmd("getblock", "123", &verbosePtr)
+				verbosePtr := dcrjson.Bool(true)
+				return dcrjson.NewCmd(Method("getblock"), "123", &verbosePtr)
 			},
 			staticCmd: func() interface{} {
-				return NewGetBlockCmd("123", Bool(true), nil)
+				return NewGetBlockCmd("123", dcrjson.Bool(true), nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getblock","params":["123",true],"id":1}`,
 			unmarshalled: &GetBlockCmd{
 				Hash:      "123",
-				Verbose:   Bool(true),
-				VerboseTx: Bool(false),
+				Verbose:   dcrjson.Bool(true),
+				VerboseTx: dcrjson.Bool(false),
 			},
 		},
 		{
 			name: "getblock required optional2",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getblock", "123", true, true)
+				return dcrjson.NewCmd(Method("getblock"), "123", true, true)
 			},
 			staticCmd: func() interface{} {
-				return NewGetBlockCmd("123", Bool(true), Bool(true))
+				return NewGetBlockCmd("123", dcrjson.Bool(true), dcrjson.Bool(true))
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getblock","params":["123",true,true],"id":1}`,
 			unmarshalled: &GetBlockCmd{
 				Hash:      "123",
-				Verbose:   Bool(true),
-				VerboseTx: Bool(true),
+				Verbose:   dcrjson.Bool(true),
+				VerboseTx: dcrjson.Bool(true),
 			},
 		},
 		{
 			name: "getblockchaininfo",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getblockchaininfo")
+				return dcrjson.NewCmd(Method("getblockchaininfo"))
 			},
 			staticCmd: func() interface{} {
 				return NewGetBlockChainInfoCmd()
@@ -292,7 +296,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getblockcount",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getblockcount")
+				return dcrjson.NewCmd(Method("getblockcount"))
 			},
 			staticCmd: func() interface{} {
 				return NewGetBlockCountCmd()
@@ -303,7 +307,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getblockhash",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getblockhash", 123)
+				return dcrjson.NewCmd(Method("getblockhash"), 123)
 			},
 			staticCmd: func() interface{} {
 				return NewGetBlockHashCmd(123)
@@ -314,7 +318,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getblockheader",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getblockheader", "123")
+				return dcrjson.NewCmd(Method("getblockheader"), "123")
 			},
 			staticCmd: func() interface{} {
 				return NewGetBlockHeaderCmd("123", nil)
@@ -322,13 +326,13 @@ func TestChainSvrCmds(t *testing.T) {
 			marshalled: `{"jsonrpc":"1.0","method":"getblockheader","params":["123"],"id":1}`,
 			unmarshalled: &GetBlockHeaderCmd{
 				Hash:    "123",
-				Verbose: Bool(true),
+				Verbose: dcrjson.Bool(true),
 			},
 		},
 		{
 			name: "getblocksubsidy",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getblocksubsidy", 123, 256)
+				return dcrjson.NewCmd(Method("getblocksubsidy"), 123, 256)
 			},
 			staticCmd: func() interface{} {
 				return NewGetBlockSubsidyCmd(123, 256)
@@ -342,7 +346,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getblocktemplate",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getblocktemplate")
+				return dcrjson.NewCmd(Method("getblocktemplate"))
 			},
 			staticCmd: func() interface{} {
 				return NewGetBlockTemplateCmd(nil)
@@ -353,7 +357,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getblocktemplate optional - template request",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getblocktemplate", `{"mode":"template","capabilities":["longpoll","coinbasetxn"]}`)
+				return dcrjson.NewCmd(Method("getblocktemplate"), `{"mode":"template","capabilities":["longpoll","coinbasetxn"]}`)
 			},
 			staticCmd: func() interface{} {
 				template := TemplateRequest{
@@ -373,7 +377,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getblocktemplate optional - template request with tweaks",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getblocktemplate", `{"mode":"template","capabilities":["longpoll","coinbasetxn"],"sigoplimit":500,"sizelimit":100000000,"maxversion":2}`)
+				return dcrjson.NewCmd(Method("getblocktemplate"), `{"mode":"template","capabilities":["longpoll","coinbasetxn"],"sigoplimit":500,"sizelimit":100000000,"maxversion":2}`)
 			},
 			staticCmd: func() interface{} {
 				template := TemplateRequest{
@@ -399,7 +403,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getblocktemplate optional - template request with tweaks 2",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getblocktemplate", `{"mode":"template","capabilities":["longpoll","coinbasetxn"],"sigoplimit":true,"sizelimit":100000000,"maxversion":2}`)
+				return dcrjson.NewCmd(Method("getblocktemplate"), `{"mode":"template","capabilities":["longpoll","coinbasetxn"],"sigoplimit":true,"sizelimit":100000000,"maxversion":2}`)
 			},
 			staticCmd: func() interface{} {
 				template := TemplateRequest{
@@ -425,7 +429,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getcfilter",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getcfilter", "123", "extended")
+				return dcrjson.NewCmd(Method("getcfilter"), "123", "extended")
 			},
 			staticCmd: func() interface{} {
 				return NewGetCFilterCmd("123", "extended")
@@ -439,7 +443,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getcfilterheader",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getcfilterheader", "123", "extended")
+				return dcrjson.NewCmd(Method("getcfilterheader"), "123", "extended")
 			},
 			staticCmd: func() interface{} {
 				return NewGetCFilterHeaderCmd("123", "extended")
@@ -453,7 +457,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getchaintips",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getchaintips")
+				return dcrjson.NewCmd(Method("getchaintips"))
 			},
 			staticCmd: func() interface{} {
 				return NewGetChainTipsCmd()
@@ -464,7 +468,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getconnectioncount",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getconnectioncount")
+				return dcrjson.NewCmd(Method("getconnectioncount"))
 			},
 			staticCmd: func() interface{} {
 				return NewGetConnectionCountCmd()
@@ -475,7 +479,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getcurrentnet",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getcurrentnet")
+				return dcrjson.NewCmd(Method("getcurrentnet"))
 			},
 			staticCmd: func() interface{} {
 				return NewGetCurrentNetCmd()
@@ -486,7 +490,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getdifficulty",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getdifficulty")
+				return dcrjson.NewCmd(Method("getdifficulty"))
 			},
 			staticCmd: func() interface{} {
 				return NewGetDifficultyCmd()
@@ -497,7 +501,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getgenerate",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getgenerate")
+				return dcrjson.NewCmd(Method("getgenerate"))
 			},
 			staticCmd: func() interface{} {
 				return NewGetGenerateCmd()
@@ -508,7 +512,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "gethashespersec",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("gethashespersec")
+				return dcrjson.NewCmd(Method("gethashespersec"))
 			},
 			staticCmd: func() interface{} {
 				return NewGetHashesPerSecCmd()
@@ -519,7 +523,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getinfo",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getinfo")
+				return dcrjson.NewCmd(Method("getinfo"))
 			},
 			staticCmd: func() interface{} {
 				return NewGetInfoCmd()
@@ -530,7 +534,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getmempoolinfo",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getmempoolinfo")
+				return dcrjson.NewCmd(Method("getmempoolinfo"))
 			},
 			staticCmd: func() interface{} {
 				return NewGetMempoolInfoCmd()
@@ -541,7 +545,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getmininginfo",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getmininginfo")
+				return dcrjson.NewCmd(Method("getmininginfo"))
 			},
 			staticCmd: func() interface{} {
 				return NewGetMiningInfoCmd()
@@ -552,7 +556,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getnetworkinfo",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getnetworkinfo")
+				return dcrjson.NewCmd(Method("getnetworkinfo"))
 			},
 			staticCmd: func() interface{} {
 				return NewGetNetworkInfoCmd()
@@ -563,7 +567,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getnettotals",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getnettotals")
+				return dcrjson.NewCmd(Method("getnettotals"))
 			},
 			staticCmd: func() interface{} {
 				return NewGetNetTotalsCmd()
@@ -574,49 +578,49 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getnetworkhashps",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getnetworkhashps")
+				return dcrjson.NewCmd(Method("getnetworkhashps"))
 			},
 			staticCmd: func() interface{} {
 				return NewGetNetworkHashPSCmd(nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getnetworkhashps","params":[],"id":1}`,
 			unmarshalled: &GetNetworkHashPSCmd{
-				Blocks: Int(120),
-				Height: Int(-1),
+				Blocks: dcrjson.Int(120),
+				Height: dcrjson.Int(-1),
 			},
 		},
 		{
 			name: "getnetworkhashps optional1",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getnetworkhashps", 200)
+				return dcrjson.NewCmd(Method("getnetworkhashps"), 200)
 			},
 			staticCmd: func() interface{} {
-				return NewGetNetworkHashPSCmd(Int(200), nil)
+				return NewGetNetworkHashPSCmd(dcrjson.Int(200), nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getnetworkhashps","params":[200],"id":1}`,
 			unmarshalled: &GetNetworkHashPSCmd{
-				Blocks: Int(200),
-				Height: Int(-1),
+				Blocks: dcrjson.Int(200),
+				Height: dcrjson.Int(-1),
 			},
 		},
 		{
 			name: "getnetworkhashps optional2",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getnetworkhashps", 200, 123)
+				return dcrjson.NewCmd(Method("getnetworkhashps"), 200, 123)
 			},
 			staticCmd: func() interface{} {
-				return NewGetNetworkHashPSCmd(Int(200), Int(123))
+				return NewGetNetworkHashPSCmd(dcrjson.Int(200), dcrjson.Int(123))
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getnetworkhashps","params":[200,123],"id":1}`,
 			unmarshalled: &GetNetworkHashPSCmd{
-				Blocks: Int(200),
-				Height: Int(123),
+				Blocks: dcrjson.Int(200),
+				Height: dcrjson.Int(123),
 			},
 		},
 		{
 			name: "getpeerinfo",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getpeerinfo")
+				return dcrjson.NewCmd(Method("getpeerinfo"))
 			},
 			staticCmd: func() interface{} {
 				return NewGetPeerInfoCmd()
@@ -627,47 +631,47 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getrawmempool",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getrawmempool")
+				return dcrjson.NewCmd(Method("getrawmempool"))
 			},
 			staticCmd: func() interface{} {
 				return NewGetRawMempoolCmd(nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getrawmempool","params":[],"id":1}`,
 			unmarshalled: &GetRawMempoolCmd{
-				Verbose: Bool(false),
+				Verbose: dcrjson.Bool(false),
 			},
 		},
 		{
 			name: "getrawmempool optional",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getrawmempool", false)
+				return dcrjson.NewCmd(Method("getrawmempool"), false)
 			},
 			staticCmd: func() interface{} {
-				return NewGetRawMempoolCmd(Bool(false), nil)
+				return NewGetRawMempoolCmd(dcrjson.Bool(false), nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getrawmempool","params":[false],"id":1}`,
 			unmarshalled: &GetRawMempoolCmd{
-				Verbose: Bool(false),
+				Verbose: dcrjson.Bool(false),
 			},
 		},
 		{
 			name: "getrawmempool optional 2",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getrawmempool", false, "all")
+				return dcrjson.NewCmd(Method("getrawmempool"), false, "all")
 			},
 			staticCmd: func() interface{} {
-				return NewGetRawMempoolCmd(Bool(false), String("all"))
+				return NewGetRawMempoolCmd(dcrjson.Bool(false), dcrjson.String("all"))
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getrawmempool","params":[false,"all"],"id":1}`,
 			unmarshalled: &GetRawMempoolCmd{
-				Verbose: Bool(false),
-				TxType:  String("all"),
+				Verbose: dcrjson.Bool(false),
+				TxType:  dcrjson.String("all"),
 			},
 		},
 		{
 			name: "getrawtransaction",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getrawtransaction", "123")
+				return dcrjson.NewCmd(Method("getrawtransaction"), "123")
 			},
 			staticCmd: func() interface{} {
 				return NewGetRawTransactionCmd("123", nil)
@@ -675,27 +679,27 @@ func TestChainSvrCmds(t *testing.T) {
 			marshalled: `{"jsonrpc":"1.0","method":"getrawtransaction","params":["123"],"id":1}`,
 			unmarshalled: &GetRawTransactionCmd{
 				Txid:    "123",
-				Verbose: Int(0),
+				Verbose: dcrjson.Int(0),
 			},
 		},
 		{
 			name: "getrawtransaction optional",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getrawtransaction", "123", 1)
+				return dcrjson.NewCmd(Method("getrawtransaction"), "123", 1)
 			},
 			staticCmd: func() interface{} {
-				return NewGetRawTransactionCmd("123", Int(1))
+				return NewGetRawTransactionCmd("123", dcrjson.Int(1))
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getrawtransaction","params":["123",1],"id":1}`,
 			unmarshalled: &GetRawTransactionCmd{
 				Txid:    "123",
-				Verbose: Int(1),
+				Verbose: dcrjson.Int(1),
 			},
 		},
 		{
 			name: "getstakeversions",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getstakeversions", "deadbeef", 1)
+				return dcrjson.NewCmd(Method("getstakeversions"), "deadbeef", 1)
 			},
 			staticCmd: func() interface{} {
 				return NewGetStakeVersionsCmd("deadbeef", 1)
@@ -709,7 +713,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "gettxout",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("gettxout", "123", 1)
+				return dcrjson.NewCmd(Method("gettxout"), "123", 1)
 			},
 			staticCmd: func() interface{} {
 				return NewGetTxOutCmd("123", 1, nil)
@@ -718,28 +722,28 @@ func TestChainSvrCmds(t *testing.T) {
 			unmarshalled: &GetTxOutCmd{
 				Txid:           "123",
 				Vout:           1,
-				IncludeMempool: Bool(true),
+				IncludeMempool: dcrjson.Bool(true),
 			},
 		},
 		{
 			name: "gettxout optional",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("gettxout", "123", 1, true)
+				return dcrjson.NewCmd(Method("gettxout"), "123", 1, true)
 			},
 			staticCmd: func() interface{} {
-				return NewGetTxOutCmd("123", 1, Bool(true))
+				return NewGetTxOutCmd("123", 1, dcrjson.Bool(true))
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"gettxout","params":["123",1,true],"id":1}`,
 			unmarshalled: &GetTxOutCmd{
 				Txid:           "123",
 				Vout:           1,
-				IncludeMempool: Bool(true),
+				IncludeMempool: dcrjson.Bool(true),
 			},
 		},
 		{
 			name: "gettxoutsetinfo",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("gettxoutsetinfo")
+				return dcrjson.NewCmd(Method("gettxoutsetinfo"))
 			},
 			staticCmd: func() interface{} {
 				return NewGetTxOutSetInfoCmd()
@@ -750,7 +754,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getvoteinfo",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getvoteinfo", 1)
+				return dcrjson.NewCmd(Method("getvoteinfo"), 1)
 			},
 			staticCmd: func() interface{} {
 				return NewGetVoteInfoCmd(1)
@@ -763,7 +767,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getwork",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getwork")
+				return dcrjson.NewCmd(Method("getwork"))
 			},
 			staticCmd: func() interface{} {
 				return NewGetWorkCmd(nil)
@@ -776,20 +780,20 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "getwork optional",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("getwork", "00112233")
+				return dcrjson.NewCmd(Method("getwork"), "00112233")
 			},
 			staticCmd: func() interface{} {
-				return NewGetWorkCmd(String("00112233"))
+				return NewGetWorkCmd(dcrjson.String("00112233"))
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getwork","params":["00112233"],"id":1}`,
 			unmarshalled: &GetWorkCmd{
-				Data: String("00112233"),
+				Data: dcrjson.String("00112233"),
 			},
 		},
 		{
 			name: "help",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("help")
+				return dcrjson.NewCmd(Method("help"))
 			},
 			staticCmd: func() interface{} {
 				return NewHelpCmd(nil)
@@ -802,20 +806,20 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "help optional",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("help", "getblock")
+				return dcrjson.NewCmd(Method("help"), "getblock")
 			},
 			staticCmd: func() interface{} {
-				return NewHelpCmd(String("getblock"))
+				return NewHelpCmd(dcrjson.String("getblock"))
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"help","params":["getblock"],"id":1}`,
 			unmarshalled: &HelpCmd{
-				Command: String("getblock"),
+				Command: dcrjson.String("getblock"),
 			},
 		},
 		{
 			name: "node option remove",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("node", NRemove, "1.1.1.1")
+				return dcrjson.NewCmd(Method("node"), NRemove, "1.1.1.1")
 			},
 			staticCmd: func() interface{} {
 				return NewNodeCmd("remove", "1.1.1.1", nil)
@@ -829,7 +833,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "node option disconnect",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("node", NDisconnect, "1.1.1.1")
+				return dcrjson.NewCmd(Method("node"), NDisconnect, "1.1.1.1")
 			},
 			staticCmd: func() interface{} {
 				return NewNodeCmd("disconnect", "1.1.1.1", nil)
@@ -843,22 +847,22 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "node option connect",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("node", NConnect, "1.1.1.1", "perm")
+				return dcrjson.NewCmd(Method("node"), NConnect, "1.1.1.1", "perm")
 			},
 			staticCmd: func() interface{} {
-				return NewNodeCmd("connect", "1.1.1.1", String("perm"))
+				return NewNodeCmd("connect", "1.1.1.1", dcrjson.String("perm"))
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"node","params":["connect","1.1.1.1","perm"],"id":1}`,
 			unmarshalled: &NodeCmd{
 				SubCmd:        NConnect,
 				Target:        "1.1.1.1",
-				ConnectSubCmd: String("perm"),
+				ConnectSubCmd: dcrjson.String("perm"),
 			},
 		},
 		{
 			name: "ping",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("ping")
+				return dcrjson.NewCmd(Method("ping"))
 			},
 			staticCmd: func() interface{} {
 				return NewPingCmd()
@@ -869,7 +873,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "searchrawtransactions",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("searchrawtransactions", "1Address")
+				return dcrjson.NewCmd(Method("searchrawtransactions"), "1Address")
 			},
 			staticCmd: func() interface{} {
 				return NewSearchRawTransactionsCmd("1Address", nil, nil, nil, nil, nil, nil)
@@ -877,140 +881,140 @@ func TestChainSvrCmds(t *testing.T) {
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address"],"id":1}`,
 			unmarshalled: &SearchRawTransactionsCmd{
 				Address:     "1Address",
-				Verbose:     Int(1),
-				Skip:        Int(0),
-				Count:       Int(100),
-				VinExtra:    Int(0),
-				Reverse:     Bool(false),
+				Verbose:     dcrjson.Int(1),
+				Skip:        dcrjson.Int(0),
+				Count:       dcrjson.Int(100),
+				VinExtra:    dcrjson.Int(0),
+				Reverse:     dcrjson.Bool(false),
 				FilterAddrs: nil,
 			},
 		},
 		{
 			name: "searchrawtransactions",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("searchrawtransactions", "1Address", 0)
+				return dcrjson.NewCmd(Method("searchrawtransactions"), "1Address", 0)
 			},
 			staticCmd: func() interface{} {
 				return NewSearchRawTransactionsCmd("1Address",
-					Int(0), nil, nil, nil, nil, nil)
+					dcrjson.Int(0), nil, nil, nil, nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0],"id":1}`,
 			unmarshalled: &SearchRawTransactionsCmd{
 				Address:     "1Address",
-				Verbose:     Int(0),
-				Skip:        Int(0),
-				Count:       Int(100),
-				VinExtra:    Int(0),
-				Reverse:     Bool(false),
+				Verbose:     dcrjson.Int(0),
+				Skip:        dcrjson.Int(0),
+				Count:       dcrjson.Int(100),
+				VinExtra:    dcrjson.Int(0),
+				Reverse:     dcrjson.Bool(false),
 				FilterAddrs: nil,
 			},
 		},
 		{
 			name: "searchrawtransactions",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("searchrawtransactions", "1Address", 0, 5)
+				return dcrjson.NewCmd(Method("searchrawtransactions"), "1Address", 0, 5)
 			},
 			staticCmd: func() interface{} {
 				return NewSearchRawTransactionsCmd("1Address",
-					Int(0), Int(5), nil, nil, nil, nil)
+					dcrjson.Int(0), dcrjson.Int(5), nil, nil, nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0,5],"id":1}`,
 			unmarshalled: &SearchRawTransactionsCmd{
 				Address:     "1Address",
-				Verbose:     Int(0),
-				Skip:        Int(5),
-				Count:       Int(100),
-				VinExtra:    Int(0),
-				Reverse:     Bool(false),
+				Verbose:     dcrjson.Int(0),
+				Skip:        dcrjson.Int(5),
+				Count:       dcrjson.Int(100),
+				VinExtra:    dcrjson.Int(0),
+				Reverse:     dcrjson.Bool(false),
 				FilterAddrs: nil,
 			},
 		},
 		{
 			name: "searchrawtransactions",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("searchrawtransactions", "1Address", 0, 5, 10)
+				return dcrjson.NewCmd(Method("searchrawtransactions"), "1Address", 0, 5, 10)
 			},
 			staticCmd: func() interface{} {
 				return NewSearchRawTransactionsCmd("1Address",
-					Int(0), Int(5), Int(10), nil, nil, nil)
+					dcrjson.Int(0), dcrjson.Int(5), dcrjson.Int(10), nil, nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0,5,10],"id":1}`,
 			unmarshalled: &SearchRawTransactionsCmd{
 				Address:     "1Address",
-				Verbose:     Int(0),
-				Skip:        Int(5),
-				Count:       Int(10),
-				VinExtra:    Int(0),
-				Reverse:     Bool(false),
+				Verbose:     dcrjson.Int(0),
+				Skip:        dcrjson.Int(5),
+				Count:       dcrjson.Int(10),
+				VinExtra:    dcrjson.Int(0),
+				Reverse:     dcrjson.Bool(false),
 				FilterAddrs: nil,
 			},
 		},
 		{
 			name: "searchrawtransactions",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("searchrawtransactions", "1Address", 0, 5, 10, 1)
+				return dcrjson.NewCmd(Method("searchrawtransactions"), "1Address", 0, 5, 10, 1)
 			},
 			staticCmd: func() interface{} {
 				return NewSearchRawTransactionsCmd("1Address",
-					Int(0), Int(5), Int(10), Int(1), nil, nil)
+					dcrjson.Int(0), dcrjson.Int(5), dcrjson.Int(10), dcrjson.Int(1), nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0,5,10,1],"id":1}`,
 			unmarshalled: &SearchRawTransactionsCmd{
 				Address:     "1Address",
-				Verbose:     Int(0),
-				Skip:        Int(5),
-				Count:       Int(10),
-				VinExtra:    Int(1),
-				Reverse:     Bool(false),
+				Verbose:     dcrjson.Int(0),
+				Skip:        dcrjson.Int(5),
+				Count:       dcrjson.Int(10),
+				VinExtra:    dcrjson.Int(1),
+				Reverse:     dcrjson.Bool(false),
 				FilterAddrs: nil,
 			},
 		},
 		{
 			name: "searchrawtransactions",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("searchrawtransactions", "1Address", 0, 5, 10, 1, true)
+				return dcrjson.NewCmd(Method("searchrawtransactions"), "1Address", 0, 5, 10, 1, true)
 			},
 			staticCmd: func() interface{} {
 				return NewSearchRawTransactionsCmd("1Address",
-					Int(0), Int(5), Int(10),
-					Int(1), Bool(true), nil)
+					dcrjson.Int(0), dcrjson.Int(5), dcrjson.Int(10),
+					dcrjson.Int(1), dcrjson.Bool(true), nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0,5,10,1,true],"id":1}`,
 			unmarshalled: &SearchRawTransactionsCmd{
 				Address:     "1Address",
-				Verbose:     Int(0),
-				Skip:        Int(5),
-				Count:       Int(10),
-				VinExtra:    Int(1),
-				Reverse:     Bool(true),
+				Verbose:     dcrjson.Int(0),
+				Skip:        dcrjson.Int(5),
+				Count:       dcrjson.Int(10),
+				VinExtra:    dcrjson.Int(1),
+				Reverse:     dcrjson.Bool(true),
 				FilterAddrs: nil,
 			},
 		},
 		{
 			name: "searchrawtransactions",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("searchrawtransactions", "1Address", 0, 5, 10, 1, true, []string{"1Address"})
+				return dcrjson.NewCmd(Method("searchrawtransactions"), "1Address", 0, 5, 10, 1, true, []string{"1Address"})
 			},
 			staticCmd: func() interface{} {
 				return NewSearchRawTransactionsCmd("1Address",
-					Int(0), Int(5), Int(10),
-					Int(1), Bool(true), &[]string{"1Address"})
+					dcrjson.Int(0), dcrjson.Int(5), dcrjson.Int(10),
+					dcrjson.Int(1), dcrjson.Bool(true), &[]string{"1Address"})
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0,5,10,1,true,["1Address"]],"id":1}`,
 			unmarshalled: &SearchRawTransactionsCmd{
 				Address:     "1Address",
-				Verbose:     Int(0),
-				Skip:        Int(5),
-				Count:       Int(10),
-				VinExtra:    Int(1),
-				Reverse:     Bool(true),
+				Verbose:     dcrjson.Int(0),
+				Skip:        dcrjson.Int(5),
+				Count:       dcrjson.Int(10),
+				VinExtra:    dcrjson.Int(1),
+				Reverse:     dcrjson.Bool(true),
 				FilterAddrs: &[]string{"1Address"},
 			},
 		},
 		{
 			name: "sendrawtransaction",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("sendrawtransaction", "1122")
+				return dcrjson.NewCmd(Method("sendrawtransaction"), "1122")
 			},
 			staticCmd: func() interface{} {
 				return NewSendRawTransactionCmd("1122", nil)
@@ -1018,27 +1022,27 @@ func TestChainSvrCmds(t *testing.T) {
 			marshalled: `{"jsonrpc":"1.0","method":"sendrawtransaction","params":["1122"],"id":1}`,
 			unmarshalled: &SendRawTransactionCmd{
 				HexTx:         "1122",
-				AllowHighFees: Bool(false),
+				AllowHighFees: dcrjson.Bool(false),
 			},
 		},
 		{
 			name: "sendrawtransaction optional",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("sendrawtransaction", "1122", false)
+				return dcrjson.NewCmd(Method("sendrawtransaction"), "1122", false)
 			},
 			staticCmd: func() interface{} {
-				return NewSendRawTransactionCmd("1122", Bool(false))
+				return NewSendRawTransactionCmd("1122", dcrjson.Bool(false))
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"sendrawtransaction","params":["1122",false],"id":1}`,
 			unmarshalled: &SendRawTransactionCmd{
 				HexTx:         "1122",
-				AllowHighFees: Bool(false),
+				AllowHighFees: dcrjson.Bool(false),
 			},
 		},
 		{
 			name: "setgenerate",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("setgenerate", true)
+				return dcrjson.NewCmd(Method("setgenerate"), true)
 			},
 			staticCmd: func() interface{} {
 				return NewSetGenerateCmd(true, nil)
@@ -1046,27 +1050,27 @@ func TestChainSvrCmds(t *testing.T) {
 			marshalled: `{"jsonrpc":"1.0","method":"setgenerate","params":[true],"id":1}`,
 			unmarshalled: &SetGenerateCmd{
 				Generate:     true,
-				GenProcLimit: Int(-1),
+				GenProcLimit: dcrjson.Int(-1),
 			},
 		},
 		{
 			name: "setgenerate optional",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("setgenerate", true, 6)
+				return dcrjson.NewCmd(Method("setgenerate"), true, 6)
 			},
 			staticCmd: func() interface{} {
-				return NewSetGenerateCmd(true, Int(6))
+				return NewSetGenerateCmd(true, dcrjson.Int(6))
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"setgenerate","params":[true,6],"id":1}`,
 			unmarshalled: &SetGenerateCmd{
 				Generate:     true,
-				GenProcLimit: Int(6),
+				GenProcLimit: dcrjson.Int(6),
 			},
 		},
 		{
 			name: "stop",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("stop")
+				return dcrjson.NewCmd(Method("stop"))
 			},
 			staticCmd: func() interface{} {
 				return NewStopCmd()
@@ -1077,7 +1081,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "submitblock",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("submitblock", "112233")
+				return dcrjson.NewCmd(Method("submitblock"), "112233")
 			},
 			staticCmd: func() interface{} {
 				return NewSubmitBlockCmd("112233", nil)
@@ -1091,7 +1095,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "submitblock optional",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("submitblock", "112233", `{"workid":"12345"}`)
+				return dcrjson.NewCmd(Method("submitblock"), "112233", `{"workid":"12345"}`)
 			},
 			staticCmd: func() interface{} {
 				options := SubmitBlockOptions{
@@ -1110,7 +1114,7 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "validateaddress",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("validateaddress", "1Address")
+				return dcrjson.NewCmd(Method("validateaddress"), "1Address")
 			},
 			staticCmd: func() interface{} {
 				return NewValidateAddressCmd("1Address")
@@ -1123,49 +1127,49 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "verifychain",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("verifychain")
+				return dcrjson.NewCmd(Method("verifychain"))
 			},
 			staticCmd: func() interface{} {
 				return NewVerifyChainCmd(nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"verifychain","params":[],"id":1}`,
 			unmarshalled: &VerifyChainCmd{
-				CheckLevel: Int64(3),
-				CheckDepth: Int64(288),
+				CheckLevel: dcrjson.Int64(3),
+				CheckDepth: dcrjson.Int64(288),
 			},
 		},
 		{
 			name: "verifychain optional1",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("verifychain", 2)
+				return dcrjson.NewCmd(Method("verifychain"), 2)
 			},
 			staticCmd: func() interface{} {
-				return NewVerifyChainCmd(Int64(2), nil)
+				return NewVerifyChainCmd(dcrjson.Int64(2), nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"verifychain","params":[2],"id":1}`,
 			unmarshalled: &VerifyChainCmd{
-				CheckLevel: Int64(2),
-				CheckDepth: Int64(288),
+				CheckLevel: dcrjson.Int64(2),
+				CheckDepth: dcrjson.Int64(288),
 			},
 		},
 		{
 			name: "verifychain optional2",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("verifychain", 2, 500)
+				return dcrjson.NewCmd(Method("verifychain"), 2, 500)
 			},
 			staticCmd: func() interface{} {
-				return NewVerifyChainCmd(Int64(2), Int64(500))
+				return NewVerifyChainCmd(dcrjson.Int64(2), dcrjson.Int64(500))
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"verifychain","params":[2,500],"id":1}`,
 			unmarshalled: &VerifyChainCmd{
-				CheckLevel: Int64(2),
-				CheckDepth: Int64(500),
+				CheckLevel: dcrjson.Int64(2),
+				CheckDepth: dcrjson.Int64(500),
 			},
 		},
 		{
 			name: "verifymessage",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("verifymessage", "1Address", "301234", "test")
+				return dcrjson.NewCmd(Method("verifymessage"), "1Address", "301234", "test")
 			},
 			staticCmd: func() interface{} {
 				return NewVerifyMessageCmd("1Address", "301234", "test")
@@ -1183,7 +1187,7 @@ func TestChainSvrCmds(t *testing.T) {
 	for i, test := range tests {
 		// Marshal the command as created by the new static command
 		// creation function.
-		marshalled, err := MarshalCmd("1.0", testID, test.staticCmd())
+		marshalled, err := dcrjson.MarshalCmd("1.0", testID, test.staticCmd())
 		if err != nil {
 			t.Errorf("MarshalCmd #%d (%s) unexpected error: %v", i,
 				test.name, err)
@@ -1202,13 +1206,13 @@ func TestChainSvrCmds(t *testing.T) {
 		// new command creation function.
 		cmd, err := test.newCmd()
 		if err != nil {
-			t.Errorf("Test #%d (%s) unexpected NewCmd error: %v ",
+			t.Errorf("Test #%d (%s) unexpected dcrjson.NewCmd error: %v ",
 				i, test.name, err)
 		}
 
 		// Marshal the command as created by the generic new command
 		// creation function.
-		marshalled, err = MarshalCmd("1.0", testID, cmd)
+		marshalled, err = dcrjson.MarshalCmd("1.0", testID, cmd)
 		if err != nil {
 			t.Errorf("MarshalCmd #%d (%s) unexpected error: %v", i,
 				test.name, err)
@@ -1222,7 +1226,7 @@ func TestChainSvrCmds(t *testing.T) {
 			continue
 		}
 
-		var request Request
+		var request dcrjson.Request
 		if err := json.Unmarshal(marshalled, &request); err != nil {
 			t.Errorf("Test #%d (%s) unexpected error while "+
 				"unmarshalling JSON-RPC request: %v", i,
@@ -1230,9 +1234,9 @@ func TestChainSvrCmds(t *testing.T) {
 			continue
 		}
 
-		cmd, err = UnmarshalCmd(&request)
+		cmd, err = dcrjson.ParseParams(Method(request.Method), request.Params)
 		if err != nil {
-			t.Errorf("UnmarshalCmd #%d (%s) unexpected error: %v", i,
+			t.Errorf("ParseParams #%d (%s) unexpected error: %v", i,
 				test.name, err)
 			continue
 		}
@@ -1268,13 +1272,13 @@ func TestChainSvrCmdErrors(t *testing.T) {
 			name:       "invalid template request sigoplimit field",
 			result:     &TemplateRequest{},
 			marshalled: `{"sigoplimit":"invalid"}`,
-			err:        Error{Code: ErrInvalidType},
+			err:        dcrjson.Error{Code: dcrjson.ErrInvalidType},
 		},
 		{
 			name:       "invalid template request sizelimit field",
 			result:     &TemplateRequest{},
 			marshalled: `{"sizelimit":"invalid"}`,
-			err:        Error{Code: ErrInvalidType},
+			err:        dcrjson.Error{Code: dcrjson.ErrInvalidType},
 		},
 	}
 
@@ -1287,8 +1291,8 @@ func TestChainSvrCmdErrors(t *testing.T) {
 			continue
 		}
 
-		if terr, ok := test.err.(Error); ok {
-			gotErrorCode := err.(Error).Code
+		if terr, ok := test.err.(dcrjson.Error); ok {
+			gotErrorCode := err.(dcrjson.Error).Code
 			if gotErrorCode != terr.Code {
 				t.Errorf("Test #%d (%s) mismatched error code "+
 					"- got %v (%v), want %v", i, test.name,

--- a/rpc/jsonrpc/types/chainsvrresults.go
+++ b/rpc/jsonrpc/types/chainsvrresults.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package dcrjson
+package types
 
 import "encoding/json"
 

--- a/rpc/jsonrpc/types/chainsvrresults_test.go
+++ b/rpc/jsonrpc/types/chainsvrresults_test.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package dcrjson
+package types
 
 import (
 	"encoding/json"

--- a/rpc/jsonrpc/types/chainsvrwscmds.go
+++ b/rpc/jsonrpc/types/chainsvrwscmds.go
@@ -6,7 +6,9 @@
 // NOTE: This file is intended to house the RPC commands that are supported by
 // a chain server, but are only available via websockets.
 
-package dcrjson
+package types
+
+import "github.com/decred/dcrd/dcrjson/v3"
 
 // AuthenticateCmd defines the authenticate JSON-RPC command.
 type AuthenticateCmd struct {
@@ -150,34 +152,32 @@ func NewStopNotifyNewTransactionsCmd() *StopNotifyNewTransactionsCmd {
 
 // RescanCmd defines the rescan JSON-RPC command.
 type RescanCmd struct {
-	// Concatenated block hashes in non-byte-reversed hex encoding.  Must
-	// have length evenly divisible by 2*chainhash.HashSize.
-	BlockHashes string
+	BlockHashes []string
 }
 
 // NewRescanCmd returns a new instance which can be used to issue a rescan
 // JSON-RPC command.
-func NewRescanCmd(blockHashes string) *RescanCmd {
+func NewRescanCmd(blockHashes []string) *RescanCmd {
 	return &RescanCmd{BlockHashes: blockHashes}
 }
 
 func init() {
 	// The commands in this file are only usable by websockets.
-	flags := UFWebsocketOnly
+	flags := dcrjson.UFWebsocketOnly
 
-	MustRegisterCmd("authenticate", (*AuthenticateCmd)(nil), flags)
-	MustRegisterCmd("loadtxfilter", (*LoadTxFilterCmd)(nil), flags)
-	MustRegisterCmd("notifyblocks", (*NotifyBlocksCmd)(nil), flags)
-	MustRegisterCmd("notifynewtransactions", (*NotifyNewTransactionsCmd)(nil), flags)
-	MustRegisterCmd("notifynewtickets", (*NotifyNewTicketsCmd)(nil), flags)
-	MustRegisterCmd("notifyspentandmissedtickets",
+	dcrjson.MustRegister(Method("authenticate"), (*AuthenticateCmd)(nil), flags)
+	dcrjson.MustRegister(Method("loadtxfilter"), (*LoadTxFilterCmd)(nil), flags)
+	dcrjson.MustRegister(Method("notifyblocks"), (*NotifyBlocksCmd)(nil), flags)
+	dcrjson.MustRegister(Method("notifynewtransactions"), (*NotifyNewTransactionsCmd)(nil), flags)
+	dcrjson.MustRegister(Method("notifynewtickets"), (*NotifyNewTicketsCmd)(nil), flags)
+	dcrjson.MustRegister(Method("notifyspentandmissedtickets"),
 		(*NotifySpentAndMissedTicketsCmd)(nil), flags)
-	MustRegisterCmd("notifystakedifficulty",
+	dcrjson.MustRegister(Method("notifystakedifficulty"),
 		(*NotifyStakeDifficultyCmd)(nil), flags)
-	MustRegisterCmd("notifywinningtickets",
+	dcrjson.MustRegister(Method("notifywinningtickets"),
 		(*NotifyWinningTicketsCmd)(nil), flags)
-	MustRegisterCmd("session", (*SessionCmd)(nil), flags)
-	MustRegisterCmd("stopnotifyblocks", (*StopNotifyBlocksCmd)(nil), flags)
-	MustRegisterCmd("stopnotifynewtransactions", (*StopNotifyNewTransactionsCmd)(nil), flags)
-	MustRegisterCmd("rescan", (*RescanCmd)(nil), flags)
+	dcrjson.MustRegister(Method("session"), (*SessionCmd)(nil), flags)
+	dcrjson.MustRegister(Method("stopnotifyblocks"), (*StopNotifyBlocksCmd)(nil), flags)
+	dcrjson.MustRegister(Method("stopnotifynewtransactions"), (*StopNotifyNewTransactionsCmd)(nil), flags)
+	dcrjson.MustRegister(Method("rescan"), (*RescanCmd)(nil), flags)
 }

--- a/rpc/jsonrpc/types/chainsvrwscmds_test.go
+++ b/rpc/jsonrpc/types/chainsvrwscmds_test.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package dcrjson
+package types
 
 import (
 	"bytes"
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/decred/dcrd/dcrjson/v3"
 )
 
 // TestChainSvrWsCmds tests all of the chain server websocket-specific commands
@@ -31,7 +33,7 @@ func TestChainSvrWsCmds(t *testing.T) {
 		{
 			name: "authenticate",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("authenticate", "user", "pass")
+				return dcrjson.NewCmd(Method("authenticate"), "user", "pass")
 			},
 			staticCmd: func() interface{} {
 				return NewAuthenticateCmd("user", "pass")
@@ -42,7 +44,7 @@ func TestChainSvrWsCmds(t *testing.T) {
 		{
 			name: "notifywinningtickets",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("notifywinningtickets")
+				return dcrjson.NewCmd(Method("notifywinningtickets"))
 			},
 			staticCmd: func() interface{} {
 				return NewNotifyWinningTicketsCmd()
@@ -53,7 +55,7 @@ func TestChainSvrWsCmds(t *testing.T) {
 		{
 			name: "notifyspentandmissedtickets",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("notifyspentandmissedtickets")
+				return dcrjson.NewCmd(Method("notifyspentandmissedtickets"))
 			},
 			staticCmd: func() interface{} {
 				return NewNotifySpentAndMissedTicketsCmd()
@@ -64,7 +66,7 @@ func TestChainSvrWsCmds(t *testing.T) {
 		{
 			name: "notifynewtickets",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("notifynewtickets")
+				return dcrjson.NewCmd(Method("notifynewtickets"))
 			},
 			staticCmd: func() interface{} {
 				return NewNotifyNewTicketsCmd()
@@ -75,7 +77,7 @@ func TestChainSvrWsCmds(t *testing.T) {
 		{
 			name: "notifystakedifficulty",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("notifystakedifficulty")
+				return dcrjson.NewCmd(Method("notifystakedifficulty"))
 			},
 			staticCmd: func() interface{} {
 				return NewNotifyStakeDifficultyCmd()
@@ -86,7 +88,7 @@ func TestChainSvrWsCmds(t *testing.T) {
 		{
 			name: "notifyblocks",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("notifyblocks")
+				return dcrjson.NewCmd(Method("notifyblocks"))
 			},
 			staticCmd: func() interface{} {
 				return NewNotifyBlocksCmd()
@@ -97,7 +99,7 @@ func TestChainSvrWsCmds(t *testing.T) {
 		{
 			name: "stopnotifyblocks",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("stopnotifyblocks")
+				return dcrjson.NewCmd(Method("stopnotifyblocks"))
 			},
 			staticCmd: func() interface{} {
 				return NewStopNotifyBlocksCmd()
@@ -108,33 +110,33 @@ func TestChainSvrWsCmds(t *testing.T) {
 		{
 			name: "notifynewtransactions",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("notifynewtransactions")
+				return dcrjson.NewCmd(Method("notifynewtransactions"))
 			},
 			staticCmd: func() interface{} {
 				return NewNotifyNewTransactionsCmd(nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"notifynewtransactions","params":[],"id":1}`,
 			unmarshalled: &NotifyNewTransactionsCmd{
-				Verbose: Bool(false),
+				Verbose: dcrjson.Bool(false),
 			},
 		},
 		{
 			name: "notifynewtransactions optional",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("notifynewtransactions", true)
+				return dcrjson.NewCmd(Method("notifynewtransactions"), true)
 			},
 			staticCmd: func() interface{} {
-				return NewNotifyNewTransactionsCmd(Bool(true))
+				return NewNotifyNewTransactionsCmd(dcrjson.Bool(true))
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"notifynewtransactions","params":[true],"id":1}`,
 			unmarshalled: &NotifyNewTransactionsCmd{
-				Verbose: Bool(true),
+				Verbose: dcrjson.Bool(true),
 			},
 		},
 		{
 			name: "stopnotifynewtransactions",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("stopnotifynewtransactions")
+				return dcrjson.NewCmd(Method("stopnotifynewtransactions"))
 			},
 			staticCmd: func() interface{} {
 				return NewStopNotifyNewTransactionsCmd()
@@ -145,14 +147,14 @@ func TestChainSvrWsCmds(t *testing.T) {
 		{
 			name: "rescan",
 			newCmd: func() (interface{}, error) {
-				return NewCmd("rescan", "0000000000000000000000000000000000000000000000000000000000000123")
+				return dcrjson.NewCmd(Method("rescan"), []string{"0000000000000000000000000000000000000000000000000000000000000123"})
 			},
 			staticCmd: func() interface{} {
-				return NewRescanCmd("0000000000000000000000000000000000000000000000000000000000000123")
+				return NewRescanCmd([]string{"0000000000000000000000000000000000000000000000000000000000000123"})
 			},
-			marshalled: `{"jsonrpc":"1.0","method":"rescan","params":["0000000000000000000000000000000000000000000000000000000000000123"],"id":1}`,
+			marshalled: `{"jsonrpc":"1.0","method":"rescan","params":[["0000000000000000000000000000000000000000000000000000000000000123"]],"id":1}`,
 			unmarshalled: &RescanCmd{
-				BlockHashes: "0000000000000000000000000000000000000000000000000000000000000123",
+				BlockHashes: []string{"0000000000000000000000000000000000000000000000000000000000000123"},
 			},
 		},
 	}
@@ -161,7 +163,7 @@ func TestChainSvrWsCmds(t *testing.T) {
 	for i, test := range tests {
 		// Marshal the command as created by the new static command
 		// creation function.
-		marshalled, err := MarshalCmd("1.0", testID, test.staticCmd())
+		marshalled, err := dcrjson.MarshalCmd("1.0", testID, test.staticCmd())
 		if err != nil {
 			t.Errorf("MarshalCmd #%d (%s) unexpected error: %v", i,
 				test.name, err)
@@ -179,13 +181,13 @@ func TestChainSvrWsCmds(t *testing.T) {
 		// new command creation function.
 		cmd, err := test.newCmd()
 		if err != nil {
-			t.Errorf("Test #%d (%s) unexpected NewCmd error: %v ",
+			t.Errorf("Test #%d (%s) unexpected dcrjson.NewCmd error: %v ",
 				i, test.name, err)
 		}
 
 		// Marshal the command as created by the generic new command
 		// creation function.
-		marshalled, err = MarshalCmd("1.0", testID, cmd)
+		marshalled, err = dcrjson.MarshalCmd("1.0", testID, cmd)
 		if err != nil {
 			t.Errorf("MarshalCmd #%d (%s) unexpected error: %v", i,
 				test.name, err)
@@ -199,7 +201,7 @@ func TestChainSvrWsCmds(t *testing.T) {
 			continue
 		}
 
-		var request Request
+		var request dcrjson.Request
 		if err := json.Unmarshal(marshalled, &request); err != nil {
 			t.Errorf("Test #%d (%s) unexpected error while "+
 				"unmarshalling JSON-RPC request: %v", i,
@@ -207,9 +209,9 @@ func TestChainSvrWsCmds(t *testing.T) {
 			continue
 		}
 
-		cmd, err = UnmarshalCmd(&request)
+		cmd, err = dcrjson.ParseParams(Method(request.Method), request.Params)
 		if err != nil {
-			t.Errorf("UnmarshalCmd #%d (%s) unexpected error: %v", i,
+			t.Errorf("ParseParams #%d (%s) unexpected error: %v", i,
 				test.name, err)
 			continue
 		}

--- a/rpc/jsonrpc/types/chainsvrwsntfns.go
+++ b/rpc/jsonrpc/types/chainsvrwsntfns.go
@@ -6,50 +6,52 @@
 // NOTE: This file is intended to house the RPC websocket notifications that are
 // supported by a chain server.
 
-package dcrjson
+package types
+
+import "github.com/decred/dcrd/dcrjson/v3"
 
 const (
 	// BlockConnectedNtfnMethod is the method used for notifications from
 	// the chain server that a block has been connected.
-	BlockConnectedNtfnMethod = "blockconnected"
+	BlockConnectedNtfnMethod Method = "blockconnected"
 
 	// BlockDisconnectedNtfnMethod is the method used for notifications from
 	// the chain server that a block has been disconnected.
-	BlockDisconnectedNtfnMethod = "blockdisconnected"
+	BlockDisconnectedNtfnMethod Method = "blockdisconnected"
 
 	// NewTicketsNtfnMethod is the method of the daemon newtickets notification.
-	NewTicketsNtfnMethod = "newtickets"
+	NewTicketsNtfnMethod Method = "newtickets"
 
 	// ReorganizationNtfnMethod is the method used for notifications that the
 	// block chain is in the process of a reorganization.
-	ReorganizationNtfnMethod = "reorganization"
+	ReorganizationNtfnMethod Method = "reorganization"
 
 	// TxAcceptedNtfnMethod is the method used for notifications from the
 	// chain server that a transaction has been accepted into the mempool.
-	TxAcceptedNtfnMethod = "txaccepted"
+	TxAcceptedNtfnMethod Method = "txaccepted"
 
 	// TxAcceptedVerboseNtfnMethod is the method used for notifications from
 	// the chain server that a transaction has been accepted into the
 	// mempool.  This differs from TxAcceptedNtfnMethod in that it provides
 	// more details in the notification.
-	TxAcceptedVerboseNtfnMethod = "txacceptedverbose"
+	TxAcceptedVerboseNtfnMethod Method = "txacceptedverbose"
 
 	// RelevantTxAcceptedNtfnMethod is the method used for notifications
 	// from the chain server that inform a client that a relevant
 	// transaction was accepted by the mempool.
-	RelevantTxAcceptedNtfnMethod = "relevanttxaccepted"
+	RelevantTxAcceptedNtfnMethod Method = "relevanttxaccepted"
 
 	// SpentAndMissedTicketsNtfnMethod is the method of the daemon
 	// spentandmissedtickets notification.
-	SpentAndMissedTicketsNtfnMethod = "spentandmissedtickets"
+	SpentAndMissedTicketsNtfnMethod Method = "spentandmissedtickets"
 
 	// StakeDifficultyNtfnMethod is the method of the daemon stakedifficulty
 	// notification.
-	StakeDifficultyNtfnMethod = "stakedifficulty"
+	StakeDifficultyNtfnMethod Method = "stakedifficulty"
 
 	// WinningTicketsNtfnMethod is the method of the daemon winningtickets
 	// notification.
-	WinningTicketsNtfnMethod = "winningtickets"
+	WinningTicketsNtfnMethod Method = "winningtickets"
 )
 
 // BlockConnectedNtfn defines the blockconnected JSON-RPC notification.
@@ -215,16 +217,16 @@ func NewWinningTicketsNtfn(hash string, height int32, tickets map[string]string)
 func init() {
 	// The commands in this file are only usable by websockets and are
 	// notifications.
-	flags := UFWebsocketOnly | UFNotification
+	flags := dcrjson.UFWebsocketOnly | dcrjson.UFNotification
 
-	MustRegisterCmd(BlockConnectedNtfnMethod, (*BlockConnectedNtfn)(nil), flags)
-	MustRegisterCmd(BlockDisconnectedNtfnMethod, (*BlockDisconnectedNtfn)(nil), flags)
-	MustRegisterCmd(NewTicketsNtfnMethod, (*NewTicketsNtfn)(nil), flags)
-	MustRegisterCmd(ReorganizationNtfnMethod, (*ReorganizationNtfn)(nil), flags)
-	MustRegisterCmd(TxAcceptedNtfnMethod, (*TxAcceptedNtfn)(nil), flags)
-	MustRegisterCmd(TxAcceptedVerboseNtfnMethod, (*TxAcceptedVerboseNtfn)(nil), flags)
-	MustRegisterCmd(RelevantTxAcceptedNtfnMethod, (*RelevantTxAcceptedNtfn)(nil), flags)
-	MustRegisterCmd(SpentAndMissedTicketsNtfnMethod, (*SpentAndMissedTicketsNtfn)(nil), flags)
-	MustRegisterCmd(StakeDifficultyNtfnMethod, (*StakeDifficultyNtfn)(nil), flags)
-	MustRegisterCmd(WinningTicketsNtfnMethod, (*WinningTicketsNtfn)(nil), flags)
+	dcrjson.MustRegister(BlockConnectedNtfnMethod, (*BlockConnectedNtfn)(nil), flags)
+	dcrjson.MustRegister(BlockDisconnectedNtfnMethod, (*BlockDisconnectedNtfn)(nil), flags)
+	dcrjson.MustRegister(NewTicketsNtfnMethod, (*NewTicketsNtfn)(nil), flags)
+	dcrjson.MustRegister(ReorganizationNtfnMethod, (*ReorganizationNtfn)(nil), flags)
+	dcrjson.MustRegister(TxAcceptedNtfnMethod, (*TxAcceptedNtfn)(nil), flags)
+	dcrjson.MustRegister(TxAcceptedVerboseNtfnMethod, (*TxAcceptedVerboseNtfn)(nil), flags)
+	dcrjson.MustRegister(RelevantTxAcceptedNtfnMethod, (*RelevantTxAcceptedNtfn)(nil), flags)
+	dcrjson.MustRegister(SpentAndMissedTicketsNtfnMethod, (*SpentAndMissedTicketsNtfn)(nil), flags)
+	dcrjson.MustRegister(StakeDifficultyNtfnMethod, (*StakeDifficultyNtfn)(nil), flags)
+	dcrjson.MustRegister(WinningTicketsNtfnMethod, (*WinningTicketsNtfn)(nil), flags)
 }

--- a/rpc/jsonrpc/types/chainsvrwsntfns_test.go
+++ b/rpc/jsonrpc/types/chainsvrwsntfns_test.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package dcrjson
+package types
 
 import (
 	"bytes"
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/decred/dcrd/dcrjson/v3"
 )
 
 // TestChainSvrWsNtfns tests all of the chain server websocket-specific
@@ -30,7 +32,7 @@ func TestChainSvrWsNtfns(t *testing.T) {
 		{
 			name: "blockconnected",
 			newNtfn: func() (interface{}, error) {
-				return NewCmd("blockconnected", "header", []string{"tx0", "tx1"})
+				return dcrjson.NewCmd(Method("blockconnected"), "header", []string{"tx0", "tx1"})
 			},
 			staticNtfn: func() interface{} {
 				return NewBlockConnectedNtfn("header", []string{"tx0", "tx1"})
@@ -44,7 +46,7 @@ func TestChainSvrWsNtfns(t *testing.T) {
 		{
 			name: "blockdisconnected",
 			newNtfn: func() (interface{}, error) {
-				return NewCmd("blockdisconnected", "header")
+				return dcrjson.NewCmd(Method("blockdisconnected"), "header")
 			},
 			staticNtfn: func() interface{} {
 				return NewBlockDisconnectedNtfn("header")
@@ -57,7 +59,7 @@ func TestChainSvrWsNtfns(t *testing.T) {
 		{
 			name: "newtickets",
 			newNtfn: func() (interface{}, error) {
-				return NewCmd("newtickets", "123", 100, 3, []string{"a", "b"})
+				return dcrjson.NewCmd(Method("newtickets"), "123", 100, 3, []string{"a", "b"})
 			},
 			staticNtfn: func() interface{} {
 				return NewNewTicketsNtfn("123", 100, 3, []string{"a", "b"})
@@ -73,7 +75,7 @@ func TestChainSvrWsNtfns(t *testing.T) {
 		{
 			name: "relevanttxaccepted",
 			newNtfn: func() (interface{}, error) {
-				return NewCmd("relevanttxaccepted", "001122")
+				return dcrjson.NewCmd(Method("relevanttxaccepted"), "001122")
 			},
 			staticNtfn: func() interface{} {
 				return NewRelevantTxAcceptedNtfn("001122")
@@ -86,7 +88,7 @@ func TestChainSvrWsNtfns(t *testing.T) {
 		{
 			name: "spentandmissedtickets",
 			newNtfn: func() (interface{}, error) {
-				return NewCmd("spentandmissedtickets", "123", 100, 3, map[string]string{"a": "b"})
+				return dcrjson.NewCmd(Method("spentandmissedtickets"), "123", 100, 3, map[string]string{"a": "b"})
 			},
 			staticNtfn: func() interface{} {
 				return NewSpentAndMissedTicketsNtfn("123", 100, 3, map[string]string{"a": "b"})
@@ -102,7 +104,7 @@ func TestChainSvrWsNtfns(t *testing.T) {
 		{
 			name: "txaccepted",
 			newNtfn: func() (interface{}, error) {
-				return NewCmd("txaccepted", "123", 1.5)
+				return dcrjson.NewCmd(Method("txaccepted"), "123", 1.5)
 			},
 			staticNtfn: func() interface{} {
 				return NewTxAcceptedNtfn("123", 1.5)
@@ -116,7 +118,7 @@ func TestChainSvrWsNtfns(t *testing.T) {
 		{
 			name: "txacceptedverbose",
 			newNtfn: func() (interface{}, error) {
-				return NewCmd("txacceptedverbose", `{"hex":"001122","txid":"123","version":1,"locktime":4294967295,"vin":null,"vout":null,"confirmations":0}`)
+				return dcrjson.NewCmd(Method("txacceptedverbose"), `{"hex":"001122","txid":"123","version":1,"locktime":4294967295,"vin":null,"vout":null,"confirmations":0}`)
 			},
 			staticNtfn: func() interface{} {
 				txResult := TxRawResult{
@@ -146,7 +148,7 @@ func TestChainSvrWsNtfns(t *testing.T) {
 		{
 			name: "winningtickets",
 			newNtfn: func() (interface{}, error) {
-				return NewCmd("winningtickets", "123", 100, map[string]string{"a": "b"})
+				return dcrjson.NewCmd(Method("winningtickets"), "123", 100, map[string]string{"a": "b"})
 			},
 			staticNtfn: func() interface{} {
 				return NewWinningTicketsNtfn("123", 100, map[string]string{"a": "b"})
@@ -164,7 +166,7 @@ func TestChainSvrWsNtfns(t *testing.T) {
 	for i, test := range tests {
 		// Marshal the notification as created by the new static
 		// creation function.  The ID is nil for notifications.
-		marshalled, err := MarshalCmd("1.0", nil, test.staticNtfn())
+		marshalled, err := dcrjson.MarshalCmd("1.0", nil, test.staticNtfn())
 		if err != nil {
 			t.Errorf("MarshalCmd #%d (%s) unexpected error: %v", i,
 				test.name, err)
@@ -182,14 +184,14 @@ func TestChainSvrWsNtfns(t *testing.T) {
 		// generic new notification creation function.
 		cmd, err := test.newNtfn()
 		if err != nil {
-			t.Errorf("Test #%d (%s) unexpected NewCmd error: %v ",
+			t.Errorf("Test #%d (%s) unexpected dcrjson.NewCmd error: %v ",
 				i, test.name, err)
 		}
 
 		// Marshal the notification as created by the generic new
 		// notification creation function.    The ID is nil for
 		// notifications.
-		marshalled, err = MarshalCmd("1.0", nil, cmd)
+		marshalled, err = dcrjson.MarshalCmd("1.0", nil, cmd)
 		if err != nil {
 			t.Errorf("MarshalCmd #%d (%s) unexpected error: %v", i,
 				test.name, err)
@@ -203,7 +205,7 @@ func TestChainSvrWsNtfns(t *testing.T) {
 			continue
 		}
 
-		var request Request
+		var request dcrjson.Request
 		if err := json.Unmarshal(marshalled, &request); err != nil {
 			t.Errorf("Test #%d (%s) unexpected error while "+
 				"unmarshalling JSON-RPC request: %v", i,
@@ -211,9 +213,9 @@ func TestChainSvrWsNtfns(t *testing.T) {
 			continue
 		}
 
-		cmd, err = UnmarshalCmd(&request)
+		cmd, err = dcrjson.ParseParams(Method(request.Method), request.Params)
 		if err != nil {
-			t.Errorf("UnmarshalCmd #%d (%s) unexpected error: %v", i,
+			t.Errorf("ParseParams #%d (%s) unexpected error: %v", i,
 				test.name, err)
 			continue
 		}

--- a/rpc/jsonrpc/types/chainsvrwsresults.go
+++ b/rpc/jsonrpc/types/chainsvrwsresults.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package dcrjson
+package types
 
 // SessionResult models the data from the session command.
 type SessionResult struct {

--- a/rpc/jsonrpc/types/go.mod
+++ b/rpc/jsonrpc/types/go.mod
@@ -1,0 +1,7 @@
+module github.com/decred/dcrd/rpc/jsonrpc/types
+
+go 1.11
+
+require github.com/decred/dcrd/dcrjson/v3 v3.0.0
+
+replace github.com/decred/dcrd/dcrjson/v3 => ../../../dcrjson

--- a/rpc/jsonrpc/types/go.sum
+++ b/rpc/jsonrpc/types/go.sum
@@ -1,0 +1,8 @@
+github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
+github.com/dchest/blake256 v1.0.0/go.mod h1:xXNWCE1jsAP8DAjP+rKw2MbeqLczjI3TRx2VK+9OEYY=
+github.com/decred/dcrd v1.3.0 h1:EEXm7BdiROfazDtuFsOu9mfotnyy00bgCuVwUqaszFo=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.1 h1:0vG7U9+dSjSCaHQKdoSKURK2pOb47+b+8FK5q4+Je7M=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.1/go.mod h1:OVfvaOsNLS/A1y4Eod0Ip/Lf8qga7VXCQjUQLbkY0Go=
+github.com/decred/dcrd/dcrjson v1.2.0 h1:3BFFQHq3/YO/zae9WLxQkXsX6AXKx3+M8H3yk4oXZi0=
+github.com/decred/dcrd/dcrjson/v2 v2.0.0 h1:W0q4Alh36c5N318eUpfmU8kXoCNgImMLI87NIXni9Us=
+github.com/decred/dcrd/dcrjson/v2 v2.0.0/go.mod h1:FYueNy8BREAFq04YNEwcTsmGFcNqY+ehUUO81w2igi4=

--- a/rpc/jsonrpc/types/helpers.go
+++ b/rpc/jsonrpc/types/helpers.go
@@ -1,0 +1,10 @@
+package types
+
+// EstimateSmartFeeModeAddr is a helper routine that allocates a new
+// EstimateSmartFeeMode value to store v and returns a pointer to it. This is
+// useful when assigning optional parameters.
+func EstimateSmartFeeModeAddr(v EstimateSmartFeeMode) *EstimateSmartFeeMode {
+	p := new(EstimateSmartFeeMode)
+	*p = v
+	return p
+}

--- a/rpc/jsonrpc/types/method.go
+++ b/rpc/jsonrpc/types/method.go
@@ -1,0 +1,8 @@
+// Copyright (c) 2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package types
+
+// Method is the type used to register method and parameter pairs with dcrjson.
+type Method string

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -11,7 +11,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/decred/dcrd/dcrjson/v2"
+	"github.com/decred/dcrd/dcrjson/v3"
+	"github.com/decred/dcrd/rpc/jsonrpc/types"
 )
 
 // helpDescsEnUS defines the English descriptions used for the help strings.
@@ -169,14 +170,14 @@ var helpDescsEnUS = map[string]string{
 	"existsaddresses--result0":  "Bitset of bools showing if addresses exist or not",
 
 	// ExitsMissedTicketsCmd help.
-	"existsmissedtickets--synopsis":  "Test for the existence of the provided tickets in the missed ticket map",
-	"existsmissedtickets-txhashblob": "Blob containing the hashes to check",
-	"existsmissedtickets--result0":   "Bool blob showing if the ticket exists in the missed ticket database or not",
+	"existsmissedtickets--synopsis": "Test for the existence of the provided tickets in the missed ticket map",
+	"existsmissedtickets-txhashes":  "Array of hashes to check",
+	"existsmissedtickets--result0":  "Bool blob showing if the ticket exists in the missed ticket database or not",
 
 	// ExistsExpiredTicketsCmd help.
-	"existsexpiredtickets--synopsis":  "Test for the existence of the provided tickets in the expired ticket map",
-	"existsexpiredtickets-txhashblob": "Blob containing the hashes to check",
-	"existsexpiredtickets--result0":   "Bool blob showing if ticket exists in the expired ticket database or not",
+	"existsexpiredtickets--synopsis": "Test for the existence of the provided tickets in the expired ticket map",
+	"existsexpiredtickets-txhashes":  "Array of hashes to check",
+	"existsexpiredtickets--result0":  "Bool blob showing if ticket exists in the expired ticket database or not",
 
 	// ExistsLiveTicketCmd help.
 	"existsliveticket--synopsis": "Test for the existence of the provided ticket",
@@ -184,14 +185,14 @@ var helpDescsEnUS = map[string]string{
 	"existsliveticket--result0":  "Bool showing if address exists in the live ticket database or not",
 
 	// ExistsLiveTicketsCmd help.
-	"existslivetickets--synopsis":  "Test for the existence of the provided tickets in the live ticket map",
-	"existslivetickets-txhashblob": "Blob containing the hashes to check",
-	"existslivetickets--result0":   "Bool blob showing if ticket exists in the live ticket database or not",
+	"existslivetickets--synopsis": "Test for the existence of the provided tickets in the live ticket map",
+	"existslivetickets-txhashes":  "Array of hashes to check",
+	"existslivetickets--result0":  "Bool blob showing if ticket exists in the live ticket database or not",
 
 	// ExistsMempoolTxsCmd help.
-	"existsmempooltxs--synopsis":  "Test for the existence of the provided txs in the mempool",
-	"existsmempooltxs-txhashblob": "Blob containing the hashes to check",
-	"existsmempooltxs--result0":   "Bool blob showing if txs exist in the mempool or not",
+	"existsmempooltxs--synopsis": "Test for the existence of the provided txs in the mempool",
+	"existsmempooltxs-txhashes":  "Array of hashes to check",
+	"existsmempooltxs--result0":  "Bool blob showing if txs exist in the mempool or not",
 
 	// GenerateCmd help
 	"generate--synopsis": "Generates a set number of blocks (simnet or regtest only) and returns a JSON\n" +
@@ -571,7 +572,7 @@ var helpDescsEnUS = map[string]string{
 
 	// GetHeadersCmd help.
 	"getheaders--synopsis":     "Returns block headers starting with the first known block hash from the request",
-	"getheaders-blocklocators": "Concatenated hashes of blocks.  Headers are returned starting from the first known hash in this list",
+	"getheaders-blocklocators": "Array of block locator hashes.  Headers are returned starting from the first known hash in this list",
 	"getheaders-hashstop":      "Optional block hash to stop including block headers for",
 	"getheadersresult-headers": "Serialized block headers of all located blocks, limited to some arbitrary maximum number of hashes (currently 2000, which matches the wire protocol headers message, but this is not guaranteed)",
 
@@ -827,7 +828,7 @@ var helpDescsEnUS = map[string]string{
 
 	// Rescan help.
 	"rescan--synopsis":   "Rescan blocks for transactions matching the loaded transaction filter.",
-	"rescan-blockhashes": "Concatenated block hashes to rescan.  Each next block must be a child of the previous.",
+	"rescan-blockhashes": "Array of block hashes to rescan.  Each next block must be a child of the previous.",
 
 	// -------- Decred-specific help --------
 
@@ -943,17 +944,17 @@ var helpDescsEnUS = map[string]string{
 // rpcResultTypes specifies the result types that each RPC command can return.
 // This information is used to generate the help.  Each result type must be a
 // pointer to the type (or nil to indicate no return value).
-var rpcResultTypes = map[string][]interface{}{
+var rpcResultTypes = map[types.Method][]interface{}{
 	"addnode":               nil,
 	"createrawsstx":         {(*string)(nil)},
 	"createrawssrtx":        {(*string)(nil)},
 	"createrawtransaction":  {(*string)(nil)},
 	"debuglevel":            {(*string)(nil), (*string)(nil)},
-	"decoderawtransaction":  {(*dcrjson.TxRawDecodeResult)(nil)},
-	"decodescript":          {(*dcrjson.DecodeScriptResult)(nil)},
+	"decoderawtransaction":  {(*types.TxRawDecodeResult)(nil)},
+	"decodescript":          {(*types.DecodeScriptResult)(nil)},
 	"estimatefee":           {(*float64)(nil)},
 	"estimatesmartfee":      {(*float64)(nil)},
-	"estimatestakediff":     {(*dcrjson.EstimateStakeDiffResult)(nil)},
+	"estimatestakediff":     {(*types.EstimateStakeDiffResult)(nil)},
 	"existsaddress":         {(*bool)(nil)},
 	"existsaddresses":       {(*string)(nil)},
 	"existsmissedtickets":   {(*string)(nil)},
@@ -961,66 +962,66 @@ var rpcResultTypes = map[string][]interface{}{
 	"existsliveticket":      {(*bool)(nil)},
 	"existslivetickets":     {(*string)(nil)},
 	"existsmempooltxs":      {(*string)(nil)},
-	"getaddednodeinfo":      {(*[]string)(nil), (*[]dcrjson.GetAddedNodeInfoResult)(nil)},
-	"getbestblock":          {(*dcrjson.GetBestBlockResult)(nil)},
+	"getaddednodeinfo":      {(*[]string)(nil), (*[]types.GetAddedNodeInfoResult)(nil)},
+	"getbestblock":          {(*types.GetBestBlockResult)(nil)},
 	"generate":              {(*[]string)(nil)},
 	"getbestblockhash":      {(*string)(nil)},
-	"getblock":              {(*string)(nil), (*dcrjson.GetBlockVerboseResult)(nil)},
-	"getblockchaininfo":     {(*dcrjson.GetBlockChainInfoResult)(nil)},
+	"getblock":              {(*string)(nil), (*types.GetBlockVerboseResult)(nil)},
+	"getblockchaininfo":     {(*types.GetBlockChainInfoResult)(nil)},
 	"getblockcount":         {(*int64)(nil)},
 	"getblockhash":          {(*string)(nil)},
-	"getblockheader":        {(*string)(nil), (*dcrjson.GetBlockHeaderVerboseResult)(nil)},
-	"getblocksubsidy":       {(*dcrjson.GetBlockSubsidyResult)(nil)},
-	"getblocktemplate":      {(*dcrjson.GetBlockTemplateResult)(nil), (*string)(nil), nil},
+	"getblockheader":        {(*string)(nil), (*types.GetBlockHeaderVerboseResult)(nil)},
+	"getblocksubsidy":       {(*types.GetBlockSubsidyResult)(nil)},
+	"getblocktemplate":      {(*types.GetBlockTemplateResult)(nil), (*string)(nil), nil},
 	"getcfilter":            {(*string)(nil)},
 	"getcfilterheader":      {(*string)(nil)},
-	"getchaintips":          {(*[]dcrjson.GetChainTipsResult)(nil)},
+	"getchaintips":          {(*[]types.GetChainTipsResult)(nil)},
 	"getconnectioncount":    {(*int32)(nil)},
 	"getcurrentnet":         {(*uint32)(nil)},
 	"getdifficulty":         {(*float64)(nil)},
-	"getstakedifficulty":    {(*dcrjson.GetStakeDifficultyResult)(nil)},
-	"getstakeversioninfo":   {(*dcrjson.GetStakeVersionInfoResult)(nil)},
-	"getstakeversions":      {(*dcrjson.GetStakeVersionsResult)(nil)},
+	"getstakedifficulty":    {(*types.GetStakeDifficultyResult)(nil)},
+	"getstakeversioninfo":   {(*types.GetStakeVersionInfoResult)(nil)},
+	"getstakeversions":      {(*types.GetStakeVersionsResult)(nil)},
 	"getgenerate":           {(*bool)(nil)},
 	"gethashespersec":       {(*float64)(nil)},
-	"getheaders":            {(*dcrjson.GetHeadersResult)(nil)},
-	"getinfo":               {(*dcrjson.InfoChainResult)(nil)},
-	"getmempoolinfo":        {(*dcrjson.GetMempoolInfoResult)(nil)},
-	"getmininginfo":         {(*dcrjson.GetMiningInfoResult)(nil)},
-	"getnettotals":          {(*dcrjson.GetNetTotalsResult)(nil)},
+	"getheaders":            {(*types.GetHeadersResult)(nil)},
+	"getinfo":               {(*types.InfoChainResult)(nil)},
+	"getmempoolinfo":        {(*types.GetMempoolInfoResult)(nil)},
+	"getmininginfo":         {(*types.GetMiningInfoResult)(nil)},
+	"getnettotals":          {(*types.GetNetTotalsResult)(nil)},
 	"getnetworkhashps":      {(*int64)(nil)},
-	"getpeerinfo":           {(*[]dcrjson.GetPeerInfoResult)(nil)},
-	"getrawmempool":         {(*[]string)(nil), (*dcrjson.GetRawMempoolVerboseResult)(nil)},
-	"getrawtransaction":     {(*string)(nil), (*dcrjson.TxRawResult)(nil)},
+	"getpeerinfo":           {(*[]types.GetPeerInfoResult)(nil)},
+	"getrawmempool":         {(*[]string)(nil), (*types.GetRawMempoolVerboseResult)(nil)},
+	"getrawtransaction":     {(*string)(nil), (*types.TxRawResult)(nil)},
 	"getticketpoolvalue":    {(*float64)(nil)},
-	"gettxout":              {(*dcrjson.GetTxOutResult)(nil)},
-	"getvoteinfo":           {(*dcrjson.GetVoteInfoResult)(nil)},
-	"getwork":               {(*dcrjson.GetWorkResult)(nil), (*bool)(nil)},
+	"gettxout":              {(*types.GetTxOutResult)(nil)},
+	"getvoteinfo":           {(*types.GetVoteInfoResult)(nil)},
+	"getwork":               {(*types.GetWorkResult)(nil), (*bool)(nil)},
 	"getcoinsupply":         {(*int64)(nil)},
 	"help":                  {(*string)(nil), (*string)(nil)},
-	"livetickets":           {(*dcrjson.LiveTicketsResult)(nil)},
-	"missedtickets":         {(*dcrjson.MissedTicketsResult)(nil)},
+	"livetickets":           {(*types.LiveTicketsResult)(nil)},
+	"missedtickets":         {(*types.MissedTicketsResult)(nil)},
 	"node":                  nil,
 	"ping":                  nil,
 	"rebroadcastmissed":     nil,
 	"rebroadcastwinners":    nil,
-	"searchrawtransactions": {(*string)(nil), (*[]dcrjson.SearchRawTransactionsResult)(nil)},
+	"searchrawtransactions": {(*string)(nil), (*[]types.SearchRawTransactionsResult)(nil)},
 	"sendrawtransaction":    {(*string)(nil)},
 	"setgenerate":           nil,
 	"stop":                  {(*string)(nil)},
 	"submitblock":           {nil, (*string)(nil)},
-	"ticketfeeinfo":         {(*dcrjson.TicketFeeInfoResult)(nil)},
-	"ticketsforaddress":     {(*dcrjson.TicketsForAddressResult)(nil)},
+	"ticketfeeinfo":         {(*types.TicketFeeInfoResult)(nil)},
+	"ticketsforaddress":     {(*types.TicketsForAddressResult)(nil)},
 	"ticketvwap":            {(*float64)(nil)},
-	"txfeeinfo":             {(*dcrjson.TxFeeInfoResult)(nil)},
-	"validateaddress":       {(*dcrjson.ValidateAddressChainResult)(nil)},
+	"txfeeinfo":             {(*types.TxFeeInfoResult)(nil)},
+	"validateaddress":       {(*types.ValidateAddressChainResult)(nil)},
 	"verifychain":           {(*bool)(nil)},
 	"verifymessage":         {(*bool)(nil)},
-	"version":               {(*map[string]dcrjson.VersionResult)(nil)},
+	"version":               {(*map[string]types.VersionResult)(nil)},
 
 	// Websocket commands.
 	"loadtxfilter":                nil,
-	"session":                     {(*dcrjson.SessionResult)(nil)},
+	"session":                     {(*types.SessionResult)(nil)},
 	"notifywinningtickets":        nil,
 	"notifyspentandmissedtickets": nil,
 	"notifynewtickets":            nil,
@@ -1041,13 +1042,13 @@ var rpcResultTypes = map[string][]interface{}{
 type helpCacher struct {
 	sync.Mutex
 	usage      string
-	methodHelp map[string]string
+	methodHelp map[types.Method]string
 }
 
 // rpcMethodHelp returns an RPC help string for the provided method.
 //
 // This function is safe for concurrent access.
-func (c *helpCacher) rpcMethodHelp(method string) (string, error) {
+func (c *helpCacher) rpcMethodHelp(method types.Method) (string, error) {
 	c.Lock()
 	defer c.Unlock()
 
@@ -1060,7 +1061,7 @@ func (c *helpCacher) rpcMethodHelp(method string) (string, error) {
 	resultTypes, ok := rpcResultTypes[method]
 	if !ok {
 		return "", errors.New("no result types specified for method " +
-			method)
+			string(method))
 	}
 
 	// Generate, cache, and return the help.
@@ -1114,6 +1115,6 @@ func (c *helpCacher) rpcUsage(includeWebsockets bool) (string, error) {
 // usage for the RPC server commands and caches the results for future calls.
 func newHelpCacher() *helpCacher {
 	return &helpCacher{
-		methodHelp: make(map[string]string),
+		methodHelp: make(map[types.Method]string),
 	}
 }


### PR DESCRIPTION
This commit introduces a new major version of the dcrjson module which
removes all dcrd RPC type support, instead focusing only on method and
type registration.  The dcrd methods and types are moved to the
github.com/decred/dcrd/rpc/jsonrpc/types module.

In order to improve backwards compatibility with dcrjson/v2, the API
has been modified to register methods as interface{} instead of
string.  This allows different method string types to be used to key
parameter types during registration and lookup, and will allow
dcrjson/v2 to forward registrations of RPC methods to v3 without
causing duplicate registrations errors for incompatible types.

With the introduction of the new types package, the RPC API has been
modified to replace concatenated hash blobs to JSON string arrays of
hash strings.  The RPC API major version is bumped to reflect this
change.

A future update to dcrjson/v2 will add additional registrations,
forwarding the registrations to v3 and replacing command types with
type aliases where possible.  Unfortunately, this can not be done
entirely in a single commit due to dcrjson/v2 and dcrjson/v3 sharing
the same directory in the source tree, and a branch will need to be
used for this update.

Module replacements are temporarily used to enable the changes for the
main module, including dcrctl.  After the aforementioned update to
dcrjson/v2 and a forthcoming update to dcrwallet's RPC types package,
these replacements will be removed.