### PR TITLE
txscript: Export various consensus funcs and types.

### DIFF
--- a/txscript/consensus.go
+++ b/txscript/consensus.go
@@ -313,7 +313,7 @@ func IsStrictNullData(scriptVersion uint16, script []byte, requiredLen uint32) b
 	tokenizer := MakeScriptTokenizer(scriptVersion, script[1:])
 	return tokenizer.Next() && tokenizer.Done() &&
 		isCanonicalPush(tokenizer.Opcode(), tokenizer.Data()) &&
-		((isSmallInt(tokenizer.Opcode()) && requiredLen == 1) ||
+		((IsSmallInt(tokenizer.Opcode()) && requiredLen == 1) ||
 			(tokenizer.Opcode() <= OP_DATA_75 &&
 				uint32(len(tokenizer.Data())) == requiredLen))
 }

--- a/txscript/opcode.go
+++ b/txscript/opcode.go
@@ -963,7 +963,7 @@ func opcodeCheckLockTimeVerify(op *opcode, data []byte, vm *Engine) error {
 	// maximum of 2^31-1 (the year 2038).  Thus, a 5-byte ScriptNum is used
 	// here since it will support up to 2^39-1 which allows dates beyond the
 	// current locktime limit.
-	lockTime, err := vm.dstack.PeekInt(0, cltvMaxScriptNumLen)
+	lockTime, err := vm.dstack.PeekInt(0, CltvMaxScriptNumLen)
 	if err != nil {
 		return err
 	}

--- a/txscript/opcode.go
+++ b/txscript/opcode.go
@@ -726,7 +726,7 @@ func opcodePushData(op *opcode, data []byte, vm *Engine) error {
 
 // opcode1Negate pushes -1, encoded as a number, to the data stack.
 func opcode1Negate(op *opcode, data []byte, vm *Engine) error {
-	vm.dstack.PushInt(scriptNum(-1))
+	vm.dstack.PushInt(ScriptNum(-1))
 	return nil
 }
 
@@ -736,7 +736,7 @@ func opcode1Negate(op *opcode, data []byte, vm *Engine) error {
 func opcodeN(op *opcode, data []byte, vm *Engine) error {
 	// The opcodes are all defined consecutively, so the numeric value is
 	// the difference.
-	vm.dstack.PushInt(scriptNum((op.value - (OP_1 - 1))))
+	vm.dstack.PushInt(ScriptNum((op.value - (OP_1 - 1))))
 	return nil
 }
 
@@ -958,9 +958,9 @@ func opcodeCheckLockTimeVerify(op *opcode, data []byte, vm *Engine) error {
 	}
 
 	// The current transaction locktime is a uint32 resulting in a maximum
-	// locktime of 2^32-1 (the year 2106).  However, scriptNums are signed
-	// and therefore a standard 4-byte scriptNum would only support up to a
-	// maximum of 2^31-1 (the year 2038).  Thus, a 5-byte scriptNum is used
+	// locktime of 2^32-1 (the year 2106).  However, ScriptNums are signed
+	// and therefore a standard 4-byte ScriptNum would only support up to a
+	// maximum of 2^31-1 (the year 2038).  Thus, a 5-byte ScriptNum is used
 	// here since it will support up to 2^39-1 which allows dates beyond the
 	// current locktime limit.
 	lockTime, err := vm.dstack.PeekInt(0, cltvMaxScriptNumLen)
@@ -1025,9 +1025,9 @@ func opcodeCheckSequenceVerify(op *opcode, data []byte, vm *Engine) error {
 	}
 
 	// The current transaction sequence is a uint32 resulting in a maximum
-	// sequence of 2^32-1.  However, scriptNums are signed and therefore a
-	// standard 4-byte scriptNum would only support up to a maximum of
-	// 2^31-1.  Thus, a 5-byte scriptNum is used here since it will support
+	// sequence of 2^32-1.  However, ScriptNums are signed and therefore a
+	// standard 4-byte ScriptNum would only support up to a maximum of
+	// 2^31-1.  Thus, a 5-byte ScriptNum is used here since it will support
 	// up to 2^39-1 which allows sequences beyond the current sequence
 	// limit.
 	stackSequence, err := vm.dstack.PeekInt(0, csvMaxScriptNumLen)
@@ -1177,7 +1177,7 @@ func opcodeIfDup(op *opcode, data []byte, vm *Engine) error {
 // Example with 2 items: [x1 x2] -> [x1 x2 2]
 // Example with 3 items: [x1 x2 x3] -> [x1 x2 x3 3]
 func opcodeDepth(op *opcode, data []byte, vm *Engine) error {
-	vm.dstack.PushInt(scriptNum(vm.dstack.Depth()))
+	vm.dstack.PushInt(ScriptNum(vm.dstack.Depth()))
 	return nil
 }
 
@@ -1491,7 +1491,7 @@ func opcodeSize(op *opcode, data []byte, vm *Engine) error {
 		return err
 	}
 
-	vm.dstack.PushInt(scriptNum(len(so)))
+	vm.dstack.PushInt(ScriptNum(len(so)))
 	return nil
 }
 
@@ -1505,7 +1505,7 @@ func opcodeInvert(op *opcode, data []byte, vm *Engine) error {
 		return err
 	}
 
-	vm.dstack.PushInt(scriptNum(^v0.Int32()))
+	vm.dstack.PushInt(ScriptNum(^v0.Int32()))
 	return nil
 }
 
@@ -1524,7 +1524,7 @@ func opcodeAnd(op *opcode, data []byte, vm *Engine) error {
 		return err
 	}
 
-	vm.dstack.PushInt(scriptNum(v0.Int32() & v1.Int32()))
+	vm.dstack.PushInt(ScriptNum(v0.Int32() & v1.Int32()))
 	return nil
 }
 
@@ -1543,7 +1543,7 @@ func opcodeOr(op *opcode, data []byte, vm *Engine) error {
 		return err
 	}
 
-	vm.dstack.PushInt(scriptNum(v0.Int32() | v1.Int32()))
+	vm.dstack.PushInt(ScriptNum(v0.Int32() | v1.Int32()))
 	return nil
 }
 
@@ -1562,7 +1562,7 @@ func opcodeXor(op *opcode, data []byte, vm *Engine) error {
 		return err
 	}
 
-	vm.dstack.PushInt(scriptNum(v0.Int32() ^ v1.Int32()))
+	vm.dstack.PushInt(ScriptNum(v0.Int32() ^ v1.Int32()))
 	return nil
 }
 
@@ -1612,16 +1612,16 @@ func rotateRight(value int32, count int32) int32 {
 //
 // Stack transformation: [... x1 x2] -> [... rotr(x1, x2)]
 func opcodeRotr(op *opcode, data []byte, vm *Engine) error {
-	// WARNING: Since scriptNums are signed, a standard 4-byte scriptNum only
+	// WARNING: Since ScriptNums are signed, a standard 4-byte ScriptNum only
 	// supports up to a maximum of 2^31-1.  The value (v1) really should allow
-	// 5-byte scriptNums and have an overflow check later to clamp it to uint32,
+	// 5-byte ScriptNums and have an overflow check later to clamp it to uint32,
 	// so the full range of uint32 could be covered.  This has undesirable
 	// consequences on the semantics of right rotations such that attempting to
 	// do rotr(rotr(0x00000001, 1), 1) will fail due to the first rotation
 	// producing a value greater than the max int32 while rotr(0x00000001, 2)
 	// will work as expected.
 	//
-	// Unfortunately, a 4-byte scriptNum is now part of consensus, so changing
+	// Unfortunately, a 4-byte ScriptNum is now part of consensus, so changing
 	// it requires a consensus vote.
 	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen) // x2
 	if err != nil {
@@ -1647,7 +1647,7 @@ func opcodeRotr(op *opcode, data []byte, vm *Engine) error {
 		return scriptError(ErrOverflowRotation, str)
 	}
 
-	vm.dstack.PushInt(scriptNum(rotateRight(value, count)))
+	vm.dstack.PushInt(ScriptNum(rotateRight(value, count)))
 	return nil
 }
 
@@ -1664,16 +1664,16 @@ func rotateLeft(value int32, count int32) int32 {
 //
 // Stack transformation: [... x1 x2] -> [... rotl(x1, x2)]
 func opcodeRotl(op *opcode, data []byte, vm *Engine) error {
-	// WARNING: Since scriptNums are signed, a standard 4-byte scriptNum only
+	// WARNING: Since ScriptNums are signed, a standard 4-byte ScriptNum only
 	// supports up to a maximum of 2^31-1.  The value (v1) really should allow
-	// 5-byte scriptNums and have an overflow check later to clamp it to uint32,
+	// 5-byte ScriptNums and have an overflow check later to clamp it to uint32,
 	// so the full range of uint32 could be covered.  This has undesirable
 	// consequences on the semantics of left rotations such that attempting to
 	// do rotl(rotl(0x40000000, 1), 1) will fail due to the first rotation
 	// producing a value greater than the max int32 while rotl(0x40000000, 2)
 	// will work as expected.
 	//
-	// Unfortunately, a 4-byte scriptNum is now part of consensus, so changing
+	// Unfortunately, a 4-byte ScriptNum is now part of consensus, so changing
 	// it requires a consensus vote.
 	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen) // x2
 	if err != nil {
@@ -1699,7 +1699,7 @@ func opcodeRotl(op *opcode, data []byte, vm *Engine) error {
 		return scriptError(ErrOverflowRotation, str)
 	}
 
-	vm.dstack.PushInt(scriptNum(rotateLeft(value, count)))
+	vm.dstack.PushInt(ScriptNum(rotateLeft(value, count)))
 	return nil
 }
 
@@ -1781,9 +1781,9 @@ func opcodeNot(op *opcode, data []byte, vm *Engine) error {
 	}
 
 	if m == 0 {
-		vm.dstack.PushInt(scriptNum(1))
+		vm.dstack.PushInt(ScriptNum(1))
 	} else {
-		vm.dstack.PushInt(scriptNum(0))
+		vm.dstack.PushInt(ScriptNum(0))
 	}
 	return nil
 }
@@ -1864,7 +1864,7 @@ func opcodeMul(op *opcode, data []byte, vm *Engine) error {
 
 	v2 := v0.Int32() * v1.Int32()
 
-	vm.dstack.PushInt(scriptNum(v2))
+	vm.dstack.PushInt(ScriptNum(v2))
 	return nil
 }
 
@@ -1892,7 +1892,7 @@ func opcodeDiv(op *opcode, data []byte, vm *Engine) error {
 		return scriptError(ErrDivideByZero, "division by zero")
 	}
 
-	vm.dstack.PushInt(scriptNum(dividend / divisor))
+	vm.dstack.PushInt(ScriptNum(dividend / divisor))
 	return nil
 }
 
