### PR TITLE
secp256k1: Use new mod n scalar in ec mults.

### DIFF
--- a/dcrec/secp256k1/bench_test.go
+++ b/dcrec/secp256k1/bench_test.go
@@ -65,10 +65,10 @@ func BenchmarkScalarBaseMult(b *testing.B) {
 // BenchmarkScalarBaseMultJacobian benchmarks the scalarBaseMultJacobian
 // function.
 func BenchmarkScalarBaseMultJacobian(b *testing.B) {
-	k := fromHex("d74bf844b0862475103d96a611cf2d898447e288d34b360bc885cb8ce7c00575")
+	k := new(ModNScalar).SetHex("d74bf844b0862475103d96a611cf2d898447e288d34b360bc885cb8ce7c00575")
 	var result jacobianPoint
 	for i := 0; i < b.N; i++ {
-		scalarBaseMultJacobian(k.Bytes(), &result)
+		scalarBaseMultJacobian(k, &result)
 	}
 }
 

--- a/dcrec/secp256k1/curve_test.go
+++ b/dcrec/secp256k1/curve_test.go
@@ -598,7 +598,7 @@ func TestScalarMultRand(t *testing.T) {
 	var want jacobianPoint
 	var point jacobianPoint
 	bigAffineToJacobian(curveParams.Gx, curveParams.Gy, &point)
-	exponent := big.NewInt(1)
+	exponent := new(ModNScalar).SetInt(1)
 	for i := 0; i < 1024; i++ {
 		data := make([]byte, 32)
 		_, err := rand.Read(data)
@@ -606,9 +606,12 @@ func TestScalarMultRand(t *testing.T) {
 			t.Fatalf("failed to read random data at %d", i)
 			break
 		}
-		scalarMultJacobian(data, &point, &point)
-		exponent.Mul(exponent, new(big.Int).SetBytes(data))
-		scalarBaseMultJacobian(exponent.Bytes(), &want)
+		var k ModNScalar
+		k.SetByteSlice(data)
+		scalarMultJacobian(&k, &point, &point)
+
+		exponent.Mul(&k)
+		scalarBaseMultJacobian(exponent, &want)
 		point.ToAffine()
 		want.ToAffine()
 		if !point.IsStrictlyEqual(&want) {

--- a/dcrec/secp256k1/privkey.go
+++ b/dcrec/secp256k1/privkey.go
@@ -53,9 +53,8 @@ func GeneratePrivateKey() (*PrivateKey, error) {
 // PubKey computes and returns the public key corresponding to this private key.
 // PubKey returns the PublicKey corresponding to this private key.
 func (p *PrivateKey) PubKey() *PublicKey {
-	privKeyBytes := p.key.Bytes()
 	var result jacobianPoint
-	scalarBaseMultJacobian(privKeyBytes[:], &result)
+	scalarBaseMultJacobian(&p.key, &result)
 	return NewPublicKey(jacobianToBigAffine(&result))
 }
 

--- a/dcrec/secp256k1/signature.go
+++ b/dcrec/secp256k1/signature.go
@@ -411,18 +411,22 @@ func recoverKeyFromSignature(sig *Signature, msg []byte, iter int, doChecks bool
 	// first term.
 	invrS := new(big.Int).Mul(invr, sig.S)
 	invrS.Mod(invrS, curve.Params().N)
+	var invrSModN ModNScalar
+	invrSModN.SetByteSlice(invrS.Bytes())
 	var fR, sR jacobianPoint
 	bigAffineToJacobian(Rx, Ry, &fR)
-	scalarMultJacobian(invrS.Bytes(), &fR, &sR)
+	scalarMultJacobian(&invrSModN, &fR, &sR)
 
 	// second term.
 	e.Neg(e)
 	e.Mod(e, curve.Params().N)
 	e.Mul(e, invr)
 	e.Mod(e, curve.Params().N)
+	var eModN ModNScalar
+	eModN.SetByteSlice(e.Bytes())
 
 	var minusEG, q jacobianPoint
-	scalarBaseMultJacobian(e.Bytes(), &minusEG)
+	scalarBaseMultJacobian(&eModN, &minusEG)
 	addJacobian(&sR, &minusEG, &q)
 
 	Qx, Qy := jacobianToBigAffine(&q)


### PR DESCRIPTION
**This requires #2063.**

This modifies the internal `scalarMultJacobian` and `scalarBaseMultJacobian` functions to accept the new `ModNScalar` type instead of a raw byte slices and updates the code accordingly.

It also moves the `moduloReduce` function from `curve.go` to `ellipticadaptor.go` since it is only required in the adaptor code now.

This is work towards eventually using the new more efficient mod n scalar throughout.
