### PR TITLE
database: Separate dbs for concurrent db tests.

### DIFF
--- a/database/example_test.go
+++ b/database/example_test.go
@@ -31,7 +31,7 @@ func ExampleCreate() {
 	// Typically you wouldn't want to remove the database right away like
 	// this, nor put it in the temp directory, but it's done here to ensure
 	// the example cleans up after itself.
-	dbPath := filepath.Join(os.TempDir(), "examplecreate")
+	dbPath := filepath.Join(os.TempDir(), "examplecreate-v2")
 	db, err := database.Create("ffldb", dbPath, wire.MainNet)
 	if err != nil {
 		fmt.Println(err)
@@ -57,7 +57,7 @@ func Example_basicUsage() {
 	// Typically you wouldn't want to remove the database right away like
 	// this, nor put it in the temp directory, but it's done here to ensure
 	// the example cleans up after itself.
-	dbPath := filepath.Join(os.TempDir(), "exampleusage")
+	dbPath := filepath.Join(os.TempDir(), "exampleusage-v2")
 	db, err := database.Create("ffldb", dbPath, wire.MainNet)
 	if err != nil {
 		fmt.Println(err)
@@ -123,7 +123,7 @@ func Example_blockStorageAndRetrieval() {
 	// Typically you wouldn't want to remove the database right away like
 	// this, nor put it in the temp directory, but it's done here to ensure
 	// the example cleans up after itself.
-	dbPath := filepath.Join(os.TempDir(), "exampleblkstorage")
+	dbPath := filepath.Join(os.TempDir(), "exampleblkstorage-v2")
 	db, err := database.Create("ffldb", dbPath, wire.MainNet)
 	if err != nil {
 		fmt.Println(err)

--- a/database/ffldb/driver_test.go
+++ b/database/ffldb/driver_test.go
@@ -103,7 +103,7 @@ func TestCreateOpenFail(t *testing.T) {
 
 	// Ensure operations against a closed database return the expected
 	// error.
-	dbPath := filepath.Join(os.TempDir(), "ffldb-createfail")
+	dbPath := filepath.Join(os.TempDir(), "ffldb-createfail-v2")
 	_ = os.RemoveAll(dbPath)
 	db, err := database.Create(dbType, dbPath, blockDataNet)
 	if err != nil {


### PR DESCRIPTION
This updates v2 test database names to avoid conflicts when multiple database modules are being tested concurrently, continues the work started by #1806. 