### PR TITLE
rpcwebsocket: Use nonblocking messages and ntfns.

### DIFF
--- a/rpcwebsocket.go
+++ b/rpcwebsocket.go
@@ -1993,7 +1993,15 @@ func (c *wsClient) SendMessage(marshalledJSON []byte, doneChan chan bool) {
 		return
 	}
 
-	c.sendChan <- wsResponse{msg: marshalledJSON, doneChan: doneChan}
+	// Use select statement to unblock enqueuing the message once the client has
+	// begun shutting down.
+	select {
+	case c.sendChan <- wsResponse{msg: marshalledJSON, doneChan: doneChan}:
+	case <-c.quit:
+		if doneChan != nil {
+			doneChan <- false
+		}
+	}
 }
 
 // ErrClientQuit describes the error where a client send is not processed due
@@ -2015,7 +2023,14 @@ func (c *wsClient) QueueNotification(marshalledJSON []byte) error {
 		return ErrClientQuit
 	}
 
-	c.ntfnChan <- marshalledJSON
+	// Use select statement to unblock enqueuing the message once the client has
+	// begun shutting down.
+	select {
+	case c.ntfnChan <- marshalledJSON:
+	case <-c.quit:
+		return ErrClientQuit
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
All sends to channels that are serviced by separate goroutines that can be shutdown via a `quit` channel need to ensure they select across that `quit` channel when sending to the associated channel to ensure they can't end up blocking on the send during shutdown.