### PR TITLE
schnorr: Add examples.

### DIFF
--- a/dcrec/secp256k1/ciphering.go
+++ b/dcrec/secp256k1/ciphering.go
@@ -45,10 +45,12 @@ var (
 // public key using Diffie-Hellman key exchange (ECDH) (RFC 4753).
 // RFC5903 Section 9 states we should only return x.
 func GenerateSharedSecret(privkey *PrivateKey, pubkey *PublicKey) []byte {
-	privKeyBytes := privkey.Key.Bytes()
-	x, _ := S256().ScalarMult(pubkey.x, pubkey.y, privKeyBytes[:])
-	zeroArray32(&privKeyBytes)
-	return x.Bytes()
+	var point, result JacobianPoint
+	pubkey.AsJacobian(&point)
+	ScalarMultNonConst(&privkey.Key, &point, &result)
+	result.ToAffine()
+	xBytes := result.X.Bytes()
+	return xBytes[:]
 }
 
 // Encrypt encrypts data for the target public key using AES-256-CBC. It also

--- a/dcrec/secp256k1/curve_test.go
+++ b/dcrec/secp256k1/curve_test.go
@@ -736,20 +736,20 @@ func TestSplitKRand(t *testing.T) {
 }
 
 // Test this curve's usage with the ecdsa package.
-func testKeyGeneration(t *testing.T, c *KoblitzCurve, tag string) {
+func testKeyGeneration(t *testing.T, tag string) {
 	priv, err := GeneratePrivateKey()
 	if err != nil {
 		t.Errorf("%s: error: %s", tag, err)
 		return
 	}
 	pub := priv.PubKey()
-	if !c.IsOnCurve(pub.x, pub.y) {
+	if !isOnCurve(&pub.x, &pub.y) {
 		t.Errorf("%s: public key invalid: %s", tag, err)
 	}
 }
 
 func TestKeyGeneration(t *testing.T) {
-	testKeyGeneration(t, S256(), "S256")
+	testKeyGeneration(t, "S256")
 }
 
 func TestNAF(t *testing.T) {

--- a/dcrec/secp256k1/ecdsa/signature.go
+++ b/dcrec/secp256k1/ecdsa/signature.go
@@ -8,7 +8,6 @@ package ecdsa
 import (
 	"errors"
 	"fmt"
-	"math/big"
 
 	"github.com/decred/dcrd/dcrec/secp256k1/v3"
 )
@@ -158,18 +157,6 @@ func modNScalarToField(v *secp256k1.ModNScalar) secp256k1.FieldVal {
 	var fv secp256k1.FieldVal
 	fv.SetBytes(&buf)
 	return fv
-}
-
-// jacobianToBigAffine takes a Jacobian point (x, y, z) as field values and
-// converts it to an affine point as big integers.
-func jacobianToBigAffine(point *secp256k1.JacobianPoint) (*big.Int, *big.Int) {
-	point.ToAffine()
-
-	// Convert the field values for the now affine point to big.Ints.
-	x3, y3 := new(big.Int), new(big.Int)
-	x3.SetBytes(point.X.Bytes()[:])
-	y3.SetBytes(point.Y.Bytes()[:])
-	return x3, y3
 }
 
 // Verify returns whether or not the signature is valid for the provided hash
@@ -932,6 +919,7 @@ func RecoverCompact(signature, hash []byte) (*secp256k1.PublicKey, bool, error) 
 	}
 
 	// Notice that the public key is in affine coordinates.
-	pubKey := secp256k1.NewPublicKey(jacobianToBigAffine(&Q))
+	Q.ToAffine()
+	pubKey := secp256k1.NewPublicKey(&Q.X, &Q.Y)
 	return pubKey, wasCompressed, nil
 }

--- a/dcrec/secp256k1/ellipticadaptor.go
+++ b/dcrec/secp256k1/ellipticadaptor.go
@@ -186,12 +186,22 @@ func (curve *KoblitzCurve) ScalarBaseMult(k []byte) (*big.Int, *big.Int) {
 	return jacobianToBigAffine(&result)
 }
 
+// X returns the x coordinate of the public key.
+func (p *PublicKey) X() *big.Int {
+	return new(big.Int).SetBytes(p.x.Bytes()[:])
+}
+
+// Y returns the y coordinate of the public key.
+func (p *PublicKey) Y() *big.Int {
+	return new(big.Int).SetBytes(p.y.Bytes()[:])
+}
+
 // ToECDSA returns the public key as a *ecdsa.PublicKey.
-func (p PublicKey) ToECDSA() *ecdsa.PublicKey {
+func (p *PublicKey) ToECDSA() *ecdsa.PublicKey {
 	return &ecdsa.PublicKey{
 		Curve: S256(),
-		X:     p.x,
-		Y:     p.y,
+		X:     p.X(),
+		Y:     p.Y(),
 	}
 }
 

--- a/dcrec/secp256k1/ellipticadaptor_test.go
+++ b/dcrec/secp256k1/ellipticadaptor_test.go
@@ -15,7 +15,7 @@ import (
 func TestIsOnCurveAdaptor(t *testing.T) {
 	s256 := S256()
 	if !s256.IsOnCurve(s256.Params().Gx, s256.Params().Gy) {
-		t.Fatalf("generator point does not claim to be on the curve")
+		t.Fatal("generator point does not claim to be on the curve")
 	}
 }
 

--- a/dcrec/secp256k1/privkey.go
+++ b/dcrec/secp256k1/privkey.go
@@ -55,7 +55,8 @@ func GeneratePrivateKey() (*PrivateKey, error) {
 func (p *PrivateKey) PubKey() *PublicKey {
 	var result JacobianPoint
 	ScalarBaseMultNonConst(&p.Key, &result)
-	return NewPublicKey(jacobianToBigAffine(&result))
+	result.ToAffine()
+	return NewPublicKey(&result.X, &result.Y)
 }
 
 // Zero manually clears the memory associated with the private key.  This can be

--- a/dcrec/secp256k1/pubkey.go
+++ b/dcrec/secp256k1/pubkey.go
@@ -5,71 +5,85 @@
 
 package secp256k1
 
+// References:
+//   [SEC1] Elliptic Curve Cryptography
+//     https://www.secg.org/sec1-v2.pdf
+//
+//   [SEC2] Recommended Elliptic Curve Domain Parameters
+//     https://www.secg.org/sec2-v2.pdf
+//
+//   [ANSI X9.62-1998] Public Key Cryptography For The Financial Services
+//     Industry: The Elliptic Curve Digital Signature Algorithm (ECDSA)
+
 import (
 	"fmt"
-	"math/big"
 )
 
-// These constants define the lengths of serialized public keys.
 const (
-	PubKeyBytesLenCompressed   = 33
+	// PubKeyBytesLenCompressed is the number of bytes of a serialized
+	// compressed public key.
+	PubKeyBytesLenCompressed = 33
+
+	// PubKeyBytesLenCompressed is the number of bytes of a serialized
+	// uncompressed public key.
 	PubKeyBytesLenUncompressed = 65
+
+	// PubKeyFormatCompressedEven is the identifier prefix byte for a public key
+	// whose Y coordinate is even when serialized in the compressed format per
+	// section 2.3.4 of [SEC1](https://secg.org/sec1-v2.pdf#subsubsection.2.3.4).
+	PubKeyFormatCompressedEven byte = 0x02
+
+	// PubKeyFormatCompressedOdd is the identifier prefix byte for a public key
+	// whose Y coordinate is odd when serialized in the compressed format per
+	// section 2.3.4 of [SEC1](https://secg.org/sec1-v2.pdf#subsubsection.2.3.4).
+	PubKeyFormatCompressedOdd byte = 0x03
+
+	// PubKeyFormatUncompressed is the identifier prefix byte for a public key
+	// when serialized according in the uncompressed format per section 2.3.3 of
+	// [SEC1](https://secg.org/sec1-v2.pdf#subsubsection.2.3.3).
+	PubKeyFormatUncompressed byte = 0x04
+
+	// PubKeyFormatHybridEven is the identifier prefix byte for a public key
+	// whose Y coordinate is even when serialized according to the hybrid format
+	// per section 4.3.6 of [ANSI X9.62-1998].
+	//
+	// NOTE: This format makes little sense in practice an therefore this
+	// package will not produce public keys serialized in this format.  However,
+	// it will parse them since they exist in the wild.
+	PubKeyFormatHybridEven byte = 0x06
+
+	// PubKeyIDHybridEven is the identifier prefix byte for a public key whose Y
+	// coordingate is odd when serialized according to the hybrid format per
+	// section 4.3.6 of [ANSI X9.62-1998].
+	//
+	// NOTE: This format makes little sense in practice an therefore this
+	// package will not produce public keys serialized in this format.  However,
+	// it will parse them since they exist in the wild.
+	PubKeyFormatHybridOdd byte = 0x07
 )
 
-// PublicKey provides facilities for efficiently working with secp256k1 private
+// PublicKey provides facilities for efficiently working with secp256k1 public
 // keys within this package and includes functions to serialize in both
 // uncompressed and compressed SEC (Standards for Efficient Cryptography)
 // formats.
 type PublicKey struct {
-	x *big.Int
-	y *big.Int
+	x FieldVal
+	y FieldVal
 }
 
-// X returns the x coordinate of the public key.
-func (p *PublicKey) X() *big.Int {
-	return p.x
+// NewPublicKey instantiates a new public key with the given x and y
+// coordinates.
+//
+// It should be noted that, unlike ParsePubKey, since this accepts arbitrary x
+// and y coordinates, it allows creation of public keys that are not valid
+// points on the secp256k1 curve.  The IsOnCurve method of the returned instance
+// can be used to determine validity.
+func NewPublicKey(x, y *FieldVal) *PublicKey {
+	var pubKey PublicKey
+	pubKey.x.Set(x)
+	pubKey.y.Set(y)
+	return &pubKey
 }
-
-// Y returns the y coordinate of the public key.
-func (p *PublicKey) Y() *big.Int {
-	return p.y
-}
-
-// NewPublicKey instantiates a new public key with the given X,Y coordinates.
-func NewPublicKey(x *big.Int, y *big.Int) *PublicKey {
-	return &PublicKey{
-		x: x,
-		y: y,
-	}
-}
-
-func isOdd(a *big.Int) bool {
-	return a.Bit(0) == 1
-}
-
-// decompressPoint decompresses a point on the given curve given the X point and
-// the solution to use.
-func decompressPoint(x *big.Int, ybit bool) (*big.Int, error) {
-	var fx, fy FieldVal
-	if overflow := fx.SetByteSlice(x.Bytes()); overflow {
-		str := "invalid public key: x >= field prime"
-		return nil, makeError(ErrPubKeyXTooBig, str)
-	}
-	if !DecompressY(&fx, ybit, &fy) {
-		str := fmt.Sprintf("invalid public key: x coordinate %v is not on the "+
-			"secp256k1 curve", fx)
-		return nil, makeError(ErrPubKeyNotOnCurve, str)
-	}
-	fy.Normalize()
-
-	return new(big.Int).SetBytes(fy.Bytes()[:]), nil
-}
-
-const (
-	pubkeyCompressed   byte = 0x2 // y_bit + x coord
-	pubkeyUncompressed byte = 0x4 // x coord + y coord
-	pubkeyHybrid       byte = 0x6 // y_bit + x coord + y coord
-)
 
 // ParsePubKey parses a secp256k1 public key encoded according to the format
 // specified by ANSI X9.62-1998, which means it is also compatible with the
@@ -87,121 +101,132 @@ const (
 // NOTE: The hybrid format makes little sense in practice an therefore this
 // package will not produce public keys serialized in this format.  However,
 // this function will properly parse them since they exist in the wild.
-func ParsePubKey(pubKeyStr []byte) (key *PublicKey, err error) {
-	pubkey := PublicKey{}
-
-	if len(pubKeyStr) == 0 {
-		str := "invalid public key: empty"
-		return nil, makeError(ErrPubKeyInvalidLen, str)
-	}
-
-	format := pubKeyStr[0]
-	ybit := (format & 0x1) == 0x1
-	format &= ^byte(0x1)
-
-	switch len(pubKeyStr) {
+func ParsePubKey(serialized []byte) (key *PublicKey, err error) {
+	var x, y FieldVal
+	switch len(serialized) {
 	case PubKeyBytesLenUncompressed:
-		if format != pubkeyUncompressed && format != pubkeyHybrid {
+		// Reject unsupported public key formats for the given length.
+		format := serialized[0]
+		switch format {
+		case PubKeyFormatUncompressed:
+		case PubKeyFormatHybridEven, PubKeyFormatHybridOdd:
+		default:
 			str := fmt.Sprintf("invalid public key: unsupported format: %x",
 				format)
 			return nil, makeError(ErrPubKeyInvalidFormat, str)
 		}
 
-		pubkey.x = new(big.Int).SetBytes(pubKeyStr[1:33])
-		pubkey.y = new(big.Int).SetBytes(pubKeyStr[33:])
-		// hybrid keys have extra information, make use of it.
-		if format == pubkeyHybrid && ybit != isOdd(pubkey.y) {
-			str := fmt.Sprintf("invalid public key: y oddness does not match "+
-				"specified value of %v", ybit)
-			return nil, makeError(ErrPubKeyMismatchedOddness, str)
+		// Parse the x and y coordinates while ensuring that they are in the
+		// allowed range.
+		if overflow := x.SetByteSlice(serialized[1:33]); overflow {
+			str := "invalid public key: x >= field prime"
+			return nil, makeError(ErrPubKeyXTooBig, str)
+		}
+		if overflow := y.SetByteSlice(serialized[33:]); overflow {
+			str := "invalid public key: y >= field prime"
+			return nil, makeError(ErrPubKeyYTooBig, str)
+		}
+
+		// Ensure the oddness of the y coordinate matches the specified format
+		// for hybrid public keys.
+		if format == PubKeyFormatHybridEven || format == PubKeyFormatHybridOdd {
+			wantOddY := format == PubKeyFormatHybridOdd
+			if y.IsOdd() != wantOddY {
+				str := fmt.Sprintf("invalid public key: y oddness does not "+
+					"match specified value of %v", wantOddY)
+				return nil, makeError(ErrPubKeyMismatchedOddness, str)
+			}
 		}
 
 	case PubKeyBytesLenCompressed:
-		// format is 0x2 | solution, <X coordinate>
-		// solution determines which solution of the curve we use.
-		/// y^2 = x^3 + Curve.B
-		if format != pubkeyCompressed {
+		// Reject unsupported public key formats for the given length.
+		format := serialized[0]
+		switch format {
+		case PubKeyFormatCompressedEven, PubKeyFormatCompressedOdd:
+		default:
 			str := fmt.Sprintf("invalid public key: unsupported format: %x",
 				format)
 			return nil, makeError(ErrPubKeyInvalidFormat, str)
 		}
-		pubkey.x = new(big.Int).SetBytes(pubKeyStr[1:33])
-		pubkey.y, err = decompressPoint(pubkey.x, ybit)
-		if err != nil {
-			return nil, err
+
+		// Parse the x coordinate while ensuring that it is in the allowed
+		// range.
+		if overflow := x.SetByteSlice(serialized[1:33]); overflow {
+			str := "invalid public key: x >= field prime"
+			return nil, makeError(ErrPubKeyXTooBig, str)
 		}
 
-	default: // wrong!
+		// Attempt to calculate the y coordinate for the given x coordinate such
+		// that the result pair is a point on the secp256k1 curve and the
+		// solution with desired oddness is chosen.
+		wantOddY := format == PubKeyFormatCompressedOdd
+		if !DecompressY(&x, wantOddY, &y) {
+			str := fmt.Sprintf("invalid public key: x coordinate %v is not on "+
+				"the secp256k1 curve", &x)
+			return nil, makeError(ErrPubKeyNotOnCurve, str)
+		}
+		y.Normalize()
+
+	default:
 		str := fmt.Sprintf("malformed public key: invalid length: %d",
-			len(pubKeyStr))
+			len(serialized))
 		return nil, makeError(ErrPubKeyInvalidLen, str)
 	}
 
-	curve := S256()
-	if pubkey.x.Cmp(curveParams.P) >= 0 {
-		str := "invalid public key: x >= field prime"
-		return nil, makeError(ErrPubKeyXTooBig, str)
-	}
-	if pubkey.y.Cmp(curveParams.P) >= 0 {
-		str := "invalid public key: y >= field prime"
-		return nil, makeError(ErrPubKeyYTooBig, str)
-	}
-	if !curve.IsOnCurve(pubkey.x, pubkey.y) {
+	// Reject public keys that are not on the secp256k1 curve.
+	if !isOnCurve(&x, &y) {
 		str := fmt.Sprintf("invalid public key: [%v,%v] not on secp256k1 curve",
-			pubkey.x, pubkey.y)
+			x, y)
 		return nil, makeError(ErrPubKeyNotOnCurve, str)
 	}
-	return &pubkey, nil
+
+	return NewPublicKey(&x, &y), nil
 }
 
-// paddedAppend appends the src byte slice to dst, returning the new slice.
-// If the length of the source is smaller than the passed size, leading zero
-// bytes are appended to the dst slice before appending src.
-func paddedAppend(size uint, dst, src []byte) []byte {
-	for i := 0; i < int(size)-len(src); i++ {
-		dst = append(dst, 0)
-	}
-	return append(dst, src...)
-}
-
-// SerializeUncompressed serializes a public key in a 65-byte uncompressed
+// SerializeUncompressed serializes a public key in the 65-byte uncompressed
 // format.
 func (p PublicKey) SerializeUncompressed() []byte {
-	b := make([]byte, 0, PubKeyBytesLenUncompressed)
-	b = append(b, pubkeyUncompressed)
-	b = paddedAppend(32, b, p.x.Bytes())
-	return paddedAppend(32, b, p.y.Bytes())
+	// 0x04 || 32-byte x coordinate || 32-byte y coordinate
+	var b [PubKeyBytesLenUncompressed]byte
+	b[0] = PubKeyFormatUncompressed
+	p.x.PutBytesUnchecked(b[1:33])
+	p.y.PutBytesUnchecked(b[33:65])
+	return b[:]
 }
 
-// SerializeCompressed serializes a public key in a 33-byte compressed format.
+// SerializeCompressed serializes a public key in the 33-byte compressed format.
 func (p PublicKey) SerializeCompressed() []byte {
-	b := make([]byte, 0, PubKeyBytesLenCompressed)
-	format := pubkeyCompressed
-	if isOdd(p.y) {
-		format |= 0x1
+	// Choose the format byte depending on the oddness of the Y coordinate.
+	format := PubKeyFormatCompressedEven
+	if p.y.IsOdd() {
+		format = PubKeyFormatCompressedOdd
 	}
-	b = append(b, format)
-	return paddedAppend(32, b, p.x.Bytes())
+
+	// 0x02 or 0x03 || 32-byte x coordinate
+	var b [PubKeyBytesLenCompressed]byte
+	b[0] = format
+	p.x.PutBytesUnchecked(b[1:33])
+	return b[:]
 }
 
 // IsEqual compares this PublicKey instance to the one passed, returning true if
 // both PublicKeys are equivalent. A PublicKey is equivalent to another, if they
 // both have the same X and Y coordinate.
 func (p *PublicKey) IsEqual(otherPubKey *PublicKey) bool {
-	return p.x.Cmp(otherPubKey.x) == 0 && p.y.Cmp(otherPubKey.y) == 0
+	return p.x.Equals(&otherPubKey.x) && p.y.Equals(&otherPubKey.y)
 }
 
 // AsJacobian converts the public key into a Jacobian point with Z=1 and stores
 // the result in the provided result param.  This allows the public key to be
 // treated a Jacobian point in the secp256k1 group in calculations.
 func (p *PublicKey) AsJacobian(result *JacobianPoint) {
-	bigAffineToJacobian(p.x, p.y, result)
+	result.X.Set(&p.x)
+	result.Y.Set(&p.y)
+	result.Z.SetInt(1)
 }
 
 // IsOnCurve returns whether or not the public key represents a point on the
 // secp256k1 curve.
 func (p *PublicKey) IsOnCurve() bool {
-	var point JacobianPoint
-	bigAffineToJacobian(p.x, p.y, &point)
-	return isOnCurve(&point.X, &point.Y)
+	return isOnCurve(&p.x, &p.y)
 }

--- a/dcrec/secp256k1/schnorr/README.md
+++ b/dcrec/secp256k1/schnorr/README.md
@@ -325,6 +325,10 @@ $ go get -u github.com/decred/dcrd/dcrec/secp25k1/v3/schnorr
   secp256k1 private key that is first parsed from raw bytes and serializing the
   generated signature.
 
+* [Verify Signature](https://pkg.go.dev/github.com/decred/dcrd/dcrec/secp256k1/v3/schnorr#example-Signature.Verify)  
+  Demonstrates verifying an EC-Schnorr-DCRv0 signature against a public key that
+  is first parsed from raw bytes.  The signature is also parsed from raw bytes.
+
 ## License
 
 Package schnorr is licensed under the [copyfree](http://copyfree.org) ISC

--- a/dcrec/secp256k1/schnorr/README.md
+++ b/dcrec/secp256k1/schnorr/README.md
@@ -3,7 +3,7 @@ schnorr
 
 [![Build Status](https://github.com/decred/dcrd/workflows/Build%20and%20Test/badge.svg)](https://github.com/decred/dcrd/actions)
 [![ISC License](https://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](https://godoc.org/github.com/decred/dcrd/dcrec/sec256pk1/v3/schnorr)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](https://pkg.go.dev/github.com/decred/dcrd/dcrec/secp256k1/v3/schnorr)
 
 Package schnorr provides custom Schnorr signing and verification via secp256k1.
 
@@ -317,6 +317,13 @@ standardization attempts:
 ```bash
 $ go get -u github.com/decred/dcrd/dcrec/secp25k1/v3/schnorr
 ```
+
+## Examples
+
+* [Sign Message](https://pkg.go.dev/github.com/decred/dcrd/dcrec/secp256k1/v3/schnorr#example-package-SignMessage)  
+  Demonstrates signing a message with the EC-Schnorr-DCRv0 scheme using a
+  secp256k1 private key that is first parsed from raw bytes and serializing the
+  generated signature.
 
 ## License
 

--- a/dcrec/secp256k1/schnorr/example_test.go
+++ b/dcrec/secp256k1/schnorr/example_test.go
@@ -47,3 +47,44 @@ func ExampleSign() {
 	// Serialized Signature: 970603d8ccd2475b1ff66cfb3ce7e622c5938348304c5a7bc2e6015fb98e3b457d4e912fcca6ca87c04390aa5e6e0e613bbbba7ffd6f15bc59f95bbd92ba50f0
 	// Signature Verified? true
 }
+
+// This example demonstrates verifying an EC-Schnorr-DCRv0 signature against a
+// public key that is first parsed from raw bytes.  The signature is also parsed
+// from raw bytes.
+func ExampleSignature_Verify() {
+	// Decode hex-encoded serialized public key.
+	pubKeyBytes, err := hex.DecodeString("02a673638cb9587cb68ea08dbef685c6f2d" +
+		"2a751a8b3c6f2a7e9a4999e6e4bfaf5")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	pubKey, err := schnorr.ParsePubKey(pubKeyBytes)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	// Decode hex-encoded serialized signature.
+	sigBytes, err := hex.DecodeString("970603d8ccd2475b1ff66cfb3ce7e622c59383" +
+		"48304c5a7bc2e6015fb98e3b457d4e912fcca6ca87c04390aa5e6e0e613bbbba7ffd" +
+		"6f15bc59f95bbd92ba50f0")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	signature, err := schnorr.ParseSignature(sigBytes)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	// Verify the signature for the message using the public key.
+	message := "test message"
+	messageHash := chainhash.HashB([]byte(message))
+	verified := signature.Verify(messageHash, pubKey)
+	fmt.Println("Signature Verified?", verified)
+
+	// Output:
+	// Signature Verified? true
+}

--- a/dcrec/secp256k1/schnorr/example_test.go
+++ b/dcrec/secp256k1/schnorr/example_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package schnorr_test
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/dcrec/secp256k1/v3"
+	"github.com/decred/dcrd/dcrec/secp256k1/v3/schnorr"
+)
+
+// This example demonstrates signing a message with the EC-Schnorr-DCRv0 scheme
+// using a secp256k1 private key that is first parsed from raw bytes and
+// serializing the generated signature.
+func ExampleSign() {
+	// Decode a hex-encoded private key.
+	pkBytes, err := hex.DecodeString("22a47fa09a223f2aa079edf85a7c2d4f8720ee6" +
+		"3e502ee2869afab7de234b80c")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	privKey := secp256k1.PrivKeyFromBytes(pkBytes)
+
+	// Sign a message using the private key.
+	message := "test message"
+	messageHash := chainhash.HashB([]byte(message))
+	signature, err := schnorr.Sign(privKey, messageHash)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	// Serialize and display the signature.
+	fmt.Printf("Serialized Signature: %x\n", signature.Serialize())
+
+	// Verify the signature for the message using the public key.
+	pubKey := privKey.PubKey()
+	verified := signature.Verify(messageHash, pubKey)
+	fmt.Printf("Signature Verified? %v\n", verified)
+
+	// Output:
+	// Serialized Signature: 970603d8ccd2475b1ff66cfb3ce7e622c5938348304c5a7bc2e6015fb98e3b457d4e912fcca6ca87c04390aa5e6e0e613bbbba7ffd6f15bc59f95bbd92ba50f0
+	// Signature Verified? true
+}

--- a/dcrec/secp256k1/schnorr/signature.go
+++ b/dcrec/secp256k1/schnorr/signature.go
@@ -52,9 +52,8 @@ func NewSignature(r *secp256k1.FieldVal, s *secp256k1.ModNScalar) *Signature {
 // Serialize returns the Schnorr signature in the more strict format.
 //
 // The signatures are encoded as
-//   sig[0:32]  R, a point encoded as big endian
-//   sig[32:64] S, scalar multiplication/addition results = (ab+c) mod l
-//     encoded also as big endian
+//   sig[0:32]  x coordinate of the point R, encoded as a big-endian uint256
+//   sig[32:64] s, encoded also as big-endian uint256
 func (sig Signature) Serialize() []byte {
 	// Total length of returned signature is the length of r and s.
 	var b [SignatureSize]byte
@@ -144,8 +143,7 @@ func schnorrVerify(sig *Signature, hash []byte, pubKey *secp256k1.PublicKey) err
 	// Step 2.
 	//
 	// Fail if Q is not a point on the curve
-	curve := secp256k1.S256()
-	if !curve.IsOnCurve(pubKey.X(), pubKey.Y()) {
+	if !pubKey.IsOnCurve() {
 		str := "pubkey point is not on curve"
 		return signatureError(ErrPubKeyNotOnCurve, str)
 	}

--- a/dcrec/secp256k1/schnorr/signature_bench_test.go
+++ b/dcrec/secp256k1/schnorr/signature_bench_test.go
@@ -6,7 +6,6 @@ package schnorr
 
 import (
 	"encoding/hex"
-	"math/big"
 	"testing"
 
 	"github.com/decred/dcrd/dcrec/secp256k1/v3"
@@ -40,16 +39,20 @@ func hexToBytes(s string) []byte {
 	return b
 }
 
-// hexToBigInt converts the passed hex string into a big integer and will panic
-// is there is an error.  This is only provided for the hard-coded constants so
-// errors in the source code can bet detected. It will only (and must only) be
-// called for initialization purposes.
-func hexToBigInt(s string) *big.Int {
-	r, ok := new(big.Int).SetString(s, 16)
-	if !ok {
+// hexToFieldVal converts the passed hex string into a FieldVal and will panic
+// if there is an error.  This is only provided for the hard-coded constants so
+// errors in the source code can be detected. It will only (and must only) be
+// called with hard-coded values.
+func hexToFieldVal(s string) *secp256k1.FieldVal {
+	b, err := hex.DecodeString(s)
+	if err != nil {
 		panic("invalid hex in source file: " + s)
 	}
-	return r
+	var f secp256k1.FieldVal
+	if overflow := f.SetByteSlice(b); overflow {
+		panic("hex in source file overflows mod P: " + s)
+	}
+	return &f
 }
 
 // BenchmarkSign benchmarks how long it takes to sign a message.
@@ -74,8 +77,8 @@ func BenchmarkSigVerify(b *testing.B) {
 	d := hexToModNScalar("9e0699c91ca1e3b7e3c9ba71eb71c89890872be97576010fe593fbf3fd57e66d")
 	privKey := secp256k1.NewPrivateKey(d)
 	pubKey := secp256k1.NewPublicKey(
-		hexToBigInt("d2e670a19c6d753d1a6d8b20bd045df8a08fb162cf508956c31268c6d81ffdab"),
-		hexToBigInt("ab65528eefbb8057aa85d597258a3fbd481a24633bc9b47a9aa045c91371de52"),
+		hexToFieldVal("d2e670a19c6d753d1a6d8b20bd045df8a08fb162cf508956c31268c6d81ffdab"),
+		hexToFieldVal("ab65528eefbb8057aa85d597258a3fbd481a24633bc9b47a9aa045c91371de52"),
 	)
 
 	// blake256 of []byte{0x01, 0x02, 0x03, 0x04}.

--- a/dcrec/secp256k1/schnorr/signature_test.go
+++ b/dcrec/secp256k1/schnorr/signature_test.go
@@ -522,7 +522,7 @@ func TestVerifyErrors(t *testing.T) {
 	for _, test := range tests {
 		// Parse test data into types.
 		hash := hexToBytes(test.hash)
-		pubX, pubY := hexToBigInt(test.pubX), hexToBigInt(test.pubY)
+		pubX, pubY := hexToFieldVal(test.pubX), hexToFieldVal(test.pubY)
 		pubKey := secp256k1.NewPublicKey(pubX, pubY)
 
 		// Create the serialized signature from the bytes and attempt to parse


### PR DESCRIPTION
**This is rebased on #2163**.

This adds examples for signing a message and verifying a signature over a message for a public key.