### PR TITLE
secp256k1: Rework pubkey tests.

### DIFF
--- a/dcrec/secp256k1/error.go
+++ b/dcrec/secp256k1/error.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package secp256k1
+
+import (
+	"fmt"
+)
+
+// ErrorCode identifies a kind of pubkey-related error.  It has full support for
+// errors.Is and errors.As, so the caller can directly check against an error
+// code when determining the reason for an error.
+type ErrorCode int
+
+// These constants are used to identify a specific RuleError.
+const (
+	// ErrPubKeyInvalidLen indicates that the length of a serialized public
+	// key is not one of the allowed lengths.
+	ErrPubKeyInvalidLen ErrorCode = iota
+
+	// ErrPubKeyInvalidFormat indicates an attempt was made to parse a public
+	// key that does not specify one of the supported formats.
+	ErrPubKeyInvalidFormat
+
+	// ErrPubKeyXTooBig indicates that the x coordinate for a public key
+	// is greater than or equal to the prime of the field underlying the group.
+	ErrPubKeyXTooBig
+
+	// ErrPubKeyYTooBig indicates that the y coordinate for a public key is
+	// greater than or equal to the prime of the field underlying the group.
+	ErrPubKeyYTooBig
+
+	// ErrPubKeyNotOnCurve indicates that a public key is not a point on the
+	// secp256k1 curve.
+	ErrPubKeyNotOnCurve
+
+	// ErrPubKeyMismatchedOddness indicates that a hybrid public key specified
+	// an oddness of the y coordinate that does not match the actual oddness of
+	// the provided y coordinate.
+	ErrPubKeyMismatchedOddness
+
+	// numErrorCodes is the maximum error code number used in tests.  This entry
+	// MUST be the last entry in the enum.
+	numErrorCodes
+)
+
+// Map of ErrorCode values back to their constant names for pretty printing.
+var errorCodeStrings = map[ErrorCode]string{
+	ErrPubKeyInvalidLen:        "ErrPubKeyInvalidLen",
+	ErrPubKeyXTooBig:           "ErrPubKeyXTooBig",
+	ErrPubKeyYTooBig:           "ErrPubKeyYTooBig",
+	ErrPubKeyNotOnCurve:        "ErrPubKeyNotOnCurve",
+	ErrPubKeyMismatchedOddness: "ErrPubKeyMismatchedOddness",
+	ErrPubKeyInvalidFormat:     "ErrPubKeyInvalidFormat",
+}
+
+// String returns the ErrorCode as a human-readable name.
+func (e ErrorCode) String() string {
+	if s := errorCodeStrings[e]; s != "" {
+		return s
+	}
+	return fmt.Sprintf("Unknown ErrorCode (%d)", int(e))
+}
+
+// Error implements the error interface.
+func (e ErrorCode) Error() string {
+	return e.String()
+}
+
+// Is implements the interface to work with the standard library's errors.Is.
+//
+// It returns true in the following cases:
+// - The target is a Error and the error codes match
+// - The target is a ErrorCode and the error codes match
+func (e ErrorCode) Is(target error) bool {
+	switch target := target.(type) {
+	case Error:
+		return e == target.ErrorCode
+
+	case ErrorCode:
+		return e == target
+	}
+
+	return false
+}
+
+// Error identifies a pubkey-related error.  It has full support for errors.Is
+// and errors.As, so the caller can ascertain the specific reason for the error
+// by checking the underlying error code.
+type Error struct {
+	ErrorCode   ErrorCode // Describes the kind of error
+	Description string    // Human readable description of the issue
+}
+
+// Error satisfies the error interface and prints human-readable errors.
+func (e Error) Error() string {
+	return e.Description
+}
+
+// Is implements the interface to work with the standard library's errors.Is.
+//
+// It returns true in the following cases:
+// - The target is a Error and the error codes match
+// - The target is a ErrorCode and it the error codes match
+func (e Error) Is(target error) bool {
+	switch target := target.(type) {
+	case Error:
+		return e.ErrorCode == target.ErrorCode
+
+	case ErrorCode:
+		return target == e.ErrorCode
+	}
+
+	return false
+}
+
+// Unwrap returns the underlying wrapped error code.
+func (e Error) Unwrap() error {
+	return e.ErrorCode
+}
+
+// makeError creates a Error given a set of arguments.
+func makeError(c ErrorCode, desc string) Error {
+	return Error{ErrorCode: c, Description: desc}
+}

