### PR TITLE
hdkeychain:  ECPrivKey -> SerializedPrivKey.

### DIFF
--- a/hdkeychain/extendedkey.go
+++ b/hdkeychain/extendedkey.go
@@ -365,17 +365,18 @@ func (k *ExtendedKey) SerializedPubKey() []byte {
 	return k.pubKeyBytes()
 }
 
-// ECPrivKey converts the extended key to a dcrec private key and returns it.
+// SerializedPrivKey converts the extended key to a secp256k1 private key and
+// returns its serialization.  The returned bytes must not be modified.
+//
 // As you might imagine this is only possible if the extended key is a private
 // extended key (as determined by the IsPrivate function).  The ErrNotPrivExtKey
 // error will be returned if this function is called on a public extended key.
-func (k *ExtendedKey) ECPrivKey() (*secp256k1.PrivateKey, error) {
+func (k *ExtendedKey) SerializedPrivKey() ([]byte, error) {
 	if !k.isPrivate {
 		return nil, ErrNotPrivExtKey
 	}
 
-	privKey := secp256k1.PrivKeyFromBytes(k.key)
-	return privKey, nil
+	return k.key, nil
 }
 
 // paddedAppend appends the src byte slice to dst, returning the new slice.

--- a/hdkeychain/extendedkey_test.go
+++ b/hdkeychain/extendedkey_test.go
@@ -636,16 +636,17 @@ func TestExtendedKeyAPI(t *testing.T) {
 			continue
 		}
 
-		privKey, err := key.ECPrivKey()
+		privKey, err := key.SerializedPrivKey()
 		if !reflect.DeepEqual(err, test.privKeyErr) {
-			t.Errorf("ECPrivKey #%d (%s): mismatched error: want "+
-				"%v, got %v", i, test.name, test.privKeyErr, err)
+			t.Errorf("SerializedPrivKey #%d (%s): mismatched "+
+				"error: want %v, got %v", i, test.name,
+				test.privKeyErr, err)
 			continue
 		}
 		if test.privKeyErr == nil {
-			privKeyStr := hex.EncodeToString(privKey.Serialize())
+			privKeyStr := hex.EncodeToString(privKey)
 			if privKeyStr != test.privKey {
-				t.Errorf("ECPrivKey #%d (%s): mismatched "+
+				t.Errorf("SerializedPrivKey #%d (%s): mismatched "+
 					"private key -- want %s, got %s", i,
 					test.name, test.privKey, privKeyStr)
 				continue
@@ -812,10 +813,11 @@ func TestZero(t *testing.T) {
 		}
 
 		wantErr := ErrNotPrivExtKey
-		_, err := key.ECPrivKey()
+		_, err := key.SerializedPrivKey()
 		if !reflect.DeepEqual(err, wantErr) {
-			t.Errorf("ECPrivKey #%d (%s): mismatched error: want "+
-				"%v, got %v", i, testName, wantErr, err)
+			t.Errorf("SerializedPrivKey #%d (%s): mismatched "+
+				"error: want %v, got %v", i, testName, wantErr,
+				err)
 			return false
 		}
 


### PR DESCRIPTION
This replace the `ECPrivKey` method with a `SerializedPrivKey` method to be consistent with the newly added `SerializePubKey` method and updates the tests accordingly.

The primary reason for this change is that it removes the `secp256k1` type from the public API and is more efficient in practice because the serialized bytes are already available internally and callers are exceedingly likely to just serialize the returned privkey again, so the current approach  almost always resulted in an additional needless round trip through parsing the private key.
