### PR TITLE
[release-v1.5] release: Bump for 1.5.1.

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -28,7 +28,7 @@ const (
 const (
 	Major uint = 1
 	Minor uint = 5
-	Patch uint = 0
+	Patch uint = 1
 )
 
 var (
@@ -37,14 +37,14 @@ var (
 	// '-ldflags "-X github.com/decred/dcrd/internal/version.PreRelease=foo"'
 	// if needed.  It MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.
-	PreRelease = "pre"
+	PreRelease = ""
 
 	// BuildMetadata is defined as a variable so it can be overridden during the
 	// build process with:
 	// '-ldflags "-X github.com/decred/dcrd/internal/version.BuildMetadata=foo"'
 	// if needed.  It MUST only contain characters from semanticBuildAlphabet
 	// per the semantic versioning spec.
-	BuildMetadata = "dev"
+	BuildMetadata = "release.local"
 )
 
 // String returns the application version as a properly formed string per the


### PR DESCRIPTION
Also, per previous discussions, set the clear the `PreRelease` and set the `BuildMetadata` to `release.local` here on the release branch so that anyone building the release branch will end up with version "1.5.1+release.local" indicating it was a local build as opposed to a reproducible release build.