### PR TITLE
secp256k1: Use mod n scalar when signing.

### DIFF
--- a/dcrec/secp256k1/bench_test.go
+++ b/dcrec/secp256k1/bench_test.go
@@ -130,6 +130,22 @@ func BenchmarkSigVerify(b *testing.B) {
 	}
 }
 
+// BenchmarkSign benchmarks how long it takes to sign a message.
+func BenchmarkSign(b *testing.B) {
+	// Randomly generated keypair.
+	d := new(ModNScalar).SetHex("9e0699c91ca1e3b7e3c9ba71eb71c89890872be97576010fe593fbf3fd57e66d")
+	privKey := NewPrivateKey(d)
+
+	// blake256 of []byte{0x01, 0x02, 0x03, 0x04}.
+	msgHash := hexToBytes("c301ba9de5d6053caad9f5eb46523f007702add2c62fa39de03146a36b8026b7")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		signRFC6979(privKey, msgHash)
+	}
+}
+
 // BenchmarkFieldNormalize benchmarks how long it takes the internal field
 // to perform normalization (which includes modular reduction).
 func BenchmarkFieldNormalize(b *testing.B) {


### PR DESCRIPTION
**This requires PR #2084.**

This modifies the function that produces signatures to use the new `ModNScalar` type instead of big ints and also fleshes out the comments to include a reference to original signing algorithm in GECC, a paraphrased version of it for those without access to the book, and the modifications made so that it is deterministic per RFC6979 and conforms to BIP0062.  It also adds a signing benchmark.

This is work towards eventually using the new more efficient mod n scalar throughout.

While the primary focus of this change is not optimization since signing happens infrequently enough that it is not in a performance hot path, as can be seen from the benchmark below, it does have the effect of making signing a bit faster.

The following benchmark shows a before and after comparison of producing a typical signature:
```
benchmark       old ns/op    new ns/op    delta
-------------------------------------------------
BenchmarkSign   59788        54905        -8.17%

benchmark       old allocs   new allocs   delta
-------------------------------------------------
BenchmarkSign   43           36           -16.28%

benchmark       old bytes    new bytes    delta
-------------------------------------------------
BenchmarkSign   2338         1776         -24.04%
```