### PR TITLE
rpcserver/mining: Use bg tpl generator for getwork.

### DIFF
--- a/server.go
+++ b/server.go
@@ -2767,7 +2767,7 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 		TimeSource:         s.timeSource,
 		FeeEstimator:       s.feeEstimator,
 		TxMemPool:          s.txMemPool,
-		BgBlkTmplGenerator: s.bg,
+		BgBlkTmplGenerator: nil, // Created later.
 		NotifyWinningTickets: func(wtnd *WinningTicketsNtfnData) {
 			if s.rpcServer != nil {
 				s.rpcServer.ntfnMgr.NotifyWinningTickets(wtnd)
@@ -2800,6 +2800,7 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 	// mining address.
 	if len(cfg.miningAddrs) > 0 {
 		s.bg = newBgBlkTmplGenerator(tg, cfg.miningAddrs, cfg.SimNet)
+		s.blockManager.cfg.BgBlkTmplGenerator = s.bg
 	}
 
 	s.cpuMiner = newCPUMiner(&cpuminerConfig{


### PR DESCRIPTION
This updates the `getwork` RPC to make use of the background template generator infrastructure and removes code that is no longer needed as a result.

This has a lot of benefits, many of which were discussed more in depth in the previous commit that overhauled the background template generator, however  the following is a non-exhaustive overview that highlights the major benefits of the change:

- Requests for updated templates during the normal mining process in between tip changes will now be nearly instant instead of potentially taking several seconds to build the new template on the spot
- When the chain tip changes, requesting a template will now attempt to wait until either all votes have been received or a timeout occurs prior to handing out a template which is beneficial for PoW miners, PoS miners, and the network as a whole
- PoW miners are much less likely to end up with template with less than the max number of votes which means they are less likely to receive a reduced subsidy
- PoW miners will be much less likely to receive stale templates during chain tip changes due to vote propagation
- PoS stakers whose votes end up arriving to the miner slightly slower than the minimum number required are much less likely to have their votes excluded despite having voted simply due to propagation delay

The following is a high level overview of the changes:

- Move the template pool to the work state struct
- Remove fields from work state struct that dealt with determining when to update the template
- Introduce a new function named `getWorkTemplateKey` to construct a unique template key for storing and retrieving delivered block templates
- Make `pruneOldBlockTemplates` a method of the work state and clean it up
- Completely rework `handleGetWorkRequest` to use the background template generator infrastructure
  - Wait for a new template to be generated with a timeout when the best chain tip to bias towards giving out templates with max possible votes
  - Ensure the timestamp is updated with each invocation
  - Shallow copy the header (versus deep copying the entire template as before) to avoid mutations to the shared templates
- Rework `handleGetWorkSubmission`
  - Improve logging
  - Use new template key to lookup the template used to reconstruct the block
  - Shallow copy the block from the template before updating it with the solved versus the more expensive method used before
- Remove no longer used funcs and methods:
  - `extractCoinbaseExtraNonce`
  - `extractCoinbaseTxExtraNonce`
  - `deepCopyBlockTemplate`