### PR TITLE
rpcserver: Correct JSON-RPC request unmarshal.

### DIFF
--- a/dcrjson/jsonrpc.go
+++ b/dcrjson/jsonrpc.go
@@ -74,51 +74,6 @@ type Request struct {
 	ID      interface{}       `json:"id"`
 }
 
-// UnmarshalJSON is a custom unmarshal func for the Request struct. The param
-// field defaults to an empty json.RawMessage array it is omitted by the request
-// or nil if the supplied value is invalid.
-func (request *Request) UnmarshalJSON(b []byte) error {
-	var data map[string]interface{}
-	err := json.Unmarshal(b, &data)
-	if err != nil {
-		return err
-	}
-
-	request.ID = data["id"]
-	methodValue, hasMethod := data["method"]
-	if hasMethod {
-		request.Method = methodValue.(string)
-	}
-	jsonrpcValue, hasJsonrpc := data["jsonrpc"]
-	if hasJsonrpc {
-		request.Jsonrpc = jsonrpcValue.(string)
-	}
-	paramsValue, hasParams := data["params"]
-	if !hasParams {
-		// set the request param to an empty array if it is omitted in the request
-		request.Params = []json.RawMessage{}
-	}
-	if hasParams {
-		// assert the request params is an array of data
-		params, paramsOk := paramsValue.([]interface{})
-		if paramsOk {
-			rawParams := make([]json.RawMessage, 0, len(params))
-			for _, param := range params {
-				marshalledParam, err := json.Marshal(param)
-				if err != nil {
-					return err
-				}
-				rawMessage := json.RawMessage(marshalledParam)
-				rawParams = append(rawParams, rawMessage)
-			}
-
-			request.Params = rawParams
-		}
-	}
-
-	return nil
-}
-
 // NewRequest returns a new JSON-RPC request object given the provided rpc
 // version, id, method, and parameters.  The parameters are marshalled into a
 // json.RawMessage for the Params field of the returned request object. This

--- a/rpcwebsocket.go
+++ b/rpcwebsocket.go
@@ -1514,7 +1514,7 @@ out:
 				continue
 			}
 
-			if req.Method == "" || req.Params == nil {
+			if req.Method == "" {
 				jsonErr := &dcrjson.RPCError{
 					Code:    dcrjson.ErrRPCInvalidRequest.Code,
 					Message: "Invalid request: malformed",
@@ -1643,7 +1643,7 @@ out:
 
 		// Process a batched request
 		if batchedRequest {
-			var batchedRequests []interface{}
+			var batchedRequests []json.RawMessage
 			var results []json.RawMessage
 			var batchSize int
 			var reply json.RawMessage
@@ -1695,33 +1695,8 @@ out:
 				if len(batchedRequests) > 0 {
 					batchSize = len(batchedRequests)
 					for _, entry := range batchedRequests {
-						var reqBytes []byte
-						reqBytes, err = json.Marshal(entry)
-						if err != nil {
-							// Only process requests from authenticated clients
-							if !c.authenticated {
-								break out
-							}
-
-							jsonErr := &dcrjson.RPCError{
-								Code: dcrjson.ErrRPCInvalidRequest.Code,
-								Message: fmt.Sprintf("Invalid request: %v",
-									err),
-							}
-							reply, err = dcrjson.MarshalResponse("2.0", nil, nil, jsonErr)
-							if err != nil {
-								rpcsLog.Errorf("Failed to create reply: %v", err)
-								continue
-							}
-
-							if reply != nil {
-								results = append(results, reply)
-							}
-							continue
-						}
-
 						var req dcrjson.Request
-						err := json.Unmarshal(reqBytes, &req)
+						err := json.Unmarshal(entry, &req)
 						if err != nil {
 							// Only process requests from authenticated clients
 							if !c.authenticated {


### PR DESCRIPTION
This reworks the JSON-RPC unmarshalling logic to correct some error handling cases as well as optimize the normal path.

It accomplishes this as follows:

- Removes the custom, and incorrect, unmarshalling code in favor of just unmarshalling into the `Request` struct directly
- Allows the `Params` to be `nil` (unspecified) per the spec
- Corrects the per-entry batch unmarshal logic such that it first unmarshals into an array of `json.RawMessage` and then unmarshals each individual entry into the `Request` struct
- No longer attempts to process non-batched requests that fail to unmarshal properly

Fixes #2217.
