### PR TITLE
mempool: Start v4 module dev cycle.

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -22,7 +22,7 @@ import (
 	"github.com/decred/dcrd/database/v2"
 	"github.com/decred/dcrd/dcrutil/v3"
 	"github.com/decred/dcrd/fees/v2"
-	"github.com/decred/dcrd/mempool/v3"
+	"github.com/decred/dcrd/mempool/v4"
 	peerpkg "github.com/decred/dcrd/peer/v2"
 	"github.com/decred/dcrd/wire"
 )

--- a/config.go
+++ b/config.go
@@ -26,7 +26,7 @@ import (
 	_ "github.com/decred/dcrd/database/v2/ffldb"
 	"github.com/decred/dcrd/dcrutil/v3"
 	"github.com/decred/dcrd/internal/version"
-	"github.com/decred/dcrd/mempool/v3"
+	"github.com/decred/dcrd/mempool/v4"
 	"github.com/decred/dcrd/rpc/jsonrpc/types/v2"
 	"github.com/decred/dcrd/sampleconfig"
 	"github.com/decred/go-socks/socks"

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/decred/dcrd/gcs/v2 v2.0.1
 	github.com/decred/dcrd/hdkeychain/v2 v2.1.0
 	github.com/decred/dcrd/lru v1.0.0
-	github.com/decred/dcrd/mempool/v3 v3.1.0
+	github.com/decred/dcrd/mempool/v4 v4.0.0-00010101000000-000000000000
 	github.com/decred/dcrd/mining/v3 v3.0.0-00010101000000-000000000000
 	github.com/decred/dcrd/peer/v2 v2.1.0
 	github.com/decred/dcrd/rpc/jsonrpc/types/v2 v2.0.0
@@ -62,7 +62,7 @@ replace (
 	github.com/decred/dcrd/hdkeychain/v2 => ./hdkeychain
 	github.com/decred/dcrd/limits => ./limits
 	github.com/decred/dcrd/lru => ./lru
-	github.com/decred/dcrd/mempool/v3 => ./mempool
+	github.com/decred/dcrd/mempool/v4 => ./mempool
 	github.com/decred/dcrd/mining/v3 => ./mining
 	github.com/decred/dcrd/peer/v2 => ./peer
 	github.com/decred/dcrd/rpc/jsonrpc/types/v2 => ./rpc/jsonrpc/types

--- a/log.go
+++ b/log.go
@@ -18,7 +18,7 @@ import (
 	"github.com/decred/dcrd/database/v2"
 	"github.com/decred/dcrd/fees/v2"
 	"github.com/decred/dcrd/internal/rpcserver"
-	"github.com/decred/dcrd/mempool/v3"
+	"github.com/decred/dcrd/mempool/v4"
 	"github.com/decred/dcrd/peer/v2"
 	"github.com/decred/dcrd/txscript/v3"
 	"github.com/decred/slog"

--- a/mempool/go.mod
+++ b/mempool/go.mod
@@ -1,4 +1,4 @@
-module github.com/decred/dcrd/mempool/v3
+module github.com/decred/dcrd/mempool/v4
 
 go 1.11
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -49,7 +49,7 @@ import (
 	"github.com/decred/dcrd/fees/v2"
 	"github.com/decred/dcrd/internal/rpcserver"
 	"github.com/decred/dcrd/internal/version"
-	"github.com/decred/dcrd/mempool/v3"
+	"github.com/decred/dcrd/mempool/v4"
 	"github.com/decred/dcrd/rpc/jsonrpc/types/v2"
 	"github.com/decred/dcrd/txscript/v3"
 	"github.com/decred/dcrd/wire"

--- a/server.go
+++ b/server.go
@@ -37,7 +37,7 @@ import (
 	"github.com/decred/dcrd/gcs/v2/blockcf"
 	"github.com/decred/dcrd/internal/version"
 	"github.com/decred/dcrd/lru"
-	"github.com/decred/dcrd/mempool/v3"
+	"github.com/decred/dcrd/mempool/v4"
 	"github.com/decred/dcrd/mining/v3"
 	"github.com/decred/dcrd/peer/v2"
 	"github.com/decred/dcrd/txscript/v3"


### PR DESCRIPTION
Several upcoming changes constitute breaking public API changes to the `mempool` module, therefore, this follows the process for introducing major API breaks which consists of:

- Bump the major version in the go.mod of the affected module if not already done since the last release tag
- Add a replacement to the go.mod in the main module if not already done since the last release tag
- Update all imports in the repo to use the new major version as necessary
- Make necessary modifications to allow all other modules to use the new version in the same commit
  - Repeat the process for any other modules the require a new major as a result of consuming the new major(s)