### PR TITLE
connmgr: Remove deprecated funcs and types.

### DIFF
--- a/connmgr/log.go
+++ b/connmgr/log.go
@@ -13,14 +13,6 @@ import "github.com/decred/slog"
 // The default amount of logging is none.
 var log = slog.Disabled
 
-// DisableLog disables all library log output.  Logging output is disabled
-// by default until UseLogger is called.
-//
-// Deprecated: Use UseLogger(slog.Disabled) instead.
-func DisableLog() {
-	log = slog.Disabled
-}
-
 // UseLogger uses a specified Logger to output package logging info.
 // This should be used in preference to SetLogWriter if the caller is also
 // using slog.

--- a/connmgr/tor.go
+++ b/connmgr/tor.go
@@ -56,13 +56,6 @@ var (
 	}
 )
 
-// TorLookupIP uses Tor to resolve DNS via the passed SOCKS proxy.
-//
-// Deprecated: use TorLookupIPContext instead.
-func TorLookupIP(host, proxy string) ([]net.IP, error) {
-	return TorLookupIPContext(context.Background(), host, proxy)
-}
-
 // TorLookupIPContext uses Tor to resolve DNS via the passed SOCKS proxy.
 func TorLookupIPContext(ctx context.Context, host, proxy string) ([]net.IP, error) {
 	var dialer net.Dialer


### PR DESCRIPTION
This removes the deprecated functions and types from the `connmgr` package since the major module version has been bumped since the last release.

It consists of three commits for easier review which combined remove the following deprecated items:

- `DisableLog` function
- `LookupFunc` type
- `SeedFromDNS` function
- `TorLookupIP` function