### PR TITLE
secp256k1: Reduce EC operation normalizes.

### DIFF
--- a/dcrec/secp256k1/signature.go
+++ b/dcrec/secp256k1/signature.go
@@ -753,8 +753,8 @@ func RecoverCompact(signature, hash []byte) (*PublicKey, bool, error) {
 	//
 	// X = (r, y)
 	var X jacobianPoint
-	X.x.Set(&fieldR)
-	X.y.Set(&y)
+	X.x.Set(&fieldR).Normalize()
+	X.y.Set(&y).Normalize()
 	X.z.SetInt(1)
 
 	// Step 6.


### PR DESCRIPTION
**This requires #2118**.

This modifies the various EC operations to reduce the overall number of normalizations that are needed by requiring the caller to provide normalized points instead of blindly normalizing the inputs.  It also updates the operations to ensure the result is normalized along with updating the comments to call out the new semantics and updating all of the callers accordingly to ensure the new requirements are met.

This results in less overall normalizations because the caller has more information about whether or not normalization is needed and can therefore avoid it in many cases, particularly when it is using the result that is already normalized as part of a chain of operations.

The following benchmarks show a before and after comparison of the affected operations:

```
benchmark                         old ns/op   new ns/op   delta
-----------------------------------------------------------------
BenchmarkAddJacobian              569         442         -22.32%
BenchmarkAddJacobianNotZOne       1087        1080        -0.64%
BenchmarkScalarBaseMult           46966       46164       -1.71%
BenchmarkScalarBaseMultJacobian   34218       34165       -0.15%
BenchmarkScalarBaseMultLarge      47077       46819       -0.55%
BenchmarkScalarMult               155318      148019      -4.70%
BenchmarkSigVerify                176007      168422      -4.31%
BenchmarkSign                     57636       57561       -0.13%
BenchmarkSignCompact              57883       57653       -0.40%
BenchmarkRecoverCompact           206361      197419      -4.33%
```