### PR TITLE
docs: README.md updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,16 +44,9 @@ transactions to other Decred nodes around the world.
 This software is currently under active development.  It is extremely stable and
 has been in production use since February 2016.
 
-The software was originally forked from [btcd](https://github.com/btcsuite/btcd),
-which is a bitcoin full node implementation that is still under active
-development.  To gain the benefit of btcd's ongoing upgrades, including improved
-peer and connection handling, database optimization, and other blockchain
-related technology improvements, dcrd is continuously synced with the btcd
-codebase.
-
-Like btcd, dcrd does *NOT* include wallet functionality, and users who desire a
-wallet will need to use [dcrwallet (CLI)](https://github.com/decred/dcrwallet) or 
-[Decrediton (GUI)](https://github.com/decred/decrediton).
+It important to note that dcrd does *NOT* include wallet functionality.  Users
+who desire a wallet will need to use [dcrwallet(CLI)](https://github.com/decred/dcrwallet)
+or [Decrediton(GUI)](https://github.com/decred/decrediton).
 
 ## What is a full node?
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ Core software:
 
 Bundles:
 
-* [Decrediton](https://github.com/decred/decrediton): a GUI bundle for `dcrd` 
-and `dcrwallet`.
-* [CLI app suite](https://github.com/decred/decred-release/releases/tag/v1.5.1): 
-a CLI bundle for `dcrd` and `dcrwallet`.
+* [Decrediton](https://github.com/decred/decrediton): a GUI bundle for `dcrd`
+  and `dcrwallet`
+* [CLI app suite](https://github.com/decred/decred-release/releases/tag/v1.5.1):
+  a CLI bundle for `dcrd` and `dcrwallet`
 
 ## What is dcrd?
 
@@ -110,9 +110,9 @@ Also, make sure your firewall is configured to allow inbound connections to port
 
 ### Binaries (Windows/Linux/macOS)
 
-Binary releases are provided for common operating systems and architectures. 
-The easiest method is to download Decrediton from the link below, which will 
-include dcrd. Advanced users may prefer the Command-line app suite, which 
+Binary releases are provided for common operating systems and architectures.
+The easiest method is to download Decrediton from the link below, which will
+include dcrd. Advanced users may prefer the Command-line app suite, which
 includes dcrd and dcrwallet.
 
 https://decred.org/downloads
@@ -133,10 +133,10 @@ https://decred.org/downloads
   $ go version
   $ go env GOROOT GOPATH
   ```
-  NOTE: `GOROOT` and `GOPATH` must not be on the same path. Since Go 1.8 (2016), 
-  `GOROOT` and `GOPATH` are set automatically, and you do not need to change 
-  them. However, you still need to add `$GOPATH/bin` to your `PATH` in order to 
-  run binaries installed by `go get` and `go install` (On Windows, this happens 
+  NOTE: `GOROOT` and `GOPATH` must not be on the same path. Since Go 1.8 (2016),
+  `GOROOT` and `GOPATH` are set automatically, and you do not need to change
+  them. However, you still need to add `$GOPATH/bin` to your `PATH` in order to
+  run binaries installed by `go get` and `go install` (On Windows, this happens
   automatically).
 
   Unix example -- add these lines to .profile:
@@ -168,7 +168,7 @@ https://decred.org/downloads
 </details>
 <details><summary><b>Unix Example</b></summary>
 
-  This assumes you have already added `$GOPATH/bin` to your `$PATH` as described 
+  This assumes you have already added `$GOPATH/bin` to your `$PATH` as described
   in dependencies.
 
   ```sh


### PR DESCRIPTION
This removes the references to btcd from `README.md` since the code base has diverged so much that there isn't very much in common anymore and thus the text no longer reflected reality.

It also removes some stray trailing spaces while here.
