### PR TITLE
dcrutil: Add VerifyMessage API

### DIFF
--- a/dcrutil/util.go
+++ b/dcrutil/util.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2013, 2014 The btcsuite developers
+// Copyright (c) 2015-2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package dcrutil
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/dcrec/secp256k1/v3/ecdsa"
+	"github.com/decred/dcrd/wire"
+)
+
+// VerifyMessage verifies that signature is a valid signature of message and was created
+// using the secp256k1 private key for address.
+func VerifyMessage(address string, signature string, message string, params AddressParams) (bool, error) {
+	// Decode the provided address.  This also ensures the network encoded with
+	// the address matches the network the server is currently on.
+	addr, err := DecodeAddress(address, params)
+	if err != nil {
+		return false, err
+	}
+
+	// Only P2PKH addresses are valid for signing.
+	if _, ok := addr.(*AddressPubKeyHash); !ok {
+		return false, fmt.Errorf("address is not a pay-to-pubkey-hash address")
+	}
+
+	// Decode base64 signature.
+	sig, err := base64.StdEncoding.DecodeString(signature)
+	if err != nil {
+		return false, fmt.Errorf("malformed base64 encoding: %v", err)
+	}
+
+	// Validate the signature - this just shows that it was valid for any pubkey
+	// at all. Whether the pubkey matches is checked below.
+	var buf bytes.Buffer
+	wire.WriteVarString(&buf, 0, "Decred Signed Message:\n")
+	wire.WriteVarString(&buf, 0, message)
+	expectedMessageHash := chainhash.HashB(buf.Bytes())
+	pk, wasCompressed, err := ecdsa.RecoverCompact(sig, expectedMessageHash)
+	if err != nil {
+		return false, err
+	}
+
+	// Reconstruct the address from the recovered pubkey.
+	var serializedPK []byte
+	if wasCompressed {
+		serializedPK = pk.SerializeCompressed()
+	} else {
+		serializedPK = pk.SerializeUncompressed()
+	}
+	recoveredAddr, err := NewAddressSecpPubKey(serializedPK, params)
+	if err != nil {
+		return false, err
+	}
+
+	// Return whether addresses match.
+	return recoveredAddr.Address() == addr.Address(), nil
+}

--- a/dcrutil/util_test.go
+++ b/dcrutil/util_test.go
@@ -33,8 +33,8 @@ func TestVerifyMessage(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		isValid, err := VerifyMessage(test.addr, test.sig, msg, test.params)
-		if (test.isValid && err != nil) || (test.isValid != isValid) {
+		err := VerifyMessage(test.addr, test.sig, msg, test.params)
+		if (test.isValid && err != nil) || (!test.isValid && err == nil) {
 			t.Fatalf("VerifyMessage test #%d failed", i+1)
 		}
 	}

--- a/dcrutil/util_test.go
+++ b/dcrutil/util_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package dcrutil
+
+import (
+	"testing"
+
+	"github.com/decred/dcrd/chaincfg/v3"
+)
+
+func TestVerifyMessage(t *testing.T) {
+	msg := "verifymessage test"
+
+	var tests = []struct {
+		addr    string
+		sig     string
+		params  AddressParams
+		isValid bool
+	}{
+		// valid
+		{"TsdbYVDoh3JsyP6oEg2aHVoTjsFuHzUgGKv", "IITPXfmkfLPULbX9Im3XIyHAKiXRw5N9j6P7qf0MdEP9YQinn51lWjS+8jbTceRxCWckKKssu3ZpQm1xCWKz9GA=", chaincfg.TestNet3Params(), true},
+
+		// wrong address
+		{"TsWeG3TJzucZgYyMfZFC2GhBvbeNfA48LTo", "IITPXfmkfLPULbX9Im3XIyHAKiXRw5N9j6P7qf0MdEP9YQinn51lWjS+8jbTceRxCWckKKssu3ZpQm1xCWKz9GA=", chaincfg.TestNet3Params(), false},
+
+		// wrong signature
+		{"TsdbYVDoh3JsyP6oEg2aHVoTjsFuHzUgGKv", "HxzZggzHMljSWpKHnw1Dow84KGWvTRBCG2JqBM5W4Q7iePW0dirZXCggSeXHVQ26D0MbDFffi3yw+x2Z5nQ94gg=", chaincfg.TestNet3Params(), false},
+
+		// wrong params
+		{"TsdbYVDoh3JsyP6oEg2aHVoTjsFuHzUgGKv", "IITPXfmkfLPULbX9Im3XIyHAKiXRw5N9j6P7qf0MdEP9YQinn51lWjS+8jbTceRxCWckKKssu3ZpQm1xCWKz9GA=", chaincfg.MainNetParams(), false},
+	}
+
+	for i, test := range tests {
+		isValid, err := VerifyMessage(test.addr, test.sig, msg, test.params)
+		if (test.isValid && err != nil) || (test.isValid != isValid) {
+			t.Fatalf("VerifyMessage test #%d failed", i+1)
+		}
+	}
+}


### PR DESCRIPTION
The API can be used to verify signed messages without the need for an RPC connection.