### PR TITLE
schnorr: Remove generalized Verify.

### DIFF
--- a/dcrec/secp256k1/schnorr/ecdsa.go
+++ b/dcrec/secp256k1/schnorr/ecdsa.go
@@ -296,14 +296,3 @@ func schnorrVerify(sig []byte,
 
 	return true, nil
 }
-
-// Verify is the generalized and exported function for the verification of a
-// secp256k1 Schnorr signature. BLAKE256 is used as the hashing function.
-func Verify(pubkey *secp256k1.PublicKey,
-	msg []byte, r *big.Int, s *big.Int) bool {
-	sig := NewSignature(r, s)
-	ok, _ := schnorrVerify(sig.Serialize(), pubkey, msg,
-		chainhash.HashB)
-
-	return ok
-}

--- a/dcrec/secp256k1/schnorr/ecdsa_test.go
+++ b/dcrec/secp256k1/schnorr/ecdsa_test.go
@@ -268,7 +268,7 @@ func TestSignatures(t *testing.T) {
 			t.Fatalf("expected an error, got %v", err)
 		}
 
-		ok := Verify(pubkey, tv.msg, sig.R, sig.S)
+		ok := sig.Verify(tv.msg, pubkey)
 		if !ok {
 			t.Fatalf("expected %v, got %v", true, ok)
 		}
@@ -325,13 +325,11 @@ func benchmarkVerification(b *testing.B) {
 	sigList := randSigList(numSigs)
 
 	for n := 0; n < b.N; n++ {
-		randIndex := r.Intn(numSigs - 1)
-		ver := Verify(sigList[randIndex].pubkey,
-			sigList[randIndex].msg,
-			sigList[randIndex].sig.R,
-			sigList[randIndex].sig.S)
-		if !ver {
-			panic("made invalid sig")
+		sigEntry := sigList[r.Intn(numSigs-1)]
+		sig := sigEntry.sig
+		verified := sig.Verify(sigEntry.msg, sigEntry.pubkey)
+		if !verified {
+			b.Fatalf("made invalid sig -- %x", sig.Serialize())
 		}
 	}
 }

--- a/dcrec/secp256k1/schnorr/signature.go
+++ b/dcrec/secp256k1/schnorr/signature.go
@@ -73,8 +73,6 @@ func (sig Signature) IsEqual(otherSig *Signature) bool {
 // Verify is the generalized and exported function for the verification of a
 // secp256k1 Schnorr signature. BLAKE256 is used as the hashing function.
 func (sig Signature) Verify(msg []byte, pubkey *secp256k1.PublicKey) bool {
-	ok, _ := schnorrVerify(sig.Serialize(), pubkey, msg,
-		chainhash.HashB)
-
+	ok, _ := schnorrVerify(sig.Serialize(), pubkey, msg, chainhash.HashB)
 	return ok
 }

--- a/txscript/opcode.go
+++ b/txscript/opcode.go
@@ -2886,7 +2886,7 @@ func opcodeCheckSigAlt(op *opcode, data []byte, vm *Engine) error {
 			vm.dstack.PushBool(false)
 			return nil
 		}
-		ok := schnorr.Verify(pubKeySec, hash, sigSec.R, sigSec.S)
+		ok := sigSec.Verify(hash, pubKeySec)
 		vm.dstack.PushBool(ok)
 		return nil
 	}


### PR DESCRIPTION
**This is rebased on #2122**.

This removes the unnecessary generalized `Verify` function in favor of the `Verify` method on the `Signature` to be more consistent with the `secp256k1` package.