### PR TITLE
multi: replace GetScriptClass consensus calls.

### DIFF
--- a/blockchain/stake/scripttype.go
+++ b/blockchain/stake/scripttype.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package stake
+
+import (
+	"github.com/decred/dcrd/txscript/v3"
+)
+
+// isScriptHashScript returns whether or not the passed script is a
+// pay-to-script-hash script per consensus rules.
+func isScriptHashScript(script []byte) bool {
+	// A pay-to-script-hash script is of the form:
+	//  OP_HASH160 <20-byte scripthash> OP_EQUAL
+	return len(script) == 23 &&
+		script[0] == txscript.OP_HASH160 &&
+		script[1] == txscript.OP_DATA_20 &&
+		script[22] == txscript.OP_EQUAL
+}
+
+// isPubKeyHashScript returns whether or not the passed script is
+// a pay-to-pubkey-hash script per consensus rules.
+func isPubKeyHashScript(script []byte) bool {
+	// A pay-to-pubkey-hash script is of the form:
+	//  OP_DUP OP_HASH160 <20-byte hash> OP_EQUALVERIFY OP_CHECKSIG
+	return len(script) == 25 &&
+		script[0] == txscript.OP_DUP &&
+		script[1] == txscript.OP_HASH160 &&
+		script[2] == txscript.OP_DATA_20 &&
+		script[23] == txscript.OP_EQUALVERIFY &&
+		script[24] == txscript.OP_CHECKSIG
+}
+
+// isTaggedScript checks if the provided script is tagged by the
+// provided op code.
+func isTaggedScript(version uint16, script []byte, op int) bool {
+	// The only supported version is 0.
+	if version != 0 {
+		return false
+	}
+
+	if len(script) < 1 {
+		return false
+	}
+
+	// A stake script pay-to-script-hash is of the form:
+	//   <opcode> <P2PKH or P2SH script>
+	if int(script[0]) != op {
+		return false
+	}
+
+	return isPubKeyHashScript(script[1:]) || isScriptHashScript(script[1:])
+}
+
+// IsTicketPurchaseScript checks if the provided script is a ticket purchase
+// script.
+func IsTicketPurchaseScript(version uint16, script []byte) bool {
+	return isTaggedScript(version, script, txscript.OP_SSTX)
+}
+
+// IsRevocationScript checks if the provided script is a ticket revocation
+// script.
+func IsRevocationScript(version uint16, script []byte) bool {
+	return isTaggedScript(version, script, txscript.OP_SSRTX)
+}
+
+// IsStakeChangeScript checks if the provided script is a stake change script.
+func IsStakeChangeScript(version uint16, script []byte) bool {
+	return isTaggedScript(version, script, txscript.OP_SSTXCHANGE)
+}
+
+// IsVoteScript checks if the provided script is a vote script.
+func IsVoteScript(version uint16, script []byte) bool {
+	return isTaggedScript(version, script, txscript.OP_SSGEN)
+}

