### PR TITLE
schnorr: Use PutBytesUnchecked for serialize.

### DIFF
--- a/dcrec/secp256k1/schnorr/signature_bench_test.go
+++ b/dcrec/secp256k1/schnorr/signature_bench_test.go
@@ -90,3 +90,23 @@ func BenchmarkSigVerify(b *testing.B) {
 		sig.Verify(msgHash, pubKey)
 	}
 }
+
+// BenchmarkSigVerify benchmarks how long it takes to serialize Schnorr
+// signatures.
+func BenchmarkSigSerialize(b *testing.B) {
+	// From randomly generated keypair.
+	d := hexToModNScalar("9e0699c91ca1e3b7e3c9ba71eb71c89890872be97576010fe593fbf3fd57e66d")
+	privKey := secp256k1.NewPrivateKey(d)
+
+	// blake256 of []byte{0x01, 0x02, 0x03, 0x04}.
+	msgHash := hexToBytes("c301ba9de5d6053caad9f5eb46523f007702add2c62fa39de03146a36b8026b7")
+
+	// Generate the signature.
+	sig, _ := Sign(privKey, msgHash)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sig.Serialize()
+	}
+}


### PR DESCRIPTION
**This requires #2154**.

schnorr: Use PutBytesUnchecked for serialize.

This updates the code to use the recently-added `PutBytesUnchecked` of the `FieldVal` and `ModNScalar` types to serialize directly into larger buffers where possible to avoid the need for additional copies.

The following benchmarks show a before and after comparison of the affected operations:

```
benchmark               old ns/op    new ns/op    delta
--------------------------------------------------------
BenchmarkSign           52682        52284        -0.76%
BenchmarkSigVerify      178050       176977       -0.60%
BenchmarkSigSerialize   87.5         73.3         -16.23%

benchmark               old allocs   new allocs   delta
--------------------------------------------------------
BenchmarkSign           16           16           +0.00%
BenchmarkSigVerify      21           21           +0.00%
BenchmarkSigSerialize   1            1            +0.00%

benchmark               old bytes    new bytes    delta
--------------------------------------------------------
BenchmarkSign           960          960          +0.00%
BenchmarkSigVerify      1105         1105         +0.00%
```