### PR TITLE
multi: Update all prerel module release versions.

### DIFF
--- a/blockchain/go.mod
+++ b/blockchain/go.mod
@@ -3,16 +3,16 @@ module github.com/decred/dcrd/blockchain/v3
 go 1.11
 
 require (
-	github.com/decred/dcrd/blockchain/stake/v3 v3.0.0-20200104000002-54b67d3474fb
+	github.com/decred/dcrd/blockchain/stake/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/blockchain/standalone v1.1.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/chaincfg/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/database/v2 v2.0.1
 	github.com/decred/dcrd/dcrec v1.0.0
 	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0-20200214194519-928737b3e580
-	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200104000002-54b67d3474fb
+	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/gcs/v2 v2.0.0
-	github.com/decred/dcrd/txscript/v3 v3.0.0-20200104000002-54b67d3474fb
+	github.com/decred/dcrd/txscript/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/wire v1.3.0
 	github.com/decred/slog v1.0.0
 )

--- a/blockchain/stake/go.mod
+++ b/blockchain/stake/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/decred/dcrd/chaincfg/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/database/v2 v2.0.1
 	github.com/decred/dcrd/dcrec v1.0.0
-	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200104000002-54b67d3474fb
-	github.com/decred/dcrd/txscript/v3 v3.0.0-20200104000002-54b67d3474fb
+	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200214194519-928737b3e580
+	github.com/decred/dcrd/txscript/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/wire v1.3.0
 	github.com/decred/slog v1.0.0
 )

--- a/database/go.mod
+++ b/database/go.mod
@@ -5,7 +5,7 @@ go 1.11
 require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/chaincfg/v3 v3.0.0-20200214194519-928737b3e580
-	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200104000002-54b67d3474fb
+	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/wire v1.3.0
 	github.com/decred/slog v1.0.0
 	github.com/golang/protobuf v1.3.2 // indirect

