### PR TITLE
mempool: Fix TestDust

### DIFF
--- a/mempool/policy_test.go
+++ b/mempool/policy_test.go
@@ -215,11 +215,11 @@ func TestDust(t *testing.T) {
 		isDust   bool
 	}{
 		{
-			// Any value is allowed with a zero relay fee.
+			// Any value except 0 is not dust with zero relay fee.
 			"zero value with zero relay fee",
-			wire.TxOut{Value: 0, Version: 0, PkScript: pkScript},
+			wire.TxOut{Value: 1000, Version: 0, PkScript: pkScript},
 			0,
-			true,
+			false,
 		},
 		{
 			// Zero value is dust with any relay fee"


### PR DESCRIPTION
TestDust in mempool/policy_test had a test case that conflicted with the
associated comment and the succeeding test. The intention was to test
any value other than 0 atoms with a 0 atom/kb relay fee.