### PR TITLE
rpctest: Add debug and trace facility to rpctest.

### DIFF
--- a/rpctest/debug.go
+++ b/rpctest/debug.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package rpctest
+
+import (
+	"testing"
+)
+
+// This package is very hard to debug so we add a couple of variables that
+// enable debug and tracing output. Leave them false before committing to
+// master.
+var (
+	debug bool // Set to true to enable additional verbosity.
+	trace bool // Set to true to enable tracing.
+)
+
+func init() {
+	debug = false
+	trace = false
+}
+
+func logf(t *testing.T, format string, args ...interface{}) {
+	t.Logf(format, args...)
+}
+
+func tracef(t *testing.T, format string, args ...interface{}) {
+	if !trace {
+		return
+	}
+	t.Logf(format, args...)
+}
+
+func debugf(t *testing.T, format string, args ...interface{}) {
+	if !debug {
+		return
+	}
+	t.Logf(format, args...)
+}

--- a/rpctest/rpc_harness.go
+++ b/rpctest/rpc_harness.go
@@ -35,6 +35,9 @@ const (
 )
 
 var (
+	// XXX these variables are accessed in what should be accessor
+	// functions yet it is all global
+
 	// current number of active test nodes.
 	numTestInstances = 0
 
@@ -92,6 +95,8 @@ type Harness struct {
 	maxConnRetries int
 	nodeNum        int
 
+	t *testing.T
+
 	sync.Mutex
 }
 
@@ -101,7 +106,7 @@ type Harness struct {
 // used.
 //
 // NOTE: This function is safe for concurrent access.
-func New(activeNet *chaincfg.Params, handlers *rpcclient.NotificationHandlers, extraArgs []string) (*Harness, error) {
+func New(t *testing.T, activeNet *chaincfg.Params, handlers *rpcclient.NotificationHandlers, extraArgs []string) (*Harness, error) {
 	harnessStateMtx.Lock()
 	defer harnessStateMtx.Unlock()
 
@@ -126,6 +131,7 @@ func New(activeNet *chaincfg.Params, handlers *rpcclient.NotificationHandlers, e
 	if err != nil {
 		return nil, err
 	}
+	debugf(t, "temp dir: %v\n", nodeTestData)
 
 	certFile := filepath.Join(nodeTestData, "rpc.cert")
 	keyFile := filepath.Join(nodeTestData, "rpc.key")
@@ -133,7 +139,7 @@ func New(activeNet *chaincfg.Params, handlers *rpcclient.NotificationHandlers, e
 		return nil, err
 	}
 
-	wallet, err := newMemWallet(activeNet, uint32(numTestInstances))
+	wallet, err := newMemWallet(t, activeNet, uint32(numTestInstances))
 	if err != nil {
 		return nil, err
 	}
@@ -146,13 +152,16 @@ func New(activeNet *chaincfg.Params, handlers *rpcclient.NotificationHandlers, e
 		return nil, err
 	}
 
+	// Uncomment and change to enable additional dcrd debug/trace output.
+	//config.debugLevel = "TXMP=trace,TRSY=trace,RPCS=trace,PEER=trace"
+
 	// Generate p2p+rpc listening addresses.
 	config.listen, config.rpcListen = generateListeningAddresses()
 
 	// Create the testing node bounded to the simnet.
-	node := newNode(config, nodeTestData)
+	node := newNode(t, config, nodeTestData)
 	nodeNum := numTestInstances
-	numTestInstances++
+	numTestInstances++ // XXX this really should be the length of the harness map.
 
 	if handlers == nil {
 		handlers = &rpcclient.NotificationHandlers{}
@@ -190,6 +199,7 @@ func New(activeNet *chaincfg.Params, handlers *rpcclient.NotificationHandlers, e
 		ActiveNet:      activeNet,
 		nodeNum:        nodeNum,
 		wallet:         wallet,
+		t:              t,
 	}
 
 	// Track this newly created test instance within the package level
@@ -231,12 +241,15 @@ func (h *Harness) SetUp(createTestChain bool, numMatureOutputs uint32) error {
 		return err
 	}
 
+	tracef(h.t, "createTestChain %v numMatureOutputs %v", createTestChain,
+		numMatureOutputs)
 	// Create a test chain with the desired number of mature coinbase
 	// outputs.
 	if createTestChain && numMatureOutputs != 0 {
 		// Include an extra block to account for the premine block.
 		numToGenerate := (uint32(h.ActiveNet.CoinbaseMaturity) +
 			numMatureOutputs) + 1
+		tracef(h.t, "Generate: %v", numToGenerate)
 		_, err := h.Node.Generate(ctx, numToGenerate)
 		if err != nil {
 			return err
@@ -249,6 +262,7 @@ func (h *Harness) SetUp(createTestChain bool, numMatureOutputs uint32) error {
 	if err != nil {
 		return err
 	}
+	tracef(h.t, "Best block height: %v", height)
 	ticker := time.NewTicker(time.Millisecond * 100)
 	for range ticker.C {
 		walletHeight := h.wallet.SyncedHeight()
@@ -256,6 +270,7 @@ func (h *Harness) SetUp(createTestChain bool, numMatureOutputs uint32) error {
 			break
 		}
 	}
+	tracef(h.t, "Synced: %v", height)
 
 	return nil
 }
@@ -266,18 +281,26 @@ func (h *Harness) SetUp(createTestChain bool, numMatureOutputs uint32) error {
 // NOTE: This method and SetUp should always be called from the same goroutine
 // as they are not concurrent safe.
 func (h *Harness) TearDown() error {
+	tracef(h.t, "TearDown %p %p", h.Node, h.node)
+	defer tracef(h.t, "TearDown done")
+
 	if h.Node != nil {
+		tracef(h.t, "TearDown: Node")
 		h.Node.Shutdown()
 	}
 
+	tracef(h.t, "TearDown: node")
 	if err := h.node.shutdown(); err != nil {
 		return err
 	}
 
-	if err := os.RemoveAll(h.testNodeDir); err != nil {
-		return err
+	if !(debug || trace) {
+		if err := os.RemoveAll(h.testNodeDir); err != nil {
+			return err
+		}
 	}
 
+	tracef(h.t, "TearDown deleting %v", h.node.pid)
 	delete(testInstances, h.testNodeDir)
 
 	return nil

--- a/rpctest/votingwallet_test.go
+++ b/rpctest/votingwallet_test.go
@@ -82,7 +82,7 @@ func TestMinimalVotingWallet(t *testing.T) {
 		}
 	}
 
-	hn, err := New(net, handlers, extraArgs)
+	hn, err := New(t, net, handlers, extraArgs)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The rpctest suite is useful however it is impossible to debug in its
current state. This diff adds debug and tracing facilities to the test
that are worth keeping.

It adds two global flags `debug` and `trace` that can be enabled when
additional output is required. In addition, it sends the test object
around so that segregated parts of the code use the same logging
facility. And lastly, it will always print `dcrd` panics to the console.