### PR TITLE
wire: Test no-relay case in TestVersionWire

### DIFF
--- a/wire/msgversion_test.go
+++ b/wire/msgversion_test.go
@@ -204,6 +204,12 @@ func TestVersionWire(t *testing.T) {
 			baseVersionBIP0037Encoded,
 			ProtocolVersion,
 		},
+		{
+			verRelayTxFalse,
+			verRelayTxFalse,
+			verRelayTxFalseEncoded,
+			ProtocolVersion,
+		},
 	}
 
 	t.Logf("Running %d tests", len(tests))


### PR DESCRIPTION
The structs were created for testing the `DisableRelayTx = true` case, but they weren't being used. Linter didn't pick up on it because they were being modified.