### PR TITLE
hdkeychain: Provide SerializedPubKey method

### DIFF
--- a/hdkeychain/extendedkey.go
+++ b/hdkeychain/extendedkey.go
@@ -364,6 +364,12 @@ func (k *ExtendedKey) ECPubKey() (*secp256k1.PublicKey, error) {
 	return secp256k1.ParsePubKey(k.pubKeyBytes())
 }
 
+// SerializedPubKey returns the compressed serialization of the secp256k1 public
+// key.  The bytes must not be modified.
+func (k *ExtendedKey) SerializedPubKey() []byte {
+	return k.pubKeyBytes()
+}
+
 // ECPrivKey converts the extended key to a dcrec private key and returns it.
 // As you might imagine this is only possible if the extended key is a private
 // extended key (as determined by the IsPrivate function).  The ErrNotPrivExtKey


### PR DESCRIPTION
The SerializedPubKey method returns the internal and memoized bytes
representing the compressed serialization of the HD key's secp256k1
public key.  The motivation for providing this method is to avoid an
extra serialization and deserialization through *secp256k1.PublicKey
when creating the pubkey hash.  Wallet profiling revealed that roughly
30% of CPU time deriving child addresses from account branch extended
keys was a result of the extra forced serialization steps.