### PR TITLE
bech32: Ensure HRP is lowercase when encoding.

### DIFF
--- a/bech32/bech32.go
+++ b/bech32/bech32.go
@@ -150,12 +150,13 @@ func bech32VerifyChecksum(hrp string, data []byte) bool {
 }
 
 // DecodeNoLimit decodes a bech32 encoded string, returning the human-readable
-// part and the data part excluding the checksum. This function does NOT
+// part and the data part excluding the checksum.  This function does NOT
 // validate against the BIP-173 maximum length allowed for bech32 strings and
 // is meant for use in custom applications (such as lightning network payment
 // requests), NOT on-chain addresses.
 //
-// Note that the returned data is 5-bit (base32) encoded.
+// Note that the returned data is 5-bit (base32) encoded and the human-readable
+// part will be lowercase.
 func DecodeNoLimit(bech string) (string, []byte, error) {
 	// The minimum allowed size of a bech32 string is 8 characters, since it
 	// needs a non-empty HRP, a separator, and a 6 character checksum.
@@ -234,7 +235,8 @@ func DecodeNoLimit(bech string) (string, []byte, error) {
 // Decode decodes a bech32 encoded string, returning the human-readable part and
 // the data part excluding the checksum.
 //
-// Note that the returned data is 5-bit (base32) encoded.
+// Note that the returned data is 5-bit (base32) encoded and the human-readable
+// part will be lowercase.
 func Decode(bech string) (string, []byte, error) {
 	// The maximum allowed length for a bech32 string is 90.
 	if len(bech) > 90 {
@@ -244,13 +246,14 @@ func Decode(bech string) (string, []byte, error) {
 	return DecodeNoLimit(bech)
 }
 
-// Encode encodes a byte slice into a bech32 string with the
-// human-readable part hrb. Note that the bytes must each encode 5 bits
-// (base32).
+// Encode encodes a byte slice into a bech32 string with the given
+// human-readable part (HRP).  The HRP will be converted to lowercase if needed
+// since mixed cased encodings are not permitted and lowercase is used for
+// checksum purposes.  Note that the bytes must each encode 5 bits (base32).
 func Encode(hrp string, data []byte) (string, error) {
-
-	// The resulting bech32 string is the concatenation of the hrp, the
-	// separator 1, data and the 6-byte checksum.
+	// The resulting bech32 string is the concatenation of the lowercase hrp,
+	// the separator 1, data and the 6-byte checksum.
+	hrp = strings.ToLower(hrp)
 	var bldr strings.Builder
 	bldr.Grow(len(hrp) + 1 + len(data) + 6)
 	bldr.WriteString(hrp)

--- a/bech32/example_test.go
+++ b/bech32/example_test.go
@@ -55,5 +55,5 @@ func ExampleEncode() {
 	fmt.Println("Encoded Data:", encoded)
 
 	// Output:
-	// Encoded Data: customHrp!11111q123jhxapqv3shgcgumastr
+	// Encoded Data: customhrp!11111q123jhxapqv3shgcgkxpuhe
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/btcsuite/winsvc v1.0.0
 	github.com/decred/base58 v1.0.2
 	github.com/decred/dcrd/addrmgr v1.1.0
+	github.com/decred/dcrd/bech32 v1.0.0
 	github.com/decred/dcrd/blockchain/stake/v3 v3.0.0-00010101000000-000000000000
 	github.com/decred/dcrd/blockchain/standalone v1.1.0
 	github.com/decred/dcrd/blockchain/v3 v3.0.0-00010101000000-000000000000
@@ -43,6 +44,7 @@ require (
 
 replace (
 	github.com/decred/dcrd/addrmgr => ./addrmgr
+	github.com/decred/dcrd/bech32 => ./bech32
 	github.com/decred/dcrd/blockchain/stake/v3 => ./blockchain/stake
 	github.com/decred/dcrd/blockchain/standalone => ./blockchain/standalone
 	github.com/decred/dcrd/blockchain/v3 => ./blockchain

--- a/require.go
+++ b/require.go
@@ -12,6 +12,7 @@
 package main
 
 import (
+	_ "github.com/decred/dcrd/bech32"
 	_ "github.com/decred/dcrd/dcrec/secp256k1/v2"
 	_ "github.com/decred/dcrd/fees/v2"
 )


### PR DESCRIPTION
BIP173 specifically calls out that encoders must always output an all lowercase bech32 string and that the lowercase form is used when determining a character's value for calculating the checksum.

Currently, the implementation does not respect either of those requirements.

This modifies the `Encode` function to convert the provided HRP to lowercase to ensure the requirements are satisfied and adds tests accordingly.