### PR TITLE
gcs: Add filter version support.

### DIFF
--- a/blockchain/go.mod
+++ b/blockchain/go.mod
@@ -3,6 +3,7 @@ module github.com/decred/dcrd/blockchain/v2
 go 1.11
 
 require (
+	github.com/dchest/blake256 v1.1.0 // indirect
 	github.com/decred/dcrd/blockchain/stake/v2 v2.0.1
 	github.com/decred/dcrd/blockchain/standalone v1.0.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2

--- a/blockchain/go.sum
+++ b/blockchain/go.sum
@@ -10,6 +10,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
 github.com/dchest/blake256 v1.0.0/go.mod h1:xXNWCE1jsAP8DAjP+rKw2MbeqLczjI3TRx2VK+9OEYY=
+github.com/dchest/blake256 v1.1.0 h1:4AuEhGPT/3TTKFhTfBpZ8hgZE7wJpawcYaEawwsbtqM=
+github.com/dchest/blake256 v1.1.0/go.mod h1:xXNWCE1jsAP8DAjP+rKw2MbeqLczjI3TRx2VK+9OEYY=
 github.com/dchest/siphash v1.2.1 h1:4cLinnzVJDKxTCl9B01807Yiy+W7ZzVHj/KIroQRvT4=
 github.com/dchest/siphash v1.2.1/go.mod h1:q+IRvb2gOSrUnYoPqHiyHXS0FOBBOdl6tONBlVnOnt4=
 github.com/decred/base58 v1.0.0 h1:BVi1FQCThIjZ0ehG+I99NJ51o0xcc9A/fDKhmJxY6+w=

--- a/blockchain/indexers/cfindex.go
+++ b/blockchain/indexers/cfindex.go
@@ -174,7 +174,7 @@ func (idx *CFIndex) Create(dbTx database.Tx) error {
 
 // storeFilter stores a given filter, and performs the steps needed to
 // generate the filter's header.
-func storeFilter(dbTx database.Tx, block *dcrutil.Block, f *gcs.Filter, filterType wire.FilterType) error {
+func storeFilter(dbTx database.Tx, block *dcrutil.Block, f *gcs.FilterV1, filterType wire.FilterType) error {
 	if uint8(filterType) > maxFilterType {
 		return errors.New("unsupported filter type")
 	}

--- a/gcs/bench_test.go
+++ b/gcs/bench_test.go
@@ -46,7 +46,7 @@ func BenchmarkFilterBuild50000(b *testing.B) {
 	b.ResetTimer()
 	var key [KeySize]byte
 	for i := 0; i < b.N; i++ {
-		_, err := NewFilter(P, key, contents)
+		_, err := NewFilterV1(P, key, contents)
 		if err != nil {
 			b.Fatalf("unable to generate filter: %v", err)
 		}
@@ -66,7 +66,7 @@ func BenchmarkFilterBuild100000(b *testing.B) {
 	b.ResetTimer()
 	var key [KeySize]byte
 	for i := 0; i < b.N; i++ {
-		_, err := NewFilter(P, key, contents)
+		_, err := NewFilterV1(P, key, contents)
 		if err != nil {
 			b.Fatalf("unable to generate filter: %v", err)
 		}
@@ -83,7 +83,7 @@ func BenchmarkFilterMatch(b *testing.B) {
 	}
 
 	var key [KeySize]byte
-	filter, err := NewFilter(P, key, contents)
+	filter, err := NewFilterV1(P, key, contents)
 	if err != nil {
 		b.Fatalf("Failed to build filter")
 	}
@@ -114,7 +114,7 @@ func BenchmarkFilterMatchAny(b *testing.B) {
 	}
 
 	var key [KeySize]byte
-	filter, err := NewFilter(P, key, contents)
+	filter, err := NewFilterV1(P, key, contents)
 	if err != nil {
 		b.Fatalf("Failed to build filter")
 	}

--- a/gcs/blockcf/blockcf.go
+++ b/gcs/blockcf/blockcf.go
@@ -28,8 +28,10 @@ import (
 	"github.com/decred/dcrd/wire"
 )
 
-// P is the collision probability used for block committed filters (2^-20)
-const P = 20
+const (
+	// P is the collision probability used for block committed filters (2^-20)
+	P = 20
+)
 
 // Entries describes all of the filter entries used to create a GCS filter and
 // provides methods for appending data structures found in blocks.
@@ -95,7 +97,7 @@ func Key(hash *chainhash.Hash) [gcs.KeySize]byte {
 // contain all the previous regular outpoints spent within a block, as well as
 // the data pushes within all the outputs created within a block which can be
 // spent by regular transactions.
-func Regular(block *wire.MsgBlock) (*gcs.Filter, error) {
+func Regular(block *wire.MsgBlock) (*gcs.FilterV1, error) {
 	var data Entries
 
 	// Add "regular" data from stake transactions.  For each class of stake
@@ -163,14 +165,14 @@ func Regular(block *wire.MsgBlock) (*gcs.Filter, error) {
 	blockHash := block.BlockHash()
 	key := Key(&blockHash)
 
-	return gcs.NewFilter(P, key, data)
+	return gcs.NewFilterV1(P, key, data)
 }
 
 // Extended builds an extended GCS filter from a block.  An extended filter
 // supplements a regular basic filter by including all transaction hashes of
 // regular and stake transactions, and adding the witness data (a.k.a. the
 // signature script) found within every non-coinbase regular transaction.
-func Extended(block *wire.MsgBlock) (*gcs.Filter, error) {
+func Extended(block *wire.MsgBlock) (*gcs.FilterV1, error) {
 	var data Entries
 
 	// For each stake transaction, commit the transaction hash.  If the
@@ -207,5 +209,5 @@ func Extended(block *wire.MsgBlock) (*gcs.Filter, error) {
 	blockHash := block.BlockHash()
 	key := Key(&blockHash)
 
-	return gcs.NewFilter(P, key, data)
+	return gcs.NewFilterV1(P, key, data)
 }

--- a/rpcclient/chain.go
+++ b/rpcclient/chain.go
@@ -787,7 +787,7 @@ type FutureGetCFilterResult chan *response
 
 // Receive waits for the response promised by the future and returns the
 // discovered rescan data.
-func (r FutureGetCFilterResult) Receive() (*gcs.Filter, error) {
+func (r FutureGetCFilterResult) Receive() (*gcs.FilterV1, error) {
 	res, err := receiveFuture(r)
 	if err != nil {
 		return nil, err
@@ -803,7 +803,7 @@ func (r FutureGetCFilterResult) Receive() (*gcs.Filter, error) {
 		return nil, err
 	}
 
-	return gcs.FromNBytes(blockcf.P, filterNBytes)
+	return gcs.FromNBytesV1(blockcf.P, filterNBytes)
 }
 
 // GetCFilterAsync returns an instance of a type that can be used to get the
@@ -827,7 +827,7 @@ func (c *Client) GetCFilterAsync(blockHash *chainhash.Hash, filterType wire.Filt
 }
 
 // GetCFilter returns the committed filter of type filterType for a block.
-func (c *Client) GetCFilter(blockHash *chainhash.Hash, filterType wire.FilterType) (*gcs.Filter, error) {
+func (c *Client) GetCFilter(blockHash *chainhash.Hash, filterType wire.FilterType) (*gcs.FilterV1, error) {
 	return c.GetCFilterAsync(blockHash, filterType).Receive()
 }
 

--- a/server.go
+++ b/server.go
@@ -957,7 +957,7 @@ func (sp *serverPeer) OnGetCFilter(p *peer.Peer, msg *wire.MsgGetCFilter) {
 			return
 		}
 
-		var f *gcs.Filter
+		var f *gcs.FilterV1
 		switch msg.FilterType {
 		case wire.GCSFilterRegular:
 			f, err = blockcf.Regular(block.MsgBlock())


### PR DESCRIPTION
This refactors the primary `gcs` filter logic into an internal struct with a version parameter in in order to pave the way for supporting `v2` filters which will have a different serialization that makes them incompatible with `v1` filters while still retaining the ability to work with `v1` filters in the interim.

The exported type is renamed to `FilterV1` and the new internal struct is embedded so its methods are externally available.

The tests and all callers in the repo have been updated accordingly.