### PR TITLE
gcs: update error types.

### DIFF
--- a/gcs/bits_test.go
+++ b/gcs/bits_test.go
@@ -7,6 +7,7 @@ package gcs
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
 	"io"
 	"testing"
 )
@@ -340,7 +341,7 @@ nextTest:
 			// Read unary and ensure expected result if requested.
 			if prTest.doUnary {
 				gotUnary, err := r.readUnary()
-				if err != prTest.unaryErr {
+				if !errors.Is(err, prTest.unaryErr) {
 					t.Errorf("%q-%q: unexpected unary err -- got %v, want %v",
 						test.name, prTest.name, err, prTest.unaryErr)
 					continue nextTest
@@ -359,7 +360,7 @@ nextTest:
 			// Read specified number of bits as uint64 and ensure expected
 			// result.
 			gotVal, err := r.readNBits(prTest.nValBits)
-			if err != prTest.bitsErr {
+			if !errors.Is(err, prTest.bitsErr) {
 				t.Errorf("%q-%q: unexpected nbits err -- got %v, want %v",
 					test.name, prTest.name, err, prTest.bitsErr)
 				continue nextTest

--- a/gcs/error.go
+++ b/gcs/error.go
@@ -1,59 +1,43 @@
-// Copyright (c) 2019 The Decred developers
+// Copyright (c) 2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package gcs
 
-import (
-	"fmt"
-)
-
-// ErrorCode identifies a kind of error.
-type ErrorCode int
+// ErrorKind identifies a kind of error.  It has full support for errors.Is and
+// errors.As, so the caller can directly check against an error kind when
+// determining the reason for an error.
+type ErrorKind string
 
 // These constants are used to identify a specific RuleError.
 const (
 	// ErrNTooBig signifies that the filter can't handle N items.
-	ErrNTooBig ErrorCode = iota
+	ErrNTooBig = ErrorKind("ErrNTooBig")
 
 	// ErrPTooBig signifies that the filter can't handle `1/2**P`
 	// collision probability.
-	ErrPTooBig
+	ErrPTooBig = ErrorKind("ErrPTooBig")
 
 	// ErrBTooBig signifies that the provided Golomb coding bin size is larger
 	// than the maximum allowed value.
-	ErrBTooBig
+	ErrBTooBig = ErrorKind("ErrBTooBig")
 
 	// ErrMisserialized signifies a filter was misserialized and is missing the
 	// N and/or P parameters of a serialized filter.
-	ErrMisserialized
-
-	// numErrorCodes is the maximum error code number used in tests.
-	numErrorCodes
+	ErrMisserialized = ErrorKind("ErrMisserialized")
 )
 
-// Map of ErrorCode values back to their constant names for pretty printing.
-var errorCodeStrings = map[ErrorCode]string{
-	ErrNTooBig:       "ErrNTooBig",
-	ErrPTooBig:       "ErrPTooBig",
-	ErrBTooBig:       "ErrBTooBig",
-	ErrMisserialized: "ErrMisserialized",
+// Error satisfies the error interface and prints human-readable errors.
+func (e ErrorKind) Error() string {
+	return string(e)
 }
 
-// String returns the ErrorCode as a human-readable name.
-func (e ErrorCode) String() string {
-	if s := errorCodeStrings[e]; s != "" {
-		return s
-	}
-	return fmt.Sprintf("Unknown ErrorCode (%d)", int(e))
-}
-
-// Error identifies a filter-related error.  The caller can use type assertions
-// to access the ErrorCode field to ascertain the specific reason for the
-// failure.
+// Error identifies an error related to gcs filters. It has full support for
+// errors.Is and errors.As, so the caller can ascertain the specific reason
+// for the error by checking the underlying error.
 type Error struct {
-	ErrorCode   ErrorCode // Describes the kind of error
-	Description string    // Human readable description of the issue
+	Err         error
+	Description string
 }
 
 // Error satisfies the error interface and prints human-readable errors.
@@ -61,14 +45,12 @@ func (e Error) Error() string {
 	return e.Description
 }
 
-// makeError creates an Error given a set of arguments.  The error code must
-// be one of the error codes provided by this package.
-func makeError(c ErrorCode, desc string) Error {
-	return Error{ErrorCode: c, Description: desc}
+// Unwrap returns the underlying wrapped error.
+func (e Error) Unwrap() error {
+	return e.Err
 }
 
-// IsErrorCode returns whether err is an Error with a matching error code.
-func IsErrorCode(err error, c ErrorCode) bool {
-	e, ok := err.(Error)
-	return ok && e.ErrorCode == c
+// makeError creates an Error given a set of arguments.
+func makeError(kind ErrorKind, desc string) Error {
+	return Error{Err: kind, Description: desc}
 }

--- a/gcs/gcs_test.go
+++ b/gcs/gcs_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"math/rand"
 	"testing"
 	"time"
@@ -465,12 +466,12 @@ func TestFilterCorners(t *testing.T) {
 	const largeP = 33
 	var key [KeySize]byte
 	_, err := NewFilterV1(largeP, key, nil)
-	if !IsErrorCode(err, ErrPTooBig) {
+	if !errors.Is(err, ErrPTooBig) {
 		t.Fatalf("did not receive expected err for P too big -- got %v, want %v",
 			err, ErrPTooBig)
 	}
 	_, err = FromBytesV1(largeP, nil)
-	if !IsErrorCode(err, ErrPTooBig) {
+	if !errors.Is(err, ErrPTooBig) {
 		t.Fatalf("did not receive expected err for P too big -- got %v, want %v",
 			err, ErrPTooBig)
 	}
@@ -479,19 +480,19 @@ func TestFilterCorners(t *testing.T) {
 	const largeB = 33
 	const smallM = 1 << 10
 	_, err = NewFilterV2(largeB, smallM, key, nil)
-	if !IsErrorCode(err, ErrBTooBig) {
+	if !errors.Is(err, ErrBTooBig) {
 		t.Fatalf("did not receive expected err for B too big -- got %v, want %v",
 			err, ErrBTooBig)
 	}
 	_, err = FromBytesV2(largeB, smallM, nil)
-	if !IsErrorCode(err, ErrBTooBig) {
+	if !errors.Is(err, ErrBTooBig) {
 		t.Fatalf("did not receive expected err for B too big -- got %v, want %v",
 			err, ErrBTooBig)
 	}
 
 	// Attempt to decode a v1 filter without the N value serialized properly.
 	_, err = FromBytesV1(20, []byte{0x00})
-	if !IsErrorCode(err, ErrMisserialized) {
+	if !errors.Is(err, ErrMisserialized) {
 		t.Fatalf("did not receive expected err -- got %v, want %v", err,
 			ErrMisserialized)
 	}

--- a/gcs/go.mod
+++ b/gcs/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrd/gcs/v3
 
-go 1.11
+go 1.13
 
 require (
 	github.com/dchest/siphash v1.2.1


### PR DESCRIPTION
**depends on #2463**

This updates the gcs error types to leverage go 1.13 errors.Is/As functionality as well as confirm to the error infrastructure best practices outlined in #2181.