### PR TITLE
TravisCI: Use more portable module ver stripping.

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -49,8 +49,8 @@ testrepo () {
     env CC=gcc $GO test -short -tags rpctest ${module}/...
 
     # check linters
-    MODNAME=$(echo $module | sed -e "s/^$ROOTPATHPATTERN//" \
-      -e 's/^\///' -e 's/\/v[0-9]\+$//')
+    MODNAME=$(echo $module | sed -E -e "s/^$ROOTPATHPATTERN//" \
+      -e 's,^/,,' -e 's,/v[0-9]+$,,')
     if [ -z "$MODNAME" ]; then
       MODNAME=.
     fi


### PR DESCRIPTION
This modifies the script that strips the module version from listed modules for the purposes of changing to the relevant directory to be more portable by adding the -E flag to sed.  This allows it to work properly on Mac as well.

While here, it also switches the sed separator to a comma in the relevant removals to avoid the need to escape the slashes in the path.

Thanks to @jrick for testing and the suggestion to use a comma for the sed separator.