### PR TITLE
secp256k1: Add PutBytesUnchecked to some types.

### DIFF
--- a/dcrec/secp256k1/modnscalar_test.go
+++ b/dcrec/secp256k1/modnscalar_test.go
@@ -261,9 +261,8 @@ func TestModNScalarSetBytes(t *testing.T) {
 }
 
 // TestModNScalarBytes ensures that retrieving the bytes for a 256-bit
-// big-endian unsigned integer via both the return copy and direct put methods
-// works as expected for edge cases.  Random cases are tested via the various
-// other tests.
+// big-endian unsigned integer via the various methods works as expected for
+// edge cases.  Random cases are tested via the various other tests.
 func TestModNScalarBytes(t *testing.T) {
 	tests := []struct {
 		name     string // test description
@@ -342,6 +341,15 @@ func TestModNScalarBytes(t *testing.T) {
 		if !bytes.Equal(b32[:], expected) {
 			t.Errorf("%s: unexpected result\ngot: %x\nwant: %x", test.name,
 				b32, expected)
+			continue
+		}
+
+		// Ensure getting the bytes directly into a slice works as expected.
+		var buffer [64]byte
+		s.PutBytesUnchecked(buffer[:])
+		if !bytes.Equal(buffer[:32], expected) {
+			t.Errorf("%s: unexpected result\ngot: %x\nwant: %x", test.name,
+				buffer[:32], expected)
 			continue
 		}
 	}


### PR DESCRIPTION
**This is rebased on #2153**.

This consists of two commits which add a new method named `PutBytesUnchecked to `FieldVal` and `ModNScalar`, respecitvely, which can be used by callers to serialize the types directly into a target byte slice with the caveat that the caller must ensure the target has at least 32 bytes available or it will panic.

This is useful in cases where the caller wishes to write into a larger buffer without having to first serialize into a 32-byte array and copy it.

It also updates the tests to ensure they work as expected.
