### PR TITLE
[rpcclient-v5] rpcclient: Reregister work ntfns on reconnect.

### DIFF
--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -283,6 +283,9 @@ func (c *Client) trackRegisteredNtfns(cmd interface{}) {
 		} else {
 			c.ntfnState.notifyNewTx = true
 		}
+
+	case *chainjson.NotifyWorkCmd:
+		c.ntfnState.notifyWork = true
 	}
 }
 


### PR DESCRIPTION
This is a backport of #2228 to the rpcclient-v5 release branch.

It ensures the rpcclient automatically reregisters for work notifications on reconnect if it had previously registered for them.