### PR TITLE
connmgr: Rename TorLookupIPContext to TorLookupIP.

### DIFF
--- a/config.go
+++ b/config.go
@@ -1176,7 +1176,7 @@ func loadConfig() (*config, []string, error) {
 		cfg.dial = proxy.DialContext
 		if !cfg.NoOnion {
 			cfg.lookup = func(host string) ([]net.IP, error) {
-				return connmgr.TorLookupIPContext(context.Background(), host, cfg.Proxy)
+				return connmgr.TorLookupIP(context.Background(), host, cfg.Proxy)
 			}
 		}
 	}
@@ -1216,7 +1216,7 @@ func loadConfig() (*config, []string, error) {
 			return proxy.DialContext(ctx, a, b)
 		}
 		cfg.onionlookup = func(host string) ([]net.IP, error) {
-			return connmgr.TorLookupIPContext(context.Background(), host, cfg.OnionProxy)
+			return connmgr.TorLookupIP(context.Background(), host, cfg.OnionProxy)
 		}
 	} else {
 		cfg.oniondial = cfg.dial

--- a/connmgr/tor.go
+++ b/connmgr/tor.go
@@ -56,8 +56,8 @@ var (
 	}
 )
 
-// TorLookupIPContext uses Tor to resolve DNS via the passed SOCKS proxy.
-func TorLookupIPContext(ctx context.Context, host, proxy string) ([]net.IP, error) {
+// TorLookupIP uses Tor to resolve DNS via the passed SOCKS proxy.
+func TorLookupIP(ctx context.Context, host, proxy string) ([]net.IP, error) {
 	var dialer net.Dialer
 	conn, err := dialer.DialContext(ctx, "tcp", proxy)
 	if err != nil {


### PR DESCRIPTION
**This requires #2187**.

Now that the deprecated non-context version of `TorLookupIP` has been removed, this renames the version that accepts a context to take its place.