### PR TITLE
txscript: Add support for errors.Is/As.

### DIFF
--- a/txscript/doc.go
+++ b/txscript/doc.go
@@ -25,15 +25,15 @@ which proves the spender owns the associated private key.  This information
 is used to prove the spender is authorized to perform the transaction.
 
 One benefit of using a scripting language is added flexibility in specifying
-what conditions must be met in order to spend decreds.
+what conditions must be met in order to spend decred.
 
 Errors
 
-Errors returned by this package are of type txscript.Error.  This allows the
-caller to programmatically determine the specific error by examining the
-ErrorCode field of the type asserted txscript.Error while still providing rich
-error messages with contextual information.  A convenience function named
-IsErrorCode is also provided to allow callers to easily check for a specific
-error code.  See ErrorCode in the package documentation for a full list.
+Errors returned by this package are of type txscript.ErrorKind wrapped by
+txscript.Error which has full support for the standard library errors.Is and
+errors.As functions.  This allows the caller to programmatically determine the
+specific error while still providing rich error messages with contextual
+information.  See the constants defined with ErrorKind in the package
+documentation for a full list.
 */
 package txscript

--- a/txscript/engine_test.go
+++ b/txscript/engine_test.go
@@ -6,6 +6,7 @@
 package txscript
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
@@ -130,7 +131,7 @@ func TestCheckErrorCondition(t *testing.T) {
 		}
 
 		err = vm.CheckErrorCondition(false)
