### PR TITLE
connmgr: Fix potential panic via RPC.

### DIFF
--- a/connmgr/connmanager.go
+++ b/connmgr/connmanager.go
@@ -362,6 +362,9 @@ out:
 				var idToRemove uint64
 				var connReq *ConnReq
 				for id, req := range pending {
+					if req == nil || req.Addr == nil {
+						continue
+					}
 					if pendingAddr == req.Addr.String() {
 						idToRemove, connReq = id, req
 						break


### PR DESCRIPTION
req or Addr are potentially not set when the state machine moves to
handleCancelPending. Ignore this case.

Discussed with @davec
