### PR TITLE
secp256k1: Expose IsXBit on field val type.

### DIFF
--- a/dcrec/secp256k1/field.go
+++ b/dcrec/secp256k1/field.go
@@ -485,6 +485,26 @@ func (f *FieldVal) IsZero() bool {
 	return bits == 0
 }
 
+// IsOneBit returns 1 when the field value is equal to one or 0 otherwise in
+// constant time.
+//
+// Note that a bool is not used here because it is not possible in Go to convert
+// from a bool to numeric value in constant time and many constant-time
+// operations require a numeric value.  See IsOne for the version that returns a
+// bool.
+//
+// Preconditions:
+//   - The field value MUST be normalized
+func (f *FieldVal) IsOneBit() uint32 {
+	// The value can only be one if the single lowest significant bit is set in
+	// the the first word and no other bits are set in any of the other words.
+	// This is a constant time implementation.
+	bits := (f.n[0] ^ 1) | f.n[1] | f.n[2] | f.n[3] | f.n[4] | f.n[5] |
+		f.n[6] | f.n[7] | f.n[8] | f.n[9]
+
+	return constantTimeEq(bits, 0)
+}
+
 // IsOne returns whether or not the field value is equal to one in constant
 // time.
 //

--- a/dcrec/secp256k1/field.go
+++ b/dcrec/secp256k1/field.go
@@ -471,6 +471,25 @@ func (f *FieldVal) Bytes() *[32]byte {
 	return b
 }
 
+// IsZeroBit returns 1 when the field value is equal to zero or 0 otherwise in
+// constant time.
+//
+// Note that a bool is not used here because it is not possible in Go to convert
+// from a bool to numeric value in constant time and many constant-time
+// operations require a numeric value.  See IsZero for the version that returns
+// a bool.
+//
+// Preconditions:
+//   - The field value MUST be normalized
+func (f *FieldVal) IsZeroBit() uint32 {
+	// The value can only be zero if no bits are set in any of the words.
+	// This is a constant time implementation.
+	bits := f.n[0] | f.n[1] | f.n[2] | f.n[3] | f.n[4] |
+		f.n[5] | f.n[6] | f.n[7] | f.n[8] | f.n[9]
+
+	return constantTimeEq(bits, 0)
+}
+
 // IsZero returns whether or not the field value is equal to zero in constant
 // time.
 //

--- a/dcrec/secp256k1/field.go
+++ b/dcrec/secp256k1/field.go
@@ -500,6 +500,21 @@ func (f *FieldVal) IsOne() bool {
 	return bits == 0
 }
 
+// IsOddBit returns 1 when the field value is an odd number or 0 otherwise in
+// constant time.
+//
+// Note that a bool is not used here because it is not possible in Go to convert
+// from a bool to numeric value in constant time and many constant-time
+// operations require a numeric value.  See IsOdd for the version that returns a
+// bool.
+//
+// Preconditions:
+//   - The field value MUST be normalized
+func (f *FieldVal) IsOddBit() uint32 {
+	// Only odd numbers have the bottom bit set.
+	return f.n[0] & 1
+}
+
 // IsOdd returns whether or not the field value is an odd number in constant
 // time.
 //

--- a/dcrec/secp256k1/field_test.go
+++ b/dcrec/secp256k1/field_test.go
@@ -134,7 +134,8 @@ func TestFieldIsZero(t *testing.T) {
 	}
 }
 
