### PR TITLE
rpcserver: Correctly assign TxIn amounts

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -735,7 +735,7 @@ func handleCreateRawSStx(_ context.Context, s *rpcServer, cmd interface{}) (inte
 		}
 
 		prevOut := wire.NewOutPoint(txHash, input.Vout, input.Tree)
-		txIn := wire.NewTxIn(prevOut, wire.NullValueIn, []byte{})
+		txIn := wire.NewTxIn(prevOut, input.Amt, nil)
 		mtx.AddTxIn(txIn)
 	}
 


### PR DESCRIPTION
Use the passed amounts instead of wire.NullValueIn for inputs to the
transaction.

I'm fairly sure that this should be the passed amounts. With my current knowledge I can't image why it would be wire.NullValueIn. When voting, these amounts decide the ratio to divide up the stakebase.