### PR TITLE
rpcserver: Move error check for generate RPC.

### DIFF
--- a/cpuminer.go
+++ b/cpuminer.go
@@ -606,13 +606,6 @@ func (m *CPUMiner) NumWorkers() int32 {
 // generating a new block template.  When a block is solved, it is submitted.
 // The function returns a list of the hashes of generated blocks.
 func (m *CPUMiner) GenerateNBlocks(n uint32) ([]*chainhash.Hash, error) {
-	// Respond with an error if there's virtually 0 chance of CPU-mining a block.
-	if !m.cfg.ChainParams.GenerateSupported {
-		return nil, errors.New("no support for `generate` on the current " +
-			"network, " + m.cfg.ChainParams.Net.String() +
-			", as it's unlikely to be possible to CPU-mine a block.")
-	}
-
 	// Respond with an error if server is already mining.
 	m.Lock()
 	if m.started || m.discreteMining {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1625,6 +1625,17 @@ func handleGenerate(_ context.Context, s *rpcServer, cmd interface{}) (interface
 			"via --miningaddr", "Configuration")
 	}
 
+	// Respond with an error if there's virtually 0 chance of CPU-mining a block.
+	params := s.cfg.ChainParams
+	if !params.GenerateSupported {
+		return nil, &dcrjson.RPCError{
+			Code: dcrjson.ErrRPCDifficulty,
+			Message: fmt.Sprintf("No support for `generate` on the current "+
+				"network, %s, as it's unlikely to be possible to main a block "+
+				"with the CPU.", params.Net),
+		}
+	}
+
 	c := cmd.(*types.GenerateCmd)
 
 	// Respond with an error if the client is requesting 0 blocks to be generated.


### PR DESCRIPTION
This moves the error check for an attempt to call the generate RPC when on a network that there is virtually no chance of mining a block with the CPU into the RPC server where it more naturally belongs.  The caller of the CPU miner should be the one to determine if it wants to allow
mining or not.  While here, use a more accurate RPC error code of `ErrDifficulty` instead of `ErrInternal`.

This change is a step towards being able to separate the CPU mining code into its own subpackage.