### PR TITLE
rpcserver: Add handleEstimateSmartFee test.

### DIFF
--- a/fees/estimator.go
+++ b/fees/estimator.go
@@ -293,7 +293,7 @@ func (stats *Estimator) DumpBuckets() string {
 // possible to load from a different set of configuration parameters.
 //
 // The current code does not currently save mempool information, since saving
-// information in the estimator without the saving the corresponding data in the
+// information in the estimator without saving the corresponding data in the
 // mempool itself could result in transactions lingering in the mempool
 // estimator forever.
 func (stats *Estimator) loadFromDatabase(replaceBuckets bool) error {
@@ -756,10 +756,10 @@ func (stats *Estimator) IsEnabled() bool {
 	return enabled
 }
 
-// AddMemPoolTransaction to the estimator in order to account for it in the
-// estimations. It assumes that this transaction is entering the mempool at the
-// currently recorded best chain hash, using the total fee amount (in atoms) and
-// with the provided size (in bytes).
+// AddMemPoolTransaction adds a mempool transaction to the estimator in order to
+// account for it in the estimations. It assumes that this transaction is
+// entering the mempool at the currently recorded best chain hash, using the
+// total fee amount (in atoms) and with the provided size (in bytes).
 //
 // This is safe to be called from multiple goroutines.
 func (stats *Estimator) AddMemPoolTransaction(txHash *chainhash.Hash, fee, size int64, txType stake.TxType) {
@@ -806,7 +806,8 @@ func (stats *Estimator) AddMemPoolTransaction(txHash *chainhash.Hash, fee, size 
 	stats.newMemPoolTx(tx.bucketIndex, rate)
 }
 
-// RemoveMemPoolTransaction from statistics tracking.
+// RemoveMemPoolTransaction removes a mempool transaction from statistics
+// tracking.
 //
 // This is safe to be called from multiple goroutines.
 func (stats *Estimator) RemoveMemPoolTransaction(txHash *chainhash.Hash) {

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -424,3 +424,16 @@ type Clock interface {
 	// Since returns the time elapsed since t.
 	Since(t time.Time) time.Duration
 }
+
+// FeeEstimator provides an interface that tracks historical data for published
+// and mined transactions in order to estimate fees to be used in new
+// transactions for confirmation within a target block window.
+//
+// The interface contract requires that all of these methods are safe for
+// concurrent access.
+type FeeEstimator interface {
+	// EstimateFee calculates the suggested fee for a transaction to be
+	// confirmed in at most `targetConfs` blocks after publishing with a
+	// high degree of certainty.
+	EstimateFee(targetConfs int32) (dcrutil.Amount, error)
+}

--- a/rpc/jsonrpc/types/chainsvrresults.go
+++ b/rpc/jsonrpc/types/chainsvrresults.go
@@ -28,6 +28,11 @@ type DecodeScriptResult struct {
 
 // EstimateSmartFeeResult models the data returned from the estimatesmartfee
 // command.
+//
+// NOTE: EstimateSmartFee currently returns a float. This result type is
+// unused.
+//
+// TODO: Rework EstimateSmartFee to return this result type.
 type EstimateSmartFeeResult struct {
 	FeeRate float64  `json:"feerate"`
 	Errors  []string `json:"errors"`

--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -15,6 +15,7 @@ import (
 	"github.com/decred/dcrd/blockchain/v3/indexers"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil/v3"
+	"github.com/decred/dcrd/fees/v2"
 	"github.com/decred/dcrd/internal/rpcserver"
 	"github.com/decred/dcrd/mempool/v4"
 	"github.com/decred/dcrd/peer/v2"
@@ -453,4 +454,13 @@ func (*rpcClock) Now() time.Time {
 // rpcserver.Clock interface implementation.
 func (*rpcClock) Since(t time.Time) time.Duration {
 	return time.Since(t)
+}
+
+// Ensure rpcFeeEstimator implements the rpcserver.FeeEstimator interface.
+var _ rpcserver.FeeEstimator = (*rpcFeeEstimator)(nil)
+
+// rpcFeeEstimator provides a fee estimator for use with the RPC server and
+// implements the rpcserver.FeeEstimator interface.
+type rpcFeeEstimator struct {
+	*fees.Estimator
 }

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -46,7 +46,6 @@ import (
 	"github.com/decred/dcrd/dcrec/secp256k1/v3/ecdsa"
 	"github.com/decred/dcrd/dcrjson/v3"
 	"github.com/decred/dcrd/dcrutil/v3"
-	"github.com/decred/dcrd/fees/v2"
 	"github.com/decred/dcrd/internal/rpcserver"
 	"github.com/decred/dcrd/internal/version"
 	"github.com/decred/dcrd/mempool/v4"
@@ -5548,7 +5547,7 @@ type rpcserverConfig struct {
 	Chain        rpcserver.Chain
 	ChainParams  *chaincfg.Params
 	DB           database.DB
-	FeeEstimator *fees.Estimator
+	FeeEstimator rpcserver.FeeEstimator
 	Services     wire.ServiceFlag
 
 	// SubsidyCache defines a cache for efficient access to consensus-critical

--- a/server.go
+++ b/server.go
@@ -3237,7 +3237,7 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 			ConnMgr:      &rpcConnManager{&s},
 			SyncMgr:      &rpcSyncMgr{&s, s.blockManager},
 			PeerNotifier: &s,
-			FeeEstimator: s.feeEstimator,
+			FeeEstimator: &rpcFeeEstimator{s.feeEstimator},
 			TimeSource:   s.timeSource,
 			Services:     s.services,
 			AddrManager:  &rpcAddrManager{s.addrManager},


### PR DESCRIPTION
Creates a new interface that fees.Estimator satisfies that can be used
with the rpcserver. Corrects some grammar issues and removes the unused
chainserver result type EstimateSmartFeeResult.