### PR TITLE
hdkeychain: Start v3 module dev cycle.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/chaincfg/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/connmgr/v3 v3.0.0-20200104000002-54b67d3474fb
-	github.com/decred/dcrd/crypto/blake256 v1.0.0
 	github.com/decred/dcrd/crypto/ripemd160 v1.0.0
 	github.com/decred/dcrd/database/v2 v2.0.1
 	github.com/decred/dcrd/dcrec v1.0.0
@@ -23,7 +22,7 @@ require (
 	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200104000002-54b67d3474fb
 	github.com/decred/dcrd/fees/v2 v2.0.0
 	github.com/decred/dcrd/gcs/v2 v2.0.1
-	github.com/decred/dcrd/hdkeychain/v2 v2.1.0
+	github.com/decred/dcrd/hdkeychain/v3 v3.0.0
 	github.com/decred/dcrd/lru v1.0.0
 	github.com/decred/dcrd/mempool/v4 v4.0.0-20200104000002-54b67d3474fb
 	github.com/decred/dcrd/mining/v3 v3.0.0-20200104000002-54b67d3474fb
@@ -62,7 +61,7 @@ replace (
 	github.com/decred/dcrd/dcrutil/v3 => ./dcrutil
 	github.com/decred/dcrd/fees/v2 => ./fees
 	github.com/decred/dcrd/gcs/v2 => ./gcs
-	github.com/decred/dcrd/hdkeychain/v2 => ./hdkeychain
+	github.com/decred/dcrd/hdkeychain/v3 => ./hdkeychain
 	github.com/decred/dcrd/limits => ./limits
 	github.com/decred/dcrd/lru => ./lru
 	github.com/decred/dcrd/mempool/v4 => ./mempool

--- a/hdkeychain/example_test.go
+++ b/hdkeychain/example_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/dcrec"
 	"github.com/decred/dcrd/dcrutil/v3"
-	"github.com/decred/dcrd/hdkeychain/v2"
+	"github.com/decred/dcrd/hdkeychain/v3"
 )
 
 // This example demonstrates how to generate a cryptographically random seed

--- a/hdkeychain/go.mod
+++ b/hdkeychain/go.mod
@@ -1,4 +1,4 @@
-module github.com/decred/dcrd/hdkeychain/v2
+module github.com/decred/dcrd/hdkeychain/v3
 
 go 1.11
 

--- a/rpcclient/go.mod
+++ b/rpcclient/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/decred/dcrd/dcrjson/v3 v3.0.1
 	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200104000002-54b67d3474fb
 	github.com/decred/dcrd/gcs/v2 v2.0.0
-	github.com/decred/dcrd/hdkeychain/v2 v2.1.0
+	github.com/decred/dcrd/hdkeychain/v3 v3.0.0
 	github.com/decred/dcrd/rpc/jsonrpc/types v1.0.1
 	github.com/decred/dcrd/rpc/jsonrpc/types/v2 v2.0.0
 	github.com/decred/dcrd/wire v1.3.0
@@ -22,5 +22,6 @@ replace (
 	github.com/decred/dcrd/chaincfg/v3 => ../chaincfg
 	github.com/decred/dcrd/dcrec/secp256k1/v3 => ../dcrec/secp256k1
 	github.com/decred/dcrd/dcrutil/v3 => ../dcrutil
+	github.com/decred/dcrd/hdkeychain/v3 => ../hdkeychain
 	github.com/decred/dcrd/rpc/jsonrpc/types/v2 => ../rpc/jsonrpc/types
 )

--- a/rpcclient/go.sum
+++ b/rpcclient/go.sum
@@ -36,8 +36,6 @@ github.com/decred/dcrd/dcrutil/v2 v2.0.1 h1:aL+c7o7Q66HV1gIif+XkNYo9DeorN3l01Vns
 github.com/decred/dcrd/dcrutil/v2 v2.0.1/go.mod h1:JdEgF6eh0TTohPeiqDxqDSikTSvAczq0J7tFMyyeD+k=
 github.com/decred/dcrd/gcs/v2 v2.0.0 h1:nCc3q9iIwIpF0khTSiC7xYgojKoKnPrqrgVjboOBXDE=
 github.com/decred/dcrd/gcs/v2 v2.0.0/go.mod h1:3XjKcrtvB+r2ezhIsyNCLk6dRnXRJVyYmsd1P3SkU3o=
-github.com/decred/dcrd/hdkeychain/v2 v2.1.0 h1:NVNIz36HPukOnaysBDsLO+2kWqijLM4tvLUsLLyLfME=
-github.com/decred/dcrd/hdkeychain/v2 v2.1.0/go.mod h1:DR+lD4uV8G0i3c9qnUJwjiGaaEWK+nSrbWCz1BRHBL8=
 github.com/decred/dcrd/rpc/jsonrpc/types v1.0.1 h1:sWsGtWzdmrna6aysDCHwjANTJh+Lxt2xp6S10ahP79Y=
 github.com/decred/dcrd/rpc/jsonrpc/types v1.0.1/go.mod h1:dJUp9PoyFYklzmlImpVkVLOr6j4zKuUv66YgemP2sd8=
 github.com/decred/dcrd/txscript/v2 v2.1.0 h1:IKIpNm0lPmNQoaZ2zxZm1qMwfmLb/XXeahxXlfc+MrA=

--- a/rpcclient/wallet.go
+++ b/rpcclient/wallet.go
@@ -13,7 +13,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrjson/v3"
 	"github.com/decred/dcrd/dcrutil/v3"
-	"github.com/decred/dcrd/hdkeychain/v2"
+	"github.com/decred/dcrd/hdkeychain/v3"
 	chainjsonv1 "github.com/decred/dcrd/rpc/jsonrpc/types"
 	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v2"
 	"github.com/decred/dcrd/wire"

--- a/rpctest/memwallet.go
+++ b/rpctest/memwallet.go
@@ -18,7 +18,7 @@ import (
 	"github.com/decred/dcrd/dcrec"
 	"github.com/decred/dcrd/dcrec/secp256k1/v3"
 	"github.com/decred/dcrd/dcrutil/v3"
-	"github.com/decred/dcrd/hdkeychain/v2"
+	"github.com/decred/dcrd/hdkeychain/v3"
 	"github.com/decred/dcrd/rpcclient/v6"
 	"github.com/decred/dcrd/txscript/v3"
 	"github.com/decred/dcrd/wire"


### PR DESCRIPTION
hdkeychain has received breaking changes since the last release (break
occurred in 85f0c09df2), and further releases must use a bumped major
version.  The standard process for introducing major API breaks has
been followed:

  - Bump the major version in the go.mod of the affected module if not
    already done since the last release tag
  - Add a replacement to the go.mod in the main module if not already done
    since the last release tag
  - Update all imports in the repo to use the new major version as
    necessary
  - Make necessary modifications to allow all other modules to use the new
    version in the same commit
  - Repeat the process for any other modules the require a new major as a
    result of consuming the new major(s)

Closes #2075.