### PR TITLE
rpcclient: Reregister work ntfns on reconnect.

### DIFF
--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -298,6 +298,9 @@ func (c *Client) trackRegisteredNtfns(cmd interface{}) {
 		} else {
 			c.ntfnState.notifyNewTx = true
 		}
+
+	case *chainjson.NotifyWorkCmd:
+		c.ntfnState.notifyWork = true
 	}
 }
 


### PR DESCRIPTION
This ensures the `rpcclient` automatically reregisters for work notifications on reconnect if it had previously registered for them.

The infrastructure for the notification was added to the rpcclient in #1410, however, it failed to properly set the flag so it would resend the notification on reconnect.