### PR TITLE
secp256k1: Make signature opaque.

### DIFF
--- a/dcrec/secp256k1/bench_test.go
+++ b/dcrec/secp256k1/bench_test.go
@@ -115,8 +115,8 @@ func BenchmarkSigVerify(b *testing.B) {
 	// Double sha256 of []byte{0x01, 0x02, 0x03, 0x04}
 	msgHash := fromHex("8de472e2399610baaa7f84840547cd409434e31f5d3bd71e4d947f283874f9c0")
 	sig := Signature{
-		R: fromHex("fef45d2892953aa5bbcdb057b5e98b208f1617a7498af7eb765574e29b5d9c2c"),
-		S: fromHex("d47563f52aac6b04b55de236b7c515eb9311757db01e02cff079c3ca6efb063f"),
+		r: fromHex("fef45d2892953aa5bbcdb057b5e98b208f1617a7498af7eb765574e29b5d9c2c"),
+		s: fromHex("d47563f52aac6b04b55de236b7c515eb9311757db01e02cff079c3ca6efb063f"),
 	}
 
 	if !sig.Verify(msgHash.Bytes(), &pubKey) {

--- a/dcrec/secp256k1/signature_test.go
+++ b/dcrec/secp256k1/signature_test.go
@@ -236,8 +236,8 @@ func TestSignatureSerialize(t *testing.T) {
 		{
 			"valid 1 - r and s most significant bits are zero",
 			&Signature{
-				R: hexToBigInt("4e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd41"),
-				S: hexToBigInt("181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d09"),
+				r: hexToBigInt("4e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd41"),
+				s: hexToBigInt("181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d09"),
 			},
 			hexToBytes("304402204e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d62" +
 				"4c6c61548ab5fb8cd410220181522ec8eca07de4860a4acdd12909d831cc" +
@@ -248,8 +248,8 @@ func TestSignatureSerialize(t *testing.T) {
 		{
 			"valid 2 - r most significant bit is one",
 			&Signature{
-				R: hexToBigInt("0082235e21a2300022738dabb8e1bbd9d19cfb1e7ab8c30a23b0afbb8d178abcf3"),
-				S: hexToBigInt("24bf68e256c534ddfaf966bf908deb944305596f7bdcc38d69acad7f9c868724"),
+				r: hexToBigInt("0082235e21a2300022738dabb8e1bbd9d19cfb1e7ab8c30a23b0afbb8d178abcf3"),
+				s: hexToBigInt("24bf68e256c534ddfaf966bf908deb944305596f7bdcc38d69acad7f9c868724"),
 			},
 			hexToBytes("304502210082235e21a2300022738dabb8e1bbd9d19cfb1e7ab8c" +
 				"30a23b0afbb8d178abcf3022024bf68e256c534ddfaf966bf908deb94430" +
@@ -260,8 +260,8 @@ func TestSignatureSerialize(t *testing.T) {
 		{
 			"valid 3 - s most significant bit is one",
 			&Signature{
-				R: hexToBigInt("1cadddc2838598fee7dc35a12b340c6bde8b389f7bfd19a1252a17c4b5ed2d71"),
-				S: new(big.Int).Add(hexToBigInt("00c1a251bbecb14b058a8bd77f65de87e51c47e95904f4c0e9d52eddc21c1415ac"), S256().N),
+				r: hexToBigInt("1cadddc2838598fee7dc35a12b340c6bde8b389f7bfd19a1252a17c4b5ed2d71"),
+				s: new(big.Int).Add(hexToBigInt("00c1a251bbecb14b058a8bd77f65de87e51c47e95904f4c0e9d52eddc21c1415ac"), S256().N),
 			},
 			hexToBytes("304502201cadddc2838598fee7dc35a12b340c6bde8b389f7bfd1" +
 				"9a1252a17c4b5ed2d71022100c1a251bbecb14b058a8bd77f65de87e51c4" +
@@ -270,8 +270,8 @@ func TestSignatureSerialize(t *testing.T) {
 		{
 			"zero signature",
 			&Signature{
-				R: big.NewInt(0),
-				S: big.NewInt(0),
+				r: big.NewInt(0),
+				s: big.NewInt(0),
 			},
 			hexToBytes("3006020100020100"),
 		},
@@ -575,16 +575,16 @@ func TestRFC6979Compat(t *testing.T) {
 // works as expected.
 func TestSignatureIsEqual(t *testing.T) {
 	sig1 := &Signature{
-		R: hexToBigInt("0082235e21a2300022738dabb8e1bbd9d19cfb1e7ab8c30a23b0afbb8d178abcf3"),
-		S: hexToBigInt("24bf68e256c534ddfaf966bf908deb944305596f7bdcc38d69acad7f9c868724"),
+		r: hexToBigInt("0082235e21a2300022738dabb8e1bbd9d19cfb1e7ab8c30a23b0afbb8d178abcf3"),
+		s: hexToBigInt("24bf68e256c534ddfaf966bf908deb944305596f7bdcc38d69acad7f9c868724"),
 	}
 	sig1Copy := &Signature{
-		R: hexToBigInt("0082235e21a2300022738dabb8e1bbd9d19cfb1e7ab8c30a23b0afbb8d178abcf3"),
-		S: hexToBigInt("24bf68e256c534ddfaf966bf908deb944305596f7bdcc38d69acad7f9c868724"),
+		r: hexToBigInt("0082235e21a2300022738dabb8e1bbd9d19cfb1e7ab8c30a23b0afbb8d178abcf3"),
+		s: hexToBigInt("24bf68e256c534ddfaf966bf908deb944305596f7bdcc38d69acad7f9c868724"),
 	}
 	sig2 := &Signature{
-		R: hexToBigInt("4e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd41"),
-		S: hexToBigInt("181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d09"),
+		r: hexToBigInt("4e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd41"),
+		s: hexToBigInt("181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d09"),
 	}
 
 	if !sig1.IsEqual(sig1) {

--- a/txscript/sign.go
+++ b/txscript/sign.go
@@ -396,9 +396,7 @@ sigLoop:
 			// If it matches we put it in the map. We only
 			// can take one signature per public key so if we
 			// already have one, we can throw this away.
-			r := pSig.R
-			s := pSig.S
-			if secp256k1.NewSignature(r, s).Verify(hash, pubKey) {
+			if pSig.Verify(hash, pubKey) {
 				aStr := addr.Address()
 				if _, ok := addrToSig[aStr]; !ok {
 					addrToSig[aStr] = sig


### PR DESCRIPTION
This modifies the `Signature` type to be opaque in order to facilitate eventually using the new more efficient mod n scalar.  For now, it makes no other changes beyond making the type opaque.
