### PR TITLE
gcs: Add filter version support.

### DIFF
--- a/gcs/bench_test.go
+++ b/gcs/bench_test.go
@@ -42,11 +42,12 @@ func BenchmarkFilterBuild50000(b *testing.B) {
 		b.Fatalf("unable to generate random item: %v", err)
 	}
 
+	const filterVersion = 1
 	b.ReportAllocs()
 	b.ResetTimer()
 	var key [KeySize]byte
 	for i := 0; i < b.N; i++ {
-		_, err := NewFilter(P, key, contents)
+		_, err := NewFilter(filterVersion, P, key, contents)
 		if err != nil {
 			b.Fatalf("unable to generate filter: %v", err)
 		}
@@ -62,11 +63,12 @@ func BenchmarkFilterBuild100000(b *testing.B) {
 		b.Fatalf("unable to generate random item: %v", err)
 	}
 
+	const filterVersion = 1
 	b.ReportAllocs()
 	b.ResetTimer()
 	var key [KeySize]byte
 	for i := 0; i < b.N; i++ {
-		_, err := NewFilter(P, key, contents)
+		_, err := NewFilter(filterVersion, P, key, contents)
 		if err != nil {
 			b.Fatalf("unable to generate filter: %v", err)
 		}
@@ -82,8 +84,9 @@ func BenchmarkFilterMatch(b *testing.B) {
 		b.Fatalf("unable to generate random item: %v", err)
 	}
 
+	const filterVersion = 1
 	var key [KeySize]byte
-	filter, err := NewFilter(P, key, contents)
+	filter, err := NewFilter(filterVersion, P, key, contents)
 	if err != nil {
 		b.Fatalf("Failed to build filter")
 	}
@@ -113,8 +116,9 @@ func BenchmarkFilterMatchAny(b *testing.B) {
 		b.Fatalf("unable to generate random item: %v", err)
 	}
 
+	const filterVersion = 1
 	var key [KeySize]byte
-	filter, err := NewFilter(P, key, contents)
+	filter, err := NewFilter(filterVersion, P, key, contents)
 	if err != nil {
 		b.Fatalf("Failed to build filter")
 	}

--- a/gcs/blockcf/blockcf.go
+++ b/gcs/blockcf/blockcf.go
@@ -28,8 +28,13 @@ import (
 	"github.com/decred/dcrd/wire"
 )
 
-// P is the collision probability used for block committed filters (2^-20)
-const P = 20
+const (
+	// P is the collision probability used for block committed filters (2^-20)
+	P = 20
+
+	// filterVersion is the version of the gcs filter.
+	filterVersion = 1
+)
 
 // Entries describes all of the filter entries used to create a GCS filter and
 // provides methods for appending data structures found in blocks.
@@ -163,7 +168,7 @@ func Regular(block *wire.MsgBlock) (*gcs.Filter, error) {
 	blockHash := block.BlockHash()
 	key := Key(&blockHash)
 
-	return gcs.NewFilter(P, key, data)
+	return gcs.NewFilter(filterVersion, P, key, data)
 }
 
 // Extended builds an extended GCS filter from a block.  An extended filter
@@ -207,5 +212,5 @@ func Extended(block *wire.MsgBlock) (*gcs.Filter, error) {
 	blockHash := block.BlockHash()
 	key := Key(&blockHash)
 
-	return gcs.NewFilter(P, key, data)
+	return gcs.NewFilter(filterVersion, P, key, data)
 }

--- a/gcs/error.go
+++ b/gcs/error.go
@@ -24,15 +24,20 @@ const (
 	// N and/or P parameters of a serialized filter.
 	ErrMisserialized
 
+	// ErrUnsupportedVersion is returned when a filter version that is not
+	// supported has been specified.
+	ErrUnsupportedVersion
+
 	// numErrorCodes is the maximum error code number used in tests.
 	numErrorCodes
 )
 
 // Map of ErrorCode values back to their constant names for pretty printing.
 var errorCodeStrings = map[ErrorCode]string{
-	ErrNTooBig:       "ErrNTooBig",
-	ErrPTooBig:       "ErrPTooBig",
-	ErrMisserialized: "ErrMisserialized",
+	ErrNTooBig:            "ErrNTooBig",
+	ErrPTooBig:            "ErrPTooBig",
+	ErrMisserialized:      "ErrMisserialized",
+	ErrUnsupportedVersion: "ErrUnsupportedVersion",
 }
 
 // String returns the ErrorCode as a human-readable name.

--- a/gcs/error.go
+++ b/gcs/error.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package gcs
+
+import (
+	"fmt"
+)
+
+// ErrorCode identifies a kind of error.
+type ErrorCode int
+
+// These constants are used to identify a specific RuleError.
+const (
+	// ErrNTooBig signifies that the filter can't handle N items.
+	ErrNTooBig ErrorCode = iota
+
+	// ErrPTooBig signifies that the filter can't handle `1/2**P`
+	// collision probability.
+	ErrPTooBig
+
+	// ErrMisserialized signifies a filter was misserialized and is missing the
+	// N and/or P parameters of a serialized filter.
+	ErrMisserialized
+
+	// numErrorCodes is the maximum error code number used in tests.
+	numErrorCodes
+)
+
+// Map of ErrorCode values back to their constant names for pretty printing.
+var errorCodeStrings = map[ErrorCode]string{
+	ErrNTooBig:       "ErrNTooBig",
+	ErrPTooBig:       "ErrPTooBig",
+	ErrMisserialized: "ErrMisserialized",
+}
+
+// String returns the ErrorCode as a human-readable name.
+func (e ErrorCode) String() string {
+	if s := errorCodeStrings[e]; s != "" {
+		return s
+	}
+	return fmt.Sprintf("Unknown ErrorCode (%d)", int(e))
+}
+
+// Error identifies a filter-related error.  The caller can use type assertions
+// to access the ErrorCode field to ascertain the specific reason for the
+// failure.
+type Error struct {
+	ErrorCode   ErrorCode // Describes the kind of error
+	Description string    // Human readable description of the issue
+}
+
+// Error satisfies the error interface and prints human-readable errors.
+func (e Error) Error() string {
+	return e.Description
+}
+
+// makeError creates an Error given a set of arguments.  The error code must
+// be one of the error codes provided by this package.
+func makeError(c ErrorCode, desc string) Error {
+	return Error{ErrorCode: c, Description: desc}
+}
+
+// IsError returns whether err is an Error with a matching error code.
+func IsErrorCode(err error, c ErrorCode) bool {
+	e, ok := err.(Error)
+	return ok && e.ErrorCode == c
+}

--- a/gcs/error_test.go
+++ b/gcs/error_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package gcs
+
+import (
+	"testing"
+)
+
+// TestErrorCodeStringer tests the stringized output for the ErrorCode type.
+func TestErrorCodeStringer(t *testing.T) {
+	tests := []struct {
+		in   ErrorCode
+		want string
+	}{
+		{ErrNTooBig, "ErrNTooBig"},
+		{ErrPTooBig, "ErrPTooBig"},
+		{ErrMisserialized, "ErrMisserialized"},
+		{0xffff, "Unknown ErrorCode (65535)"},
+	}
+
+	// Detect additional error codes that don't have the stringer added.
+	if len(tests)-1 != int(numErrorCodes) {
+		t.Errorf("It appears an error code was added without adding an " +
+			"associated stringer test")
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		result := test.in.String()
+		if result != test.want {
+			t.Errorf("String #%d\n got: %s want: %s", i, result, test.want)
+			continue
+		}
+	}
+}
+
+// TestError tests the error output for the Error type.
+func TestError(t *testing.T) {
+	tests := []struct {
+		in   Error
+		want string
+	}{{
+		Error{Description: "duplicate block"},
+		"duplicate block",
+	}, {
+		Error{Description: "human-readable error"},
+		"human-readable error",
+	},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		result := test.in.Error()
+		if result != test.want {
+			t.Errorf("Error #%d\n got: %s want: %s", i, result, test.want)
+			continue
+		}
+	}
+}
+
+// TestIsErrorCode ensures IsErrorCode works as intended.
+func TestIsErrorCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		code ErrorCode
+		want bool
+	}{{
+		name: "ErrNTooBig testing for ErrNTooBig",
+		err:  makeError(ErrNTooBig, ""),
+		code: ErrNTooBig,
+		want: true,
+	}, {
+		name: "ErrPTooBig testing for ErrPTooBig",
+		err:  makeError(ErrPTooBig, ""),
+		code: ErrPTooBig,
+		want: true,
+	}, {
+		name: "ErrMisserialized testing for ErrMisserialized",
+		err:  makeError(ErrMisserialized, ""),
+		code: ErrMisserialized,
+		want: true,
+	}, {
+		name: "ErrNTooBig error testing for ErrPTooBig",
+		err:  makeError(ErrNTooBig, ""),
+		code: ErrPTooBig,
+		want: false,
+	}, {
+		name: "ErrNTooBig error testing for unknown error code",
+		err:  makeError(ErrNTooBig, ""),
+		code: 0xffff,
+		want: false,
+	}, {
+		name: "nil error testing for ErrNTooBig",
+		err:  nil,
+		code: ErrNTooBig,
+		want: false,
+	}}
+	for _, test := range tests {
+		result := IsErrorCode(test.err, test.code)
+		if result != test.want {
+			t.Errorf("%s: unexpected result -- got: %v want: %v", test.name,
+				result, test.want)
+			continue
+		}
+	}
+}

