### PR TITLE
secp256k1: Remove unused chainec code.

### DIFF
--- a/dcrec/secp256k1/btcec.go
+++ b/dcrec/secp256k1/btcec.go
@@ -33,9 +33,6 @@ var (
 	fieldOne = new(fieldVal).SetInt(1)
 )
 
-// ecTypeSecp256k1 is the ECDSA type for the chainec interface.
-var ecTypeSecp256k1 int
-
 // KoblitzCurve supports a koblitz curve implementation that fits the ECC Curve
 // interface from crypto/elliptic.
 type KoblitzCurve struct {

--- a/dcrec/secp256k1/privkey.go
+++ b/dcrec/secp256k1/privkey.go
@@ -105,18 +105,3 @@ func (p PrivateKey) Serialize() []byte {
 	b := make([]byte, 0, PrivKeyBytesLen)
 	return paddedAppend(PrivKeyBytesLen, b, p.ToECDSA().D.Bytes())
 }
-
-// SerializeSecret satisfies the chainec PrivateKey interface.
-func (p PrivateKey) SerializeSecret() []byte {
-	return p.Serialize()
-}
-
-// GetD satisfies the chainec PrivateKey interface.
-func (p PrivateKey) GetD() *big.Int {
-	return p.D
-}
-
-// GetType satisfies the chainec PrivateKey interface.
-func (p PrivateKey) GetType() int {
-	return ecTypeSecp256k1
-}

--- a/dcrec/secp256k1/pubkey.go
+++ b/dcrec/secp256k1/pubkey.go
@@ -125,12 +125,6 @@ func (p PublicKey) ToECDSA() *ecdsa.PublicKey {
 	return &ecpk
 }
 
-// Serialize serializes a public key in a 33-byte compressed format.
-// It is the default serialization method.
-func (p PublicKey) Serialize() []byte {
-	return p.SerializeCompressed()
-}
-
 // SerializeUncompressed serializes a public key in a 65-byte uncompressed
 // format.
 func (p PublicKey) SerializeUncompressed() []byte {
@@ -167,24 +161,4 @@ func paddedAppend(size uint, dst, src []byte) []byte {
 		dst = append(dst, 0)
 	}
 	return append(dst, src...)
-}
-
-// GetCurve satisfies the chainec PublicKey interface.
-func (p PublicKey) GetCurve() interface{} {
-	return p.Curve
-}
-
-// GetX satisfies the chainec PublicKey interface.
-func (p PublicKey) GetX() *big.Int {
-	return p.X
-}
-
-// GetY satisfies the chainec PublicKey interface.
-func (p PublicKey) GetY() *big.Int {
-	return p.Y
-}
-
-// GetType satisfies the chainec PublicKey interface.
-func (p PublicKey) GetType() int {
-	return ecTypeSecp256k1
 }

--- a/dcrec/secp256k1/schnorr/ecdsa.go
+++ b/dcrec/secp256k1/schnorr/ecdsa.go
@@ -159,7 +159,7 @@ func schnorrSign(msg []byte, ps []byte, k []byte,
 func Sign(priv *secp256k1.PrivateKey,
 	hash []byte) (r, s *big.Int, err error) {
 	// Convert the private scalar to a 32 byte big endian number.
-	pA := bigIntToEncodedBytes(priv.GetD())
+	pA := bigIntToEncodedBytes(priv.D)
 	defer zeroArray(pA)
 
 	// Generate a 32-byte scalar to use as a nonce. Try RFC6979
@@ -170,8 +170,8 @@ func Sign(priv *secp256k1.PrivateKey,
 		sig, err := schnorrSign(hash, pA[:], kB, nil, nil,
 			chainhash.HashB)
 		if err == nil {
-			r = sig.GetR()
-			s = sig.GetS()
+			r = sig.R
+			s = sig.S
 			break
 		}
 
@@ -219,7 +219,7 @@ func schnorrVerify(sig []byte,
 		return false, schnorrError(ErrInputValue, str)
 	}
 
-	if !curve.IsOnCurve(pubkey.GetX(), pubkey.GetY()) {
+	if !curve.IsOnCurve(pubkey.X, pubkey.Y) {
 		str := fmt.Sprintf("pubkey point is not on curve")
 		return false, schnorrError(ErrPointNotOnCurve, str)
 	}
@@ -260,7 +260,7 @@ func schnorrVerify(sig []byte,
 	}
 
 	// r' = hQ + sG
-	lx, ly := curve.ScalarMult(pubkey.GetX(), pubkey.GetY(), h)
+	lx, ly := curve.ScalarMult(pubkey.X, pubkey.Y, h)
 	rx, ry := curve.ScalarBaseMult(sigS)
 	rlx, rly := curve.Add(lx, ly, rx, ry)
 
@@ -371,7 +371,7 @@ func schnorrRecover(sig, msg []byte,
 	sBig.Mod(sBig, curve.N)
 
 	// Q = h^(-1)R + s'G
-	lx, ly := curve.ScalarMult(rPoint.GetX(), rPoint.GetY(), hInv.Bytes())
+	lx, ly := curve.ScalarMult(rPoint.X, rPoint.Y, hInv.Bytes())
 	rx, ry := curve.ScalarBaseMult(sBig.Bytes())
 	pkx, pky := curve.Add(lx, ly, rx, ry)
 

--- a/dcrec/secp256k1/schnorr/ecdsa_test.go
+++ b/dcrec/secp256k1/schnorr/ecdsa_test.go
@@ -152,7 +152,8 @@ func TestSchnorrSigning(t *testing.T) {
 			t.Fatalf("unexpected error %v", err)
 		}
 
-		cmp = bytes.Equal(pubkey.Serialize()[:], pkRecover.Serialize()[:])
+		cmp = bytes.Equal(pubkey.SerializeCompressed()[:],
+			pkRecover.SerializeCompressed()[:])
 		if !cmp {
 			t.Fatalf("expected %v, got %v", true, cmp)
 		}
@@ -173,7 +174,8 @@ func TestSchnorrSigning(t *testing.T) {
 		pkRecover, valid, err = schnorrRecover(sigBad, tv.msg,
 			testSchnorrHash)
 		if valid {
-			cmp = bytes.Equal(pubkey.Serialize()[:], pkRecover.Serialize()[:])
+			cmp = bytes.Equal(pubkey.SerializeCompressed()[:],
+				pkRecover.SerializeCompressed()[:])
 			if cmp {
 				t.Fatalf("expected %v, got %v", false, cmp)
 			}
@@ -310,7 +312,8 @@ func TestSignaturesAndRecovery(t *testing.T) {
 			t.Fatalf("unexpected error %s", err)
 		}
 
-		cmp := bytes.Equal(pubkey.Serialize()[:], pkRecover.Serialize()[:])
+		cmp := bytes.Equal(pubkey.SerializeCompressed()[:],
+			pkRecover.SerializeCompressed()[:])
 		if !cmp {
 			t.Fatalf("expected %v, got %v", true, cmp)
 		}
@@ -336,7 +339,8 @@ func TestSignaturesAndRecovery(t *testing.T) {
 		pkRecover, valid, err = schnorrRecover(sigBad, tv.msg,
 			testSchnorrHash)
 		if valid {
-			cmp := bytes.Equal(pubkey.Serialize()[:], pkRecover.Serialize()[:])
+			cmp := bytes.Equal(pubkey.SerializeCompressed()[:],
+				pkRecover.SerializeCompressed()[:])
 			if cmp {
 				t.Fatalf("expected %v, got %v", false, cmp)
 			}

--- a/dcrec/secp256k1/schnorr/threshold.go
+++ b/dcrec/secp256k1/schnorr/threshold.go
@@ -39,13 +39,11 @@ func combinePubkeys(pks []*secp256k1.PublicKey) *secp256k1.PublicKey {
 	var pkSumX *big.Int
 	var pkSumY *big.Int
 
-	pkSumX, pkSumY = curve.Add(pks[0].GetX(), pks[0].GetY(),
-		pks[1].GetX(), pks[1].GetY())
+	pkSumX, pkSumY = curve.Add(pks[0].X, pks[0].Y, pks[1].X, pks[1].Y)
 
 	if numPubKeys > 2 {
 		for i := 2; i < numPubKeys; i++ {
-			pkSumX, pkSumY = curve.Add(pkSumX, pkSumY,
-				pks[i].GetX(), pks[i].GetY())
+			pkSumX, pkSumY = curve.Add(pkSumX, pkSumY, pks[i].X, pks[i].Y)
 		}
 	}
 
@@ -116,13 +114,12 @@ func schnorrPartialSign(msg []byte, priv []byte, privNonce []byte,
 	}
 	privNonceBig.SetInt64(0)
 
-	if !curve.IsOnCurve(pubSum.GetX(), pubSum.GetY()) {
+	if !curve.IsOnCurve(pubSum.X, pubSum.Y) {
 		str := fmt.Sprintf("public key sum is off curve")
 		return nil, schnorrError(ErrInputValue, str)
 	}
 
-	return schnorrSign(msg, priv, privNonce, pubSum.GetX(),
-		pubSum.GetY(), hashFunc)
+	return schnorrSign(msg, priv, privNonce, pubSum.X, pubSum.Y, hashFunc)
 }
 
 // schnorrCombineSigs combines a list of partial Schnorr signatures s values

--- a/dcrec/secp256k1/schnorr/threshold_test.go
+++ b/dcrec/secp256k1/schnorr/threshold_test.go
@@ -226,13 +226,15 @@ func TestSchnorrThresholdRef(t *testing.T) {
 			}
 
 			_, pubkey := secp256k1.PrivKeyFromBytes(signer.privkey)
-			cmp = bytes.Equal(pubkey.Serialize()[:], signer.pubkey.Serialize()[:])
+			cmp = bytes.Equal(pubkey.SerializeCompressed()[:],
+				signer.pubkey.SerializeCompressed()[:])
 			if !cmp {
 				t.Fatalf("expected %v, got %v", true, cmp)
 			}
 
 			_, pubNonce := secp256k1.PrivKeyFromBytes(nonce)
-			cmp = bytes.Equal(pubNonce.Serialize()[:], signer.publicNonce.Serialize()[:])
+			cmp = bytes.Equal(pubNonce.SerializeCompressed()[:],
+				signer.publicNonce.SerializeCompressed()[:])
 			if !cmp {
 				t.Fatalf("expected %v, got %v", true, cmp)
 			}
@@ -242,15 +244,16 @@ func TestSchnorrThresholdRef(t *testing.T) {
 
 			itr := 0
 			for _, signer := range tv.signers {
-				if bytes.Equal(signer.publicNonce.Serialize(),
-					tv.signers[i].publicNonce.Serialize()) {
+				if bytes.Equal(signer.publicNonce.SerializeCompressed(),
+					tv.signers[i].publicNonce.SerializeCompressed()) {
 					continue
 				}
 				pubKeys[itr] = signer.publicNonce
 				itr++
 			}
 			publicNonceSum := combinePubkeys(pubKeys)
-			cmp = bytes.Equal(publicNonceSum.Serialize()[:], signer.pubKeySumLocal.Serialize()[:])
+			cmp = bytes.Equal(publicNonceSum.SerializeCompressed()[:],
+				signer.pubKeySumLocal.SerializeCompressed()[:])
 			if !cmp {
 				t.Fatalf("expected %v, got %v", true, cmp)
 			}
@@ -340,7 +343,8 @@ func TestSchnorrThreshold(t *testing.T) {
 			localPubNonces := make([]*secp256k1.PublicKey, numKeysForTest-1)
 			itr := 0
 			for _, pubNonce := range pubNoncesToUse {
-				if bytes.Equal(thisPubNonce.Serialize(), pubNonce.Serialize()) {
+				if bytes.Equal(thisPubNonce.SerializeCompressed(),
+					pubNonce.SerializeCompressed()) {
 					continue
 				}
 				localPubNonces[itr] = pubNonce
@@ -395,11 +399,11 @@ func TestSchnorrThreshold(t *testing.T) {
 		}
 		// Corrupt public key.
 		if corruptWhat == 1 {
-			pubXCorrupt := bigIntToEncodedBytes(pubKeysToUse[randItem].GetX())
+			pubXCorrupt := bigIntToEncodedBytes(pubKeysToUse[randItem].X)
 			pos := tRand.Intn(31)
 			bitPos := tRand.Intn(7)
 			pubXCorrupt[pos] ^= 1 << uint8(bitPos)
-			pubKeysToUse[randItem].GetX().SetBytes(pubXCorrupt[:])
+			pubKeysToUse[randItem].X.SetBytes(pubXCorrupt[:])
 		}
 		// Corrupt private nonce.
 		if corruptWhat == 2 {
@@ -411,11 +415,11 @@ func TestSchnorrThreshold(t *testing.T) {
 		}
 		// Corrupt public nonce.
 		if corruptWhat == 3 {
-			pubXCorrupt := bigIntToEncodedBytes(pubNoncesToUse[randItem].GetX())
+			pubXCorrupt := bigIntToEncodedBytes(pubNoncesToUse[randItem].X)
 			pos := tRand.Intn(31)
 			bitPos := tRand.Intn(7)
 			pubXCorrupt[pos] ^= 1 << uint8(bitPos)
-			pubNoncesToUse[randItem].GetX().SetBytes(pubXCorrupt[:])
+			pubNoncesToUse[randItem].X.SetBytes(pubXCorrupt[:])
 		}
 
 		for j := range keysToUse {
@@ -423,7 +427,8 @@ func TestSchnorrThreshold(t *testing.T) {
 			localPubNonces := make([]*secp256k1.PublicKey, numKeysForTest-1)
 			itr := 0
 			for _, pubNonce := range pubNoncesToUse {
-				if bytes.Equal(thisPubNonce.Serialize(), pubNonce.Serialize()) {
+				if bytes.Equal(thisPubNonce.SerializeCompressed(),
+					pubNonce.SerializeCompressed()) {
 					continue
 				}
 				localPubNonces[itr] = pubNonce

--- a/dcrec/secp256k1/signature.go
+++ b/dcrec/secp256k1/signature.go
@@ -83,7 +83,7 @@ func (sig *Signature) Serialize() []byte {
 // Verify calls ecdsa.Verify to verify the signature of hash using the public
 // key.  It returns true if the signature is valid, false otherwise.
 func (sig *Signature) Verify(hash []byte, pubKey *PublicKey) bool {
-	return ecdsa.Verify(pubKey.ToECDSA(), hash, sig.GetR(), sig.GetS())
+	return ecdsa.Verify(pubKey.ToECDSA(), hash, sig.R, sig.S)
 }
 
 // IsEqual compares this Signature instance to the one passed, returning true
@@ -553,19 +553,4 @@ func bits2octets(in []byte, rolen int) []byte {
 		return int2octets(z1, rolen)
 	}
 	return int2octets(z2, rolen)
-}
-
-// GetR satisfies the chainec PublicKey interface.
-func (sig Signature) GetR() *big.Int {
-	return sig.R
-}
-
-// GetS satisfies the chainec PublicKey interface.
-func (sig Signature) GetS() *big.Int {
-	return sig.S
-}
-
-// GetType satisfies the chainec Signature interface.
-func (sig Signature) GetType() int {
-	return ecTypeSecp256k1
 }

--- a/dcrutil/address.go
+++ b/dcrutil/address.go
@@ -574,7 +574,7 @@ func NewAddressSecSchnorrPubKey(serializedPubKey []byte, net AddressParams) (*Ad
 // serialize returns the serialization of the public key according to the
 // format associated with the address.
 func (a *AddressSecSchnorrPubKey) serialize() []byte {
-	return a.pubKey.Serialize()
+	return a.pubKey.SerializeCompressed()
 }
 
 // Address returns the string encoding of the public key as a
@@ -600,7 +600,7 @@ func (a *AddressSecSchnorrPubKey) ScriptAddress() []byte {
 // when an array is more appropriate than a slice (for example, when used as map
 // keys).
 func (a *AddressSecSchnorrPubKey) Hash160() *[ripemd160.Size]byte {
-	h160 := Hash160(a.pubKey.Serialize())
+	h160 := Hash160(a.pubKey.SerializeCompressed())
 	array := new([ripemd160.Size]byte)
 	copy(array[:], h160)
 

--- a/txscript/sign.go
+++ b/txscript/sign.go
@@ -94,7 +94,7 @@ func SignatureScript(tx *wire.MsgTx, idx int, subscript []byte, hashType SigHash
 		pkData = pub.Serialize()
 	case dcrec.STSchnorrSecp256k1:
 		_, pub := secp256k1.PrivKeyFromBytes(privKey)
-		pkData = pub.Serialize()
+		pkData = pub.SerializeCompressed()
 	default:
 		return nil, fmt.Errorf("unsupported signature type '%v'", sigType)
 	}
@@ -399,8 +399,8 @@ sigLoop:
 			// If it matches we put it in the map. We only
 			// can take one signature per public key so if we
 			// already have one, we can throw this away.
-			r := pSig.GetR()
-			s := pSig.GetS()
+			r := pSig.R
+			s := pSig.S
 			if secp256k1.NewSignature(r, s).Verify(hash, pubKey) {
 				aStr := addr.Address()
 				if _, ok := addrToSig[aStr]; !ok {

--- a/txscript/sign_test.go
+++ b/txscript/sign_test.go
@@ -232,7 +232,7 @@ func TestSignTxOutput(t *testing.T) {
 				case dcrec.STSchnorrSecp256k1:
 					keyDB, _, _, _ = schnorr.GenerateKey(rand.Reader)
 					_, pk := secp256k1.PrivKeyFromBytes(keyDB)
-					pkBytes = pk.Serialize()
+					pkBytes = pk.SerializeCompressed()
 				}
 
 				msg := fmt.Sprintf("%d:%d:%d", hashType, i, suite)
@@ -291,7 +291,7 @@ func TestSignTxOutput(t *testing.T) {
 				case dcrec.STSchnorrSecp256k1:
 					keyDB, _, _, _ = schnorr.GenerateKey(rand.Reader)
 					_, pk := secp256k1.PrivKeyFromBytes(keyDB)
-					pkBytes = pk.Serialize()
+					pkBytes = pk.SerializeCompressed()
 				}
 
 				msg := fmt.Sprintf("%d:%d:%d", hashType, i, suite)
@@ -755,7 +755,7 @@ func TestSignTxOutput(t *testing.T) {
 				case dcrec.STSchnorrSecp256k1:
 					keyDB, _, _, _ = schnorr.GenerateKey(rand.Reader)
 					_, pk := secp256k1.PrivKeyFromBytes(keyDB)
-					pkBytes = pk.Serialize()
+					pkBytes = pk.SerializeCompressed()
 					address, err = dcrutil.NewAddressSecSchnorrPubKey(pkBytes,
 						testingParams)
 					if err != nil {
@@ -839,7 +839,7 @@ func TestSignTxOutput(t *testing.T) {
 				case dcrec.STSchnorrSecp256k1:
 					keyDB, _, _, _ = schnorr.GenerateKey(rand.Reader)
 					_, pk := secp256k1.PrivKeyFromBytes(keyDB)
-					pkBytes = pk.Serialize()
+					pkBytes = pk.SerializeCompressed()
 					address, err = dcrutil.NewAddressSecSchnorrPubKey(pkBytes,
 						testingParams)
 					if err != nil {
@@ -909,7 +909,7 @@ func TestSignTxOutput(t *testing.T) {
 				case dcrec.STSchnorrSecp256k1:
 					keyDB, _, _, _ = schnorr.GenerateKey(rand.Reader)
 					_, pk := secp256k1.PrivKeyFromBytes(keyDB)
-					pkBytes = pk.Serialize()
+					pkBytes = pk.SerializeCompressed()
 					address, err = dcrutil.NewAddressSecSchnorrPubKey(pkBytes,
 						testingParams)
 					if err != nil {
@@ -977,7 +977,7 @@ func TestSignTxOutput(t *testing.T) {
 				case dcrec.STSchnorrSecp256k1:
 					keyDB, _, _, _ = schnorr.GenerateKey(rand.Reader)
 					_, pk := secp256k1.PrivKeyFromBytes(keyDB)
-					pkBytes = pk.Serialize()
+					pkBytes = pk.SerializeCompressed()
 				}
 
 				msg := fmt.Sprintf("%d:%d:%d", hashType, i, suite)
@@ -1054,7 +1054,7 @@ func TestSignTxOutput(t *testing.T) {
 				case dcrec.STSchnorrSecp256k1:
 					keyDB, _, _, _ = schnorr.GenerateKey(rand.Reader)
 					_, pk := secp256k1.PrivKeyFromBytes(keyDB)
-					pkBytes = pk.Serialize()
+					pkBytes = pk.SerializeCompressed()
 				}
 
 				msg := fmt.Sprintf("%d:%d:%d", hashType, i, suite)
@@ -1333,7 +1333,7 @@ func TestSignTxOutput(t *testing.T) {
 				case dcrec.STSchnorrSecp256k1:
 					keyDB, _, _, _ = schnorr.GenerateKey(rand.Reader)
 					_, pk := secp256k1.PrivKeyFromBytes(keyDB)
-					pkBytes = pk.Serialize()
+					pkBytes = pk.SerializeCompressed()
 					address, err = dcrutil.NewAddressSecSchnorrPubKey(pkBytes,
 						testingParams)
 					if err != nil {
@@ -1422,7 +1422,7 @@ func TestSignTxOutput(t *testing.T) {
 				case dcrec.STSchnorrSecp256k1:
 					keyDB, _, _, _ = schnorr.GenerateKey(rand.Reader)
 					_, pk := secp256k1.PrivKeyFromBytes(keyDB)
-					pkBytes = pk.Serialize()
+					pkBytes = pk.SerializeCompressed()
 					address, err = dcrutil.NewAddressSecSchnorrPubKey(pkBytes,
 						testingParams)
 					if err != nil {
@@ -1524,7 +1524,7 @@ func TestSignTxOutput(t *testing.T) {
 				case dcrec.STSchnorrSecp256k1:
 					keyDB, _, _, _ = schnorr.GenerateKey(rand.Reader)
 					_, pk := secp256k1.PrivKeyFromBytes(keyDB)
-					pkBytes = pk.Serialize()
+					pkBytes = pk.SerializeCompressed()
 					address, err = dcrutil.NewAddressSecSchnorrPubKey(pkBytes,
 						testingParams)
 					if err != nil {
@@ -1613,7 +1613,7 @@ func TestSignTxOutput(t *testing.T) {
 				case dcrec.STSchnorrSecp256k1:
 					keyDB, _, _, _ = schnorr.GenerateKey(rand.Reader)
 					_, pk := secp256k1.PrivKeyFromBytes(keyDB)
-					pkBytes = pk.Serialize()
+					pkBytes = pk.SerializeCompressed()
 					address, err = dcrutil.NewAddressSecSchnorrPubKey(pkBytes,
 						testingParams)
 					if err != nil {


### PR DESCRIPTION
**This requires #2040.**

This removes several functions that only existed to satisfy the `chainec` interfaces which no longer exist.  It also updates any callers that were directly using functions instead of just directly access the fields or underlying functions accordingly.
