### PR TITLE
rpcserver: Better error message.

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1023,13 +1023,13 @@ func handleCreateRawSSRtx(s *rpcServer, cmd interface{}, closeChan <-chan struct
 			ssrtxOutScript, err = txscript.PayToSSRtxPKHDirect(ssrtxPkh)
 			if err != nil {
 				return nil, rpcInvalidError("Could not "+
-					"generate PKH script: %v", err)
+					"generate P2PKH script: %v", err)
 			}
 		case true: // P2SH
 			ssrtxOutScript, err = txscript.PayToSSRtxSHDirect(ssrtxPkh)
 			if err != nil {
 				return nil, rpcInvalidError("Could not "+
-					"generate SHD script: %v", err)
+					"generate P2SH script: %v", err)
 			}
 		}
 


### PR DESCRIPTION
There's no such thing as an "SHD" script, so fix the error message
to correctly reference a pay-to-script-hash script instead.