### PR TITLE
rpcserver: Bump to 6.1.1.

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -58,10 +58,10 @@ import (
 
 // API version constants
 const (
-	jsonrpcSemverString = "6.1.0"
+	jsonrpcSemverString = "6.1.1"
 	jsonrpcSemverMajor  = 6
 	jsonrpcSemverMinor  = 1
-	jsonrpcSemverPatch  = 0
+	jsonrpcSemverPatch  = 1
 )
 
 const (


### PR DESCRIPTION
This bumps the `rpcserver` version patch to correspond with the recent change to correct the `getvoteinfo` error response when provided a version that does not exist.

Ref #1953.
