### PR TITLE
txscript: Add tests for new strict null data func.

### DIFF
--- a/txscript/consensus.go
+++ b/txscript/consensus.go
@@ -289,10 +289,10 @@ func IsStrictCompressedPubKeyEncoding(pubKey []byte) bool {
 }
 
 // IsStrictNullData returns whether or not the passed data is an OP_RETURN
-// followed by specified length data push. It explicitly verifies that the
-// opcode is identical to the expected length. This function does not support
-// checks for data > 75 bytes.
-func IsStrictNullData(scriptVersion uint16, script []byte, expectedLength int) bool {
+// followed by specified length data push.  It explicitly verifies that the
+// opcode is identical to the required length.  This function will always return
+// false for required lengths > 75 bytes.
+func IsStrictNullData(scriptVersion uint16, script []byte, requiredLen uint32) bool {
 	// The only currently supported script version is 0.
 	if scriptVersion != 0 {
 		return false
@@ -304,18 +304,18 @@ func IsStrictNullData(scriptVersion uint16, script []byte, expectedLength int) b
 		return false
 	}
 
-	// Allow bare OP_RETURN when the expected length is 0.
-	if len(script) == 1 && expectedLength == 0 {
+	// Allow bare OP_RETURN when the required length is 0.
+	if len(script) == 1 && requiredLen == 0 {
 		return true
 	}
 
-	// OP_RETURN followed by data push of the expect size.
+	// OP_RETURN followed by data push of the required size.
 	tokenizer := MakeScriptTokenizer(scriptVersion, script[1:])
 	return tokenizer.Next() && tokenizer.Done() &&
 		isCanonicalPush(tokenizer.Opcode(), tokenizer.Data()) &&
-		((isSmallInt(tokenizer.Opcode()) && expectedLength == 1) ||
+		((isSmallInt(tokenizer.Opcode()) && requiredLen == 1) ||
 			(tokenizer.Opcode() <= OP_DATA_75 &&
-				len(tokenizer.Data()) == expectedLength))
+				uint32(len(tokenizer.Data())) == requiredLen))
 }
 
 // IsPubKeyHashScript returns whether or not the passed script is a standard

--- a/txscript/consensus_test.go
+++ b/txscript/consensus_test.go
@@ -300,3 +300,167 @@ func TestCheckPubKeyEncoding(t *testing.T) {
 		}
 	}
 }
