### PR TITLE
txscript: Don't use GetScriptClass in consensus.

### DIFF
--- a/txscript/engine.go
+++ b/txscript/engine.go
@@ -937,7 +937,7 @@ func NewEngine(scriptPubKey []byte, tx *wire.MsgTx, txIdx int, flags ScriptFlags
 	// Redeem scripts for pay to script hash outputs are not allowed to use any
 	// stake tag opcodes if the script version is 0.
 	if scriptVersion == 0 {
-		err := hasP2SHScriptSigStakeOpCodes(scriptVersion, scriptSig,
+		err := hasP2SHRedeemScriptStakeOpCodes(scriptVersion, scriptSig,
 			scriptPubKey)
 		if err != nil {
 			return nil, err

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -577,20 +577,6 @@ func GetScriptClass(version uint16, script []byte) ScriptClass {
 	return typeOfScript(version, script)
 }
 
-// isStakeOutput returns true is a script output is a stake type.
-//
-// NOTE: This function is only valid for version 0 scripts.  Since the function
-// does not accept a script version, the results are undefined for other script
-// versions.
-func isStakeOutput(pkScript []byte) bool {
-	const scriptVersion = 0
-	class := typeOfScript(scriptVersion, pkScript)
-	return class == StakeSubmissionTy ||
-		class == StakeGenTy ||
-		class == StakeRevocationTy ||
-		class == StakeSubChangeTy
-}
-
 // GetStakeOutSubclass extracts the subclass (P2PKH or P2SH)
 // from a stake output.
 //

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -527,7 +527,7 @@ func isStakeChangeScript(scriptVersion uint16, script []byte) bool {
 		extractStakeScriptHash(script, stakeOpcode) != nil
 }
 
-// scriptType returns the type of the script being inspected from the known
+// typeOfScript returns the type of the script being inspected from the known
 // standard types.
 //
 // NOTE:  All scripts that are not version 0 are currently considered non


### PR DESCRIPTION
This modifies the consensus critical function which determines if the redeem script of a p2sh or stake-tagged p2sh contains stake opcodes to avoid calling the `GetScriptClass` function which is only intended explicitly for working with standard script forms which only apply in the context of the more restrictive standardness policy rules.

It also renames the function to better indicate its purpose is to specifically check the redeem script as opposed to the entire signature script.

Finally, it removes the now unused `isStakeOutput` function.