### PR TITLE
rpcserver: Internal err on gettxout utxo fetch err.

### DIFF
--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -1892,7 +1892,9 @@ of the best block.
 # <code>includemempool</code>: <code>(string,default=true)</code> Include the mempool when true.
 |-
 !Description
-| Returns information about an unspent transaction output.
+|
+: Returns information about an unspent transaction output.
+: Returns <code>null</code> if the output is spent or never existed.
 |-
 !Returns
 |<code>(json object)</code>

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -62,7 +62,7 @@ const (
 	jsonrpcSemverString = "6.1.1"
 	jsonrpcSemverMajor  = 6
 	jsonrpcSemverMinor  = 1
-	jsonrpcSemverPatch  = 1
+	jsonrpcSemverPatch  = 2
 )
 
 const (
@@ -3136,11 +3136,13 @@ func handleGetTxOut(_ context.Context, s *rpcServer, cmd interface{}) (interface
 	} else {
 		entry, err := s.cfg.Chain.FetchUtxoEntry(txHash)
 		if err != nil {
-			return nil, rpcNoTxInfoError(txHash)
+			context := "Failed to retrieve utxo entry"
+			return nil, rpcInternalError(err.Error(), context)
 		}
 
 		// To match the behavior of the reference client, return nil
-		// (JSON null) if the transaction output is spent by another
+		// (JSON null) if the transaction output could not be found
+		// (never existed or was pruned) or is spent by another
 		// transaction already in the main chain.  Mined transactions
 		// that are spent by a mempool transaction are not affected by
 		// this.


### PR DESCRIPTION
Replace `noTxInfoError` with `rpcInternalError` when fetching utxo
entry errors in gettxout cmd handler. `gettxout` should never return
`noTxInfoError` because `gettxout` is about tx outputs not txs.

Update code comment and json-rpc docs to more clearly describe the
semantics of the gettxout method, particularly that JSON null is
returned if the requested txout cannot be found either because it
never existed or because it is spent (and possibly pruned).
