### PR TITLE
schnorr: Remove GetCode method from Error type.

### DIFF
--- a/dcrec/secp256k1/schnorr/ecdsa.go
+++ b/dcrec/secp256k1/schnorr/ecdsa.go
@@ -200,7 +200,7 @@ func Sign(priv *secp256k1.PrivateKey, hash []byte) (r, s *big.Int, err error) {
 		if !ok {
 			return nil, nil, fmt.Errorf("unknown error type")
 		}
-		if errTyped.GetCode() != ErrSchnorrHashValue {
+		if errTyped.ErrorCode != ErrSchnorrHashValue {
 			return nil, nil, err
 		}
 	}

--- a/dcrec/secp256k1/schnorr/error.go
+++ b/dcrec/secp256k1/schnorr/error.go
@@ -98,11 +98,6 @@ func (e Error) Error() string {
 	return e.Description
 }
 
-// GetCode satisfies the error interface and prints human-readable errors.
-func (e Error) GetCode() ErrorCode {
-	return e.ErrorCode
-}
-
 // schnorrError creates a Error given a set of arguments.
 func schnorrError(c ErrorCode, desc string) Error {
 	return Error{ErrorCode: c, Description: desc}


### PR DESCRIPTION
**This is rebased on #2121**.

There is no reason for the method to exist as the `ErrorCode` field is exported and it also goes against effective Go guidelines in terms of naming.