--- a/fees/go.mod
+++ b/fees/go.mod
@@ -3,9 +3,9 @@ module github.com/decred/dcrd/fees/v2
 go 1.11
 
 require (
-	github.com/decred/dcrd/blockchain/stake/v3 v3.0.0-20200104000002-54b67d3474fb
+	github.com/decred/dcrd/blockchain/stake/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
-	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200104000002-54b67d3474fb
+	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/slog v1.0.0
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d

--- a/gcs/go.mod
+++ b/gcs/go.mod
@@ -4,10 +4,10 @@ go 1.11
 
 require (
 	github.com/dchest/siphash v1.2.1
-	github.com/decred/dcrd/blockchain/stake/v3 v3.0.0-20200104000002-54b67d3474fb
+	github.com/decred/dcrd/blockchain/stake/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/crypto/blake256 v1.0.0
-	github.com/decred/dcrd/txscript/v3 v3.0.0-20200104000002-54b67d3474fb
+	github.com/decred/dcrd/txscript/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/wire v1.3.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -7,29 +7,30 @@ require (
 	github.com/decred/base58 v1.0.2
 	github.com/decred/dcrd/addrmgr v1.1.0
 	github.com/decred/dcrd/bech32 v1.0.0
-	github.com/decred/dcrd/blockchain/stake/v3 v3.0.0-20200104000002-54b67d3474fb
+	github.com/decred/dcrd/blockchain/stake/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/blockchain/standalone v1.1.0
-	github.com/decred/dcrd/blockchain/v3 v3.0.0-20200104000002-54b67d3474fb
+	github.com/decred/dcrd/blockchain/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/certgen v1.1.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/chaincfg/v3 v3.0.0-20200214194519-928737b3e580
-	github.com/decred/dcrd/connmgr/v3 v3.0.0-20200104000002-54b67d3474fb
+	github.com/decred/dcrd/connmgr/v3 v3.0.0-20200214194519-928737b3e580
+	github.com/decred/dcrd/crypto/blake256 v1.0.0
 	github.com/decred/dcrd/crypto/ripemd160 v1.0.0
 	github.com/decred/dcrd/database/v2 v2.0.1
 	github.com/decred/dcrd/dcrec v1.0.0
 	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/dcrjson/v3 v3.0.1
-	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200104000002-54b67d3474fb
+	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/fees/v2 v2.0.0
 	github.com/decred/dcrd/gcs/v2 v2.0.1
 	github.com/decred/dcrd/hdkeychain/v3 v3.0.0
 	github.com/decred/dcrd/lru v1.0.0
-	github.com/decred/dcrd/mempool/v4 v4.0.0-20200104000002-54b67d3474fb
-	github.com/decred/dcrd/mining/v3 v3.0.0-20200104000002-54b67d3474fb
+	github.com/decred/dcrd/mempool/v4 v4.0.0-20200214194519-928737b3e580
+	github.com/decred/dcrd/mining/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/peer/v2 v2.1.0
 	github.com/decred/dcrd/rpc/jsonrpc/types/v2 v2.0.0
 	github.com/decred/dcrd/rpcclient/v6 v6.0.0-20200214194519-928737b3e580
-	github.com/decred/dcrd/txscript/v3 v3.0.0-20200104000002-54b67d3474fb
+	github.com/decred/dcrd/txscript/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/wire v1.3.0
 	github.com/decred/dcrwallet/rpc/jsonrpc/types v1.4.0
 	github.com/decred/go-socks v1.1.0

--- a/hdkeychain/go.mod
+++ b/hdkeychain/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/decred/dcrd/chaincfg/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/dcrec v1.0.0
 	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0-20200214194519-928737b3e580
-	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200104000002-54b67d3474fb
+	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200214194519-928737b3e580
 )
 
 replace (

--- a/mempool/go.mod
+++ b/mempool/go.mod
@@ -3,16 +3,16 @@ module github.com/decred/dcrd/mempool/v4
 go 1.11
 
 require (
-	github.com/decred/dcrd/blockchain/stake/v3 v3.0.0-20200104000002-54b67d3474fb
+	github.com/decred/dcrd/blockchain/stake/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/blockchain/standalone v1.1.0
-	github.com/decred/dcrd/blockchain/v3 v3.0.0-20200104000002-54b67d3474fb
+	github.com/decred/dcrd/blockchain/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/chaincfg/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/dcrec v1.0.0
 	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0-20200214194519-928737b3e580
-	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200104000002-54b67d3474fb
-	github.com/decred/dcrd/mining/v3 v3.0.0-20200104000002-54b67d3474fb
-	github.com/decred/dcrd/txscript/v3 v3.0.0-20200104000002-54b67d3474fb
+	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200214194519-928737b3e580
+	github.com/decred/dcrd/mining/v3 v3.0.0-20200214194519-928737b3e580
+	github.com/decred/dcrd/txscript/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/wire v1.3.0
 	github.com/decred/slog v1.0.0
 )

--- a/mining/go.mod
+++ b/mining/go.mod
@@ -3,9 +3,9 @@ module github.com/decred/dcrd/mining/v3
 go 1.11
 
 require (
-	github.com/decred/dcrd/blockchain/stake/v3 v3.0.0-20200104000002-54b67d3474fb
+	github.com/decred/dcrd/blockchain/stake/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
-	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200104000002-54b67d3474fb
+	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/wire v1.3.0
 )
 

--- a/peer/go.mod
+++ b/peer/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/lru v1.0.0
-	github.com/decred/dcrd/txscript/v3 v3.0.0-20200104000002-54b67d3474fb
+	github.com/decred/dcrd/txscript/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/wire v1.3.0
 	github.com/decred/go-socks v1.1.0
 	github.com/decred/slog v1.0.0

--- a/rpcclient/go.mod
+++ b/rpcclient/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/dcrjson/v3 v3.0.1
-	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200104000002-54b67d3474fb
+	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/gcs/v2 v2.0.0
 	github.com/decred/dcrd/hdkeychain/v3 v3.0.0
 	github.com/decred/dcrd/rpc/jsonrpc/types v1.0.1

--- a/txscript/go.mod
+++ b/txscript/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/decred/dcrd/dcrec v1.0.0
 	github.com/decred/dcrd/dcrec/edwards/v2 v2.0.0
 	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0-20200214194519-928737b3e580
-	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200104000002-54b67d3474fb
+	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200214194519-928737b3e580
 	github.com/decred/dcrd/wire v1.3.0
 	github.com/decred/slog v1.0.0
 )


### PR DESCRIPTION
This modifies all prelease modules to use the latest version so they can be used in require statements in consumer code that is also under development without running into transitive dependency issues.

The updated direct dependencies are as follows:

- github.com/decred/dcrd/blockchain/stake/v3@v3.0.0-20200214194519-928737b3e580
- github.com/decred/dcrd/blockchain/v3@v3.0.0-20200214194519-928737b3e580
- github.com/decred/dcrd/connmgr/v3@v3.0.0-20200214194519-928737b3e580
- github.com/decred/dcrd/dcrutil/v3@v3.0.0-20200214194519-928737b3e580
- github.com/decred/dcrd/mempool/v4@v4.0.0-20200214194519-928737b3e580
- github.com/decred/dcrd/mining/v3@v3.0.0-20200214194519-928737b3e580
- github.com/decred/dcrd/txscript/v3@v3.0.0-20200214194519-928737b3e580