-// TestFieldIsOne ensures that checking if a field is one works as expected.
+// TestFieldIsOne ensures that checking if a field is one via IsOne and IsOneBit
+// works as expected.
 func TestFieldIsOne(t *testing.T) {
 	tests := []struct {
 		name      string // test description
@@ -225,8 +226,15 @@ func TestFieldIsOne(t *testing.T) {
 		}
 		result := f.IsOne()
 		if result != test.expected {
-			t.Errorf("%s: wrong result\ngot: %v\nwant: %v", test.name, result,
+			t.Errorf("%s: wrong result -- got: %v, want: %v", test.name, result,
 				test.expected)
+			continue
+		}
+
+		result2 := f.IsOneBit() == 1
+		if result2 != test.expected {
+			t.Errorf("%s: wrong result -- got: %v, want: %v", test.name,
+				result2, test.expected)
 			continue
 		}
 	}

--- a/dcrec/secp256k1/field_test.go
+++ b/dcrec/secp256k1/field_test.go
@@ -490,8 +490,8 @@ func TestFieldNormalize(t *testing.T) {
 	}
 }
 
-// TestFieldIsOdd ensures that checking if a field value IsOdd works as
-// expected.
+// TestFieldIsOdd ensures that checking if a field value is odd via IsOdd and
+// IsOddBit works as expected.
 func TestFieldIsOdd(t *testing.T) {
 	tests := []struct {
 		name     string // test description
@@ -528,10 +528,18 @@ func TestFieldIsOdd(t *testing.T) {
 	}}
 
 	for _, test := range tests {
-		result := new(FieldVal).SetHex(test.in).IsOdd()
+		f := new(FieldVal).SetHex(test.in)
+		result := f.IsOdd()
 		if result != test.expected {
 			t.Errorf("%s: wrong result -- got: %v, want: %v", test.name,
 				result, test.expected)
+			continue
+		}
+
+		result2 := f.IsOddBit() == 1
+		if result2 != test.expected {
+			t.Errorf("%s: wrong result -- got: %v, want: %v", test.name,
+				result2, test.expected)
 			continue
 		}
 	}

--- a/dcrec/secp256k1/field_test.go
+++ b/dcrec/secp256k1/field_test.go
@@ -109,11 +109,14 @@ func TestFieldZero(t *testing.T) {
 	}
 }
 
-// TestFieldIsZero ensures that checking if a field is zero works as
-// expected.
+// TestFieldIsZero ensures that checking if a field is zero via IsZero and
+// IsZeroBit works as expected.
 func TestFieldIsZero(t *testing.T) {
 	f := new(FieldVal)
 	if !f.IsZero() {
+		t.Errorf("new field value is not zero - got %v (rawints %x)", f, f.n)
+	}
+	if f.IsZeroBit() != 1 {
 		t.Errorf("new field value is not zero - got %v (rawints %x)", f, f.n)
 	}
 
@@ -121,15 +124,24 @@ func TestFieldIsZero(t *testing.T) {
 	if f.IsZero() {
 		t.Errorf("claims zero for nonzero field - got %v (rawints %x)", f, f.n)
 	}
+	if f.IsZeroBit() == 1 {
+		t.Errorf("claims zero for nonzero field - got %v (rawints %x)", f, f.n)
+	}
 
 	f.Zero()
 	if !f.IsZero() {
+		t.Errorf("claims nonzero for zero field - got %v (rawints %x)", f, f.n)
+	}
+	if f.IsZeroBit() != 1 {
 		t.Errorf("claims nonzero for zero field - got %v (rawints %x)", f, f.n)
 	}
 
 	f.SetInt(1)
 	f.Zero()
 	if !f.IsZero() {
+		t.Errorf("claims zero for nonzero field - got %v (rawints %x)", f, f.n)
+	}
+	if f.IsZeroBit() != 1 {
 		t.Errorf("claims zero for nonzero field - got %v (rawints %x)", f, f.n)
 	}
 }

--- a/dcrec/secp256k1/signature.go
+++ b/dcrec/secp256k1/signature.go
@@ -881,7 +881,7 @@ func signRFC6979(privateKey *PrivateKey, hash []byte) (*Signature, byte) {
 		// points since that would require breaking the ECDLP, but, in practice
 		// this strongly implies with extremely high probability that there are
 		// only a few actual points for which this case is true.
-		pubKeyRecoveryCode := byte(overflow<<1) | byte(kG.y.n[0]&0x01)
+		pubKeyRecoveryCode := byte(overflow<<1) | byte(kG.y.IsOddBit())
 
 		// Step 4.
 		//


### PR DESCRIPTION
**This requires #2134**.

This exposes new functions on the `FieldVal` type named `IsOddBit`, `IsOneBit`, and `IsZeroBit` which operates similarly to their counterparts except they return a 0 or 1 instead of a bool.

These are being provided because it is not possible in Go to convert from a bool to numeric value in constant time and many constant-time operations require a numeric value.

Since the type is now exported for external use, consumers would otherwise have no way to perform the conversion.