### PR TITLE
multi: Decouple orphan handling from blockchain.

### DIFF
--- a/blockchain/README.md
+++ b/blockchain/README.md
@@ -37,10 +37,6 @@ is by no means exhaustive:
    transaction amounts, script complexity, and merkle root calculations
  - Compare the block against predetermined checkpoints for expected timestamps
    and difficulty based on elapsed time since the checkpoint
- - Save the most recent orphan blocks for a limited time in case their parent
-   blocks become available
- - Stop processing if the block is an orphan as the rest of the processing
-   depends on the block's position within the block chain
  - Perform a series of more thorough checks that depend on the block's position
    within the block chain such as verifying block difficulties adhere to
    difficulty retarget rules, timestamps are after the median of the last

--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -101,7 +101,7 @@ func TestBlockchainFunctions(t *testing.T) {
 			t.Errorf("NewBlockFromBytes error: %v", err.Error())
 		}
 
-		_, _, err = chain.ProcessBlock(bl, BFNone)
+		_, err = chain.ProcessBlock(bl, BFNone)
 		if err != nil {
 			t.Fatalf("ProcessBlock error at height %v: %v", i, err.Error())
 		}

--- a/blockchain/common_test.go
+++ b/blockchain/common_test.go
@@ -343,24 +343,19 @@ func (g *chaingenHarness) AcceptBlock(blockName string) {
 	g.t.Logf("Testing block %s (hash %s, height %d)", blockName, block.Hash(),
 		blockHeight)
 
-	forkLen, isOrphan, err := g.chain.ProcessBlock(block, BFNone)
+	forkLen, err := g.chain.ProcessBlock(block, BFNone)
 	if err != nil {
 		g.t.Fatalf("block %q (hash %s, height %d) should have been accepted: %v",
 			blockName, block.Hash(), blockHeight, err)
 	}
 
-	// Ensure the main chain and orphan flags match the values specified in the
-	// test.
-	isMainChain := !isOrphan && forkLen == 0
+	// Ensure the block was accepted to the main chain as indicated by a fork
+	// length of zero.
+	isMainChain := forkLen == 0
 	if !isMainChain {
 		g.t.Fatalf("block %q (hash %s, height %d) unexpected main chain flag "+
 			"-- got %v, want true", blockName, block.Hash(), blockHeight,
 			isMainChain)
-	}
-	if isOrphan {
-		g.t.Fatalf("block %q (hash %s, height %d) unexpected orphan flag -- "+
-			"got %v, want false", blockName, block.Hash(), blockHeight,
-			isOrphan)
 	}
 }
 
