### PR TITLE
schnorr: Make signature opaque.

### DIFF
--- a/dcrec/secp256k1/schnorr/ecdsa.go
+++ b/dcrec/secp256k1/schnorr/ecdsa.go
@@ -191,8 +191,8 @@ func Sign(priv *secp256k1.PrivateKey, hash []byte) (r, s *big.Int, err error) {
 		kB := nonceRFC6979(priv.Serialize(), hash, nil, nil, iteration)
 		sig, err := schnorrSign(hash, pA[:], kB, nil, nil, chainhash.HashB)
 		if err == nil {
-			r = sig.R
-			s = sig.S
+			r = sig.r
+			s = sig.s
 			break
 		}
 

--- a/dcrec/secp256k1/schnorr/signature.go
+++ b/dcrec/secp256k1/schnorr/signature.go
@@ -15,8 +15,8 @@ import (
 
 // Signature is a type representing a Schnorr signature.
 type Signature struct {
-	R *big.Int
-	S *big.Int
+	r *big.Int
+	s *big.Int
 }
 
 // SignatureSize is the size of an encoded Schnorr signature.
@@ -34,8 +34,8 @@ func NewSignature(r, s *big.Int) *Signature {
 //   sig[32:64] S, scalar multiplication/addition results = (ab+c) mod l
 //     encoded also as big endian
 func (sig Signature) Serialize() []byte {
-	rBytes := bigIntToEncodedBytes(sig.R)
-	sBytes := bigIntToEncodedBytes(sig.S)
+	rBytes := bigIntToEncodedBytes(sig.r)
+	sBytes := bigIntToEncodedBytes(sig.s)
 
 	all := append(rBytes[:], sBytes[:]...)
 
@@ -66,8 +66,8 @@ func ParseSignature(sigStr []byte) (*Signature, error) {
 // if both Signatures are equivalent. A signature is equivalent to another, if
 // they both have the same scalar value for R and S.
 func (sig Signature) IsEqual(otherSig *Signature) bool {
-	return sig.R.Cmp(otherSig.R) == 0 &&
-		sig.S.Cmp(otherSig.S) == 0
+	return sig.r.Cmp(otherSig.r) == 0 &&
+		sig.s.Cmp(otherSig.s) == 0
 }
 
 // Verify is the generalized and exported function for the verification of a


### PR DESCRIPTION
**This requires #2123**.

This modifies the `Signature` type to be opaque in order to facilitate eventually using the new more efficient mod n scalar from `secp256k1`.  For now, it makes no other changes beyond making the type opaque.