### PR TITLE
connmgr: Finish recent connmgr err type additions.

### DIFF
--- a/connmgr/connmanager.go
+++ b/connmgr/connmanager.go
@@ -672,11 +672,11 @@ func (cm *ConnManager) Run(ctx context.Context) {
 // Use Run to start listening and/or connecting to the network.
 func New(cfg *Config) (*ConnManager, error) {
 	if cfg.Dial == nil && cfg.DialAddr == nil {
-		return nil, Error{"dial cannot be nil", ErrDialNil}
+		return nil, MakeError(ErrDialNil, "dial cannot be nil")
 	}
 	if cfg.Dial != nil && cfg.DialAddr != nil {
-		return nil, Error{"cannot specify both Dial and DialAddr",
-			ErrBothDialsFilled}
+		return nil, MakeError(ErrBothDialsFilled,
+			"cannot specify both Dial and DialAddr")
 	}
 	// Default to sane values
 	if cfg.RetryDuration <= 0 {

--- a/connmgr/error.go
+++ b/connmgr/error.go
@@ -4,60 +4,81 @@
 
 package connmgr
 
-type Err string
+// ErrorKind identifies a kind of error.  It has full support for errors.Is and
+// errors.As, so the caller can directly check against an error kind when
+// determining the reason for an error.
+type ErrorKind string
 
-func (e Err) Error() string { return string(e) }
+const (
+	// ErrDialNil is used to indicate that Dial cannot be nil in
+	// the configuration.
+	ErrDialNil = ErrorKind("ErrDialNil")
 
+	// ErrBothDialsFilled is used to indicate that Dial and DialAddr
+	// cannot both be specified in the configuration.
+	ErrBothDialsFilled = ErrorKind("ErrBothDialsFilled")
+
+	// ErrTorInvalidAddressResponse indicates an invalid address was
+	// returned by the Tor DNS resolver.
+	ErrTorInvalidAddressResponse = ErrorKind("ErrTorInvalidAddressResponse")
+
+	// ErrTorInvalidProxyResponse indicates the Tor proxy returned a
+	// response in an unexpected format.
+	ErrTorInvalidProxyResponse = ErrorKind("ErrTorInvalidProxyResponse")
+
+	// ErrTorUnrecognizedAuthMethod indicates the authentication method
+	// provided is not recognized.
+	ErrTorUnrecognizedAuthMethod = ErrorKind("ErrTorUnrecognizedAuthMethod")
+
+	// ErrTorGeneralError indicates a general tor error.
+	ErrTorGeneralError = ErrorKind("ErrTorGeneralError")
+
+	// ErrTorNotAllowed indicates tor connections are not allowed.
+	ErrTorNotAllowed = ErrorKind("ErrTorNotAllowed")
+
+	// ErrTorNetUnreachable indicates the tor network is unreachable.
+	ErrTorNetUnreachable = ErrorKind("ErrTorNetUnreachable")
+
+	// ErrTorHostUnreachable indicates the tor host is unreachable.
+	ErrTorHostUnreachable = ErrorKind("ErrTorHostUnreachable")
+
+	// ErrTorConnectionRefused indicates the tor connection was refused.
+	ErrTorConnectionRefused = ErrorKind("ErrTorConnectionRefused")
+
+	// ErrTorTTLExpired indicates the tor request Time-To-Live (TTL) expired.
+	ErrTorTTLExpired = ErrorKind("ErrTorTTLExpired")
+
+	// ErrTorCmdNotSupported indicates the tor command is not supported.
+	ErrTorCmdNotSupported = ErrorKind("ErrTorCmdNotSupported")
+
+	// ErrTorAddrNotSupported indicates the tor address type is not supported.
+	ErrTorAddrNotSupported = ErrorKind("ErrTorAddrNotSupported")
+)
+
+// Error satisfies the error interface and prints human-readable errors.
+func (e ErrorKind) Error() string {
+	return string(e)
+}
+
+// Error identifies an error related to the connection manager error.  It has
+// full support for errors.Is and errors.As, so the caller can ascertain the
+// specific reason for the error by checking the underlying error.
 type Error struct {
 	Description string
 	Err         error
 }
 
-func (e Error) Error() string { return e.Description }
-func (e Error) Unwrap() error { return e.Err }
+// Error satisfies the error interface and prints human-readable errors.
+func (e Error) Error() string {
+	return e.Description
+}
 
-var (
-	// ErrDialNil is used to indicate that Dial cannot be nil in
-	// the configuration.
-	ErrDialNil = Err("ErrDialNil")
+// Unwrap returns the underlying wrapped error.
+func (e Error) Unwrap() error {
+	return e.Err
+}
 
-	// ErrBothDialsFilled is used to indicate that Dial and DialAddr
-	// cannot both be specified in the configuration.
-	ErrBothDialsFilled = Err("ErrBothDialsFilled")
-
-	// ErrTorInvalidAddressResponse indicates an invalid address was
-	// returned by the Tor DNS resolver.
-	ErrTorInvalidAddressResponse = Err("ErrTorInvalidAddressResponse")
-
-	// ErrTorInvalidProxyResponse indicates the Tor proxy returned a
-	// response in an unexpected format.
-	ErrTorInvalidProxyResponse = Err("ErrTorInvalidProxyResponse")
-
-	// ErrTorUnrecognizedAuthMethod indicates the authentication method
-	// provided is not recognized.
-	ErrTorUnrecognizedAuthMethod = Err("ErrTorUnrecognizedAuthMethod")
-
-	// ErrTorGeneralError indicates a general tor error.
-	ErrTorGeneralError = Err("ErrTorGeneralError")
-
-	// ErrTorNotAllowed indicates tor connections are not allowed.
-	ErrTorNotAllowed = Err("ErrTorNotAllowed")
-
-	// ErrTorNetUnreachable indicates the tor network is unreachable.
-	ErrTorNetUnreachable = Err("ErrTorNetUnreachable")
-
-	// ErrTorHostUnreachable indicates the tor host is unreachable.
-	ErrTorHostUnreachable = Err("ErrTorHostUnreachable")
-
-	// ErrTorConnectionRefused indicates the tor connection was refused.
-	ErrTorConnectionRefused = Err("ErrTorConnectionRefused")
-
-	// ErrTorTTLExpired indicates the tor request Time-To-Live (TTL) expired.
-	ErrTorTTLExpired = Err("ErrTorTTLExpired")
-
-	// ErrTorCmdNotSupported indicates the tor command is not supported.
-	ErrTorCmdNotSupported = Err("ErrTorCmdNotSupported")
-
-	// ErrTorAddrNotSupported indicates the tor address type is not supported.
-	ErrTorAddrNotSupported = Err("ErrTorAddrNotSupported")
-)
+// MakeError creates an Error given a set of arguments.
+func MakeError(kind ErrorKind, desc string) Error {
+	return Error{Err: kind, Description: desc}
+}

--- a/connmgr/error_test.go
+++ b/connmgr/error_test.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package connmgr
+
+import (
+	"errors"
+	"io"
+	"testing"
+)
+
+// TestErrorKindStringer tests the stringized output for the ErrorKind type.
+func TestErrorKindStringer(t *testing.T) {
+	tests := []struct {
+		in   ErrorKind
+		want string
+	}{
+		{ErrDialNil, "ErrDialNil"},
+		{ErrBothDialsFilled, "ErrBothDialsFilled"},
+		{ErrTorInvalidAddressResponse, "ErrTorInvalidAddressResponse"},
+		{ErrTorInvalidProxyResponse, "ErrTorInvalidProxyResponse"},
+		{ErrTorUnrecognizedAuthMethod, "ErrTorUnrecognizedAuthMethod"},
+		{ErrTorGeneralError, "ErrTorGeneralError"},
+		{ErrTorNotAllowed, "ErrTorNotAllowed"},
+		{ErrTorNetUnreachable, "ErrTorNetUnreachable"},
+		{ErrTorHostUnreachable, "ErrTorHostUnreachable"},
+		{ErrTorConnectionRefused, "ErrTorConnectionRefused"},
+		{ErrTorTTLExpired, "ErrTorTTLExpired"},
+		{ErrTorCmdNotSupported, "ErrTorCmdNotSupported"},
+		{ErrTorAddrNotSupported, "ErrTorAddrNotSupported"},
+	}
+
+	for i, test := range tests {
+		result := test.in.Error()
+		if result != test.want {
+			t.Errorf("#%d: got: %s want: %s", i, result, test.want)
+			continue
+		}
+	}
+}
+
+// TestError tests the error output for the Error type.
+func TestError(t *testing.T) {
+	tests := []struct {
+		in   Error
+		want string
+	}{{
+		Error{Description: "some error"},
+		"some error",
+	}, {
+		Error{Description: "human-readable error"},
+		"human-readable error",
+	}}
+
+	for i, test := range tests {
+		result := test.in.Error()
+		if result != test.want {
+			t.Errorf("#%d: got: %s want: %s", i, result, test.want)
+			continue
+		}
+	}
+}
+
+// TestErrorKindIsAs ensures both ErrorKind and Error can be identified as being
+// a specific error kind via errors.Is and unwrapped via errors.As.
+func TestErrorKindIsAs(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		target    error
+		wantMatch bool
+		wantAs    ErrorKind
+	}{{
+		name:      "ErrDialNil == ErrDialNil",
+		err:       ErrDialNil,
+		target:    ErrDialNil,
+		wantMatch: true,
+		wantAs:    ErrDialNil,
+	}, {
+		name:      "Error.ErrDialNil == ErrDialNil",
+		err:       MakeError(ErrDialNil, ""),
+		target:    ErrDialNil,
+		wantMatch: true,
+		wantAs:    ErrDialNil,
+	}, {
+		name:      "Error.ErrDialNil == Error.ErrDialNil",
+		err:       MakeError(ErrDialNil, ""),
+		target:    MakeError(ErrDialNil, ""),
+		wantMatch: true,
+		wantAs:    ErrDialNil,
+	}, {
+		name:      "ErrBothDialsFilled != ErrDialNil",
+		err:       ErrBothDialsFilled,
+		target:    ErrDialNil,
+		wantMatch: false,
+		wantAs:    ErrBothDialsFilled,
+	}, {
+		name:      "Error.ErrBothDialsFilled != ErrDialNil",
+		err:       MakeError(ErrBothDialsFilled, ""),
+		target:    ErrDialNil,
+		wantMatch: false,
+		wantAs:    ErrBothDialsFilled,
+	}, {
+		name:      "ErrBothDialsFilled != Error.ErrDialNil",
+		err:       ErrBothDialsFilled,
+		target:    MakeError(ErrDialNil, ""),
+		wantMatch: false,
+		wantAs:    ErrBothDialsFilled,
+	}, {
+		name:      "Error.ErrBothDialsFilled != Error.ErrDialNil",
+		err:       MakeError(ErrBothDialsFilled, ""),
+		target:    MakeError(ErrDialNil, ""),
+		wantMatch: false,
+		wantAs:    ErrBothDialsFilled,
+	}, {
+		name:      "Error.ErrBothDialsFilled != io.EOF",
+		err:       MakeError(ErrBothDialsFilled, ""),
+		target:    io.EOF,
+		wantMatch: false,
+		wantAs:    ErrBothDialsFilled,
+	}}
+
+	for _, test := range tests {
+		// Ensure the error matches or not depending on the expected result.
+		result := errors.Is(test.err, test.target)
+		if result != test.wantMatch {
+			t.Errorf("%s: incorrect error identification -- got %v, want %v",
+				test.name, result, test.wantMatch)
+			continue
+		}
+
+		// Ensure the underlying error kind can be unwrapped is and is the
+		// expected kind.
+		var kind ErrorKind
+		if !errors.As(test.err, &kind) {
+			t.Errorf("%s: unable to unwrap to error kind", test.name)
+			continue
+		}
+		if kind != test.wantAs {
+			t.Errorf("%s: unexpected unwrapped error kind -- got %v, want %v",
+				test.name, kind, test.wantAs)
+			continue
+		}
+	}
+}


### PR DESCRIPTION
This continues the work which switched the errors in the `connmgr` package to be compatible with `errors.Is/As` introduced in go 1.13 to make it match the best practices.

The following is a high level overview of the changes:

- Change the name of the error kind type to `ErrorKind`
- Make error definitions constant
- Add comments to all exported functions and types as required by the code contribution guidelines and various linters
- Add a `MakeError` function to create the errors instead of creating the structs with unnamed fields which goes against standard Go recommendations
- Add full test coverage to ensure the definitions work as intended

This is a followup to #2206.