### PR TITLE
mining: Fix regenHandler shutdown.

### DIFF
--- a/mining.go
+++ b/mining.go
@@ -3127,7 +3127,12 @@ func (g *BgBlkTmplGenerator) regenHandler(ctx context.Context) {
 	if err != nil {
 		g.setCurrentTemplate(nil, turUnknown, err)
 	} else {
-		g.queueRegenEvent <- regenEvent{rtBlockConnected, tipBlock}
+		select {
+		case <-ctx.Done():
+			g.wg.Done()
+			return
+		case g.queueRegenEvent <- regenEvent{rtBlockConnected, tipBlock}:
+		}
 	}
 
 	state := makeRegenHandlerState()


### PR DESCRIPTION
This fixes a case where`queueRegenEvent` blocks indefinitely (because it's not being read) in `regenHandler` when the template generator is shutting down.