### PR TITLE
multi: fix rpc listener error.

### DIFF
--- a/dcrd.go
+++ b/dcrd.go
@@ -180,8 +180,7 @@ func dcrdMain() error {
 	svr, err := newServer(ctx, cfg.Listeners, db, cfg.params.Params,
 		cfg.DataDir, ctx.Done())
 	if err != nil {
-		dcrdLog.Errorf("Unable to start server with listeners %v: %v",
-			cfg.Listeners, err)
+		dcrdLog.Errorf("Unable to start server: %v", err)
 		return err
 	}
 	serverDone := make(chan struct{})

--- a/server.go
+++ b/server.go
@@ -3095,7 +3095,7 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 		}
 
 		if len(rpcListeners) == 0 {
-			return nil, errors.New("no listening addresses provided")
+			return nil, errors.New("no usable rpc listen addresses")
 		}
 
 		s.rpcServer, err = newRPCServer(&rpcserverConfig{


### PR DESCRIPTION
This updates the rpc listener error message associated with having no usable listeners.