### PR TITLE
cpuminer: Fix off-by-one error in extraNonce iterator.

### DIFF
--- a/cpuminer.go
+++ b/cpuminer.go
@@ -251,7 +251,7 @@ func (m *CPUMiner) solveBlock(msgBlock *wire.MsgBlock, ticker *time.Ticker, quit
 	// Note that the entire extra nonce range is iterated and the offset is
 	// added relying on the fact that overflow will wrap around 0 as
 	// provided by the Go spec.
-	for extraNonce := uint64(0); extraNonce < maxExtraNonce; extraNonce++ {
+	for extraNonce := uint64(0); extraNonce <= maxExtraNonce; extraNonce++ {
 		// Update the extra nonce in the block template header with the
 		// new value.
 		littleEndian.PutUint64(header.ExtraData[:], extraNonce+enOffset)


### PR DESCRIPTION
Since maxExtraNonce is defined as 2^64-1, we should include that exact
value in the iteration, just as is already done for the 32-bit maxNonce.