### PR TITLE
multi: add peer connection timeout config option.

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -138,6 +138,9 @@ Application Options:
       --altdnsnames:        Specify additional dns names to use when
                             generating the rpc server certificate
                             [supports DCRD_ALT_DNSNAMES environment variable]
+      --peeridletimeout     The duration of inactivity before a peer is timed
+                            out. Valid time units are {s,m,h}.
+                            Minimum 15 seconds. (default: 120s)
 
 Help Options:
   -h, --help           Show this help message

--- a/peer/example_test.go
+++ b/peer/example_test.go
@@ -23,6 +23,7 @@ func mockRemotePeer() error {
 		UserAgentName:    "peer",  // User agent name to advertise.
 		UserAgentVersion: "1.0.0", // User agent version to advertise.
 		Net:              wire.SimNet,
+		IdleTimeout:      time.Second * 120,
 	}
 
 	// Accept connections on the simnet port.
@@ -78,6 +79,7 @@ func Example_newOutboundPeer() {
 				verack <- struct{}{}
 			},
 		},
+		IdleTimeout: time.Second * 120,
 	}
 	p, err := peer.NewOutboundPeer(peerCfg, "127.0.0.1:18555")
 	if err != nil {

--- a/sampleconfig/sampleconfig.go
+++ b/sampleconfig/sampleconfig.go
@@ -383,6 +383,10 @@ const DcrctlSampleConfig = `[Application Options]
 ; Use simnet (cannot be used with testnet=1).
 ; simnet=1
 
+; The duration of inactivity before a peer is timed out.
+; Valid time units are {s,m,h}. Minimum 15 seconds.
+; peeridletimeout=120s
+
 
 ; ------------------------------------------------------------------------------
 ; RPC client settings

--- a/server.go
+++ b/server.go
@@ -2063,6 +2063,7 @@ func newPeerConfig(sp *serverPeer) *peer.Config {
 		Services:          sp.server.services,
 		DisableRelayTx:    cfg.BlocksOnly,
 		ProtocolVersion:   maxProtocolVersion,
+		IdleTimeout:       cfg.PeerIdleTimeout,
 	}
 }
 


### PR DESCRIPTION
This adds `--peeridletimeout` config option and updates peer connections to enforce idle timeouts using the connection's read deadline. Associated tests have also been updated.

This resolves #383.