### PR TITLE
config: Add flag to allow unsynced testnet mining.

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -119,8 +119,11 @@ Application Options:
       --nonaggressive       Disable mining off of the parent block of the blockchain
                             if there aren't enough voters
       --nominingstatesync   Disable synchronizing the mining state with other nodes
+      --allowunsyncedmining Allow block templates to be generated even when the
+                            chain is not considered synced on networks other
+                            than the main network -- This is automatically
+                            enabled when the simnet option is set
       --allowoldvotes       Enable the addition of very old votes to the mempool
-
       --sigcachemaxsize=    The maximum number of entries in the signature
                             verification cache.
       --blocksonly          Do not accept transactions from remote peers.

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3448,20 +3448,20 @@ func handleGetWork(ctx context.Context, s *rpcServer, cmd interface{}) (interfac
 			"via --miningaddr", "Configuration")
 	}
 
-	// Return an error if there are no peers connected since there is no
-	// way to relay a found block or receive transactions to work on.
-	// However, allow this state when running in the regression test or
-	// simulation test mode.
-	if !cfg.SimNet && s.cfg.ConnMgr.ConnectedCount() == 0 {
+	// Return an error if there are no peers connected since there is no way to
+	// relay a found block or receive transactions to work on unless
+	// unsynchronized mining has specifically been allowed.
+	if !cfg.AllowUnsyncedMining && s.cfg.ConnMgr.ConnectedCount() == 0 {
 		return nil, &dcrjson.RPCError{
 			Code:    dcrjson.ErrRPCClientNotConnected,
 			Message: "Decred is not connected",
 		}
 	}
 
-	// No point in generating or accepting work before the chain is synced.
+	// No point in generating or accepting work before the chain is synced
+	// unless unsynchronized mining has specifically been allowed.
 	bestHeight := s.cfg.Chain.BestSnapshot().Height
-	if bestHeight != 0 && !s.cfg.Chain.IsCurrent() {
+	if !cfg.AllowUnsyncedMining && bestHeight != 0 && !s.cfg.Chain.IsCurrent() {
 		return nil, &dcrjson.RPCError{
 			Code:    dcrjson.ErrRPCClientInInitialDownload,
 			Message: "Decred is downloading blocks...",

--- a/sampleconfig/sampleconfig.go
+++ b/sampleconfig/sampleconfig.go
@@ -327,6 +327,15 @@ const FileContents = `[Application Options]
 ; by the blockmaxsize option and will be limited as needed.
 ; blockprioritysize=20000
 
+; Allow block templates to be generated even when the chain is not considered
+; synced and there are no connections to other nodes on networks other than the
+; main network.  Specifying this option with the main network will result in a
+; configuration parse error.  This option is automatically enabled when the
+; simulation network is active.
+;
+; NOTE: This is an advanced option and should not be used unless you understand
+; exactly why it exists and what it implications it carries.
+; allowunsyncedmining=0
 
 ; ------------------------------------------------------------------------------
 ; Debug

--- a/server.go
+++ b/server.go
@@ -2956,7 +2956,7 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 	// Create the background block template generator if the config has a
 	// mining address.
 	if len(cfg.miningAddrs) > 0 {
-		s.bg = newBgBlkTmplGenerator(tg, cfg.miningAddrs, cfg.SimNet)
+		s.bg = newBgBlkTmplGenerator(tg, cfg.miningAddrs, cfg.AllowUnsyncedMining)
 		s.blockManager.cfg.BgBlkTmplGenerator = s.bg
 	}
 


### PR DESCRIPTION
**This is rebased on #2022**.

This introduces a new flag named `allowunsyncedmining` which allows checks that prevent unsynchonrized mining to be disabled on `testnet`.  This is an advanced option and should not be used unless you understand exactly why it exists and what it implications it carries.