### PR TITLE
secp256k1: Rework DER sig parsing tests.

### DIFF
--- a/dcrec/secp256k1/go.mod
+++ b/dcrec/secp256k1/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrd/dcrec/secp256k1/v3
 
-go 1.11
+go 1.13
 
 require (
 	github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
**This requires #2106**.

This reworks the DER signature parsing tests to ensure 100% test coverage of all branches in the parsing code and also test for the explicit reason for a failure to ensure that each test is actually testing the intended condition.

Compare this to the previous more generic validity testing which only tested that a signature failed to parse as opposed to _why_ it failed to parse.  The result was that some of the tests were not actually testing what they claimed.