### PR TITLE
chaincfg: Introduce agenda for header cmtmts vote.

### DIFF
--- a/blockchain/fullblocktests/params.go
+++ b/blockchain/fullblocktests/params.go
@@ -255,6 +255,34 @@ var regNetParams = &chaincfg.Params{
 			StartTime:  0,             // Always available for vote
 			ExpireTime: math.MaxInt64, // Never expires
 		}},
+		8: {{
+			Vote: chaincfg.Vote{
+				Id:          chaincfg.VoteIDHeaderCommitments,
+				Description: "Enable header commitments as defined in DCP0005",
+				Mask:        0x0006, // Bits 1 and 2
+				Choices: []chaincfg.Choice{{
+					Id:          "abstain",
+					Description: "abstain voting for change",
+					Bits:        0x0000,
+					IsAbstain:   true,
+					IsNo:        false,
+				}, {
+					Id:          "no",
+					Description: "keep the existing consensus rules",
+					Bits:        0x0002, // Bit 1
+					IsAbstain:   false,
+					IsNo:        true,
+				}, {
+					Id:          "yes",
+					Description: "change to the new consensus rules",
+					Bits:        0x0004, // Bit 2
+					IsAbstain:   false,
+					IsNo:        false,
+				}},
+			},
+			StartTime:  0,             // Always available for vote
+			ExpireTime: math.MaxInt64, // Never expires
+		}},
 	},
 
 	// Enforce current block version once majority of the network has

--- a/chaincfg/mainnetparams.go
+++ b/chaincfg/mainnetparams.go
@@ -250,6 +250,34 @@ func MainNetParams() *Params {
 				StartTime:  1548633600, // Jan 28th, 2019
 				ExpireTime: 1580169600, // Jan 28th, 2020
 			}},
+			7: {{
+				Vote: Vote{
+					Id:          VoteIDHeaderCommitments,
+					Description: "Enable header commitments as defined in DCP0005",
+					Mask:        0x0006, // Bits 1 and 2
+					Choices: []Choice{{
+						Id:          "abstain",
+						Description: "abstain voting for change",
+						Bits:        0x0000,
+						IsAbstain:   true,
+						IsNo:        false,
+					}, {
+						Id:          "no",
+						Description: "keep the existing consensus rules",
+						Bits:        0x0002, // Bit 1
+						IsAbstain:   false,
+						IsNo:        true,
+					}, {
+						Id:          "yes",
+						Description: "change to the new consensus rules",
+						Bits:        0x0004, // Bit 2
+						IsAbstain:   false,
+						IsNo:        false,
+					}},
+				},
+				StartTime:  1567641600, // Sep 5th, 2019
+				ExpireTime: 1599264000, // Sep 5th, 2020
+			}},
 		},
 
 		// Enforce current block version once majority of the network has

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -135,6 +135,11 @@ const (
 	// sequence lock functionality needed for Lightning Network (among other
 	// uses) defined by DCP0004.
 	VoteIDFixLNSeqLocks = "fixlnseqlocks"
+
+	// VoteIDHeaderCommitments is the vote ID for the agenda that repurposes
+	// the stake root header field to support header commitments and provides
+	// an initial commitment to version 2 GCS filters defined by DCP0005.
+	VoteIDHeaderCommitments = "headercommitments"
 )
 
 // ConsensusDeployment defines details related to a specific consensus rule

--- a/chaincfg/regnetparams.go
+++ b/chaincfg/regnetparams.go
@@ -233,6 +233,34 @@ func RegNetParams() *Params {
 				StartTime:  0,             // Always available for vote
 				ExpireTime: math.MaxInt64, // Never expires
 			}},
+			8: {{
+				Vote: Vote{
+					Id:          VoteIDHeaderCommitments,
+					Description: "Enable header commitments as defined in DCP0005",
+					Mask:        0x0006, // Bits 1 and 2
+					Choices: []Choice{{
+						Id:          "abstain",
+						Description: "abstain voting for change",
+						Bits:        0x0000,
+						IsAbstain:   true,
+						IsNo:        false,
+					}, {
+						Id:          "no",
+						Description: "keep the existing consensus rules",
+						Bits:        0x0002, // Bit 1
+						IsAbstain:   false,
+						IsNo:        true,
+					}, {
+						Id:          "yes",
+						Description: "change to the new consensus rules",
+						Bits:        0x0004, // Bit 2
+						IsAbstain:   false,
+						IsNo:        false,
+					}},
+				},
+				StartTime:  0,             // Always available for vote
+				ExpireTime: math.MaxInt64, // Never expires
+			}},
 		},
 
 		// Enforce current block version once majority of the network has

--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -146,6 +146,34 @@ func TestNet3Params() *Params {
 				StartTime:  1548633600, // Jan 28th, 2019
 				ExpireTime: 1580169600, // Jan 28th, 2020
 			}},
+			8: {{
+				Vote: Vote{
+					Id:          VoteIDHeaderCommitments,
+					Description: "Enable header commitments as defined in DCP0005",
+					Mask:        0x0006, // Bits 1 and 2
+					Choices: []Choice{{
+						Id:          "abstain",
+						Description: "abstain voting for change",
+						Bits:        0x0000,
+						IsAbstain:   true,
+						IsNo:        false,
+					}, {
+						Id:          "no",
+						Description: "keep the existing consensus rules",
+						Bits:        0x0002, // Bit 1
+						IsAbstain:   false,
+						IsNo:        true,
+					}, {
+						Id:          "yes",
+						Description: "change to the new consensus rules",
+						Bits:        0x0004, // Bit 2
+						IsAbstain:   false,
+						IsNo:        false,
+					}},
+				},
+				StartTime:  1567641600, // Sep 5th, 2019
+				ExpireTime: 1599264000, // Sep 5th, 2020
+			}},
 		},
 
 		// Enforce current block version once majority of the network has

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/decred/dcrd/blockchain/v2 v2.0.2
 	github.com/decred/dcrd/certgen v1.1.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
-	github.com/decred/dcrd/chaincfg/v2 v2.2.0
+	github.com/decred/dcrd/chaincfg/v2 v2.3.0
 	github.com/decred/dcrd/connmgr/v2 v2.0.0
 	github.com/decred/dcrd/crypto/ripemd160 v1.0.0
 	github.com/decred/dcrd/database/v2 v2.0.0


### PR DESCRIPTION
This adds a new definition for the upcoming agenda vote to enable header commitments a provide an initial commitment to a version 2 GCS filter as defined by DCP0005.  It does not include any code to make decisions or bump the versions.  It is only the definition.

Also, bump the `chaincfg` module to v2.3.0 so the new definitions are available to consumers.