### PR TITLE
secp256k1: Make public keys opaque.

### DIFF
--- a/dcrec/secp256k1/ciphering.go
+++ b/dcrec/secp256k1/ciphering.go
@@ -46,7 +46,7 @@ var (
 // RFC5903 Section 9 states we should only return x.
 func GenerateSharedSecret(privkey *PrivateKey, pubkey *PublicKey) []byte {
 	privKeyBytes := privkey.key.Bytes()
-	x, _ := S256().ScalarMult(pubkey.X, pubkey.Y, privKeyBytes[:])
+	x, _ := S256().ScalarMult(pubkey.x, pubkey.y, privKeyBytes[:])
 	zeroArray32(&privKeyBytes)
 	return x.Bytes()
 }

--- a/dcrec/secp256k1/curve_test.go
+++ b/dcrec/secp256k1/curve_test.go
@@ -741,7 +741,7 @@ func testKeyGeneration(t *testing.T, c *KoblitzCurve, tag string) {
 		return
 	}
 	pub := priv.PubKey()
-	if !c.IsOnCurve(pub.X, pub.Y) {
+	if !c.IsOnCurve(pub.x, pub.y) {
 		t.Errorf("%s: public key invalid: %s", tag, err)
 	}
 }

--- a/dcrec/secp256k1/ellipticadaptor.go
+++ b/dcrec/secp256k1/ellipticadaptor.go
@@ -187,8 +187,8 @@ func (curve *KoblitzCurve) ScalarBaseMult(k []byte) (*big.Int, *big.Int) {
 func (p PublicKey) ToECDSA() *ecdsa.PublicKey {
 	return &ecdsa.PublicKey{
 		Curve: S256(),
-		X:     p.X,
-		Y:     p.Y,
+		X:     p.x,
+		Y:     p.y,
 	}
 }
 

--- a/dcrec/secp256k1/schnorr/ecdsa.go
+++ b/dcrec/secp256k1/schnorr/ecdsa.go
@@ -236,7 +236,7 @@ func schnorrVerify(sig []byte,
 		return false, schnorrError(ErrInputValue, str)
 	}
 
-	if !curve.IsOnCurve(pubkey.X, pubkey.Y) {
+	if !curve.IsOnCurve(pubkey.X(), pubkey.Y()) {
 		str := fmt.Sprintf("pubkey point is not on curve")
 		return false, schnorrError(ErrPointNotOnCurve, str)
 	}
@@ -277,7 +277,7 @@ func schnorrVerify(sig []byte,
 	}
 
 	// r' = hQ + sG
-	lx, ly := curve.ScalarMult(pubkey.X, pubkey.Y, h)
+	lx, ly := curve.ScalarMult(pubkey.X(), pubkey.Y(), h)
 	rx, ry := curve.ScalarBaseMult(sigS)
 	rlx, rly := curve.Add(lx, ly, rx, ry)
 
@@ -388,7 +388,7 @@ func schnorrRecover(sig, msg []byte,
 	sBig.Mod(sBig, curve.N)
 
 	// Q = h^(-1)R + s'G
-	lx, ly := curve.ScalarMult(rPoint.X, rPoint.Y, hInv.Bytes())
+	lx, ly := curve.ScalarMult(rPoint.X(), rPoint.Y(), hInv.Bytes())
 	rx, ry := curve.ScalarBaseMult(sBig.Bytes())
 	pkx, pky := curve.Add(lx, ly, rx, ry)
 

--- a/dcrec/secp256k1/signature.go
+++ b/dcrec/secp256k1/signature.go
@@ -217,7 +217,7 @@ func (sig *Signature) Verify(hash []byte, pubKey *PublicKey) bool {
 	//
 	// X = u1G + u2Q
 	var X, Q, u1G, u2Q jacobianPoint
-	bigAffineToJacobian(pubKey.X, pubKey.Y, &Q)
+	bigAffineToJacobian(pubKey.x, pubKey.y, &Q)
 	scalarBaseMultJacobian(u1, &u1G)
 	scalarMultJacobian(u2, &Q, &u2Q)
 	addJacobian(&u1G, &u2Q, &X)

--- a/dcrec/secp256k1/signature_bench_test.go
+++ b/dcrec/secp256k1/signature_bench_test.go
@@ -15,10 +15,10 @@ func BenchmarkSigVerify(b *testing.B) {
 	b.StopTimer()
 	// Randomly generated keypair.
 	// Private key: 9e0699c91ca1e3b7e3c9ba71eb71c89890872be97576010fe593fbf3fd57e66d
-	pubKey := PublicKey{
-		X: fromHex("d2e670a19c6d753d1a6d8b20bd045df8a08fb162cf508956c31268c6d81ffdab"),
-		Y: fromHex("ab65528eefbb8057aa85d597258a3fbd481a24633bc9b47a9aa045c91371de52"),
-	}
+	pubKey := NewPublicKey(
+		fromHex("d2e670a19c6d753d1a6d8b20bd045df8a08fb162cf508956c31268c6d81ffdab"),
+		fromHex("ab65528eefbb8057aa85d597258a3fbd481a24633bc9b47a9aa045c91371de52"),
+	)
 
 	// Double sha256 of []byte{0x01, 0x02, 0x03, 0x04}
 	msgHash := fromHex("8de472e2399610baaa7f84840547cd409434e31f5d3bd71e4d947f283874f9c0")
@@ -27,14 +27,14 @@ func BenchmarkSigVerify(b *testing.B) {
 		s: *new(ModNScalar).SetHex("d47563f52aac6b04b55de236b7c515eb9311757db01e02cff079c3ca6efb063f"),
 	}
 
-	if !sig.Verify(msgHash.Bytes(), &pubKey) {
+	if !sig.Verify(msgHash.Bytes(), pubKey) {
 		b.Errorf("Signature failed to verify")
 		return
 	}
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		sig.Verify(msgHash.Bytes(), &pubKey)
+		sig.Verify(msgHash.Bytes(), pubKey)
 	}
 }
 
@@ -114,10 +114,10 @@ func BenchmarkSignCompact(b *testing.B) {
 // given a compact signature and message.
 func BenchmarkRecoverCompact(b *testing.B) {
 	// Private key: 9e0699c91ca1e3b7e3c9ba71eb71c89890872be97576010fe593fbf3fd57e66d
-	wantPubKey := PublicKey{
-		X: fromHex("d2e670a19c6d753d1a6d8b20bd045df8a08fb162cf508956c31268c6d81ffdab"),
-		Y: fromHex("ab65528eefbb8057aa85d597258a3fbd481a24633bc9b47a9aa045c91371de52"),
-	}
+	wantPubKey := NewPublicKey(
+		fromHex("d2e670a19c6d753d1a6d8b20bd045df8a08fb162cf508956c31268c6d81ffdab"),
+		fromHex("ab65528eefbb8057aa85d597258a3fbd481a24633bc9b47a9aa045c91371de52"),
+	)
 
 	compactSig := hexToBytes("205978b7896bc71676ba2e459882a8f52e1299449596c4f" +
 		"93c59bf1fbfa2f9d3b76ecd0c99406f61a6de2bb5a8937c061c176ecf381d0231e0d" +
@@ -134,7 +134,7 @@ func BenchmarkRecoverCompact(b *testing.B) {
 	if !wasCompressed {
 		b.Fatal("recover claims uncompressed pubkey")
 	}
-	if !pubKey.IsEqual(&wantPubKey) {
+	if !pubKey.IsEqual(wantPubKey) {
 		b.Fatal("recover returned unexpected pubkey")
 	}
 

--- a/dcrec/secp256k1/signature_test.go
+++ b/dcrec/secp256k1/signature_test.go
@@ -290,8 +290,8 @@ func testSignCompact(t *testing.T, tag string, data []byte, isCompressed bool) {
 	}
 	if !pk.IsEqual(signingPubKey) {
 		t.Errorf("%s: recovered pubkey doesn't match original "+
-			"(%v,%v) vs (%v,%v) ", tag, pk.X, pk.Y, signingPubKey.X,
-			signingPubKey.Y)
+			"(%v,%v) vs (%v,%v) ", tag, pk.x, pk.y, signingPubKey.x,
+			signingPubKey.y)
 		return
 	}
 	if wasCompressed != isCompressed {
@@ -315,8 +315,8 @@ func testSignCompact(t *testing.T, tag string, data []byte, isCompressed bool) {
 	}
 	if !pk.IsEqual(signingPubKey) {
 		t.Errorf("%s: recovered pubkey (2) doesn't match original "+
-			"(%v,%v) vs (%v,%v) ", tag, pk.X, pk.Y, signingPubKey.X,
-			signingPubKey.Y)
+			"(%v,%v) vs (%v,%v) ", tag, pk.x, pk.y, signingPubKey.x,
+			signingPubKey.y)
 		return
 	}
 	if wasCompressed == isCompressed {

--- a/hdkeychain/extendedkey.go
+++ b/hdkeychain/extendedkey.go
@@ -340,7 +340,7 @@ func (k *ExtendedKey) Child(i uint32) (*ExtendedKey, error) {
 		// derive the final child key.
 		//
 		// childKey = serP(point(parse256(Il)) + parentKey)
-		childX, childY := curve.Add(ilx, ily, pubKey.X, pubKey.Y)
+		childX, childY := curve.Add(ilx, ily, pubKey.X(), pubKey.Y())
 		pk := secp256k1.NewPublicKey(childX, childY)
 		childKey = pk.SerializeCompressed()
 	}


### PR DESCRIPTION
**This is rebased on #2107**.

This modifies the `PublicKey` type to be opaque in order to facilitate eventually using the new more efficient mod n scalar.  For now, it makes no other changes beyond making the type opaque.
