### PR TITLE
blockchain: Use skip list for ancestor traversal.

### DIFF
--- a/blockchain/bench_test.go
+++ b/blockchain/bench_test.go
@@ -15,9 +15,9 @@ func BenchmarkAncestor(b *testing.B) {
 	// 	0 -> 1 -> 2 -> ... -> 499997 -> 499998 -> 499999  -> 500000
 	// 	                                      \-> 499999a
 	// 	                            \-> 499998a
-	branch0Nodes := chainedFakeNodes(nil, 500001)
-	branch1Nodes := chainedFakeNodes(branch0Nodes[499998], 1)
-	branch2Nodes := chainedFakeNodes(branch0Nodes[499997], 1)
+	branch0Nodes := chainedFakeSkipListNodes(nil, 500001)
+	branch1Nodes := chainedFakeSkipListNodes(branch0Nodes[499998], 1)
+	branch2Nodes := chainedFakeSkipListNodes(branch0Nodes[499997], 1)
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/blockchain/bench_test.go
+++ b/blockchain/bench_test.go
@@ -1,9 +1,32 @@
-// Copyright (c) 2015 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package blockchain
 
-// TODO Make benchmarking tests for various functions, such as sidechain
-// evaluation.
+import (
+	"testing"
+)
+
+// BenchmarkAncestor benchmarks ancestor traversal for various numbers of nodes.
+func BenchmarkAncestor(b *testing.B) {
+	// Construct a synthetic block chain with consisting of the following
+	// structure.
+	// 	0 -> 1 -> 2 -> ... -> 499997 -> 499998 -> 499999  -> 500000
+	// 	                                      \-> 499999a
+	// 	                            \-> 499998a
+	branch0Nodes := chainedFakeNodes(nil, 500001)
+	branch1Nodes := chainedFakeNodes(branch0Nodes[499998], 1)
+	branch2Nodes := chainedFakeNodes(branch0Nodes[499997], 1)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		branchTip(branch0Nodes).Ancestor(0)
+		branchTip(branch0Nodes).Ancestor(131072) // Power of two.
+		branchTip(branch0Nodes).Ancestor(131071) // One less than power of two.
+		branchTip(branch0Nodes).Ancestor(131070) // Two less than power of two.
+		branchTip(branch1Nodes).Ancestor(0)
+		branchTip(branch2Nodes).Ancestor(0)
+	}
+}

--- a/blockchain/chainview.go
+++ b/blockchain/chainview.go
@@ -305,8 +305,8 @@ func (c *chainView) findFork(node *blockNode) *blockNode {
 	// find the node as well, however, it is more efficient to avoid the
 	// contains check since it is already known that the common node can't
 	// possibly be past the end of the current chain view.  It also allows
-	// this code to take advantage of any potential future optimizations to
-	// the Ancestor function such as using an O(log n) skip list.
+	// this code to take advantage of the Ancestor function which uses a near
+	// O(log n) skip list.
 	chainHeight := c.height()
 	if node.height > chainHeight {
 		node = node.Ancestor(chainHeight)

--- a/blockchain/common_test.go
+++ b/blockchain/common_test.go
@@ -199,6 +199,29 @@ func chainedFakeNodes(parent *blockNode, numNodes int) []*blockNode {
 	return nodes
 }
 
+// chainedFakeSkipListNodes returns the specified number of nodes populated with
+// only the fields specifically needed to test the skip list functionality and
+// constructed such that each subsequent node points to the previous one to
+// create a chain.  The first node will point to the passed parent which can be
+// nil if desired.
+//
+// This is used over the chainedFakeNodes function for skip list testing because
+// the skip list tests involve large numbers of nodes which take much longer to
+// create with all of the other fields populated by said function.
+func chainedFakeSkipListNodes(parent *blockNode, numNodes int) []*blockNode {
+	nodes := make([]*blockNode, numNodes)
+	for i := 0; i < numNodes; i++ {
+		node := &blockNode{parent: parent, height: int64(i)}
+		if parent != nil {
+			node.skipToAncestor = nodes[calcSkipListHeight(int64(i))]
+		}
+		parent = node
+
+		nodes[i] = node
+	}
+	return nodes
+}
+
 // branchTip is a convenience function to grab the tip of a chain of block nodes
 // created via chainedFakeNodes.
 func branchTip(nodes []*blockNode) *blockNode {


### PR DESCRIPTION
There are several places when processing blocks and headers that require the ability to traverse the chain to ancestors of a given block such as tallying votes and versions to determine threshold states, finding forks, and calculating PoW difficulty, ticket price, and sequence locks.

Currently most traversal of this type is linear and therefore does not scale well as the chain height grows.  In addition, the ability to quickly locate ancestors, potentially deep in history, will be needed when decoupling the connection code from the download logic as well as several planned future optimizations.

Consequently, this significantly optimizes ancestor traversal by introducing a deterministic skip list and adds tests to ensure proper functionality.

The following is a before and after comparison of ancestor traversal for a large number of nodes:

```
benchmark           old ns/op     new ns/op   delta
------------------------------------------------------
BenchmarkAncestor   67901581      158         -100.00%

benchmark           old allocs   new allocs   delta
------------------------------------------------------
BenchmarkAncestor   0            0            +0.00%

benchmark           old bytes    new bytes    delta
------------------------------------------------------
BenchmarkAncestor   0            0            +0.00%
```

The following is a scatter plot of the number of steps to traverse back to a height of 1 for all heights up to 2^14 along with a logarithmic regression to help visualize the behavior.

![steps_vs_height](https://user-images.githubusercontent.com/2115102/69477340-aad66480-0daa-11ea-812d-7563be10bd03.png)


