### PR TITLE
rpcserver: Warn on alt DNS names when certs exist.

### DIFF
--- a/config.go
+++ b/config.go
@@ -170,7 +170,7 @@ type config struct {
 	PipeRx               uint          `long:"piperx" description:"File descriptor of read end pipe to enable parent -> child process communication"`
 	PipeTx               uint          `long:"pipetx" description:"File descriptor of write end pipe to enable parent <- child process communication"`
 	LifetimeEvents       bool          `long:"lifetimeevents" description:"Send lifetime notifications over the TX pipe"`
-	AltDNSNames          []string      `long:"altdnsnames" description:"Specify additional dns names to use when generating the rpc server certificate" env:"DCRD_ALT_DNSNAMES" env-delim:","`
+	AltDNSNames          []string      `long:"altdnsnames" description:"Specify additional DNS names to use when generating the RPC server certificate" env:"DCRD_ALT_DNSNAMES" env-delim:","`
 	onionlookup          func(string) ([]net.IP, error)
 	lookup               func(string) ([]net.IP, error)
 	oniondial            func(string, string) (net.Conn, error)

--- a/server.go
+++ b/server.go
@@ -2664,9 +2664,17 @@ func setupRPCListeners() ([]net.Listener, error) {
 	// Setup TLS if not disabled.
 	listenFunc := net.Listen
 	if !cfg.DisableRPC && !cfg.DisableTLS {
-		// Generate the TLS cert and key file if both don't already
-		// exist.
-		if !fileExists(cfg.RPCKey) && !fileExists(cfg.RPCCert) {
+		// Generate the TLS cert and key file if both don't already exist.
+		keyFileExists := fileExists(cfg.RPCKey)
+		certFileExists := fileExists(cfg.RPCCert)
+		if len(cfg.AltDNSNames) != 0 && (keyFileExists || certFileExists) {
+			rpcsLog.Warn("Additional DNS names specified when TLS " +
+				"certificates already exist will NOT be included:")
+			rpcsLog.Warnf("- In order to create TLS certs that include the "+
+				"additional DNS names, delete %q and %q and restart the server",
+				cfg.RPCKey, cfg.RPCCert)
+		}
+		if !keyFileExists && !certFileExists {
 			err := genCertPair(cfg.RPCCert, cfg.RPCKey, cfg.AltDNSNames)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
This adds a warning when alternative DNS names are specified and the TLS certificate key or cert already exist to make it clear the additional names will NOT be included unless the certificate and key are deleted first.

Closes #1912.