### PR TITLE
hdkeychain: Use errors api and require go 1.13+.

### DIFF
--- a/hdkeychain/go.mod
+++ b/hdkeychain/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrd/hdkeychain/v3
 
-go 1.11
+go 1.13
 
 require (
 	github.com/decred/base58 v1.0.2


### PR DESCRIPTION
**This requires #2160**.