### PR TITLE
blockmanager: notify registered ws clients of accepted block

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1877,6 +1877,11 @@ func (b *blockManager) handleBlockchainNotification(notification *blockchain.Not
 			b.cfg.PeerNotifier.RelayInventory(iv, block.MsgBlock().Header, true)
 		}
 
+		if r := b.cfg.RpcServer(); r != nil {
+			// Notify registered websocket clients of accepted block.
+			r.ntfnMgr.NotifyBlockAccepted(band)
+		}
+
 		// Inform the background block template generator about the accepted
 		// block.
 		if b.cfg.BgBlkTmplGenerator != nil {

--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -2561,11 +2561,11 @@ user.  Click the method name for further details such as parameter and return in
 |None
 |-
 |[[#notifyblocks|notifyblocks]]
-|Send notifications when a block is connected or disconnected from the best chain.
-|[[#blockconnected|blockconnected]] and [[#blockdisconnected|blockdisconnected]]
+|Send notifications when a block is accepted into the block chain and when a block is connected to or disconnected from the best chain.
+|[[#blockaccepted|blockaccepted]], [[#blockconnected|blockconnected]] and [[#blockdisconnected|blockdisconnected]]
 |-
 |[[#stopnotifyblocks|stopnotifyblocks]]
-|Cancel registered notifications for whenever a block is connected or disconnected from the main (best) chain.
+|Cancel registered notifications for whenever a block is accepted into the block chain and whenever a block is connected to or disconnected from the main (best) chain.
 |None
 |-
 |[[#notifywork|notifywork]]
@@ -2643,13 +2643,13 @@ NOTE: This is only required if an HTTP Authorization header is not being used.
 |notifyblocks
 |-
 !Notifications
-|[[#blockconnected|blockconnected]] and [[#blockdisconnected|blockdisconnected]]
+|[[#blockaccepted|blockaccepted]], [[#blockconnected|blockconnected]] and [[#blockdisconnected|blockdisconnected]]
 |-
 !Parameters
 |None
 |-
 !Description
-|Request notifications for whenever a block is connected or disconnected from the main (best) chain. NOTE: If a client subscribes to both block and transaction (recvtx and redeemingtx) notifications, the blockconnected notification will be sent after all transaction notifications have been sent.  This allows clients to know when all relevant transactions for a block have been received.
+|Request notifications for whenever a block is accepted into the block chain (i.e. accepted into the main chain or creates/extends a side chain) and whenever a block is connected or disconnected from the main (best) chain. NOTE: If a client subscribes to both block and transaction (recvtx and redeemingtx) notifications, the blockconnected notification will be sent after all transaction notifications have been sent.  This allows clients to know when all relevant transactions for a block have been received.
 |-
 !Returns
 |Nothing
@@ -2946,6 +2946,10 @@ The following is an overview of the JSON-RPC notifications used for Websocket co
 !Description
 !Request
 |-
+|[[#blockaccepted|blockaccepted]]
+|Block accepted to the block chain.
+|[[#notifyblocks|notifyblocks]]
+|-
 |[[#blockconnected|blockconnected]]
 |Block connected to the main chain.
 |[[#notifyblocks|notifyblocks]]
@@ -2984,6 +2988,34 @@ The following is an overview of the JSON-RPC notifications used for Websocket co
 |}
 
 ===7.2 Notification Details===
+
+====blockaccepted====
+{|
+!Method
+|blockaccepted
+|-
+!Request
+|[[#notifyblocks|notifyblocks]]
+|-
+!Parameters
+|
+# <code>BlockHash</code>: <code>(string)</code> hex-encoded bytes of the attached block hash.
+# <code>ForkLength</code>: <code>(numeric)</code> length of the side chain the block extended or zero in the case the block extended the main chain.
+# <code>BestHeight</code>: <code>(numeric)</code> height of the current best chain.
+|-
+!Description
+|Notifies when a block has been accepted to the block chain.  Notification is sent to all connected clients.
+: Note that the block that was accepted does not necessarily extend the best chain as it might have created or extended a side chain.
+: Also, since the accepted block might be on a side chain, the <code>BestHeight</code> is not necessarily the same as the height of the accepted block.
+: The <code>ForkLength</code> can be used in conjunction with the <code>BestHeight</code> to determine the height at which the side chain the block created or extended forked from the best chain.
+|-
+!Example
+|Example blockaccepted notification for testnet block 409148:
+
+: <code>{"jsonrpc": "1.0", "method": "blockaccepted", "params": ["0000000f26a0b1601fdd2eaed98fa148f3cb219473f4527cb4c52a5a239fd0b1", 1, 409148],"id": null}</code>
+|}
+
+----
 
 ====blockconnected====
 {|

--- a/rpc/jsonrpc/types/chainsvrwsntfns.go
+++ b/rpc/jsonrpc/types/chainsvrwsntfns.go
@@ -11,6 +11,10 @@ package types
 import "github.com/decred/dcrd/dcrjson/v3"
 
 const (
+	// BlockAcceptedNtfnMethod is the method used for notifications from
+	// the chain server that a block has been accepted.
+	BlockAcceptedNtfnMethod Method = "blockaccepted"
+
 	// BlockConnectedNtfnMethod is the method used for notifications from
 	// the chain server that a block has been connected.
 	BlockConnectedNtfnMethod Method = "blockconnected"
@@ -57,6 +61,23 @@ const (
 	// notification.
 	WinningTicketsNtfnMethod Method = "winningtickets"
 )
+
+// BlockAcceptedNtfn defines the blockconnected JSON-RPC notification.
+type BlockAcceptedNtfn struct {
+	Header     string `json:"header"`
+	ForkLen    int64  `json:"forklen"`
+	BestHeight int64  `json:"bestheight"`
+}
+
+// NewBlockAcceptedNtfn returns a new instance which can be used to issue a
+// blockaccepted JSON-RPC notification.
+func NewBlockAcceptedNtfn(header string, forkLen, bestHeight int64) *BlockAcceptedNtfn {
+	return &BlockAcceptedNtfn{
+		Header:     header,
+		ForkLen:    forkLen,
+		BestHeight: bestHeight,
+	}
+}
 
 // BlockConnectedNtfn defines the blockconnected JSON-RPC notification.
 type BlockConnectedNtfn struct {
@@ -239,6 +260,7 @@ func init() {
 	// notifications.
 	flags := dcrjson.UFWebsocketOnly | dcrjson.UFNotification
 
+	dcrjson.MustRegister(BlockAcceptedNtfnMethod, (*BlockAcceptedNtfn)(nil), flags)
 	dcrjson.MustRegister(BlockConnectedNtfnMethod, (*BlockConnectedNtfn)(nil), flags)
 	dcrjson.MustRegister(BlockDisconnectedNtfnMethod, (*BlockDisconnectedNtfn)(nil), flags)
 	dcrjson.MustRegister(WorkNtfnMethod, (*WorkNtfn)(nil), flags)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -59,9 +59,9 @@ import (
 
 // API version constants
 const (
-	jsonrpcSemverString = "6.1.1"
+	jsonrpcSemverString = "6.2.1"
 	jsonrpcSemverMajor  = 6
-	jsonrpcSemverMinor  = 1
+	jsonrpcSemverMinor  = 2
 	jsonrpcSemverPatch  = 1
 )
 


### PR DESCRIPTION
Send a `blockaccepted` notification when a block is accepted into the block chain.

Provides a means for clients to get knowledge of blocks added to side chains instead of having to continuously poll `getchaintips`.

`blockconnected` remains the primary notification method for when blocks are added to the main chain.

The data sent to clients on `blockaccepted` include the `BlockHash` for the accepted block, the the best height of the main chain (`BestHeight`) and the length of the side chain the block extended or zero in the case the block extended the main chain (`ForkLength`).

The `ForkLength` can be used in conjunction with the `BestHeight` to determine the height at which the side chain the block created or extended forked from the best chain.