--- a/dcrec/secp256k1/error_test.go
+++ b/dcrec/secp256k1/error_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package secp256k1
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestErrorCodeStringer tests the stringized output for the ErrorCode type.
+func TestErrorCodeStringer(t *testing.T) {
+	tests := []struct {
+		in   ErrorCode
+		want string
+	}{
+		{ErrPubKeyInvalidLen, "ErrPubKeyInvalidLen"},
+		{ErrPubKeyInvalidFormat, "ErrPubKeyInvalidFormat"},
+		{ErrPubKeyXTooBig, "ErrPubKeyXTooBig"},
+		{ErrPubKeyYTooBig, "ErrPubKeyYTooBig"},
+		{ErrPubKeyNotOnCurve, "ErrPubKeyNotOnCurve"},
+		{ErrPubKeyMismatchedOddness, "ErrPubKeyMismatchedOddness"},
+		{0xffff, "Unknown ErrorCode (65535)"},
+	}
+
+	// Detect additional error codes that don't have the stringer added.
+	if len(tests)-1 != int(numErrorCodes) {
+		t.Fatalf("It appears an error code was added without adding an " +
+			"associated stringer test")
+	}
+
+	for i, test := range tests {
+		result := test.in.String()
+		if result != test.want {
+			t.Errorf("#%d: got: %s want: %s", i, result, test.want)
+			continue
+		}
+	}
+}
+
+// TestError tests the error output for the Error type.
+func TestError(t *testing.T) {
+	tests := []struct {
+		in   Error
+		want string
+	}{{
+		Error{Description: "some error"},
+		"some error",
+	}, {
+		Error{Description: "human-readable error"},
+		"human-readable error",
+	}}
+
+	for i, test := range tests {
+		result := test.in.Error()
+		if result != test.want {
+			t.Errorf("#%d: got: %s want: %s", i, result, test.want)
+			continue
+		}
+	}
+}
+
+// TestErrorCodeIsAs ensures both ErrorCode and Error can be identified as being
+// a specific error code via errors.Is and unwrapped via errors.As.
+func TestErrorCodeIsAs(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		target    error
+		wantMatch bool
+		wantAs    ErrorCode
+	}{{
+		name:      "ErrPubKeyInvalidLen == ErrPubKeyInvalidLen",
+		err:       ErrPubKeyInvalidLen,
+		target:    ErrPubKeyInvalidLen,
+		wantMatch: true,
+		wantAs:    ErrPubKeyInvalidLen,
+	}, {
+		name:      "Error.ErrPubKeyInvalidLen == ErrPubKeyInvalidLen",
+		err:       makeError(ErrPubKeyInvalidLen, ""),
+		target:    ErrPubKeyInvalidLen,
+		wantMatch: true,
+		wantAs:    ErrPubKeyInvalidLen,
+	}, {
+		name:      "ErrPubKeyInvalidLen == Error.ErrPubKeyInvalidLen",
+		err:       ErrPubKeyInvalidLen,
+		target:    makeError(ErrPubKeyInvalidLen, ""),
+		wantMatch: true,
+		wantAs:    ErrPubKeyInvalidLen,
+	}, {
+		name:      "Error.ErrPubKeyInvalidLen == Error.ErrPubKeyInvalidLen",
+		err:       makeError(ErrPubKeyInvalidLen, ""),
+		target:    makeError(ErrPubKeyInvalidLen, ""),
+		wantMatch: true,
+		wantAs:    ErrPubKeyInvalidLen,
+	}, {
+		name:      "ErrPubKeyInvalidFormat != ErrPubKeyInvalidLen",
+		err:       ErrPubKeyInvalidFormat,
+		target:    ErrPubKeyInvalidLen,
+		wantMatch: false,
+		wantAs:    ErrPubKeyInvalidFormat,
+	}, {
+		name:      "Error.ErrPubKeyInvalidFormat != ErrPubKeyInvalidLen",
+		err:       makeError(ErrPubKeyInvalidFormat, ""),
+		target:    ErrPubKeyInvalidLen,
+		wantMatch: false,
+		wantAs:    ErrPubKeyInvalidFormat,
+	}, {
+		name:      "ErrPubKeyInvalidFormat != Error.ErrPubKeyInvalidLen",
+		err:       ErrPubKeyInvalidFormat,
+		target:    makeError(ErrPubKeyInvalidLen, ""),
+		wantMatch: false,
+		wantAs:    ErrPubKeyInvalidFormat,
+	}, {
+		name:      "Error.ErrPubKeyInvalidFormat != Error.ErrPubKeyInvalidLen",
+		err:       makeError(ErrPubKeyInvalidFormat, ""),
+		target:    makeError(ErrPubKeyInvalidLen, ""),
+		wantMatch: false,
+		wantAs:    ErrPubKeyInvalidFormat,
+	}}
+
+	for _, test := range tests {
+		// Ensure the error matches or not depending on the expected result.
+		result := errors.Is(test.err, test.target)
+		if result != test.wantMatch {
+			t.Errorf("%s: incorrect error identification -- got %v, want %v",
+				test.name, result, test.wantMatch)
+			continue
+		}
+
+		// Ensure the underlying error code can be unwrapped and is the expected
+		// code.
+		var code ErrorCode
+		if !errors.As(test.err, &code) {
+			t.Errorf("%s: unable to unwrap to error code", test.name)
+			continue
+		}
+		if code != test.wantAs {
+			t.Errorf("%s: unexpected unwrapped error code -- got %v, want %v",
+				test.name, code, test.wantAs)
+			continue
+		}
+	}
+}

