### PR TITLE
ecdsa: Correct README.md documentation links.

### DIFF
--- a/dcrec/secp256k1/ecdsa/README.md
+++ b/dcrec/secp256k1/ecdsa/README.md
@@ -3,7 +3,7 @@ ecdsa
 
 [![Build Status](https://github.com/decred/dcrd/workflows/Build%20and%20Test/badge.svg)](https://github.com/decred/dcrd/actions)
 [![ISC License](https://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](https://godoc.org/github.com/decred/dcrd/dcrec/sec256pk1/v3/ecdsa)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](https://pkg.go.dev/github.com/decred/dcrd/dcrec/secp256k1/v3/ecdsa)
 
 Package ecdsa provides secp256k1-optimized ECDSA signing and verification.
 
@@ -44,7 +44,7 @@ $ go get -u github.com/decred/dcrd/dcrec/secp25k1/v3/ecdsa
   Demonstrates signing a message with a secp256k1 private key that is first
   parsed from raw bytes and serializing the generated signature.
 
-* [Verify Signature](https://pkg.go.dev/github.com/decred/dcrd/dcrec/secp256k1/v3/ecdsa#example-package-VerifySignature)  
+* [Verify Signature](https://pkg.go.dev/github.com/decred/dcrd/dcrec/secp256k1/v3/ecdsa#example-Signature.Verify)  
   Demonstrates verifying a secp256k1 signature against a public key that is
   first parsed from raw bytes.  The signature is also parsed from raw bytes.
 


### PR DESCRIPTION
**This is rebased on #2164**.