### PR TITLE
hdkeychain: Remove Neuter error return

### DIFF
--- a/hdkeychain/example_test.go
+++ b/hdkeychain/example_test.go
@@ -187,11 +187,7 @@ func Example_audits() {
 	// Neuter the master key to generate a master public extended key.  This
 	// gives the path:
 	//   N(m/*)
-	masterPubKey, err := masterKey.Neuter()
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
+	masterPubKey := masterKey.Neuter()
 
 	// Share the master public extended key with the auditor.
 	fmt.Println("Audit key N(m/*):", masterPubKey)

--- a/hdkeychain/extendedkey.go
+++ b/hdkeychain/extendedkey.go
@@ -360,10 +360,10 @@ func (k *ExtendedKey) Child(i uint32) (*ExtendedKey, error) {
 // private key, so it is not capable of signing transactions or deriving
 // child extended private keys.  However, it is capable of deriving further
 // child extended public keys.
-func (k *ExtendedKey) Neuter() (*ExtendedKey, error) {
+func (k *ExtendedKey) Neuter() *ExtendedKey {
 	// Already an extended public key.
 	if !k.isPrivate {
-		return k, nil
+		return k
 	}
 
 	// Convert it to an extended public key.  The key for the new extended
@@ -371,7 +371,7 @@ func (k *ExtendedKey) Neuter() (*ExtendedKey, error) {
 	//
 	// This is the function N((k,c)) -> (K, c) from [BIP32].
 	return newExtendedKey(k.privVer, k.pubVer, k.pubKeyBytes(), k.chainCode,
-		k.parentFP, k.depth, k.childNum, false), nil
+		k.parentFP, k.depth, k.childNum, false)
 }
 
 // SerializedPubKey returns the compressed serialization of the secp256k1 public

--- a/hdkeychain/extendedkey_test.go
+++ b/hdkeychain/extendedkey_test.go
@@ -263,18 +263,13 @@ tests:
 			continue
 		}
 
-		pubKey, err := extKey.Neuter()
-		if err != nil {
-			t.Errorf("Neuter #%d (%s): unexpected error: %v ", i,
-				test.name, err)
-			continue
-		}
+		pubKey := extKey.Neuter()
 
 		// Neutering a second time should have no effect.
-		pubKey, err = pubKey.Neuter()
-		if err != nil {
-			t.Errorf("Neuter #%d (%s): unexpected error: %v", i,
-				test.name, err)
+		// Test for referencial equality.
+		if pubKey != pubKey.Neuter() {
+			t.Errorf("Neuter of extended public key returned " +
+				"different object address")
 			return
 		}
 
@@ -692,11 +687,7 @@ func TestErrors(t *testing.T) {
 		t.Errorf("NewMaster: unexpected error: %v", err)
 		return
 	}
-	pubKey, err := extKey.Neuter()
-	if err != nil {
-		t.Errorf("Neuter: unexpected error: %v", err)
-		return
-	}
+	pubKey := extKey.Neuter()
 
 	// Deriving a hardened child extended key should fail from a public key.
 	_, err = pubKey.Child(HardenedKeyStart)
@@ -707,11 +698,9 @@ func TestErrors(t *testing.T) {
 
 	// NewKeyFromString failure tests.
 	tests := []struct {
-		name      string
-		key       string
-		err       error
-		neuter    bool
-		neuterErr error
+		name string
+		key  string
+		err  error
 	}{
 		{
 			name: "invalid key length",
@@ -737,22 +726,12 @@ func TestErrors(t *testing.T) {
 
 	mainNetParams := mockMainNetParams()
 	for i, test := range tests {
-		extKey, err := NewKeyFromString(test.key, mainNetParams)
+		_, err := NewKeyFromString(test.key, mainNetParams)
 		if !reflect.DeepEqual(err, test.err) {
 			t.Errorf("NewKeyFromString #%d (%s): mismatched error "+
 				"-- got: %v, want: %v", i, test.name, err,
 				test.err)
 			continue
-		}
-
-		if test.neuter {
-			_, err := extKey.Neuter()
-			if !reflect.DeepEqual(err, test.neuterErr) {
-				t.Errorf("Neuter #%d (%s): mismatched error "+
-					"-- got: %v, want: %v", i, test.name,
-					err, test.neuterErr)
-				continue
-			}
 		}
 	}
 }
@@ -847,12 +826,7 @@ func TestZero(t *testing.T) {
 				err)
 			continue
 		}
-		neuteredKey, err := key.Neuter()
-		if err != nil {
-			t.Errorf("Neuter #%d (%s): unexpected error: %v", i,
-				test.name, err)
-			continue
-		}
+		neuteredKey := key.Neuter()
 
 		// Ensure both non-neutered and neutered keys are zeroed
 		// properly.
@@ -872,12 +846,7 @@ func TestZero(t *testing.T) {
 				"error: %v", i, test.name, err)
 			continue
 		}
-		neuteredKey, err = key.Neuter()
-		if err != nil {
-			t.Errorf("Neuter #%d (%s): unexpected error: %v", i,
-				test.name, err)
-			continue
-		}
+		neuteredKey = key.Neuter()
 
 		// Ensure both non-neutered and neutered keys are zeroed
 		// properly.


### PR DESCRIPTION
This method never errors now, allowing the API to be simplified
slightly.