### PR TITLE
schnorr: Use specialized types when signing.

### DIFF
--- a/dcrec/secp256k1/schnorr/error.go
+++ b/dcrec/secp256k1/schnorr/error.go
@@ -54,9 +54,6 @@ const (
 	// unusable.
 	ErrBadNonce
 
-	// ErrZeroSigS indicates a zero signature S value, which is invalid.
-	ErrZeroSigS
-
 	// ErrNonmatchingR indicates that all signatures to be combined in a
 	// threshold signature failed to have a matching R value.
 	ErrNonmatchingR
@@ -94,7 +91,6 @@ var errorCodeStrings = map[ErrorCode]string{
 	ErrRegenerateRPoint:  "ErrRegenerateRPoint",
 	ErrRegenSig:          "ErrRegenSig",
 	ErrBadNonce:          "ErrBadNonce",
-	ErrZeroSigS:          "ErrZeroSigS",
 	ErrNonmatchingR:      "ErrNonmatchingR",
 	ErrSigTooShort:       "ErrSigTooShort",
 	ErrSigTooLong:        "ErrSigTooLong",

--- a/dcrec/secp256k1/schnorr/error_test.go
+++ b/dcrec/secp256k1/schnorr/error_test.go
@@ -25,7 +25,6 @@ func TestErrorCodeStringer(t *testing.T) {
 		{ErrRegenerateRPoint, "ErrRegenerateRPoint"},
 		{ErrRegenSig, "ErrRegenSig"},
 		{ErrBadNonce, "ErrBadNonce"},
-		{ErrZeroSigS, "ErrZeroSigS"},
 		{ErrNonmatchingR, "ErrNonmatchingR"},
 		{ErrSigTooShort, "ErrSigTooShort"},
 		{ErrSigTooLong, "ErrSigTooLong"},

--- a/dcrec/secp256k1/schnorr/signature_bench_test.go
+++ b/dcrec/secp256k1/schnorr/signature_bench_test.go
@@ -82,8 +82,7 @@ func BenchmarkSigVerify(b *testing.B) {
 	msgHash := hexToBytes("c301ba9de5d6053caad9f5eb46523f007702add2c62fa39de03146a36b8026b7")
 
 	// Generate the signature.
-	r, s, _ := Sign(privKey, msgHash)
-	sig := NewSignature(r, s)
+	sig, _ := Sign(privKey, msgHash)
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/txscript/sign.go
+++ b/txscript/sign.go
@@ -50,11 +50,11 @@ func RawTxInSignature(tx *wire.MsgTx, idx int, subScript []byte,
 		sigBytes = sig.Serialize()
 	case dcrec.STSchnorrSecp256k1:
 		priv := secp256k1.PrivKeyFromBytes(key)
-		r, s, err := schnorr.Sign(priv, hash)
+		sig, err := schnorr.Sign(priv, hash)
 		if err != nil {
 			return nil, fmt.Errorf("cannot sign tx input: %s", err)
 		}
-		sigBytes = schnorr.NewSignature(r, s).Serialize()
+		sigBytes = sig.Serialize()
 	default:
 		return nil, fmt.Errorf("unknown signature type '%v'", sigType)
 	}


### PR DESCRIPTION
**This requires #2149**.

schnorr: Use specialized types when signing.

This modifies the function that produces signatures to use the `ModNScalar` and `FieldVal` types instead of big ints and also fleshes out the comments to include a reference to the signing algorithm specified in `README.md`.

This is work towards eventually using the specialized types throughout.

While the primary focus of this change is not optimization since signing happens infrequently enough that it is not in a performance hot path, as can be seen from the benchmark below, it does have the effect of making signing a bit faster.

The following benchmark shows a before and after comparison of producing a typical signature:

```
benchmark       old ns/op    new ns/op    delta
-------------------------------------------------
BenchmarkSign   54270        52622        -3.04%

benchmark       old allocs   new allocs   delta
-------------------------------------------------
BenchmarkSign   34           20           -41.18%

benchmark       old bytes    new bytes    delta
-------------------------------------------------
BenchmarkSign   1809         1088         -39.86%
```