### PR TITLE
main: Add database/v2 override for tests.

### DIFF
--- a/database/ffldb/driver_test.go
+++ b/database/ffldb/driver_test.go
@@ -154,7 +154,7 @@ func TestPersistence(t *testing.T) {
 	t.Parallel()
 
 	// Create a new database to run tests against.
-	dbPath := filepath.Join(os.TempDir(), "ffldb-persistencetest")
+	dbPath := filepath.Join(os.TempDir(), "ffldb-persistencetest-v2")
 	_ = os.RemoveAll(dbPath)
 	db, err := database.Create(dbType, dbPath, blockDataNet)
 	if err != nil {
@@ -261,7 +261,7 @@ func TestInterface(t *testing.T) {
 	t.Parallel()
 
 	// Create a new database to run tests against.
-	dbPath := filepath.Join(os.TempDir(), "ffldb-interfacetest")
+	dbPath := filepath.Join(os.TempDir(), "ffldb-interfacetest-v2")
 	_ = os.RemoveAll(dbPath)
 	db, err := database.Create(dbType, dbPath, blockDataNet)
 	if err != nil {
@@ -274,7 +274,7 @@ func TestInterface(t *testing.T) {
 	// Ensure the driver type is the expected value.
 	gotDbType := db.Type()
 	if gotDbType != dbType {
-		t.Errorf("Type: unepxected driver type - got %v, want %v",
+		t.Errorf("Type: unexpected driver type - got %v, want %v",
 			gotDbType, dbType)
 		return
 	}

--- a/database/ffldb/whitebox_test.go
+++ b/database/ffldb/whitebox_test.go
@@ -143,7 +143,7 @@ func TestCornerCases(t *testing.T) {
 	t.Parallel()
 
 	// Create a file at the datapase path to force the open below to fail.
-	dbPath := filepath.Join(os.TempDir(), "ffldb-errors")
+	dbPath := filepath.Join(os.TempDir(), "ffldb-errors-v2")
 	_ = os.RemoveAll(dbPath)
 	fi, err := os.Create(dbPath)
 	if err != nil {
@@ -580,7 +580,7 @@ func testCorruption(tc *testContext) bool {
 // correctly.
 func TestFailureScenarios(t *testing.T) {
 	// Create a new database to run tests against.
-	dbPath := filepath.Join(os.TempDir(), "ffldb-failurescenarios")
+	dbPath := filepath.Join(os.TempDir(), "ffldb-failurescenarios-v2")
 	_ = os.RemoveAll(dbPath)
 	idb, err := database.Create(dbType, dbPath, blockDataNet)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
 	github.com/decred/dcrd/connmgr v1.0.2
 	github.com/decred/dcrd/database v1.1.0
+	github.com/decred/dcrd/database/v2 v2.0.0
 	github.com/decred/dcrd/dcrec v1.0.0
 	github.com/decred/dcrd/dcrec/secp256k1 v1.0.2
 	github.com/decred/dcrd/dcrjson/v2 v2.2.0
@@ -46,6 +47,7 @@ replace (
 	github.com/decred/dcrd/chaincfg/chainhash => ./chaincfg/chainhash
 	github.com/decred/dcrd/chaincfg/v2 => ./chaincfg
 	github.com/decred/dcrd/connmgr => ./connmgr
+	github.com/decred/dcrd/database/v2 => ./database
 	github.com/decred/dcrd/dcrec => ./dcrec
 	github.com/decred/dcrd/dcrjson/v3 => ./dcrjson
 	github.com/decred/dcrd/dcrutil/v2 => ./dcrutil


### PR DESCRIPTION
This adds an override to the `main` module for `v2` of the `database` module to ensure tests are executed against the latest code in the repository for the `v2` module.

It also modifies the `database` tests to include `v2` in the test database names to ensure they do not conflict with the `v1` module in the case both are being concurrently tested.
