### PR TITLE
multi: Introduce initial sync min known chain work.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1588,16 +1588,17 @@ func (b *BlockChain) connectBestChain(node *blockNode, block, parent *dcrutil.Bl
 // isCurrent returns whether or not the chain believes it is current.  Several
 // factors are used to guess, but the key factors that allow the chain to
 // believe it is current are:
-//  - Latest block height is after the latest checkpoint (if enabled)
+//  - Total amount of cumulative work is more than the minimum known work
+//    specified by the parameters for the network
 //  - Latest block has a timestamp newer than 24 hours ago
 //
 // This function MUST be called with the chain state lock held (for reads).
 func (b *BlockChain) isCurrent() bool {
-	// Not current if the latest main (best) chain height is before the
-	// latest known good checkpoint (when checkpoints are enabled).
+	// Not current if the latest best block has a cumulative work less than the
+	// minimum known work specified by the network parameters.
 	tip := b.bestChain.Tip()
-	checkpoint := b.latestCheckpoint()
-	if checkpoint != nil && tip.height < checkpoint.Height {
+	minKnownWork := b.chainParams.MinKnownChainWork
+	if minKnownWork != nil && tip.workSum.Cmp(minKnownWork) < 0 {
 		return false
 	}
 
@@ -1613,7 +1614,8 @@ func (b *BlockChain) isCurrent() bool {
 // IsCurrent returns whether or not the chain believes it is current.  Several
 // factors are used to guess, but the key factors that allow the chain to
 // believe it is current are:
-//  - Latest block height is after the latest checkpoint (if enabled)
+//  - Total amount of cumulative work is more than the minimum known work
+//    specified by the parameters for the network
 //  - Latest block has a timestamp newer than 24 hours ago
 //
 // This function is safe for concurrent access.

--- a/blockchain/go.mod
+++ b/blockchain/go.mod
@@ -19,6 +19,7 @@ require (
 
 replace (
 	github.com/decred/dcrd/blockchain/stake/v3 => ./stake
+	github.com/decred/dcrd/chaincfg/v2 => ../chaincfg
 	github.com/decred/dcrd/dcrutil/v3 => ../dcrutil
 	github.com/decred/dcrd/txscript/v3 => ../txscript
 )

--- a/chaincfg/mainnetparams.go
+++ b/chaincfg/mainnetparams.go
@@ -133,6 +133,14 @@ func MainNetParams() *Params {
 			{384170, newHashFromStr("00000000000000001704bbc6bda8c4864a71cd0febcc0b44d753c69d83840f04")},
 		},
 
+		// MinKnownChainWork is the minimum amount of known total work for the
+		// chain at a given point in time.  This is intended to be updated
+		// periodically with new releases.
+		//
+		// Block 00000000000000001c654e2935e7722ddae8277da482e31557ac5c70ec101792
+		// Height: 395000
+		MinKnownChainWork: hexToBigInt("0000000000000000000000000000000000000000000ae01920a7ee4b769cc620"),
+
 		// The miner confirmation window is defined as:
 		//   target proof of work timespan / target proof of work spacing
 		RuleChangeActivationQuorum:     4032, // 10 % of RuleChangeActivationInterval * TicketsPerBlock

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -308,6 +308,11 @@ type Params struct {
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints []Checkpoint
 
+	// MinKnownChainWork is the minimum amount of known total work for the chain
+	// at a given point in time.  This is intended to be updated periodically
+	// with new releases.  It may be nil for networks that do not require it.
+	MinKnownChainWork *big.Int
+
 	// These fields are related to voting on consensus rule changes as
 	// defined by BIP0009.
 	//
@@ -598,12 +603,28 @@ func newHashFromStr(hexStr string) *chainhash.Hash {
 	return hash
 }
 
+// hexDecode decodes the passed hex string and returns the resulting bytes.  It
+// panics if an error occurs. This is only provided for the hard-coded constants
+// so errors in the source code can be detected. It will only (and must only) be
+// called with hard-coded values.
 func hexDecode(hexStr string) []byte {
 	b, err := hex.DecodeString(hexStr)
 	if err != nil {
 		panic(err)
 	}
 	return b
+}
+
+// hexToBigInt converts the passed hex string into a big integer and will panic
+// if there is an error.  This is only provided for the hard-coded constants so
+// errors in the source code can be detected. It will only (and must only) be
+// called with hard-coded values.
+func hexToBigInt(hexStr string) *big.Int {
+	val, ok := new(big.Int).SetString(hexStr, 16)
+	if !ok {
+		panic("failed to parse big integer from hex: " + hexStr)
+	}
+	return val
 }
 
 // BlockOneSubsidy returns the total subsidy of block height 1 for the

--- a/chaincfg/regnetparams.go
+++ b/chaincfg/regnetparams.go
@@ -112,6 +112,12 @@ func RegNetParams() *Params {
 		// Checkpoints ordered from oldest to newest.
 		Checkpoints: nil,
 
+		// MinKnownChainWork is the minimum amount of known total work for the
+		// chain at a given point in time.
+		//
+		// Not set for regression test network since its chain is dynamic.
+		MinKnownChainWork: nil,
+
 		// Consensus rule change deployments.
 		//
 		// The miner confirmation window is defined as:

--- a/chaincfg/simnetparams.go
+++ b/chaincfg/simnetparams.go
@@ -111,6 +111,12 @@ func SimNetParams() *Params {
 		// Checkpoints ordered from oldest to newest.
 		Checkpoints: nil,
 
+		// MinKnownChainWork is the minimum amount of known total work for the
+		// chain at a given point in time.
+		//
+		// Not set for simnet test network since its chain is dynamic.
+		MinKnownChainWork: nil,
+
 		// Consensus rule change deployments.
 		//
 		// The miner confirmation window is defined as:

--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -110,6 +110,14 @@ func TestNet3Params() *Params {
 			{282340, newHashFromStr("0000001f538d6343316fe50709fa544b680a1be38141d003e755da8ad30f67a8")},
 		},
 
+		// MinKnownChainWork is the minimum amount of known total work for the
+		// chain at a given point in time.  This is intended to be updated
+		// periodically with new releases.
+		//
+		// Block 0000004ce20783706c005901e44b984d8d0f9d62855f266f064a25f8131f84e4
+		// Height: 301000
+		MinKnownChainWork: hexToBigInt("0000000000000000000000000000000000000000000000005df2701ec6263182"),
+
 		// Consensus rule change deployments.
 		//
 		// The miner confirmation window is defined as:


### PR DESCRIPTION
This adds a new parameter to the chain parameters to allow a minimum total known cumulative amount of chain work to be specified as of a given point in time and updates the check which determines if the blockchain believes it is current to make use of the value instead of the height of the final checkpoint.  In other words, the chain is not considered synced if the best chain does not yet have the amount of work specified.

This approach is preferred because it easier to maintain, does not rely on trusted known good checkpoints, is valid regardless of the order that blocks are received and processed, and, in general, is a more objective value that can't be invalidated by a chain reorganization.

It also adds initial values for the main and test networks as follows:

> mainnet: 0x0000000000000000000000000000000000000000000ae01920a7ee4b769cc620
> testnet: 0x0000000000000000000000000000000000000000000000005df2701ec6263182