### PR TITLE
gcs: Prevent empty data elements in v2 filters.

### DIFF
--- a/gcs/gcs.go
+++ b/gcs/gcs.go
@@ -122,6 +122,9 @@ func newFilter(version uint16, B uint8, M uint64, key [KeySize]byte, data [][]by
 	case version > 1:
 		seen := make(map[uint64]struct{}, numEntries*2)
 		for _, d := range data {
+			if len(d) == 0 {
+				continue
+			}
 			v := siphash.Hash(k0, k1, d)
 			if _, ok := seen[v]; ok {
 				continue


### PR DESCRIPTION
This ensures any empty/nil data elements in the input array to version 2 filter construction are not added to the filter since empty elements do not make sense given how the filters are used.  It also updates the tests to ensure proper behavior.

The single match function already failed attempts to match an empty element as intended, however, prior to this change, it was possible to match an empty item in the multi-item matching path.  This is not desirable since the matching behavior must be consistent in both the single and multi-match cases.