### PR TITLE
gcs: Prevent empty data elements fp matches.

### DIFF
--- a/gcs/gcs.go
+++ b/gcs/gcs.go
@@ -321,9 +321,15 @@ func (f *filter) MatchAny(key [KeySize]byte, data [][]byte) bool {
 	k0 := binary.LittleEndian.Uint64(key[0:8])
 	k1 := binary.LittleEndian.Uint64(key[8:16])
 	for _, d := range data {
+		if len(d) == 0 {
+			continue
+		}
 		v := siphash.Hash(k0, k1, d)
 		v = reduceFn(v, f.modulusNM)
 		*values = append(*values, v)
+	}
+	if len(*values) == 0 {
+		return false
 	}
 	sort.Sort((*uint64s)(values))
 


### PR DESCRIPTION
This prunes any empty/nil data elements from the input array to `MatchAny` to prevent potential false positive matches of empty data.

The matching code is not used in consensus, so it is safe to modify without a vote and for all filter versions.

The single match function already failed attempts to match an empty element as intended, however, prior to this change, it was possible to match an empty item in the multi-item matching path due to a false positive.  This is not desirable since the matching behavior must be consistent in both the single and multi-match cases.