### PR TITLE
blockchain: Remove unconfigurable chain var.

### DIFF
--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1890,13 +1890,13 @@ func (b *BlockChain) initChainState() error {
 		if err != nil {
 			return err
 		}
-		b.mainchainBlockCache[tip.hash] = utilBlock
+		b.mainChainBlockCache[tip.hash] = utilBlock
 		if tip.parent != nil {
 			parentBlock, err := dbFetchBlockByNode(dbTx, tip.parent)
 			if err != nil {
 				return err
 			}
-			b.mainchainBlockCache[tip.parent.hash] = parentBlock
+			b.mainChainBlockCache[tip.parent.hash] = parentBlock
 		}
 
 		// Initialize the state related to the best block.


### PR DESCRIPTION
This removes the main chain block size instance variable since it is merely set to a constant and is not configurable anyway.  While here, it also moves the prune height calculation outside of the loop and renames the variables related to the main chain block cache to be more consistent with the rest of the code.