### PR TITLE
travis: Allow staged builds with build cache.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,25 +9,25 @@ matrix:
       cache:
         directories:
           - $HOME/.cache/go-build
-          - $HOME/gopath/pkg/mod
+          - $HOME/go/pkg/mod
     - os: linux
       go: 1.11.x
       cache:
         directories:
           - $HOME/.cache/go-build
-          - $HOME/gopath/pkg/mod
+          - $HOME/go/pkg/mod
     - os: osx
       go: 1.12.x
       cache:
         directories:
           - $HOME/.cache/go-build
-          - $HOME/gopath/pkg/mod
+          - $HOME/go/pkg/mod
     - os: osx
       go: 1.11.x
       cache:
         directories:
           - $HOME/Library/Caches/go-build
-          - $HOME/gopath/pkg/mod
+          - $HOME/go/pkg/mod
 install:
   - go get -v github.com/golangci/golangci-lint/cmd/golangci-lint
 script:

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -37,6 +37,7 @@ for module in $MODPATHS; do
     MODNAME=.
   fi
   (cd $MODNAME && \
+    go mod download && \
     golangci-lint run --build-tags=rpctest --disable-all --deadline=10m \
       --enable=gofmt \
       --enable=gosimple \


### PR DESCRIPTION
This updates the tests to ensure all modules are downloaded prior to running the linter.  This is necessary in order to support the travis build cache with staged builds on all platforms.