### PR TITLE
schnorr: Accept sig type in internal verify func.

### DIFF
--- a/dcrec/secp256k1/schnorr/signature_test.go
+++ b/dcrec/secp256k1/schnorr/signature_test.go
@@ -237,7 +237,7 @@ func TestSchnorrSignAndVerify(t *testing.T) {
 
 		// Ensure the produced signature verifies as well.
 		pubKey := secp256k1.NewPrivateKey(hexToModNScalar(test.key)).PubKey()
-		ok, err := schnorrVerify(gotSigBytes, pubKey, hash, chainhash.HashB)
+		ok, err := schnorrVerify(gotSig, pubKey, hash, chainhash.HashB)
 		if err != nil {
 			t.Errorf("%s: signature failed to verify with error: %v", test.name,
 				err)


### PR DESCRIPTION
**This requires #2128**.

This modifies the internal `schnorrVerify` function to accept the signature as a type instead of its raw serialized form.  This will ultimately facilitate making it easier to switch over to more efficient types for the r and s components.
