### PR TITLE
stake: Check minimum req outputs for votes earlier.

### DIFF
--- a/blockchain/stake/staketx.go
+++ b/blockchain/stake/staketx.go
@@ -706,10 +706,10 @@ func CheckSSGen(tx *wire.MsgTx) error {
 			"many outputs")
 	}
 
-	// Check to make sure there are some outputs.
-	if len(tx.TxOut) == 0 {
-		return stakeRuleError(ErrSSGenNoOutputs, "SSgen tx no "+
-			"many outputs")
+	// Check to make sure there are enough outputs.
+	if len(tx.TxOut) < 2 {
+		return stakeRuleError(ErrSSGenNoOutputs, "SSgen tx does not "+
+			"have enough outputs")
 	}
 
 	// Ensure that the first input is a stake base null input.


### PR DESCRIPTION
There is no reason to perform a bunch of additional checks when there is no possible way a transaction can be vote due to not having at least the minimum required number of outputs for it to possibly be one.