### PR TITLE
peer: Ensure listener tests sync with messages.

### DIFF
--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -426,9 +426,16 @@ func TestPeerListeners(t *testing.T) {
 		select {
 		case <-verack:
 		case <-time.After(time.Second * 1):
-			t.Errorf("TestPeerListeners: verack timeout\n")
+			t.Error("TestPeerListeners: verack timeout\n")
 			return
 		}
+	}
+
+	select {
+	case <-ok:
+	case <-time.After(time.Second * 1):
+		t.Error("TestPeerListeners: version timeout")
+		return
 	}
 
 	tests := []struct {


### PR DESCRIPTION
This adds an additional read from the `ok` channel in the peer listener tests to ensure the version message is consumed as well as the `verack` so that the remaining tests line up with the messages that are being tested.