+
+// TestIsStrictNullData ensures the function that deals with strict null data
+// requirements works as expected.
+func TestIsStrictNullData(t *testing.T) {
+	tests := []struct {
+		name        string
+		scriptVer   uint16
+		script      []byte
+		requiredLen uint32
+		want        bool
+	}{{
+		name:        "empty (bare OP_RETURN), req len 0",
+		scriptVer:   0,
+		script:      mustParseShortForm("RETURN"),
+		requiredLen: 0,
+		want:        true,
+	}, {
+		name:        "empty (bare OP_RETURN), req len 0, unsupported script ver",
+		scriptVer:   65535,
+		script:      mustParseShortForm("RETURN"),
+		requiredLen: 0,
+		want:        false,
+	}, {
+		name:        "small int push 0, req len 1",
+		scriptVer:   0,
+		script:      mustParseShortForm("RETURN 0"),
+		requiredLen: 1,
+		want:        true,
+	}, {
+		name:        "small int push 0, req len 1, unsupported script ver",
+		scriptVer:   65535,
+		script:      mustParseShortForm("RETURN 0"),
+		requiredLen: 1,
+		want:        false,
+	}, {
+		name:        "non-canonical small int push 0, req len 1",
+		scriptVer:   0,
+		script:      mustParseShortForm("RETURN DATA_1 0x00"),
+		requiredLen: 1,
+		want:        false,
+	}, {
+		name:        "small int push 1, req len 1",
+		scriptVer:   0,
+		script:      mustParseShortForm("RETURN 1"),
+		requiredLen: 1,
+		want:        true,
+	}, {
+		name:        "small int push 1, req len 1, unsupported script ver",
+		scriptVer:   65535,
+		script:      mustParseShortForm("RETURN 1"),
+		requiredLen: 1,
+		want:        false,
+	}, {
+		name:        "small int push 16, req len 1",
+		scriptVer:   0,
+		script:      mustParseShortForm("RETURN 16"),
+		requiredLen: 1,
+		want:        true,
+	}, {
+		name:        "small int push 16, req len 1, unsupported script ver",
+		scriptVer:   65535,
+		script:      mustParseShortForm("RETURN 16"),
+		requiredLen: 1,
+		want:        false,
+	}, {
+		name:        "small int push 0, req len 2",
+		scriptVer:   0,
+		script:      mustParseShortForm("RETURN 0"),
+		requiredLen: 2,
+		want:        false,
+	}, {
+		name:        "small int push 1, req len 2",
+		scriptVer:   0,
+		script:      mustParseShortForm("RETURN 1"),
+		requiredLen: 2,
+		want:        false,
+	}, {
+		name:        "small int push 16, req len 2",
+		scriptVer:   0,
+		script:      mustParseShortForm("RETURN 16"),
+		requiredLen: 2,
+		want:        false,
+	}, {
+		name:      "32-byte push, req len 32",
+		scriptVer: 0,
+		script: mustParseShortForm("RETURN DATA_32 0x0102030405060708090a0b0c" +
+			"0d0e0f101112131415161718191a1b1c1d1e1f20"),
+		requiredLen: 32,
+		want:        true,
+	}, {
+		name:      "32-byte push, req len 32, unsupported script ver",
+		scriptVer: 65535,
+		script: mustParseShortForm("RETURN DATA_32 0x0102030405060708090a0b0c" +
+			"0d0e0f101112131415161718191a1b1c1d1e1f20"),
+		requiredLen: 32,
+		want:        false,
+	}, {
+		name:      "32-byte push, req len 31",
+		scriptVer: 0,
+		script: mustParseShortForm("RETURN DATA_32 0x0102030405060708090a0b0c" +
+			"0d0e0f101112131415161718191a1b1c1d1e1f20"),
+		requiredLen: 31,
+		want:        false,
+	}, {
+		name:      "32-byte push, req len 33",
+		scriptVer: 0,
+		script: mustParseShortForm("RETURN DATA_32 0x0102030405060708090a0b0c" +
+			"0d0e0f101112131415161718191a1b1c1d1e1f20"),
+		requiredLen: 33,
+		want:        false,
+	}, {
+		name:      "32-byte push, req len 32, no leading OP_RETURN",
+		scriptVer: 0,
+		script: mustParseShortForm("DATA_32 0x0102030405060708090a0b0c0d0e0f" +
+			"101112131415161718191a1b1c1d1e1f20"),
+		requiredLen: 32,
+		want:        false,
+	}, {
+		name:      "non-canonical 32-byte push via PUSHDATA1, req len 32",
+		scriptVer: 0,
+		script: mustParseShortForm("RETURN PUSHDATA1 0x20 0x0102030405060708" +
+			"090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"),
+		requiredLen: 32,
+		want:        false,
+	}, {
+		name:      "non-canonical 32-byte push via PUSHDATA2, req len 32",
+		scriptVer: 0,
+		script: mustParseShortForm("RETURN PUSHDATA2 0x2000 0x01020304050607" +
+			"08090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"),
+		requiredLen: 32,
+		want:        false,
+	}, {
+		name:      "non-canonical 32-byte push via PUSHDATA4, req len 32",
+		scriptVer: 0,
+		script: mustParseShortForm("RETURN PUSHDATA4 0x20000000 0x0102030405" +
+			"060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"),
+		requiredLen: 32,
+		want:        false,
+	}, {
+		name:      "76-byte push, req len 76",
+		scriptVer: 0,
+		script: mustParseShortForm("RETURN PUSHDATA1 0x4c 0x0102030405060708" +
+			"090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728" +
+			"292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748" +
+			"494a4b4c"),
+		requiredLen: 76,
+		want:        false,
+	}}
+
+	for _, test := range tests {
+		// Ensure the test data scripts are well formed.
+		if err := checkScriptParses(0, test.script); err != nil {
+			t.Errorf("%s: unexpected script parse failure: %v", test.name, err)
+			continue
+		}
+
+		// Ensure the result is as expected.
+		got := IsStrictNullData(test.scriptVer, test.script, test.requiredLen)
+		if got != test.want {
+			t.Errorf("%s: mismatched result -- got %v, want %v", test.name, got,
+				test.want)
+		}
+	}
+}


### PR DESCRIPTION
This adds tests for the new `IsStrictNullData` function and also updates the function to take a uint32 since it is going to be used consensus via the upcoming decentralized treasury code and therefore types that vary by architecture can't be used.

Finally, it also renames the `expectedLength` param to `requiredLen` to make it more clear it is a requirement.