### PR TITLE
schnorr: Remove unused GenerateKey.

### DIFF
--- a/dcrec/secp256k1/schnorr/signature.go
+++ b/dcrec/secp256k1/schnorr/signature.go
@@ -7,9 +7,7 @@ package schnorr
 
 import (
 	"bytes"
-	"crypto/ecdsa"
 	"fmt"
-	"io"
 	"math/big"
 
 	"github.com/decred/dcrd/crypto/blake256"
@@ -188,16 +186,6 @@ func zeroBigInt(v *big.Int) {
 		words[i] = 0
 	}
 	v.SetInt64(0)
-}
-
-// GenerateKey generates a key using a random number generator, returning
-// the private scalar and the corresponding public key points.
-func GenerateKey(rand io.Reader) (priv []byte, x, y *big.Int, err error) {
-	key, err := ecdsa.GenerateKey(secp256k1.S256(), rand)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	return key.D.Bytes(), key.PublicKey.X, key.PublicKey.Y, nil
 }
 
 // schnorrSign signs a Schnorr signature using a specified hash function

--- a/txscript/sign_test.go
+++ b/txscript/sign_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/decred/dcrd/dcrec"
 	"github.com/decred/dcrd/dcrec/edwards/v2"
 	"github.com/decred/dcrd/dcrec/secp256k1/v3"
-	"github.com/decred/dcrd/dcrec/secp256k1/v3/schnorr"
 	"github.com/decred/dcrd/dcrutil/v3"
 	"github.com/decred/dcrd/wire"
 )
@@ -230,8 +229,8 @@ func TestSignTxOutput(t *testing.T) {
 					_, pk := edwards.PrivKeyFromBytes(keyDB)
 					pkBytes = pk.SerializeUncompressed()
 				case dcrec.STSchnorrSecp256k1:
-					keyDB, _, _, _ = schnorr.GenerateKey(rand.Reader)
-					privKey := secp256k1.PrivKeyFromBytes(keyDB)
+					privKey, _ := secp256k1.GeneratePrivateKey()
+					keyDB = privKey.Serialize()
 					pkBytes = privKey.PubKey().SerializeCompressed()
 				}
 
@@ -289,8 +288,8 @@ func TestSignTxOutput(t *testing.T) {
 					_, pk := edwards.PrivKeyFromBytes(keyDB)
 					pkBytes = pk.SerializeUncompressed()
 				case dcrec.STSchnorrSecp256k1:
-					keyDB, _, _, _ = schnorr.GenerateKey(rand.Reader)
-					privKey := secp256k1.PrivKeyFromBytes(keyDB)
+					privKey, _ := secp256k1.GeneratePrivateKey()
+					keyDB = privKey.Serialize()
 					pkBytes = privKey.PubKey().SerializeCompressed()
 				}
 
@@ -361,8 +360,8 @@ func TestSignTxOutput(t *testing.T) {
 					_, pk := edwards.PrivKeyFromBytes(keyDB)
 					pkBytes = pk.SerializeCompressed()
 				case dcrec.STSchnorrSecp256k1:
-					keyDB, _, _, _ = schnorr.GenerateKey(rand.Reader)
-					privKey := secp256k1.PrivKeyFromBytes(keyDB)
+					privKey, _ := secp256k1.GeneratePrivateKey()
+					keyDB = privKey.Serialize()
 					pkBytes = privKey.PubKey().SerializeCompressed()
 				}
 
@@ -419,8 +418,8 @@ func TestSignTxOutput(t *testing.T) {
 					_, pk := edwards.PrivKeyFromBytes(keyDB)
 					pkBytes = pk.SerializeCompressed()
 				case dcrec.STSchnorrSecp256k1:
-					keyDB, _, _, _ = schnorr.GenerateKey(rand.Reader)
-					privKey := secp256k1.PrivKeyFromBytes(keyDB)
+					privKey, _ := secp256k1.GeneratePrivateKey()
+					keyDB = privKey.Serialize()
 					pkBytes = privKey.PubKey().SerializeCompressed()
 				}
 
@@ -755,8 +754,8 @@ func TestSignTxOutput(t *testing.T) {
 					}
 
 				case dcrec.STSchnorrSecp256k1:
-					keyDB, _, _, _ = schnorr.GenerateKey(rand.Reader)
-					privKey := secp256k1.PrivKeyFromBytes(keyDB)
+					privKey, _ := secp256k1.GeneratePrivateKey()
+					keyDB = privKey.Serialize()
 					pkBytes = privKey.PubKey().SerializeCompressed()
 					address, err = dcrutil.NewAddressSecSchnorrPubKey(pkBytes,
 						testingParams)
@@ -840,8 +839,8 @@ func TestSignTxOutput(t *testing.T) {
 					}
 
 				case dcrec.STSchnorrSecp256k1:
-					keyDB, _, _, _ = schnorr.GenerateKey(rand.Reader)
-					privKey := secp256k1.PrivKeyFromBytes(keyDB)
+					privKey, _ := secp256k1.GeneratePrivateKey()
+					keyDB = privKey.Serialize()
 					pkBytes = privKey.PubKey().SerializeCompressed()
 					address, err = dcrutil.NewAddressSecSchnorrPubKey(pkBytes,
 						testingParams)
@@ -911,8 +910,8 @@ func TestSignTxOutput(t *testing.T) {
 					}
 
 				case dcrec.STSchnorrSecp256k1:
