### PR TITLE
secp256k1: Introduce jacobian point struct.

### DIFF
--- a/dcrec/secp256k1/bench_test.go
+++ b/dcrec/secp256k1/bench_test.go
@@ -13,18 +13,22 @@ import (
 // BenchmarkAddJacobian benchmarks the secp256k1 curve addJacobian function with
 // Z values of 1 so that the associated optimizations are used.
 func BenchmarkAddJacobian(b *testing.B) {
-	x1 := new(fieldVal).SetHex("34f9460f0e4f08393d192b3c5133a6ba099aa0ad9fd54ebccfacdfa239ff49c6")
-	y1 := new(fieldVal).SetHex("0b71ea9bd730fd8923f6d25a7a91e7dd7728a960686cb5a901bb419e0f2ca232")
-	z1 := new(fieldVal).SetHex("1")
-	x2 := new(fieldVal).SetHex("34f9460f0e4f08393d192b3c5133a6ba099aa0ad9fd54ebccfacdfa239ff49c6")
-	y2 := new(fieldVal).SetHex("0b71ea9bd730fd8923f6d25a7a91e7dd7728a960686cb5a901bb419e0f2ca232")
-	z2 := new(fieldVal).SetHex("1")
-	x3, y3, z3 := new(fieldVal), new(fieldVal), new(fieldVal)
+	p1 := jacobianPointFromHex(
+		"34f9460f0e4f08393d192b3c5133a6ba099aa0ad9fd54ebccfacdfa239ff49c6",
+		"0b71ea9bd730fd8923f6d25a7a91e7dd7728a960686cb5a901bb419e0f2ca232",
+		"1",
+	)
+	p2 := jacobianPointFromHex(
+		"34f9460f0e4f08393d192b3c5133a6ba099aa0ad9fd54ebccfacdfa239ff49c6",
+		"0b71ea9bd730fd8923f6d25a7a91e7dd7728a960686cb5a901bb419e0f2ca232",
+		"1",
+	)
 
 	b.ReportAllocs()
 	b.ResetTimer()
+	var result jacobianPoint
 	for i := 0; i < b.N; i++ {
-		addJacobian(x1, y1, z1, x2, y2, z2, x3, y3, z3)
+		addJacobian(&p1, &p2, &result)
 	}
 }
 
@@ -38,12 +42,14 @@ func BenchmarkAddJacobianNotZOne(b *testing.B) {
 	x2 := new(fieldVal).SetHex("91abba6a34b7481d922a4bd6a04899d5a686f6cf6da4e66a0cb427fb25c04bd4")
 	y2 := new(fieldVal).SetHex("03fede65e30b4e7576a2abefc963ddbf9fdccbf791b77c29beadefe49951f7d1")
 	z2 := new(fieldVal).SetHex("3")
-	x3, y3, z3 := new(fieldVal), new(fieldVal), new(fieldVal)
+	p1 := makeJacobianPoint(x1, y1, z1)
+	p2 := makeJacobianPoint(x2, y2, z2)
 
 	b.ReportAllocs()
 	b.ResetTimer()
+	var result jacobianPoint
 	for i := 0; i < b.N; i++ {
-		addJacobian(x1, y1, z1, x2, y2, z2, x3, y3, z3)
+		addJacobian(&p1, &p2, &result)
 	}
 }
 
@@ -61,9 +67,9 @@ func BenchmarkScalarBaseMult(b *testing.B) {
 // function.
 func BenchmarkScalarBaseMultJacobian(b *testing.B) {
 	k := fromHex("d74bf844b0862475103d96a611cf2d898447e288d34b360bc885cb8ce7c00575")
-	rx, ry, rz := new(fieldVal), new(fieldVal), new(fieldVal)
+	var result jacobianPoint
 	for i := 0; i < b.N; i++ {
-		scalarBaseMultJacobian(k.Bytes(), rx, ry, rz)
+		scalarBaseMultJacobian(k.Bytes(), &result)
 	}
 }
 

--- a/dcrec/secp256k1/privkey.go
+++ b/dcrec/secp256k1/privkey.go
@@ -49,9 +49,9 @@ func GeneratePrivateKey() (*PrivateKey, error) {
 // PubKey computes and returns the public key corresponding to this private key.
 // PubKey returns the PublicKey corresponding to this private key.
 func (p *PrivateKey) PubKey() *PublicKey {
-	fx, fy, fz := new(fieldVal), new(fieldVal), new(fieldVal)
-	scalarBaseMultJacobian(p.D.Bytes(), fx, fy, fz)
-	return NewPublicKey(fieldJacobianToBigAffine(fx, fy, fz))
+	var result jacobianPoint
+	scalarBaseMultJacobian(p.D.Bytes(), &result)
+	return NewPublicKey(jacobianToBigAffine(&result))
 }
 
 // Sign generates an ECDSA signature for the provided hash (which should be the


### PR DESCRIPTION
**This requires #2056**.

This introduces a new structure for passing around Jacobian coordinates and updates the code to make use of it.

This increases the readability of the code by reducing a lot of extra parameter clutter and makes it more obvious what type of coordinates the functions expect (Jacobian vs affine) as well as which parameters are for passing the results back out.  It also makes the internal code less cumbersome to work with.

The only reason it was originally split into coords was due to early versions of the Go compiler having issues with escape analysis leading to slower performance in performance-critical code.  However, that is no longer the case as can be seen by the benchmarks below which show everything within the margin of error in terms of performance.  A few reductions in allocations were achieved in the scalar multiplication path, but the focus of these changes are not optimization.

```
benchmark                         old ns/op    new ns/op    delta
------------------------------------------------------------------
BenchmarkAddJacobian              582          577          -0.86%
BenchmarkAddJacobianNotZOne       1091         1093         +0.18%
BenchmarkScalarBaseMult           46389        46681        +0.63%
BenchmarkScalarBaseMultJacobian   34437        34386        -0.15%
BenchmarkScalarBaseMultLarge      47012        47216        +0.43%
BenchmarkScalarMult               155915       156262       +0.22%
BenchmarkNAF                      1447         1372         -5.18%
BenchmarkSigVerify                215279       217324       +0.95%
BenchmarkFieldNormalize           21.3         21.5         +0.94%
BenchmarkNonceRFC6979             6402         6393         -0.14%

benchmark                         old allocs   new allocs   delta
------------------------------------------------------------------
 BenchmarkAddJacobian              0            0            +0.00%
 BenchmarkAddJacobianNotZOne       0            0            +0.00%
 BenchmarkScalarBaseMult           5            5            +0.00%
 BenchmarkScalarBaseMultJacobian   1            1            +0.00%
 BenchmarkScalarBaseMultLarge      8            8            +0.00%
 BenchmarkScalarMult               24           22           -8.33%
 BenchmarkNAF                      3            3            +0.00%
 BenchmarkSigVerify                64           58           -9.38%
 BenchmarkFieldNormalize           0            0            +0.00%
 BenchmarkNonceRFC6979             17           17           +0.00%

 benchmark                         old bytes    new bytes    delta
 ------------------------------------------------------------------
 BenchmarkAddJacobian              0            0            +0.00%
 BenchmarkAddJacobianNotZOne       0            0            +0.00%
 BenchmarkScalarBaseMult           224          224          +0.00%
 BenchmarkScalarBaseMultJacobian   32           32           +0.00%
 BenchmarkScalarBaseMultLarge      400          400          +0.00%
 BenchmarkScalarMult               1233         1137         -7.79%
 BenchmarkNAF                      128          128          +0.00%
 BenchmarkSigVerify                3138         2850         -9.18%
 BenchmarkFieldNormalize           0            0            +0.00%
 BenchmarkNonceRFC6979             976          976          +0.00%
```