### PR TITLE
connmgr: Prepare v1.1.0.

### DIFF
--- a/connmgr/go.mod
+++ b/connmgr/go.mod
@@ -3,7 +3,7 @@ module github.com/decred/dcrd/connmgr
 go 1.11
 
 require (
-	github.com/decred/dcrd/chaincfg v1.5.1
+	github.com/decred/dcrd/chaincfg v1.5.2
 	github.com/decred/dcrd/wire v1.2.0
 	github.com/decred/slog v1.0.0
 )

--- a/connmgr/go.sum
+++ b/connmgr/go.sum
@@ -5,8 +5,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
 github.com/dchest/blake256 v1.0.0/go.mod h1:xXNWCE1jsAP8DAjP+rKw2MbeqLczjI3TRx2VK+9OEYY=
-github.com/decred/dcrd/chaincfg v1.5.1 h1:u1Xbq0VTnAXIHW5ECqrWe0VYSgf5vWHqpSiwoLBzxAQ=
-github.com/decred/dcrd/chaincfg v1.5.1/go.mod h1:FukMzTjkwzjPU+hK7CqDMQe3NMbSZAYU5PAcsx1wlv0=
+github.com/decred/dcrd/chaincfg v1.5.2 h1:dd6l9rqcpxg2GF5neBmE2XxRc5Lqda45fWmN4XOJRW8=
+github.com/decred/dcrd/chaincfg v1.5.2/go.mod h1:FukMzTjkwzjPU+hK7CqDMQe3NMbSZAYU5PAcsx1wlv0=
 github.com/decred/dcrd/chaincfg/chainhash v1.0.1 h1:0vG7U9+dSjSCaHQKdoSKURK2pOb47+b+8FK5q4+Je7M=
 github.com/decred/dcrd/chaincfg/chainhash v1.0.1/go.mod h1:OVfvaOsNLS/A1y4Eod0Ip/Lf8qga7VXCQjUQLbkY0Go=
 github.com/decred/dcrd/dcrec/edwards v1.0.0/go.mod h1:HblVh1OfMt7xSxUL1ufjToaEvpbjpWvvTAUx4yem8BI=


### PR DESCRIPTION
This updates the mining module dependencies and serves as a base for `connmgr/v1.1.0`.

The updated direct dependencies in this commit are as follows:

- github.com/decred/dcrd/chaincfg@v1.5.2

The full list of updated direct dependencies since the previous `connmgr/v1.0.2` release are as follows:

- github.com/decred/dcrd/chaincfg@v1.5.2