### PR TITLE
connmgr: define connmgr error types.

### DIFF
--- a/connmgr/connmanager.go
+++ b/connmgr/connmanager.go
@@ -7,7 +7,6 @@ package connmgr
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"sync"
@@ -16,12 +15,6 @@ import (
 )
 
 var (
-	// ErrDialNil is used to indicate that Dial cannot be nil in the configuration.
-	ErrDialNil = errors.New("config: dial cannot be nil")
-
-	// ErrBothDialsFilled is used to indicate that Dial and DialAddr cannot both
-	// be specified in the configuration.
-	ErrBothDialsFilled = errors.New("config: cannot specify both Dial and DialAddr")
 
 	// maxRetryDuration is the max duration of time retrying of a persistent
 	// connection is allowed to grow to.  This is necessary since the retry
@@ -679,10 +672,11 @@ func (cm *ConnManager) Run(ctx context.Context) {
 // Use Run to start listening and/or connecting to the network.
 func New(cfg *Config) (*ConnManager, error) {
 	if cfg.Dial == nil && cfg.DialAddr == nil {
-		return nil, ErrDialNil
+		return nil, Error{"dial cannot be nil", ErrDialNil}
 	}
 	if cfg.Dial != nil && cfg.DialAddr != nil {
-		return nil, ErrBothDialsFilled
+		return nil, Error{"cannot specify both Dial and DialAddr",
+			ErrBothDialsFilled}
 	}
 	// Default to sane values
 	if cfg.RetryDuration <= 0 {

--- a/connmgr/error.go
+++ b/connmgr/error.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package connmgr
+
+type Err string
+
+func (e Err) Error() string { return string(e) }
+
+type Error struct {
+	Description string
+	Err         error
+}
+
+func (e Error) Error() string { return e.Description }
+func (e Error) Unwrap() error { return e.Err }
+
+var (
+	// ErrDialNil is used to indicate that Dial cannot be nil in
+	// the configuration.
+	ErrDialNil = Err("ErrDialNil")
+
+	// ErrBothDialsFilled is used to indicate that Dial and DialAddr
+	// cannot both be specified in the configuration.
+	ErrBothDialsFilled = Err("ErrBothDialsFilled")
+
+	// ErrTorInvalidAddressResponse indicates an invalid address was
+	// returned by the Tor DNS resolver.
+	ErrTorInvalidAddressResponse = Err("ErrTorInvalidAddressResponse")
+
+	// ErrTorInvalidProxyResponse indicates the Tor proxy returned a
+	// response in an unexpected format.
+	ErrTorInvalidProxyResponse = Err("ErrTorInvalidProxyResponse")
+
+	// ErrTorUnrecognizedAuthMethod indicates the authentication method
+	// provided is not recognized.
+	ErrTorUnrecognizedAuthMethod = Err("ErrTorUnrecognizedAuthMethod")
+
+	// ErrTorGeneralError indicates a general tor error.
+	ErrTorGeneralError = Err("ErrTorGeneralError")
+
+	// ErrTorNotAllowed indicates tor connections are not allowed.
+	ErrTorNotAllowed = Err("ErrTorNotAllowed")
+
+	// ErrTorNetUnreachable indicates the tor network is unreachable.
+	ErrTorNetUnreachable = Err("ErrTorNetUnreachable")
+
+	// ErrTorHostUnreachable indicates the tor host is unreachable.
+	ErrTorHostUnreachable = Err("ErrTorHostUnreachable")
+
+	// ErrTorConnectionRefused indicates the tor connection was refused.
+	ErrTorConnectionRefused = Err("ErrTorConnectionRefused")
+
+	// ErrTorTTLExpired indicates the tor request Time-To-Live (TTL) expired.
+	ErrTorTTLExpired = Err("ErrTorTTLExpired")
+
+	// ErrTorCmdNotSupported indicates the tor command is not supported.
+	ErrTorCmdNotSupported = Err("ErrTorCmdNotSupported")
+
+	// ErrTorAddrNotSupported indicates the tor address type is not supported.
+	ErrTorAddrNotSupported = Err("ErrTorAddrNotSupported")
+)


### PR DESCRIPTION
This defines the connmgr error types compatible with `errors.Is/As` introduced in go 1.13. This also removes the tor success state from the status error set.

