### PR TITLE
main: Use rpcclient/v3.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/decred/dcrd/mining v1.1.0
 	github.com/decred/dcrd/peer v1.1.0
 	github.com/decred/dcrd/rpc/jsonrpc/types v1.0.0
-	github.com/decred/dcrd/rpcclient/v2 v2.1.0
+	github.com/decred/dcrd/rpcclient/v3 v3.0.0
 	github.com/decred/dcrd/txscript v1.1.0
 	github.com/decred/dcrd/wire v1.2.0
 	github.com/decred/dcrwallet/rpc/jsonrpc/types v1.1.0
@@ -60,6 +60,7 @@ replace (
 	github.com/decred/dcrd/mining => ./mining
 	github.com/decred/dcrd/peer => ./peer
 	github.com/decred/dcrd/rpc/jsonrpc/types => ./rpc/jsonrpc/types
+	github.com/decred/dcrd/rpcclient/v3 => ./rpcclient
 	github.com/decred/dcrd/txscript/v2 => ./txscript
 	github.com/decred/dcrd/wire => ./wire
 )

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/decred/dcrd/dcrutil v1.3.0 h1:LtKIiDnq925yJT/4OpIKKiU9/WaxfD9LfhxrpLS
 github.com/decred/dcrd/dcrutil v1.3.0/go.mod h1:7fUT70QAarhDwQK62g92uDbbYpjXlXngpy5RBiecufo=
 github.com/decred/dcrd/dcrutil v1.4.0 h1:xD5aUqysGQnsnP1c9J0kGeW8lDIwFGC3ja/gE3HnpCs=
 github.com/decred/dcrd/dcrutil v1.4.0/go.mod h1:Bs74gm1jQ9ZAbmEh9FWOEZ1HQzlMg5iPATDMzMnCMlQ=
-github.com/decred/dcrd/rpcclient/v2 v2.1.0 h1:oaHR2ZIe6TyINbLgmrRkS8xddLr5gDmkX6BkWwSFy6Q=
-github.com/decred/dcrd/rpcclient/v2 v2.1.0/go.mod h1:tVaa1C6a0Cqdcpi393nm2AQZeZdxKwrCfToashLIv8w=
+github.com/decred/dcrd/rpcclient/v3 v3.0.0 h1:doabWkWWd8O6ccYqaLamE1mkQ5p8YoO5UJhkl5pAGpQ=
+github.com/decred/dcrd/rpcclient/v3 v3.0.0/go.mod h1:OQ361/iQMrJtWIg+S0XpZT4/AA6mU/46oOkBRWp/P/s=
 github.com/decred/dcrd/txscript v1.0.2/go.mod h1:hmUOHFlOjU7H6T/czt6kurWwXJvGPGKKGtXoft6w/qY=
 github.com/decred/dcrd/txscript v1.1.0 h1:MwkLXdc4Yq83oeNNEQJdlBTkNlorKXn8Nd5W2JXyMZg=
 github.com/decred/dcrd/txscript v1.1.0/go.mod h1:gbcq6gpGfKddPmZSKp+17ils2cLzUqHopXf8H5rCY7Y=

--- a/rpctest/memwallet.go
+++ b/rpctest/memwallet.go
@@ -17,7 +17,7 @@ import (
 	"github.com/decred/dcrd/dcrec/secp256k1"
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrd/hdkeychain/v2"
-	"github.com/decred/dcrd/rpcclient/v2"
+	"github.com/decred/dcrd/rpcclient/v3"
 	"github.com/decred/dcrd/txscript"
 	"github.com/decred/dcrd/wire"
 )

--- a/rpctest/node.go
+++ b/rpctest/node.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/decred/dcrd/certgen"
-	rpc "github.com/decred/dcrd/rpcclient/v2"
+	rpc "github.com/decred/dcrd/rpcclient/v3"
 )
 
 // nodeConfig contains all the args, and data required to launch a dcrd process

--- a/rpctest/rpc_harness.go
+++ b/rpctest/rpc_harness.go
@@ -19,7 +19,7 @@ import (
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil"
-	"github.com/decred/dcrd/rpcclient/v2"
+	"github.com/decred/dcrd/rpcclient/v3"
 	"github.com/decred/dcrd/wire"
 )
 

--- a/rpctest/utils.go
+++ b/rpctest/utils.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/decred/dcrd/dcrjson/v2"
-	"github.com/decred/dcrd/rpcclient/v2"
+	"github.com/decred/dcrd/rpcclient/v3"
 )
 
 // JoinType is an enum representing a particular type of "node join". A node

--- a/rpctest/votingwallet.go
+++ b/rpctest/votingwallet.go
@@ -18,7 +18,7 @@ import (
 	"github.com/decred/dcrd/dcrec/secp256k1"
 	"github.com/decred/dcrd/dcrjson/v2"
 	"github.com/decred/dcrd/dcrutil"
-	"github.com/decred/dcrd/rpcclient/v2"
+	"github.com/decred/dcrd/rpcclient/v3"
 	"github.com/decred/dcrd/txscript"
 	"github.com/decred/dcrd/wire"
 )

--- a/rpctest/votingwallet_test.go
+++ b/rpctest/votingwallet_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/decred/dcrd/chaincfg"
-	"github.com/decred/dcrd/rpcclient/v2"
+	"github.com/decred/dcrd/rpcclient/v3"
 )
 
 // testCanPassSVH tests whether the wallet can maintain the chain going past SVH


### PR DESCRIPTION
**This requires PR #1793**.

This updates the `main` module and `rpctest` package (which is part of the `main` module) to use `v3` of the `rpcclient` module.