@@ -1923,7 +1923,7 @@ func opcodeMod(op *opcode, data []byte, vm *Engine) error {
 		return scriptError(ErrDivideByZero, "division by zero")
 	}
 
-	vm.dstack.PushInt(scriptNum(dividend % divisor))
+	vm.dstack.PushInt(ScriptNum(dividend % divisor))
 	return nil
 }
 
@@ -1934,16 +1934,16 @@ func opcodeMod(op *opcode, data []byte, vm *Engine) error {
 //
 // Stack transformation: [... x1 x2] -> [... x1 << x2]
 func opcodeLShift(op *opcode, data []byte, vm *Engine) error {
-	// WARNING: Since scriptNums are signed, a standard 4-byte scriptNum only
+	// WARNING: Since ScriptNums are signed, a standard 4-byte ScriptNum only
 	// supports up to a maximum of 2^31-1.  The value (v1) really should allow
-	// 5-byte scriptNums and have an overflow check later to clamp it to uint32,
+	// 5-byte ScriptNums and have an overflow check later to clamp it to uint32,
 	// so the full range of uint32 could be covered.  This has undesirable
 	// consequences on the semantics of left shift such that attempting to
 	// do ((0x40000000 << 1) << 1) will fail due to the first shift producing
 	// a value greater than the max int32 while (0x40000000 << 2) will work as
 	// expected.
 	//
-	// Unfortunately, a 4-byte scriptNum is now part of consensus, so changing
+	// Unfortunately, a 4-byte ScriptNum is now part of consensus, so changing
 	// it requires a consensus vote.
 	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen) // x2
 	if err != nil {
@@ -1969,7 +1969,7 @@ func opcodeLShift(op *opcode, data []byte, vm *Engine) error {
 		return scriptError(ErrOverflowShift, str)
 	}
 
-	vm.dstack.PushInt(scriptNum(value << uint(count)))
+	vm.dstack.PushInt(ScriptNum(value << uint(count)))
 	return nil
 }
 
@@ -1981,15 +1981,15 @@ func opcodeLShift(op *opcode, data []byte, vm *Engine) error {
 //
 // Stack transformation: [... x1 x2] -> [... x1 >> x2]
 func opcodeRShift(op *opcode, data []byte, vm *Engine) error {
-	// WARNING: Since scriptNums are signed, a standard 4-byte scriptNum only
+	// WARNING: Since ScriptNums are signed, a standard 4-byte ScriptNum only
 	// supports up to a maximum of 2^31-1.  The value (v1) really should allow
-	// 5-byte scriptNums and have an overflow check later to clamp it to uint32,
+	// 5-byte ScriptNums and have an overflow check later to clamp it to uint32,
 	// so the full range of uint32 could be covered.  This has undesirable
 	// consequences on the semantics of right shift such that attempting to
 	// do ((0x40000000 << 1) >> 1) will fail due to the first shift producing
 	// a value greater than the max int32.
 	//
-	// Unfortunately, a 4-byte scriptNum is now part of consensus, so changing
+	// Unfortunately, a 4-byte ScriptNum is now part of consensus, so changing
 	// it requires a consensus vote.
 	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen) // x2
 	if err != nil {
@@ -2015,7 +2015,7 @@ func opcodeRShift(op *opcode, data []byte, vm *Engine) error {
 		return scriptError(ErrOverflowShift, str)
 	}
 
-	vm.dstack.PushInt(scriptNum(value >> uint(count)))
+	vm.dstack.PushInt(ScriptNum(value >> uint(count)))
 	return nil
 }
 
@@ -2038,9 +2038,9 @@ func opcodeBoolAnd(op *opcode, data []byte, vm *Engine) error {
 	}
 
 	if v0 != 0 && v1 != 0 {
-		vm.dstack.PushInt(scriptNum(1))
+		vm.dstack.PushInt(ScriptNum(1))
 	} else {
-		vm.dstack.PushInt(scriptNum(0))
+		vm.dstack.PushInt(ScriptNum(0))
 	}
 
 	return nil
@@ -2065,9 +2065,9 @@ func opcodeBoolOr(op *opcode, data []byte, vm *Engine) error {
 	}
 
 	if v0 != 0 || v1 != 0 {
-		vm.dstack.PushInt(scriptNum(1))
+		vm.dstack.PushInt(ScriptNum(1))
 	} else {
-		vm.dstack.PushInt(scriptNum(0))
+		vm.dstack.PushInt(ScriptNum(0))
 	}
 
 	return nil
@@ -2090,9 +2090,9 @@ func opcodeNumEqual(op *opcode, data []byte, vm *Engine) error {
 	}
 
 	if v0 == v1 {
-		vm.dstack.PushInt(scriptNum(1))
+		vm.dstack.PushInt(ScriptNum(1))
 	} else {
-		vm.dstack.PushInt(scriptNum(0))
+		vm.dstack.PushInt(ScriptNum(0))
 	}
 
 	return nil
@@ -2131,9 +2131,9 @@ func opcodeNumNotEqual(op *opcode, data []byte, vm *Engine) error {
 	}
 
 	if v0 != v1 {
-		vm.dstack.PushInt(scriptNum(1))
+		vm.dstack.PushInt(ScriptNum(1))
 	} else {
-		vm.dstack.PushInt(scriptNum(0))
+		vm.dstack.PushInt(ScriptNum(0))
 	}
 
 	return nil
@@ -2156,9 +2156,9 @@ func opcodeLessThan(op *opcode, data []byte, vm *Engine) error {
 	}
 
 	if v1 < v0 {
-		vm.dstack.PushInt(scriptNum(1))
+		vm.dstack.PushInt(ScriptNum(1))
 	} else {
-		vm.dstack.PushInt(scriptNum(0))
+		vm.dstack.PushInt(ScriptNum(0))
 	}
 
 	return nil
@@ -2181,9 +2181,9 @@ func opcodeGreaterThan(op *opcode, data []byte, vm *Engine) error {
 	}
 
 	if v1 > v0 {
-		vm.dstack.PushInt(scriptNum(1))
+		vm.dstack.PushInt(ScriptNum(1))
 	} else {
-		vm.dstack.PushInt(scriptNum(0))
+		vm.dstack.PushInt(ScriptNum(0))
 	}
 	return nil
 }
@@ -2205,9 +2205,9 @@ func opcodeLessThanOrEqual(op *opcode, data []byte, vm *Engine) error {
 	}
 
 	if v1 <= v0 {
-		vm.dstack.PushInt(scriptNum(1))
+		vm.dstack.PushInt(ScriptNum(1))
 	} else {
-		vm.dstack.PushInt(scriptNum(0))
+		vm.dstack.PushInt(ScriptNum(0))
 	}
 	return nil
 }
@@ -2229,9 +2229,9 @@ func opcodeGreaterThanOrEqual(op *opcode, data []byte, vm *Engine) error {
 	}
 
 	if v1 >= v0 {
-		vm.dstack.PushInt(scriptNum(1))
+		vm.dstack.PushInt(ScriptNum(1))
 	} else {
-		vm.dstack.PushInt(scriptNum(0))
+		vm.dstack.PushInt(ScriptNum(0))
 	}
 
 	return nil
@@ -2310,9 +2310,9 @@ func opcodeWithin(op *opcode, data []byte, vm *Engine) error {
 	}
 
 	if x >= minVal && x < maxVal {
-		vm.dstack.PushInt(scriptNum(1))
+		vm.dstack.PushInt(ScriptNum(1))
 	} else {
-		vm.dstack.PushInt(scriptNum(0))
+		vm.dstack.PushInt(ScriptNum(0))
 	}
 	return nil
 }

