### PR TITLE
rpcserver: Correct adaptor for utxo entry fetch.

### DIFF
--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -368,5 +368,8 @@ func (c *rpcChain) ConvertUtxosToMinimalOutputs(entry rpcserver.UtxoEntry) []*st
 // any) is NOT.
 func (c *rpcChain) FetchUtxoEntry(txHash *chainhash.Hash) (rpcserver.UtxoEntry, error) {
 	utxo, err := c.BlockChain.FetchUtxoEntry(txHash)
-	return &rpcUtxoEntry{UtxoEntry: utxo}, err
+	if utxo == nil || err != nil {
+		return nil, err
+	}
+	return &rpcUtxoEntry{UtxoEntry: utxo}, nil
 }


### PR DESCRIPTION
This corrects the adaptor that converts a concrete `blockchain.UtxoEntry` to the `rpcserver.UtxoEntry` interface that was recently introduced #2211.

In particular, it should not return an instance of the wrapper when either the entry does not exist (is nil) or there was an error.