--- a/gcs/error_test.go
+++ b/gcs/error_test.go
@@ -17,6 +17,7 @@ func TestErrorCodeStringer(t *testing.T) {
 		{ErrNTooBig, "ErrNTooBig"},
 		{ErrPTooBig, "ErrPTooBig"},
 		{ErrMisserialized, "ErrMisserialized"},
+		{ErrUnsupportedVersion, "ErrUnsupportedVersion"},
 		{0xffff, "Unknown ErrorCode (65535)"},
 	}
 

--- a/gcs/gcs_test.go
+++ b/gcs/gcs_test.go
@@ -327,20 +327,20 @@ func TestFilterCorners(t *testing.T) {
 	const largeP = 33
 	var key [KeySize]byte
 	_, err := NewFilter(largeP, key, nil)
-	if err != ErrPTooBig {
+	if !IsErrorCode(err, ErrPTooBig) {
 		t.Fatalf("did not receive expected err for P too big -- got %v, want %v",
 			err, ErrPTooBig)
 	}
 	_, err = FromBytes(0, largeP, nil)
-	if err != ErrPTooBig {
+	if !IsErrorCode(err, ErrPTooBig) {
 		t.Fatalf("did not receive expected err for P too big -- got %v, want %v",
 			err, ErrPTooBig)
 	}
 
 	// Attempt to decode a filter without the N value serialized properly.
 	_, err = FromNBytes(20, []byte{0x00})
-	if err != ErrMisserialized {
-		t.Fatalf("did not receive expected err -- got %v, want %v",
-			err, ErrMisserialized)
+	if !IsErrorCode(err, ErrMisserialized) {
+		t.Fatalf("did not receive expected err -- got %v, want %v", err,
+			ErrMisserialized)
 	}
 }


### PR DESCRIPTION
This adds a version parameter to the `gcs` filters in order to pave the way for supporting `v2` filters which will have a different serialization that makes them incompatible with `v1` filters while still retaining the ability to work with `v1` filters in the interim.

A new error code is added, the tests have been updated accordingly, and new tests are added to ensure the expected error is thrown on an unsupported filter version.
