### PR TITLE
server: Remove unused interrupt chan param.

### DIFF
--- a/dcrd.go
+++ b/dcrd.go
@@ -178,7 +178,7 @@ func dcrdMain() error {
 	// Create server and start it.
 	lifetimeNotifier.notifyStartupEvent(lifetimeEventP2PServer)
 	svr, err := newServer(ctx, cfg.Listeners, db, cfg.params.Params,
-		cfg.DataDir, ctx.Done())
+		cfg.DataDir)
 	if err != nil {
 		dcrdLog.Errorf("Unable to start server: %v", err)
 		return err

--- a/server.go
+++ b/server.go
@@ -2778,7 +2778,7 @@ func setupRPCListeners() ([]net.Listener, error) {
 // newServer returns a new dcrd server configured to listen on addr for the
 // decred network type specified by chainParams.  Use start to begin accepting
 // connections from peers.
-func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainParams *chaincfg.Params, dataDir string, interrupt <-chan struct{}) (*server, error) {
+func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainParams *chaincfg.Params, dataDir string) (*server, error) {
 	services := defaultServices
 	if cfg.NoCFilters {
 		services &^= wire.SFNodeCF


### PR DESCRIPTION
This removes the `interrupt` channel parameter from the `newServer` function since it is no longer used due to the use of contexts instead.