### PR TITLE
blockchain: Make checkpoints configurable.

### DIFF
--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -2927,7 +2927,7 @@ func (b *BlockChain) checkConnectBlock(node *blockNode, block, parent *dcrutil.B
 	// will therefore be detected by the next checkpoint).  This is a huge
 	// optimization because running the scripts is the most time consuming
 	// portion of block handling.
-	checkpoint := b.latestCheckpoint()
+	checkpoint := b.LatestCheckpoint()
 	runScripts := !b.noVerify
 	if checkpoint != nil && node.height <= checkpoint.Height {
 		runScripts = false

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -2461,7 +2461,6 @@ func newBlockManager(config *blockManagerConfig) (*blockManager, error) {
 	}
 
 	best := bm.cfg.Chain.BestSnapshot()
-	bm.cfg.Chain.DisableCheckpoints(cfg.DisableCheckpoints)
 	if !cfg.DisableCheckpoints {
 		// Initialize the next checkpoint based on the current height.
 		bm.nextCheckpoint = bm.findNextHeaderCheckpoint(best.Height)

--- a/cmd/addblock/import.go
+++ b/cmd/addblock/import.go
@@ -340,6 +340,7 @@ func newBlockImporter(db database.DB, r io.ReadSeeker) (*blockImporter, error) {
 		&blockchain.Config{
 			DB:           db,
 			ChainParams:  activeNetParams,
+			Checkpoints:  activeNetParams.Checkpoints,
 			TimeSource:   blockchain.NewMedianTime(),
 			IndexManager: indexManager,
 		})

--- a/server.go
+++ b/server.go
@@ -2849,11 +2849,18 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 		indexManager = indexers.NewManager(db, indexes, chainParams)
 	}
 
+	// Only configure checkpoints when enabled.
+	var checkpoints []chaincfg.Checkpoint
+	if !cfg.DisableCheckpoints {
+		checkpoints = s.chainParams.Checkpoints
+	}
+
 	// Create a new block chain instance with the appropriate configuration.
 	s.chain, err = blockchain.New(ctx,
 		&blockchain.Config{
 			DB:          s.db,
 			ChainParams: s.chainParams,
+			Checkpoints: checkpoints,
 			TimeSource:  s.timeSource,
 			Notifications: func(notification *blockchain.Notification) {
 				if s.blockManager != nil {


### PR DESCRIPTION
**This is rebased on PR #2012**.

This modifies blockchain to expose a new field named `Checkpoints` in the `Config` struct which allows the checkpoints to use to be specified by the caller instead of assuming the checkpoint associated with the current chain parameters.  This allows the caller to customize the checkpoints as it sees fit, such as adding custom checkpoints or removing default checkpoints.

In addition, this removes the `DisableCheckpoints` function in favor of the caller simply configuring the chain instance without checkpoints when they're disabled and updates the code to remove the associated flag accordingly.  This produces simpler code and is faster since the mutex that was required to protect the aforementioned flag is no longer required.

Finally, this also paves the way to significantly simplify the checkpoint finding logic and make further progress towards the overall effort to decouple the connection code from the download logic.