### PR TITLE
stakeext: Fix comments on concurrency.

### DIFF
--- a/blockchain/stakeext.go
+++ b/blockchain/stakeext.go
@@ -78,7 +78,7 @@ func (b *BlockChain) LotteryDataForBlock(hash *chainhash.Hash) ([]chainhash.Hash
 
 // LiveTickets returns all currently live tickets from the stake database.
 //
-// This function is NOT safe for concurrent access.
+// This function is safe for concurrent access.
 func (b *BlockChain) LiveTickets() ([]chainhash.Hash, error) {
 	b.chainLock.RLock()
 	sn := b.bestChain.Tip().stakeNode
@@ -89,7 +89,7 @@ func (b *BlockChain) LiveTickets() ([]chainhash.Hash, error) {
 
 // MissedTickets returns all currently missed tickets from the stake database.
 //
-// This function is NOT safe for concurrent access.
+// This function is safe for concurrent access.
 func (b *BlockChain) MissedTickets() ([]chainhash.Hash, error) {
 	b.chainLock.RLock()
 	sn := b.bestChain.Tip().stakeNode


### PR DESCRIPTION
Both LiveTickets and MissedTickets were incorrectly tagged as not
concurrent safe. However, as these methods work on an immutable tree on
the tip's stake node, there is no way they will be changed at the time
of reading, as only older nodes are pruned.