### PR TITLE
connmgr: Remain responsive with simul failed conns.

### DIFF
--- a/connmgr/connmanager_test.go
+++ b/connmgr/connmanager_test.go
@@ -99,7 +99,7 @@ func mockDialerAddr(ctx context.Context, addr net.Addr) (net.Conn, error) {
 func TestNewConfig(t *testing.T) {
 	_, err := New(&Config{})
 	if err == nil {
-		t.Fatalf("New expected error: 'Dial can't be nil', got nil")
+		t.Fatal("New expected error: 'Dial can't be nil', got nil")
 	}
 	_, err = New(&Config{
 		Dial: mockDialer,
@@ -113,7 +113,7 @@ func TestNewConfig(t *testing.T) {
 		DialAddr: mockDialerAddr,
 	})
 	if err == nil {
-		t.Fatalf("New expected error: 'Dial and DialAddr can't be both nil', got nil")
+		t.Fatal("New expected error: 'Dial and DialAddr can't be both nil', got nil")
 	}
 
 	_, err = New(&Config{
@@ -269,13 +269,13 @@ func TestPassAddrAlongDialAddr(t *testing.T) {
 	case c := <-connected:
 		receivedMock, isMockAddr := c.Addr.(mockAddr)
 		if !isMockAddr {
-			t.Fatalf("connected to an address that was not a mockAddr")
+			t.Fatal("connected to an address that was not a mockAddr")
 		}
 		if receivedMock != targetAddr {
-			t.Fatalf("connected to an address different than the expected target")
+			t.Fatal("connected to an address different than the expected target")
 		}
 	case <-time.After(time.Millisecond * 5):
-		t.Fatalf("did not get connection to target address before timeout")
+		t.Fatal("did not get connection to target address before timeout")
 	}
 
 	// Ensure clean shutdown of connection manager.
@@ -390,7 +390,7 @@ func TestMaxRetryDuration(t *testing.T) {
 	select {
 	case <-connected:
 	case <-time.After(20 * time.Millisecond):
-		t.Fatalf("max retry duration: connection timeout")
+		t.Fatal("max retry duration: connection timeout")
 	}
 
 	// Ensure clean shutdown of connection manager.
@@ -619,7 +619,7 @@ func TestCancelIgnoreDelayedConnection(t *testing.T) {
 	// allowed to properly elapse.
 	select {
 	case <-connected:
-		t.Fatalf("on-connect should not be called for canceled req")
+		t.Fatal("on-connect should not be called for canceled req")
 	case <-time.After(5 * retryTimeout):
 	}
 

--- a/server.go
+++ b/server.go
@@ -2024,6 +2024,7 @@ func (s *server) handleQuery(state *peerState, querymsg interface{}) {
 				Permanent: msg.permanent,
 			})
 		msg.reply <- nil
+
 	case removeNodeMsg:
 		found := disconnectPeer(state.persistentPeers, msg.cmp, func(sp *serverPeer) {
 			// Keep group counts ok since we remove from
@@ -2045,6 +2046,7 @@ func (s *server) handleQuery(state *peerState, querymsg interface{}) {
 		} else {
 			msg.reply <- errors.New("peer not found")
 		}
+
 	case cancelPendingMsg:
 		netAddr, err := addrStringToNetAddr(msg.addr)
 		if err != nil {
@@ -2052,6 +2054,7 @@ func (s *server) handleQuery(state *peerState, querymsg interface{}) {
 			return
 		}
 		msg.reply <- s.connManager.CancelPending(netAddr)
+
 	case getOutboundGroup:
 		count, ok := state.outboundGroups[msg.key]
 		if ok {
@@ -2059,7 +2062,7 @@ func (s *server) handleQuery(state *peerState, querymsg interface{}) {
 		} else {
 			msg.reply <- 0
 		}
-	// Request a list of the persistent (added) peers.
+
 	case getAddedNodesMsg:
 		// Respond with a slice of the relevant peers.
 		peers := make([]*serverPeer, 0, len(state.persistentPeers))
@@ -2067,6 +2070,7 @@ func (s *server) handleQuery(state *peerState, querymsg interface{}) {
 			peers = append(peers, sp)
 		}
 		msg.reply <- peers
+
 	case disconnectNodeMsg:
 		// Check inbound peers. We pass a nil callback since we don't
 		// require any additional actions on disconnect for inbound peers.


### PR DESCRIPTION
This modifies the connection manager handler for failed connections so that it remains responsive to requests when there are multiple simultaneous failed connections in the retry state and adds a test to ensure proper functionality.

While here it also updates a few formatting nits in the server code and modifies the connection manager test code to use `t.Fatal` instead of `t.Fatalf` when the message has no parameters.
