### PR TITLE
multi: CancelPending error for no pending conns.

### DIFF
--- a/server.go
+++ b/server.go
@@ -1955,8 +1955,7 @@ func (s *server) handleQuery(state *peerState, querymsg interface{}) {
 			msg.reply <- err
 			return
 		}
-		s.connManager.CancelPending(netAddr)
-		msg.reply <- nil
+		msg.reply <- s.connManager.CancelPending(netAddr)
 	case getOutboundGroup:
 		count, ok := state.outboundGroups[msg.key]
 		if ok {


### PR DESCRIPTION
`connmgr.CancelPending` currently returns no error if there is no pending connection to an address.

This undesired behaviour was uncovered by the node removal rpctests as reported by @davecgh:
```
$ (go install && cd rpctest && go test -tags=rpctest -run=TestHarness)
--- FAIL: TestHarness (1.46s)
    rpc_harness_test.go:202: removeNode on unconnected peers should return an error
FAIL
exit status 1
FAIL    github.com/decred/dcrd/rpctest  2.677s
```