### PR TITLE
secp256k1: Add specialized field check for one.

### DIFF
--- a/dcrec/secp256k1/curve.go
+++ b/dcrec/secp256k1/curve.go
@@ -20,13 +20,6 @@ import (
 // where x = x1/z1^2 and y = y1/z1^3.
 
 var (
-	// fieldOne is simply the integer 1 in field representation.  It is
-	// used to avoid needing to create it multiple times during the internal
-	// arithmetic.
-	fieldOne = new(fieldVal).SetInt(1)
-)
-
-var (
 	// Next 6 constants are from Hal Finney's bitcointalk.org post:
 	// https://bitcointalk.org/index.php?topic=3238.msg45565#msg45565
 	// May he rest in peace.
@@ -421,8 +414,8 @@ func addJacobian(p1, p2, result *jacobianPoint) {
 	// by using those assumptions.
 	p1.z.Normalize()
 	p2.z.Normalize()
-	isZ1One := p1.z.Equals(fieldOne)
-	isZ2One := p2.z.Equals(fieldOne)
+	isZ1One := p1.z.IsOne()
+	isZ2One := p2.z.IsOne()
 	switch {
 	case isZ1One && isZ2One:
 		addZ1AndZ2EqualsOne(p1, p2, result)
@@ -560,7 +553,7 @@ func doubleJacobian(p, result *jacobianPoint) {
 	// by avoiding the multiplication on the z value.  This section calls
 	// a point doubling function which is accelerated by using that
 	// assumption when possible.
-	if p.z.Normalize().Equals(fieldOne) {
+	if p.z.Normalize().IsOne() {
 		doubleZ1EqualsOne(p, result)
 		return
 	}

--- a/dcrec/secp256k1/field.go
+++ b/dcrec/secp256k1/field.go
@@ -424,11 +424,28 @@ func (f *fieldVal) Bytes() *[32]byte {
 }
 
 // IsZero returns whether or not the field value is equal to zero.
+//
+// The field value must be normalized for this function to return correct
+// result.
 func (f *fieldVal) IsZero() bool {
 	// The value can only be zero if no bits are set in any of the words.
 	// This is a constant time implementation.
 	bits := f.n[0] | f.n[1] | f.n[2] | f.n[3] | f.n[4] |
 		f.n[5] | f.n[6] | f.n[7] | f.n[8] | f.n[9]
+
+	return bits == 0
+}
+
+// IsOne returns whether or not the field value is equal to one.
+//
+// The field value must be normalized for this function to return correct
+// result.
+func (f *fieldVal) IsOne() bool {
+	// The value can only be one if the single lowest significant bit is set in
+	// the the first word and no other bits are set in any of the other words.
+	// This is a constant time implementation.
+	bits := (f.n[0] ^ 1) | f.n[1] | f.n[2] | f.n[3] | f.n[4] | f.n[5] |
+		f.n[6] | f.n[7] | f.n[8] | f.n[9]
 
 	return bits == 0
 }

--- a/dcrec/secp256k1/field_test.go
+++ b/dcrec/secp256k1/field_test.go
@@ -38,7 +38,7 @@ func TestSetInt(t *testing.T) {
 	}
 }
 
-// TestZero ensures that zeroing a field value zero works as expected.
+// TestZero ensures that zeroing a field value works as expected.
 func TestZero(t *testing.T) {
 	f := new(fieldVal).SetInt(2)
 	f.Zero()
@@ -50,7 +50,7 @@ func TestZero(t *testing.T) {
 	}
 }
 
-// TestIsZero ensures that checking if a field IsZero works as expected.
+// TestIsZero ensures that checking if a field is zero works as expected.
 func TestIsZero(t *testing.T) {
 	f := new(fieldVal)
 	if !f.IsZero() {
@@ -68,6 +68,104 @@ func TestIsZero(t *testing.T) {
 	if !f.IsZero() {
 		t.Errorf("field claims it's not zero when it is - got %v "+
 			"(raw rawints %x)", f, f.n)
+	}
+}
+
+// TestIsOne ensures that checking if a field is one works as expected.
+func TestIsOne(t *testing.T) {
+	tests := []struct {
+		name      string // test description
+		in        string // hex encoded test value
+		normalize bool   // whether or not to normalize the test value
+		expected  bool   // expected result
+	}{{
+		name:      "zero",
+		in:        "0",
+		normalize: true,
+		expected:  false,
+	}, {
+		name:      "one",
+		in:        "1",
+		normalize: true,
+		expected:  true,
+	}, {
+		name:      "secp256k1 prime NOT normalized (would be 0)",
+		in:        "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+		normalize: false,
+		expected:  false,
+	}, {
+		name:      "secp256k1 prime normalized (aka 0)",
+		in:        "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+		normalize: true,
+		expected:  false,
+	}, {
+		name:      "secp256k1 prime + 1 normalized (aka 1)",
+		in:        "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+		normalize: true,
+		expected:  true,
+	}, {
+		name:      "secp256k1 prime + 1 NOT normalized (would be 1)",
+		in:        "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+		normalize: false,
+		expected:  false,
+	}, {
+		name:      "2^26 (one bit in second internal field word",
+		in:        "4000000",
+		normalize: false,
+		expected:  false,
+	}, {
+		name:      "2^52 (one bit in third internal field word",
+		in:        "10000000000000",
+		normalize: false,
+		expected:  false,
+	}, {
+		name:      "2^78 (one bit in fourth internal field word",
+		in:        "40000000000000000000",
+		normalize: false,
+		expected:  false,
+	}, {
+		name:      "2^104 (one bit in fifth internal field word",
+		in:        "100000000000000000000000000",
+		normalize: false,
+		expected:  false,
+	}, {
+		name:      "2^130 (one bit in sixth internal field word",
+		in:        "400000000000000000000000000000000",
+		normalize: false,
+		expected:  false,
+	}, {
+		name:      "2^156 (one bit in seventh internal field word",
+		in:        "1000000000000000000000000000000000000000",
+		normalize: false,
+		expected:  false,
+	}, {
+		name:      "2^182 (one bit in eighth internal field word",
+		in:        "4000000000000000000000000000000000000000000000",
+		normalize: false,
+		expected:  false,
+	}, {
+		name:      "2^208 (one bit in ninth internal field word",
+		in:        "10000000000000000000000000000000000000000000000000000",
+		normalize: false,
+		expected:  false,
+	}, {
+		name:      "2^234 (one bit in tenth internal field word",
+		in:        "40000000000000000000000000000000000000000000000000000000000",
+		normalize: false,
+		expected:  false,
+	}}
+
+	for _, test := range tests {
+		f := new(fieldVal).SetHex(test.in)
+		if test.normalize {
+			f.Normalize()
+		}
+		result := f.IsOne()
+		if result != test.expected {
+			t.Errorf("%s: wrong result\ngot: %v\nwant: %v", test.name,
+				result, test.expected)
+			continue
+		}
 	}
 }
 


### PR DESCRIPTION
**This is rebased on #2058.**

This adds a specialized function for testing if a field value is one that is constant time and faster than an equality check along with comprehensive tests for correct functionality.  As the benchmarks below show, it results in a reduction of roughly 2.5% for addition which translates to about a 1% reduction in typical signature verification time.

```
benchmark                         old ns/op     new ns/op     delta
--------------------------------------------------------------------
BenchmarkAddJacobian              580           564           -2.76%
BenchmarkScalarBaseMultJacobian   34629         33885         -2.15%
BenchmarkScalarBaseMultLarge      47468         47021         -0.94%
BenchmarkScalarMult               157832        156503        -0.84%
BenchmarkSigVerify                216043        213725        -1.07%
BenchmarkNonceRFC6979             6447          6370          -1.19%
```