### PR TITLE
blockchain: Support hdr checkpoints and simplify.

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -137,6 +137,9 @@ func (b *BlockChain) maybeAcceptBlock(block *dcrutil.Block, flags BehaviorFlags)
 		return 0, err
 	}
 
+	// Potentially update the most recently known checkpoint to this block.
+	b.maybeUpdateMostRecentCheckpoint(newNode)
+
 	// Notify the caller that the new block was accepted into the block
 	// chain.  The caller would typically want to react by relaying the
 	// inventory to other peers unless it was already relayed above

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -183,9 +183,9 @@ type BlockChain struct {
 	disapprovedViewLock sync.Mutex
 	disapprovedView     *UtxoViewpoint
 
-	// These fields are related to checkpoint handling.  They are protected
-	// by the chain lock.
-	nextCheckpoint *chaincfg.Checkpoint
+	// checkpointNode tracks the most recently known checkpoint.  It will be nil
+	// when no checkpoints are known or are disabled.  It is protected by the
+	// chain lock.
 	checkpointNode *blockNode
 
 	// The state is used as a fairly efficient way to cache information

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1911,6 +1911,17 @@ func (b *BlockChain) initChainState(ctx context.Context) error {
 			return err
 		}
 
+		// Find the most recent checkpoint.
+		for i := len(b.checkpoints) - 1; i >= 0; i-- {
+			node := b.index.lookupNode(b.checkpoints[i].Hash)
+			if node != nil {
+				log.Debugf("Most recent checkpoint is %s (height %d)",
+					node.hash, node.height)
+				b.checkpointNode = node
+				break
+			}
+		}
+
 		b.stateSnapshot = newBestState(tip, blockSize, numTxns,
 			state.totalTxns, tip.CalcPastMedianTime(),
 			state.totalSubsidy, uint32(tip.stakeNode.PoolSize()),

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -918,18 +918,14 @@ func (b *BlockChain) checkBlockHeaderPositional(header *wire.BlockHeader, prevNo
 		return ruleError(ErrBadCheckpoint, str)
 	}
 
-	// Find the previous checkpoint and prevent blocks which fork the main
-	// chain before it.  This prevents storage of new, otherwise valid,
-	// blocks which build off of old blocks that are likely at a much easier
-	// difficulty and therefore could be used to waste cache and disk space.
-	checkpointNode, err := b.findPreviousCheckpoint()
-	if err != nil {
-		return err
-	}
-	if checkpointNode != nil && blockHeight < checkpointNode.height {
+	// Prevent blocks that fork the main chain before the most recently known
+	// checkpoint.  This prevents storage of new, otherwise valid, blocks which
+	// build off of old blocks that are likely at a much easier difficulty and
+	// therefore could be used to waste cache and disk space.
+	if b.checkpointNode != nil && blockHeight < b.checkpointNode.height {
 		str := fmt.Sprintf("block at height %d forks the main chain "+
 			"before the previous checkpoint at height %d",
-			blockHeight, checkpointNode.height)
+			blockHeight, b.checkpointNode.height)
 		return ruleError(ErrForkTooOld, str)
 	}
 


### PR DESCRIPTION
**This requires PR #2013**.

This reworks the checkpoint logic in blockchain to greatly simplify it and pave the way to support checkpoints based on only the headers being available.

Previously there was more complex logic that attempted to find the most recent checkpoint that is already available in the downloaded portion of the block chain on demand along with the next checkpoint that is expected.  Instead, the new logic this introduces updates the most recent checkpoint as the blocks are processed as needed and finds the most recent checkpoint once during initialization.

This approach will eventually make it possible to update the most recent checkpoint based on headers alone since it is no longer tightly tied to the active best chain which will be important when decoupling the connection code from the download logic.
