### PR TITLE
release: Add example OpenBSD rc.d service script

### DIFF
--- a/release/services/rc.d/dcrd
+++ b/release/services/rc.d/dcrd
@@ -1,0 +1,25 @@
+#!/bin/ksh
+
+# OpenBSD rc.d service file for dcrd.
+# Assumes a _dcrd user is created with home directory /var/dcrd.
+# All logs and crash traces are written to syslog, with dcrd's built-in
+# file logging and log rotation disabled by default.
+# Save to /etc/rc.d/dcrd and enable with 'dcrd_flags=' in
+# /etc/rc.conf.local.
+
+daemon="/usr/local/bin/dcrd"
+daemon_user=_dcrd
+defaults="-A /var/dcrd --nofilelogging"
+
+. /etc/rc.d/rc.subr
+
+pexp="${daemon} ${defaults} ${daemon_flags}.*"
+rc_bg=YES
+rc_reload=NO
+
+rc_start() {
+	${rcexec} "${daemon} ${defaults} ${daemon_flags} 2>&1 | \
+		logger -p daemon.info -t dcrd"
+}
+
+rc_cmd $1


### PR DESCRIPTION
This script removes the default file logging, instead preferring to
write all stdout and stderr (including panic traces) to syslog.
