### PR TITLE
schnorr: Remove deprecated chainec methods.

### DIFF
--- a/dcrec/secp256k1/schnorr/ecdsa.go
+++ b/dcrec/secp256k1/schnorr/ecdsa.go
@@ -21,9 +21,6 @@ const scalarSize = 32
 var (
 	// bigZero is the big representation of zero.
 	bigZero = new(big.Int).SetInt64(0)
-
-	// ecTypeSecSchnorr is the ECDSA type for the chainec interface.
-	ecTypeSecSchnorr = 2
 )
 
 // zeroArray zeroes the memory of a scalar array.

--- a/dcrec/secp256k1/schnorr/signature.go
+++ b/dcrec/secp256k1/schnorr/signature.go
@@ -62,21 +62,6 @@ func ParseSignature(sigStr []byte) (*Signature, error) {
 	return parseSig(sigStr)
 }
 
-// GetR satisfies the chainec PublicKey interface.
-func (sig Signature) GetR() *big.Int {
-	return sig.R
-}
-
-// GetS satisfies the chainec PublicKey interface.
-func (sig Signature) GetS() *big.Int {
-	return sig.S
-}
-
-// GetType satisfies the chainec Signature interface.
-func (sig Signature) GetType() int {
-	return ecTypeSecSchnorr
-}
-
 // IsEqual compares this Signature instance to the one passed, returning true
 // if both Signatures are equivalent. A signature is equivalent to another, if
 // they both have the same scalar value for R and S.

--- a/txscript/opcode.go
+++ b/txscript/opcode.go
@@ -2886,7 +2886,7 @@ func opcodeCheckSigAlt(op *opcode, data []byte, vm *Engine) error {
 			vm.dstack.PushBool(false)
 			return nil
 		}
-		ok := schnorr.Verify(pubKeySec, hash, sigSec.GetR(), sigSec.GetS())
+		ok := schnorr.Verify(pubKeySec, hash, sigSec.R, sigSec.S)
 		vm.dstack.PushBool(ok)
 		return nil
 	}


### PR DESCRIPTION
This removes the `GetR`, `GetS`, and `GetType` methods that were only used to satisfy the `chainec` interface which no longer exists.