### PR TITLE
wire: Use new errors.Is capabilities in tests.

### DIFF
--- a/wire/msgblock_test.go
+++ b/wire/msgblock_test.go
@@ -499,10 +499,10 @@ func TestBlockOverflowErrors(t *testing.T) {
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 				0x5c, 0xa1, 0xab, 0x1e, //StakeVersion
+				0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 				0xff, // TxnCount
-			}, pver, &MessageError{},
+			}, pver, ErrTooManyTxs,
 		},
 	}
 
@@ -512,27 +512,27 @@ func TestBlockOverflowErrors(t *testing.T) {
 		var msg MsgBlock
 		r := bytes.NewReader(test.buf)
 		err := msg.BtcDecode(r, test.pver)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.err) {
-			t.Errorf("BtcDecode #%d wrong error got: %v, want: %v",
-				i, err, reflect.TypeOf(test.err))
+		if !errors.Is(err, test.err) {
+			t.Errorf("BtcDecode #%d wrong error got: %v, want: %v", i, err,
+				test.err)
 			continue
 		}
 
 		// Deserialize from wire format.
 		r = bytes.NewReader(test.buf)
 		err = msg.Deserialize(r)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.err) {
-			t.Errorf("Deserialize #%d wrong error got: %v, want: %v",
-				i, err, reflect.TypeOf(test.err))
+		if !errors.Is(err, test.err) {
+			t.Errorf("Deserialize #%d wrong error got: %v, want: %v", i, err,
+				test.err)
 			continue
 		}
 
 		// Deserialize with transaction location info from wire format.
 		br := bytes.NewBuffer(test.buf)
 		_, _, err = msg.DeserializeTxLoc(br)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.err) {
-			t.Errorf("DeserializeTxLoc #%d wrong error got: %v, "+
-				"want: %v", i, err, reflect.TypeOf(test.err))
+		if !errors.Is(err, test.err) {
+			t.Errorf("DeserializeTxLoc #%d wrong error got: %v, want: %v", i,
+				err, test.err)
 			continue
 		}
 	}

