### PR TITLE
 connmgr: Allow pending outbound conn removal. 

### DIFF
--- a/connmgr/connmanager.go
+++ b/connmgr/connmanager.go
@@ -354,24 +354,20 @@ out:
 				cm.handleFailedConn(connReq)
 
 			case handleCancelPending:
-				found := false
+				pendingAddr := msg.addr.String()
 				var idToRemove uint64
-				connReq := &ConnReq{}
+				var connReq *ConnReq
 				for id, req := range pending {
-					if msg.addr.String() == req.Addr.String() {
-						idToRemove = id
-						connReq = req
-						found = true
+					if pendingAddr == req.Addr.String() {
+						idToRemove, connReq = id, req
 						break
 					}
 
 				}
-				if found {
+				if connReq != nil {
 					delete(pending, idToRemove)
 					connReq.updateState(ConnCanceled)
 					log.Debugf("Canceled pending connection to %v", msg.addr)
-				} else {
-					log.Errorf("Did not find connection to cancel at address %v", msg.addr)
 				}
 				close(msg.done)
 			}


### PR DESCRIPTION
NOTE: This is a resubmission of #1842 with the requested changes applied in a separate commit since the author of that PR was not responsive in addressing them for several months.  I've squashed the commits in that PR per standard practice and also updated the commit title to conform to the code contribution guidelines, but otherwise left them unchanged and attributed to the original author to ensure proper credit is given.  Along those lines, I've added a separate commit which applies the requested changes as well as adds the additional code needed to make it work with incompatible changes that have since been made to master in the mean time.

This PR resolves #1725. Currently, if there is a call made by `dcrctl addnode <ip_addr:port> add` to an unresponsive port, the connReq will repeatedly retry to connect until the timeout period has been reached. `dcrctl addnode <ip_addr:port> remove` will not stop the retry attempts. The PR removes the addr from the list of pending failed connections if the `dcrctl addnode <ip_addr:port> remove` does not find an active connection. 

Fixes #1725.