### PR TITLE
multi: Update to prerel module release versions.

### DIFF
--- a/blockchain/go.mod
+++ b/blockchain/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/decred/dcrd/blockchain/stake/v3 v3.0.0-20200104000002-54b67d3474fb
 	github.com/decred/dcrd/blockchain/standalone v1.1.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
-	github.com/decred/dcrd/chaincfg/v3 v3.0.0-00010101000000-000000000000
+	github.com/decred/dcrd/chaincfg/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/database/v2 v2.0.1
 	github.com/decred/dcrd/dcrec v1.0.0
-	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0-00010101000000-000000000000
+	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200104000002-54b67d3474fb
 	github.com/decred/dcrd/gcs/v2 v2.0.0
 	github.com/decred/dcrd/txscript/v3 v3.0.0-20200104000002-54b67d3474fb

--- a/blockchain/stake/go.mod
+++ b/blockchain/stake/go.mod
@@ -4,7 +4,7 @@ go 1.11
 
 require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
-	github.com/decred/dcrd/chaincfg/v3 v3.0.0-00010101000000-000000000000
+	github.com/decred/dcrd/chaincfg/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/database/v2 v2.0.1
 	github.com/decred/dcrd/dcrec v1.0.0
 	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200104000002-54b67d3474fb

--- a/database/go.mod
+++ b/database/go.mod
@@ -4,7 +4,7 @@ go 1.11
 
 require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
-	github.com/decred/dcrd/chaincfg/v3 v3.0.0-00010101000000-000000000000
+	github.com/decred/dcrd/chaincfg/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200104000002-54b67d3474fb
 	github.com/decred/dcrd/wire v1.3.0
 	github.com/decred/slog v1.0.0

--- a/dcrutil/go.mod
+++ b/dcrutil/go.mod
@@ -6,11 +6,11 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/base58 v1.0.2
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
-	github.com/decred/dcrd/chaincfg/v3 v3.0.0-00010101000000-000000000000
+	github.com/decred/dcrd/chaincfg/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/crypto/ripemd160 v1.0.0
 	github.com/decred/dcrd/dcrec v1.0.0
 	github.com/decred/dcrd/dcrec/edwards/v2 v2.0.0
-	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0-00010101000000-000000000000
+	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/wire v1.3.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -12,12 +12,13 @@ require (
 	github.com/decred/dcrd/blockchain/v3 v3.0.0-20200104000002-54b67d3474fb
 	github.com/decred/dcrd/certgen v1.1.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
-	github.com/decred/dcrd/chaincfg/v3 v3.0.0-00010101000000-000000000000
+	github.com/decred/dcrd/chaincfg/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/connmgr/v3 v3.0.0-20200104000002-54b67d3474fb
+	github.com/decred/dcrd/crypto/blake256 v1.0.0
 	github.com/decred/dcrd/crypto/ripemd160 v1.0.0
 	github.com/decred/dcrd/database/v2 v2.0.1
 	github.com/decred/dcrd/dcrec v1.0.0
-	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0-00010101000000-000000000000
+	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/dcrjson/v3 v3.0.1
 	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200104000002-54b67d3474fb
 	github.com/decred/dcrd/fees/v2 v2.0.0
@@ -28,7 +29,7 @@ require (
 	github.com/decred/dcrd/mining/v3 v3.0.0-20200104000002-54b67d3474fb
 	github.com/decred/dcrd/peer/v2 v2.1.0
 	github.com/decred/dcrd/rpc/jsonrpc/types/v2 v2.0.0
-	github.com/decred/dcrd/rpcclient/v6 v6.0.0-00010101000000-000000000000
+	github.com/decred/dcrd/rpcclient/v6 v6.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/txscript/v3 v3.0.0-20200104000002-54b67d3474fb
 	github.com/decred/dcrd/wire v1.3.0
 	github.com/decred/dcrwallet/rpc/jsonrpc/types v1.4.0

--- a/hdkeychain/go.mod
+++ b/hdkeychain/go.mod
@@ -5,9 +5,9 @@ go 1.11
 require (
 	github.com/decred/base58 v1.0.2
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
-	github.com/decred/dcrd/chaincfg/v3 v3.0.0-00010101000000-000000000000
+	github.com/decred/dcrd/chaincfg/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/dcrec v1.0.0
-	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0-00010101000000-000000000000
+	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200104000002-54b67d3474fb
 )
 

--- a/mempool/go.mod
+++ b/mempool/go.mod
@@ -7,9 +7,9 @@ require (
 	github.com/decred/dcrd/blockchain/standalone v1.1.0
 	github.com/decred/dcrd/blockchain/v3 v3.0.0-20200104000002-54b67d3474fb
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
-	github.com/decred/dcrd/chaincfg/v3 v3.0.0-00010101000000-000000000000
+	github.com/decred/dcrd/chaincfg/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/dcrec v1.0.0
-	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0-00010101000000-000000000000
+	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200104000002-54b67d3474fb
 	github.com/decred/dcrd/mining/v3 v3.0.0-20200104000002-54b67d3474fb
 	github.com/decred/dcrd/txscript/v3 v3.0.0-20200104000002-54b67d3474fb

--- a/txscript/go.mod
+++ b/txscript/go.mod
@@ -4,11 +4,11 @@ go 1.11
 
 require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
-	github.com/decred/dcrd/chaincfg/v3 v3.0.0-00010101000000-000000000000
+	github.com/decred/dcrd/chaincfg/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/crypto/ripemd160 v1.0.0
 	github.com/decred/dcrd/dcrec v1.0.0
 	github.com/decred/dcrd/dcrec/edwards/v2 v2.0.0
-	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0-00010101000000-000000000000
+	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200104000002-54b67d3474fb
 	github.com/decred/dcrd/wire v1.3.0
 	github.com/decred/slog v1.0.0


### PR DESCRIPTION
This modifies some recently-updated modules to use a valid prerelease version so they can be used in require statements in consumer code that is also under development.

The updated direct dependencies are as follows:

- github.com/decred/dcrd/chaincfg/v3@v3.0.0-20200214194519-928737b3e580
- github.com/decred/dcrd/dcrec/secp256k1/v3@v3.0.0-20200214194519-928737b3e580
