### PR TITLE
mining: Remove unused extra nonce update code.

### DIFF
--- a/mining.go
+++ b/mining.go
@@ -479,33 +479,6 @@ func extractCoinbaseExtraNonce(msgBlock *wire.MsgBlock) uint64 {
 	return extractCoinbaseTxExtraNonce(msgBlock.Transactions[0])
 }
 
-// UpdateExtraNonce updates the extra nonce in the coinbase script of the passed
-// block by regenerating the coinbase script with the passed value and block
-// height.  It also recalculates and updates the new merkle root that results
-// from changing the coinbase script.
-func UpdateExtraNonce(msgBlock *wire.MsgBlock, blockHeight int64, extraNonce uint64) error {
-	// First block has no extranonce.
-	if blockHeight == 1 {
-		return nil
-	}
-
-	coinbaseOpReturn, err := standardCoinbaseOpReturn(uint32(blockHeight),
-		extraNonce)
-	if err != nil {
-		return err
-	}
-	msgBlock.Transactions[0].TxOut[1].PkScript = coinbaseOpReturn
-
-	// TODO(davec): A dcrutil.Block should use saved in the state to avoid
-	// recalculating all of the other transaction hashes.
-	// block.Transactions[0].InvalidateCache()
-
-	// Recalculate the merkle root with the updated extra nonce.
-	block := dcrutil.NewBlockDeepCopyCoinbase(msgBlock)
-	msgBlock.Header.MerkleRoot = calcTxTreeMerkleRoot(block.Transactions())
-	return nil
-}
-
 // createCoinbaseTx returns a coinbase transaction paying an appropriate subsidy
 // based on the passed block height to the provided address.  When the address
 // is nil, the coinbase transaction will instead be redeemable by anyone.

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3227,20 +3227,6 @@ func handleGetWorkRequest(s *rpcServer) (interface{}, error) {
 				"Failed to update block time")
 		}
 
-		if templateCopy.Height > 1 {
-			// Increment the extra nonce and update the block template
-			// with the new value by regenerating the coinbase script and
-			// setting the merkle root to the new value.
-			en := extractCoinbaseExtraNonce(msgBlock) + 1
-			state.extraNonce++
-			err := UpdateExtraNonce(msgBlock, best.Height+1, en)
-			if err != nil {
-				errStr := fmt.Sprintf("Failed to update extra nonce: "+
-					"%v", err)
-				return nil, rpcInternalError(errStr, "")
-			}
-		}
-
 		rpcsLog.Debugf("Updated block template (timestamp %v, extra "+
 			"nonce %d, target %064x, merkle root %s)",
 			msgBlock.Header.Timestamp,


### PR DESCRIPTION
This removes the `UpdateExtraNonce` function which updated an extra nonce in the coinbase transaction and recalculated the merkle root since it is not necessary and wasteful for Decred due to the extra nonce being available the block header.

Further, due to the aforementioned and the fact the template doesn't have a height set, it isn't currently actually being called anyway as can be seen by diffing the decoded output of subsequent `getwork` calls and noting the only thing that is being updated in between full regeneration of new templates is the timestamp as expected.

```diff
$ diff -uNp work1.txt work2.txt
--- work1.txt   2019-09-07 08:18:58.410917100 -0500
+++ work2.txt   2019-09-07 08:19:01.216456300 -0500
@@ -16,7 +16,7 @@
     "sbits": 0.00021026,
     "height": 98,
     "size": 7221,
-    "time": 1567862338,
+    "time": 1567862341,
     "nonce": 0,
     "extradata": "0000000000000000000000000000000000000000000000000000000000000000",
     "stakeversion": 0,
```