### PR TITLE
secp256k1: Add IsOnCurve method to PublicKey.

### DIFF
--- a/dcrec/secp256k1/curve.go
+++ b/dcrec/secp256k1/curve.go
@@ -93,8 +93,9 @@ func (p *JacobianPoint) Set(other *JacobianPoint) {
 	p.Z.Set(&other.Z)
 }
 
-// ToAffine reduces the Jacobian point Z value to 1 effectively making it an
-// affine coordinate.
+// ToAffine reduces the Z value of the existing point to 1 effectively
+// making it an affine coordinate in constant time.  The point will be
+// normalized.
 func (p *JacobianPoint) ToAffine() {
 	// Inversions are expensive and both point addition and point doubling
 	// are faster when working with points that have a z value of one.  So,

--- a/dcrec/secp256k1/pubkey.go
+++ b/dcrec/secp256k1/pubkey.go
@@ -197,3 +197,11 @@ func (p *PublicKey) IsEqual(otherPubKey *PublicKey) bool {
 func (p *PublicKey) AsJacobian(result *JacobianPoint) {
 	bigAffineToJacobian(p.x, p.y, result)
 }
+
+// IsOnCurve returns whether or not the public key represents a point on the
+// secp256k1 curve.
+func (p *PublicKey) IsOnCurve() bool {
+	var point JacobianPoint
+	bigAffineToJacobian(p.x, p.y, &point)
+	return isOnCurve(&point.X, &point.Y)
+}

--- a/dcrec/secp256k1/pubkey_test.go
+++ b/dcrec/secp256k1/pubkey_test.go
@@ -438,3 +438,47 @@ func TestPublicKeyAsJacobian(t *testing.T) {
 		}
 	}
 }
+
+// TestPublicKeyIsOnCurve ensures testing if a public key is on the curve works
+// as expected.
+func TestPublicKeyIsOnCurve(t *testing.T) {
+	tests := []struct {
+		name string // test description
+		pubX string // hex encoded x coordinate for pubkey to serialize
+		pubY string // hex encoded y coordinate for pubkey to serialize
+		want bool   // expected result
+	}{{
+		name: "valid with even y",
+		pubX: "11db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c",
+		pubY: "4d1f1522047b33068bbb9b07d1e9f40564749b062b3fc0666479bc08a94be98c",
+		want: true,
+	}, {
+		name: "valid with odd y",
+		pubX: "11db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c",
+		pubY: "b2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3",
+		want: true,
+	}, {
+		name: "invalid due to x coord",
+		pubX: "15db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c",
+		pubY: "b2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3",
+		want: false,
+	}, {
+		name: "invalid due to y coord",
+		pubX: "15db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c",
+		pubY: "b2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a4",
+		want: false,
+	}}
+
+	for _, test := range tests {
+		// Parse the test data.
+		x, y := hexToBigInt(test.pubX), hexToBigInt(test.pubY)
+		pubKey := NewPublicKey(x, y)
+
+		result := pubKey.IsOnCurve()
+		if result != test.want {
+			t.Errorf("%s: mismatched is on curve result -- got %v, want %v",
+				test.name, result, test.want)
+			continue
+		}
+	}
+}


### PR DESCRIPTION
**This is rebased on #2161**.

This adds a new method to the `PublicKey` type which can be used to determine if the public key is on the `secp256k1` curve directly.

It also adds tests to ensure proper functionality.