@@ -383,7 +378,7 @@ func (g *chaingenHarness) RejectBlock(blockName string, code ErrorCode) {
 	g.t.Logf("Testing block %s (hash %s, height %d)", blockName, block.Hash(),
 		blockHeight)
 
-	_, _, err := g.chain.ProcessBlock(block, BFNone)
+	_, err := g.chain.ProcessBlock(block, BFNone)
 	if err == nil {
 		g.t.Fatalf("block %q (hash %s, height %d) should not have been accepted",
 			blockName, block.Hash(), blockHeight)
@@ -440,24 +435,19 @@ func (g *chaingenHarness) AcceptedToSideChainWithExpectedTip(tipName string) {
 	g.t.Logf("Testing block %s (hash %s, height %d)", g.TipName(), block.Hash(),
 		blockHeight)
 
-	forkLen, isOrphan, err := g.chain.ProcessBlock(block, BFNone)
+	forkLen, err := g.chain.ProcessBlock(block, BFNone)
 	if err != nil {
 		g.t.Fatalf("block %q (hash %s, height %d) should have been accepted: %v",
 			g.TipName(), block.Hash(), blockHeight, err)
 	}
 
-	// Ensure the main chain and orphan flags match the values specified in
-	// the test.
-	isMainChain := !isOrphan && forkLen == 0
+	// Ensure the block was accepted to a side chain as indicated by a non-zero
+	// fork length.
+	isMainChain := forkLen == 0
 	if isMainChain {
 		g.t.Fatalf("block %q (hash %s, height %d) unexpected main chain flag "+
 			"-- got %v, want false", g.TipName(), block.Hash(), blockHeight,
 			isMainChain)
-	}
-	if isOrphan {
-		g.t.Fatalf("block %q (hash %s, height %d) unexpected orphan flag -- "+
-			"got %v, want false", g.TipName(), block.Hash(), blockHeight,
-			isOrphan)
 	}
 
 	g.ExpectTip(tipName)

--- a/blockchain/doc.go
+++ b/blockchain/doc.go
@@ -15,13 +15,12 @@ extremely important that fully validating nodes agree on all rules.
 At a high level, this package provides support for inserting new blocks into the
 block chain according to the aforementioned rules.  It includes functionality
 such as rejecting duplicate blocks, ensuring blocks and transactions follow all
-rules, orphan handling, and best chain selection along with reorganization.
+rules, and best chain selection along with reorganization.
 
 Since this package does not deal with other Decred specifics such as network
 communication or wallets, it provides a notification system which gives the
 caller a high level of flexibility in how they want to react to certain events
-such as orphan blocks which need their parents requested and newly connected
-main chain blocks which might result in wallet updates.
+such as newly connected main chain blocks which might result in wallet updates.
 
 Decred Chain Processing Overview
 
@@ -36,10 +35,6 @@ is by no means exhaustive:
    transaction amounts, script complexity, and merkle root calculations
  - Compare the block against predetermined checkpoints for expected timestamps
    and difficulty based on elapsed time since the checkpoint
- - Save the most recent orphan blocks for a limited time in case their parent
-   blocks become available
- - Stop processing if the block is an orphan as the rest of the processing
-   depends on the block's position within the block chain
  - Perform a series of more thorough checks that depend on the block's position
    within the block chain such as verifying block difficulties adhere to
    difficulty retarget rules, timestamps are after the median of the last

--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -634,3 +634,10 @@ func (e RuleError) Error() string {
 func ruleError(c ErrorCode, desc string) RuleError {
 	return RuleError{ErrorCode: c, Description: desc}
 }
+
+// IsErrorCode returns whether or not the provided error is a rule error with
+// the provided error code.
+func IsErrorCode(err error, c ErrorCode) bool {
+	e, ok := err.(RuleError)
+	return ok && e.ErrorCode == c
+}

--- a/blockchain/error_test.go
+++ b/blockchain/error_test.go
@@ -162,3 +162,46 @@ func TestRuleError(t *testing.T) {
 		}
 	}
 }
+
+// TestIsErrorCode ensures IsErrorCode works as intended.
+func TestIsErrorCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		code ErrorCode
+		want bool
+	}{{
+		name: "ErrUnexpectedDifficulty testing for ErrUnexpectedDifficulty",
+		err:  ruleError(ErrUnexpectedDifficulty, ""),
+		code: ErrUnexpectedDifficulty,
+		want: true,
+	}, {
+		name: "ErrHighHash testing for ErrHighHash",
+		err:  ruleError(ErrHighHash, ""),
+		code: ErrHighHash,
+		want: true,
+	}, {
+		name: "ErrHighHash error testing for ErrUnexpectedDifficulty",
+		err:  ruleError(ErrHighHash, ""),
+		code: ErrUnexpectedDifficulty,
+		want: false,
+	}, {
+		name: "ErrHighHash error testing for unknown error code",
+		err:  ruleError(ErrHighHash, ""),
+		code: 0xffff,
+		want: false,
+	}, {
+		name: "nil error testing for ErrUnexpectedDifficulty",
+		err:  nil,
+		code: ErrUnexpectedDifficulty,
+		want: false,
+	}}
+	for _, test := range tests {
+		result := IsErrorCode(test.err, test.code)
+		if result != test.want {
+			t.Errorf("%s: unexpected result -- got: %v want: %v", test.name,
+				result, test.want)
+			continue
+		}
+	}
+}

