### PR TITLE
blockchain: Rename KnownValid to HasValidated.

### DIFF
--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1581,7 +1581,7 @@ func (b *BlockChain) createChainState() error {
 	genesisBlock := dcrutil.NewBlock(b.chainParams.GenesisBlock)
 	header := &genesisBlock.MsgBlock().Header
 	node := newBlockNode(header, nil)
-	node.status = statusDataStored | statusValid
+	node.status = statusDataStored | statusValidated
 
 	// Initialize the state related to the best block.  Since it is the
 	// genesis block, use its timestamp for the median time.

--- a/blockchain/chainio_test.go
+++ b/blockchain/chainio_test.go
@@ -148,7 +148,7 @@ func TestBlockIndexSerialization(t *testing.T) {
 			name: "no votes, no revokes",
 			entry: blockIndexEntry{
 				header:         baseHeader,
-				status:         statusDataStored | statusValid,
+				status:         statusDataStored | statusValidated,
 				voteInfo:       nil,
 				ticketsVoted:   nil,
 				ticketsRevoked: nil,
@@ -159,7 +159,7 @@ func TestBlockIndexSerialization(t *testing.T) {
 			name: "1 vote, no revokes",
 			entry: blockIndexEntry{
 				header:         baseHeader,
-				status:         statusDataStored | statusValid,
+				status:         statusDataStored | statusValidated,
 				voteInfo:       baseVoteInfo[:1],
 				ticketsVoted:   baseTicketsVoted[:1],
 				ticketsRevoked: nil,
@@ -170,7 +170,7 @@ func TestBlockIndexSerialization(t *testing.T) {
 			name: "no votes, 1 revoke",
 			entry: blockIndexEntry{
 				header:         baseHeader,
-				status:         statusDataStored | statusValid,
+				status:         statusDataStored | statusValidated,
 				voteInfo:       nil,
 				ticketsVoted:   nil,
 				ticketsRevoked: baseTicketsRevoked[:1],
@@ -181,7 +181,7 @@ func TestBlockIndexSerialization(t *testing.T) {
 			name: "4 votes, same vote versions, different vote bits, 2 revokes",
 			entry: blockIndexEntry{
 				header:         baseHeader,
-				status:         statusDataStored | statusValid,
+				status:         statusDataStored | statusValidated,
 				voteInfo:       baseVoteInfo,
 				ticketsVoted:   baseTicketsVoted,
 				ticketsRevoked: baseTicketsRevoked,

--- a/blockchain/chainquery.go
+++ b/blockchain/chainquery.go
@@ -121,7 +121,7 @@ func (b *BlockChain) ChainTips() []ChainTipInfo {
 			result.Status = "invalid"
 		} else if !tipStatus.HaveData() {
 			result.Status = "headers-only"
-		} else if tipStatus.KnownValid() {
+		} else if tipStatus.HasValidated() {
 			result.Status = "valid-fork"
 		} else {
 			result.Status = "valid-headers"

--- a/blockchain/common_test.go
+++ b/blockchain/common_test.go
@@ -126,7 +126,7 @@ func newFakeChain(params *chaincfg.Params) *BlockChain {
 	// Create a genesis block node and block index populated with it for use
 	// when creating the fake chain below.
 	node := newBlockNode(&params.GenesisBlock.Header, nil)
-	node.status = statusDataStored | statusValid
+	node.status = statusDataStored | statusValidated
 	index := newBlockIndex(nil)
 	index.AddNode(node)
 
@@ -175,7 +175,7 @@ func newFakeNode(parent *blockNode, blockVersion int32, stakeVersion uint32, bit
 		StakeVersion: stakeVersion,
 	}
 	node := newBlockNode(header, parent)
-	node.status = statusDataStored | statusValid
+	node.status = statusDataStored | statusValidated
 	return node
 }
 

--- a/blockchain/thresholdstate.go
+++ b/blockchain/thresholdstate.go
@@ -527,7 +527,7 @@ func (b *BlockChain) StateLastChangedHeight(hash *chainhash.Hash, version uint32
 	// available, but there is not currently any tracking to be able to
 	// efficiently determine that state.
 	node := b.index.LookupNode(hash)
-	if node == nil || !b.index.NodeStatus(node).KnownValid() {
+	if node == nil || !b.index.NodeStatus(node).HasValidated() {
 		return 0, HashError(hash.String())
 	}
 
@@ -577,7 +577,7 @@ func (b *BlockChain) NextThresholdState(hash *chainhash.Hash, version uint32, de
 	// available, but there is not currently any tracking to be able to
 	// efficiently determine that state.
 	node := b.index.LookupNode(hash)
-	if node == nil || !b.index.NodeStatus(node).KnownValid() {
+	if node == nil || !b.index.NodeStatus(node).HasValidated() {
 		invalidState := ThresholdStateTuple{
 			State:  ThresholdInvalid,
 			Choice: invalidChoice,
@@ -720,7 +720,7 @@ func (b *BlockChain) IsHeaderCommitmentsAgendaActive(prevHash *chainhash.Hash) (
 	// available, but there is not currently any tracking to be able to
 	// efficiently determine that state.
 	node := b.index.LookupNode(prevHash)
-	if node == nil || !b.index.NodeStatus(node).KnownValid() {
+	if node == nil || !b.index.NodeStatus(node).HasValidated() {
 		return false, HashError(prevHash.String())
 	}
 

--- a/blockchain/upgrade.go
+++ b/blockchain/upgrade.go
@@ -351,7 +351,7 @@ func migrateBlockIndex(ctx context.Context, db database.DB) error {
 			// blocks were never validated.
 			status := statusDataStored
 			if hashIdxBucket.Get(blockHash[:]) != nil {
-				status |= statusValid
+				status |= statusValidated
 			}
 
 			// Write the serialized block index entry to the new bucket keyed by
@@ -665,7 +665,7 @@ func (b *BlockChain) maybeFinishV5Upgrade(ctx context.Context) error {
 		// valid.  This is necessary due to older software versions not marking
 		// nodes before the final checkpoint as valid.
 		for node := targetTip; node != nil; node = node.parent {
-			b.index.SetStatusFlags(node, statusValid)
+			b.index.SetStatusFlags(node, statusValidated)
 		}
 		if err := b.index.flush(); err != nil {
 			return err


### PR DESCRIPTION
This renames the `KnownValid` and associated status flag of `statusValid` to `HasValidated` and `statusValidated`, respectively in order to better clarify the behavior .

While this distinction doesn't currently make much difference the intention in the future to decouple the block process and download logic at which point the distinction will become more important.