### PR TITLE
secp256k1: Optimize pubkey parse.

### DIFF
--- a/dcrec/secp256k1/bench_test.go
+++ b/dcrec/secp256k1/bench_test.go
@@ -115,3 +115,17 @@ func BenchmarkPubKeyDecompress(b *testing.B) {
 		_ = DecompressY(pubKeyX, false, &y)
 	}
 }
+
+// BenchmarkParsePubKeyCompressed benchmarks how long it takes to parse a
+// compressed public key with an even y coordinate.
+func BenchmarkParsePubKeyCompressed(b *testing.B) {
+	format := "02"
+	x := "ce0b14fb842b1ba549fdd675c98075f12e9c510f8ef52bd021a9a1f4809d3b4d"
+	pubKeyBytes := hexToBytes(format + x)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ParsePubKey(pubKeyBytes)
+	}
+}

--- a/dcrec/secp256k1/bench_test.go
+++ b/dcrec/secp256k1/bench_test.go
@@ -129,3 +129,18 @@ func BenchmarkParsePubKeyCompressed(b *testing.B) {
 		ParsePubKey(pubKeyBytes)
 	}
 }
+
+// BenchmarkParsePubKeyUncompressed benchmarks how long it takes to parse an
+// uncompressed public key.
+func BenchmarkParsePubKeyUncompressed(b *testing.B) {
+	format := "04"
+	x := "11db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5c"
+	y := "b2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3"
+	pubKeyBytes := hexToBytes(format + x + y)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ParsePubKey(pubKeyBytes)
+	}
+}

--- a/dcrec/secp256k1/pubkey.go
+++ b/dcrec/secp256k1/pubkey.go
@@ -138,6 +138,13 @@ func ParsePubKey(serialized []byte) (key *PublicKey, err error) {
 			}
 		}
 
+		// Reject public keys that are not on the secp256k1 curve.
+		if !isOnCurve(&x, &y) {
+			str := fmt.Sprintf("invalid public key: [%v,%v] not on secp256k1 "+
+				"curve", x, y)
+			return nil, makeError(ErrPubKeyNotOnCurve, str)
+		}
+
 	case PubKeyBytesLenCompressed:
 		// Reject unsupported public key formats for the given length.
 		format := serialized[0]
@@ -162,7 +169,7 @@ func ParsePubKey(serialized []byte) (key *PublicKey, err error) {
 		wantOddY := format == PubKeyFormatCompressedOdd
 		if !DecompressY(&x, wantOddY, &y) {
 			str := fmt.Sprintf("invalid public key: x coordinate %v is not on "+
-				"the secp256k1 curve", &x)
+				"the secp256k1 curve", x)
 			return nil, makeError(ErrPubKeyNotOnCurve, str)
 		}
 		y.Normalize()
@@ -171,13 +178,6 @@ func ParsePubKey(serialized []byte) (key *PublicKey, err error) {
 		str := fmt.Sprintf("malformed public key: invalid length: %d",
 			len(serialized))
 		return nil, makeError(ErrPubKeyInvalidLen, str)
-	}
-
-	// Reject public keys that are not on the secp256k1 curve.
-	if !isOnCurve(&x, &y) {
-		str := fmt.Sprintf("invalid public key: [%v,%v] not on secp256k1 curve",
-			x, y)
-		return nil, makeError(ErrPubKeyNotOnCurve, str)
 	}
 
 	return NewPublicKey(&x, &y), nil


### PR DESCRIPTION
**This requires #2163**.

This modifies the `ParsePubKey` function to avoid an additional unnecessary check if the point is on the curve in the compressed pubkey case because it necessarily has already determined if that is true via the point decompression from the x coordinate.

Also, prevent x from escaping to the heap for the error print in compressed case while here.

```
benchmark                          old ns/op    new ns/op   delta
------------------------------------------------------------------
BenchmarkParsePubKeyCompressed     11901        11745       -1.31%
BenchmarkParsePubKeyUncompressed   335          325         -2.99%

benchmark                          old allocs   new allocs  delta
-------------------------------------------------------------------
BenchmarkParsePubKeyCompressed     2            1           -50.00%
BenchmarkParsePubKeyUncompressed   2            1           -50.00%

benchmark                          old bytes    new bytes   delta
-------------------------------------------------------------------
BenchmarkParsePubKeyCompressed     128          80          -37.50%
BenchmarkParsePubKeyUncompressed   128          80          -37.50%
```