--- a/wire/msgcfilterv2_test.go
+++ b/wire/msgcfilterv2_test.go
@@ -215,7 +215,6 @@ func TestCFilterV2Wire(t *testing.T) {
 // decode of MsgCFilterV2 to confirm error paths work correctly.
 func TestCFilterV2WireErrors(t *testing.T) {
 	pver := ProtocolVersion
-	wireErr := &MessageError{}
 
 	// Message with valid mock values.
 	baseCFilterV2 := baseMsgCFilterV2(t)
@@ -297,9 +296,9 @@ func TestCFilterV2WireErrors(t *testing.T) {
 		// Force error in middle of first proof hash.
 		{baseCFilterV2, baseCFilterV2Encoded, pver, 77, io.ErrShortWrite, io.ErrUnexpectedEOF},
 		// Force error with greater than max filter data.
-		{maxDataCFilterV2, maxDataCFilterV2Encoded, pver, 37, wireErr, wireErr},
+		{maxDataCFilterV2, maxDataCFilterV2Encoded, pver, 37, ErrFilterTooLarge, ErrVarBytesTooLong},
 		// Force error with greater than max proof hashes.
-		{maxHashesCFilterV2, maxHashesCFilterV2Encoded, pver, 67, wireErr, wireErr},
+		{maxHashesCFilterV2, maxHashesCFilterV2Encoded, pver, 67, ErrTooManyProofs, ErrTooManyProofs},
 	}
 
 	t.Logf("Running %d tests", len(tests))
@@ -307,41 +306,20 @@ func TestCFilterV2WireErrors(t *testing.T) {
 		// Encode to wire format.
 		w := newFixedWriter(test.max)
 		err := test.in.BtcEncode(w, test.pver)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.writeErr) {
+		if !errors.Is(err, test.writeErr) {
 			t.Errorf("BtcEncode #%d wrong error got: %v, want: %v", i, err,
 				test.writeErr)
 			continue
-		}
-
-		// For errors which are not of type MessageError, check them for
-		// equality.
-		var merr *MessageError
-		if !errors.As(err, &merr) {
-			if !errors.Is(err, test.writeErr) {
-				t.Errorf("BtcEncode #%d wrong error got: %v, want: %v", i, err,
-					test.writeErr)
-				continue
-			}
 		}
 
 		// Decode from wire format.
 		var msg MsgCFilterV2
 		r := newFixedReader(test.max, test.buf)
 		err = msg.BtcDecode(r, test.pver)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.readErr) {
+		if !errors.Is(err, test.readErr) {
 			t.Errorf("BtcDecode #%d wrong error got: %v, want: %v", i, err,
 				test.readErr)
 			continue
-		}
-
-		// For errors which are not of type MessageError, check them for
-		// equality.
-		if !errors.As(err, &merr) {
-			if !errors.Is(err, test.readErr) {
-				t.Errorf("BtcDecode #%d wrong error got: %v, want: %v", i, err,
-					test.readErr)
-				continue
-			}
 		}
 	}
 }

--- a/wire/msgcftypes_test.go
+++ b/wire/msgcftypes_test.go
@@ -168,7 +168,6 @@ func TestCFTypesWire(t *testing.T) {
 func TestCFTypesWireErrors(t *testing.T) {
 	pver := ProtocolVersion
 	oldPver := NodeCFVersion - 1
-	wireErr := &MessageError{}
 
 	// Valid MsgCFTypes with its encoded format.
 	baseCf := NewMsgCFTypes([]FilterType{GCSFilterExtended})
@@ -201,8 +200,8 @@ func TestCFTypesWireErrors(t *testing.T) {
 		readErr  error       // Expected read error
 	}{
 		// Error in old protocol version with and without enough buffer.
-		{baseCf, baseCfEncoded, oldPver, 0, wireErr, wireErr},
-		{baseCf, baseCfEncoded, oldPver, 100, wireErr, wireErr},
+		{baseCf, baseCfEncoded, oldPver, 0, ErrMsgInvalidForPVer, ErrMsgInvalidForPVer},
+		{baseCf, baseCfEncoded, oldPver, 100, ErrMsgInvalidForPVer, ErrMsgInvalidForPVer},
 
 		// Force error in count of filter types.
 		{baseCf, baseCfEncoded, pver, 0, io.ErrShortWrite, io.EOF},
@@ -210,7 +209,7 @@ func TestCFTypesWireErrors(t *testing.T) {
 		{baseCf, baseCfEncoded, pver, 1, io.ErrShortWrite, io.EOF},
 
 		// Error for maximum allowed filter types with enough buffer.
-		{maxCf, cfInvalidEncoded, pver, 1000, wireErr, wireErr},
+		{maxCf, cfInvalidEncoded, pver, 1000, ErrTooManyFilterTypes, ErrTooManyFilterTypes},
 	}
 
 	t.Logf("Running %d tests", len(tests))
@@ -218,41 +217,20 @@ func TestCFTypesWireErrors(t *testing.T) {
 		// Encode to wire format.
 		w := newFixedWriter(test.max)
 		err := test.in.BtcEncode(w, test.pver)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.writeErr) {
-			t.Errorf("BtcEncode #%d wrong error got: %v, want: %v",
-				i, err, test.writeErr)
+		if !errors.Is(err, test.writeErr) {
+			t.Errorf("BtcEncode #%d wrong error got: %v, want: %v", i, err,
+				test.writeErr)
 			continue
-		}
-
-		// For errors which are not of type MessageError, check them for
-		// equality.
-		var merr *MessageError
-		if !errors.As(err, &merr) {
-			if !errors.Is(err, test.writeErr) {
-				t.Errorf("BtcEncode #%d wrong error got: %v, "+
-					"want: %v", i, err, test.writeErr)
-				continue
-			}
 		}
 
 		// Decode from wire format.
 		var msg MsgCFTypes
 		r := newFixedReader(test.max, test.buf)
 		err = msg.BtcDecode(r, test.pver)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.readErr) {
-			t.Errorf("BtcDecode #%d wrong error got: %v, want: %v",
-				i, err, test.readErr)
+		if !errors.Is(err, test.readErr) {
+			t.Errorf("BtcDecode #%d wrong error got: %v, want: %v", i, err,
+				test.readErr)
 			continue
-		}
-
-		// For errors which are not of type MessageError, check them for
-		// equality.
-		if !errors.As(err, &merr) {
-			if !errors.Is(err, test.readErr) {
-				t.Errorf("BtcDecode #%d wrong error got: %v, "+
-					"want: %v %s", i, err, test.readErr, msg)
-				continue
-			}
 		}
 	}
 }
@@ -261,7 +239,6 @@ func TestCFTypesWireErrors(t *testing.T) {
 // of CFTypes to confirm malformed encoded data doesn't pass through.
 func TestCFTypesMalformedErrors(t *testing.T) {
 	pver := ProtocolVersion
-	wireErr := &MessageError{}
 
 	tests := []struct {
 		buf []byte // Wire malformed encoded data
@@ -279,7 +256,7 @@ func TestCFTypesMalformedErrors(t *testing.T) {
 			[]byte{
 				0xfd, 0x01, 0x01, // Varint for number of filter types (257)
 				0x01, // A sample of filter type
-			}, wireErr,
+			}, ErrTooManyFilterTypes,
 		},
 
 		// Malformed varint.
@@ -287,7 +264,7 @@ func TestCFTypesMalformedErrors(t *testing.T) {
 			[]byte{
 				0xfd, 0x01, 0x00, // Invalid varint
 				0x01, // A sample of filter type
-			}, wireErr,
+			}, ErrNonCanonicalVarInt,
 		},
 	}
 
@@ -297,21 +274,10 @@ func TestCFTypesMalformedErrors(t *testing.T) {
 		var msg MsgCFTypes
 		rbuf := bytes.NewReader(test.buf)
 		err := msg.BtcDecode(rbuf, pver)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.err) {
-			t.Errorf("BtcDecode #%d wrong error got: %v, want: %v",
-				i, err, test.err)
+		if !errors.Is(err, test.err) {
+			t.Errorf("BtcDecode #%d wrong error got: %v, want: %v", i, err,
+				test.err)
 			continue
-		}
-
-		// For errors which are not of type MessageError, check them for
-		// equality.
-		var merr *MessageError
-		if !errors.As(err, &merr) {
-			if !errors.Is(err, test.err) {
-				t.Errorf("BtcDecode #%d wrong error got: %v, "+
-					"want: %v %s", i, err, test.err, msg)
-				continue
-			}
 		}
 	}
 }

--- a/wire/msggetblocks_test.go
+++ b/wire/msggetblocks_test.go
@@ -211,7 +211,6 @@ func TestGetBlocksWireErrors(t *testing.T) {
 	// specifically here instead of the latest because the test data is
 	// using bytes encoded with that protocol version.
 	pver := uint32(60002)
-	wireErr := &MessageError{}
 
 	// Block 99499 hash.
 	hashStr := "2710f40c87ec93d010a6fd95f42c59a2cbacc60b18cf6b7957535"
@@ -286,7 +285,7 @@ func TestGetBlocksWireErrors(t *testing.T) {
 		// Force error in stop hash.
 		{baseGetBlocks, baseGetBlocksEncoded, pver, 69, io.ErrShortWrite, io.EOF},
 		// Force error with greater than max block locator hashes.
-		{maxGetBlocks, maxGetBlocksEncoded, pver, 7, wireErr, wireErr},
+		{maxGetBlocks, maxGetBlocksEncoded, pver, 7, ErrTooManyLocators, ErrTooManyLocators},
 	}
 
 	t.Logf("Running %d tests", len(tests))
@@ -294,41 +293,20 @@ func TestGetBlocksWireErrors(t *testing.T) {
 		// Encode to wire format.
 		w := newFixedWriter(test.max)
 		err := test.in.BtcEncode(w, test.pver)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.writeErr) {
-			t.Errorf("BtcEncode #%d wrong error got: %v, want: %v",
-				i, err, test.writeErr)
+		if !errors.Is(err, test.writeErr) {
+			t.Errorf("BtcEncode #%d wrong error got: %v, want: %v", i, err,
+				test.writeErr)
 			continue
-		}
-
-		// For errors which are not of type MessageError, check them for
-		// equality.
-		var merr *MessageError
-		if !errors.As(err, &merr) {
-			if !errors.Is(err, test.writeErr) {
-				t.Errorf("BtcEncode #%d wrong error got: %v, "+
-					"want: %v", i, err, test.writeErr)
-				continue
-			}
 		}
 
 		// Decode from wire format.
 		var msg MsgGetBlocks
 		r := newFixedReader(test.max, test.buf)
 		err = msg.BtcDecode(r, test.pver)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.readErr) {
-			t.Errorf("BtcDecode #%d wrong error got: %v, want: %v",
-				i, err, test.readErr)
+		if !errors.Is(err, test.readErr) {
+			t.Errorf("BtcDecode #%d wrong error got: %v, want: %v", i, err,
+				test.readErr)
 			continue
-		}
-
-		// For errors which are not of type MessageError, check them for
-		// equality.
-		if !errors.As(err, &merr) {
-			if !errors.Is(err, test.readErr) {
-				t.Errorf("BtcDecode #%d wrong error got: %v, "+
-					"want: %v", i, err, test.readErr)
-				continue
-			}
 		}
 	}
 }

--- a/wire/msggetcfheaders.go
+++ b/wire/msggetcfheaders.go
@@ -42,7 +42,7 @@ func (msg *MsgGetCFHeaders) BtcDecode(r io.Reader, pver uint32) error {
 	if pver < NodeCFVersion {
 		msg := fmt.Sprintf("getcfheaders message invalid for protocol "+
 			"version %d", pver)
-		return messageError(op, ErrTooManyAddrs, msg)
+		return messageError(op, ErrMsgInvalidForPVer, msg)
 	}
 
 	// Read num block locator hashes and limit to max.

--- a/wire/msggetcfilterv2_test.go
+++ b/wire/msggetcfilterv2_test.go
@@ -207,41 +207,20 @@ func TestGetCFilterV2WireErrors(t *testing.T) {
 		// Encode to wire format.
 		w := newFixedWriter(test.max)
 		err := test.in.BtcEncode(w, test.pver)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.writeErr) {
+		if !errors.Is(err, test.writeErr) {
 			t.Errorf("BtcEncode #%d wrong error got: %v, want: %v", i, err,
 				test.writeErr)
 			continue
-		}
-
-		// For errors which are not of type MessageError, check them for
-		// equality.
-		var merr *MessageError
-		if !errors.As(err, &merr) {
-			if !errors.Is(err, test.writeErr) {
-				t.Errorf("BtcEncode #%d wrong error got: %v, want: %v", i, err,
-					test.writeErr)
-				continue
-			}
 		}
 
 		// Decode from wire format.
 		var msg MsgGetCFilterV2
 		r := newFixedReader(test.max, test.buf)
 		err = msg.BtcDecode(r, test.pver)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.readErr) {
+		if !errors.Is(err, test.readErr) {
 			t.Errorf("BtcDecode #%d wrong error got: %v, want: %v", i, err,
 				test.readErr)
 			continue
-		}
-
-		// For errors which are not of type MessageError, check them for
-		// equality.
-		if !errors.As(err, &merr) {
-			if !errors.Is(err, test.readErr) {
-				t.Errorf("BtcDecode #%d wrong error got: %v, want: %v", i, err,
-					test.readErr)
-				continue
-			}
 		}
 	}
 }

--- a/wire/msggetdata_test.go
+++ b/wire/msggetdata_test.go
@@ -179,7 +179,6 @@ func TestGetDataWire(t *testing.T) {
 // of MsgGetData to confirm error paths work correctly.
 func TestGetDataWireErrors(t *testing.T) {
 	pver := ProtocolVersion
-	wireErr := &MessageError{}
 
 	// Block 203707 hash.
 	hashStr := "3264bc2ac36a60840790ba1d475d01367e7c723da941069e9dc"
@@ -227,7 +226,7 @@ func TestGetDataWireErrors(t *testing.T) {
 		// Force error in inventory list.
 		{baseGetData, baseGetDataEncoded, pver, 1, io.ErrShortWrite, io.EOF},
 		// Force error with greater than max inventory vectors.
-		{maxGetData, maxGetDataEncoded, pver, 3, wireErr, wireErr},
+		{maxGetData, maxGetDataEncoded, pver, 3, ErrTooManyVectors, ErrTooManyVectors},
 	}
 
 	t.Logf("Running %d tests", len(tests))
@@ -235,41 +234,20 @@ func TestGetDataWireErrors(t *testing.T) {
 		// Encode to wire format.
 		w := newFixedWriter(test.max)
 		err := test.in.BtcEncode(w, test.pver)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.writeErr) {
-			t.Errorf("BtcEncode #%d wrong error got: %v, want: %v",
-				i, err, test.writeErr)
+		if !errors.Is(err, test.writeErr) {
+			t.Errorf("BtcEncode #%d wrong error got: %v, want: %v", i, err,
+				test.writeErr)
 			continue
-		}
-
-		// For errors which are not of type MessageError, check them for
-		// equality.
-		var merr *MessageError
-		if !errors.As(err, &merr) {
-			if !errors.Is(err, test.writeErr) {
-				t.Errorf("BtcEncode #%d wrong error got: %v, "+
-					"want: %v", i, err, test.writeErr)
-				continue
-			}
 		}
 
 		// Decode from wire format.
 		var msg MsgGetData
 		r := newFixedReader(test.max, test.buf)
 		err = msg.BtcDecode(r, test.pver)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.readErr) {
-			t.Errorf("BtcDecode #%d wrong error got: %v, want: %v",
-				i, err, test.readErr)
+		if !errors.Is(err, test.readErr) {
+			t.Errorf("BtcDecode #%d wrong error got: %v, want: %v", i, err,
+				test.readErr)
 			continue
-		}
-
-		// For errors which are not of type MessageError, check them for
-		// equality.
-		if !errors.As(err, &merr) {
-			if !errors.Is(err, test.readErr) {
-				t.Errorf("BtcDecode #%d wrong error got: %v, "+
-					"want: %v", i, err, test.readErr)
-				continue
-			}
 		}
 	}
 }

--- a/wire/msginv_test.go
+++ b/wire/msginv_test.go
@@ -179,7 +179,6 @@ func TestInvWire(t *testing.T) {
 // of MsgInv to confirm error paths work correctly.
 func TestInvWireErrors(t *testing.T) {
 	pver := ProtocolVersion
-	wireErr := &MessageError{}
 
 	// Block 203707 hash.
 	hashStr := "3264bc2ac36a60840790ba1d475d01367e7c723da941069e9dc"
@@ -227,7 +226,7 @@ func TestInvWireErrors(t *testing.T) {
 		// Force error in inventory list.
 		{baseInv, baseInvEncoded, pver, 1, io.ErrShortWrite, io.EOF},
 		// Force error with greater than max inventory vectors.
-		{maxInv, maxInvEncoded, pver, 3, wireErr, wireErr},
+		{maxInv, maxInvEncoded, pver, 3, ErrTooManyVectors, ErrTooManyVectors},
 	}
 
 	t.Logf("Running %d tests", len(tests))
@@ -235,41 +234,20 @@ func TestInvWireErrors(t *testing.T) {
 		// Encode to wire format.
 		w := newFixedWriter(test.max)
 		err := test.in.BtcEncode(w, test.pver)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.writeErr) {
-			t.Errorf("BtcEncode #%d wrong error got: %v, want: %v",
-				i, err, test.writeErr)
+		if !errors.Is(err, test.writeErr) {
+			t.Errorf("BtcEncode #%d wrong error got: %v, want: %v", i, err,
+				test.writeErr)
 			continue
-		}
-
-		// For errors which are not of type MessageError, check them for
-		// equality.
-		var merr *MessageError
-		if !errors.As(err, &merr) {
-			if !errors.Is(err, test.writeErr) {
-				t.Errorf("BtcEncode #%d wrong error got: %v, "+
-					"want: %v", i, err, test.writeErr)
-				continue
-			}
 		}
 
 		// Decode from wire format.
 		var msg MsgInv
 		r := newFixedReader(test.max, test.buf)
 		err = msg.BtcDecode(r, test.pver)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.readErr) {
-			t.Errorf("BtcDecode #%d wrong error got: %v, want: %v",
-				i, err, test.readErr)
+		if !errors.Is(err, test.readErr) {
+			t.Errorf("BtcDecode #%d wrong error got: %v, want: %v", i, err,
+				test.readErr)
 			continue
-		}
-
-		// For errors which are not of type MessageError, check them for
-		// equality.
-		if !errors.As(err, &merr) {
-			if !errors.Is(err, test.readErr) {
-				t.Errorf("BtcDecode #%d wrong error got: %v, "+
-					"want: %v", i, err, test.readErr)
-				continue
-			}
 		}
 	}
 }

--- a/wire/msgpong_test.go
+++ b/wire/msgpong_test.go
@@ -149,41 +149,20 @@ func TestPongWireErrors(t *testing.T) {
 		// Encode to wire format.
 		w := newFixedWriter(test.max)
 		err := test.in.BtcEncode(w, test.pver)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.writeErr) {
-			t.Errorf("BtcEncode #%d wrong error got: %v, want: %v",
-				i, err, test.writeErr)
+		if !errors.Is(err, test.writeErr) {
+			t.Errorf("BtcEncode #%d wrong error got: %v, want: %v", i, err,
+				test.writeErr)
 			continue
-		}
-
-		// For errors which are not of type MessageError, check them for
-		// equality.
-		var merr *MessageError
-		if !errors.As(err, &merr) {
-			if !errors.Is(err, test.writeErr) {
-				t.Errorf("BtcEncode #%d wrong error got: %v, "+
-					"want: %v", i, err, test.writeErr)
-				continue
-			}
 		}
 
 		// Decode from wire format.
 		var msg MsgPong
 		r := newFixedReader(test.max, test.buf)
 		err = msg.BtcDecode(r, test.pver)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.readErr) {
-			t.Errorf("BtcDecode #%d wrong error got: %v, want: %v",
-				i, err, test.readErr)
+		if !errors.Is(err, test.readErr) {
+			t.Errorf("BtcDecode #%d wrong error got: %v, want: %v", i, err,
+				test.readErr)
 			continue
-		}
-
-		// For errors which are not of type MessageError, check them for
-		// equality.
-		if !errors.As(err, &merr) {
-			if !errors.Is(err, test.readErr) {
-				t.Errorf("BtcDecode #%d wrong error got: %v, "+
-					"want: %v", i, err, test.readErr)
-				continue
-			}
 		}
 	}
 }

--- a/wire/msgreject_test.go
+++ b/wire/msgreject_test.go
@@ -238,41 +238,20 @@ func TestRejectWireErrors(t *testing.T) {
 		// Encode to wire format.
 		w := newFixedWriter(test.max)
 		err := test.in.BtcEncode(w, test.pver)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.writeErr) {
-			t.Errorf("BtcEncode #%d wrong error got: %v, want: %v",
-				i, err, test.writeErr)
+		if !errors.Is(err, test.writeErr) {
+			t.Errorf("BtcEncode #%d wrong error got: %v, want: %v", i, err,
+				test.writeErr)
 			continue
-		}
-
-		// For errors which are not of type MessageError, check them for
-		// equality.
-		var merr *MessageError
-		if !errors.As(err, &merr) {
-			if !errors.Is(err, test.writeErr) {
-				t.Errorf("BtcEncode #%d wrong error got: %v, "+
-					"want: %v", i, err, test.writeErr)
-				continue
-			}
 		}
 
 		// Decode from wire format.
 		var msg MsgReject
 		r := newFixedReader(test.max, test.buf)
 		err = msg.BtcDecode(r, test.pver)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.readErr) {
-			t.Errorf("BtcDecode #%d wrong error got: %v, want: %v",
-				i, err, test.readErr)
+		if !errors.Is(err, test.readErr) {
+			t.Errorf("BtcDecode #%d wrong error got: %v, want: %v", i, err,
+				test.readErr)
 			continue
-		}
-
-		// For errors which are not of type MessageError, check them for
-		// equality.
-		if !errors.As(err, &merr) {
-			if !errors.Is(err, test.readErr) {
-				t.Errorf("BtcDecode #%d wrong error got: %v, "+
-					"want: %v", i, err, test.readErr)
-				continue
-			}
 		}
 	}
 }

--- a/wire/msgversion_test.go
+++ b/wire/msgversion_test.go
@@ -87,10 +87,9 @@ func TestVersion(t *testing.T) {
 	// accounting for ":", "/"
 	err = msg.AddUserAgent(strings.Repeat("t",
 		MaxUserAgentLen-len(customUserAgent)-2+1), "")
-	var merr *MessageError
-	if !errors.As(err, &merr) {
-		t.Errorf("AddUserAgent: expected error not received "+
-			"- got %v, want %T", err, MessageError{})
+	if !errors.Is(err, ErrUserAgentTooLong) {
+		t.Errorf("AddUserAgent: expected error not received - got %v, want %v",
+			err, ErrUserAgentTooLong)
 	}
 
 	// Version message should not have any services set by default.
@@ -250,7 +249,6 @@ func TestVersionWireErrors(t *testing.T) {
 	// because the test data is using bytes encoded with that protocol
 	// version.
 	pver := uint32(60002)
-	wireErr := &MessageError{}
 
 	// Ensure calling MsgVersion.BtcDecode with a non *bytes.Buffer returns
 	// error.
@@ -311,7 +309,7 @@ func TestVersionWireErrors(t *testing.T) {
 		// Force error in last block.
 		{baseVersion, baseVersionEncoded, pver, 98, io.ErrShortWrite, io.ErrUnexpectedEOF},
 		// Force error due to user agent too big
-		{exceedUAVer, exceedUAVerEncoded, pver, newLen, wireErr, wireErr},
+		{exceedUAVer, exceedUAVerEncoded, pver, newLen, ErrUserAgentTooLong, ErrUserAgentTooLong},
 	}
 
 	t.Logf("Running %d tests", len(tests))
@@ -319,41 +317,20 @@ func TestVersionWireErrors(t *testing.T) {
 		// Encode to wire format.
 		w := newFixedWriter(test.max)
 		err := test.in.BtcEncode(w, test.pver)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.writeErr) {
-			t.Errorf("BtcEncode #%d wrong error got: %v, want: %v",
-				i, err, test.writeErr)
+		if !errors.Is(err, test.writeErr) {
+			t.Errorf("BtcEncode #%d wrong error got: %v, want: %v", i, err,
+				test.writeErr)
 			continue
-		}
-
-		// For errors which are not of type MessageError, check them for
-		// equality.
-		var merr *MessageError
-		if !errors.As(err, &merr) {
-			if !errors.Is(err, test.writeErr) {
-				t.Errorf("BtcEncode #%d wrong error got: %v, "+
-					"want: %v", i, err, test.writeErr)
-				continue
-			}
 		}
 
 		// Decode from wire format.
 		var msg MsgVersion
 		buf := bytes.NewBuffer(test.buf[0:test.max])
 		err = msg.BtcDecode(buf, test.pver)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.readErr) {
-			t.Errorf("BtcDecode #%d wrong error got: %v, want: %v",
-				i, err, test.readErr)
+		if !errors.Is(err, test.readErr) {
+			t.Errorf("BtcDecode #%d wrong error got: %v, want: %v", i, err,
+				test.readErr)
 			continue
-		}
-
-		// For errors which are not of type MessageError, check them for
-		// equality.
-		if !errors.As(err, &merr) {
-			if !errors.Is(err, test.readErr) {
-				t.Errorf("BtcDecode #%d wrong error got: %v, "+
-					"want: %v", i, err, test.readErr)
-				continue
-			}
 		}
 	}
 }


### PR DESCRIPTION
The error handling in the tests for the `wire` package were recently updated to make use of the new `errors.Is` and `errors.As` standard library functions introduced in Go 1.13, but they were only updated mechanically as opposed to being updated to use the new capabilities of `errors.Is` checking for a specific error code as opposed to just the error type.

Consequently, this updates the tests to remove all of the additional type checking via `errors.As` and instead look for the exact expected error code via `errors.Is`.  This change is desirable since only examining the type of error doesn't prove that the test is actually hitting the specific error it intends too, rather only that it is hitting an error of the same type.

It also corrects a couple of tests and error returns that were discovered to be incorrect in the process.