### PR TITLE
mempool/mining: Implement aggregate fee sorting.

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -2051,6 +2051,9 @@ func (b *blockManager) handleBlockchainNotification(notification *blockchain.Not
 				b.cfg.PeerNotifier.TransactionConfirmed(tx)
 			}
 		}
+
+		// Add regular transactions back to the mempool,
+		// excluding the coinbase since it does not belong in the mempool.
 		handleConnectedBlockTxns(block.Transactions()[1:])
 		if isTreasuryEnabled {
 			// Skip treasurybase

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -2278,10 +2278,11 @@ func (mp *TxPool) MiningView() mining.TxMiningView {
 
 	for key, value := range mp.miningView.ancestorStats {
 		statsCopy[key] = &mining.TxAncestorStats{
-			Fees:         value.Fees,
-			SizeBytes:    value.SizeBytes,
-			NumSigOps:    value.NumSigOps,
-			NumAncestors: value.NumAncestors,
+			Fees:          value.Fees,
+			SizeBytes:     value.SizeBytes,
+			NumSigOps:     value.NumSigOps,
+			NumP2SHSigOps: value.NumP2SHSigOps,
+			NumAncestors:  value.NumAncestors,
 		}
 	}
 
@@ -2344,6 +2345,7 @@ func aggregateStats(stats *mining.TxAncestorStats, ancestor *mining.TxDesc) {
 	stats.Fees += ancestor.Fee
 	stats.SizeBytes += int64(ancestor.Tx.MsgTx().SerializeSize())
 	stats.NumSigOps += int64(ancestor.NumSigOps)
+	stats.NumP2SHSigOps += int64(ancestor.NumP2SHSigOps)
 }
 
 // updateBundleStats ensures that the bundle stats for a given

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -2517,24 +2517,22 @@ func (mv *txMiningView) Ancestors(txHash *chainhash.Hash) []*mining.TxDesc {
 		return nil
 	}
 
-	if mv.trackAncestorStats {
-		var stats *mining.TxAncestorStats
-		seen := make(map[chainhash.Hash]struct{})
-		mv.txGraph.forEachAncestor(txHash, seen, func(txDesc *mining.TxDesc) {
-			if stats == nil {
-				stats = &mining.TxAncestorStats{}
-			}
-
-			aggregateAncestorStats(stats, txDesc)
-			ancestors = append(ancestors, txDesc)
-		})
-
+	var stats *mining.TxAncestorStats
+	seen := make(map[chainhash.Hash]struct{})
+	mv.txGraph.forEachAncestor(txHash, seen, func(txDesc *mining.TxDesc) {
 		if stats == nil {
-			delete(mv.ancestorStats, *txHash)
-		} else {
-			// Update the cache.
-			mv.ancestorStats[*txHash] = stats
+			stats = &mining.TxAncestorStats{}
 		}
+
+		aggregateAncestorStats(stats, txDesc)
+		ancestors = append(ancestors, txDesc)
+	})
+
+	if stats == nil {
+		delete(mv.ancestorStats, *txHash)
+	} else {
+		// Update the cache.
+		mv.ancestorStats[*txHash] = stats
 	}
 
 	return ancestors

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -2415,18 +2415,6 @@ func (mp *TxPool) miningDescs() []*mining.TxDesc {
 	return descs
 }
 
-// MiningDescs returns a slice of mining descriptors for all the transactions
-// in the pool.
-//
-// This is part of the mining.TxSource interface implementation and is safe for
-// concurrent access as required by the interface contract.
-func (mp *TxPool) MiningDescs() []*mining.TxDesc {
-	mp.mtx.RLock()
-	descs := mp.miningDescs()
-	mp.mtx.RUnlock()
-	return descs
-}
-
 // LastUpdated returns the last time a transaction was added to or removed from
 // the main pool.  It does not include the orphan pool.
 //

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -2500,12 +2500,14 @@ func (mv *txMiningView) notifyDescendentsAdded(txDesc *mining.TxDesc) {
 	txHash := txDesc.Tx.Hash()
 	txSize := int64(txDesc.Tx.MsgTx().SerializeSize())
 	sigOps := int64(txDesc.NumSigOps)
+	p2shSigOps := int64(txDesc.NumP2SHSigOps)
 	seen := make(map[chainhash.Hash]struct{})
 	mv.txGraph.forEachDescendent(txHash, seen, func(descendent *mining.TxDesc) {
 		descendentStats := mv.bundleStats[*descendent.Tx.Hash()]
 		descendentStats.Fees += txDesc.Fee
 		descendentStats.SizeBytes += txSize
 		descendentStats.NumSigOps += sigOps
+		descendentStats.NumP2SHSigOps += p2shSigOps
 		descendentStats.NumAncestors++
 	})
 }
@@ -2516,12 +2518,14 @@ func (mv *txMiningView) notifyDescendentsRemoved(txDesc *mining.TxDesc) {
 	txHash := txDesc.Tx.Hash()
 	txSize := int64(txDesc.Tx.MsgTx().SerializeSize())
 	sigOps := int64(txDesc.NumSigOps)
+	p2shSigOps := int64(txDesc.NumP2SHSigOps)
 	seen := make(map[chainhash.Hash]struct{})
 	mv.txGraph.forEachDescendent(txHash, seen, func(descendent *mining.TxDesc) {
 		descendentStats := mv.bundleStats[*descendent.Tx.Hash()]
 		descendentStats.Fees -= txDesc.Fee
 		descendentStats.SizeBytes -= txSize
 		descendentStats.NumSigOps -= sigOps
+		descendentStats.NumP2SHSigOps -= p2shSigOps
 		descendentStats.NumAncestors--
 	})
 }

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -783,7 +783,6 @@ func newPoolHarness(chainParams *chaincfg.Params) (*poolHarness, []spendableOutp
 		chain: chain,
 		txPool: New(&Config{
 			Policy: Policy{
-				FeeDecayRate:         0,
 				MaxTxVersion:         wire.TxVersionTreasury,
 				DisableRelayPriority: true,
 				FreeTxRelayLimit:     15.0,

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -2950,35 +2950,40 @@ func TestMiningView(t *testing.T) {
 		}
 
 		// Ensure stats are calculated before retrieving ancestors.
-		stat, hasStats := miningView.AncestorStats(txHash)
+		initialStat, hasStats := miningView.AncestorStats(txHash)
 		if !hasStats {
 			t.Fatalf("%v: expected mining view to have ancestor stats",
 				test.name)
 		}
 
-		if test.expectedAncestorFees != stat.Fees {
+		if test.expectedAncestorFees != initialStat.Fees {
 			t.Fatalf("%v: expected subject txn to have bundle fees %v, got %v",
-				test.name, test.expectedAncestorFees, stat.Fees)
+				test.name, test.expectedAncestorFees, initialStat.Fees)
 		}
 
-		if test.expectedSizeBytes != stat.SizeBytes {
+		if test.expectedSizeBytes != initialStat.SizeBytes {
 			t.Fatalf("%v: expected subject txn to have SizeBytes=%v, got %v",
-				test.name, test.expectedSizeBytes, stat.SizeBytes)
+				test.name, test.expectedSizeBytes, initialStat.SizeBytes)
 		}
 
-		if test.expectedSigOps != stat.TotalSigOps {
+		if test.expectedSigOps != initialStat.TotalSigOps {
 			t.Fatalf("%v: expected subject txn to have SigOps=%v, got %v",
-				test.name, test.expectedSigOps, stat.TotalSigOps)
+				test.name, test.expectedSigOps, initialStat.TotalSigOps)
 		}
 
-		if len(test.ancestors) != stat.NumAncestors {
+		if len(test.ancestors) != initialStat.NumAncestors {
 			t.Fatalf("%v: expected subject txn to have NumAncestors=%v, got %v",
-				test.name, len(test.ancestors), stat.NumAncestors)
+				test.name, len(test.ancestors), initialStat.NumAncestors)
 		}
 
 		// Retrieving ancestors will cause the cached stats to be updated.
 		ancestors := miningView.Ancestors(txHash)
-		stat, _ = miningView.AncestorStats(txHash)
+		stat, _ := miningView.AncestorStats(txHash)
+
+		if initialStat == stat {
+			t.Fatalf("%v: expected ancestor stats reference to have changed "+
+				"after retrieving list of ancestors", test.name)
+		}
 
 		// Get snapshot of transaction relationships as they exist in the pool.
 		descendants := harness.txPool.miningView.txGraph.descendants(txHash)

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -783,6 +783,7 @@ func newPoolHarness(chainParams *chaincfg.Params) (*poolHarness, []spendableOutp
 		chain: chain,
 		txPool: New(&Config{
 			Policy: Policy{
+				EnableMiningView:     true,
 				MaxTxVersion:         wire.TxVersionTreasury,
 				DisableRelayPriority: true,
 				FreeTxRelayLimit:     15.0,

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -2809,18 +2809,13 @@ func TestMiningView(t *testing.T) {
 	}, 2, applyTxFee(5000))
 
 	// Add all to chain.
-	allTxns := []*dcrutil.Tx{txA, txB, txC, txD, txE}
+	allTxns := []*dcrutil.Tx{txB, txA, txC, txD, txE}
 	for index, tx := range allTxns {
-		acceptedTxns, err := harness.txPool.ProcessTransaction(tx,
-			false, false, true, 0)
+		_, err := harness.txPool.ProcessTransaction(tx,
+			true, false, true, 0)
 		if err != nil {
 			t.Fatalf("ProcessTransaction: failed to accept valid "+
 				"transaction at index %d: %v", index, err)
-		}
-		if len(acceptedTxns) != 1 {
-			t.Fatalf("ProcessTransaction: reported accepted transactions "+
-				"length does not match expected -- got %d, want %d",
-				len(acceptedTxns), 1)
 		}
 	}
 

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -2751,6 +2751,17 @@ func TestHandlesTAdds(t *testing.T) {
 	acceptTAdd(tadd)
 }
 
+// descendents returns a collection of transactions in the graph that depend on
+// the provided transaction hash.
+func (g *txDescGraph) descendents(txHash *chainhash.Hash) []*chainhash.Hash {
+	seen := map[chainhash.Hash]struct{}{}
+	descendents := make([]*chainhash.Hash, 0)
+	g.forEachDescendent(txHash, seen, func(descendent *mining.TxDesc) {
+		descendents = append(descendents, descendent.Tx.Hash())
+	})
+	return descendents
+}
+
 // Tests the behavior of the mining view when returned from a mempool with
 // containing a transaction chain depicted as:
 //

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -2755,8 +2755,7 @@ func TestHandlesTAdds(t *testing.T) {
 func (p *poolHarness) countTotalSigOps(tx *dcrutil.Tx, txType stake.TxType) (int, error) {
 	isVote := txType == stake.TxTypeSSGen
 	isStakeBase := txType == stake.TxTypeSSGen
-	isTreasuryEnabled := p.treasuryActive
-	utxoView, err := p.txPool.fetchInputUtxos(tx, isTreasuryEnabled)
+	utxoView, err := p.txPool.fetchInputUtxos(tx, p.treasuryActive)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -2917,7 +2917,7 @@ func TestMiningView(t *testing.T) {
 		}
 
 		// Ensure stats are calculated before retrieving ancestors.
-		stat := miningView.BundleStats(txHash)
+		stat := miningView.AncestorStats(txHash)
 		if test.expectedFees != stat.Fees {
 			t.Fatalf("%v: expected subject txn to have bundle fees %v, got %v",
 				test.name, test.expectedFees, stat.Fees)
@@ -3003,9 +3003,9 @@ func TestMiningView(t *testing.T) {
 			child := children[0]
 			siblings := removalMiningView.Parents(child.Tx.Hash())
 
-			// Make sure parent fee has not changed.
-			oldStat := miningView.BundleStats(child.Tx.Hash())
-			newStat := removalMiningView.BundleStats(child.Tx.Hash())
+			// Make sure ancestor stats have not changed.
+			oldStat := miningView.AncestorStats(child.Tx.Hash())
+			newStat := removalMiningView.AncestorStats(child.Tx.Hash())
 
 			if *oldStat != *newStat {
 				t.Fatalf("%v: expected test subject's child bundle stats to "+
@@ -3028,8 +3028,8 @@ func TestMiningView(t *testing.T) {
 		removalMiningView.Remove(txHash, true)
 
 		for _, descendent := range descendents {
-			oldStat := miningView.BundleStats(descendent)
-			newStat := removalMiningView.BundleStats(descendent)
+			oldStat := miningView.AncestorStats(descendent)
+			newStat := removalMiningView.AncestorStats(descendent)
 
 			expectedFee := oldStat.Fees - txDesc.Fee
 			expectedSigOps := oldStat.NumSigOps - int64(txDesc.NumSigOps)

--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -103,13 +103,14 @@ type TxMiningView interface {
 	// ancestors known to the view.
 	HasParents(txHash *chainhash.Hash) bool
 
-	// Parents returns a unique set of transactions that the provided
-	// transaction hash spends from in the view. The order of elements is not
-	// guaranteed.
+	// Parents returns a set of transactions in the graph that the provided
+	// transaction hash spends from in the view. The order of elements
+	// returned is not guaranteed.
 	Parents(txHash *chainhash.Hash) []*TxDesc
 
-	// Children returns a unique set of transactions that spend from the
-	// provided transaction hash. The order of elements is not guaranteed.
+	// Children returns a set of transactions in the graph that spend
+	// from the provided transaction hash. The order of elements
+	// returned is not guaranteed.
 	Children(txHash *chainhash.Hash) []*TxDesc
 
 	// Remove causes the provided transaction to be removed from the view, if

--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -94,7 +94,7 @@ type TxAncestorStats struct {
 
 // TxMiningView is a snapshot of the tx source.
 type TxMiningView interface {
-	// MiningDescs returns a slice of mining descriptors for all the
+	// TxDescs returns a slice of mining descriptors for all minable
 	// transactions in the source pool.
 	TxDescs() []*TxDesc
 
@@ -157,10 +157,6 @@ type TxSource interface {
 	// LastUpdated returns the last time a transaction was added to or
 	// removed from the source pool.
 	LastUpdated() time.Time
-
-	// MiningDescs returns a slice of mining descriptors for all the
-	// transactions in the source pool.
-	MiningDescs() []*TxDesc
 
 	// HaveTransaction returns whether or not the passed transaction hash
 	// exists in the source pool.

--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -63,9 +63,11 @@ type TxDesc struct {
 	// Fee is the total fee the transaction associated with the entry pays.
 	Fee int64
 
-	// NumSigOps is the total sigops for this transaction
+	// NumSigOps is the total sigops for this transaction.
 	NumSigOps int
 
+	// NumP2SHSigOps is the total number of signature operations for all input
+	// transactions which are of the pay-to-script-hash type.
 	NumP2SHSigOps int
 }
 
@@ -82,6 +84,9 @@ type TxAncestorStats struct {
 	// NumSigOps is the total number of signature operations of all ancestors.
 	NumSigOps int64
 
+	// NumP2SHSigOps is the aggregate number of signature operations for all
+	// input transactions of all ancestors which are of the pay-to-script-hash
+	// type.
 	NumP2SHSigOps int64
 
 	// NumAncestors is the total number of ancestors for a given transaction.
@@ -1108,6 +1113,8 @@ func NewBlkTmplGenerator(policy *Policy, txSource TxSource,
 	}
 }
 
+// calcFeePerKb returns an adjusted fee per kilobyte taking the provided
+// transaction and its ancestors into account.
 func calcFeePerKb(txDesc *TxDesc, ancestorStats *TxAncestorStats) float64 {
 	txSize := uint32(txDesc.Tx.MsgTx().SerializeSize())
 	return (float64(txDesc.Fee+ancestorStats.Fees) * float64(kilobyte)) /

--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -1098,10 +1098,6 @@ type BlkTmplGenerator struct {
 	miningTimeOffset int
 }
 
-// noAncestorStats represents ancestor stats for a transaction where ancestors
-// are not being tracked in the view.
-var noAncestorStats = &TxAncestorStats{}
-
 // NewBlkTmplGenerator returns a new block template generator for the given
 // policy using transactions from the provided transaction source.
 func NewBlkTmplGenerator(policy *Policy, txSource TxSource,

--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -233,13 +233,12 @@ const (
 // transaction to be prioritized and track dependencies on other transactions
 // which have not been mined into a block yet.
 type txPrioItem struct {
-	tx          *dcrutil.Tx
-	txDesc      *TxDesc
-	txType      stake.TxType
-	fee         int64
-	priority    float64
-	feePerKB    float64
-	resortCount int
+	tx       *dcrutil.Tx
+	txDesc   *TxDesc
+	txType   stake.TxType
+	fee      int64
+	priority float64
+	feePerKB float64
 }
 
 // txPriorityQueueLessFunc describes a function that can be used as a compare

--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -1730,7 +1730,7 @@ nextPriorityQueueItem:
 				log.Tracef("Skipping tx %s due to error in "+
 					"CheckTransactionInputs: %v", bundledTx.Tx.Hash(), err)
 				logSkippedDeps(bundledTx.Tx, deps)
-				miningView.Reject(tx.Hash())
+				miningView.Reject(bundledTx.Tx.Hash())
 				continue nextPriorityQueueItem
 			}
 			err = blockchain.ValidateTransactionScripts(bundledTx.Tx,
@@ -1739,7 +1739,7 @@ nextPriorityQueueItem:
 				log.Tracef("Skipping tx %s due to error in "+
 					"ValidateTransactionScripts: %v", bundledTx.Tx.Hash(), err)
 				logSkippedDeps(bundledTx.Tx, deps)
-				miningView.Reject(tx.Hash())
+				miningView.Reject(bundledTx.Tx.Hash())
 				continue nextPriorityQueueItem
 			}
 		}

--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -1603,7 +1603,7 @@ nextPriorityQueueItem:
 		}
 
 		if feeDecreased {
-			// Skip the transaction if the total feePerKb decresed.
+			// Skip the transaction if the total feePerKb decreased.
 			// This addresses a vulnerability that would allow a low-fee
 			// transaction to have an inflated and inaccurate feePerKb based on
 			// ancestors that have already been included in the block template.
@@ -1748,8 +1748,7 @@ nextPriorityQueueItem:
 			// template.
 			blockTxns = append(blockTxns, bundledTx)
 			blockSize += uint32(bundledTx.MsgTx().SerializeSize())
-			bundledTxSigOps := int64(bundledTxDesc.TotalSigOps +
-				bundledTxDesc.TotalSigOps)
+			bundledTxSigOps := int64(bundledTxDesc.TotalSigOps)
 			blockSigOps += bundledTxSigOps
 
 			// Accumulate the SStxs in the block, because only a certain number

--- a/internal/mining/mining_test.go
+++ b/internal/mining/mining_test.go
@@ -47,7 +47,7 @@ func TestStakeTxFeePrioHeap(t *testing.T) {
 			randPrio := rand.Float64() * 100
 			randFeePerKB := rand.Float64() * 10
 			testItems = append(testItems, &txPrioItem{
-				tx:       nil,
+				txDesc:   nil,
 				txType:   randType,
 				feePerKB: randFeePerKB,
 				priority: randPrio,
@@ -59,7 +59,7 @@ func TestStakeTxFeePrioHeap(t *testing.T) {
 
 	// Test sorting by stake and fee per KB.
 	last := &txPrioItem{
-		tx:       nil,
+		txDesc:   nil,
 		txType:   stake.TxTypeSSGen,
 		priority: 10000.0,
 		feePerKB: 10000.0,
@@ -84,7 +84,7 @@ func TestStakeTxFeePrioHeap(t *testing.T) {
 		randPrio := rand.Float64() * 100
 		randFeePerKB := rand.Float64() * 10
 		prioItem := &txPrioItem{
-			tx:       nil,
+			txDesc:   nil,
 			txType:   randType,
 			feePerKB: randFeePerKB,
 			priority: randPrio,
@@ -95,7 +95,7 @@ func TestStakeTxFeePrioHeap(t *testing.T) {
 	// Test sorting with fees per KB for high stake priority, then
 	// priority for low stake priority.
 	last = &txPrioItem{
-		tx:       nil,
+		txDesc:   nil,
 		txType:   stake.TxTypeSSGen,
 		priority: 10000.0,
 		feePerKB: 10000.0,

--- a/internal/mining/mining_test.go
+++ b/internal/mining/mining_test.go
@@ -36,6 +36,7 @@ func TestStakeTxFeePrioHeap(t *testing.T) {
 		{feePerKB: 10000, txType: stake.TxTypeRegular, priority: 0}, // Higher fee, smaller prio
 		{feePerKB: 0, txType: stake.TxTypeRegular, priority: 10000}, // Higher prio, lower fee
 	}
+
 	ph := newTxPriorityQueue((numElements + numEdgeConditionElements), txPQByStakeAndFee)
 
 	// Add random data in addition to the edge conditions already manually

--- a/server.go
+++ b/server.go
@@ -3175,16 +3175,16 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 
 	txC := mempool.Config{
 		Policy: mempool.Policy{
-			EnableMiningView:     cfg.Generate,
-			MaxTxVersion:         wire.TxVersionTreasury,
-			DisableRelayPriority: cfg.NoRelayPriority,
-			AcceptNonStd:         cfg.AcceptNonStd,
-			FreeTxRelayLimit:     cfg.FreeTxRelayLimit,
-			MaxOrphanTxs:         cfg.MaxOrphanTxs,
-			MaxOrphanTxSize:      mempool.MaxStandardTxSize,
-			MaxSigOpsPerTx:       blockchain.MaxSigOpsPerBlock / 5,
-			MinRelayTxFee:        cfg.minRelayTxFee,
-			AllowOldVotes:        cfg.AllowOldVotes,
+			EnableAncestorTracking: cfg.Generate,
+			MaxTxVersion:           wire.TxVersionTreasury,
+			DisableRelayPriority:   cfg.NoRelayPriority,
+			AcceptNonStd:           cfg.AcceptNonStd,
+			FreeTxRelayLimit:       cfg.FreeTxRelayLimit,
+			MaxOrphanTxs:           cfg.MaxOrphanTxs,
+			MaxOrphanTxSize:        mempool.MaxStandardTxSize,
+			MaxSigOpsPerTx:         blockchain.MaxSigOpsPerBlock / 5,
+			MinRelayTxFee:          cfg.minRelayTxFee,
+			AllowOldVotes:          cfg.AllowOldVotes,
 			MaxVoteAge: func() uint16 {
 				switch chainParams.Net {
 				case wire.MainNet, wire.SimNet, wire.RegNet:

--- a/server.go
+++ b/server.go
@@ -3175,7 +3175,7 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 
 	txC := mempool.Config{
 		Policy: mempool.Policy{
-			EnableAncestorTracking: cfg.Generate,
+			EnableAncestorTracking: len(cfg.miningAddrs) > 0,
 			MaxTxVersion:           wire.TxVersionTreasury,
 			DisableRelayPriority:   cfg.NoRelayPriority,
 			AcceptNonStd:           cfg.AcceptNonStd,

--- a/server.go
+++ b/server.go
@@ -3175,6 +3175,7 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 
 	txC := mempool.Config{
 		Policy: mempool.Policy{
+			EnableMiningView:     cfg.Generate,
 			MaxTxVersion:         wire.TxVersionTreasury,
 			DisableRelayPriority: cfg.NoRelayPriority,
 			AcceptNonStd:         cfg.AcceptNonStd,


### PR DESCRIPTION
Relates to #1556 

This pull request modified the mining prioritization logic to sort transactions by an aggregate fee based on a transaction’s ancestors in the mempool.

Currently, the mining code prioritizes transactions by fee and only includes them in the block template if they have no dependencies. When a transaction is included in the block template, it is removed as a dependency from transactions that depend on it, making those dependent transactions eligible for block template inclusion.

Aggregating ancestor statistics for large graphs of transactions in the mempool may have high computational costs. Performing this aggregation in the block template generator would delay miners requesting a block template since all of the aggregation would need to occur for each transaction, at once. To solve this problem, the complexity is spread over time such that the transaction statistics are updated with mempool event hooks. Since the mempool is not locked during the entirety of template generation, a mining view interface is exposed to safely interact with a snapshot of the mempool.

The biggest risk in terms of performance are reorgs where transactions with many descendants are added back to the mempool. The number of transactions added to the mempool in this way is limited by the block size and proof of work, but the mempool has no restrictions on the number of ancestors tracked for a given transaction.

A potential - and not implemented - solution to this reorg problem would be to establish a limit on the number of ancestors a transaction may have in the mempool.