### PR TITLE
peer: Set a default idle timeout if not specified.

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -60,6 +60,11 @@ const (
 	// trickleTimeout is the duration of the ticker which trickles down the
 	// inventory to a peer.
 	trickleTimeout = 500 * time.Millisecond
+
+	// defaultIdleTimeout is the default duration of inactivity before a peer is
+	// timed out when a peer is created with the idle timeout configuration
+	// option set to 0.
+	defaultIdleTimeout = 120 * time.Second
 )
 
 var (
@@ -2070,6 +2075,11 @@ func newPeerBase(cfgOrig *Config, inbound bool) *Peer {
 	// testnet.
 	if cfg.Net == 0 {
 		cfg.Net = wire.TestNet3
+	}
+
+	// Set a default idle timeout if the caller did not specify one.
+	if cfg.IdleTimeout == 0 {
+		cfg.IdleTimeout = defaultIdleTimeout
 	}
 
 	p := Peer{


### PR DESCRIPTION
This modifies the peer initialization code to set a default idle timeout of two minutes if the caller did not specify one.

This is desirable since the default is the zero value otherwise, which results in an immediate disconnection for callers that don't specify a timeout.

It is worth noting that the server code already has a default setting that can be configured via the command-line or a configuration file which is used to configure the peers, so this has no effect on `dcrd`, but it is a nice addition for other consumers of the peer package.