### PR TITLE
rpcserver: Avoid panic during hash decode

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1471,8 +1471,11 @@ func handleExistsAddresses(_ context.Context, s *rpcServer, cmd interface{}) (in
 func decodeHashes(strs []string) ([]chainhash.Hash, error) {
 	hashes := make([]chainhash.Hash, len(strs))
 	for i, s := range strs {
-		l, err := hex.Decode(hashes[i][:], []byte(s))
-		if err != nil || l != 32 {
+		if len(s) != 2*chainhash.HashSize {
+			return nil, rpcDecodeHexError(s)
+		}
+		_, err := hex.Decode(hashes[i][:], []byte(s))
+		if err != nil {
 			return nil, rpcDecodeHexError(s)
 		}
 		// unreverse hash string bytes


### PR DESCRIPTION
The input hex string must be exactly 64 bytes, else an error will be
returned.  The input validation previously checked that the length
following decoding was correct, but was missing a check that the
destination slice was not smaller than half the source's length.
Moving the length check first keeps the existing short source check
while also preventing a panic with a long input string.

Fixes #2212.