--- a/dcrec/secp256k1/go.mod
+++ b/dcrec/secp256k1/go.mod
@@ -3,7 +3,6 @@ module github.com/decred/dcrd/dcrec/secp256k1/v3
 go 1.13
 
 require (
-	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/crypto/blake256 v1.0.0
 )

--- a/dcrec/secp256k1/pubkey_test.go
+++ b/dcrec/secp256k1/pubkey_test.go
@@ -7,6 +7,7 @@ package secp256k1
 
 import (
 	"bytes"
+	"errors"
 	"math/big"
 	"testing"
 )
@@ -27,117 +28,117 @@ func hexToBigInt(s string) *big.Int {
 // to the spec including both the positive and negative cases.
 func TestParsePubKey(t *testing.T) {
 	tests := []struct {
-		name    string // test description
-		key     string // hex encoded public key
-		isValid bool   // expected validity
-		wantX   string // expected x coordinate
-		wantY   string // expected y coordinate
+		name  string // test description
+		key   string // hex encoded public key
+		err   error  // expected error
+		wantX string // expected x coordinate
+		wantY string // expected y coordinate
 	}{{
 		name: "uncompressed ok",
 		key: "04" +
 			"11db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c" +
 			"b2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3",
-		isValid: true,
-		wantX:   "11db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c",
-		wantY:   "b2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3",
+		err:   nil,
+		wantX: "11db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c",
+		wantY: "b2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3",
 	}, {
 		name: "uncompressed x changed (not on curve)",
 		key: "04" +
 			"15db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c" +
 			"b2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3",
-		isValid: false,
+		err: ErrPubKeyNotOnCurve,
 	}, {
 		name: "uncompressed y changed (not on curve)",
 		key: "04" +
 			"11db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c" +
 			"b2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a4",
-		isValid: false,
+		err: ErrPubKeyNotOnCurve,
 	}, {
 		name: "uncompressed claims compressed",
 		key: "03" +
 			"11db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c" +
 			"b2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3",
-		isValid: false,
+		err: ErrPubKeyInvalidFormat,
 	}, {
 		name: "uncompressed as hybrid ok (ybit = 0)",
 		key: "06" +
 			"11db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c" +
 			"4d1f1522047b33068bbb9b07d1e9f40564749b062b3fc0666479bc08a94be98c",
-		isValid: true,
-		wantX:   "11db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c",
-		wantY:   "4d1f1522047b33068bbb9b07d1e9f40564749b062b3fc0666479bc08a94be98c",
+		err:   nil,
+		wantX: "11db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c",
+		wantY: "4d1f1522047b33068bbb9b07d1e9f40564749b062b3fc0666479bc08a94be98c",
 	}, {
 		name: "uncompressed as hybrid ok (ybit = 1)",
 		key: "07" +
 			"11db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c" +
 			"b2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3",
-		isValid: true,
-		wantX:   "11db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c",
-		wantY:   "b2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3",
+		err:   nil,
+		wantX: "11db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c",
+		wantY: "b2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3",
 	}, {
 		name: "uncompressed as hybrid wrong oddness",
 		key: "06" +
 			"11db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c" +
 			"b2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3",
-		isValid: false,
+		err: ErrPubKeyMismatchedOddness,
 	}, {
 		name: "compressed ok (ybit = 0)",
 		key: "02" +
 			"ce0b14fb842b1ba549fdd675c98075f12e9c510f8ef52bd021a9a1f4809d3b4d",
-		isValid: true,
-		wantX:   "ce0b14fb842b1ba549fdd675c98075f12e9c510f8ef52bd021a9a1f4809d3b4d",
-		wantY:   "0890ff84d7999d878a57bee170e19ef4b4803b4bdede64503a6ac352b03c8032",
+		err:   nil,
+		wantX: "ce0b14fb842b1ba549fdd675c98075f12e9c510f8ef52bd021a9a1f4809d3b4d",
+		wantY: "0890ff84d7999d878a57bee170e19ef4b4803b4bdede64503a6ac352b03c8032",
 	}, {
 		name: "compressed ok (ybit = 1)",
 		key: "03" +
 			"2689c7c2dab13309fb143e0e8fe396342521887e976690b6b47f5b2a4b7d448e",
-		isValid: true,
-		wantX:   "2689c7c2dab13309fb143e0e8fe396342521887e976690b6b47f5b2a4b7d448e",
-		wantY:   "499dd7852849a38aa23ed9f306f07794063fe7904e0f347bc209fdddaf37691f",
+		err:   nil,
+		wantX: "2689c7c2dab13309fb143e0e8fe396342521887e976690b6b47f5b2a4b7d448e",
+		wantY: "499dd7852849a38aa23ed9f306f07794063fe7904e0f347bc209fdddaf37691f",
 	}, {
 		name: "compressed claims uncompressed (ybit = 0)",
 		key: "04" +
 			"ce0b14fb842b1ba549fdd675c98075f12e9c510f8ef52bd021a9a1f4809d3b4d",
-		isValid: false,
+		err: ErrPubKeyInvalidFormat,
 	}, {
 		name: "compressed claims uncompressed (ybit = 1)",
 		key: "04" +
 			"2689c7c2dab13309fb143e0e8fe396342521887e976690b6b47f5b2a4b7d448e",
-		isValid: false,
+		err: ErrPubKeyInvalidFormat,
 	}, {
 		name: "compressed claims hybrid (ybit = 0)",
 		key: "06" +
 			"ce0b14fb842b1ba549fdd675c98075f12e9c510f8ef52bd021a9a1f4809d3b4d",
-		isValid: false,
+		err: ErrPubKeyInvalidFormat,
 	}, {
 		name: "compressed claims hybrid (ybit = 1)",
 		key: "07" +
 			"2689c7c2dab13309fb143e0e8fe396342521887e976690b6b47f5b2a4b7d448e",
-		isValid: false,
+		err: ErrPubKeyInvalidFormat,
 	}, {
 		name: "compressed with invalid x coord (ybit = 0)",
 		key: "03" +
 			"ce0b14fb842b1ba549fdd675c98075f12e9c510f8ef52bd021a9a1f4809d3b4c",
-		isValid: false,
+		err: ErrPubKeyNotOnCurve,
 	}, {
 		name: "compressed with invalid x coord (ybit = 1)",
 		key: "03" +
 			"2689c7c2dab13309fb143e0e8fe396342521887e976690b6b47f5b2a4b7d448d",
-		isValid: false,
+		err: ErrPubKeyNotOnCurve,
 	}, {
-		name:    "empty",
-		key:     "",
-		isValid: false,
+		name: "empty",
+		key:  "",
+		err:  ErrPubKeyInvalidLen,
 	}, {
-		name:    "wrong length",
-		key:     "05",
-		isValid: false,
+		name: "wrong length",
+		key:  "05",
+		err:  ErrPubKeyInvalidLen,
 	}, {
 		name: "uncompressed x == p",
 		key: "04" +
 			"fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f" +
 			"b2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3",
-		isValid: false,
+		err: ErrPubKeyXTooBig,
 	}, {
 		// The y coordinate produces a valid point for x == 1 (mod p), but it
 		// should fail to parse instead of wrapping around.
@@ -145,13 +146,13 @@ func TestParsePubKey(t *testing.T) {
 		key: "04" +
 			"fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30" +
 			"bde70df51939b94c9c24979fa7dd04ebd9b3572da7802290438af2a681895441",
-		isValid: false,
+		err: ErrPubKeyXTooBig,
 	}, {
 		name: "uncompressed y == p",
 		key: "04" +
 			"11db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c" +
 			"fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
-		isValid: false,
+		err: ErrPubKeyYTooBig,
 	}, {
 		// The x coordinate produces a valid point for y == 1 (mod p), but it
 		// should fail to parse instead of wrapping around.
@@ -159,37 +160,37 @@ func TestParsePubKey(t *testing.T) {
 		key: "04" +
 			"1fe1e5ef3fceb5c135ab7741333ce5a6e80d68167653f6b2b24bcbcfaaaff507" +
 			"fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
-		isValid: false,
+		err: ErrPubKeyYTooBig,
 	}, {
 		name: "compressed x == p (ybit = 0)",
 		key: "02" +
 			"fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
-		isValid: false,
+		err: ErrPubKeyXTooBig,
 	}, {
 		name: "compressed x == p (ybit = 1)",
 		key: "03" +
 			"fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
-		isValid: false,
+		err: ErrPubKeyXTooBig,
 	}, {
 		// This would be valid for x == 2 (mod p), but it should fail to parse
 		// instead of wrapping around.
 		name: "compressed x > p (p + 2 -- aka 2) (ybit = 0)",
 		key: "02" +
 			"fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc31",
-		isValid: false,
+		err: ErrPubKeyXTooBig,
 	}, {
 		// This would be valid for x == 1 (mod p), but it should fail to parse
 		// instead of wrapping around.
 		name: "compressed x > p (p + 1 -- aka 1) (ybit = 1)",
 		key: "03" +
 			"fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
-		isValid: false,
+		err: ErrPubKeyXTooBig,
 	}, {
 		name: "hybrid x == p (ybit = 1)",
 		key: "07" +
 			"fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f" +
 			"b2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3",
-		isValid: false,
+		err: ErrPubKeyXTooBig,
 	}, {
 		// The y coordinate produces a valid point for x == 1 (mod p), but it
 		// should fail to parse instead of wrapping around.
@@ -197,13 +198,13 @@ func TestParsePubKey(t *testing.T) {
 		key: "06" +
 			"fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30" +
 			"bde70df51939b94c9c24979fa7dd04ebd9b3572da7802290438af2a681895441",
-		isValid: false,
+		err: ErrPubKeyMismatchedOddness,
 	}, {
 		name: "hybrid y == p (ybit = 0 when mod p)",
 		key: "06" +
 			"11db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c" +
 			"fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
-		isValid: false,
+		err: ErrPubKeyMismatchedOddness,
 	}, {
 		// The x coordinate produces a valid point for y == 1 (mod p), but it
 		// should fail to parse instead of wrapping around.
@@ -211,20 +212,18 @@ func TestParsePubKey(t *testing.T) {
 		key: "07" +
 			"1fe1e5ef3fceb5c135ab7741333ce5a6e80d68167653f6b2b24bcbcfaaaff507" +
 			"fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
-		isValid: false,
+		err: ErrPubKeyMismatchedOddness,
 	}}
 
 	for _, test := range tests {
 		pubKeyBytes := hexToBytes(test.key)
 		pubKey, err := ParsePubKey(pubKeyBytes)
-		if err != nil {
-			if test.isValid {
-				t.Errorf("%s: pubkey failed when shouldn't: %v", test.name, err)
-			}
+		if !errors.Is(err, test.err) {
+			t.Errorf("%s mismatched err -- got %v, want %v", test.name, err,
+				test.err)
 			continue
 		}
-		if !test.isValid {
-			t.Errorf("%s: counted as valid when it should fail", test.name)
+		if err != nil {
 			continue
 		}
 

--- a/hdkeychain/extendedkey_test.go
+++ b/hdkeychain/extendedkey_test.go
@@ -15,6 +15,8 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v3"
 )
 
 // mockNetParams implements the NetworkParams interface and is used throughout
@@ -748,7 +750,10 @@ func TestErrors(t *testing.T) {
 		{
 			name: "pubkey not on curve",
 			key:  "dpubZ9169KDAEUnyoTzA7pDGtXbxpji5LuUk8johUPVGY2CDsz6S7hahGNL6QkeYrUeAPnaJD1MBmrsUnErXScGZdjL6b2gjCRX1Z1GNhLdVCjv",
-			err:  errors.New("invalid public key x coordinate"),
+			err: secp256k1.Error{
+				ErrorCode:   secp256k1.ErrPubKeyNotOnCurve,
+				Description: "invalid public key: x coordinate 0000000000000000000000000000000000000000000000000000000000000000 is not on the secp256k1 curve",
+			},
 		},
 		{
 			name: "unsupported version",


### PR DESCRIPTION
**This is rebased on #2159**.

This reworks the tests related to public keys to them more consistent with the rest of the package and improve their coverage to include all of the possible error paths, adds the error infrastructure used throughout the rest of the packages, and updates all of the tests to test for the explicit reason for the failure accordingly.

Finally, it also brings back the hybrid pubkey parsing to match what the function comment claims and corrects the tests accordingly.  The restriction as to which specific types of pubkeys are allowed must be (and is) enforced by the opcode(s) that interpret them as opposed to the lib that implements the more generic specification.

Each commit more thoroughly describes the changes being made to ease review.

The following is an overview of the changes:

- Convert all tests to use hex strings
- Add and verify the expected x and y coordinates from a parsed pubkey
- Bring back support for parsing hybrid keys
- Correct remaining existing tests for hybrid pubkeys
- Add negative tests for all combinations of encoding what would otherwise be valid pubkey with the wrong format byte and y coord oddness
- Add negative tests for x and y coordinates == p for the uncompressed, compressed, and hybrid formats
- Add negative tests for all formats such that either the x or y coordinate are > p and are constructed in such a way that they would be valid if the coordinate is taken mod p to ensure implementations don't incorrectly ignore the range check
- Add error infrastructure for pubkey parsing with `errors.Is` and `errors.As` support
- Update all tests related to pubkeys to test for the explicit reason for the failure