### PR TITLE
secp256k1: Improve and optimize nonce generation.

### DIFF
--- a/dcrec/secp256k1/bench_test.go
+++ b/dcrec/secp256k1/bench_test.go
@@ -146,7 +146,7 @@ func BenchmarkNonceRFC6979(b *testing.B) {
 	b.ResetTimer()
 	var noElideNonce *big.Int
 	for i := 0; i < b.N; i++ {
-		noElideNonce = NonceRFC6979(privKey, msgHash, nil, nil)
+		noElideNonce = NonceRFC6979(privKey, msgHash, nil, nil, 0)
 	}
 	_ = noElideNonce
 }

--- a/dcrec/secp256k1/btcec_test.go
+++ b/dcrec/secp256k1/btcec_test.go
@@ -1,5 +1,5 @@
 // Copyright 2011 The Go Authors. All rights reserved.
-// Copyright (c) 2015-2019 The Decred developers
+// Copyright (c) 2015-2020 The Decred developers
 // Copyright 2011 ThePiachu. All rights reserved.
 // Copyright 2013-2016 The btcsuite developers
 // Use of this source code is governed by an ISC
@@ -798,12 +798,7 @@ func testSignAndVerify(t *testing.T, c *KoblitzCurve, tag string) {
 	pub := NewPublicKey(pubx, puby)
 
 	hashed := []byte("testing")
-	sig, err := priv.Sign(hashed)
-	if err != nil {
-		t.Errorf("%s: error signing: %s", tag, err)
-		return
-	}
-
+	sig := priv.Sign(hashed)
 	if !sig.Verify(hashed, pub) {
 		t.Errorf("%s: Verify failed", tag)
 	}

--- a/dcrec/secp256k1/example_test.go
+++ b/dcrec/secp256k1/example_test.go
@@ -28,11 +28,7 @@ func Example_signMessage() {
 	// Sign a message using the private key.
 	message := "test message"
 	messageHash := chainhash.HashB([]byte(message))
-	signature, err := privKey.Sign(messageHash)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
+	signature := privKey.Sign(messageHash)
 
 	// Serialize and display the signature.
 	fmt.Printf("Serialized Signature: %x\n", signature.Serialize())

--- a/dcrec/secp256k1/privkey.go
+++ b/dcrec/secp256k1/privkey.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -28,8 +28,7 @@ func NewPrivateKey(d *big.Int) *PrivateKey {
 
 // PrivKeyFromBytes returns a private and public key for `curve' based on the
 // private key passed as an argument as a byte slice.
-func PrivKeyFromBytes(pk []byte) (*PrivateKey,
-	*PublicKey) {
+func PrivKeyFromBytes(pk []byte) (*PrivateKey, *PublicKey) {
 	curve := S256()
 	x, y := curve.ScalarBaseMult(pk)
 
@@ -46,8 +45,7 @@ func PrivKeyFromBytes(pk []byte) (*PrivateKey,
 }
 
 // PrivKeyFromScalar is the same as PrivKeyFromBytes in secp256k1.
-func PrivKeyFromScalar(s []byte) (*PrivateKey,
-	*PublicKey) {
+func PrivKeyFromScalar(s []byte) (*PrivateKey, *PublicKey) {
 	return PrivKeyFromBytes(s)
 }
 
@@ -63,8 +61,7 @@ func GeneratePrivateKey() (*PrivateKey, error) {
 
 // GenerateKey generates a key using a random number generator, returning
 // the private scalar and the corresponding public key points.
-func GenerateKey(rand io.Reader) (priv []byte, x,
-	y *big.Int, err error) {
+func GenerateKey(rand io.Reader) (priv []byte, x, y *big.Int, err error) {
 	key, err := ecdsa.GenerateKey(S256(), rand)
 	priv = key.D.Bytes()
 	x = key.PublicKey.X

--- a/dcrec/secp256k1/privkey.go
+++ b/dcrec/secp256k1/privkey.go
@@ -89,7 +89,7 @@ func (p *PrivateKey) ToECDSA() *ecdsa.PrivateKey {
 // result of hashing a larger message) using the private key. Produced signature
 // is deterministic (same message and same key yield the same signature) and
 // canonical in accordance with RFC6979 and BIP0062.
-func (p *PrivateKey) Sign(hash []byte) (*Signature, error) {
+func (p *PrivateKey) Sign(hash []byte) *Signature {
 	return signRFC6979(p, hash)
 }
 

--- a/dcrec/secp256k1/privkey_test.go
+++ b/dcrec/secp256k1/privkey_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2017 The Decred developers
+// Copyright (c) 2015-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -36,12 +36,7 @@ func TestPrivKeys(t *testing.T) {
 		}
 
 		hash := []byte{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9}
-		sig, err := priv.Sign(hash)
-		if err != nil {
-			t.Errorf("%s could not sign: %v", test.name, err)
-			continue
-		}
-
+		sig := priv.Sign(hash)
 		if !sig.Verify(hash, pub) {
 			t.Errorf("%s could not verify: %v", test.name, err)
 			continue

--- a/dcrec/secp256k1/pubkey.go
+++ b/dcrec/secp256k1/pubkey.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -62,8 +62,7 @@ func NewPublicKey(x *big.Int, y *big.Int) *PublicKey {
 // ParsePubKey parses a public key for a koblitz curve from a bytestring into a
 // ecdsa.Publickey, verifying that it is valid. It supports compressed and
 // uncompressed signature formats, but not the hybrid format.
-func ParsePubKey(pubKeyStr []byte) (key *PublicKey,
-	err error) {
+func ParsePubKey(pubKeyStr []byte) (key *PublicKey, err error) {
 	pubkey := PublicKey{}
 	pubkey.Curve = S256()
 

--- a/dcrec/secp256k1/schnorr/threshold.go
+++ b/dcrec/secp256k1/schnorr/threshold.go
@@ -56,11 +56,10 @@ func combinePubkeys(pks []*secp256k1.PublicKey) *secp256k1.PublicKey {
 
 // nonceRFC6979 is a local instantiation of deterministic nonce generation
 // by the standards of RFC6979.
-func nonceRFC6979(privkey []byte, hash []byte, extra []byte,
-	version []byte) []byte {
+func nonceRFC6979(privkey []byte, hash []byte, extra []byte, version []byte, extraIterations uint32) []byte {
 	pkD := new(big.Int).SetBytes(privkey)
 	defer pkD.SetInt64(0)
-	bigK := secp256k1.NonceRFC6979(pkD, hash, extra, version)
+	bigK := secp256k1.NonceRFC6979(pkD, hash, extra, version, extraIterations)
 	defer bigK.SetInt64(0)
 	k := bigIntToEncodedBytes(bigK)
 	return k[:]

--- a/dcrec/secp256k1/schnorr/threshold_test.go
+++ b/dcrec/secp256k1/schnorr/threshold_test.go
@@ -219,7 +219,7 @@ func TestSchnorrThresholdRef(t *testing.T) {
 		// Ensure all the pubkey and nonce derivation is correct.
 		for i, signer := range tv.signers {
 			nonce := nonceRFC6979(signer.privkey, tv.msg, nil,
-				Sha256VersionStringRFC6979)
+				Sha256VersionStringRFC6979, 0)
 			cmp := bytes.Equal(nonce[:], signer.privateNonce[:])
 			if !cmp {
 				t.Fatalf("expected %v, got %v", true, cmp)
@@ -329,7 +329,7 @@ func TestSchnorrThreshold(t *testing.T) {
 		pubNoncesToUse := make([]*secp256k1.PublicKey, numKeysForTest)
 		for j := 0; j < numKeysForTest; j++ {
 			nonce := nonceRFC6979(keysToUse[j].Serialize(), msg, nil,
-				BlakeVersionStringRFC6979)
+				BlakeVersionStringRFC6979, 0)
 			privNonce, pubNonce := secp256k1.PrivKeyFromBytes(nonce)
 			privNoncesToUse[j] = privNonce
 			pubNoncesToUse[j] = pubNonce

--- a/dcrec/secp256k1/signature.go
+++ b/dcrec/secp256k1/signature.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -286,8 +286,7 @@ func hashToInt(hash []byte) *big.Int {
 // of the loop * 2 - on the first iteration of j we do the R case, else the -R
 // case in step 1.6. This counter is used in the Decred compressed signature
 // format and thus we match bitcoind's behaviour here.
-func recoverKeyFromSignature(sig *Signature, msg []byte,
-	iter int, doChecks bool) (*PublicKey, error) {
+func recoverKeyFromSignature(sig *Signature, msg []byte, iter int, doChecks bool) (*PublicKey, error) {
 	// 1.1 x = (n * i) + r
 	curve := S256()
 	Rx := new(big.Int).Mul(curve.Params().N,
@@ -353,8 +352,7 @@ func recoverKeyFromSignature(sig *Signature, msg []byte,
 // returned in the format:
 // <(byte of 27+public key solution)+4 if compressed >< padded bytes for signature R><padded bytes for signature S>
 // where the R and S parameters are padded up to the bitlength of the curve.
-func SignCompact(key *PrivateKey,
-	hash []byte, isCompressedKey bool) ([]byte, error) {
+func SignCompact(key *PrivateKey, hash []byte, isCompressedKey bool) ([]byte, error) {
 	sig, err := key.Sign(hash)
 	if err != nil {
 		return nil, err
@@ -401,8 +399,7 @@ func SignCompact(key *PrivateKey,
 // Koblitz curve in "curve". If the signature matches then the recovered public
 // key will be returned as well as a boolean if the original key was compressed
 // or not, else an error will be returned.
-func RecoverCompact(signature,
-	hash []byte) (*PublicKey, bool, error) {
+func RecoverCompact(signature, hash []byte) (*PublicKey, bool, error) {
 	bitlen := (S256().BitSize + 7) / 8
 	if len(signature) != 1+bitlen*2 {
 		return nil, false, errors.New("invalid compact signature size")

--- a/dcrec/secp256k1/signature.go
+++ b/dcrec/secp256k1/signature.go
@@ -450,11 +450,13 @@ func signRFC6979(privateKey *PrivateKey, hash []byte) (*Signature, error) {
 	return &Signature{R: r, S: s}, nil
 }
 
-// NonceRFC6979 generates an ECDSA nonce (`k`) deterministically according to
-// RFC 6979. It takes a 32-byte hash as an input and returns 32-byte nonce to
-// be used in ECDSA algorithm.
-func NonceRFC6979(privkey *big.Int, hash []byte, extra []byte,
-	version []byte) *big.Int {
+// NonceRFC6979 generates a nonce deterministically according to RFC 6979 using
+// HMAC-SHA256 for the hashing function.  It takes a 32-byte hash as an input
+// and returns a 32-byte nonce to be used for deterministic signing.  The extra
+// and version arguments are optional, but allow additional data to be added to
+// the input of the HMAC.  When provided, the extra data must be 32-bytes and
+// version must be 16 bytes or they will be ignored.
+func NonceRFC6979(privkey *big.Int, hash []byte, extra []byte, version []byte) *big.Int {
 	curve := S256()
 	q := curve.Params().N
 	x := privkey

--- a/dcrec/secp256k1/signature_test.go
+++ b/dcrec/secp256k1/signature_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2019 The Decred developers
+// Copyright (c) 2015-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -560,7 +560,7 @@ func TestRFC6979(t *testing.T) {
 		hash := sha256.Sum256([]byte(test.msg))
 
 		// Ensure deterministically generated nonce is the expected value.
-		gotNonce := NonceRFC6979(privKey.D, hash[:], nil, nil).Bytes()
+		gotNonce := NonceRFC6979(privKey.D, hash[:], nil, nil, 0).Bytes()
 		wantNonce := decodeHex(test.nonce)
 		if !bytes.Equal(gotNonce, wantNonce) {
 			t.Errorf("NonceRFC6979 #%d (%s): Nonce is incorrect: "+
@@ -570,12 +570,7 @@ func TestRFC6979(t *testing.T) {
 		}
 
 		// Ensure deterministically generated signature is the expected value.
-		gotSig, err := privKey.Sign(hash[:])
-		if err != nil {
-			t.Errorf("Sign #%d (%s): unexpected error: %v", i,
-				test.msg, err)
-			continue
-		}
+		gotSig := privKey.Sign(hash[:])
 		gotSigBytes := gotSig.Serialize()
 		wantSigBytes := decodeHex(test.signature)
 		if !bytes.Equal(gotSigBytes, wantSigBytes) {

--- a/txscript/sigcache_test.go
+++ b/txscript/sigcache_test.go
@@ -30,11 +30,7 @@ func genRandomSig() (*chainhash.Hash, *secp256k1.Signature, *secp256k1.PublicKey
 		return nil, nil, nil, err
 	}
 
-	sig, err := priv.Sign(msgHash[:])
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
+	sig := priv.Sign(msgHash[:])
 	return &msgHash, sig, pub, nil
 }
 

--- a/txscript/sign.go
+++ b/txscript/sign.go
@@ -35,10 +35,7 @@ func RawTxInSignature(tx *wire.MsgTx, idx int, subScript []byte,
 	switch sigType {
 	case dcrec.STEcdsaSecp256k1:
 		priv, _ := secp256k1.PrivKeyFromBytes(key)
-		sig, err := priv.Sign(hash)
-		if err != nil {
-			return nil, fmt.Errorf("cannot sign tx input: %v", err)
-		}
+		sig := priv.Sign(hash)
 		sigBytes = sig.Serialize()
 	case dcrec.STEd25519:
 		priv, _ := edwards.PrivKeyFromBytes(key)


### PR DESCRIPTION
**This requires PR #2042.**

This consists of several commits which improve the code in regards to the signing process by significantly optimizing the deterministic nonce generation by specializing the implementation specifically for secp256k1 and modifying it in such a way that signing can no longer fail in the extremely unlikely event a returned nonce results in an invalid signature.

It has been split into several commits to help ease the review process.

---

The first commit merely reformats the functions to be consistent with the style used in the rest of the code.  It contains no functional changes.

---

The second commit improves the NonceRFC6979 comment which previously indicated it was to generate an ECDSA nonce, but that is not the case.  Instead, it is a method to generate a deterministic nonce based on a private key and message which for general use in signing applications.  As a case in point, it is used with Schnorr signing as well.

---

The third commit adds a benchmark for NonceRFC6979.

---

The fourth commit optimizes the code for generating a deterministic nonce by specializing the implementation for secp256k1 since it no longer accepts a curve argument.

It also implements a specialized version of HMAC-SHA256 in order to avoid the need to constantly allocate new instances due to the changing key.

The following is a before and after comparison of typical nonce generation:
```
benchmark               old ns/op    new ns/op    delta
---------------------------------------------------------
BenchmarkNonceRFC6979   8998         6428         -28.56%

benchmark               old allocs   new allocs   delta
---------------------------------------------------------
BenchmarkNonceRFC6979   46           17           -63.04%

benchmark               old bytes    new bytes    delta
---------------------------------------------------------
BenchmarkNonceRFC6979   3552         976          -72.52%
```
---

Finally, the firth commit modifies the deterministic nonce generation via RFC6979 to accept an additional parameter for the number of extra iterations to perform to ensure a stream of deterministic nonces can be generated if needed.

It then updates the signing for both ECDSA and Schnorr to make use of the new parameter to increment the iteration in the unlikely event a returned nonce results in an invalid signature so that it will always generate a valid signature.

Finally, it removes the error return from `Sign` since it can no longer fail.