### PR TITLE
txscript: Optimize sig enc check with mod n scalar.

### DIFF
--- a/txscript/bench_test.go
+++ b/txscript/bench_test.go
@@ -590,3 +590,20 @@ func BenchmarkExtractAltSigType(b *testing.B) {
 		}
 	}
 }
+
+// BenchmarkCheckSignatureEncoding benchmarks how long it takes to check the
+// signature encoding for correctness of a typical DER-encoded ECDSA signature.
+func BenchmarkCheckSignatureEncoding(b *testing.B) {
+	sig := hexToBytes("3045022100cd496f2ab4fe124f977ffe3caa09f7576d8a34156b4e" +
+		"55d326b4dffc0399a094022013500a0510b5094bff220c74656879b8ca0369d3da78" +
+		"004004c970790862fc03")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := CheckSignatureEncoding(sig)
+		if err != nil {
+			b.Fatalf("unexpected err: %v", err)
+		}
+	}
+}

--- a/txscript/engine.go
+++ b/txscript/engine.go
@@ -7,10 +7,8 @@ package txscript
 
 import (
 	"fmt"
-	"math/big"
 	"strings"
 
-	"github.com/decred/dcrd/dcrec/secp256k1/v3"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -66,9 +64,6 @@ const (
 	// execution state to be disabled.
 	noCondDisableDepth = -1
 )
-
-// halforder is used to tame ECDSA malleability (see BIP0062).
-var halfOrder = new(big.Int).Rsh(secp256k1.S256().N, 1)
 
 // Engine is the virtual machine that executes scripts.
 type Engine struct {


### PR DESCRIPTION
**This requires #2244**.

This modifies the signature encoding check function to use the new `secp256k1.ModNScalar` type for the half order check instead of a big int.

The following benchmark shows a before and after comparison of a typical signature encoding check:

```
benchmark                         old ns/op    new ns/op    delta
-------------------------------------------------------------------
BenchmarkCheckSignatureEncoding   79.0         46.9         -40.63%

benchmark                         old allocs   new allocs   delta
--------------------------------------------------------------------
BenchmarkCheckSignatureEncoding   1            0            -100.00%

benchmark                         old bytes    new bytes    delta
--------------------------------------------------------------------
BenchmarkCheckSignatureEncoding   64           0            -100.00%
```