-					keyDB, _, _, _ = schnorr.GenerateKey(rand.Reader)
-					privKey := secp256k1.PrivKeyFromBytes(keyDB)
+					privKey, _ := secp256k1.GeneratePrivateKey()
+					keyDB = privKey.Serialize()
 					pkBytes = privKey.PubKey().SerializeCompressed()
 					address, err = dcrutil.NewAddressSecSchnorrPubKey(pkBytes,
 						testingParams)
@@ -979,8 +978,8 @@ func TestSignTxOutput(t *testing.T) {
 					_, pk := edwards.PrivKeyFromBytes(keyDB)
 					pkBytes = pk.SerializeUncompressed()
 				case dcrec.STSchnorrSecp256k1:
-					keyDB, _, _, _ = schnorr.GenerateKey(rand.Reader)
-					privKey := secp256k1.PrivKeyFromBytes(keyDB)
+					privKey, _ := secp256k1.GeneratePrivateKey()
+					keyDB = privKey.Serialize()
 					pkBytes = privKey.PubKey().SerializeCompressed()
 				}
 
@@ -1056,8 +1055,8 @@ func TestSignTxOutput(t *testing.T) {
 					_, pk := edwards.PrivKeyFromBytes(keyDB)
 					pkBytes = pk.SerializeUncompressed()
 				case dcrec.STSchnorrSecp256k1:
-					keyDB, _, _, _ = schnorr.GenerateKey(rand.Reader)
-					privKey := secp256k1.PrivKeyFromBytes(keyDB)
+					privKey, _ := secp256k1.GeneratePrivateKey()
+					keyDB = privKey.Serialize()
 					pkBytes = privKey.PubKey().SerializeCompressed()
 				}
 
@@ -1148,8 +1147,8 @@ func TestSignTxOutput(t *testing.T) {
 					_, pk := edwards.PrivKeyFromBytes(keyDB)
 					pkBytes = pk.SerializeCompressed()
 				case dcrec.STSchnorrSecp256k1:
-					keyDB, _, _, _ = schnorr.GenerateKey(rand.Reader)
-					privKey := secp256k1.PrivKeyFromBytes(keyDB)
+					privKey, _ := secp256k1.GeneratePrivateKey()
+					keyDB = privKey.Serialize()
 					pkBytes = privKey.PubKey().SerializeCompressed()
 				}
 
@@ -1224,8 +1223,8 @@ func TestSignTxOutput(t *testing.T) {
 					_, pk := edwards.PrivKeyFromBytes(keyDB)
 					pkBytes = pk.SerializeCompressed()
 				case dcrec.STSchnorrSecp256k1:
-					keyDB, _, _, _ = schnorr.GenerateKey(rand.Reader)
-					privKey := secp256k1.PrivKeyFromBytes(keyDB)
+					privKey, _ := secp256k1.GeneratePrivateKey()
+					keyDB = privKey.Serialize()
 					pkBytes = privKey.PubKey().SerializeCompressed()
 				}
 
@@ -1336,8 +1335,8 @@ func TestSignTxOutput(t *testing.T) {
 					}
 
 				case dcrec.STSchnorrSecp256k1:
-					keyDB, _, _, _ = schnorr.GenerateKey(rand.Reader)
-					privKey := secp256k1.PrivKeyFromBytes(keyDB)
+					privKey, _ := secp256k1.GeneratePrivateKey()
+					keyDB = privKey.Serialize()
 					pkBytes = privKey.PubKey().SerializeCompressed()
 					address, err = dcrutil.NewAddressSecSchnorrPubKey(pkBytes,
 						testingParams)
@@ -1426,8 +1425,8 @@ func TestSignTxOutput(t *testing.T) {
 					}
 
 				case dcrec.STSchnorrSecp256k1:
-					keyDB, _, _, _ = schnorr.GenerateKey(rand.Reader)
-					privKey := secp256k1.PrivKeyFromBytes(keyDB)
+					privKey, _ := secp256k1.GeneratePrivateKey()
+					keyDB = privKey.Serialize()
 					pkBytes = privKey.PubKey().SerializeCompressed()
 					address, err = dcrutil.NewAddressSecSchnorrPubKey(pkBytes,
 						testingParams)
@@ -1529,8 +1528,8 @@ func TestSignTxOutput(t *testing.T) {
 					}
 
 				case dcrec.STSchnorrSecp256k1:
-					keyDB, _, _, _ = schnorr.GenerateKey(rand.Reader)
-					privKey := secp256k1.PrivKeyFromBytes(keyDB)
+					privKey, _ := secp256k1.GeneratePrivateKey()
+					keyDB = privKey.Serialize()
 					pkBytes = privKey.PubKey().SerializeCompressed()
 					address, err = dcrutil.NewAddressSecSchnorrPubKey(pkBytes,
 						testingParams)
@@ -1619,8 +1618,8 @@ func TestSignTxOutput(t *testing.T) {
 					}
 
 				case dcrec.STSchnorrSecp256k1:
-					keyDB, _, _, _ = schnorr.GenerateKey(rand.Reader)
-					privKey := secp256k1.PrivKeyFromBytes(keyDB)
+					privKey, _ := secp256k1.GeneratePrivateKey()
+					keyDB = privKey.Serialize()
 					pkBytes = privKey.PubKey().SerializeCompressed()
 					address, err = dcrutil.NewAddressSecSchnorrPubKey(pkBytes,
 						testingParams)


### PR DESCRIPTION
**This is rebased on #2130**.

This removes the `GenerateKey` function from the `schnorr` package since nothing uses it and it is expected that the caller will use `secp256k1.GeneartePrivateKey` instead since the package works with that type as private keys.
