### PR TITLE
multi: Add tpl update reason to work ntfns.

### DIFF
--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -3022,14 +3022,19 @@ The recvtx notification for the same txout, after the transaction was mined into
 |
 # <code>Data</code>: <code>(string)</code> hex-encoded block data.
 # <code>Target</code>: <code>(string)</code> the hex-encoded little-endian hash target.
+# <code>Reason</code>: <code>(string)</code> the reason the new block template was generated.
 |-
 !Description
 |Notifies a client when a new block template has been generated.
+: The possible reasons are:
+: <code>newparent</code> - The template builds on a new block as compared to the previous one.
+: <code>newvotes</code> - A new vote for the block the template builds on has been received.
+: <code>newtxns</code> - New non-vote transactions are available and have potentially been included.
 |-
 !Example
 |Example work notification  on testnet:
 
-: <code>{"jsonrpc":"1.0","method":"work","params":["06000000c9ee7cd5b14b72e41195891a9617f80049eaac06a0dfe063479523060000000088087dbb59923da4faf632a29777805a7632efbd680b86f3c6cbbe3fddf905d45045d61784ad0810749cc045d03a7b9d5e8f6b2ed3ed767c9827f1dad4925771010082ebc7097cf5050007003b1400003b84061cff2d333700000000322400003f10000070b67b5b3bc400803b057900c5575400000000000000000000000000000000000000000000000000060000008000000100000000000005a0","000000000000000000000000000000000000000000000000003b840600000000"],"id":null}</code>
+: <code>{"jsonrpc":"1.0","method":"work","params":["06000000c9ee7cd5b14b72e41195891a9617f80049eaac06a0dfe063479523060000000088087dbb59923da4faf632a29777805a7632efbd680b86f3c6cbbe3fddf905d45045d61784ad0810749cc045d03a7b9d5e8f6b2ed3ed767c9827f1dad4925771010082ebc7097cf5050007003b1400003b84061cff2d333700000000322400003f10000070b67b5b3bc400803b057900c5575400000000000000000000000000000000000000000000000000060000008000000100000000000005a0","000000000000000000000000000000000000000000000000003b840600000000","newparent"],"id":null}</code>
 |}
 
 ----

--- a/rpc/jsonrpc/types/chainsvrwsntfns.go
+++ b/rpc/jsonrpc/types/chainsvrwsntfns.go
@@ -109,6 +109,7 @@ func NewNewTicketsNtfn(hash string, height int32, stakeDiff int64, tickets []str
 type WorkNtfn struct {
 	Data   string `json:"data"`
 	Target string `json:"target"`
+	Reason string `json:"reason"`
 }
 
 // NewWorkNtfn returns a new instance which can be used to issue a

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3222,12 +3222,15 @@ func handleGetWorkRequest(s *rpcServer) (interface{}, error) {
 		// in case the new tip never gets enough votes and no other events
 		// that trigger a new template have happened.
 		templateSub := s.server.bg.Subscribe()
-		template = <-templateSub.C()
+		templateNtfn := <-templateSub.C()
+		template = templateNtfn.Template
 		templateKey := getWorkTemplateKey(&template.Block.Header)
 		if _, ok := state.templatePool[templateKey]; ok {
 			const maxTemplateTimeoutDuration = time.Millisecond * 5500
 			select {
-			case template = <-templateSub.C():
+			case templateNtfn = <-templateSub.C():
+				template = templateNtfn.Template
+
 			case <-time.After(maxTemplateTimeoutDuration):
 				template = nil
 			}


### PR DESCRIPTION
This updates the new RPC websocket `work` notification that is sent when a new template is generated and a websocket client requests updated via `notifywork` to include the reason the template was generated.

The text-based reasons delivered via the `work` notification are:
* `newparent` -- The template builds on a new block as compared to the previous one.
* `newvotes` -- A new vote for the block the template builds on has been received.
* `newtxns` -- New non-vote transactions are available and have potentially been included.

This allows pools that subscribe for work notifications to better choose when to signal workers to throw away all current work and start working on a new template immediately.  In particular, the `newparent` and `newvotes` reasons should trigger workers to immediately switch.  On the other hand new work as the result of `newtxns` is something that pools will likely want to allow workers to opportunistically switch to after completing a a work cycle.

**It is also important to note that miners should roll time timestamps as they work on templates in between updates to keep the timestamps as close to accurate as possible.**

This consists of two commits to make the review easier.

The first commit exports the template update reason type and associated constants in preparation to modify the template notifications to include the reason a new block template was generated.

The second commit modifies the background template generator subscription notifications, the RPC websockets notification manager, and the JSON-RPC work notification to include the reason and updates all of the intermediate plumbing code accordingly.

It also updates the JSON-RPC documentation to include the new field and enumerate the supported reasons.