### PR TITLE
[release-v1.5] rpcwebsocket: Remove client from missed maps

### DIFF
--- a/rpcwebsocket.go
+++ b/rpcwebsocket.go
@@ -637,6 +637,10 @@ out:
 				delete(blockNotifications, wsc.quit)
 				delete(workNotifications, wsc.quit)
 				delete(txNotifications, wsc.quit)
+				delete(winningTicketNotifications, wsc.quit)
+				delete(ticketSMNotifications, wsc.quit)
+				delete(ticketNewNotifications, wsc.quit)
+				delete(stakeDifficultyNotifications, wsc.quit)
 				delete(clients, wsc.quit)
 
 			case *notificationRegisterNewMempoolTxs:


### PR DESCRIPTION
This is a backport of #2027 to the 1.5 release branch.

It removes outstanding references of a `wsClient` `quit` chan to the notification maps in `notificationHandler()` upon client disconnection.

Previously, the left over references caused the `wsClient` and its associated `wsClientFilter` struct to not be GCd after a wallet disconnected from the node, which leaked memory.

This is specially relevant for setups that involve wallets with very large number of addresses.