### PR TITLE
hdkeychain: Use secp256k1 privkey to pubkey method.

### DIFF
--- a/hdkeychain/extendedkey.go
+++ b/hdkeychain/extendedkey.go
@@ -164,9 +164,8 @@ func (k *ExtendedKey) pubKeyBytes() []byte {
 	// This is a private extended key, so calculate and memoize the public
 	// key if needed.
 	if len(k.pubKey) == 0 {
-		pkx, pky := secp256k1.S256().ScalarBaseMult(k.key)
-		pubKey := secp256k1.NewPublicKey(pkx, pky)
-		k.pubKey = pubKey.SerializeCompressed()
+		privKey := secp256k1.PrivKeyFromBytes(k.key)
+		k.pubKey = privKey.PubKey().SerializeCompressed()
 	}
 
 	return k.pubKey


### PR DESCRIPTION
**This is rebased on #2155**.

This makes use of the `PubKey` method on `secp256k1.PrivateKey` to convert a private key to a public key instead of manually performing the conversion.

This is desirable since `secp256k1` provides the method specifically for this purpose and it also has the benefit of allowing `secp256k1` to perform the task without round tripping through big integers which results in slightly faster derivation.

The following benchmarks show a before and after comparison of the affected operations:

```
benchmark                 old ns/op    new ns/op    delta
----------------------------------------------------------
BenchmarkDeriveHardened   3702         3671         -0.84%
BenchmarkDeriveNormal     4053         3999         -1.33%

benchmark                 old allocs   new allocs   delta
----------------------------------------------------------
BenchmarkDeriveHardened   14           14           +0.00%
BenchmarkDeriveNormal     15           15           +0.00%

benchmark                 old bytes    new bytes    delta
----------------------------------------------------------
BenchmarkDeriveHardened   1360         1360         +0.00%
BenchmarkDeriveNormal     1409         1409         +0.00%
```