### PR TITLE
secp256k1: Add Zero method to private key.

### DIFF
--- a/dcrec/secp256k1/privkey.go
+++ b/dcrec/secp256k1/privkey.go
@@ -67,6 +67,13 @@ func (p *PrivateKey) Sign(hash []byte) *Signature {
 	return signature
 }
 
+// Zero manually clears the memory associated with the private key.  This can be
+// used to explicitly clear key material from memory for enhanced security
+// against memory scraping.
+func (p *PrivateKey) Zero() {
+	p.key.Zero()
+}
+
 // PrivKeyBytesLen defines the length in bytes of a serialized private key.
 const PrivKeyBytesLen = 32
 

--- a/dcrec/secp256k1/privkey_test.go
+++ b/dcrec/secp256k1/privkey_test.go
@@ -50,3 +50,24 @@ func TestPrivKeys(t *testing.T) {
 		}
 	}
 }
+
+// TestPrivateKeyZero ensures that zeroing a private key clears the memory
+// associated with it.
+func TestPrivateKeyZero(t *testing.T) {
+	// Create a new private key and zero the initial key material that is now
+	// copied into the private key.
+	key := new(ModNScalar).SetHex("eaf02ca348c524e6392655ba4d29603cd1a7347d9d65cfe93ce1ebffdca22694")
+	privKey := NewPrivateKey(key)
+	key.Zero()
+
+	// Ensure the private key is non zero.
+	if privKey.key.IsZero() {
+		t.Fatal("private key is zero when it should be non zero")
+	}
+
+	// Zero the private key and ensure it was properly zeroed.
+	privKey.Zero()
+	if !privKey.key.IsZero() {
+		t.Fatal("private key is non zero when it should be zero")
+	}
+}


### PR DESCRIPTION
This adds a method to the `PrivateKey` type to clear the memory associated with it so that consumers can explicitly clear key material for enhanced security against memory scraping.  It also adds tests to ensure it works as expected.