### PR TITLE
release: Bump for 1.6 release cycle.

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -27,7 +27,7 @@ const (
 // versioning 2.0.0 spec (https://semver.org/).
 const (
 	Major uint = 1
-	Minor uint = 5
+	Minor uint = 6
 	Patch uint = 0
 )
 


### PR DESCRIPTION
**This requires #1946.**