### PR TITLE
wire: Improve error handling.

### DIFF
--- a/wire/common.go
+++ b/wire/common.go
@@ -23,6 +23,12 @@ const (
 	// binaryFreeListMaxItems is the number of buffers to keep in the free
 	// list to use for binary serialization and deserialization.
 	binaryFreeListMaxItems = 1024
+
+	// strictAsciiRangeLower is the lower limit of the strict ASCII range.
+	strictAsciiRangeLower = 0x20
+
+	// strictAsciiRangeUpper is the upper limit of the strict ASCII range.
+	strictAsciiRangeUpper = 0x7e
 )
 
 var (
@@ -704,4 +710,16 @@ func randomUint64(r io.Reader) (uint64, error) {
 // RandomUint64 returns a cryptographically random uint64 value.
 func RandomUint64() (uint64, error) {
 	return randomUint64(rand.Reader)
+}
+
+// isStrictAscii determines returns true if the provided string only contains
+// runes that are within the strict ASCII range.
+func isStrictAscii(s string) bool {
+	for _, r := range s {
+		if r < strictAsciiRangeLower || r > strictAsciiRangeUpper {
+			return false
+		}
+	}
+
+	return true
 }

--- a/wire/message.go
+++ b/wire/message.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"unicode/utf8"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 )
@@ -326,7 +325,7 @@ func ReadMessageN(r io.Reader, pver uint32, dcrnet CurrencyNet) (int, Message, [
 
 	// Check for malformed commands.
 	command := hdr.command
-	if !utf8.ValidString(command) {
+	if !isStrictAscii(command) {
 		discardInput(r, hdr.length)
 		msg := fmt.Sprintf("invalid command %v", []byte(command))
 		return totalBytes, nil, nil, messageError(op, ErrMalformedCmd, msg)


### PR DESCRIPTION
This updates the error handling in the `wire` package to be more consistent with the rest of the code base, tightens some of the error handling in message parsing to harden the protocol, and adds tests to ensure the error implementations works correctly with the standard library `errors.Is` and `errors.As` functions introduced in Go 1.13.

In particular, the error code semantics have been changed so the first error starts at 0 instead of treating 0 is a sentinel "no error" value because it goes against Go best practices which designed the errors specifically to avoid the use of sentinel values.  Further, the use of 0 as a sentinel means that there are two different ways to indicate "no error", namely nil and an error code of zero.  Thus callers have to know that they need to check for both conditions which is incredibly error prone.  In fact, there is already at least one instance in the code base that has that mistake in the tests.

Finally, while here, this hardens the protocol by enforcing more strict parsing requirements lower in the software stack instead of relying on upper layers to take care of it.