--- a/blockchain/stake/scripttype_test.go
+++ b/blockchain/stake/scripttype_test.go
@@ -1,0 +1,352 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package stake
+
+import (
+	"testing"
+
+	"github.com/decred/dcrd/dcrutil/v3"
+	"github.com/decred/dcrd/txscript/v3"
+)
+
+var (
+	hash160 = dcrutil.Hash160([]byte("test"))
+)
+
+func TestIsRevocationScript(t *testing.T) {
+	tests := []struct {
+		name         string
+		scriptSource *txscript.ScriptBuilder
+		version      uint16
+		expected     bool
+	}{
+		{
+			name: "revocation-tagged p2pkh script",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSRTX).AddOp(txscript.OP_DUP).
+				AddOp(txscript.OP_HASH160).AddData(hash160).
+				AddOp(txscript.OP_EQUALVERIFY).AddOp(txscript.OP_CHECKSIG),
+			version:  0,
+			expected: true,
+		},
+		{
+			name: "revocation-tagged p2pkh script with unsupported version",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSRTX).AddOp(txscript.OP_DUP).
+				AddOp(txscript.OP_HASH160).AddData(hash160).
+				AddOp(txscript.OP_EQUALVERIFY).AddOp(txscript.OP_CHECKSIG),
+			version:  1,
+			expected: false,
+		},
+		{
+			name: "vote-tagged p2pkh script",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSGEN).AddOp(txscript.OP_DUP).
+				AddOp(txscript.OP_HASH160).AddData(hash160).
+				AddOp(txscript.OP_EQUALVERIFY).AddOp(txscript.OP_CHECKSIG),
+			version:  0,
+			expected: false,
+		},
+		{
+			name: "vote-tagged p2pkh script with unsupported version",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSGEN).AddOp(txscript.OP_DUP).
+				AddOp(txscript.OP_HASH160).AddData(hash160).
+				AddOp(txscript.OP_EQUALVERIFY).AddOp(txscript.OP_CHECKSIG),
+			version:  1,
+			expected: false,
+		},
+		{
+			name: "revocation-tagged p2sh script",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSRTX).AddOp(txscript.OP_HASH160).
+				AddData(hash160).AddOp(txscript.OP_EQUAL),
+			version:  0,
+			expected: true,
+		},
+		{
+			name: "revocation-tagged p2sh script with unsupported version",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSRTX).AddOp(txscript.OP_HASH160).
+				AddData(hash160).AddOp(txscript.OP_EQUAL),
+			version:  100,
+			expected: false,
+		},
+		{
+			name: "ticket purchase-tagged p2sh script",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSTX).AddOp(txscript.OP_HASH160).
+				AddData(hash160).AddOp(txscript.OP_EQUAL),
+			version:  0,
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		script, err := test.scriptSource.Script()
+		if err != nil {
+			t.Fatalf("%s: unexpected script generation error: %s",
+				test.name, err)
+		}
+
+		result := IsRevocationScript(test.version, script)
+		if result != test.expected {
+			t.Fatalf("%s: expected %v, got %v", test.name,
+				test.expected, result)
+		}
+	}
+}
+
+func TestIsTicketPurchaseScript(t *testing.T) {
+	tests := []struct {
+		name         string
+		scriptSource *txscript.ScriptBuilder
+		version      uint16
+		expected     bool
+	}{
+		{
+			name: "ticket purchase-tagged p2pkh script",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSTX).AddOp(txscript.OP_DUP).
+				AddOp(txscript.OP_HASH160).AddData(hash160).
+				AddOp(txscript.OP_EQUALVERIFY).AddOp(txscript.OP_CHECKSIG),
+			version:  0,
+			expected: true,
+		},
+		{
+			name: "ticket purchase-tagged p2pkh script with unsupported version",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSTX).AddOp(txscript.OP_DUP).
+				AddOp(txscript.OP_HASH160).AddData(hash160).
+				AddOp(txscript.OP_EQUALVERIFY).AddOp(txscript.OP_CHECKSIG),
+			version:  1,
+			expected: false,
+		},
+		{
+			name: "vote-tagged p2pkh script",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSGEN).AddOp(txscript.OP_DUP).
+				AddOp(txscript.OP_HASH160).AddData(hash160).
+				AddOp(txscript.OP_EQUALVERIFY).AddOp(txscript.OP_CHECKSIG),
+			version:  0,
+			expected: false,
+		},
+		{
+			name: "vote-tagged p2pkh script with unsupported version",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSGEN).AddOp(txscript.OP_DUP).
+				AddOp(txscript.OP_HASH160).AddData(hash160).
+				AddOp(txscript.OP_EQUALVERIFY).AddOp(txscript.OP_CHECKSIG),
+			version:  1,
+			expected: false,
+		},
+		{
+			name: "ticket purchase-tagged p2sh script",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSTX).AddOp(txscript.OP_HASH160).
+				AddData(hash160).AddOp(txscript.OP_EQUAL),
+			version:  0,
+			expected: true,
+		},
+		{
+			name: "ticket purchase-tagged p2sh script with unsupported version",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSTX).AddOp(txscript.OP_HASH160).
+				AddData(hash160).AddOp(txscript.OP_EQUAL),
+			version:  100,
+			expected: false,
+		},
+		{
+			name: "revocation-tagged p2sh script",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSRTX).AddOp(txscript.OP_HASH160).
+				AddData(hash160).AddOp(txscript.OP_EQUAL),
+			version:  0,
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		script, err := test.scriptSource.Script()
+		if err != nil {
+			t.Fatalf("%s: unexpected script generation error: %s",
+				test.name, err)
+		}
+
+		result := IsTicketPurchaseScript(test.version, script)
+		if result != test.expected {
+			t.Fatalf("%s, expected %v, got %v", test.name,
+				test.expected, result)
+		}
+	}
+}
+
+func TestIsVoteScript(t *testing.T) {
+	tests := []struct {
+		name         string
+		scriptSource *txscript.ScriptBuilder
+		version      uint16
+		expected     bool
+	}{
+		{
+			name: "vote-tagged p2pkh script",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSGEN).AddOp(txscript.OP_DUP).
+				AddOp(txscript.OP_HASH160).AddData(hash160).
+				AddOp(txscript.OP_EQUALVERIFY).AddOp(txscript.OP_CHECKSIG),
+			version:  0,
+			expected: true,
+		},
+		{
+			name: "vote-tagged p2pkh script with unsupported version",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSGEN).AddOp(txscript.OP_DUP).
+				AddOp(txscript.OP_HASH160).AddData(hash160).
+				AddOp(txscript.OP_EQUALVERIFY).AddOp(txscript.OP_CHECKSIG),
+			version:  1,
+			expected: false,
+		},
+		{
+			name: "ticket purchase-tagged p2pkh script",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSTX).AddOp(txscript.OP_DUP).
+				AddOp(txscript.OP_HASH160).AddData(hash160).
+				AddOp(txscript.OP_EQUALVERIFY).AddOp(txscript.OP_CHECKSIG),
+			version:  0,
+			expected: false,
+		},
+		{
+			name: "ticket purchase-tagged p2pkh script with unsupported version",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSTX).AddOp(txscript.OP_DUP).
+				AddOp(txscript.OP_HASH160).AddData(hash160).
+				AddOp(txscript.OP_EQUALVERIFY).AddOp(txscript.OP_CHECKSIG),
+			version:  1,
+			expected: false,
+		},
+		{
+			name: "vote-tagged p2sh script",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSGEN).AddOp(txscript.OP_HASH160).
+				AddData(hash160).AddOp(txscript.OP_EQUAL),
+			version:  0,
+			expected: true,
+		},
+		{
+			name: "vote-tagged p2sh script with unsupported version",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSGEN).AddOp(txscript.OP_HASH160).
+				AddData(hash160).AddOp(txscript.OP_EQUAL),
+			version:  100,
+			expected: false,
+		},
+		{
+			name: "revocation-tagged p2sh script",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSRTX).AddOp(txscript.OP_HASH160).
+				AddData(hash160).AddOp(txscript.OP_EQUAL),
+			version:  0,
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		script, err := test.scriptSource.Script()
+		if err != nil {
+			t.Fatalf("%s: unexpected script generation error: %s",
+				test.name, err)
+		}
+
+		result := IsVoteScript(test.version, script)
+		if result != test.expected {
+			t.Fatalf("%s, expected %v, got %v", test.name,
+				test.expected, result)
+		}
+	}
+}
+
+func TestIsStakeChangeScript(t *testing.T) {
+	tests := []struct {
+		name         string
+		scriptSource *txscript.ScriptBuilder
+		version      uint16
+		expected     bool
+	}{
+		{
+			name: "stake change-tagged p2pkh script",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSTXCHANGE).AddOp(txscript.OP_DUP).
+				AddOp(txscript.OP_HASH160).AddData(hash160).
+				AddOp(txscript.OP_EQUALVERIFY).AddOp(txscript.OP_CHECKSIG),
+			version:  0,
+			expected: true,
+		},
+		{
+			name: "stake change-tagged p2pkh script with unsupported version",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSTXCHANGE).AddOp(txscript.OP_DUP).
+				AddOp(txscript.OP_HASH160).AddData(hash160).
+				AddOp(txscript.OP_EQUALVERIFY).AddOp(txscript.OP_CHECKSIG),
+			version:  1,
+			expected: false,
+		},
+		{
+			name: "vote-tagged p2pkh script",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSGEN).AddOp(txscript.OP_DUP).
+				AddOp(txscript.OP_HASH160).AddData(hash160).
+				AddOp(txscript.OP_EQUALVERIFY).AddOp(txscript.OP_CHECKSIG),
+			version:  0,
+			expected: false,
+		},
+		{
+			name: "vote-tagged p2pkh script with unsupported version",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSGEN).AddOp(txscript.OP_DUP).
+				AddOp(txscript.OP_HASH160).AddData(hash160).
+				AddOp(txscript.OP_EQUALVERIFY).AddOp(txscript.OP_CHECKSIG),
+			version:  1,
+			expected: false,
+		},
+		{
+			name: "stake change-tagged p2sh script",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSTXCHANGE).AddOp(txscript.OP_HASH160).
+				AddData(hash160).AddOp(txscript.OP_EQUAL),
+			version:  0,
+			expected: true,
+		},
+		{
+			name: "stake change-tagged p2sh script with unsupported version",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSTXCHANGE).AddOp(txscript.OP_HASH160).
+				AddData(hash160).AddOp(txscript.OP_EQUAL),
+			version:  100,
+			expected: false,
+		},
+		{
+			name: "revocation-tagged p2sh script",
+			scriptSource: txscript.NewScriptBuilder().
+				AddOp(txscript.OP_SSRTX).AddOp(txscript.OP_HASH160).
+				AddData(hash160).AddOp(txscript.OP_EQUAL),
+			version:  0,
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		script, err := test.scriptSource.Script()
+		if err != nil {
+			t.Fatalf("%s: unexpected script generation error: %s",
+				test.name, err)
+		}
+
+		result := IsStakeChangeScript(test.version, script)
+		if result != test.expected {
+			t.Fatalf("%s, expected %v, got %v", test.name,
+				test.expected, result)
+		}
+	}
+}

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -238,7 +238,7 @@ func extractCompressedPubKey(script []byte) []byte {
 // passed script if it is a standard pay-to-uncompressed-secp256k1-pubkey
 // script.  It will return nil otherwise.
 func extractUncompressedPubKey(script []byte) []byte {
-	// A pay-to-compressed-pubkey script is of the form:
+	// A pay-to-uncompressed-pubkey script is of the form:
 	//  OP_DATA_65 <65-byte uncompressed pubkey> OP_CHECKSIG
 
 	// All non-hybrid uncompressed secp256k1 public keys must start with 0x04.


### PR DESCRIPTION
This removes `GetScriptClass` consensus calls in favour of using script type identification
functions defined in the blockchain package.

Resolves #1626.