### PR TITLE
multi: Introduce regentemplate command

### DIFF
--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -362,6 +362,10 @@ the method name for further details such as parameter and return information.
 |Y
 |Asks the daemon to rebroadcast the winners of the voting lottery.
 |-
+|[[#regentemplate|regentemplate]]
+|Y
+|Asks the daemon to regenerate the mining block template.
+|-
 |[[#searchrawtransactions|searchrawtransactions]]
 |Y
 |Query for transactions related to a particular address. 
@@ -2147,6 +2151,24 @@ of the best block.
 |-
 !Description
 |Asks the daemon to rebroadcast the winners of the voting lottery.
+|-
+!Returns
+|Nothing
+|-
+|}
+
+----
+
+====regentemplate====
+{|
+!Method
+|regentemplate
+|-
+!Parameters
+|None
+|-
+!Description
+|Asks the daemon to regenerate the block mining template. Note that template generation is an asynchronous process and some situations (such as the node performing a reorg or waiting for remaining votes after a new block was connected to the main chain) might delay template regeneration.
 |-
 !Returns
 |Nothing

--- a/rpc/jsonrpc/types/chainsvrcmds.go
+++ b/rpc/jsonrpc/types/chainsvrcmds.go
@@ -821,6 +821,15 @@ func NewGetWorkCmd(data *string) *GetWorkCmd {
 	}
 }
 
+// RegenTemplateCmd defines the regentemplate JSON-RPC command.
+type RegenTemplateCmd struct{}
+
+// NewRegenTemplateCmd returns a new instance which can be used to issue a
+// regentemplate JSON-RPC command.
+func NewRegenTemplateCmd() *RegenTemplateCmd {
+	return &RegenTemplateCmd{}
+}
+
 // HelpCmd defines the help JSON-RPC command.
 type HelpCmd struct {
 	Command *string
@@ -1183,6 +1192,7 @@ func init() {
 	dcrjson.MustRegister(Method("ping"), (*PingCmd)(nil), flags)
 	dcrjson.MustRegister(Method("rebroadcastmissed"), (*RebroadcastMissedCmd)(nil), flags)
 	dcrjson.MustRegister(Method("rebroadcastwinners"), (*RebroadcastWinnersCmd)(nil), flags)
+	dcrjson.MustRegister(Method("regentemplate"), (*RegenTemplateCmd)(nil), flags)
 	dcrjson.MustRegister(Method("searchrawtransactions"), (*SearchRawTransactionsCmd)(nil), flags)
 	dcrjson.MustRegister(Method("sendrawtransaction"), (*SendRawTransactionCmd)(nil), flags)
 	dcrjson.MustRegister(Method("setgenerate"), (*SetGenerateCmd)(nil), flags)

--- a/rpcclient/mining.go
+++ b/rpcclient/mining.go
@@ -414,3 +414,30 @@ func (c *Client) SubmitBlockAsync(block *dcrutil.Block, options *chainjson.Submi
 func (c *Client) SubmitBlock(block *dcrutil.Block, options *chainjson.SubmitBlockOptions) error {
 	return c.SubmitBlockAsync(block, options).Receive()
 }
+
+// FutureRegenTemplateResult is a future promise to deliver the result of a
+// RegenTemplate RPC invocation (or an applicable error).
+type FutureRegenTemplateResult chan *response
+
+// Receive waits for the response and returns an error if any has occurred.
+func (r FutureRegenTemplateResult) Receive() error {
+	_, err := receiveFuture(r)
+	return err
+}
+
+// RegenTemplateAsync returns an instance of a type that can be used to get the
+// result of the RPC at some future time by invoking the Receive function on
+// the returned instance.
+//
+// See RegenTemplate for the blocking version and more details.
+func (c *Client) RegenTemplateAsync() FutureRegenTemplateResult {
+	cmd := chainjson.NewRegenTemplateCmd()
+	return c.sendCmd(cmd)
+}
+
+// RegenTemplate asks the node to regenerate its current block template. Note
+// that template generation is currently asynchronous, therefore no guarantees
+// are made for when or whether a new template will actually be available.
+func (c *Client) RegenTemplate() error {
+	return c.RegenTemplateAsync().Receive()
+}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -194,6 +194,7 @@ var rpcHandlersBeforeInit = map[types.Method]commandHandler{
 	"missedtickets":         handleMissedTickets,
 	"node":                  handleNode,
 	"ping":                  handlePing,
+	"regentemplate":         handleRegenTemplate,
 	"searchrawtransactions": handleSearchRawTransactions,
 	"sendrawtransaction":    handleSendRawTransaction,
 	"setgenerate":           handleSetGenerate,
@@ -344,6 +345,7 @@ var rpcLimited = map[string]struct{}{
 	"getvoteinfo":           {},
 	"livetickets":           {},
 	"missedtickets":         {},
+	"regentemplate":         {},
 	"searchrawtransactions": {},
 	"sendrawtransaction":    {},
 	"submitblock":           {},
@@ -3563,6 +3565,16 @@ func handlePing(_ context.Context, s *rpcServer, cmd interface{}) (interface{}, 
 	}
 	s.cfg.ConnMgr.BroadcastMessage(wire.NewMsgPing(nonce))
 
+	return nil, nil
+}
+
+// handleRegenTemplate implements the regentemplate command.
+func handleRegenTemplate(_ context.Context, s *rpcServer, cmd interface{}) (interface{}, error) {
+	bg := s.cfg.BgBlkTmplGenerator()
+	if bg == nil {
+		return nil, rpcInternalError("Node is not configured for mining", "")
+	}
+	bg.ForceRegen()
 	return nil, nil
 }
 

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -935,6 +935,9 @@ var helpDescsEnUS = map[string]string{
 	"version--result0--desc":  "Version objects keyed by the program or API name",
 	"version--result0--key":   "Program or API name",
 	"version--result0--value": "Object containing the semantic version",
+
+	// regentemplate help
+	"regentemplate--synopsis": "Asks the node to regenerate its block mining template.",
 }
 
 // rpcResultTypes specifies the result types that each RPC command can return.
@@ -1001,6 +1004,7 @@ var rpcResultTypes = map[types.Method][]interface{}{
 	"missedtickets":         {(*types.MissedTicketsResult)(nil)},
 	"node":                  nil,
 	"ping":                  nil,
+	"regentemplate":         nil,
 	"searchrawtransactions": {(*string)(nil), (*[]types.SearchRawTransactionsResult)(nil)},
 	"sendrawtransaction":    {(*string)(nil)},
 	"setgenerate":           nil,


### PR DESCRIPTION
This adds the regentemplate comand to the node, which asks it to
regenerate is block template.

The node now maintains a background template generator, with various
timeouts to enable efficient generation of block templates in a
production setting.

However, external users might want to force a new template to be
generated after new regular transactions have been received but before
the regular regen timeout (currently 30 seconds) has elapsed. This is
true specially for external simnet tests that publish transactions and
rely on them being mined shortly after the node receives them.

The most flexible solution found was to add a new regentemplate command
which rpc clients can issue to force a node to regenerate the latest
template with any new transactions.
