### PR TITLE
multi: use chain ref. from blockmanager config.

### DIFF
--- a/mining.go
+++ b/mining.go
@@ -663,7 +663,7 @@ func medianAdjustedTime(best *blockchain.BestState, timeSource blockchain.Median
 func maybeInsertStakeTx(bm *blockManager, stx *dcrutil.Tx, treeValid bool) bool {
 	missingInput := false
 
-	view, err := bm.chain.FetchUtxoView(stx, treeValid)
+	view, err := bm.cfg.Chain.FetchUtxoView(stx, treeValid)
 	if err != nil {
 		minrLog.Warnf("Unable to fetch transaction store for "+
 			"stx %s: %v", stx.Hash(), err)
@@ -761,7 +761,7 @@ func handleTooFewVoters(subsidyCache *standalone.SubsidyCache, nextHeight int64,
 	// Check to see if we've fallen off the chain, for example if a
 	// reorganization had recently occurred. If this is the case,
 	// nuke the templates.
-	best := bm.chain.BestSnapshot()
+	best := bm.cfg.Chain.BestSnapshot()
 	if curTemplate != nil {
 		if !best.PrevHash.IsEqual(
 			&curTemplate.Block.Header.PrevBlock) {
@@ -816,7 +816,7 @@ func handleTooFewVoters(subsidyCache *standalone.SubsidyCache, nextHeight int64,
 
 				// Make sure the block validates.
 				block := dcrutil.NewBlockDeepCopyCoinbase(cptCopy.Block)
-				err = bm.chain.CheckConnectBlockTemplate(block)
+				err = bm.cfg.Chain.CheckConnectBlockTemplate(block)
 				if err != nil {
 					minrLog.Errorf("failed to check template while "+
 						"duplicating a parent: %v", err.Error())
@@ -835,7 +835,7 @@ func handleTooFewVoters(subsidyCache *standalone.SubsidyCache, nextHeight int64,
 			// and the contents of that stake tree. In the future
 			// we should have the option of reading some
 			// transactions from this block, too.
-			topBlock, err := bm.chain.BlockByHash(&best.Hash)
+			topBlock, err := bm.cfg.Chain.BlockByHash(&best.Hash)
 			if err != nil {
 				str := fmt.Sprintf("unable to get tip block %s",
 					best.PrevHash)
@@ -908,7 +908,7 @@ func handleTooFewVoters(subsidyCache *standalone.SubsidyCache, nextHeight int64,
 
 			// Make sure the block validates.
 			btBlock := dcrutil.NewBlockDeepCopyCoinbase(btMsgBlock)
-			err = bm.chain.CheckConnectBlockTemplate(btBlock)
+			err = bm.cfg.Chain.CheckConnectBlockTemplate(btBlock)
 			if err != nil {
 				str := fmt.Sprintf("failed to check template: %v while "+
 					"constructing a new parent", err.Error())


### PR DESCRIPTION
This removes the chain field from the block manager in favour of using the chain field in block manager config.