### PR TITLE
chaincfg/chainhash: use the new blake256.Sum256 function

### DIFF
--- a/chaincfg/chainhash/go.mod
+++ b/chaincfg/chainhash/go.mod
@@ -2,4 +2,4 @@ module github.com/decred/dcrd/chaincfg/chainhash
 
 go 1.11
 
-require github.com/dchest/blake256 v1.0.0
+require github.com/dchest/blake256 v1.0.1-0.20190804191204-0af8a5e148d3

--- a/chaincfg/chainhash/go.sum
+++ b/chaincfg/chainhash/go.sum
@@ -1,2 +1,2 @@
-github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
-github.com/dchest/blake256 v1.0.0/go.mod h1:xXNWCE1jsAP8DAjP+rKw2MbeqLczjI3TRx2VK+9OEYY=
+github.com/dchest/blake256 v1.0.1-0.20190804191204-0af8a5e148d3 h1:LzYFHRDoM7Ppon7k+8K4vHC0s8n9DbdisJObtAUkOrk=
+github.com/dchest/blake256 v1.0.1-0.20190804191204-0af8a5e148d3/go.mod h1:xXNWCE1jsAP8DAjP+rKw2MbeqLczjI3TRx2VK+9OEYY=

--- a/chaincfg/chainhash/hashfuncs.go
+++ b/chaincfg/chainhash/hashfuncs.go
@@ -10,9 +10,6 @@ import (
 )
 
 // HashFunc calculates the hash of the supplied bytes.
-// TODO(jcv) Should modify blake256 so it has the same interface as blake2
-// and sha256 so these function can look more like btcsuite.  Then should
-// try to get it to the upstream blake256 repo
 func HashFunc(b []byte) [blake256.Size]byte {
 	var outB [blake256.Size]byte
 	copy(outB[:], HashB(b))
@@ -22,15 +19,13 @@ func HashFunc(b []byte) [blake256.Size]byte {
 
 // HashB calculates hash(b) and returns the resulting bytes.
 func HashB(b []byte) []byte {
-	a := blake256.New()
-	a.Write(b)
-	out := a.Sum(nil)
-	return out
+	hash := blake256.Sum256(b)
+	return hash[:]
 }
 
 // HashH calculates hash(b) and returns the resulting bytes as a Hash.
 func HashH(b []byte) Hash {
-	return Hash(HashFunc(b))
+	return Hash(blake256.Sum256(b))
 }
 
 // HashBlockSize is the block size of the hash algorithm in bytes.

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
 github.com/dchest/blake256 v1.0.0/go.mod h1:xXNWCE1jsAP8DAjP+rKw2MbeqLczjI3TRx2VK+9OEYY=
+github.com/dchest/blake256 v1.0.1-0.20190804191204-0af8a5e148d3 h1:LzYFHRDoM7Ppon7k+8K4vHC0s8n9DbdisJObtAUkOrk=
+github.com/dchest/blake256 v1.0.1-0.20190804191204-0af8a5e148d3/go.mod h1:xXNWCE1jsAP8DAjP+rKw2MbeqLczjI3TRx2VK+9OEYY=
 github.com/dchest/siphash v1.2.1 h1:4cLinnzVJDKxTCl9B01807Yiy+W7ZzVHj/KIroQRvT4=
 github.com/dchest/siphash v1.2.1/go.mod h1:q+IRvb2gOSrUnYoPqHiyHXS0FOBBOdl6tONBlVnOnt4=
 github.com/decred/base58 v1.0.0 h1:BVi1FQCThIjZ0ehG+I99NJ51o0xcc9A/fDKhmJxY6+w=


### PR DESCRIPTION
With reference to #1810, as an alternative to #1811.

Convert the `chaincfg/chainhash` code to use the new `blake256.Sum256` function, in order to avoid heap allocations as much as possible.