### PR TITLE
indexers: Use spend journal for index catchup.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -2039,6 +2039,24 @@ func (q *chainQueryerAdapter) BestHeight() int64 {
 	return q.BestSnapshot().Height
 }
 
+// PrevScripts returns a source of previous transaction scripts and their
+// associated versions spent by the given block by using the spend journal.
+//
+// It is defined via a separate internal struct to avoid polluting the public
+// API of the BlockChain type itself.
+//
+// This is part of the indexers.ChainQueryer interface.
+func (q *chainQueryerAdapter) PrevScripts(dbTx database.Tx, block *dcrutil.Block) (indexers.PrevScripter, error) {
+	// Load all of the spent transaction output data from the database.
+	stxos, err := dbFetchSpendJournalEntry(dbTx, block)
+	if err != nil {
+		return nil, err
+	}
+
+	prevScripts := stxosToScriptSource(block, stxos, currentCompressionVersion)
+	return prevScripts, nil
+}
+
 // Config is a descriptor which specifies the blockchain instance configuration.
 type Config struct {
 	// DB defines the database which houses the blocks and will be used to

--- a/blockchain/indexers/common.go
+++ b/blockchain/indexers/common.go
@@ -89,6 +89,10 @@ type ChainQueryer interface {
 	// BlockHashByHeight returns the hash of the block at the given height in
 	// the main chain.
 	BlockHashByHeight(int64) (*chainhash.Hash, error)
+
+	// PrevScripts returns a source of previous transaction scripts and their
+	// associated versions spent by the given block.
+	PrevScripts(database.Tx, *dcrutil.Block) (PrevScripter, error)
 }
 
 // IndexManager provides a generic interface that is called when blocks are


### PR DESCRIPTION
**This requires #1968**.

When an index is enabled for the first time (or after having previously been disabled and re-enabled), the index needs to be updated to account for the current state of the main chain.

This poses a problem for indexes that require access to the previous scripts, such as the address index,  since the outputs are no longer in the utxo set due to pruning.  Currently, in order to handle this, the code has to load all of the referenced transactions in order to get access to the output scripts which is extremely inefficient.  The address index is already notoriously time consuming to generate due to the sheer amount of information, but it is only exacerbated by this inefficiency.

However, the necessary information exists in a much more efficient form in the spend journal and the recently introduced interfaces which decouple the script lookup from the concrete type provide a path to significantly optimize the index catch up process.

Consequently, this modifies the `indexer.ChainQueryer` interface to provide access to a source of previous transaction scripts and their associated versions spent by the given block, updates the index initialization to make use of it, and updates the blockchain implementation of the interface to provide the required information via the spend journal.

As an example of the speedup obtained by this, the following shows how long it took to catch up the address index from block 0 to block 391500 on a 7200 RPM HDD:

```
before: 55 minutes, 25 seconds
 after: 34 minutes, 4 seconds
```
That amounts to about a 38.5% reduction.  It is also worth noting that the speedup is not linear, so as the number of transactions continues to the grow, the speedup will be increasingly more significant.