### PR TITLE
dcrctl: Expose latest wallet privacy commands.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,4 +68,5 @@ replace (
 	github.com/decred/dcrd/rpcclient/v5 => ./rpcclient
 	github.com/decred/dcrd/txscript/v2 => ./txscript
 	github.com/decred/dcrd/wire => ./wire
+	github.com/decred/dcrwallet/rpc/jsonrpc/types => github.com/jrick/btcwallet/rpc/jsonrpc/types v0.0.0-20190916132041-beef8628a232
 )

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGAR
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jrick/bitset v1.0.0 h1:Ws0PXV3PwXqWK2n7Vz6idCdrV/9OrBXgHEJi27ZB9Dw=
 github.com/jrick/bitset v1.0.0/go.mod h1:ZOYB5Uvkla7wIEY4FEssPVi3IQXa02arznRaYaAEPe4=
+github.com/jrick/btcwallet/rpc/jsonrpc/types v0.0.0-20190916132041-beef8628a232 h1:Xq0xS3sRwoMgWNqihj/EAYUZ6mA1X0lQiVj8nCIhBN0=
+github.com/jrick/btcwallet/rpc/jsonrpc/types v0.0.0-20190916132041-beef8628a232/go.mod h1:xVD5Moj3eekagHUIR42Z6180jgoXtilmtkcs0d7VwEY=
 github.com/jrick/logrotate v1.0.0 h1:lQ1bL/n9mBNeIXoTUoYRlK4dHuNJVofX9oWqBtPnSzI=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
 github.com/onsi/ginkgo v1.6.0 h1:Ix8l273rp3QzYgXSR+c8d1fTG7UPgYkOSELPhiY/YGw=


### PR DESCRIPTION
This updates the wallet `rpc/jsonrpc/types` module dependency requirement to the latest version which includes new privacy-related RPCs.

NOTE: This is currently pointing to a fork and will need to updated to point to a tagged version of the module, once it is available, prior to be being merged.