### PR TITLE
secp256k1: Return new scalar from NonceRFC6979.

### DIFF
--- a/dcrec/secp256k1/bench_test.go
+++ b/dcrec/secp256k1/bench_test.go
@@ -6,7 +6,6 @@
 package secp256k1
 
 import (
-	"math/big"
 	"testing"
 )
 
@@ -156,7 +155,7 @@ func BenchmarkNonceRFC6979(b *testing.B) {
 
 	b.ReportAllocs()
 	b.ResetTimer()
-	var noElideNonce *big.Int
+	var noElideNonce *ModNScalar
 	for i := 0; i < b.N; i++ {
 		noElideNonce = NonceRFC6979(privKey, msgHash, nil, nil, 0)
 	}

--- a/dcrec/secp256k1/schnorr/ecdsa.go
+++ b/dcrec/secp256k1/schnorr/ecdsa.go
@@ -161,11 +161,13 @@ func schnorrSign(msg []byte, ps []byte, k []byte,
 // nonceRFC6979 is a local instantiation of deterministic nonce generation
 // by the standards of RFC6979.
 func nonceRFC6979(privKey []byte, hash []byte, extra []byte, version []byte, extraIterations uint32) []byte {
-	bigK := secp256k1.NonceRFC6979(privKey, hash, extra, version,
-		extraIterations)
+	k := secp256k1.NonceRFC6979(privKey, hash, extra, version, extraIterations)
+	kBytes := k.Bytes()
+	defer zeroArray(&kBytes)
+	bigK := new(big.Int).SetBytes(kBytes[:])
 	defer bigK.SetInt64(0)
-	k := bigIntToEncodedBytes(bigK)
-	return k[:]
+	nonce := bigIntToEncodedBytes(bigK)
+	return nonce[:]
 }
 
 // Sign is the exported version of sign. It uses RFC6979 and Blake256 to


### PR DESCRIPTION
**This requires #2062**.

This modifies the NonceRFC6979 function to return the new `ModNScalar` type instead of a `big.Int` to move closer towards big integer removal in the primary code paths.

While here, this also adds a few more explicit zeros of memory when signing which is good practice when dealing with key material.
