### PR TITLE
mempool: Add ErrorCode to returned TxRuleErrors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/decred/dcrd/gcs/v2 v2.0.0
 	github.com/decred/dcrd/hdkeychain/v2 v2.0.1
 	github.com/decred/dcrd/lru v1.0.0
-	github.com/decred/dcrd/mempool/v3 v3.0.0
+	github.com/decred/dcrd/mempool/v3 v3.1.0
 	github.com/decred/dcrd/mining/v2 v2.0.0
 	github.com/decred/dcrd/peer/v2 v2.0.0
 	github.com/decred/dcrd/rpc/jsonrpc/types/v2 v2.0.0

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4111,9 +4111,9 @@ func handleSendRawTransaction(s *rpcServer, cmd interface{}, closeChan <-chan st
 			err = fmt.Errorf("rejected transaction %v: %v", tx.Hash(),
 				err)
 			rpcsLog.Debugf("%v", err)
-			txRuleErr, ok := rErr.Err.(mempool.TxRuleError)
-			if ok && txRuleErr.RejectCode == wire.RejectDuplicate {
-				// return a duplicate tx error
+			if mempool.IsErrorCode(rErr, mempool.ErrDuplicate) {
+				// This is an actual exact duplicate tx, so
+				// return the specific duplicate tx error.
 				return nil, rpcDuplicateTxError("%v", err)
 			}
 


### PR DESCRIPTION
This adds the ErrorCode member to TxRuleError, filling it with
appropriate values throughout the mempool package. This allows clients
of the package to correctly identify error causes with a greater
granularity and respond appropriately.

It also deprecates the RejectCode attribute and ErrToRejectError
functions, to be removed in the next major version update of the
package.

All call sites that inspect mempool errors were updated to use the new
error codes instead of using RejectionCodes. Additional mempool tests
were added to ensure the correct behavior on some relevant cases.

Finally, given the introduction and use of a new public field, the main
module was updated to use an as-of-yet unfinished mempool v3.1.0, which
will include the required functionality.

Close #1900