### PR TITLE
secp256k1: Add non-const inverse for mod n scalar.

### DIFF
--- a/dcrec/secp256k1/modnscalar_bench_test.go
+++ b/dcrec/secp256k1/modnscalar_bench_test.go
@@ -233,6 +233,33 @@ func BenchmarkModNScalarNegate(b *testing.B) {
 	}
 }
 
+// BenchmarkBigIntInverseModN benchmarks calculating the multiplicative inverse
+// of an unsigned 256-bit big-endian integer modulo the group order is zero with
+// stdlib big integers.
+func BenchmarkBigIntInverseModN(b *testing.B) {
+	v1 := new(big.Int).SetBytes(benchmarkVals()[0])
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		new(big.Int).ModInverse(v1, curveParams.N)
+	}
+}
+
+// BenchmarkModNScalarInverse benchmarks calculating the multiplicative inverse
+// of an unsigned 256-bit big-endian integer modulo the group order is zero with
+// the specialized type.
+func BenchmarkModNScalarInverse(b *testing.B) {
+	var s1 ModNScalar
+	s1.SetByteSlice(benchmarkVals()[0])
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = new(ModNScalar).InverseValNonConst(&s1)
+	}
+}
+
 // BenchmarkBigIntIsOverHalfOrder benchmarks determining if an unsigned 256-bit
 // big-endian integer modulo the group order exceeds half the group order with
 // stdlib big integers.


### PR DESCRIPTION
**This requires #2064**.

This adds a function to find the modular multiplicative inverse in non-constant time by making use big ints along with the associated tests and benchmarks.

Ideally this will be replaced with an implementation that does not rely on big integers, as well as ultimately have a constant-time implementation. However, this version is being introduced to avoid blocking the ongoing work towards using the new more efficient mod n scalar throughout.
