### PR TITLE
hdkeychain: Remove ECPubKey.

### DIFF
--- a/hdkeychain/README.md
+++ b/hdkeychain/README.md
@@ -8,24 +8,22 @@ hdkeychain
 Package hdkeychain provides an API for Decred hierarchical deterministic
 extended keys (based on BIP0032).
 
-A comprehensive suite of tests is provided to ensure proper functionality.  See
-`test_coverage.txt` for the gocov coverage report.  Alternatively, if you are
-running a POSIX OS, you can run the `cov_report.sh` script for a real-time
-report.
+A comprehensive suite of tests is provided to ensure proper functionality.
 
 ## Feature Overview
 
 - Full BIP0032 implementation
 - Single type for private and public extended keys
-- Convenient cryptograpically secure seed generation
+- Convenient cryptographically secure seed generation
 - Simple creation of master nodes
 - Support for multi-layer derivation
 - Easy serialization and deserialization for both private and public extended
   keys
 - Support for custom networks by accepting a network parameters interface
-- Obtaining the underlying EC pubkeys and EC privkeys ties in seamlessly with
-  existing secp256k1 types which provide powerful tools for working with them to
-  do things like sign transactions and generate payment scripts
+- Allows obtaining the underlying serialized secp256k1 pubkeys and privkeys
+  directly so they can either be used directly or optionally converted to the
+  secp256k1 types which provide powerful tools for working with them to do
+  things like sign transactions and generate payment scripts
 - Uses the highly-optimized secp256k1 package
 - Code examples including:
   - Generating a cryptographically secure random seed and deriving a master node

--- a/hdkeychain/example_test.go
+++ b/hdkeychain/example_test.go
@@ -127,11 +127,7 @@ func Example_defaultWalletLayout() {
 	// pubKeyHashAddr is a convenience function to convert an extended
 	// pubkey to a standard pay-to-pubkey-hash address.
 	pubKeyHashAddr := func(extKey *hdkeychain.ExtendedKey) (string, error) {
-		ecPubKey, err := extKey.ECPubKey()
-		if err != nil {
-			return "", err
-		}
-		pkHash := dcrutil.Hash160(ecPubKey.SerializeCompressed())
+		pkHash := dcrutil.Hash160(extKey.SerializedPubKey())
 		addr, err := dcrutil.NewAddressPubKeyHash(pkHash, net,
 			dcrec.STEcdsaSecp256k1)
 		if err != nil {

--- a/hdkeychain/extendedkey.go
+++ b/hdkeychain/extendedkey.go
@@ -359,11 +359,6 @@ func (k *ExtendedKey) Neuter() (*ExtendedKey, error) {
 		k.parentFP, k.depth, k.childNum, false), nil
 }
 
-// ECPubKey converts the extended key to a dcrec public key and returns it.
-func (k *ExtendedKey) ECPubKey() (*secp256k1.PublicKey, error) {
-	return secp256k1.ParsePubKey(k.pubKeyBytes())
-}
-
 // SerializedPubKey returns the compressed serialization of the secp256k1 public
 // key.  The bytes must not be modified.
 func (k *ExtendedKey) SerializedPubKey() []byte {

--- a/hdkeychain/extendedkey_test.go
+++ b/hdkeychain/extendedkey_test.go
@@ -652,16 +652,10 @@ func TestExtendedKeyAPI(t *testing.T) {
 			}
 		}
 
-		pubKey, err := key.ECPubKey()
-		if err != nil {
-			t.Errorf("ECPubKey #%d (%s): unexpected error: %v", i,
-				test.name, err)
-			continue
-		}
-		pubKeyStr := hex.EncodeToString(pubKey.SerializeCompressed())
+		pubKeyStr := hex.EncodeToString(key.SerializedPubKey())
 		if pubKeyStr != test.pubKey {
-			t.Errorf("ECPubKey #%d (%s): mismatched public key -- "+
-				"want %s, got %s", i, test.name, test.pubKey,
+			t.Errorf("SerializedPubKey #%d (%s): mismatched public "+
+				"key -- want %s, got %s", i, test.name, test.pubKey,
 				pubKeyStr)
 			continue
 		}
@@ -825,11 +819,11 @@ func TestZero(t *testing.T) {
 			return false
 		}
 
-		wantErr = errors.New("pubkey string is empty")
-		_, err = key.ECPubKey()
-		if !reflect.DeepEqual(err, wantErr) {
-			t.Errorf("ECPubKey #%d (%s): mismatched error: want "+
-				"%v, got %v", i, testName, wantErr, err)
+		serializedPubKey := key.SerializedPubKey()
+		if len(serializedPubKey) != 0 {
+			t.Errorf("ECPubKey #%d (%s): mismatched serialized "+
+				"pubkey: want nil, got %x", i, testName,
+				serializedPubKey)
 			return false
 		}
 


### PR DESCRIPTION
This removes the `ECPubKey` method in favor of the newly added `SerializedPubKey` method, updates the tests and example to use the new method instead, and finally updates the `README` accordingly as well.

The primary reason for this change is that it removes the secp256k1 type from the public API and is more efficient in practice because the serialized bytes are already available internally and callers are exceedingly likely to just serialize the returned pubkey again, so the current approach  almost always resulted in an additional needless round trip through parsing the public key, which is rather expensive.