--- a/txscript/opcode.go
+++ b/txscript/opcode.go
@@ -1030,7 +1030,7 @@ func opcodeCheckSequenceVerify(op *opcode, data []byte, vm *Engine) error {
 	// 2^31-1.  Thus, a 5-byte ScriptNum is used here since it will support
 	// up to 2^39-1 which allows sequences beyond the current sequence
 	// limit.
-	stackSequence, err := vm.dstack.PeekInt(0, csvMaxScriptNumLen)
+	stackSequence, err := vm.dstack.PeekInt(0, CsvMaxScriptNumLen)
 	if err != nil {
 		return err
 	}

--- a/txscript/opcode.go
+++ b/txscript/opcode.go
@@ -1216,7 +1216,7 @@ func opcodeOver(op *opcode, data []byte, vm *Engine) error {
 // Example with n=1: [x2 x1 x0 1] -> [x2 x1 x0 x1]
 // Example with n=2: [x2 x1 x0 2] -> [x2 x1 x0 x2]
 func opcodePick(op *opcode, data []byte, vm *Engine) error {
-	val, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	val, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -1231,7 +1231,7 @@ func opcodePick(op *opcode, data []byte, vm *Engine) error {
 // Example with n=1: [x2 x1 x0 1] -> [x2 x0 x1]
 // Example with n=2: [x2 x1 x0 2] -> [x1 x0 x2]
 func opcodeRoll(op *opcode, data []byte, vm *Engine) error {
-	val, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	val, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -1315,11 +1315,11 @@ func opcodeCat(op *opcode, data []byte, vm *Engine) error {
 //
 // Stack transformation: [... x1 x2 x3] -> [... x1[x3:x2]]
 func opcodeSubstr(op *opcode, data []byte, vm *Engine) error {
-	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen) // x3
+	v0, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen) // x3
 	if err != nil {
 		return err
 	}
-	v1, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen) // x2
+	v1, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen) // x2
 	if err != nil {
 		return err
 	}
@@ -1388,7 +1388,7 @@ func opcodeSubstr(op *opcode, data []byte, vm *Engine) error {
 //
 // Stack transformation: [... x1 x2] -> [... x1[0:x2]]
 func opcodeLeft(op *opcode, data []byte, vm *Engine) error {
-	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen) // x2
+	v0, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen) // x2
 	if err != nil {
 		return err
 	}
@@ -1436,7 +1436,7 @@ func opcodeLeft(op *opcode, data []byte, vm *Engine) error {
 //
 // Stack transformation: [... x1 x2] -> [... x1[x2:]]
 func opcodeRight(op *opcode, data []byte, vm *Engine) error {
-	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen) // x2
+	v0, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen) // x2
 	if err != nil {
 		return err
 	}
@@ -1500,7 +1500,7 @@ func opcodeSize(op *opcode, data []byte, vm *Engine) error {
 //
 // Stack transformation: [... x1] -> [... ~x1]
 func opcodeInvert(op *opcode, data []byte, vm *Engine) error {
-	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v0, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -1514,12 +1514,12 @@ func opcodeInvert(op *opcode, data []byte, vm *Engine) error {
 //
 // Stack transformation: [... x1 x2] -> [... x1 & x2]
 func opcodeAnd(op *opcode, data []byte, vm *Engine) error {
-	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v0, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
 
-	v1, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v1, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -1533,12 +1533,12 @@ func opcodeAnd(op *opcode, data []byte, vm *Engine) error {
 //
 // Stack transformation: [... x1 x2] -> [... x1 | x2]
 func opcodeOr(op *opcode, data []byte, vm *Engine) error {
-	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v0, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
 
-	v1, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v1, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -1552,12 +1552,12 @@ func opcodeOr(op *opcode, data []byte, vm *Engine) error {
 //
 // Stack transformation: [... x1 x2] -> [... x1 ^ x2]
 func opcodeXor(op *opcode, data []byte, vm *Engine) error {
-	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v0, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
 
-	v1, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v1, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -1623,11 +1623,11 @@ func opcodeRotr(op *opcode, data []byte, vm *Engine) error {
 	//
 	// Unfortunately, a 4-byte ScriptNum is now part of consensus, so changing
 	// it requires a consensus vote.
-	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen) // x2
+	v0, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen) // x2
 	if err != nil {
 		return err
 	}
-	v1, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen) // x1
+	v1, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen) // x1
 	if err != nil {
 		return err
 	}
@@ -1675,11 +1675,11 @@ func opcodeRotl(op *opcode, data []byte, vm *Engine) error {
 	//
 	// Unfortunately, a 4-byte ScriptNum is now part of consensus, so changing
 	// it requires a consensus vote.
-	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen) // x2
+	v0, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen) // x2
 	if err != nil {
 		return err
 	}
-	v1, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen) // x1
+	v1, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen) // x1
 	if err != nil {
 		return err
 	}
@@ -1708,7 +1708,7 @@ func opcodeRotl(op *opcode, data []byte, vm *Engine) error {
 //
 // Stack transformation: [... x1 x2] -> [... x1 x2+1]
 func opcode1Add(op *opcode, data []byte, vm *Engine) error {
-	m, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	m, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -1722,7 +1722,7 @@ func opcode1Add(op *opcode, data []byte, vm *Engine) error {
 //
 // Stack transformation: [... x1 x2] -> [... x1 x2-1]
 func opcode1Sub(op *opcode, data []byte, vm *Engine) error {
-	m, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	m, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -1736,7 +1736,7 @@ func opcode1Sub(op *opcode, data []byte, vm *Engine) error {
 //
 // Stack transformation: [... x1 x2] -> [... x1 -x2]
 func opcodeNegate(op *opcode, data []byte, vm *Engine) error {
-	m, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	m, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -1750,7 +1750,7 @@ func opcodeNegate(op *opcode, data []byte, vm *Engine) error {
 //
 // Stack transformation: [... x1 x2] -> [... x1 abs(x2)]
 func opcodeAbs(op *opcode, data []byte, vm *Engine) error {
-	m, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	m, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -1775,7 +1775,7 @@ func opcodeAbs(op *opcode, data []byte, vm *Engine) error {
 // Stack transformation (x2!=0): [... x1 1] -> [... x1 0]
 // Stack transformation (x2!=0): [... x1 17] -> [... x1 0]
 func opcodeNot(op *opcode, data []byte, vm *Engine) error {
-	m, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	m, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -1795,7 +1795,7 @@ func opcodeNot(op *opcode, data []byte, vm *Engine) error {
 // Stack transformation (x2!=0): [... x1 1] -> [... x1 1]
 // Stack transformation (x2!=0): [... x1 17] -> [... x1 1]
 func opcode0NotEqual(op *opcode, data []byte, vm *Engine) error {
-	m, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	m, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -1812,12 +1812,12 @@ func opcode0NotEqual(op *opcode, data []byte, vm *Engine) error {
 //
 // Stack transformation: [... x1 x2] -> [... x1+x2]
 func opcodeAdd(op *opcode, data []byte, vm *Engine) error {
-	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v0, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
 
-	v1, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v1, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -1832,12 +1832,12 @@ func opcodeAdd(op *opcode, data []byte, vm *Engine) error {
 //
 // Stack transformation: [... x1 x2] -> [... x1-x2]
 func opcodeSub(op *opcode, data []byte, vm *Engine) error {
-	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v0, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
 
-	v1, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v1, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -1852,12 +1852,12 @@ func opcodeSub(op *opcode, data []byte, vm *Engine) error {
 //
 // Stack transformation: [... x1 x2] -> [... x1*x2]
 func opcodeMul(op *opcode, data []byte, vm *Engine) error {
-	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v0, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
 
-	v1, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v1, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -1874,11 +1874,11 @@ func opcodeMul(op *opcode, data []byte, vm *Engine) error {
 //
 // Stack transformation: [... x1 x2] -> [... x1/x2]
 func opcodeDiv(op *opcode, data []byte, vm *Engine) error {
-	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v0, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
-	v1, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v1, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -1905,11 +1905,11 @@ func opcodeDiv(op *opcode, data []byte, vm *Engine) error {
 //
 // Stack transformation: [... x1 x2] -> [... x1/x2]
 func opcodeMod(op *opcode, data []byte, vm *Engine) error {
-	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v0, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
-	v1, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v1, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -1945,11 +1945,11 @@ func opcodeLShift(op *opcode, data []byte, vm *Engine) error {
 	//
 	// Unfortunately, a 4-byte ScriptNum is now part of consensus, so changing
 	// it requires a consensus vote.
-	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen) // x2
+	v0, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen) // x2
 	if err != nil {
 		return err
 	}
-	v1, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen) // x1
+	v1, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen) // x1
 	if err != nil {
 		return err
 	}
@@ -1991,11 +1991,11 @@ func opcodeRShift(op *opcode, data []byte, vm *Engine) error {
 	//
 	// Unfortunately, a 4-byte ScriptNum is now part of consensus, so changing
 	// it requires a consensus vote.
-	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen) // x2
+	v0, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen) // x2
 	if err != nil {
 		return err
 	}
-	v1, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen) // x1
+	v1, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen) // x1
 	if err != nil {
 		return err
 	}
@@ -2027,12 +2027,12 @@ func opcodeRShift(op *opcode, data []byte, vm *Engine) error {
 // Stack transformation (x1==0, x2!=0): [... 0 7] -> [... 0]
 // Stack transformation (x1!=0, x2!=0): [... 4 8] -> [... 1]
 func opcodeBoolAnd(op *opcode, data []byte, vm *Engine) error {
-	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v0, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
 
-	v1, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v1, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -2054,12 +2054,12 @@ func opcodeBoolAnd(op *opcode, data []byte, vm *Engine) error {
 // Stack transformation (x1==0, x2!=0): [... 0 7] -> [... 1]
 // Stack transformation (x1!=0, x2!=0): [... 4 8] -> [... 1]
 func opcodeBoolOr(op *opcode, data []byte, vm *Engine) error {
-	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v0, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
 
-	v1, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v1, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -2079,12 +2079,12 @@ func opcodeBoolOr(op *opcode, data []byte, vm *Engine) error {
 // Stack transformation (x1==x2): [... 5 5] -> [... 1]
 // Stack transformation (x1!=x2): [... 5 7] -> [... 0]
 func opcodeNumEqual(op *opcode, data []byte, vm *Engine) error {
-	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v0, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
 
-	v1, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v1, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -2120,12 +2120,12 @@ func opcodeNumEqualVerify(op *opcode, data []byte, vm *Engine) error {
 // Stack transformation (x1==x2): [... 5 5] -> [... 0]
 // Stack transformation (x1!=x2): [... 5 7] -> [... 1]
 func opcodeNumNotEqual(op *opcode, data []byte, vm *Engine) error {
-	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v0, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
 
-	v1, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v1, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -2145,12 +2145,12 @@ func opcodeNumNotEqual(op *opcode, data []byte, vm *Engine) error {
 //
 // Stack transformation: [... x1 x2] -> [... bool]
 func opcodeLessThan(op *opcode, data []byte, vm *Engine) error {
-	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v0, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
 
-	v1, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v1, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -2170,12 +2170,12 @@ func opcodeLessThan(op *opcode, data []byte, vm *Engine) error {
 //
 // Stack transformation: [... x1 x2] -> [... bool]
 func opcodeGreaterThan(op *opcode, data []byte, vm *Engine) error {
-	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v0, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
 
-	v1, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v1, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -2194,12 +2194,12 @@ func opcodeGreaterThan(op *opcode, data []byte, vm *Engine) error {
 //
 // Stack transformation: [... x1 x2] -> [... bool]
 func opcodeLessThanOrEqual(op *opcode, data []byte, vm *Engine) error {
-	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v0, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
 
-	v1, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v1, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -2218,12 +2218,12 @@ func opcodeLessThanOrEqual(op *opcode, data []byte, vm *Engine) error {
 //
 // Stack transformation: [... x1 x2] -> [... bool]
 func opcodeGreaterThanOrEqual(op *opcode, data []byte, vm *Engine) error {
-	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v0, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
 
-	v1, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v1, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -2242,12 +2242,12 @@ func opcodeGreaterThanOrEqual(op *opcode, data []byte, vm *Engine) error {
 //
 // Stack transformation: [... x1 x2] -> [... min(x1, x2)]
 func opcodeMin(op *opcode, data []byte, vm *Engine) error {
-	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v0, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
 
-	v1, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v1, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -2266,12 +2266,12 @@ func opcodeMin(op *opcode, data []byte, vm *Engine) error {
 //
 // Stack transformation: [... x1 x2] -> [... max(x1, x2)]
 func opcodeMax(op *opcode, data []byte, vm *Engine) error {
-	v0, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v0, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
 
-	v1, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	v1, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -2294,17 +2294,17 @@ func opcodeMax(op *opcode, data []byte, vm *Engine) error {
 //
 // Stack transformation: [... x1 min max] -> [... bool]
 func opcodeWithin(op *opcode, data []byte, vm *Engine) error {
-	maxVal, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	maxVal, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
 
-	minVal, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	minVal, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
 
-	x, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	x, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -2560,7 +2560,7 @@ type parsedSigInfo struct {
 // Stack transformation:
 // [... [sig ...] numsigs [pubkey ...] numpubkeys] -> [... bool]
 func opcodeCheckMultiSig(op *opcode, data []byte, vm *Engine) error {
-	numKeys, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	numKeys, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}
@@ -2592,7 +2592,7 @@ func opcodeCheckMultiSig(op *opcode, data []byte, vm *Engine) error {
 		pubKeys = append(pubKeys, pubKey)
 	}
 
-	numSigs, err := vm.dstack.PopInt(mathOpCodeMaxScriptNumLen)
+	numSigs, err := vm.dstack.PopInt(MathOpCodeMaxScriptNumLen)
 	if err != nil {
 		return err
 	}

--- a/txscript/script.go
+++ b/txscript/script.go
@@ -68,13 +68,13 @@ func isStakeOpcode(op byte) bool {
 	return op >= OP_SSTX && op <= OP_SSTXCHANGE
 }
 
-// extractScriptHash extracts the script hash from the passed script if it is a
+// ExtractScriptHash extracts the script hash from the passed script if it is a
 // standard pay-to-script-hash script.  It will return nil otherwise.
 //
 // NOTE: This function is only valid for version 0 opcodes.  Since the function
 // does not accept a script version, the results are undefined for other script
 // versions.
-func extractScriptHash(script []byte) []byte {
+func ExtractScriptHash(script []byte) []byte {
 	// A pay-to-script-hash script is of the form:
 	//  OP_HASH160 <20-byte scripthash> OP_EQUAL
 	if len(script) == 23 &&
@@ -91,7 +91,7 @@ func extractScriptHash(script []byte) []byte {
 // isScriptHashScript returns whether or not the passed script is a standard
 // pay-to-script-hash script.
 func isScriptHashScript(script []byte) bool {
-	return extractScriptHash(script) != nil
+	return ExtractScriptHash(script) != nil
 }
 
 // isStakeScriptHashScript returns whether or not the passed script is a

--- a/txscript/script.go
+++ b/txscript/script.go
@@ -17,13 +17,13 @@ const (
 	MaxScriptElementSize  = 2048 // Max bytes pushable to the stack.
 )
 
-// isSmallInt returns whether or not the opcode is considered a small integer,
+// IsSmallInt returns whether or not the opcode is considered a small integer,
 // which is an OP_0, or OP_1 through OP_16.
 //
 // NOTE: This function is only valid for version 0 opcodes.  Since the function
 // does not accept a script version, the results are undefined for other script
 // versions.
-func isSmallInt(op byte) bool {
+func IsSmallInt(op byte) bool {
 	return op == OP_0 || (op >= OP_1 && op <= OP_16)
 }
 

--- a/txscript/script.go
+++ b/txscript/script.go
@@ -263,9 +263,14 @@ func removeOpcodeByData(script []byte, dataToRemove []byte) []byte {
 	return result
 }
 
-// asSmallInt returns the passed opcode, which must be true according to
-// isSmallInt(), as an integer.
-func asSmallInt(op byte) int {
+// AsSmallInt returns the passed opcode, which MUST be true according to the
+// IsSmallInt function, as an integer.
+//
+//
+// NOTE: This function is only valid for version 0 opcodes.  Since the function
+// does not accept a script version, the results are undefined for other script
+// versions.
+func AsSmallInt(op byte) int {
 	if op == OP_0 {
 		return 0
 	}
@@ -312,7 +317,7 @@ func countSigOpsV0(script []byte, precise bool) int {
 			// multisignature operations in new script versions should move to
 			// aggregated schemes such as Schnorr instead.
 			if precise && prevOp >= OP_1 && prevOp <= OP_16 {
-				numSigOps += asSmallInt(prevOp)
+				numSigOps += AsSmallInt(prevOp)
 			} else {
 				numSigOps += MaxPubKeysPerMultiSig
 			}

--- a/txscript/scriptbuilder.go
+++ b/txscript/scriptbuilder.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015-2019 The Decred developers
+// Copyright (c) 2015-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -251,7 +251,7 @@ func (b *ScriptBuilder) AddInt64(val int64) *ScriptBuilder {
 		return b
 	}
 
-	return b.AddData(scriptNum(val).Bytes())
+	return b.AddData(ScriptNum(val).Bytes())
 }
 
 // Reset resets the script so it has no content.

--- a/txscript/scriptnum.go
+++ b/txscript/scriptnum.go
@@ -17,7 +17,7 @@ const (
 	// interpreted as an integer may be for the majority of op codes.
 	MathOpCodeMaxScriptNumLen = 4
 
-	// cltvMaxScriptNumLen is the maximum number of bytes data being interpreted
+	// CltvMaxScriptNumLen is the maximum number of bytes data being interpreted
 	// as an integer may be for by-time and by-height locks as interpreted by
 	// CHECKLOCKTIMEVERIFY.
 	//
@@ -27,7 +27,7 @@ const (
 	// 4-byte ScriptNum would only support up to a maximum of 2^31-1 (the
 	// year 2038).  Thus, a 5-byte ScriptNum is needed since it will support
 	// up to 2^39-1 which allows dates beyond the current locktime limit.
-	cltvMaxScriptNumLen = 5
+	CltvMaxScriptNumLen = 5
 
 	// csvMaxScriptNumLen is the maximum number of bytes data being interpreted
 	// as an integer may be for by-time and by-height locks as interpreted by

--- a/txscript/scriptnum.go
+++ b/txscript/scriptnum.go
@@ -13,9 +13,9 @@ const (
 	maxInt32 = 1<<31 - 1
 	minInt32 = -1 << 31
 
-	// mathOpCodeMaxScriptNumLen is the maximum number of bytes data being
+	// MathOpCodeMaxScriptNumLen is the maximum number of bytes data being
 	// interpreted as an integer may be for the majority of op codes.
-	mathOpCodeMaxScriptNumLen = 4
+	MathOpCodeMaxScriptNumLen = 4
 
 	// cltvMaxScriptNumLen is the maximum number of bytes data being interpreted
 	// as an integer may be for by-time and by-height locks as interpreted by

--- a/txscript/scriptnum.go
+++ b/txscript/scriptnum.go
@@ -29,7 +29,7 @@ const (
 	// up to 2^39-1 which allows dates beyond the current locktime limit.
 	CltvMaxScriptNumLen = 5
 
-	// csvMaxScriptNumLen is the maximum number of bytes data being interpreted
+	// CsvMaxScriptNumLen is the maximum number of bytes data being interpreted
 	// as an integer may be for by-time and by-height locks as interpreted by
 	// CHECKSEQUENCEVERIFY.
 	//
@@ -39,7 +39,7 @@ const (
 	// only support up to a maximum of 2^31-1.  Thus, a 5-byte ScriptNum is
 	// needed since it will support up to 2^39-1 which allows sequences
 	// beyond the current sequence limit.
-	csvMaxScriptNumLen = 5
+	CsvMaxScriptNumLen = 5
 
 	// altSigSuitesMaxscriptNumLen is the maximum number of bytes for the
 	// type of alternative signature suite

--- a/txscript/scriptnum.go
+++ b/txscript/scriptnum.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2015-2017 The btcsuite developers
-// Copyright (c) 2015-2019 The Decred developers
+// Copyright (c) 2015-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -23,9 +23,9 @@ const (
 	//
 	// The value comes from the fact that the current transaction locktime
 	// is a uint32 resulting in a maximum locktime of 2^32-1 (the year
-	// 2106).  However, scriptNums are signed and therefore a standard
-	// 4-byte scriptNum would only support up to a maximum of 2^31-1 (the
-	// year 2038).  Thus, a 5-byte scriptNum is needed since it will support
+	// 2106).  However, script numbers are signed and therefore a standard
+	// 4-byte ScriptNum would only support up to a maximum of 2^31-1 (the
+	// year 2038).  Thus, a 5-byte ScriptNum is needed since it will support
 	// up to 2^39-1 which allows dates beyond the current locktime limit.
 	cltvMaxScriptNumLen = 5
 
@@ -35,8 +35,8 @@ const (
 	//
 	// The value comes from the fact that the current transaction sequence
 	// is a uint32 resulting in a maximum sequence of 2^32-1.  However,
-	// scriptNums are signed and therefore a standard 4-byte scriptNum would
-	// only support up to a maximum of 2^31-1.  Thus, a 5-byte scriptNum is
+	// ScriptNums are signed and therefore a standard 4-byte ScriptNum would
+	// only support up to a maximum of 2^31-1.  Thus, a 5-byte ScriptNum is
 	// needed since it will support up to 2^39-1 which allows sequences
 	// beyond the current sequence limit.
 	csvMaxScriptNumLen = 5
@@ -46,7 +46,7 @@ const (
 	altSigSuitesMaxscriptNumLen = 1
 )
 
-// scriptNum represents a numeric value used in the scripting engine with
+// ScriptNum represents a numeric value used in the scripting engine with
 // special handling to deal with the subtle semantics required by consensus.
 //
 // All numbers are stored on the data and alternate stacks encoded as little
@@ -68,11 +68,11 @@ const (
 // method to get the serialized representation (including values that overflow).
 //
 // Then, whenever data is interpreted as an integer, it is converted to this
-// type by using the makeScriptNum function which will return an error if the
+// type by using the MakeScriptNum function which will return an error if the
 // number is out of range or not minimally encoded depending on parameters.
 // Since all numeric opcodes involve pulling data from the stack and
 // interpreting it as an integer, it provides the required behavior.
-type scriptNum int64
+type ScriptNum int64
 
 // checkMinimalDataEncoding returns whether or not the passed byte array adheres
 // to the minimal encoding requirements.
@@ -118,7 +118,7 @@ func checkMinimalDataEncoding(v []byte) error {
 //    -32767 -> [0xff 0xff]
 //     32768 -> [0x00 0x80 0x00]
 //    -32768 -> [0x00 0x80 0x80]
-func (n scriptNum) Bytes() []byte {
+func (n ScriptNum) Bytes() []byte {
 	// Zero encodes as an empty byte slice.
 	if n == 0 {
 		return nil
@@ -167,12 +167,12 @@ func (n scriptNum) Bytes() []byte {
 // provide this behavior.
 //
 // In practice, for most opcodes, the number should never be out of range since
-// it will have been created with makeScriptNum using the defaultScriptLen
+// it will have been created with MakeScriptNum using the defaultScriptLen
 // value, which rejects them.  In case something in the future ends up calling
 // this function against the result of some arithmetic, which IS allowed to be
 // out of range before being reinterpreted as an integer, this will provide the
 // correct behavior.
-func (n scriptNum) Int32() int32 {
+func (n ScriptNum) Int32() int32 {
 	if n > maxInt32 {
 		return maxInt32
 	}
@@ -184,7 +184,7 @@ func (n scriptNum) Int32() int32 {
 	return int32(n)
 }
 
-// makeScriptNum interprets the passed serialized bytes as an encoded integer
+// MakeScriptNum interprets the passed serialized bytes as an encoded integer
 // and returns the result as a script number.
 //
 // Since the consensus rules dictate that serialized bytes interpreted as ints
@@ -210,7 +210,7 @@ func (n scriptNum) Int32() int32 {
 // overflows.
 //
 // See the Bytes function documentation for example encodings.
-func makeScriptNum(v []byte, scriptNumLen int) (scriptNum, error) {
+func MakeScriptNum(v []byte, scriptNumLen int) (ScriptNum, error) {
 	// Interpreting data requires that it is not larger than
 	// the passed scriptNumLen value.
 	if len(v) > scriptNumLen {
@@ -244,8 +244,8 @@ func makeScriptNum(v []byte, scriptNumLen int) (scriptNum, error) {
 		// above, so uint8 is enough to cover the max possible shift
 		// value of 24.
 		result &= ^(int64(0x80) << uint8(8*(len(v)-1)))
-		return scriptNum(-result), nil
+		return ScriptNum(-result), nil
 	}
 
-	return scriptNum(result), nil
+	return ScriptNum(result), nil
 }

--- a/txscript/scriptnum_test.go
+++ b/txscript/scriptnum_test.go
@@ -100,35 +100,35 @@ func TestMakeScriptNum(t *testing.T) {
 		err        error
 	}{
 		// Minimal encoding must reject negative 0.
-		{hexToBytes("80"), 0, mathOpCodeMaxScriptNumLen, ErrMinimalData},
+		{hexToBytes("80"), 0, MathOpCodeMaxScriptNumLen, ErrMinimalData},
 
 		// Minimally encoded valid values.  Should not error and return
 		// expected integral number.
-		{nil, 0, mathOpCodeMaxScriptNumLen, nil},
-		{hexToBytes("01"), 1, mathOpCodeMaxScriptNumLen, nil},
-		{hexToBytes("81"), -1, mathOpCodeMaxScriptNumLen, nil},
-		{hexToBytes("7f"), 127, mathOpCodeMaxScriptNumLen, nil},
-		{hexToBytes("ff"), -127, mathOpCodeMaxScriptNumLen, nil},
-		{hexToBytes("8000"), 128, mathOpCodeMaxScriptNumLen, nil},
-		{hexToBytes("8080"), -128, mathOpCodeMaxScriptNumLen, nil},
-		{hexToBytes("8100"), 129, mathOpCodeMaxScriptNumLen, nil},
-		{hexToBytes("8180"), -129, mathOpCodeMaxScriptNumLen, nil},
-		{hexToBytes("0001"), 256, mathOpCodeMaxScriptNumLen, nil},
-		{hexToBytes("0081"), -256, mathOpCodeMaxScriptNumLen, nil},
-		{hexToBytes("ff7f"), 32767, mathOpCodeMaxScriptNumLen, nil},
-		{hexToBytes("ffff"), -32767, mathOpCodeMaxScriptNumLen, nil},
-		{hexToBytes("008000"), 32768, mathOpCodeMaxScriptNumLen, nil},
-		{hexToBytes("008080"), -32768, mathOpCodeMaxScriptNumLen, nil},
-		{hexToBytes("ffff00"), 65535, mathOpCodeMaxScriptNumLen, nil},
-		{hexToBytes("ffff80"), -65535, mathOpCodeMaxScriptNumLen, nil},
-		{hexToBytes("000008"), 524288, mathOpCodeMaxScriptNumLen, nil},
-		{hexToBytes("000088"), -524288, mathOpCodeMaxScriptNumLen, nil},
-		{hexToBytes("000070"), 7340032, mathOpCodeMaxScriptNumLen, nil},
-		{hexToBytes("0000f0"), -7340032, mathOpCodeMaxScriptNumLen, nil},
-		{hexToBytes("00008000"), 8388608, mathOpCodeMaxScriptNumLen, nil},
-		{hexToBytes("00008080"), -8388608, mathOpCodeMaxScriptNumLen, nil},
-		{hexToBytes("ffffff7f"), 2147483647, mathOpCodeMaxScriptNumLen, nil},
-		{hexToBytes("ffffffff"), -2147483647, mathOpCodeMaxScriptNumLen, nil},
+		{nil, 0, MathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("01"), 1, MathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("81"), -1, MathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("7f"), 127, MathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("ff"), -127, MathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("8000"), 128, MathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("8080"), -128, MathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("8100"), 129, MathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("8180"), -129, MathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("0001"), 256, MathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("0081"), -256, MathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("ff7f"), 32767, MathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("ffff"), -32767, MathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("008000"), 32768, MathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("008080"), -32768, MathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("ffff00"), 65535, MathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("ffff80"), -65535, MathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("000008"), 524288, MathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("000088"), -524288, MathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("000070"), 7340032, MathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("0000f0"), -7340032, MathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("00008000"), 8388608, MathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("00008080"), -8388608, MathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("ffffff7f"), 2147483647, MathOpCodeMaxScriptNumLen, nil},
+		{hexToBytes("ffffffff"), -2147483647, MathOpCodeMaxScriptNumLen, nil},
 		{hexToBytes("ffffffff7f"), 549755813887, 5, nil},
 		{hexToBytes("ffffffffff"), -549755813887, 5, nil},
 		{hexToBytes("ffffffffffffff7f"), 9223372036854775807, 8, nil},
@@ -140,34 +140,34 @@ func TestMakeScriptNum(t *testing.T) {
 
 		// Minimally encoded values that are out of range for data that
 		// is interpreted as script numbers.  Should error and return 0.
-		{hexToBytes("0000008000"), 0, mathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
-		{hexToBytes("0000008080"), 0, mathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
-		{hexToBytes("0000009000"), 0, mathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
-		{hexToBytes("0000009080"), 0, mathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
-		{hexToBytes("ffffffff00"), 0, mathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
-		{hexToBytes("ffffffff80"), 0, mathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
-		{hexToBytes("0000000001"), 0, mathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
-		{hexToBytes("0000000081"), 0, mathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
-		{hexToBytes("ffffffffffff00"), 0, mathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
-		{hexToBytes("ffffffffffff80"), 0, mathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
-		{hexToBytes("ffffffffffffff00"), 0, mathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
-		{hexToBytes("ffffffffffffff80"), 0, mathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
-		{hexToBytes("ffffffffffffff7f"), 0, mathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
-		{hexToBytes("ffffffffffffffff"), 0, mathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
+		{hexToBytes("0000008000"), 0, MathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
+		{hexToBytes("0000008080"), 0, MathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
+		{hexToBytes("0000009000"), 0, MathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
+		{hexToBytes("0000009080"), 0, MathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
+		{hexToBytes("ffffffff00"), 0, MathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
+		{hexToBytes("ffffffff80"), 0, MathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
+		{hexToBytes("0000000001"), 0, MathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
+		{hexToBytes("0000000081"), 0, MathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
+		{hexToBytes("ffffffffffff00"), 0, MathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
+		{hexToBytes("ffffffffffff80"), 0, MathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
+		{hexToBytes("ffffffffffffff00"), 0, MathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
+		{hexToBytes("ffffffffffffff80"), 0, MathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
+		{hexToBytes("ffffffffffffff7f"), 0, MathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
+		{hexToBytes("ffffffffffffffff"), 0, MathOpCodeMaxScriptNumLen, ErrNumOutOfRange},
 
 		// Non-minimally encoded, but otherwise valid values.  Should
 		// error and return 0.
-		{hexToBytes("00"), 0, mathOpCodeMaxScriptNumLen, ErrMinimalData},       // 0
-		{hexToBytes("0100"), 0, mathOpCodeMaxScriptNumLen, ErrMinimalData},     // 1
-		{hexToBytes("7f00"), 0, mathOpCodeMaxScriptNumLen, ErrMinimalData},     // 127
-		{hexToBytes("800000"), 0, mathOpCodeMaxScriptNumLen, ErrMinimalData},   // 128
-		{hexToBytes("810000"), 0, mathOpCodeMaxScriptNumLen, ErrMinimalData},   // 129
-		{hexToBytes("000100"), 0, mathOpCodeMaxScriptNumLen, ErrMinimalData},   // 256
-		{hexToBytes("ff7f00"), 0, mathOpCodeMaxScriptNumLen, ErrMinimalData},   // 32767
-		{hexToBytes("00800000"), 0, mathOpCodeMaxScriptNumLen, ErrMinimalData}, // 32768
-		{hexToBytes("ffff0000"), 0, mathOpCodeMaxScriptNumLen, ErrMinimalData}, // 65535
-		{hexToBytes("00000800"), 0, mathOpCodeMaxScriptNumLen, ErrMinimalData}, // 524288
-		{hexToBytes("00007000"), 0, mathOpCodeMaxScriptNumLen, ErrMinimalData}, // 7340032
+		{hexToBytes("00"), 0, MathOpCodeMaxScriptNumLen, ErrMinimalData},       // 0
+		{hexToBytes("0100"), 0, MathOpCodeMaxScriptNumLen, ErrMinimalData},     // 1
+		{hexToBytes("7f00"), 0, MathOpCodeMaxScriptNumLen, ErrMinimalData},     // 127
+		{hexToBytes("800000"), 0, MathOpCodeMaxScriptNumLen, ErrMinimalData},   // 128
+		{hexToBytes("810000"), 0, MathOpCodeMaxScriptNumLen, ErrMinimalData},   // 129
+		{hexToBytes("000100"), 0, MathOpCodeMaxScriptNumLen, ErrMinimalData},   // 256
+		{hexToBytes("ff7f00"), 0, MathOpCodeMaxScriptNumLen, ErrMinimalData},   // 32767
+		{hexToBytes("00800000"), 0, MathOpCodeMaxScriptNumLen, ErrMinimalData}, // 32768
+		{hexToBytes("ffff0000"), 0, MathOpCodeMaxScriptNumLen, ErrMinimalData}, // 65535
+		{hexToBytes("00000800"), 0, MathOpCodeMaxScriptNumLen, ErrMinimalData}, // 524288
+		{hexToBytes("00007000"), 0, MathOpCodeMaxScriptNumLen, ErrMinimalData}, // 7340032
 		{hexToBytes("0009000100"), 0, 5, ErrMinimalData},                       // 16779520
 	}
 

--- a/txscript/scriptnum_test.go
+++ b/txscript/scriptnum_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2015-2017 The btcsuite developers
-// Copyright (c) 2015-2018 The Decred developers
+// Copyright (c) 2015-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -30,7 +30,7 @@ func TestScriptNumBytes(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		num        scriptNum
+		num        ScriptNum
 		serialized []byte
 	}{
 		{0, nil},
@@ -95,7 +95,7 @@ func TestMakeScriptNum(t *testing.T) {
 
 	tests := []struct {
 		serialized []byte
-		num        scriptNum
+		num        ScriptNum
 		numLen     int
 		err        error
 	}{
@@ -173,17 +173,16 @@ func TestMakeScriptNum(t *testing.T) {
 
 	for _, test := range tests {
 		// Ensure the error matches the value specified in the test instance.
-		gotNum, err := makeScriptNum(test.serialized, test.numLen)
+		gotNum, err := MakeScriptNum(test.serialized, test.numLen)
 		if !errors.Is(err, test.err) {
-			t.Errorf("makeScriptNum(%#x): unexpected error - got %v, want %v",
+			t.Errorf("MakeScriptNum(%#x): unexpected error - got %v, want %v",
 				test.serialized, err, test.err)
 			continue
 		}
 
 		if gotNum != test.num {
-			t.Errorf("makeScriptNum(%#x): did not get expected "+
-				"number - got %d, want %d", test.serialized,
-				gotNum, test.num)
+			t.Errorf("MakeScriptNum(%#x): did not get expected number - got "+
+				"%d, want %d", test.serialized, gotNum, test.num)
 			continue
 		}
 	}
@@ -195,7 +194,7 @@ func TestScriptNumInt32(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		in   scriptNum
+		in   ScriptNum
 		want int32
 	}{
 		// Values inside the valid int32 range are just the values

--- a/txscript/stack.go
+++ b/txscript/stack.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2017 The btcsuite developers
-// Copyright (c) 2015-2019 The Decred developers
+// Copyright (c) 2015-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -52,11 +52,11 @@ func (s *stack) PushByteArray(so []byte) {
 	s.stk = append(s.stk, so)
 }
 
-// PushInt converts the provided scriptNum to a suitable byte array then pushes
+// PushInt converts the provided ScriptNum to a suitable byte array then pushes
 // it onto the top of the stack.
 //
 // Stack transformation: [... x1 x2] -> [... x1 x2 int]
-func (s *stack) PushInt(val scriptNum) {
+func (s *stack) PushInt(val ScriptNum) {
 	s.PushByteArray(val.Bytes())
 }
 
@@ -80,13 +80,13 @@ func (s *stack) PopByteArray() ([]byte, error) {
 // consensus rules imposed on data interpreted as numbers.
 //
 // Stack transformation: [... x1 x2 x3] -> [... x1 x2]
-func (s *stack) PopInt(maxScriptNumLen int) (scriptNum, error) {
+func (s *stack) PopInt(maxScriptNumLen int) (ScriptNum, error) {
 	so, err := s.PopByteArray()
 	if err != nil {
 		return 0, err
 	}
 
-	return makeScriptNum(so, maxScriptNumLen)
+	return MakeScriptNum(so, maxScriptNumLen)
 }
 
 // PopBool pops the value off the top of the stack, converts it into a bool, and
@@ -117,13 +117,13 @@ func (s *stack) PeekByteArray(idx int32) ([]byte, error) {
 // PeekInt returns the Nth item on the stack as a script num without removing
 // it.  The act of converting to a script num enforces the consensus rules
 // imposed on data interpreted as numbers.
-func (s *stack) PeekInt(idx int32, maxScriptNumLen int) (scriptNum, error) {
+func (s *stack) PeekInt(idx int32, maxScriptNumLen int) (ScriptNum, error) {
 	so, err := s.PeekByteArray(idx)
 	if err != nil {
 		return 0, err
 	}
 
-	return makeScriptNum(so, maxScriptNumLen)
+	return MakeScriptNum(so, maxScriptNumLen)
 }
 
 // PeekBool returns the Nth item on the stack as a bool without removing it.

--- a/txscript/stack_test.go
+++ b/txscript/stack_test.go
@@ -46,7 +46,7 @@ func TestStack(t *testing.T) {
 			"peek underflow (int)",
 			[][]byte{{1}, {2}, {3}, {4}, {5}},
 			func(s *stack) error {
-				_, err := s.PeekInt(5, mathOpCodeMaxScriptNumLen)
+				_, err := s.PeekInt(5, MathOpCodeMaxScriptNumLen)
 				return err
 			},
 			ErrInvalidStackOperation,
@@ -156,7 +156,7 @@ func TestStack(t *testing.T) {
 			"popInt 0",
 			[][]byte{nil},
 			func(s *stack) error {
-				v, err := s.PopInt(mathOpCodeMaxScriptNumLen)
+				v, err := s.PopInt(MathOpCodeMaxScriptNumLen)
 				if err != nil {
 					return err
 				}
@@ -172,7 +172,7 @@ func TestStack(t *testing.T) {
 			"non-minimal popInt 0",
 			[][]byte{{0x0}},
 			func(s *stack) error {
-				_, err := s.PopInt(mathOpCodeMaxScriptNumLen)
+				_, err := s.PopInt(MathOpCodeMaxScriptNumLen)
 				return err
 			},
 			ErrMinimalData,
@@ -182,7 +182,7 @@ func TestStack(t *testing.T) {
 			"non-minimal popInt -0",
 			[][]byte{{0x80}},
 			func(s *stack) error {
-				_, err := s.PopInt(mathOpCodeMaxScriptNumLen)
+				_, err := s.PopInt(MathOpCodeMaxScriptNumLen)
 				return err
 			},
 			ErrMinimalData,
@@ -192,7 +192,7 @@ func TestStack(t *testing.T) {
 			"popInt 1",
 			[][]byte{{0x01}},
 			func(s *stack) error {
-				v, err := s.PopInt(mathOpCodeMaxScriptNumLen)
+				v, err := s.PopInt(MathOpCodeMaxScriptNumLen)
 				if err != nil {
 					return err
 				}
@@ -208,7 +208,7 @@ func TestStack(t *testing.T) {
 			"non-minimal popInt 1 leading 0",
 			[][]byte{{0x01, 0x00, 0x00, 0x00}},
 			func(s *stack) error {
-				_, err := s.PopInt(mathOpCodeMaxScriptNumLen)
+				_, err := s.PopInt(MathOpCodeMaxScriptNumLen)
 				return err
 			},
 			ErrMinimalData,
@@ -218,7 +218,7 @@ func TestStack(t *testing.T) {
 			"popInt -1",
 			[][]byte{{0x81}},
 			func(s *stack) error {
-				v, err := s.PopInt(mathOpCodeMaxScriptNumLen)
+				v, err := s.PopInt(MathOpCodeMaxScriptNumLen)
 				if err != nil {
 					return err
 				}
@@ -271,7 +271,7 @@ func TestStack(t *testing.T) {
 			"popInt -513",
 			[][]byte{{0x1, 0x82}},
 			func(s *stack) error {
-				v, err := s.PopInt(mathOpCodeMaxScriptNumLen)
+				v, err := s.PopInt(MathOpCodeMaxScriptNumLen)
 				if err != nil {
 					return err
 				}
@@ -289,7 +289,7 @@ func TestStack(t *testing.T) {
 			"peekint nomodify -1",
 			[][]byte{{0x81}},
 			func(s *stack) error {
-				v, err := s.PeekInt(0, mathOpCodeMaxScriptNumLen)
+				v, err := s.PeekInt(0, MathOpCodeMaxScriptNumLen)
 				if err != nil {
 					return err
 				}
@@ -824,7 +824,7 @@ func TestStack(t *testing.T) {
 			func(s *stack) error {
 				// Peek int is otherwise pretty well tested,
 				// just check it works.
-				val, err := s.PeekInt(0, mathOpCodeMaxScriptNumLen)
+				val, err := s.PeekInt(0, MathOpCodeMaxScriptNumLen)
 				if err != nil {
 					return err
 				}
@@ -842,7 +842,7 @@ func TestStack(t *testing.T) {
 			func(s *stack) error {
 				// Peek int is otherwise pretty well tested,
 				// just check it works.
-				val, err := s.PeekInt(0, mathOpCodeMaxScriptNumLen)
+				val, err := s.PeekInt(0, MathOpCodeMaxScriptNumLen)
 				if err != nil {
 					return err
 				}
@@ -895,7 +895,7 @@ func TestStack(t *testing.T) {
 			nil,
 			func(s *stack) error {
 				s.PushInt(ScriptNum(1))
-				val, err := s.PopInt(mathOpCodeMaxScriptNumLen)
+				val, err := s.PopInt(MathOpCodeMaxScriptNumLen)
 				if err != nil {
 					return err
 				}
@@ -911,7 +911,7 @@ func TestStack(t *testing.T) {
 			"pop empty",
 			nil,
 			func(s *stack) error {
-				_, err := s.PopInt(mathOpCodeMaxScriptNumLen)
+				_, err := s.PopInt(MathOpCodeMaxScriptNumLen)
 				return err
 			},
 			ErrInvalidStackOperation,

--- a/txscript/stack_test.go
+++ b/txscript/stack_test.go
@@ -306,7 +306,7 @@ func TestStack(t *testing.T) {
 			"PushInt 0",
 			nil,
 			func(s *stack) error {
-				s.PushInt(scriptNum(0))
+				s.PushInt(ScriptNum(0))
 				return nil
 			},
 			nil,
@@ -316,7 +316,7 @@ func TestStack(t *testing.T) {
 			"PushInt 1",
 			nil,
 			func(s *stack) error {
-				s.PushInt(scriptNum(1))
+				s.PushInt(ScriptNum(1))
 				return nil
 			},
 			nil,
@@ -326,7 +326,7 @@ func TestStack(t *testing.T) {
 			"PushInt -1",
 			nil,
 			func(s *stack) error {
-				s.PushInt(scriptNum(-1))
+				s.PushInt(ScriptNum(-1))
 				return nil
 			},
 			nil,
@@ -336,7 +336,7 @@ func TestStack(t *testing.T) {
 			"PushInt two bytes",
 			nil,
 			func(s *stack) error {
-				s.PushInt(scriptNum(256))
+				s.PushInt(ScriptNum(256))
 				return nil
 			},
 			nil,
@@ -348,7 +348,7 @@ func TestStack(t *testing.T) {
 			nil,
 			func(s *stack) error {
 				// this will have the highbit set
-				s.PushInt(scriptNum(128))
+				s.PushInt(ScriptNum(128))
 				return nil
 			},
 			nil,
@@ -470,7 +470,7 @@ func TestStack(t *testing.T) {
 			"PushInt PopBool",
 			nil,
 			func(s *stack) error {
-				s.PushInt(scriptNum(1))
+				s.PushInt(ScriptNum(1))
 				val, err := s.PopBool()
 				if err != nil {
 					return err
@@ -488,7 +488,7 @@ func TestStack(t *testing.T) {
 			"PushInt PopBool 2",
 			nil,
 			func(s *stack) error {
-				s.PushInt(scriptNum(0))
+				s.PushInt(ScriptNum(0))
 				val, err := s.PopBool()
 				if err != nil {
 					return err
@@ -894,7 +894,7 @@ func TestStack(t *testing.T) {
 			"pop int",
 			nil,
 			func(s *stack) error {
-				s.PushInt(scriptNum(1))
+				s.PushInt(ScriptNum(1))
 				val, err := s.PopInt(mathOpCodeMaxScriptNumLen)
 				if err != nil {
 					return err

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -1365,7 +1365,7 @@ func ExtractAtomicSwapDataPushes(version uint16, pkScript []byte) (*AtomicSwapDa
 		if tplEntry.expectCanonicalInt {
 			switch {
 			case data != nil:
-				val, err := makeScriptNum(data, tplEntry.maxIntBytes)
+				val, err := MakeScriptNum(data, tplEntry.maxIntBytes)
 				if err != nil {
 					return nil, err
 				}

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -1339,7 +1339,7 @@ func ExtractAtomicSwapDataPushes(version uint16, pkScript []byte) (*AtomicSwapDa
 		{opcode: OP_HASH160},
 		{opcode: OP_DATA_20},
 		{opcode: OP_ELSE},
-		{expectCanonicalInt: true, maxIntBytes: cltvMaxScriptNumLen},
+		{expectCanonicalInt: true, maxIntBytes: CltvMaxScriptNumLen},
 		{opcode: OP_CHECKLOCKTIMEVERIFY},
 		{opcode: OP_DROP},
 		{opcode: OP_DUP},

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -452,7 +452,7 @@ func extractStakeScriptHash(script []byte, stakeOpcode byte) []byte {
 		return nil
 	}
 
-	return extractScriptHash(script[1:])
+	return ExtractScriptHash(script[1:])
 }
 
 // isStakeSubmissionScript returns whether or not the passed script is a
@@ -1156,7 +1156,7 @@ func ExtractPkScriptAddrs(version uint16, pkScript []byte,
 	}
 
 	// Check for pay-to-script-hash.
-	if hash := extractScriptHash(pkScript); hash != nil {
+	if hash := ExtractScriptHash(pkScript); hash != nil {
 		return ScriptHashTy, scriptHashToAddrs(hash, chainParams), 1, nil
 	}
 

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -111,7 +111,7 @@ func extractMultisigScriptDetails(scriptVersion uint16, script []byte, extractPu
 	// The first opcode must be a small integer specifying the number of
 	// signatures required.
 	tokenizer := MakeScriptTokenizer(scriptVersion, script)
-	if !tokenizer.Next() || !isSmallInt(tokenizer.Opcode()) {
+	if !tokenizer.Next() || !IsSmallInt(tokenizer.Opcode()) {
 		return multiSigDetails{}
 	}
 	requiredSigs := asSmallInt(tokenizer.Opcode())
@@ -140,7 +140,7 @@ func extractMultisigScriptDetails(scriptVersion uint16, script []byte, extractPu
 	// The next opcode must be a small integer specifying the number of public
 	// keys required.
 	op := tokenizer.Opcode()
-	if !isSmallInt(op) || asSmallInt(op) != numPubKeys {
+	if !IsSmallInt(op) || asSmallInt(op) != numPubKeys {
 		return multiSigDetails{}
 	}
 
@@ -292,13 +292,13 @@ func extractPubKeyAltDetails(script []byte) ([]byte, dcrec.SignatureType) {
 	}
 
 	if len(script) == 35 && script[0] == OP_DATA_32 &&
-		isSmallInt(script[33]) && asSmallInt(script[33]) == dcrec.STEd25519 {
+		IsSmallInt(script[33]) && asSmallInt(script[33]) == dcrec.STEd25519 {
 
 		return script[1:33], dcrec.STEd25519
 	}
 
 	if len(script) == 36 && script[0] == OP_DATA_33 &&
-		isSmallInt(script[34]) &&
+		IsSmallInt(script[34]) &&
 		asSmallInt(script[34]) == dcrec.STSchnorrSecp256k1 &&
 		isStrictPubKeyEncoding(script[1:34]) {
 
@@ -342,7 +342,7 @@ func isPubKeyHashScript(script []byte) bool {
 // isStandardAltSignatureType returns whether or not the provided opcode
 // represents a push of a standard alt signature type.
 func isStandardAltSignatureType(op byte) bool {
-	if !isSmallInt(op) {
+	if !IsSmallInt(op) {
 		return false
 	}
 
@@ -417,7 +417,7 @@ func isNullDataScript(scriptVersion uint16, script []byte) bool {
 	// OP_RETURN followed by data push up to MaxDataCarrierSize bytes.
 	tokenizer := MakeScriptTokenizer(scriptVersion, script[1:])
 	return tokenizer.Next() && tokenizer.Done() &&
-		(isSmallInt(tokenizer.Opcode()) || tokenizer.Opcode() <= OP_PUSHDATA4) &&
+		(IsSmallInt(tokenizer.Opcode()) || tokenizer.Opcode() <= OP_PUSHDATA4) &&
 		len(tokenizer.Data()) <= MaxDataCarrierSize
 }
 
@@ -1371,7 +1371,7 @@ func ExtractAtomicSwapDataPushes(version uint16, pkScript []byte) (*AtomicSwapDa
 				}
 				tplEntry.extractedInt = int64(val)
 
-			case isSmallInt(op):
+			case IsSmallInt(op):
 				tplEntry.extractedInt = int64(asSmallInt(op))
 
 			// Not an atomic swap script if the opcode does not push an int.

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -114,7 +114,7 @@ func extractMultisigScriptDetails(scriptVersion uint16, script []byte, extractPu
 	if !tokenizer.Next() || !IsSmallInt(tokenizer.Opcode()) {
 		return multiSigDetails{}
 	}
-	requiredSigs := asSmallInt(tokenizer.Opcode())
+	requiredSigs := AsSmallInt(tokenizer.Opcode())
 
 	// The next series of opcodes must either push public keys or be a small
 	// integer specifying the number of public keys.
@@ -140,7 +140,7 @@ func extractMultisigScriptDetails(scriptVersion uint16, script []byte, extractPu
 	// The next opcode must be a small integer specifying the number of public
 	// keys required.
 	op := tokenizer.Opcode()
-	if !IsSmallInt(op) || asSmallInt(op) != numPubKeys {
+	if !IsSmallInt(op) || AsSmallInt(op) != numPubKeys {
 		return multiSigDetails{}
 	}
 
@@ -292,14 +292,14 @@ func extractPubKeyAltDetails(script []byte) ([]byte, dcrec.SignatureType) {
 	}
 
 	if len(script) == 35 && script[0] == OP_DATA_32 &&
-		IsSmallInt(script[33]) && asSmallInt(script[33]) == dcrec.STEd25519 {
+		IsSmallInt(script[33]) && AsSmallInt(script[33]) == dcrec.STEd25519 {
 
 		return script[1:33], dcrec.STEd25519
 	}
 
 	if len(script) == 36 && script[0] == OP_DATA_33 &&
 		IsSmallInt(script[34]) &&
-		asSmallInt(script[34]) == dcrec.STSchnorrSecp256k1 &&
+		AsSmallInt(script[34]) == dcrec.STSchnorrSecp256k1 &&
 		isStrictPubKeyEncoding(script[1:34]) {
 
 		return script[1:34], dcrec.STSchnorrSecp256k1
@@ -346,7 +346,7 @@ func isStandardAltSignatureType(op byte) bool {
 		return false
 	}
 
-	sigType := asSmallInt(op)
+	sigType := AsSmallInt(op)
 	return sigType == dcrec.STEd25519 || sigType == dcrec.STSchnorrSecp256k1
 }
 
@@ -373,7 +373,7 @@ func extractPubKeyHashAltDetails(script []byte) ([]byte, dcrec.SignatureType) {
 		isStandardAltSignatureType(script[24]) &&
 		script[25] == OP_CHECKSIGALT {
 
-		return script[3:23], dcrec.SignatureType(asSmallInt(script[24]))
+		return script[3:23], dcrec.SignatureType(AsSmallInt(script[24]))
 	}
 
 	return nil, 0
@@ -1372,7 +1372,7 @@ func ExtractAtomicSwapDataPushes(version uint16, pkScript []byte) (*AtomicSwapDa
 				tplEntry.extractedInt = int64(val)
 
 			case IsSmallInt(op):
-				tplEntry.extractedInt = int64(asSmallInt(op))
+				tplEntry.extractedInt = int64(AsSmallInt(op))
 
 			// Not an atomic swap script if the opcode does not push an int.
 			default:

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -1330,7 +1330,7 @@ func ExtractAtomicSwapDataPushes(version uint16, pkScript []byte) (*AtomicSwapDa
 	var template = [20]templateMatch{
 		{opcode: OP_IF},
 		{opcode: OP_SIZE},
-		{expectCanonicalInt: true, maxIntBytes: mathOpCodeMaxScriptNumLen},
+		{expectCanonicalInt: true, maxIntBytes: MathOpCodeMaxScriptNumLen},
 		{opcode: OP_EQUALVERIFY},
 		{opcode: OP_SHA256},
 		{opcode: OP_DATA_32},


### PR DESCRIPTION
A persistent source of confusion for maintainers has been distinguishing between consensus code and standardness/policy rules when it comes to the `txscript` package.

One of the main reasons for this is that the package itself contains a mix of consensus code, standardness rules, address to script conversion, and transaction signing code due to the fact that the aforementioned code relies on both the ability to parse scripts, which was not possible to do outside of the package prior to the addition of the tokenizer functionality, and some consensus-specific code that is still not exported.

To help make the distinction more clear, the goal is to ultimately move all non-consensus code out of the `txscript` package.  So, in order to facilitate that goal, this exports various functions and types.

Each individual type and function are exported via separate commits to ease the review process.

The following is an overview of the changes:
- Export `ScriptNum` type and `MakeScriptNum` constructor
- Export `MathOpCodeMaxScriptNumLen` constant
- Export `CltvMaxScriptNumLen` constant
- Export `CsvMaxScriptNumLen` constant
- Export `IsSmallInt` function
- Export `AsSmallInt` function
- Export `ExtractScriptHash` function