### PR TITLE
schnorr: Remove unused internal signing params.

### DIFF
--- a/dcrec/secp256k1/schnorr/signature_test.go
+++ b/dcrec/secp256k1/schnorr/signature_test.go
@@ -125,9 +125,7 @@ func TestSchnorrSigning(t *testing.T) {
 	for _, tv := range tvs {
 		pubkey := secp256k1.PrivKeyFromBytes(tv.priv).PubKey()
 
-		sig, err :=
-			schnorrSign(tv.msg, tv.priv, tv.nonce, nil, nil,
-				testSchnorrHash)
+		sig, err := schnorrSign(tv.msg, tv.priv, tv.nonce, testSchnorrHash)
 		if err != nil {
 			t.Fatalf("unexpected error %v", err)
 		}


### PR DESCRIPTION
This removes the `pubNonceX` and `Y` parameters from the internal signing function since they're always called with nil and if the tweaking functionality is desired in the future, it should take a point to operate on instead of individual big ints.
