### PR TITLE
secp256k1: Remove BER signature parsing.

### DIFF
--- a/txscript/sigcache_test.go
+++ b/txscript/sigcache_test.go
@@ -47,7 +47,7 @@ func TestSigCacheAddExists(t *testing.T) {
 	sigCache.Add(*msg1, sig1, key1)
 
 	// The previously added triplet should now be found within the sigcache.
-	sig1Copy, _ := secp256k1.ParseSignature(sig1.Serialize())
+	sig1Copy, _ := secp256k1.ParseDERSignature(sig1.Serialize())
 	key1Copy, _ := secp256k1.ParsePubKey(key1.SerializeCompressed())
 	if !sigCache.Exists(*msg1, sig1Copy, key1Copy) {
 		t.Errorf("previously added item not found in signature cache")
@@ -70,7 +70,7 @@ func TestSigCacheAddEvictEntry(t *testing.T) {
 		}
 
 		sigCache.Add(*msg, sig, key)
-		sigCopy, _ := secp256k1.ParseSignature(sig.Serialize())
+		sigCopy, _ := secp256k1.ParseDERSignature(sig.Serialize())
 		keyCopy, _ := secp256k1.ParsePubKey(key.SerializeCompressed())
 		if !sigCache.Exists(*msg, sigCopy, keyCopy) {
 			t.Errorf("previously added item not found in signature " +
@@ -99,7 +99,7 @@ func TestSigCacheAddEvictEntry(t *testing.T) {
 	}
 
 	// The entry added above should be found within the sigcache.
-	sigNewCopy, _ := secp256k1.ParseSignature(sigNew.Serialize())
+	sigNewCopy, _ := secp256k1.ParseDERSignature(sigNew.Serialize())
 	keyNewCopy, _ := secp256k1.ParsePubKey(keyNew.SerializeCompressed())
 	if !sigCache.Exists(*msgNew, sigNewCopy, keyNewCopy) {
 		t.Fatalf("previously added item not found in signature cache")
@@ -122,7 +122,7 @@ func TestSigCacheAddMaxEntriesZeroOrNegative(t *testing.T) {
 	sigCache.Add(*msg1, sig1, key1)
 
 	// The generated triplet should not be found.
-	sig1Copy, _ := secp256k1.ParseSignature(sig1.Serialize())
+	sig1Copy, _ := secp256k1.ParseDERSignature(sig1.Serialize())
 	key1Copy, _ := secp256k1.ParsePubKey(key1.SerializeCompressed())
 	if sigCache.Exists(*msg1, sig1Copy, key1Copy) {
 		t.Errorf("previously added signature found in sigcache, but " +


### PR DESCRIPTION
**This is rebased on #2095**.

This removes the ability to parse signatures encoded with the more lax Basic Encoding Rules (BER) since they have never been valid on the Decred blockchain and the existing parsing code for them really didn't follow the spec anyway given it enforced additional length restrictions that the BER spec technically allows.