### PR TITLE
gcs: Standardize serialization on a single format.

### DIFF
--- a/blockchain/indexers/cfindex.go
+++ b/blockchain/indexers/cfindex.go
@@ -187,7 +187,7 @@ func storeFilter(dbTx database.Tx, block *dcrutil.Block, f *gcs.FilterV1, filter
 	h := block.Hash()
 	var basicFilterBytes []byte
 	if f != nil {
-		basicFilterBytes = f.NBytes()
+		basicFilterBytes = f.Bytes()
 	}
 	err := dbStoreFilter(dbTx, fkey, h, basicFilterBytes)
 	if err != nil {

--- a/rpcclient/chain.go
+++ b/rpcclient/chain.go
@@ -798,12 +798,12 @@ func (r FutureGetCFilterResult) Receive() (*gcs.FilterV1, error) {
 	if err != nil {
 		return nil, err
 	}
-	filterNBytes, err := hex.DecodeString(filterHex)
+	filterBytes, err := hex.DecodeString(filterHex)
 	if err != nil {
 		return nil, err
 	}
 
-	return gcs.FromNBytesV1(blockcf.P, filterNBytes)
+	return gcs.FromBytesV1(blockcf.P, filterBytes)
 }
 
 // GetCFilterAsync returns an instance of a type that can be used to get the

--- a/server.go
+++ b/server.go
@@ -979,7 +979,7 @@ func (sp *serverPeer) OnGetCFilter(p *peer.Peer, msg *wire.MsgGetCFilter) {
 			return
 		}
 
-		filterBytes = f.NBytes()
+		filterBytes = f.Bytes()
 	}
 
 	peerLog.Tracef("Obtained CF for %v", &msg.BlockHash)


### PR DESCRIPTION
Currently, the filters provide two different serialization formats per version.  The first is the raw filter bytes without the number of items in its data set and is implemented by the `Bytes` and `FromBytesV1` functions.  The second includes that information and is implemented by the `NBytes` and `FromNBytesV1` functions.

In practice, the ability to serialize the filter independently from the number of items in its data set is not very useful since that information is required to be able to query the filter and, unlike the other parameters which are fixed (e.g. false positive rate and key), the number of items varies per filter.  For this reason, all usage in practice calls `NBytes` and `FromNBytesV1`.

Consequently, this simplifies the API for working with filters by standardizing on a single serialization format per filter version which includes the number of items in its data set.

In order to accomplish this, the current `Bytes` and `FromBytesV1` functions are removed and the `NBytes` and `FromNBytesV1` functions are renamed to take their place.

This also updates all tests and callers in the repo accordingly.