### PR TITLE
release: Remove build metadata from master branch.

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -44,7 +44,7 @@ var (
 	// '-ldflags "-X github.com/decred/dcrd/internal/version.BuildMetadata=foo"'
 	// if needed.  It MUST only contain characters from semanticBuildAlphabet
 	// per the semantic versioning spec.
-	BuildMetadata = "dev"
+	BuildMetadata = ""
 )
 
 // String returns the application version as a properly formed string per the


### PR DESCRIPTION
Releases will now use the empty string for the prerelease field and "release.local" for build metadata.  This indicates that the code is for a release, but the release was built from the repo or using go get
without the release build tool.

Development versions will use "pre" for the prerelease and default to no build metadata.

In particular, this will result in the following cases:

- Development builds performed on the master branch will show as "version X.Y.Z-pre" (where either X or Y is one version greater than the current release)
- Builds performed on the release branch without using reproducible build tools will show as "version X.Y.Z+release.local"
- Builds performed on the release branch using reproducible build tools will show as "version X.Y.Z+release"

Consequently, this this removes the "dev" marker from the build metadata on the master branch. 