### PR TITLE
secp256k1: Make private key opaque.

### DIFF
--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -1513,7 +1513,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	if err != nil {
 		panic(err)
 	}
-	privKeyBytes := privKey.D.Bytes()
+	privKeyBytes := privKey.Serialize()
 	pubKey := privKey.PubKey()
 
 	// Create a pay-to-script-hash redeem script that consists of 9

--- a/dcrec/secp256k1/ciphering.go
+++ b/dcrec/secp256k1/ciphering.go
@@ -45,7 +45,9 @@ var (
 // public key using Diffie-Hellman key exchange (ECDH) (RFC 4753).
 // RFC5903 Section 9 states we should only return x.
 func GenerateSharedSecret(privkey *PrivateKey, pubkey *PublicKey) []byte {
-	x, _ := S256().ScalarMult(pubkey.X, pubkey.Y, privkey.D.Bytes())
+	privKeyBytes := privkey.key.Bytes()
+	x, _ := S256().ScalarMult(pubkey.X, pubkey.Y, privKeyBytes[:])
+	zeroArray32(&privKeyBytes)
 	return x.Bytes()
 }
 

--- a/dcrec/secp256k1/ellipticadaptor.go
+++ b/dcrec/secp256k1/ellipticadaptor.go
@@ -175,17 +175,20 @@ func (p PublicKey) ToECDSA() *ecdsa.PublicKey {
 
 // ToECDSA returns the private key as a *ecdsa.PrivateKey.
 func (p *PrivateKey) ToECDSA() *ecdsa.PrivateKey {
+	privKeyBytes := p.key.Bytes()
 	var result jacobianPoint
-	scalarBaseMultJacobian(p.D.Bytes(), &result)
+	scalarBaseMultJacobian(privKeyBytes[:], &result)
 	x, y := jacobianToBigAffine(&result)
-	return &ecdsa.PrivateKey{
+	newPrivKey := &ecdsa.PrivateKey{
 		PublicKey: ecdsa.PublicKey{
 			Curve: S256(),
 			X:     x,
 			Y:     y,
 		},
-		D: p.D,
+		D: new(big.Int).SetBytes(privKeyBytes[:]),
 	}
+	zeroArray32(&privKeyBytes)
+	return newPrivKey
 }
 
 // fromHex converts the passed hex string into a big integer pointer and will

--- a/dcrec/secp256k1/schnorr/ecdsa.go
+++ b/dcrec/secp256k1/schnorr/ecdsa.go
@@ -173,7 +173,8 @@ func nonceRFC6979(privkey []byte, hash []byte, extra []byte, version []byte, ext
 // produce a Schnorr signature.
 func Sign(priv *secp256k1.PrivateKey, hash []byte) (r, s *big.Int, err error) {
 	// Convert the private scalar to a 32 byte big endian number.
-	pA := bigIntToEncodedBytes(priv.D)
+	bigPriv := new(big.Int).SetBytes(priv.Serialize())
+	pA := bigIntToEncodedBytes(bigPriv)
 	defer zeroArray(pA)
 
 	for iteration := uint32(0); ; iteration++ {

--- a/dcrec/secp256k1/signature_test.go
+++ b/dcrec/secp256k1/signature_test.go
@@ -407,11 +407,13 @@ func TestRFC6979(t *testing.T) {
 	}}
 
 	for i, test := range tests {
-		privKey := PrivKeyFromBytes(hexToBytes(test.key))
+		privKeyBytes := hexToBytes(test.key)
+		privKey := PrivKeyFromBytes(privKeyBytes)
+		bigPrivKey := new(big.Int).SetBytes(privKeyBytes)
 		hash := sha256.Sum256([]byte(test.msg))
 
 		// Ensure deterministically generated nonce is the expected value.
-		gotNonce := NonceRFC6979(privKey.D, hash[:], nil, nil, 0).
+		gotNonce := NonceRFC6979(bigPrivKey, hash[:], nil, nil, 0).
 			Bytes()
 		wantNonce := hexToBytes(test.nonce)
 		if !bytes.Equal(gotNonce, wantNonce) {

--- a/mempool/policy_test.go
+++ b/mempool/policy_test.go
@@ -7,7 +7,6 @@ package mempool
 
 import (
 	"bytes"
-	"math/big"
 	"testing"
 	"time"
 
@@ -102,7 +101,7 @@ func TestCalcMinRequiredTxRelayFee(t *testing.T) {
 func TestCheckPkScriptStandard(t *testing.T) {
 	var pubKeys [][]byte
 	for i := 0; i < 4; i++ {
-		pk := secp256k1.NewPrivateKey(big.NewInt(0))
+		pk := secp256k1.NewPrivateKey(new(secp256k1.ModNScalar).SetInt(0))
 		pubKeys = append(pubKeys, pk.PubKey().SerializeCompressed())
 	}
 

--- a/txscript/sign_test.go
+++ b/txscript/sign_test.go
@@ -223,7 +223,7 @@ func TestSignTxOutput(t *testing.T) {
 				switch suite {
 				case dcrec.STEcdsaSecp256k1:
 					privKey, _ := secp256k1.GeneratePrivateKey()
-					keyDB = privKey.D.Bytes()
+					keyDB = privKey.Serialize()
 					pkBytes = privKey.PubKey().SerializeUncompressed()
 				case dcrec.STEd25519:
 					keyDB, _, _, _ = edwards.GenerateKey(rand.Reader)
@@ -282,7 +282,7 @@ func TestSignTxOutput(t *testing.T) {
 				switch suite {
 				case dcrec.STEcdsaSecp256k1:
 					privKey, _ := secp256k1.GeneratePrivateKey()
-					keyDB = privKey.D.Bytes()
+					keyDB = privKey.Serialize()
 					pkBytes = privKey.PubKey().SerializeUncompressed()
 				case dcrec.STEd25519:
 					keyDB, _, _, _ = edwards.GenerateKey(rand.Reader)
@@ -354,7 +354,7 @@ func TestSignTxOutput(t *testing.T) {
 				switch suite {
 				case dcrec.STEcdsaSecp256k1:
 					privKey, _ := secp256k1.GeneratePrivateKey()
-					keyDB = privKey.D.Bytes()
+					keyDB = privKey.Serialize()
 					pkBytes = privKey.PubKey().SerializeCompressed()
 				case dcrec.STEd25519:
 					keyDB, _, _, _ = edwards.GenerateKey(rand.Reader)
@@ -412,7 +412,7 @@ func TestSignTxOutput(t *testing.T) {
 				switch suite {
 				case dcrec.STEcdsaSecp256k1:
 					privKey, _ := secp256k1.GeneratePrivateKey()
-					keyDB = privKey.D.Bytes()
+					keyDB = privKey.Serialize()
 					pkBytes = privKey.PubKey().SerializeCompressed()
 				case dcrec.STEd25519:
 					keyDB, _, _, _ = edwards.GenerateKey(rand.Reader)
@@ -485,7 +485,7 @@ func TestSignTxOutput(t *testing.T) {
 				t.Errorf("failed to generate key: %v", err)
 				break
 			}
-			keyDB := privKey.D.Bytes()
+			keyDB := privKey.Serialize()
 			pkBytes := privKey.PubKey().SerializeCompressed()
 
 			suite := dcrec.STEcdsaSecp256k1
@@ -533,7 +533,7 @@ func TestSignTxOutput(t *testing.T) {
 				t.Errorf("failed to generate key: %v", err)
 				break
 			}
-			keyDB := privKey.D.Bytes()
+			keyDB := privKey.Serialize()
 			pkBytes := privKey.PubKey().SerializeCompressed()
 
 			suite := dcrec.STEcdsaSecp256k1
@@ -581,7 +581,7 @@ func TestSignTxOutput(t *testing.T) {
 				t.Errorf("failed to generate key: %v", err)
 				break
 			}
-			keyDB := privKey.D.Bytes()
+			keyDB := privKey.Serialize()
 			pkBytes := privKey.PubKey().SerializeCompressed()
 
 			suite := dcrec.STEcdsaSecp256k1
@@ -629,7 +629,7 @@ func TestSignTxOutput(t *testing.T) {
 				t.Errorf("failed to generate key: %v", err)
 				break
 			}
-			keyDB := privKey.D.Bytes()
+			keyDB := privKey.Serialize()
 			pkBytes := privKey.PubKey().SerializeCompressed()
 
 			suite := dcrec.STEcdsaSecp256k1
@@ -678,7 +678,7 @@ func TestSignTxOutput(t *testing.T) {
 					t.Errorf("failed to generate key: %v", err)
 					break
 				}
-				keyDB := privKey.D.Bytes()
+				keyDB := privKey.Serialize()
 				pk := privKey.PubKey()
 				suite := dcrec.STEcdsaSecp256k1
 				// For address generation, consensus rules require using
@@ -731,7 +731,7 @@ func TestSignTxOutput(t *testing.T) {
 				switch suite {
 				case dcrec.STEcdsaSecp256k1:
 					privKey, _ := secp256k1.GeneratePrivateKey()
-					keyDB = privKey.D.Bytes()
+					keyDB = privKey.Serialize()
 					pk := privKey.PubKey()
 					// For address generation, consensus rules require using
 					// a compressed public key. Look up ExtractPkScriptAddrs
@@ -816,7 +816,7 @@ func TestSignTxOutput(t *testing.T) {
 				switch suite {
 				case dcrec.STEcdsaSecp256k1:
 					privKey, _ := secp256k1.GeneratePrivateKey()
-					keyDB = privKey.D.Bytes()
+					keyDB = privKey.Serialize()
 					pk := privKey.PubKey()
 					// For address generation, consensus rules require using
 					// a compressed public key. Look up ExtractPkScriptAddrs
@@ -890,7 +890,7 @@ func TestSignTxOutput(t *testing.T) {
 				switch suite {
 				case dcrec.STEcdsaSecp256k1:
 					privKey, _ := secp256k1.GeneratePrivateKey()
-					keyDB = privKey.D.Bytes()
+					keyDB = privKey.Serialize()
 					pk := privKey.PubKey()
 					address, err = dcrutil.NewAddressSecpPubKeyCompressed(pk,
 						testingParams)
@@ -972,7 +972,7 @@ func TestSignTxOutput(t *testing.T) {
 				switch suite {
 				case dcrec.STEcdsaSecp256k1:
 					privKey, _ := secp256k1.GeneratePrivateKey()
-					keyDB = privKey.D.Bytes()
+					keyDB = privKey.Serialize()
 					pkBytes = privKey.PubKey().SerializeUncompressed()
 				case dcrec.STEd25519:
 					keyDB, _, _, _ = edwards.GenerateKey(rand.Reader)
@@ -1049,7 +1049,7 @@ func TestSignTxOutput(t *testing.T) {
 				switch suite {
 				case dcrec.STEcdsaSecp256k1:
 					privKey, _ := secp256k1.GeneratePrivateKey()
-					keyDB = privKey.D.Bytes()
+					keyDB = privKey.Serialize()
 					pkBytes = privKey.PubKey().SerializeUncompressed()
 				case dcrec.STEd25519:
 					keyDB, _, _, _ = edwards.GenerateKey(rand.Reader)
@@ -1141,7 +1141,7 @@ func TestSignTxOutput(t *testing.T) {
 				switch suite {
 				case dcrec.STEcdsaSecp256k1:
 					privKey, _ := secp256k1.GeneratePrivateKey()
-					keyDB = privKey.D.Bytes()
+					keyDB = privKey.Serialize()
 					pkBytes = privKey.PubKey().SerializeCompressed()
 				case dcrec.STEd25519:
 					keyDB, _, _, _ = edwards.GenerateKey(rand.Reader)
@@ -1217,7 +1217,7 @@ func TestSignTxOutput(t *testing.T) {
 				switch suite {
 				case dcrec.STEcdsaSecp256k1:
 					privKey, _ := secp256k1.GeneratePrivateKey()
-					keyDB = privKey.D.Bytes()
+					keyDB = privKey.Serialize()
 					pkBytes = privKey.PubKey().SerializeCompressed()
 				case dcrec.STEd25519:
 					keyDB, _, _, _ = edwards.GenerateKey(rand.Reader)
@@ -1312,7 +1312,7 @@ func TestSignTxOutput(t *testing.T) {
 				switch suite {
 				case dcrec.STEcdsaSecp256k1:
 					privKey, _ := secp256k1.GeneratePrivateKey()
-					keyDB = privKey.D.Bytes()
+					keyDB = privKey.Serialize()
 					pk := privKey.PubKey()
 					// For address generation, consensus rules require using
 					// a compressed public key. Look up ExtractPkScriptAddrs
@@ -1402,7 +1402,7 @@ func TestSignTxOutput(t *testing.T) {
 				switch suite {
 				case dcrec.STEcdsaSecp256k1:
 					privKey, _ := secp256k1.GeneratePrivateKey()
-					keyDB = privKey.D.Bytes()
+					keyDB = privKey.Serialize()
 					pk := privKey.PubKey()
 					// For address generation, consensus rules require using
 					// a compressed public key. Look up ExtractPkScriptAddrs
@@ -1508,7 +1508,7 @@ func TestSignTxOutput(t *testing.T) {
 				switch suite {
 				case dcrec.STEcdsaSecp256k1:
 					privKey, _ := secp256k1.GeneratePrivateKey()
-					keyDB = privKey.D.Bytes()
+					keyDB = privKey.Serialize()
 					pk := privKey.PubKey()
 					address, err = dcrutil.NewAddressSecpPubKeyCompressed(pk,
 						testingParams)
@@ -1598,7 +1598,7 @@ func TestSignTxOutput(t *testing.T) {
 				switch suite {
 				case dcrec.STEcdsaSecp256k1:
 					privKey, _ := secp256k1.GeneratePrivateKey()
-					keyDB = privKey.D.Bytes()
+					keyDB = privKey.Serialize()
 					pk := privKey.PubKey()
 					address, err = dcrutil.NewAddressSecpPubKeyCompressed(pk,
 						testingParams)
@@ -1700,7 +1700,7 @@ func TestSignTxOutput(t *testing.T) {
 				t.Errorf("failed to generate key: %v", err)
 				break
 			}
-			keyDB1 := privKey1.D.Bytes()
+			keyDB1 := privKey1.Serialize()
 			pk1 := privKey1.PubKey()
 			suite1 := dcrec.STEcdsaSecp256k1
 
@@ -1717,7 +1717,7 @@ func TestSignTxOutput(t *testing.T) {
 				t.Errorf("failed to generate key: %v", err)
 				break
 			}
-			keyDB2 := privKey2.D.Bytes()
+			keyDB2 := privKey2.Serialize()
 			pk2 := privKey2.PubKey()
 			suite2 := dcrec.STEcdsaSecp256k1
 
@@ -1786,7 +1786,7 @@ func TestSignTxOutput(t *testing.T) {
 				t.Errorf("failed to generate key: %v", err)
 				break
 			}
-			keyDB1 := privKey1.D.Bytes()
+			keyDB1 := privKey1.Serialize()
 			pk1 := privKey1.PubKey()
 			suite1 := dcrec.STEcdsaSecp256k1
 
@@ -1803,7 +1803,7 @@ func TestSignTxOutput(t *testing.T) {
 				t.Errorf("failed to generate key: %v", err)
 				break
 			}
-			keyDB2 := privKey2.D.Bytes()
+			keyDB2 := privKey2.Serialize()
 			pk2 := privKey2.PubKey()
 			suite2 := dcrec.STEcdsaSecp256k1
 
@@ -1892,7 +1892,7 @@ func TestSignTxOutput(t *testing.T) {
 				t.Errorf("failed to generate key: %v", err)
 				break
 			}
-			keyDB1 := privKey1.D.Bytes()
+			keyDB1 := privKey1.Serialize()
 			pk1 := privKey1.PubKey()
 			suite1 := dcrec.STEcdsaSecp256k1
 
@@ -1909,7 +1909,7 @@ func TestSignTxOutput(t *testing.T) {
 				t.Errorf("failed to generate key: %v", err)
 				break
 			}
-			keyDB2 := privKey2.D.Bytes()
+			keyDB2 := privKey2.Serialize()
 			pk2 := privKey2.PubKey()
 			suite2 := dcrec.STEcdsaSecp256k1
 			address2, err := dcrutil.NewAddressSecpPubKeyCompressed(pk2,


### PR DESCRIPTION
**This requires #2060**.

This modifies the `PrivateKey` type to be opaque and updates the internal implementation of it to use the new `ModNScalar` type instead of a `big.Int`.

It also modifies `NewPrivateKey` to accept the new `ModNScalar` type instead of a `big.Int` and improves the `PrivKeyFromBytes` comment to explicitly call out the semantics that realistically already existed when using the value in calculations.

It is also worth noting that there are still a couple of internal conversions to `big.Int` when dealing with signatures that are required since that code still relies on them for now.  The goal is to eventually update them to use the more efficient specialized types and this change help facilitate that process.
