### PR TITLE
hdkeychain: Use direct hashes and remove dcrutil dep

### DIFF
--- a/hdkeychain/go.mod
+++ b/hdkeychain/go.mod
@@ -4,8 +4,9 @@ go 1.11
 
 require (
 	github.com/decred/base58 v1.0.2
-	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/chaincfg/v3 v3.0.0-20200215031403-6b2ce76f0986
+	github.com/decred/dcrd/crypto/blake256 v1.0.0
+	github.com/decred/dcrd/crypto/ripemd160 v1.0.0
 	github.com/decred/dcrd/dcrec v1.0.0
 	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0-20200215031403-6b2ce76f0986
 	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200215031403-6b2ce76f0986


### PR DESCRIPTION
This change replaces usage of chainhash (which is intended solely for
transaction and blocks) and dcrutil.Hash160 (used in scripts for
hashing redeem scripts and pubkeys) with direct calls to each hashing
function from dcrd's crypto subpackages.  This improves clarity and
shortens the transitive package imports.  Notably, dcrutil and
everything it depends on is no longer transitively imported when
importing the hdkeychain package.