### PR TITLE
connmgr: Allow pending outbound conn removal.

### DIFF
--- a/connmgr/connmanager.go
+++ b/connmgr/connmanager.go
@@ -175,6 +175,12 @@ type handleFailed struct {
 	err error
 }
 
+// handleCancelPending is used to remove failing connections from retries.
+type handleCancelPending struct {
+	addr net.Addr
+	done chan struct{}
+}
+
 // ConnManager provides a manager to handle network connections.
 type ConnManager struct {
 	// The following variables must only be used atomically.
@@ -346,6 +352,25 @@ out:
 				log.Debugf("Failed to connect to %v: %v",
 					connReq, msg.err)
 				cm.handleFailedConn(connReq)
+
+			case handleCancelPending:
+				found := false
+				var idToRemove uint64
+				for id, req := range pending {
+					if msg.addr.String() == req.Addr.String() {
+						idToRemove = id
+						found = true
+						break
+					}
+
+				}
+				if found {
+					delete(pending, idToRemove)
+					log.Debugf("Canceled pending connection to %v", msg.addr)
+				} else {
+					log.Debugf("Did not find connection to cancel")
+				}
+				close(msg.done)
 			}
 
 		case <-cm.quit:
@@ -490,6 +515,27 @@ func (cm *ConnManager) Remove(id uint64) {
 	select {
 	case cm.requests <- handleDisconnected{id, false}:
 	case <-cm.quit:
+	}
+}
+
+// CancelPending removes the connection corresponding to the given address
+// from the list of pending failed connections.
+func (cm *ConnManager) CancelPending(addr net.Addr) {
+	if atomic.LoadInt32(&cm.stop) != 0 {
+		return
+	}
+	done := make(chan struct{})
+
+	select {
+	case cm.requests <- handleCancelPending{addr, done}:
+	case <-cm.quit:
+	}
+	// Wait for the registration to successfully add the pending conn req to
+	// the conn manager's internal state.
+	select {
+	case <-done:
+	case <-cm.quit:
+		return
 	}
 }
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -500,11 +500,7 @@ func handleAddNode(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (in
 	case "add":
 		err = s.server.ConnectNode(addr, true)
 	case "remove":
-		rerr := s.server.RemoveNodeByAddr(addr)
-		// This connection is still pending, cancel it.
-		if rerr != nil {
-			err = s.server.CancelPendingConnection(addr)
-		}
+		err = s.server.RemoveNodeByAddr(addr)
 	case "onetry":
 		err = s.server.ConnectNode(addr, false)
 	default:

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -500,7 +500,11 @@ func handleAddNode(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (in
 	case "add":
 		err = s.server.ConnectNode(addr, true)
 	case "remove":
-		err = s.server.RemoveNodeByAddr(addr)
+		rerr := s.server.RemoveNodeByAddr(addr)
+		// This connection is still pending, cancel it.
+		if rerr != nil {
+			err = s.server.CancelPendingConnection(addr)
+		}
 	case "onetry":
 		err = s.server.ConnectNode(addr, false)
 	default:

--- a/server.go
+++ b/server.go
@@ -2086,7 +2086,13 @@ func (s *server) RemoveNodeByAddr(addr string) error {
 		reply: replyChan,
 	}
 
-	return <-replyChan
+	err := <-replyChan
+	if err != nil {
+		// This connection may still be pending, cancel it.
+		return s.CancelPendingConnection(addr)
+	} else {
+		return nil
+	}
 }
 
 // CancelPendingConnection removes an address from the list of

--- a/server.go
+++ b/server.go
@@ -2089,15 +2089,14 @@ func (s *server) RemoveNodeByAddr(addr string) error {
 	err := <-replyChan
 	if err != nil {
 		// This connection may still be pending, cancel it.
-		return s.CancelPendingConnection(addr)
-	} else {
-		return nil
+		return s.cancelPendingConnection(addr)
 	}
+	return nil
 }
 
-// CancelPendingConnection removes an address from the list of
+// cancelPendingConnection removes an address from the list of
 // pending connections.
-func (s *server) CancelPendingConnection(addr string) error {
+func (s *server) cancelPendingConnection(addr string) error {
 	replyChan := make(chan error)
 
 	s.query <- cancelPendingMsg{


### PR DESCRIPTION
This PR resolves https://github.com/decred/dcrd/issues/1725. Currently, if there is a call made by `dcrctl addnode <ip_addr:port>` to an unresponsive port, the connReq will repeatedly retry to connect until the timeout period has been reached. `dcrctl addnode <ip_addr:port> remove` will not stop the retry attempts. The PR removes the addr from the list of pending failed connections if the `dcrctl addnode <ip_addr:port> remove` does not find an active connection. 

I may still need to add unit tests but I wanted to push this to get feedback as early as possible. 