### PR TITLE
docker: Update image to golang:1.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12
+FROM golang:1.14
 
 #
 # NOTE: The RPC server listens on localhost by default.

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,5 +1,5 @@
 # Build image
-FROM golang:1.12
+FROM golang:1.14
 
 #
 # NOTE: The RPC server listens on localhost by default.


### PR DESCRIPTION
The docker builds currently fail on `master` due to go 1.13+ now being required. This PR updates `Dockerfile` and `Dockerfile.alpine` to use `golang:1.14`.