### PR TITLE
mempool: Tighten allowed votes range for mainnet.

### DIFF
--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -742,8 +742,20 @@ func newPoolHarness(chainParams *chaincfg.Params) (*poolHarness, []spendableOutp
 				MaxOrphanTxSize:      1000,
 				MaxSigOpsPerTx:       blockchain.MaxSigOpsPerBlock / 5,
 				MinRelayTxFee:        1000, // 1 Satoshi per byte
-				StandardVerifyFlags:  chain.StandardVerifyFlags,
-				AcceptSequenceLocks:  chain.AcceptSequenceLocks,
+				MaxVoteAge: func() uint16 {
+					switch chainParams.Net {
+					case wire.MainNet, wire.SimNet, wire.RegNet:
+						return chainParams.CoinbaseMaturity
+
+					case wire.TestNet3:
+						return 1440 // defaultMaximumVoteAge
+
+					default:
+						return chainParams.CoinbaseMaturity
+					}
+				}(),
+				StandardVerifyFlags: chain.StandardVerifyFlags,
+				AcceptSequenceLocks: chain.AcceptSequenceLocks,
 			},
 			ChainParams:         chainParams,
 			NextStakeDifficulty: chain.NextStakeDifficulty,

--- a/server.go
+++ b/server.go
@@ -57,6 +57,10 @@ const (
 	// target.
 	defaultTargetOutbound = 8
 
+	// defaultMaximumVoteAge is the threshold of blocks before the tip
+	// that can be voted on.
+	defaultMaximumVoteAge = 1440
+
 	// connectionRetryInterval is the base amount of time to wait in between
 	// retries when connecting to persistent peers.  It is adjusted by the
 	// number of retries such that there is a retry backoff.
@@ -2919,6 +2923,18 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 			MaxSigOpsPerTx:       blockchain.MaxSigOpsPerBlock / 5,
 			MinRelayTxFee:        cfg.minRelayTxFee,
 			AllowOldVotes:        cfg.AllowOldVotes,
+			MaxVoteAge: func() uint16 {
+				switch chainParams.Net {
+				case wire.MainNet, wire.SimNet, wire.RegNet:
+					return chainParams.CoinbaseMaturity
+
+				case wire.TestNet3:
+					return defaultMaximumVoteAge
+
+				default:
+					return chainParams.CoinbaseMaturity
+				}
+			}(),
 			StandardVerifyFlags: func() (txscript.ScriptFlags, error) {
 				return standardScriptVerifyFlags(s.chain)
 			},


### PR DESCRIPTION
This updates the allowed votes range for `mainnet`, `simnet` and `regnet` to coinbase maturity from tip. Testnet has been exempted due to longer reorgs that have already happened in `testnet's` history.

Resolves #81