### PR TITLE
gcs: Support empty filters.

### DIFF
--- a/blockchain/indexers/cfindex.go
+++ b/blockchain/indexers/cfindex.go
@@ -215,7 +215,7 @@ func storeFilter(dbTx database.Tx, block *dcrutil.Block, f *gcs.Filter, filterTy
 // every passed block. This is part of the Indexer interface.
 func (idx *CFIndex) ConnectBlock(dbTx database.Tx, block, parent *dcrutil.Block, view *blockchain.UtxoViewpoint) error {
 	f, err := blockcf.Regular(block.MsgBlock())
-	if err != nil && err != gcs.ErrNoData {
+	if err != nil {
 		return err
 	}
 
@@ -225,7 +225,7 @@ func (idx *CFIndex) ConnectBlock(dbTx database.Tx, block, parent *dcrutil.Block,
 	}
 
 	f, err = blockcf.Extended(block.MsgBlock())
-	if err != nil && err != gcs.ErrNoData {
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**This requires PR #1843**.

This adds support for empty filters versus being an error along with a full set of tests to ensure the empty filter works as intended.

It is part of the onging process to cleanup and improve the `gcs` module to the quality level required by consensus code for ultimate inclusion in header commitments.