--- a/blockchain/example_test.go
+++ b/blockchain/example_test.go
@@ -62,15 +62,14 @@ func ExampleBlockChain_ProcessBlock() {
 	// cause an error by trying to process the genesis block which already
 	// exists.
 	genesisBlock := dcrutil.NewBlock(mainNetParams.GenesisBlock)
-	forkLen, isOrphan, err := chain.ProcessBlock(genesisBlock,
+	forkLen, err := chain.ProcessBlock(genesisBlock,
 		blockchain.BFNone)
 	if err != nil {
 		fmt.Printf("Failed to create chain instance: %v\n", err)
 		return
 	}
-	isMainChain := !isOrphan && forkLen == 0
+	isMainChain := forkLen == 0
 	fmt.Printf("Block accepted. Is it on the main chain?: %v", isMainChain)
-	fmt.Printf("Block accepted. Is it an orphan?: %v", isOrphan)
 
 	// This output is dependent on the genesis block, and needs to be
 	// updated if the mainnet genesis block is updated.

--- a/blockchain/process.go
+++ b/blockchain/process.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/decred/dcrd/blockchain/standalone"
-	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil/v3"
 )
 
@@ -34,79 +33,21 @@ const (
 	BFNone BehaviorFlags = 0
 )
 
-// processOrphans determines if there are any orphans which depend on the passed
-// block hash (they are no longer orphans if true) and potentially accepts them.
-// It repeats the process for the newly accepted blocks (to detect further
-// orphans which may no longer be orphans) until there are no more.
-//
-// The flags do not modify the behavior of this function directly, however they
-// are needed to pass along to maybeAcceptBlock.
-//
-// This function MUST be called with the chain state lock held (for writes).
-func (b *BlockChain) processOrphans(hash *chainhash.Hash, flags BehaviorFlags) error {
-	// Start with processing at least the passed hash.  Leave a little room
-	// for additional orphan blocks that need to be processed without
-	// needing to grow the array in the common case.
-	processHashes := make([]*chainhash.Hash, 0, 10)
-	processHashes = append(processHashes, hash)
-	for len(processHashes) > 0 {
-		// Pop the first hash to process from the slice.
-		processHash := processHashes[0]
-		processHashes[0] = nil // Prevent GC leak.
-		processHashes = processHashes[1:]
-
-		// Look up all orphans that are parented by the block we just
-		// accepted.  This will typically only be one, but it could
-		// be multiple if multiple blocks are mined and broadcast
-		// around the same time.  The one with the most proof of work
-		// will eventually win out.  An indexing for loop is
-		// intentionally used over a range here as range does not
-		// reevaluate the slice on each iteration nor does it adjust the
-		// index for the modified slice.
-		for i := 0; i < len(b.prevOrphans[*processHash]); i++ {
-			orphan := b.prevOrphans[*processHash][i]
-			if orphan == nil {
-				log.Warnf("Found a nil entry at index %d in the "+
-					"orphan dependency list for block %v", i,
-					processHash)
-				continue
-			}
-
-			// Remove the orphan from the orphan pool.
-			orphanHash := orphan.block.Hash()
-			b.removeOrphanBlock(orphan)
-			i--
-
-			// Potentially accept the block into the block chain.
-			_, err := b.maybeAcceptBlock(orphan.block, flags)
-			if err != nil {
-				return err
-			}
-
-			// Add this block to the list of blocks to process so
-			// any orphan blocks that depend on this block are
-			// handled too.
-			processHashes = append(processHashes, orphanHash)
-		}
-	}
-	return nil
-}
-
 // ProcessBlock is the main workhorse for handling insertion of new blocks into
 // the block chain.  It includes functionality such as rejecting duplicate
-// blocks, ensuring blocks follow all rules, orphan handling, and insertion into
-// the block chain along with best chain selection and reorganization.
+// blocks, ensuring blocks follow all rules, and insertion into the block chain
+// along with best chain selection and reorganization.
+//
+// It is up to the caller to ensure the blocks are processed in order since
+// orphans are rejected.
 //
 // When no errors occurred during processing, the first return value indicates
 // the length of the fork the block extended.  In the case it either extended
 // the best chain or is now the tip of the best chain due to causing a
-// reorganize, the fork length will be 0.  The second return value indicates
-// whether or not the block is an orphan, in which case the fork length will
-// also be zero as expected, because it, by definition, does not connect to the
-// best chain.
+// reorganize, the fork length will be 0.
 //
 // This function is safe for concurrent access.
-func (b *BlockChain) ProcessBlock(block *dcrutil.Block, flags BehaviorFlags) (int64, bool, error) {
+func (b *BlockChain) ProcessBlock(block *dcrutil.Block, flags BehaviorFlags) (int64, error) {
 	b.chainLock.Lock()
 	defer b.chainLock.Unlock()
 
@@ -124,19 +65,13 @@ func (b *BlockChain) ProcessBlock(block *dcrutil.Block, flags BehaviorFlags) (in
 	// The block must not already exist in the main chain or side chains.
 	if b.index.HaveBlock(blockHash) {
 		str := fmt.Sprintf("already have block %v", blockHash)
-		return 0, false, ruleError(ErrDuplicateBlock, str)
-	}
-
-	// The block must not already exist as an orphan.
-	if _, exists := b.orphans[*blockHash]; exists {
-		str := fmt.Sprintf("already have block (orphan) %v", blockHash)
-		return 0, false, ruleError(ErrDuplicateBlock, str)
+		return 0, ruleError(ErrDuplicateBlock, str)
 	}
 
 	// Perform preliminary sanity checks on the block and its transactions.
 	err := checkBlockSanity(block, b.timeSource, flags, b.chainParams)
 	if err != nil {
-		return 0, false, err
+		return 0, err
 	}
 
 	// Find the previous checkpoint and perform some additional checks based
@@ -148,7 +83,7 @@ func (b *BlockChain) ProcessBlock(block *dcrutil.Block, flags BehaviorFlags) (in
 	blockHeader := &block.MsgBlock().Header
 	checkpointNode, err := b.findPreviousCheckpoint()
 	if err != nil {
-		return 0, false, err
+		return 0, err
 	}
 	if checkpointNode != nil {
 		// Ensure the block timestamp is after the checkpoint timestamp.
@@ -157,7 +92,7 @@ func (b *BlockChain) ProcessBlock(block *dcrutil.Block, flags BehaviorFlags) (in
 			str := fmt.Sprintf("block %v has timestamp %v before "+
 				"last checkpoint timestamp %v", blockHash,
 				blockHeader.Timestamp, checkpointTime)
-			return 0, false, ruleError(ErrCheckpointTimeTooOld, str)
+			return 0, ruleError(ErrCheckpointTimeTooOld, str)
 		}
 
 		if !fastAdd {
@@ -175,39 +110,28 @@ func (b *BlockChain) ProcessBlock(block *dcrutil.Block, flags BehaviorFlags) (in
 				str := fmt.Sprintf("block target difficulty of %064x "+
 					"is too low when compared to the previous "+
 					"checkpoint", currentTarget)
-				return 0, false, ruleError(ErrDifficultyTooLow, str)
+				return 0, ruleError(ErrDifficultyTooLow, str)
 			}
 		}
 	}
 
-	// Handle orphan blocks.
+	// This function should never be called with orphans or the genesis block.
 	prevHash := &blockHeader.PrevBlock
 	if !b.index.HaveBlock(prevHash) {
-		log.Infof("Adding orphan block %v with parent %v", blockHash,
-			prevHash)
-		b.addOrphanBlock(block)
-
 		// The fork length of orphans is unknown since they, by definition, do
 		// not connect to the best chain.
-		return 0, true, nil
+		str := fmt.Sprintf("previous block %s is not known", prevHash)
+		return 0, ruleError(ErrMissingParent, str)
 	}
 
 	// The block has passed all context independent checks and appears sane
 	// enough to potentially accept it into the block chain.
 	forkLen, err := b.maybeAcceptBlock(block, flags)
 	if err != nil {
-		return 0, false, err
-	}
-
-	// Accept any orphan blocks that depend on this block (they are no
-	// longer orphans) and repeat for those accepted blocks until there are
-	// no more.
-	err = b.processOrphans(blockHash, flags)
-	if err != nil {
-		return 0, false, err
+		return 0, err
 	}
 
 	log.Debugf("Accepted block %v", blockHash)
 
-	return forkLen, false, nil
+	return forkLen, nil
 }

--- a/blockchain/process_test.go
+++ b/blockchain/process_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/decred/dcrd/blockchain/v3/chaingen"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v2"
-	"github.com/decred/dcrd/dcrutil/v3"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -23,38 +22,6 @@ func TestProcessOrder(t *testing.T) {
 	params := chaincfg.RegNetParams()
 	g, teardownFunc := newChaingenHarness(t, params, "processordertest")
 	defer teardownFunc()
-
-	// Define additional convenience helper function to process the current tip
-	// block associated with the generator.
-	//
-	// orphaned expects the block to be accepted as an orphan.
-	orphaned := func() {
-		msgBlock := g.Tip()
-		blockHeight := msgBlock.Header.Height
-		block := dcrutil.NewBlock(msgBlock)
-		t.Logf("Testing orphan block %s (hash %s, height %d)", g.TipName(),
-			block.Hash(), blockHeight)
-
-		forkLen, isOrphan, err := g.chain.ProcessBlock(block, BFNone)
-		if err != nil {
-			g.t.Fatalf("block %q (hash %s, height %d) not accepted: %v",
-				g.TipName(), block.Hash(), blockHeight, err)
-		}
-
-		// Ensure the main chain and orphan flags match the values specified in
-		// the test.
-		isMainChain := !isOrphan && forkLen == 0
-		if isMainChain {
-			g.t.Fatalf("block %q (hash %s, height %d) unexpected main chain "+
-				"flag -- got %v, want true", g.TipName(), block.Hash(),
-				blockHeight, isMainChain)
-		}
-		if !isOrphan {
-			g.t.Fatalf("block %q (hash %s, height %d) unexpected orphan flag "+
-				"-- got %v, want false", g.TipName(), block.Hash(), blockHeight,
-				isOrphan)
-		}
-	}
 
 	// Shorter versions of useful params for convenience.
 	coinbaseMaturity := params.CoinbaseMaturity
@@ -115,7 +82,7 @@ func TestProcessOrder(t *testing.T) {
 	g.NextBlock("borphan0", outs[1], ticketOuts[1], func(b *wire.MsgBlock) {
 		b.Header.PrevBlock = chainhash.Hash{}
 	})
-	orphaned()
+	g.RejectTipBlock(ErrMissingParent)
 
 	// Create valid orphan block.
 	//
@@ -124,13 +91,20 @@ func TestProcessOrder(t *testing.T) {
 	g.SetTip("b1")
 	g.NextBlock("borphanbase", outs[1], ticketOuts[1])
 	g.NextBlock("borphan1", outs[2], ticketOuts[2])
-	orphaned()
+	g.RejectTipBlock(ErrMissingParent)
 
 	// Ensure duplicate orphan blocks are rejected.
-	g.RejectTipBlock(ErrDuplicateBlock)
+	g.RejectTipBlock(ErrMissingParent)
 
 	// ---------------------------------------------------------------------
 	// Out-of-order forked reorg to invalid block tests.
+	//
+	// NOTE: These tests have been modified to be processed in order despite
+	// the comments for now due to the removal of orphan processing.  They
+	// are otherwise left intact because future commits will allow headers
+	// to be processed independently from the block data which will allow
+	// out of order processing of data again so long as the headers are
+	// processed in order.
 	// ---------------------------------------------------------------------
 
 	// Create a fork that ends with block that generates too much proof-of-work
@@ -146,14 +120,14 @@ func TestProcessOrder(t *testing.T) {
 
 	g.SetTip("b1")
 	g.NextBlock("bpw1", outs[1], ticketOuts[1])
+	g.AcceptedToSideChainWithExpectedTip("b2")
 	g.NextBlock("bpw2", outs[2], ticketOuts[2])
-	orphaned()
 	g.NextBlock("bpw3", outs[3], ticketOuts[3], func(b *wire.MsgBlock) {
 		// Increase the first proof-of-work coinbase subsidy.
 		b.Transactions[0].TxOut[2].Value += 1
 	})
-	orphaned()
-	g.RejectBlock("bpw1", ErrBadCoinbaseValue)
+	g.AcceptBlock("bpw2")
+	g.RejectBlock("bpw3", ErrBadCoinbaseValue)
 	g.ExpectTip("bpw2")
 
 	// Create a fork that ends with block that generates too much dev-org
@@ -164,13 +138,13 @@ func TestProcessOrder(t *testing.T) {
 	//                             (bdc1 added last)
 	g.SetTip("bpw1")
 	g.NextBlock("bdc1", outs[2], ticketOuts[2])
+	g.AcceptedToSideChainWithExpectedTip("bpw2")
 	g.NextBlock("bdc2", outs[3], ticketOuts[3])
-	orphaned()
 	g.NextBlock("bdc3", outs[4], ticketOuts[4], func(b *wire.MsgBlock) {
 		// Increase the proof-of-work dev subsidy by the provided amount.
 		b.Transactions[0].TxOut[0].Value += 1
 	})
-	orphaned()
-	g.RejectBlock("bdc1", ErrNoTax)
+	g.AcceptBlock("bdc2")
+	g.RejectBlock("bdc3", ErrNoTax)
 	g.ExpectTip("bdc2")
 }

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -89,11 +89,11 @@ func TestBlockchainSpendJournal(t *testing.T) {
 			t.Fatalf("NewBlockFromBytes error: %v", err.Error())
 		}
 
-		forkLen, isOrphan, err := chain.ProcessBlock(bl, BFNone)
+		forkLen, err := chain.ProcessBlock(bl, BFNone)
 		if err != nil {
 			t.Fatalf("ProcessBlock error at height %v: %v", i, err.Error())
 		}
-		isMainChain := !isOrphan && forkLen == 0
+		isMainChain := forkLen == 0
 		if !isMainChain {
 			t.Fatalf("block %s (height %d) should have been "+
 				"accepted to the main chain", bl.Hash(),


### PR DESCRIPTION
This decouples and removes the orphan handling from blockchain in favor of implementing it in the block manager as part of the overall effort to decouple the connection code from the download logic.

The change might not make a ton of sense in isolation, since there is no major functional change, however, decoupling the orphan handling independently helps make the review process easier and alleviates what would otherwise result in additional intermediate code to handle cases that ultimately will no longer exist.

The following is a high level overview of the changes:

- Introduce blockchain function to more easily determine if an error is a rule error with a given error code
- Move core orphan handling code from blockchain to block manager
  - Move data structures used to cache and track orphan blocks
  - Move all functions releated to orphans
    - `BlockChain.IsKnownOrphan` -> `blockManager.isKnownOrphan`
    - `BlockChain.GetOrphanRoot` -> `blockManager.orphanRoot`
    - `BlockChain.removeOrphanBlock` -> `blockManager.removeOrphanBlock`
    - `BlockChain.addOrphanBlock` -> `blockManager.addOrphanBlock`
- Implement orphan handling in block manager
  - Rework to use the moved functions and data structs
  - Add check for known orphans in addition `HaveBlock` calls to retain the same behavior
- Remove remaining orphan related code from blockchain
  - Update `ProcessBlock` to return an error when called with an orphan
  - Remove additional orphan processing from `ProcessBlock`
  - Remove orphan cache check from `HaveBlock`
  - Adjust example to account for the removed parameter
  - Change `chaingen` harness tests to detect orphans via returned error
  - Modify fullblock tests to detect orphans via returned error
  - Adapt process order logic tests to cope with lack of orphan processing
  - Update all other tests accordingly
  - Update various comments and the `README.md` and `doc.go` to properly reflect the removal of orphan handling

This is work towards #1145.