-		if !IsErrorCode(err, ErrScriptUnfinished) {
+		if !errors.Is(err, ErrScriptUnfinished) {
 			t.Fatalf("got unexpected error %v on %dth iteration",
 				err, i)
 		}

--- a/txscript/error.go
+++ b/txscript/error.go
@@ -7,121 +7,115 @@ package txscript
 
 import (
 	"errors"
-	"fmt"
 )
 
-// ErrorCode identifies a kind of script error.
-type ErrorCode int
+// ErrorKind identifies a kind of script error.
+type ErrorKind string
 
-// These constants are used to identify a specific Error.
+// These constants are used to identify a specific ErrorKind.
 const (
-	// ErrInternal is returned if internal consistency checks fail.  In
-	// practice this error should never be seen as it would mean there is an
-	// error in the engine logic.
-	ErrInternal ErrorCode = iota
-
 	// ---------------------------------------
 	// Failures related to improper API usage.
 	// ---------------------------------------
 
 	// ErrInvalidIndex is returned when an out-of-bounds index is passed to
 	// a function.
-	ErrInvalidIndex
+	ErrInvalidIndex = ErrorKind("ErrInvalidIndex")
 
 	// ErrInvalidSigHashSingleIndex is returned when an attempt is
 	// made to sign an input with the SigHashSingle hash type and an
 	// index that is greater than or equal to the number of outputs.
-	ErrInvalidSigHashSingleIndex
+	ErrInvalidSigHashSingleIndex = ErrorKind("ErrInvalidSigHashSingleIndex")
 
 	// ErrUnsupportedAddress is returned when a concrete type that
 	// implements a dcrutil.Address is not a supported type.
-	ErrUnsupportedAddress
+	ErrUnsupportedAddress = ErrorKind("ErrUnsupportedAddress")
 
 	// ErrNotMultisigScript is returned from CalcMultiSigStats when the
 	// provided script is not a multisig script.
-	ErrNotMultisigScript
+	ErrNotMultisigScript = ErrorKind("ErrNotMultisigScript")
 
 	// ErrTooManyRequiredSigs is returned from MultiSigScript when the
 	// specified number of required signatures is larger than the number of
 	// provided public keys.
-	ErrTooManyRequiredSigs
+	ErrTooManyRequiredSigs = ErrorKind("ErrTooManyRequiredSigs")
 
 	// ErrMalformedCoinbaseNullData is returned when the nulldata output
 	// of a coinbase transaction that is used to ensure the coinbase has a
 	// unique hash is not properly formed.
 	//
 	// Deprecated: This will be removed in the next major version bump.
-	ErrMalformedCoinbaseNullData
+	ErrMalformedCoinbaseNullData = ErrorKind("ErrMalformedCoinbaseNullData")
 
 	// ErrTooMuchNullData is returned from NullDataScript when the length of
 	// the provided data exceeds MaxDataCarrierSize.
-	ErrTooMuchNullData
+	ErrTooMuchNullData = ErrorKind("ErrTooMuchNullData")
 
 	// ErrUnsupportedScriptVersion is returned when an unsupported script
 	// version is passed to a function which deals with script analysis.
-	ErrUnsupportedScriptVersion
+	ErrUnsupportedScriptVersion = ErrorKind("ErrUnsupportedScriptVersion")
 
 	// ------------------------------------------
 	// Failures related to final execution state.
 	// ------------------------------------------
 
 	// ErrEarlyReturn is returned when OP_RETURN is executed in the script.
-	ErrEarlyReturn
+	ErrEarlyReturn = ErrorKind("ErrEarlyReturn")
 
 	// ErrEmptyStack is returned when the script evaluated without error,
 	// but terminated with an empty top stack element.
-	ErrEmptyStack
+	ErrEmptyStack = ErrorKind("ErrEmptyStack")
 
 	// ErrEvalFalse is returned when the script evaluated without error but
 	// terminated with a false top stack element.
-	ErrEvalFalse
+	ErrEvalFalse = ErrorKind("ErrEvalFalse")
 
 	// ErrScriptUnfinished is returned when CheckErrorCondition is called on
 	// a script that has not finished executing.
-	ErrScriptUnfinished
+	ErrScriptUnfinished = ErrorKind("ErrScriptUnfinished")
 
 	// ErrScriptDone is returned when an attempt to execute an opcode is
 	// made once all of them have already been executed.  This can happen
 	// due to things such as a second call to Execute or calling Step after
 	// all opcodes have already been executed.
-	ErrInvalidProgramCounter
+	ErrInvalidProgramCounter = ErrorKind("ErrInvalidProgramCounter")
 
 	// -----------------------------------------------------
 	// Failures related to exceeding maximum allowed limits.
 	// -----------------------------------------------------
 
 	// ErrScriptTooBig is returned if a script is larger than MaxScriptSize.
-	ErrScriptTooBig
+	ErrScriptTooBig = ErrorKind("ErrScriptTooBig")
 
 	// ErrElementTooBig is returned if the size of an element to be pushed
 	// to the stack is over MaxScriptElementSize.
-	ErrElementTooBig
+	ErrElementTooBig = ErrorKind("ErrElementTooBig")
 
 	// ErrTooManyOperations is returned if a script has more than
 	// MaxOpsPerScript opcodes that do not push data.
-	ErrTooManyOperations
+	ErrTooManyOperations = ErrorKind("ErrTooManyOperations")
 
 	// ErrStackOverflow is returned when stack and altstack combined depth
 	// is over the limit.
-	ErrStackOverflow
+	ErrStackOverflow = ErrorKind("ErrStackOverflow")
 
 	// ErrInvalidPubKeyCount is returned when the number of public keys
 	// specified for a multsig is either negative or greater than
 	// MaxPubKeysPerMultiSig.
-	ErrInvalidPubKeyCount
+	ErrInvalidPubKeyCount = ErrorKind("ErrInvalidPubKeyCount")
 
 	// ErrInvalidSignatureCount is returned when the number of signatures
 	// specified for a multisig is either negative or greater than the
 	// number of public keys.
-	ErrInvalidSignatureCount
+	ErrInvalidSignatureCount = ErrorKind("ErrInvalidSignatureCount")
 
 	// ErrNumOutOfRange is returned when the argument for an opcode that
 	// expects numeric input is larger than the expected maximum number of
 	// bytes.  For the most part, opcodes that deal with stack manipulation
 	// via offsets, arithmetic, numeric comparison, and boolean logic are
 	// those that this applies to.  However, any opcode that expects numeric
-	// input may fail with this code.
-	ErrNumOutOfRange
+	// input may fail with this error.
+	ErrNumOutOfRange = ErrorKind("ErrNumOutOfRange")
 
 	// --------------------------------------------
 	// Failures related to verification operations.
@@ -129,31 +123,31 @@ const (
 
 	// ErrVerify is returned when OP_VERIFY is encountered in a script and
 	// the top item on the data stack does not evaluate to true.
-	ErrVerify
+	ErrVerify = ErrorKind("ErrVerify")
 
 	// ErrEqualVerify is returned when OP_EQUALVERIFY is encountered in a
 	// script and the top item on the data stack does not evaluate to true.
-	ErrEqualVerify
+	ErrEqualVerify = ErrorKind("ErrEqualVerify")
 
 	// ErrNumEqualVerify is returned when OP_NUMEQUALVERIFY is encountered
 	// in a script and the top item on the data stack does not evaluate to
 	// true.
-	ErrNumEqualVerify
+	ErrNumEqualVerify = ErrorKind("ErrNumEqualVerify")
 
 	// ErrCheckSigVerify is returned when OP_CHECKSIGVERIFY is encountered
 	// in a script and the top item on the data stack does not evaluate to
 	// true.
-	ErrCheckSigVerify
+	ErrCheckSigVerify = ErrorKind("ErrCheckSigVerify")
 
 	// ErrCheckSigVerify is returned when OP_CHECKMULTISIGVERIFY is
 	// encountered in a script and the top item on the data stack does not
 	// evaluate to true.
-	ErrCheckMultiSigVerify
+	ErrCheckMultiSigVerify = ErrorKind("ErrCheckMultiSigVerify")
 
 	// ErrCheckSigAltVerify is returned when OP_CHECKSIGALTVERIFY is
 	// encountered in a script and the top item on the data stack does not
 	// evaluate to true.
-	ErrCheckSigAltVerify
+	ErrCheckSigAltVerify = ErrorKind("ErrCheckSigAltVerify")
 
 	// --------------------------------------------
 	// Failures related to improper use of opcodes.
@@ -161,61 +155,61 @@ const (
 
 	// ErrP2SHStakeOpCodes is returned when one or more stake opcodes are
 	// found in the redeem script of a pay-to-script-hash script.
-	ErrP2SHStakeOpCodes
+	ErrP2SHStakeOpCodes = ErrorKind("ErrP2SHStakeOpCodes")
 
 	// ErrDisabledOpcode is returned when a disabled opcode is encountered
 	// in a script.
-	ErrDisabledOpcode
+	ErrDisabledOpcode = ErrorKind("ErrDisabledOpcode")
 
 	// ErrReservedOpcode is returned when an opcode marked as reserved
 	// is encountered in a script.
-	ErrReservedOpcode
+	ErrReservedOpcode = ErrorKind("ErrReservedOpcode")
 
 	// ErrMalformedPush is returned when a data push opcode tries to push
 	// more bytes than are left in the script.
-	ErrMalformedPush
+	ErrMalformedPush = ErrorKind("ErrMalformedPush")
 
 	// ErrInvalidStackOperation is returned when a stack operation is
 	// attempted with a number that is invalid for the current stack size.
-	ErrInvalidStackOperation
+	ErrInvalidStackOperation = ErrorKind("ErrInvalidStackOperation")
 
 	// ErrUnbalancedConditional is returned when an OP_ELSE or OP_ENDIF is
 	// encountered in a script without first having an OP_IF or OP_NOTIF or
 	// the end of script is reached without encountering an OP_ENDIF when
 	// an OP_IF or OP_NOTIF was previously encountered.
-	ErrUnbalancedConditional
+	ErrUnbalancedConditional = ErrorKind("ErrUnbalancedConditional")
 
 	// ErrNegativeSubstrIdx is returned when an OP_SUBSTR, OP_LEFT, or
 	// OP_RIGHT opcode encounters a negative index.
-	ErrNegativeSubstrIdx
+	ErrNegativeSubstrIdx = ErrorKind("ErrNegativeSubstrIdx")
 
 	// ErrOverflowSubstrIdx is returned when an OP_SUBSTR, OP_LEFT, or
 	// OP_RIGHT opcode encounters an index that is larger than the max
 	// allowed index that can operate on the string or the start index
 	// is greater than the end index for OP_SUBSTR.
-	ErrOverflowSubstrIdx
+	ErrOverflowSubstrIdx = ErrorKind("ErrOverflowSubstrIdx")
 
 	// ErrNegativeRotation is returned when an OP_ROTL or OP_ROTR attempts
 	// to perform a rotation with a negative rotation count.
-	ErrNegativeRotation
+	ErrNegativeRotation = ErrorKind("ErrNegativeRotation")
 
 	// ErrOverflowRotation is returned when an OP_ROTL or OP_ROTR opcode
 	// encounters a rotation count that is larger than the maximum allowed
 	// value for a uint32 bit rotation.
-	ErrOverflowRotation
+	ErrOverflowRotation = ErrorKind("ErrOverflowRotation")
 
 	// ErrDivideByZero is returned when an OP_DIV of OP_MOD attempts to
 	// divide by zero.
-	ErrDivideByZero
+	ErrDivideByZero = ErrorKind("ErrDivideByZero")
 
 	// ErrNegativeRotation is returned when an OP_LSHIFT or OP_RSHIFT opcode
 	// attempts to perform a shift with a negative count.
-	ErrNegativeShift
+	ErrNegativeShift = ErrorKind("ErrNegativeShift")
 
 	// ErrOverflowShift is returned when an OP_LSHIFT or OP_RSHIFT opcode
 	// encounters a shift count that is larger than the maximum allowed value
 	// for a shift.
-	ErrOverflowShift
+	ErrOverflowShift = ErrorKind("ErrOverflowShift")
 
 	// ---------------------------------
 	// Failures related to malleability.
@@ -223,96 +217,96 @@ const (
 
 	// ErrMinimalData is returned when the script contains push operations
 	// that do not use the minimal opcode required.
-	ErrMinimalData
+	ErrMinimalData = ErrorKind("ErrMinimalData")
 
 	// ErrInvalidSigHashType is returned when a signature hash type is not
 	// one of the supported types.
-	ErrInvalidSigHashType
+	ErrInvalidSigHashType = ErrorKind("ErrInvalidSigHashType")
 
 	// ErrSigTooShort is returned when a signature that should be a
 	// canonically-encoded DER signature is too short.
-	ErrSigTooShort
+	ErrSigTooShort = ErrorKind("ErrSigTooShort")
 
 	// ErrSigTooLong is returned when a signature that should be a
 	// canonically-encoded DER signature is too long.
-	ErrSigTooLong
+	ErrSigTooLong = ErrorKind("ErrSigTooLong")
 
 	// ErrSigInvalidSeqID is returned when a signature that should be a
 	// canonically-encoded DER signature does not have the expected ASN.1
 	// sequence ID.
-	ErrSigInvalidSeqID
+	ErrSigInvalidSeqID = ErrorKind("ErrSigInvalidSeqID")
 
-	// ErrSigInvalidDataLen is returned a signature that should be a
+	// ErrSigInvalidDataLen is returned when a signature that should be a
 	// canonically-encoded DER signature does not specify the correct number
 	// of remaining bytes for the R and S portions.
-	ErrSigInvalidDataLen
+	ErrSigInvalidDataLen = ErrorKind("ErrSigInvalidDataLen")
 
-	// ErrSigMissingSTypeID is returned a signature that should be a
+	// ErrSigMissingSTypeID is returned when a signature that should be a
 	// canonically-encoded DER signature does not provide the ASN.1 type ID
 	// for S.
-	ErrSigMissingSTypeID
+	ErrSigMissingSTypeID = ErrorKind("ErrSigMissingSTypeID")
 
 	// ErrSigMissingSLen is returned when a signature that should be a
 	// canonically-encoded DER signature does not provide the length of S.
-	ErrSigMissingSLen
+	ErrSigMissingSLen = ErrorKind("ErrSigMissingSLen")
 
-	// ErrSigInvalidSLen is returned a signature that should be a
+	// ErrSigInvalidSLen is returned when a signature that should be a
 	// canonically-encoded DER signature does not specify the correct number
 	// of bytes for the S portion.
-	ErrSigInvalidSLen
+	ErrSigInvalidSLen = ErrorKind("ErrSigInvalidSLen")
 
 	// ErrSigInvalidRIntID is returned when a signature that should be a
 	// canonically-encoded DER signature does not have the expected ASN.1
 	// integer ID for R.
-	ErrSigInvalidRIntID
+	ErrSigInvalidRIntID = ErrorKind("ErrSigInvalidRIntID")
 
 	// ErrSigZeroRLen is returned when a signature that should be a
 	// canonically-encoded DER signature has an R length of zero.
-	ErrSigZeroRLen
+	ErrSigZeroRLen = ErrorKind("ErrSigZeroRLen")
 
 	// ErrSigNegativeR is returned when a signature that should be a
 	// canonically-encoded DER signature has a negative value for R.
-	ErrSigNegativeR
+	ErrSigNegativeR = ErrorKind("ErrSigNegativeR")
 
 	// ErrSigTooMuchRPadding is returned when a signature that should be a
 	// canonically-encoded DER signature has too much padding for R.
-	ErrSigTooMuchRPadding
+	ErrSigTooMuchRPadding = ErrorKind("ErrSigTooMuchRPadding")
 
 	// ErrSigInvalidSIntID is returned when a signature that should be a
 	// canonically-encoded DER signature does not have the expected ASN.1
 	// integer ID for S.
-	ErrSigInvalidSIntID
+	ErrSigInvalidSIntID = ErrorKind("ErrSigInvalidSIntID")
 
 	// ErrSigZeroSLen is returned when a signature that should be a
 	// canonically-encoded DER signature has an S length of zero.
-	ErrSigZeroSLen
+	ErrSigZeroSLen = ErrorKind("ErrSigZeroSLen")
 
 	// ErrSigNegativeS is returned when a signature that should be a
 	// canonically-encoded DER signature has a negative value for S.
-	ErrSigNegativeS
+	ErrSigNegativeS = ErrorKind("ErrSigNegativeS")
 
 	// ErrSigTooMuchSPadding is returned when a signature that should be a
 	// canonically-encoded DER signature has too much padding for S.
-	ErrSigTooMuchSPadding
+	ErrSigTooMuchSPadding = ErrorKind("ErrSigTooMuchSPadding")
 
 	// ErrSigHighS is returned when a signature that should be a
 	// canonically-encoded DER signature has an S value that is higher than
 	// the curve half order.
-	ErrSigHighS
+	ErrSigHighS = ErrorKind("ErrSigHighS")
 
 	// ErrNotPushOnly is returned when a script that is required to only
 	// push data to the stack performs other operations.  A couple of cases
 	// where this applies is for a pay-to-script-hash signature script when
 	// bip16 is active and when the ScriptVerifySigPushOnly flag is set.
-	ErrNotPushOnly
+	ErrNotPushOnly = ErrorKind("ErrNotPushOnly")
 
 	// ErrPubKeyType is returned when the script contains invalid public keys.
-	ErrPubKeyType
+	ErrPubKeyType = ErrorKind("ErrPubKeyType")
 
 	// ErrCleanStack is returned when the ScriptVerifyCleanStack flag
 	// is set, and after evaluation, the stack does not contain only a
 	// single element.
-	ErrCleanStack
+	ErrCleanStack = ErrorKind("ErrCleanStack")
 
 	// -------------------------------
 	// Failures related to soft forks.
@@ -321,96 +315,21 @@ const (
 	// ErrDiscourageUpgradableNOPs is returned when the
 	// ScriptDiscourageUpgradableNops flag is set and a NOP opcode is
 	// encountered in a script.
-	ErrDiscourageUpgradableNOPs
+	ErrDiscourageUpgradableNOPs = ErrorKind("ErrDiscourageUpgradableNOPs")
 
 	// ErrNegativeLockTime is returned when a script contains an opcode that
 	// interprets a negative lock time.
-	ErrNegativeLockTime
+	ErrNegativeLockTime = ErrorKind("ErrNegativeLockTime")
 
 	// ErrUnsatisfiedLockTime is returned when a script contains an opcode
 	// that involves a lock time and the required lock time has not been
 	// reached.
-	ErrUnsatisfiedLockTime
-
-	// numErrorCodes is the maximum error code number used in tests.  This
-	// entry MUST be the last entry in the enum.
-	numErrorCodes
+	ErrUnsatisfiedLockTime = ErrorKind("ErrUnsatisfiedLockTime")
 )
 
-// Map of ErrorCode values back to their constant names for pretty printing.
-var errorCodeStrings = map[ErrorCode]string{
-	ErrInternal:                  "ErrInternal",
-	ErrInvalidIndex:              "ErrInvalidIndex",
-	ErrInvalidSigHashSingleIndex: "ErrInvalidSigHashSingleIndex",
-	ErrUnsupportedAddress:        "ErrUnsupportedAddress",
-	ErrNotMultisigScript:         "ErrNotMultisigScript",
-	ErrTooManyRequiredSigs:       "ErrTooManyRequiredSigs",
-	ErrMalformedCoinbaseNullData: "ErrMalformedCoinbaseNullData",
-	ErrTooMuchNullData:           "ErrTooMuchNullData",
-	ErrUnsupportedScriptVersion:  "ErrUnsupportedScriptVersion",
-	ErrEarlyReturn:               "ErrEarlyReturn",
-	ErrEmptyStack:                "ErrEmptyStack",
-	ErrEvalFalse:                 "ErrEvalFalse",
-	ErrScriptUnfinished:          "ErrScriptUnfinished",
-	ErrInvalidProgramCounter:     "ErrInvalidProgramCounter",
-	ErrScriptTooBig:              "ErrScriptTooBig",
-	ErrElementTooBig:             "ErrElementTooBig",
-	ErrTooManyOperations:         "ErrTooManyOperations",
-	ErrStackOverflow:             "ErrStackOverflow",
-	ErrInvalidPubKeyCount:        "ErrInvalidPubKeyCount",
-	ErrInvalidSignatureCount:     "ErrInvalidSignatureCount",
-	ErrNumOutOfRange:             "ErrNumOutOfRange",
-	ErrVerify:                    "ErrVerify",
-	ErrEqualVerify:               "ErrEqualVerify",
-	ErrNumEqualVerify:            "ErrNumEqualVerify",
-	ErrCheckSigVerify:            "ErrCheckSigVerify",
-	ErrCheckMultiSigVerify:       "ErrCheckMultiSigVerify",
-	ErrCheckSigAltVerify:         "ErrCheckSigAltVerify",
-	ErrP2SHStakeOpCodes:          "ErrP2SHStakeOpCodes",
-	ErrDisabledOpcode:            "ErrDisabledOpcode",
-	ErrReservedOpcode:            "ErrReservedOpcode",
-	ErrMalformedPush:             "ErrMalformedPush",
-	ErrInvalidStackOperation:     "ErrInvalidStackOperation",
-	ErrUnbalancedConditional:     "ErrUnbalancedConditional",
-	ErrNegativeSubstrIdx:         "ErrNegativeSubstrIdx",
-	ErrSigTooMuchSPadding:        "ErrSigTooMuchSPadding",
-	ErrOverflowSubstrIdx:         "ErrOverflowSubstrIdx",
-	ErrNegativeRotation:          "ErrNegativeRotation",
-	ErrOverflowRotation:          "ErrOverflowRotation",
-	ErrDivideByZero:              "ErrDivideByZero",
-	ErrNegativeShift:             "ErrNegativeShift",
-	ErrOverflowShift:             "ErrOverflowShift",
-	ErrMinimalData:               "ErrMinimalData",
-	ErrInvalidSigHashType:        "ErrInvalidSigHashType",
-	ErrSigTooShort:               "ErrSigTooShort",
-	ErrSigTooLong:                "ErrSigTooLong",
-	ErrSigInvalidSeqID:           "ErrSigInvalidSeqID",
-	ErrSigInvalidDataLen:         "ErrSigInvalidDataLen",
-	ErrSigMissingSTypeID:         "ErrSigMissingSTypeID",
-	ErrSigMissingSLen:            "ErrSigMissingSLen",
-	ErrSigInvalidSLen:            "ErrSigInvalidSLen",
-	ErrSigInvalidRIntID:          "ErrSigInvalidRIntID",
-	ErrSigZeroRLen:               "ErrSigZeroRLen",
-	ErrSigNegativeR:              "ErrSigNegativeR",
-	ErrSigTooMuchRPadding:        "ErrSigTooMuchRPadding",
-	ErrSigInvalidSIntID:          "ErrSigInvalidSIntID",
-	ErrSigZeroSLen:               "ErrSigZeroSLen",
-	ErrSigNegativeS:              "ErrSigNegativeS",
-	ErrSigHighS:                  "ErrSigHighS",
-	ErrNotPushOnly:               "ErrNotPushOnly",
-	ErrPubKeyType:                "ErrPubKeyType",
-	ErrCleanStack:                "ErrCleanStack",
-	ErrDiscourageUpgradableNOPs:  "ErrDiscourageUpgradableNOPs",
-	ErrNegativeLockTime:          "ErrNegativeLockTime",
-	ErrUnsatisfiedLockTime:       "ErrUnsatisfiedLockTime",
-}
-
-// String returns the ErrorCode as a human-readable name.
-func (e ErrorCode) String() string {
-	if s := errorCodeStrings[e]; s != "" {
-		return s
-	}
-	return fmt.Sprintf("Unknown ErrorCode (%d)", int(e))
+// Error satisfies the error interface and prints human-readable errors.
+func (e ErrorKind) Error() string {
+	return string(e)
 }
 
 // Error identifies a script-related error.  It is used to indicate three
@@ -420,12 +339,10 @@ func (e ErrorCode) String() string {
 // 2) Improper API usage by callers
 // 3) Internal consistency check failures
 //
-// The caller can use type assertions on the returned errors to access the
-// ErrorCode field to ascertain the specific reason for the error.  As an
-// additional convenience, the caller may make use of the IsErrorCode function
-// to check for a specific error code.
+// It has full support for errors.Is and errors.As, so the caller can ascertain
+// the specific reason for the error by checking the underlying error.
 type Error struct {
-	ErrorCode   ErrorCode
+	Err         error
 	Description string
 }
 
@@ -434,28 +351,26 @@ func (e Error) Error() string {
 	return e.Description
 }
 
-// scriptError creates an Error given a set of arguments.
-func scriptError(c ErrorCode, desc string) Error {
-	return Error{ErrorCode: c, Description: desc}
+// Unwrap returns the underlying wrapped error.
+func (e Error) Unwrap() error {
+	return e.Err
 }
 
-// IsErrorCode returns whether or not the provided error is a script error with
-// the provided error code.
-func IsErrorCode(err error, c ErrorCode) bool {
-	var serr Error
-	return errors.As(err, &serr) && serr.ErrorCode == c
+// scriptError creates a ScriptError given a set of arguments.
+func scriptError(kind ErrorKind, desc string) Error {
+	return Error{Err: kind, Description: desc}
 }
 
-// IsDERSigError returns whether or not the provided error is a script error
-// with one of the error codes which are caused due to encountering a signature
-// that is not a canonically-encoded DER signature.
+// IsDERSigError returns whether or not the provided error is one of the error
+// kinds which are caused due to encountering a signature that is not a
+// canonically-encoded DER signature.
 func IsDERSigError(err error) bool {
-	var serr Error
-	if !errors.As(err, &serr) {
+	var kind ErrorKind
+	if !errors.As(err, &kind) {
 		return false
 	}
 
-	switch serr.ErrorCode {
+	switch kind {
 	case ErrSigTooShort, ErrSigTooLong, ErrSigInvalidSeqID,
 		ErrSigInvalidDataLen, ErrSigMissingSTypeID, ErrSigMissingSLen,
 		ErrSigInvalidSLen, ErrSigInvalidRIntID, ErrSigZeroRLen, ErrSigNegativeR,

--- a/txscript/opcode.go
+++ b/txscript/opcode.go
@@ -894,8 +894,8 @@ func opcodeEndif(op *opcode, data []byte, vm *Engine) error {
 // verifies it evaluates to true.  An error is returned either when there is no
 // item on the stack or when that item evaluates to false.  In the latter case
 // where the verification fails specifically due to the top item evaluating
-// to false, the returned error will use the passed error code.
-func abstractVerify(op *opcode, vm *Engine, c ErrorCode) error {
+// to false, the returned error will use the passed error kind.
+func abstractVerify(op *opcode, vm *Engine, kind ErrorKind) error {
 	verified, err := vm.dstack.PopBool()
 	if err != nil {
 		return err
@@ -903,7 +903,7 @@ func abstractVerify(op *opcode, vm *Engine, c ErrorCode) error {
 
 	if !verified {
 		str := fmt.Sprintf("%s failed", op.name)
-		return scriptError(c, str)
+		return scriptError(kind, str)
 	}
 	return nil
 }

--- a/txscript/opcode_test.go
+++ b/txscript/opcode_test.go
@@ -7,6 +7,7 @@ package txscript
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -38,7 +39,7 @@ func TestOpcodeDisabled(t *testing.T) {
 	for _, opcodeVal := range tests {
 		op := &opcodeArray[opcodeVal]
 		err := opcodeDisabled(op, nil, nil)
-		if !IsErrorCode(err, ErrDisabledOpcode) {
+		if !errors.Is(err, ErrDisabledOpcode) {
 			t.Errorf("opcodeDisabled: unexpected error - got %v, "+
 				"want %v", err, ErrDisabledOpcode)
 			continue

--- a/txscript/reference_test.go
+++ b/txscript/reference_test.go
@@ -249,110 +249,110 @@ func parseScriptFlags(flagStr string) (ScriptFlags, error) {
 }
 
 // parseExpectedResult parses the provided expected result string into allowed
-// script error codes.  An error is returned if the expected result string is
+// script error kinds.  An error is returned if the expected result string is
 // not supported.
-func parseExpectedResult(expected string) ([]ErrorCode, error) {
+func parseExpectedResult(expected string) ([]ErrorKind, error) {
 	switch expected {
 	case "OK":
 		return nil, nil
 	case "ERR_EARLY_RETURN":
-		return []ErrorCode{ErrEarlyReturn}, nil
+		return []ErrorKind{ErrEarlyReturn}, nil
 	case "ERR_EMPTY_STACK":
-		return []ErrorCode{ErrEmptyStack}, nil
+		return []ErrorKind{ErrEmptyStack}, nil
 	case "ERR_EVAL_FALSE":
-		return []ErrorCode{ErrEvalFalse}, nil
+		return []ErrorKind{ErrEvalFalse}, nil
 	case "ERR_SCRIPT_SIZE":
-		return []ErrorCode{ErrScriptTooBig}, nil
+		return []ErrorKind{ErrScriptTooBig}, nil
 	case "ERR_PUSH_SIZE":
-		return []ErrorCode{ErrElementTooBig}, nil
+		return []ErrorKind{ErrElementTooBig}, nil
 	case "ERR_OP_COUNT":
-		return []ErrorCode{ErrTooManyOperations}, nil
+		return []ErrorKind{ErrTooManyOperations}, nil
 	case "ERR_STACK_SIZE":
-		return []ErrorCode{ErrStackOverflow}, nil
+		return []ErrorKind{ErrStackOverflow}, nil
 	case "ERR_PUBKEY_COUNT":
-		return []ErrorCode{ErrInvalidPubKeyCount}, nil
+		return []ErrorKind{ErrInvalidPubKeyCount}, nil
 	case "ERR_SIG_COUNT":
-		return []ErrorCode{ErrInvalidSignatureCount}, nil
+		return []ErrorKind{ErrInvalidSignatureCount}, nil
 	case "ERR_OUT_OF_RANGE":
-		return []ErrorCode{ErrNumOutOfRange}, nil
+		return []ErrorKind{ErrNumOutOfRange}, nil
 	case "ERR_VERIFY":
-		return []ErrorCode{ErrVerify}, nil
+		return []ErrorKind{ErrVerify}, nil
 	case "ERR_EQUAL_VERIFY":
-		return []ErrorCode{ErrEqualVerify}, nil
+		return []ErrorKind{ErrEqualVerify}, nil
 	case "ERR_DISABLED_OPCODE":
-		return []ErrorCode{ErrDisabledOpcode}, nil
+		return []ErrorKind{ErrDisabledOpcode}, nil
 	case "ERR_RESERVED_OPCODE":
-		return []ErrorCode{ErrReservedOpcode}, nil
+		return []ErrorKind{ErrReservedOpcode}, nil
 	case "ERR_P2SH_STAKE_OPCODES":
-		return []ErrorCode{ErrP2SHStakeOpCodes}, nil
+		return []ErrorKind{ErrP2SHStakeOpCodes}, nil
 	case "ERR_MALFORMED_PUSH":
-		return []ErrorCode{ErrMalformedPush}, nil
+		return []ErrorKind{ErrMalformedPush}, nil
 	case "ERR_INVALID_STACK_OPERATION", "ERR_INVALID_ALTSTACK_OPERATION":
-		return []ErrorCode{ErrInvalidStackOperation}, nil
+		return []ErrorKind{ErrInvalidStackOperation}, nil
 	case "ERR_UNBALANCED_CONDITIONAL":
-		return []ErrorCode{ErrUnbalancedConditional}, nil
+		return []ErrorKind{ErrUnbalancedConditional}, nil
 	case "ERR_NEGATIVE_SUBSTR_INDEX":
-		return []ErrorCode{ErrNegativeSubstrIdx}, nil
+		return []ErrorKind{ErrNegativeSubstrIdx}, nil
 	case "ERR_OVERFLOW_SUBSTR_INDEX":
-		return []ErrorCode{ErrOverflowSubstrIdx}, nil
+		return []ErrorKind{ErrOverflowSubstrIdx}, nil
 	case "ERR_NEGATIVE_ROTATION":
-		return []ErrorCode{ErrNegativeRotation}, nil
+		return []ErrorKind{ErrNegativeRotation}, nil
 	case "ERR_OVERFLOW_ROTATION":
-		return []ErrorCode{ErrOverflowRotation}, nil
+		return []ErrorKind{ErrOverflowRotation}, nil
 	case "ERR_DIVIDE_BY_ZERO":
-		return []ErrorCode{ErrDivideByZero}, nil
+		return []ErrorKind{ErrDivideByZero}, nil
 	case "ERR_NEGATIVE_SHIFT":
-		return []ErrorCode{ErrNegativeShift}, nil
+		return []ErrorKind{ErrNegativeShift}, nil
 	case "ERR_OVERFLOW_SHIFT":
-		return []ErrorCode{ErrOverflowShift}, nil
+		return []ErrorKind{ErrOverflowShift}, nil
 	case "ERR_MINIMAL_DATA":
-		return []ErrorCode{ErrMinimalData}, nil
+		return []ErrorKind{ErrMinimalData}, nil
 	case "ERR_SIG_HASH_TYPE":
-		return []ErrorCode{ErrInvalidSigHashType}, nil
+		return []ErrorKind{ErrInvalidSigHashType}, nil
 	case "ERR_SIG_TOO_SHORT":
-		return []ErrorCode{ErrSigTooShort}, nil
+		return []ErrorKind{ErrSigTooShort}, nil
 	case "ERR_SIG_TOO_LONG":
-		return []ErrorCode{ErrSigTooLong}, nil
+		return []ErrorKind{ErrSigTooLong}, nil
 	case "ERR_SIG_INVALID_SEQ_ID":
-		return []ErrorCode{ErrSigInvalidSeqID}, nil
+		return []ErrorKind{ErrSigInvalidSeqID}, nil
 	case "ERR_SIG_INVALID_DATA_LEN":
-		return []ErrorCode{ErrSigInvalidDataLen}, nil
+		return []ErrorKind{ErrSigInvalidDataLen}, nil
 	case "ERR_SIG_MISSING_S_TYPE_ID":
-		return []ErrorCode{ErrSigMissingSTypeID}, nil
+		return []ErrorKind{ErrSigMissingSTypeID}, nil
 	case "ERR_SIG_MISSING_S_LEN":
-		return []ErrorCode{ErrSigMissingSLen}, nil
+		return []ErrorKind{ErrSigMissingSLen}, nil
 	case "ERR_SIG_INVALID_S_LEN":
-		return []ErrorCode{ErrSigInvalidSLen}, nil
+		return []ErrorKind{ErrSigInvalidSLen}, nil
 	case "ERR_SIG_INVALID_R_INT_ID":
-		return []ErrorCode{ErrSigInvalidRIntID}, nil
+		return []ErrorKind{ErrSigInvalidRIntID}, nil
 	case "ERR_SIG_ZERO_R_LEN":
-		return []ErrorCode{ErrSigZeroRLen}, nil
+		return []ErrorKind{ErrSigZeroRLen}, nil
 	case "ERR_SIG_NEGATIVE_R":
-		return []ErrorCode{ErrSigNegativeR}, nil
+		return []ErrorKind{ErrSigNegativeR}, nil
 	case "ERR_SIG_TOO_MUCH_R_PADDING":
-		return []ErrorCode{ErrSigTooMuchRPadding}, nil
+		return []ErrorKind{ErrSigTooMuchRPadding}, nil
 	case "ERR_SIG_INVALID_S_INT_ID":
-		return []ErrorCode{ErrSigInvalidSIntID}, nil
+		return []ErrorKind{ErrSigInvalidSIntID}, nil
 	case "ERR_SIG_ZERO_S_LEN":
-		return []ErrorCode{ErrSigZeroSLen}, nil
+		return []ErrorKind{ErrSigZeroSLen}, nil
 	case "ERR_SIG_NEGATIVE_S":
-		return []ErrorCode{ErrSigNegativeS}, nil
+		return []ErrorKind{ErrSigNegativeS}, nil
 	case "ERR_SIG_TOO_MUCH_S_PADDING":
-		return []ErrorCode{ErrSigTooMuchSPadding}, nil
+		return []ErrorKind{ErrSigTooMuchSPadding}, nil
 	case "ERR_SIG_HIGH_S":
-		return []ErrorCode{ErrSigHighS}, nil
+		return []ErrorKind{ErrSigHighS}, nil
 	case "ERR_SIG_PUSHONLY":
-		return []ErrorCode{ErrNotPushOnly}, nil
+		return []ErrorKind{ErrNotPushOnly}, nil
 	case "ERR_PUBKEY_TYPE":
-		return []ErrorCode{ErrPubKeyType}, nil
+		return []ErrorKind{ErrPubKeyType}, nil
 	case "ERR_CLEAN_STACK":
-		return []ErrorCode{ErrCleanStack}, nil
+		return []ErrorKind{ErrCleanStack}, nil
 	case "ERR_DISCOURAGE_UPGRADABLE_NOPS":
-		return []ErrorCode{ErrDiscourageUpgradableNOPs}, nil
+		return []ErrorKind{ErrDiscourageUpgradableNOPs}, nil
 	case "ERR_NEGATIVE_LOCKTIME":
-		return []ErrorCode{ErrNegativeLockTime}, nil
+		return []ErrorKind{ErrNegativeLockTime}, nil
 	case "ERR_UNSATISFIED_LOCKTIME":
-		return []ErrorCode{ErrUnsatisfiedLockTime}, nil
+		return []ErrorKind{ErrUnsatisfiedLockTime}, nil
 	}
 
 	return nil, fmt.Errorf("unrecognized expected result in test data: %v",
@@ -431,12 +431,12 @@ func testScripts(t *testing.T, tests [][]string, useSigCache bool) {
 
 		// Extract and parse the expected result from the test fields.
 		//
-		// Convert the expected result string into the allowed script error
-		// codes.  This allows txscript to be more fine grained with its errors
-		// than the reference test data by allowing some of the test data errors
-		// to map to more than one possibility.
+		// Convert the expected result string into the allowed script errors.
+		// This allows txscript to be more fine grained with its errors than the
+		// reference test data by allowing some of the test data errors to map
+		// to more than one possibility.
 		resultStr := test[3]
-		allowedErrorCodes, err := parseExpectedResult(resultStr)
+		allowErrorKinds, err := parseExpectedResult(resultStr)
 		if err != nil {
 			t.Errorf("%s: %v", name, err)
 			continue
@@ -462,8 +462,8 @@ func testScripts(t *testing.T, tests [][]string, useSigCache bool) {
 		// At this point an error was expected so ensure the result of the
 		// execution matches it.
 		success := false
-		for _, code := range allowedErrorCodes {
-			if IsErrorCode(err, code) {
+		for _, kind := range allowErrorKinds {
+			if errors.Is(err, kind) {
 				success = true
 				break
 			}
@@ -471,12 +471,12 @@ func testScripts(t *testing.T, tests [][]string, useSigCache bool) {
 		if !success {
 			var serr Error
 			if errors.As(err, &serr) {
-				t.Errorf("%s: want error codes %v, got %v", name,
-					allowedErrorCodes, serr.ErrorCode)
+				t.Errorf("%s: want error kinds %v, got %v", name,
+					allowErrorKinds, serr.Err)
 				continue
 			}
-			t.Errorf("%s: want error codes %v, got err: %v (%T)", name,
-				allowedErrorCodes, err, err)
+			t.Errorf("%s: want error kinds %v, got err: %v (%T)", name,
+				allowErrorKinds, err, err)
 			continue
 		}
 	}
@@ -798,15 +798,14 @@ testloop:
 }
 
 // parseSigHashExpectedResult parses the provided expected result string into
-// allowed error codes.  An error is returned if the expected result string is
+// allowed error kinds.  An error is returned if the expected result string is
 // not supported.
-func parseSigHashExpectedResult(expected string) (*ErrorCode, error) {
+func parseSigHashExpectedResult(expected string) (error, error) {
 	switch expected {
 	case "OK":
 		return nil, nil
 	case "SIGHASH_SINGLE_IDX":
-		code := ErrInvalidSigHashSingleIndex
-		return &code, nil
+		return ErrInvalidSigHashSingleIndex, nil
 	}
 
 	return nil, fmt.Errorf("unrecognized expected result in test data: %v",
@@ -865,8 +864,7 @@ func TestCalcSignatureHashReference(t *testing.T) {
 		}
 		subScript, err := hex.DecodeString(subScriptStr)
 		if err != nil {
-			t.Errorf("Test #%d: unable to decode script: %v", i,
-				err)
+			t.Errorf("Test #%d: unable to decode script: %v", i, err)
 			continue
 		}
 		err = checkScriptParses(scriptVersion, subScript)
@@ -917,16 +915,8 @@ func TestCalcSignatureHashReference(t *testing.T) {
 		// Calculate the signature hash and verify expected result.
 		hash, err := CalcSignatureHash(subScript, hashType, &tx,
 			int(inputIdxF64), nil)
-		if (err == nil) != (expectedErr == nil) ||
-			expectedErr != nil && !IsErrorCode(err, *expectedErr) {
-
-			var serr Error
-			if errors.As(err, &serr) {
-				t.Errorf("Test #%d: want error code %v, got %v", i, expectedErr,
-					serr.ErrorCode)
-				continue
-			}
-			t.Errorf("Test #%d: want error code %v, got err: %v (%T)", i,
+		if !errors.Is(err, expectedErr) {
+			t.Errorf("Test #%d: want error kind %v, got err: %v (%T)", i,
 				expectedErr, err, err)
 			continue
 		}

--- a/txscript/script_test.go
+++ b/txscript/script_test.go
@@ -7,6 +7,7 @@ package txscript
 
 import (
 	"bytes"
+	"errors"
 	"reflect"
 	"testing"
 )
@@ -359,13 +360,13 @@ func TestRemoveOpcodeByData(t *testing.T) {
 			name:   "invalid length (instruction)",
 			before: []byte{OP_PUSHDATA1},
 			remove: []byte{1, 2, 3, 4},
-			err:    scriptError(ErrMalformedPush, ""),
+			err:    ErrMalformedPush,
 		},
 		{
 			name:   "invalid length (data)",
 			before: []byte{OP_PUSHDATA1, 255, 254},
 			remove: []byte{1, 2, 3, 4},
-			err:    scriptError(ErrMalformedPush, ""),
+			err:    ErrMalformedPush,
 		},
 	}
 
@@ -382,8 +383,9 @@ func TestRemoveOpcodeByData(t *testing.T) {
 
 	for _, test := range tests {
 		result, err := tstRemoveOpcodeByData(test.before, test.remove)
-		if e := tstCheckScriptError(err, test.err); e != nil {
-			t.Errorf("%s: %v", test.name, e)
+		if !errors.Is(err, test.err) {
+			t.Errorf("%s: unexpected error - got %v, want %v", test.name, err,
+				test.err)
 			continue
 		}
 

--- a/txscript/stack_test.go
+++ b/txscript/stack_test.go
@@ -9,41 +9,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"reflect"
 	"testing"
 )
-
-// tstCheckScriptError ensures the type of the two passed errors are of the
-// same type (either both nil or both of type Error) and their error codes
-// match when not nil.
-func tstCheckScriptError(gotErr, wantErr error) error {
-	// Ensure the error code is of the expected type and the error
-	// code matches the value specified in the test instance.
-	if reflect.TypeOf(gotErr) != reflect.TypeOf(wantErr) {
-		return fmt.Errorf("wrong error - got %T (%[1]v), want %T",
-			gotErr, wantErr)
-	}
-	if gotErr == nil {
-		return nil
-	}
-
-	// Ensure the want error type is a script error.
-	var werr Error
-	if !errors.As(wantErr, &werr) {
-		return fmt.Errorf("unexpected test error type %T", wantErr)
-	}
-
-	// Ensure the error codes match.  It's safe to use a raw type assert
-	// here since the code above already proved they are the same type and
-	// the want error is a script error.
-	var gerr Error
-	if !errors.As(gotErr, &gerr) || gerr.ErrorCode != werr.ErrorCode {
-		return fmt.Errorf("mismatched error code - got %v (%v), want %v",
-			gerr.ErrorCode, gotErr, werr.ErrorCode)
-	}
-
-	return nil
-}
 
 // TestStack tests that all of the stack operations work as expected.
 func TestStack(t *testing.T) {
@@ -72,7 +39,7 @@ func TestStack(t *testing.T) {
 				_, err := s.PeekByteArray(5)
 				return err
 			},
-			scriptError(ErrInvalidStackOperation, ""),
+			ErrInvalidStackOperation,
 			nil,
 		},
 		{
@@ -82,7 +49,7 @@ func TestStack(t *testing.T) {
 				_, err := s.PeekInt(5, mathOpCodeMaxScriptNumLen)
 				return err
 			},
-			scriptError(ErrInvalidStackOperation, ""),
+			ErrInvalidStackOperation,
 			nil,
 		},
 		{
@@ -92,7 +59,7 @@ func TestStack(t *testing.T) {
 				_, err := s.PeekBool(5)
 				return err
 			},
-			scriptError(ErrInvalidStackOperation, ""),
+			ErrInvalidStackOperation,
 			nil,
 		},
 		{
@@ -138,7 +105,7 @@ func TestStack(t *testing.T) {
 				}
 				return nil
 			},
-			scriptError(ErrInvalidStackOperation, ""),
+			ErrInvalidStackOperation,
 			nil,
 		},
 		{
@@ -182,7 +149,7 @@ func TestStack(t *testing.T) {
 				_, err := s.PopBool()
 				return err
 			},
-			scriptError(ErrInvalidStackOperation, ""),
+			ErrInvalidStackOperation,
 			nil,
 		},
 		{
@@ -208,7 +175,7 @@ func TestStack(t *testing.T) {
 				_, err := s.PopInt(mathOpCodeMaxScriptNumLen)
 				return err
 			},
-			scriptError(ErrMinimalData, ""),
+			ErrMinimalData,
 			nil,
 		},
 		{
@@ -218,7 +185,7 @@ func TestStack(t *testing.T) {
 				_, err := s.PopInt(mathOpCodeMaxScriptNumLen)
 				return err
 			},
-			scriptError(ErrMinimalData, ""),
+			ErrMinimalData,
 			nil,
 		},
 		{
@@ -244,7 +211,7 @@ func TestStack(t *testing.T) {
 				_, err := s.PopInt(mathOpCodeMaxScriptNumLen)
 				return err
 			},
-			scriptError(ErrMinimalData, ""),
+			ErrMinimalData,
 			nil,
 		},
 		{
@@ -286,7 +253,7 @@ func TestStack(t *testing.T) {
 				_, err := s.PopInt(5)
 				return err
 			},
-			scriptError(ErrMinimalData, ""),
+			ErrMinimalData,
 			nil,
 		},
 		{
@@ -296,7 +263,7 @@ func TestStack(t *testing.T) {
 				_, err := s.PopInt(5)
 				return err
 			},
-			scriptError(ErrNumOutOfRange, ""),
+			ErrNumOutOfRange,
 			nil,
 		},
 		// Triggers the multibyte case in asInt
@@ -420,7 +387,7 @@ func TestStack(t *testing.T) {
 			func(s *stack) error {
 				return s.DupN(0)
 			},
-			scriptError(ErrInvalidStackOperation, ""),
+			ErrInvalidStackOperation,
 			nil,
 		},
 		{
@@ -429,7 +396,7 @@ func TestStack(t *testing.T) {
 			func(s *stack) error {
 				return s.DupN(-1)
 			},
-			scriptError(ErrInvalidStackOperation, ""),
+			ErrInvalidStackOperation,
 			nil,
 		},
 		{
@@ -438,7 +405,7 @@ func TestStack(t *testing.T) {
 			func(s *stack) error {
 				return s.DupN(2)
 			},
-			scriptError(ErrInvalidStackOperation, ""),
+			ErrInvalidStackOperation,
 			nil,
 		},
 		{
@@ -569,7 +536,7 @@ func TestStack(t *testing.T) {
 				// bite off more than we can chew
 				return s.NipN(3)
 			},
-			scriptError(ErrInvalidStackOperation, ""),
+			ErrInvalidStackOperation,
 			[][]byte{{2}, {3}},
 		},
 		{
@@ -587,7 +554,7 @@ func TestStack(t *testing.T) {
 			func(s *stack) error {
 				return s.Tuck()
 			},
-			scriptError(ErrInvalidStackOperation, ""),
+			ErrInvalidStackOperation,
 			nil,
 		},
 		{
@@ -596,7 +563,7 @@ func TestStack(t *testing.T) {
 			func(s *stack) error {
 				return s.Tuck()
 			},
-			scriptError(ErrInvalidStackOperation, ""),
+			ErrInvalidStackOperation,
 			nil,
 		},
 		{
@@ -641,7 +608,7 @@ func TestStack(t *testing.T) {
 			func(s *stack) error {
 				return s.DropN(5)
 			},
-			scriptError(ErrInvalidStackOperation, ""),
+			ErrInvalidStackOperation,
 			nil,
 		},
 		{
@@ -650,7 +617,7 @@ func TestStack(t *testing.T) {
 			func(s *stack) error {
 				return s.DropN(0)
 			},
-			scriptError(ErrInvalidStackOperation, ""),
+			ErrInvalidStackOperation,
 			nil,
 		},
 		{
@@ -677,7 +644,7 @@ func TestStack(t *testing.T) {
 			func(s *stack) error {
 				return s.RotN(1)
 			},
-			scriptError(ErrInvalidStackOperation, ""),
+			ErrInvalidStackOperation,
 			nil,
 		},
 		{
@@ -686,7 +653,7 @@ func TestStack(t *testing.T) {
 			func(s *stack) error {
 				return s.RotN(0)
 			},
-			scriptError(ErrInvalidStackOperation, ""),
+			ErrInvalidStackOperation,
 			nil,
 		},
 		{
@@ -713,7 +680,7 @@ func TestStack(t *testing.T) {
 			func(s *stack) error {
 				return s.SwapN(1)
 			},
-			scriptError(ErrInvalidStackOperation, ""),
+			ErrInvalidStackOperation,
 			nil,
 		},
 		{
@@ -722,7 +689,7 @@ func TestStack(t *testing.T) {
 			func(s *stack) error {
 				return s.SwapN(0)
 			},
-			scriptError(ErrInvalidStackOperation, ""),
+			ErrInvalidStackOperation,
 			nil,
 		},
 		{
@@ -749,7 +716,7 @@ func TestStack(t *testing.T) {
 			func(s *stack) error {
 				return s.OverN(1)
 			},
-			scriptError(ErrInvalidStackOperation, ""),
+			ErrInvalidStackOperation,
 			nil,
 		},
 		{
@@ -758,7 +725,7 @@ func TestStack(t *testing.T) {
 			func(s *stack) error {
 				return s.OverN(0)
 			},
-			scriptError(ErrInvalidStackOperation, ""),
+			ErrInvalidStackOperation,
 			nil,
 		},
 		{
@@ -785,7 +752,7 @@ func TestStack(t *testing.T) {
 			func(s *stack) error {
 				return s.PickN(1)
 			},
-			scriptError(ErrInvalidStackOperation, ""),
+			ErrInvalidStackOperation,
 			nil,
 		},
 		{
@@ -812,7 +779,7 @@ func TestStack(t *testing.T) {
 			func(s *stack) error {
 				return s.RollN(1)
 			},
-			scriptError(ErrInvalidStackOperation, ""),
+			ErrInvalidStackOperation,
 			nil,
 		},
 		{
@@ -910,7 +877,7 @@ func TestStack(t *testing.T) {
 				_, err := s.PeekInt(1, 5)
 				return err
 			},
-			scriptError(ErrMinimalData, ""),
+			ErrMinimalData,
 			nil,
 		},
 		{
@@ -920,7 +887,7 @@ func TestStack(t *testing.T) {
 				_, err := s.PeekInt(1, 5)
 				return err
 			},
-			scriptError(ErrNumOutOfRange, ""),
+			ErrNumOutOfRange,
 			nil,
 		},
 		{
@@ -947,7 +914,7 @@ func TestStack(t *testing.T) {
 				_, err := s.PopInt(mathOpCodeMaxScriptNumLen)
 				return err
 			},
-			scriptError(ErrInvalidStackOperation, ""),
+			ErrInvalidStackOperation,
 			nil,
 		},
 	}
@@ -960,10 +927,10 @@ func TestStack(t *testing.T) {
 		}
 		err := test.operation(&s)
 
-		// Ensure the error code is of the expected type and the error
-		// code matches the value specified in the test instance.
-		if e := tstCheckScriptError(err, test.err); e != nil {
-			t.Errorf("%s: %v", test.name, e)
+		// Ensure the error matches the value specified in the test instance.
+		if !errors.Is(err, test.err) {
+			t.Errorf("%s: unexpected error - got %v, want %v", test.name, err,
+				test.err)
 			continue
 		}
 		if err != nil {

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -999,9 +999,8 @@ func GenerateSSGenVotes(votebits uint16) ([]byte, error) {
 }
 
 // GenerateProvablyPruneableOut creates a provably-prunable script containing
-// OP_RETURN followed by the passed data.  An Error with the error code
-// ErrTooMuchNullData will be returned if the length of the passed data exceeds
-// MaxDataCarrierSize.
+// OP_RETURN followed by the passed data.  An Error with kind ErrTooMuchNullData
+// will be returned if the length of the passed data exceeds MaxDataCarrierSize.
 func GenerateProvablyPruneableOut(data []byte) ([]byte, error) {
 	if len(data) > MaxDataCarrierSize {
 		str := fmt.Sprintf("data size %d is larger than max "+
@@ -1066,8 +1065,8 @@ func PayToAddrScript(addr dcrutil.Address) ([]byte, error) {
 
 // MultiSigScript returns a valid script for a multisignature redemption where
 // nrequired of the keys in pubkeys are required to have signed the transaction
-// for success.  An Error with the error code ErrTooManyRequiredSigs will be
-// returned if nrequired is larger than the number of keys provided.
+// for success.  An Error with kind ErrTooManyRequiredSigs will be returned if
+// nrequired is larger than the number of keys provided.
 func MultiSigScript(pubkeys []*dcrutil.AddressSecpPubKey, nrequired int) ([]byte, error) {
 	if len(pubkeys) < nrequired {
 		str := fmt.Sprintf("unable to generate multisig script with "+


### PR DESCRIPTION
This updates the `txscript` package to provide support for the `errors.Is` and `errors.As` functions introduced in Go 1.13 per the recently documented best practices.

The following is an overview of the changes:

- Rename the `ErrorCode` type to `ErrorKind` and make it a string
- Implement the error interface on `ErrorKind`
- Update all error code definitions to the new type
 - Remove unused `ErrInternal` definition
- Remove error code string map that is no longer required
- Change the error code field of the `Error` type to `Err`
- Implement `Unwrap` on the `Error` type to support unwrapping via `errors.Is/As`
- Remove the `IsErrorCode` function since it is no longer needed due to `errors.Is`
- Update `IsDERSigError` to cope with the changes
- Modify various comments to refer to error kinds instead of codes
- Update all test code to use the new `ErrorKind` directly along with `errors.Is` for detecting the expect errors
- Add full test coverage to ensure the new error definitions work as intended
- Update the `doc.go` errors section accordingly