### PR TITLE
bech32: Add base256 conversion convenience funcs.

### DIFF
--- a/bech32/bech32.go
+++ b/bech32/bech32.go
@@ -348,3 +348,31 @@ func ConvertBits(data []byte, fromBits, toBits uint8, pad bool) ([]byte, error) 
 
 	return regrouped, nil
 }
+
+// EncodeFromBase256 converts a base256-encoded byte slice into a base32-encoded
+// byte slice and then encodes it into a bech32 string with the given
+// human-readable part (HRP).  The HRP will be converted to lowercase if needed
+// since mixed cased encodings are not permitted and lowercase is used for
+// checksum purposes.
+func EncodeFromBase256(hrp string, data []byte) (string, error) {
+	converted, err := ConvertBits(data, 8, 5, true)
+	if err != nil {
+		return "", err
+	}
+	return Encode(hrp, converted)
+}
+
+// DecodeToBase256 decodes a bech32-encoded string into its associated
+// human-readable part (HRP) and base32-encoded data, converts that data to a
+// base256-encoded byte slice and returns it along with the lowercase HRP.
+func DecodeToBase256(bech string) (string, []byte, error) {
+	hrp, data, err := Decode(bech)
+	if err != nil {
+		return "", nil, err
+	}
+	converted, err := ConvertBits(data, 5, 8, false)
+	if err != nil {
+		return "", nil, err
+	}
+	return hrp, converted, nil
+}


### PR DESCRIPTION
**This requires PR #2024**.

Since `bech32` itself works with data encoded with 5 bits per byte (aka base32) padded out to the nearest byte boundary, the existing functions for `Encode` and `Decode` accept and return data encoded that way.

However, the most common way to use `bech32` is to encode data that is already encoded with 8 bits per byte (aka base256) without padding which means it is up to the caller to use the `ConvertBits` function properly to convert between the two encodings.

Consequently, this introduces two convenience functions for working directly with base256-encoded data named `EncodeFromBase256` and `DecodeToBase256` along with a full set of tests to ensure they work as expected.

