### PR TITLE
dcrjson: Prepare v3.0.1.

### DIFF
--- a/dcrjson/go.mod
+++ b/dcrjson/go.mod
@@ -2,4 +2,4 @@ module github.com/decred/dcrd/dcrjson/v3
 
 go 1.11
 
-require github.com/decred/dcrd/chaincfg/chainhash v1.0.1
+require github.com/decred/dcrd/chaincfg/chainhash v1.0.2

--- a/dcrjson/go.sum
+++ b/dcrjson/go.sum
@@ -1,4 +1,4 @@
-github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
-github.com/dchest/blake256 v1.0.0/go.mod h1:xXNWCE1jsAP8DAjP+rKw2MbeqLczjI3TRx2VK+9OEYY=
-github.com/decred/dcrd/chaincfg/chainhash v1.0.1 h1:0vG7U9+dSjSCaHQKdoSKURK2pOb47+b+8FK5q4+Je7M=
-github.com/decred/dcrd/chaincfg/chainhash v1.0.1/go.mod h1:OVfvaOsNLS/A1y4Eod0Ip/Lf8qga7VXCQjUQLbkY0Go=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.2 h1:rt5Vlq/jM3ZawwiacWjPa+smINyLRN07EO0cNBV6DGU=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.2/go.mod h1:BpbrGgrPTr3YJYRN3Bm+D9NuaFd+zGyNeIKgrhCXK60=
+github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
+github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=


### PR DESCRIPTION
This updates the `dcrjson` module dependencies and serves as a base for `dcrjson/v3.0.1`.

The updated direct dependencies in this commit are as follows:

- github.com/decred/dcrd/chaincfg/chainhash@v1.0.2

The full list of updated direct dependencies since the previous `dcrjson/v3.0.0` release are as follows:

- github.com/decred/dcrd/chaincfg/chainhash@v1.0.2