### PR TITLE
secp256k1: Use mod n scalar in signature type.

### DIFF
--- a/dcrec/secp256k1/signature_bench_test.go
+++ b/dcrec/secp256k1/signature_bench_test.go
@@ -23,8 +23,8 @@ func BenchmarkSigVerify(b *testing.B) {
 	// Double sha256 of []byte{0x01, 0x02, 0x03, 0x04}
 	msgHash := fromHex("8de472e2399610baaa7f84840547cd409434e31f5d3bd71e4d947f283874f9c0")
 	sig := Signature{
-		r: fromHex("fef45d2892953aa5bbcdb057b5e98b208f1617a7498af7eb765574e29b5d9c2c"),
-		s: fromHex("d47563f52aac6b04b55de236b7c515eb9311757db01e02cff079c3ca6efb063f"),
+		r: *new(ModNScalar).SetHex("fef45d2892953aa5bbcdb057b5e98b208f1617a7498af7eb765574e29b5d9c2c"),
+		s: *new(ModNScalar).SetHex("d47563f52aac6b04b55de236b7c515eb9311757db01e02cff079c3ca6efb063f"),
 	}
 
 	if !sig.Verify(msgHash.Bytes(), &pubKey) {
@@ -61,8 +61,8 @@ func BenchmarkSigSerialize(b *testing.B) {
 	// Private key: 9e0699c91ca1e3b7e3c9ba71eb71c89890872be97576010fe593fbf3fd57e66d
 	// Signature for double sha256 of []byte{0x01, 0x02, 0x03, 0x04}.
 	sig := Signature{
-		r: fromHex("fef45d2892953aa5bbcdb057b5e98b208f1617a7498af7eb765574e29b5d9c2c"),
-		s: fromHex("d47563f52aac6b04b55de236b7c515eb9311757db01e02cff079c3ca6efb063f"),
+		r: *new(ModNScalar).SetHex("fef45d2892953aa5bbcdb057b5e98b208f1617a7498af7eb765574e29b5d9c2c"),
+		s: *new(ModNScalar).SetHex("d47563f52aac6b04b55de236b7c515eb9311757db01e02cff079c3ca6efb063f"),
 	}
 
 	b.ReportAllocs()

--- a/dcrec/secp256k1/signature_test.go
+++ b/dcrec/secp256k1/signature_test.go
@@ -12,21 +12,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"math/big"
 	"testing"
 )
-
-// hexToBigInt converts the passed hex string into a big integer and will panic
-// if there is an error.  This is only provided for the hard-coded constants so
-// errors in the source code can be detected. It will only (and must only) be
-// called with hard-coded values.
-func hexToBigInt(hexStr string) *big.Int {
-	val, ok := new(big.Int).SetString(hexStr, 16)
-	if !ok {
-		panic("failed to parse big integer from hex: " + hexStr)
-	}
-	return val
-}
 
 // hexToBytes converts the passed hex string into bytes and will panic if there
 // is an error.  This is only provided for the hard-coded constants so errors in
@@ -232,8 +219,8 @@ func TestSignatureSerialize(t *testing.T) {
 		// 0437cd7f8525ceed2324359c2d0ba26006d92d85
 		"valid 1 - r and s most significant bits are zero",
 		&Signature{
-			r: hexToBigInt("4e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd41"),
-			s: hexToBigInt("181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d09"),
+			r: *new(ModNScalar).SetHex("4e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd41"),
+			s: *new(ModNScalar).SetHex("181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d09"),
 		},
 		hexToBytes("304402204e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d62" +
 			"4c6c61548ab5fb8cd410220181522ec8eca07de4860a4acdd12909d831cc" +
@@ -243,8 +230,8 @@ func TestSignatureSerialize(t *testing.T) {
 		// cb00f8a0573b18faa8c4f467b049f5d202bf1101d9ef2633bc611be70376a4b4
 		"valid 2 - r most significant bit is one",
 		&Signature{
-			r: hexToBigInt("0082235e21a2300022738dabb8e1bbd9d19cfb1e7ab8c30a23b0afbb8d178abcf3"),
-			s: hexToBigInt("24bf68e256c534ddfaf966bf908deb944305596f7bdcc38d69acad7f9c868724"),
+			r: *new(ModNScalar).SetHex("82235e21a2300022738dabb8e1bbd9d19cfb1e7ab8c30a23b0afbb8d178abcf3"),
+			s: *new(ModNScalar).SetHex("24bf68e256c534ddfaf966bf908deb944305596f7bdcc38d69acad7f9c868724"),
 		},
 		hexToBytes("304502210082235e21a2300022738dabb8e1bbd9d19cfb1e7ab8c" +
 			"30a23b0afbb8d178abcf3022024bf68e256c534ddfaf966bf908deb94430" +
@@ -258,8 +245,8 @@ func TestSignatureSerialize(t *testing.T) {
 		// modified to expect the equally valid low S signature variant.
 		"valid 3 - s most significant bit is one",
 		&Signature{
-			r: hexToBigInt("1cadddc2838598fee7dc35a12b340c6bde8b389f7bfd19a1252a17c4b5ed2d71"),
-			s: hexToBigInt("c1a251bbecb14b058a8bd77f65de87e51c47e95904f4c0e9d52eddc21c1415ac"),
+			r: *new(ModNScalar).SetHex("1cadddc2838598fee7dc35a12b340c6bde8b389f7bfd19a1252a17c4b5ed2d71"),
+			s: *new(ModNScalar).SetHex("c1a251bbecb14b058a8bd77f65de87e51c47e95904f4c0e9d52eddc21c1415ac"),
 		},
 		hexToBytes("304402201cadddc2838598fee7dc35a12b340c6bde8b389f7bfd1" +
 			"9a1252a17c4b5ed2d7102203e5dae44134eb4fa757428809a2178199e66f" +
@@ -267,8 +254,8 @@ func TestSignatureSerialize(t *testing.T) {
 	}, {
 		"zero signature",
 		&Signature{
-			r: big.NewInt(0),
-			s: big.NewInt(0),
+			r: *new(ModNScalar).SetInt(0),
+			s: *new(ModNScalar).SetInt(0),
 		},
 		hexToBytes("3006020100020100"),
 	}}
@@ -570,16 +557,16 @@ func TestRFC6979Compat(t *testing.T) {
 // works as expected.
 func TestSignatureIsEqual(t *testing.T) {
 	sig1 := &Signature{
-		r: hexToBigInt("0082235e21a2300022738dabb8e1bbd9d19cfb1e7ab8c30a23b0afbb8d178abcf3"),
-		s: hexToBigInt("24bf68e256c534ddfaf966bf908deb944305596f7bdcc38d69acad7f9c868724"),
+		r: *new(ModNScalar).SetHex("82235e21a2300022738dabb8e1bbd9d19cfb1e7ab8c30a23b0afbb8d178abcf3"),
+		s: *new(ModNScalar).SetHex("24bf68e256c534ddfaf966bf908deb944305596f7bdcc38d69acad7f9c868724"),
 	}
 	sig1Copy := &Signature{
-		r: hexToBigInt("0082235e21a2300022738dabb8e1bbd9d19cfb1e7ab8c30a23b0afbb8d178abcf3"),
-		s: hexToBigInt("24bf68e256c534ddfaf966bf908deb944305596f7bdcc38d69acad7f9c868724"),
+		r: *new(ModNScalar).SetHex("82235e21a2300022738dabb8e1bbd9d19cfb1e7ab8c30a23b0afbb8d178abcf3"),
+		s: *new(ModNScalar).SetHex("24bf68e256c534ddfaf966bf908deb944305596f7bdcc38d69acad7f9c868724"),
 	}
 	sig2 := &Signature{
-		r: hexToBigInt("4e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd41"),
-		s: hexToBigInt("181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d09"),
+		r: *new(ModNScalar).SetHex("4e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd41"),
+		s: *new(ModNScalar).SetHex("181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d09"),
 	}
 
 	if !sig1.IsEqual(sig1) {


### PR DESCRIPTION
**This requires #2106**.

This updates the internal implementation of the `Signature` type to use the new `ModNScalar` type instead of `big.Int`s and modifies `NewSignature` to accept the new `ModNScalar` type accordingly.

Signature parsing and signing operations are now completely free of `big.Int`s.  Verification still relies on them due to their use in public keys.
