### PR TITLE
blockchain/stake: update error types.

### DIFF
--- a/blockchain/stake/error.go
+++ b/blockchain/stake/error.go
@@ -5,25 +5,23 @@
 
 package stake
 
-import (
-	"fmt"
-)
-
-// ErrorCode identifies a kind of error.
-type ErrorCode int
+// ErrorKind identifies a kind of error.  It has full support for errors.Is and
+// errors.As, so the caller can directly check against an error kind when
+// determining the reason for an error.
+type ErrorKind string
 
 // These constants are used to identify a specific RuleError.
 const (
 	// ErrSStxTooManyInputs indicates that a given SStx contains too many
 	// inputs.
-	ErrSStxTooManyInputs = iota
+	ErrSStxTooManyInputs = ErrorKind("ErrSStxTooManyInputs")
 
 	// ErrSStxTooManyOutputs indicates that a given SStx contains too many
 	// outputs.
-	ErrSStxTooManyOutputs
+	ErrSStxTooManyOutputs = ErrorKind("ErrSStxTooManyOutputs")
 
 	// ErrSStxNoOutputs indicates that a given SStx has no outputs.
-	ErrSStxNoOutputs
+	ErrSStxNoOutputs = ErrorKind("ErrSStxNoOutputs")
 
 	// ErrSStxInvalidInput indicates that an invalid output has been used as
 	// an input for a SStx; only non-SStx tagged outputs may be used to
@@ -31,361 +29,283 @@ const (
 	// TODO: Add this into validate
 	// Ensure that all inputs are not tagged SStx outputs of some sort,
 	// along with checks to make sure they exist and are available.
-	ErrSStxInvalidInputs
+	ErrSStxInvalidInputs = ErrorKind("ErrSStxInvalidInputs")
 
 	// ErrSStxInvalidOutput indicates that the output for an SStx tx is
 	// invalid; in particular, either the output was not tagged SStx or the
 	// OP_RETURNs were missing or contained invalid addresses.
-	ErrSStxInvalidOutputs
+	ErrSStxInvalidOutputs = ErrorKind("ErrSStxInvalidOutputs")
 
 	// ErrSStxInOutProportions indicates the number of inputs in an SStx
 	// was not equal to the number of output minus one.
-	ErrSStxInOutProportions
+	ErrSStxInOutProportions = ErrorKind("ErrSStxInOutProportions")
 
 	// ErrSStxBadCommitAmount indicates that a ticket tried to commit 0 or
 	// a negative value as the commitment amount.
-	ErrSStxBadCommitAmount
+	ErrSStxBadCommitAmount = ErrorKind("ErrSStxBadCommitAmount")
 
 	// ErrSStxBadChangeAmts indicates that the change amount for some SStx
 	// was invalid, for instance spending more than its inputs.
-	ErrSStxBadChangeAmts
+	ErrSStxBadChangeAmts = ErrorKind("ErrSStxBadChangeAmts")
 
 	// ErrSStxVerifyCalcAmts indicates that passed calculated amounts failed
 	// to conform to the amounts found in the ticket.
-	ErrSStxVerifyCalcAmts
+	ErrSStxVerifyCalcAmts = ErrorKind("ErrSStxVerifyCalcAmts")
 
 	// ErrSSGenWrongNumInputs indicates that a given SSGen tx contains an
 	// invalid number of inputs.
-	ErrSSGenWrongNumInputs
+	ErrSSGenWrongNumInputs = ErrorKind("ErrSSGenWrongNumInputs")
 
 	// ErrSSGenTooManyOutputs indicates that a given SSGen tx contains too
 	// many outputs.
-	ErrSSGenTooManyOutputs
+	ErrSSGenTooManyOutputs = ErrorKind("ErrSSGenTooManyOutputs")
 
 	// ErrSSGenNoOutputs indicates that a given SSGen has no outputs.
-	ErrSSGenNoOutputs
+	ErrSSGenNoOutputs = ErrorKind("ErrSSGenNoOutputs")
 
 	// ErrSSGenWrongIndex indicates that a given SSGen sstx input was not
 	// using the correct index.
-	ErrSSGenWrongIndex
+	ErrSSGenWrongIndex = ErrorKind("ErrSSGenWrongIndex")
 
 	// ErrSSGenWrongTxTree indicates that a given SSGen tx input was not found in
 	// the stake tx tree.
-	ErrSSGenWrongTxTree
+	ErrSSGenWrongTxTree = ErrorKind("ErrSSGenWrongTxTree")
 
 	// ErrSSGenNoStakebase indicates that the SSGen tx did not contain a
 	// valid StakeBase in the zeroeth position of inputs.
-	ErrSSGenNoStakebase
+	ErrSSGenNoStakebase = ErrorKind("ErrSSGenNoStakebase")
 
 	// ErrSSGenNoReference indicates that there is no reference OP_RETURN
 	// included as the first output.
-	ErrSSGenNoReference
+	ErrSSGenNoReference = ErrorKind("ErrSSGenNoReference")
 
 	// ErrSSGenNoReference indicates that the OP_RETURN included as the
 	// first output was corrupted in some way.
-	ErrSSGenBadReference
+	ErrSSGenBadReference = ErrorKind("ErrSSGenBadReference")
 
 	// ErrSSGenNoVotePush indicates that there is no vote bits OP_RETURN
 	// included as the second output.
-	ErrSSGenNoVotePush
+	ErrSSGenNoVotePush = ErrorKind("ErrSSGenNoVotePush")
 
 	// ErrSSGenBadVotePush indicates that the OP_RETURN included as the
 	// second output was corrupted in some way.
-	ErrSSGenBadVotePush
+	ErrSSGenBadVotePush = ErrorKind("ErrSSGenBadVotePush")
 
 	// ErrSSGenInvalidDiscriminatorLength indicates that the discriminator
 	// length is too short.
-	ErrSSGenInvalidDiscriminatorLength
+	ErrSSGenInvalidDiscriminatorLength = ErrorKind("ErrSSGenInvalidDiscriminatorLength")
 
 	// ErrSSGenInvalidNullScript indicates that the passed script is not a
 	// valid nullscript.
-	ErrSSGenInvalidNullScript
+	ErrSSGenInvalidNullScript = ErrorKind("ErrSSGenInvalidNullScript")
 
 	// ErrSSGenInvalidTVLength indicates that this is an invalid Treasury
 	// Vote length.
-	ErrSSGenInvalidTVLength
+	ErrSSGenInvalidTVLength = ErrorKind("ErrSSGenInvalidTVLength")
 
 	// ErrSSGenInvalidTreasuryVote indicates that this is an invalid
 	// treasury vote.
-	ErrSSGenInvalidTreasuryVote
+	ErrSSGenInvalidTreasuryVote = ErrorKind("ErrSSGenInvalidTreasuryVote")
 
 	// ErrSSGenDuplicateTreasuryVote indicates that there is a duplicate
 	// treasury vote.
-	ErrSSGenDuplicateTreasuryVote
+	ErrSSGenDuplicateTreasuryVote = ErrorKind("ErrSSGenDuplicateTreasuryVote")
 
 	// ErrSSGenInvalidTxVersion indicates that this transaction has the
 	// wrong version.
-	ErrSSGenInvalidTxVersion
+	ErrSSGenInvalidTxVersion = ErrorKind("ErrSSGenInvalidTxVersion")
 
 	// ErrSSGenUnknownDiscriminator indicates that the supplied
 	// discriminator is unsupported.
-	ErrSSGenUnknownDiscriminator
+	ErrSSGenUnknownDiscriminator = ErrorKind("ErrSSGenUnknownDiscriminator")
 
 	// ErrSSGenBadGenOuts indicates that something was wrong with the stake
 	// generation outputs that were present after the first two OP_RETURN
 	// pushes in an SSGen tx.
-	ErrSSGenBadGenOuts
+	ErrSSGenBadGenOuts = ErrorKind("ErrSSGenBadGenOuts")
 
 	// ErrSSRtxWrongNumInputs indicates that a given SSRtx contains an
 	// invalid number of inputs.
-	ErrSSRtxWrongNumInputs
+	ErrSSRtxWrongNumInputs = ErrorKind("ErrSSRtxWrongNumInputs")
 
 	// ErrSSRtxTooManyOutputs indicates that a given SSRtx contains too many
 	// outputs.
-	ErrSSRtxTooManyOutputs
+	ErrSSRtxTooManyOutputs = ErrorKind("ErrSSRtxTooManyOutputs")
 
 	// ErrSSRtxNoOutputs indicates that a given SSRtx has no outputs.
-	ErrSSRtxNoOutputs
+	ErrSSRtxNoOutputs = ErrorKind("ErrSSRtxNoOutputs")
 
 	// ErrSSRtxWrongTxTree indicates that a given SSRtx input was not found in
 	// the stake tx tree.
-	ErrSSRtxWrongTxTree
+	ErrSSRtxWrongTxTree = ErrorKind("ErrSSRtxWrongTxTree")
 
 	// ErrSSRtxBadGenOuts indicates that there was a non-SSRtx tagged output
 	// present in an SSRtx.
-	ErrSSRtxBadOuts
+	ErrSSRtxBadOuts = ErrorKind("ErrSSRtxBadOuts")
 
 	// ErrVerSStxAmts indicates there was an error verifying the calculated
 	// SStx out amounts and the actual SStx out amounts.
-	ErrVerSStxAmts
+	ErrVerSStxAmts = ErrorKind("ErrVerSStxAmts")
 
 	// ErrVerifyInput indicates that there was an error in verification
 	// function input.
-	ErrVerifyInput
+	ErrVerifyInput = ErrorKind("ErrVerifyInput")
 
 	// ErrVerifyOutType indicates that there was a non-equivalence in the
 	// output type.
-	ErrVerifyOutType
+	ErrVerifyOutType = ErrorKind("ErrVerifyOutType")
 
 	// ErrVerifyTooMuchFees indicates that a transaction's output gave
 	// too much in fees after taking into accounts the limits imposed
 	// by the SStx output's version field.
-	ErrVerifyTooMuchFees
+	ErrVerifyTooMuchFees = ErrorKind("ErrVerifyTooMuchFees")
 
 	// ErrVerifySpendTooMuch indicates that a transaction's output spent more
 	// than it was allowed to spend based on the calculated subsidy or return
 	// for a vote or revocation.
-	ErrVerifySpendTooMuch
+	ErrVerifySpendTooMuch = ErrorKind("ErrVerifySpendTooMuch")
 
 	// ErrVerifyOutputAmt indicates that for a vote/revocation spend output,
 	// the rule was given that it must exactly match the calculated maximum,
 	// however the amount in the output did not (e.g. it gave fees).
-	ErrVerifyOutputAmt
+	ErrVerifyOutputAmt = ErrorKind("ErrVerifyOutputAmt")
 
 	// ErrVerifyOutPkhs indicates that the recipient of the P2PKH or P2SH
 	// script was different from that indicated in the SStx input.
-	ErrVerifyOutPkhs
+	ErrVerifyOutPkhs = ErrorKind("ErrVerifyOutPkhs")
 
 	// ErrDatabaseCorrupt indicates a database inconsistency.
-	ErrDatabaseCorrupt
+	ErrDatabaseCorrupt = ErrorKind("ErrDatabaseCorrupt")
 
 	// ErrMissingDatabaseTx indicates that a node disconnection failed to
 	// pass a database transaction when attempted to remove a very old
 	// node.
-	ErrMissingDatabaseTx
+	ErrMissingDatabaseTx = ErrorKind("ErrMissingDatabaseTx")
 
 	// ErrMemoryCorruption indicates that memory has somehow become corrupt,
 	// for example invalid block header serialization from an in memory
 	// struct.
-	ErrMemoryCorruption
+	ErrMemoryCorruption = ErrorKind("ErrMemoryCorruption")
 
 	// ErrFindTicketIdxs indicates a failure to find the selected ticket
 	// indexes from the block header.
-	ErrFindTicketIdxs
+	ErrFindTicketIdxs = ErrorKind("ErrFindTicketIdxs")
 
 	// ErrMissingTicket indicates that a ticket was missing in one of the
 	// ticket treaps when it was attempted to be fetched.
-	ErrMissingTicket
+	ErrMissingTicket = ErrorKind("ErrMissingTicket")
 
 	// ErrDuplicateTicket indicates that a duplicate ticket was attempted
 	// to be inserted into a ticket treap or the database.
-	ErrDuplicateTicket
+	ErrDuplicateTicket = ErrorKind("ErrDuplicateTicket")
 
 	// ErrUnknownTicketSpent indicates that an unknown ticket was spent by
 	// the block.
-	ErrUnknownTicketSpent
+	ErrUnknownTicketSpent = ErrorKind("ErrUnknownTicketSpent")
 
 	// ErrTAddInvalidTxVersion indicates that this transaction has the
 	// wrong version.
-	ErrTAddInvalidTxVersion
+	ErrTAddInvalidTxVersion = ErrorKind("ErrTAddInvalidTxVersion")
 
 	// ErrTAddInvalidCount indicates that this transaction contains an
 	// invalid TADD script count.
-	ErrTAddInvalidCount
+	ErrTAddInvalidCount = ErrorKind("ErrTAddInvalidCount")
 
 	// ErrTAddInvalidVersion indicates that this transaction has an invalid
 	// version in an output script.
-	ErrTAddInvalidVersion
+	ErrTAddInvalidVersion = ErrorKind("ErrTAddInvalidVersion")
 
 	// ErrTAddInvalidScriptLength indicates that this transaction has a zero
 	// length output script.
-	ErrTAddInvalidScriptLength
+	ErrTAddInvalidScriptLength = ErrorKind("ErrTAddInvalidScriptLength")
 
 	// ErrTAddInvalidLength indicates that output 0 is not exactly 1 byte.
-	ErrTAddInvalidLength
+	ErrTAddInvalidLength = ErrorKind("ErrTAddInvalidLength")
 
 	// ErrTAddInvalidOpcode indicates that this transaction does not have a
 	// TADD opcode.
-	ErrTAddInvalidOpcode
+	ErrTAddInvalidOpcode = ErrorKind("ErrTAddInvalidOpcode")
 
 	// ErrTAddInvalidChange indicates that this transaction contains an
 	// invalid change script.
-	ErrTAddInvalidChange
+	ErrTAddInvalidChange = ErrorKind("ErrTAddInvalidChange")
 
 	// ErrTSpendInvalidTxVersion indicates that this transaction has
 	// the wrong version.
-	ErrTSpendInvalidTxVersion
+	ErrTSpendInvalidTxVersion = ErrorKind("ErrTSpendInvalidTxVersion")
 
 	// ErrTSpendInvalidLength indicates that this transaction has an
 	// invalid number of inputs and/or outputs.
-	ErrTSpendInvalidLength
+	ErrTSpendInvalidLength = ErrorKind("ErrTSpendInvalidLength")
 
 	// ErrTSpendInvalidVersion indicates that this transaction has an
 	// invalid version in an output script.
-	ErrTSpendInvalidVersion
+	ErrTSpendInvalidVersion = ErrorKind("ErrTSpendInvalidVersion")
 
 	// ErrTSpendInvalidScriptLength indicates that the TSPEND transaction
 	// has outputs that have a zero length script.
-	ErrTSpendInvalidScriptLength
+	ErrTSpendInvalidScriptLength = ErrorKind("ErrTSpendInvalidScriptLength")
 
 	// ErrTSpendInvalidPubkey indicates that this transaction contains an
 	// invalid public key.
-	ErrTSpendInvalidPubkey
+	ErrTSpendInvalidPubkey = ErrorKind("ErrTSpendInvalidPubkey")
 
 	// ErrTSpendInvalidScript indicates that this transaction does not
 	// match the required TSPEND transaction signature.
-	ErrTSpendInvalidScript
+	ErrTSpendInvalidScript = ErrorKind("ErrTSpendInvalidScript")
 
 	// ErrTSpendInvalidTGen indicates that the TSPEND transaction has
 	// outputs that are not tagged with OP_TGEN.
-	ErrTSpendInvalidTGen
+	ErrTSpendInvalidTGen = ErrorKind("ErrTSpendInvalidTGen")
 
 	// ErrTSpendInvalidTransaction indicates that a TSPEND transaction
 	// output 0 does not have an a valid null data script.
-	ErrTSpendInvalidTransaction
+	ErrTSpendInvalidTransaction = ErrorKind("ErrTSpendInvalidTransaction")
 
 	// ErrTSpendInvalidSpendScript indicates that this transaction contains
 	// an invalid P2SH or P2PKH script.
-	ErrTSpendInvalidSpendScript
+	ErrTSpendInvalidSpendScript = ErrorKind("ErrTSpendInvalidSpendScript")
 
 	// ErrTreasuryBaseInvalidTxVersion indicates that this transaction has
 	// the wrong version.
-	ErrTreasuryBaseInvalidTxVersion
+	ErrTreasuryBaseInvalidTxVersion = ErrorKind("ErrTreasuryBaseInvalidTxVersion")
 
 	// ErrTreasuryBaseInvalidCount indicates that this transaction contains
 	// an invalid treasury base script count.
-	ErrTreasuryBaseInvalidCount
+	ErrTreasuryBaseInvalidCount = ErrorKind("ErrTreasuryBaseInvalidCount")
 
 	// ErrTreasuryBaseInvalidLength indicates that this transaction contains
 	// an invalid treasury base input script length.
-	ErrTreasuryBaseInvalidLength
+	ErrTreasuryBaseInvalidLength = ErrorKind("ErrTreasuryBaseInvalidLength")
 
 	// ErrTreasuryBaseInvalidVersion indicates that this transaction has an
 	// invalid version in an output script.
-	ErrTreasuryBaseInvalidVersion
+	ErrTreasuryBaseInvalidVersion = ErrorKind("ErrTreasuryBaseInvalidVersion")
 
 	// ErrTreasuryBaseInvalidOpcode0 indicates that this transaction does
 	// not have a TADD opcode in TxOut[0].
-	ErrTreasuryBaseInvalidOpcode0
+	ErrTreasuryBaseInvalidOpcode0 = ErrorKind("ErrTreasuryBaseInvalidOpcode0")
 
 	// ErrTreasuryBaseInvalidOpcode1 indicates that this transaction does
 	// not have an OP_RETURN opcode in TxOut[1].
-	ErrTreasuryBaseInvalidOpcode1
+	ErrTreasuryBaseInvalidOpcode1 = ErrorKind("ErrTreasuryBaseInvalidOpcode1")
 
 	// ErrTreasuryBaseInvalid indicates that this transaction contains
 	// invalid treasurybase TxIn constants.
-	ErrTreasuryBaseInvalid
+	ErrTreasuryBaseInvalid = ErrorKind("ErrTreasuryBaseInvalid")
 )
 
-// Map of ErrorCode values back to their constant names for pretty printing.
-var errorCodeStrings = map[ErrorCode]string{
-	ErrSStxTooManyInputs:               "ErrSStxTooManyInputs",
-	ErrSStxTooManyOutputs:              "ErrSStxTooManyOutputs",
-	ErrSStxNoOutputs:                   "ErrSStxNoOutputs",
-	ErrSStxInvalidInputs:               "ErrSStxInvalidInputs",
-	ErrSStxInvalidOutputs:              "ErrSStxInvalidOutputs",
-	ErrSStxInOutProportions:            "ErrSStxInOutProportions",
-	ErrSStxBadCommitAmount:             "ErrSStxBadCommitAmount",
-	ErrSStxBadChangeAmts:               "ErrSStxBadChangeAmts",
-	ErrSStxVerifyCalcAmts:              "ErrSStxVerifyCalcAmts",
-	ErrSSGenWrongNumInputs:             "ErrSSGenWrongNumInputs",
-	ErrSSGenTooManyOutputs:             "ErrSSGenTooManyOutputs",
-	ErrSSGenNoOutputs:                  "ErrSSGenNoOutputs",
-	ErrSSGenWrongIndex:                 "ErrSSGenWrongIndex",
-	ErrSSGenWrongTxTree:                "ErrSSGenWrongTxTree",
-	ErrSSGenNoStakebase:                "ErrSSGenNoStakebase",
-	ErrSSGenNoReference:                "ErrSSGenNoReference",
-	ErrSSGenBadReference:               "ErrSSGenBadReference",
-	ErrSSGenNoVotePush:                 "ErrSSGenNoVotePush",
-	ErrSSGenBadVotePush:                "ErrSSGenBadVotePush",
-	ErrSSGenInvalidDiscriminatorLength: "ErrSSGenInvalidDiscriminatorLength",
-	ErrSSGenInvalidNullScript:          "ErrSSGenInvalidNullScript",
-	ErrSSGenInvalidTVLength:            "ErrSSGenInvalidTVLength",
-	ErrSSGenInvalidTreasuryVote:        "ErrSSGenInvalidTreasuryVote",
-	ErrSSGenDuplicateTreasuryVote:      "ErrSSGenDuplicateTreasuryVote",
-	ErrSSGenInvalidTxVersion:           "ErrSSGenInvalidTxVersion",
-	ErrSSGenUnknownDiscriminator:       "ErrSSGenUnknownDiscriminator",
-	ErrSSGenBadGenOuts:                 "ErrSSGenBadGenOuts",
-	ErrSSRtxWrongNumInputs:             "ErrSSRtxWrongNumInputs",
-	ErrSSRtxTooManyOutputs:             "ErrSSRtxTooManyOutputs",
-	ErrSSRtxNoOutputs:                  "ErrSSRtxNoOutputs",
-	ErrSSRtxWrongTxTree:                "ErrSSRtxWrongTxTree",
-	ErrSSRtxBadOuts:                    "ErrSSRtxBadOuts",
-	ErrVerSStxAmts:                     "ErrVerSStxAmts",
-	ErrVerifyInput:                     "ErrVerifyInput",
-	ErrVerifyOutType:                   "ErrVerifyOutType",
-	ErrVerifyTooMuchFees:               "ErrVerifyTooMuchFees",
-	ErrVerifySpendTooMuch:              "ErrVerifySpendTooMuch",
-	ErrVerifyOutputAmt:                 "ErrVerifyOutputAmt",
-	ErrVerifyOutPkhs:                   "ErrVerifyOutPkhs",
-	ErrDatabaseCorrupt:                 "ErrDatabaseCorrupt",
-	ErrMissingDatabaseTx:               "ErrMissingDatabaseTx",
-	ErrMemoryCorruption:                "ErrMemoryCorruption",
-	ErrFindTicketIdxs:                  "ErrFindTicketIdxs",
-	ErrMissingTicket:                   "ErrMissingTicket",
-	ErrDuplicateTicket:                 "ErrDuplicateTicket",
-	ErrUnknownTicketSpent:              "ErrUnknownTicketSpent",
-	ErrTAddInvalidTxVersion:            "ErrTAddInvalidTxVersion",
-	ErrTAddInvalidCount:                "ErrTAddInvalidCount",
-	ErrTAddInvalidVersion:              "ErrTAddInvalidVersion",
-	ErrTAddInvalidScriptLength:         "ErrTAddInvalidScriptLength",
-	ErrTAddInvalidLength:               "ErrTAddInvalidLength",
-	ErrTAddInvalidOpcode:               "ErrTAddInvalidOpcode",
-	ErrTAddInvalidChange:               "ErrTAddInvalidChange",
-	ErrTSpendInvalidTxVersion:          "ErrTSpendInvalidTxVersion",
-	ErrTSpendInvalidLength:             "ErrTSpendInvalidLength",
-	ErrTSpendInvalidVersion:            "ErrTSpendInvalidVersion",
-	ErrTSpendInvalidScriptLength:       "ErrTSpendInvalidScriptLength",
-	ErrTSpendInvalidPubkey:             "ErrTSpendInvalidPubkey",
-	ErrTSpendInvalidScript:             "ErrTSpendInvalidScript",
-	ErrTSpendInvalidTransaction:        "ErrTSpendInvalidTransaction",
-	ErrTSpendInvalidTGen:               "ErrTSpendInvalidTGen",
-	ErrTSpendInvalidSpendScript:        "ErrTSpendInvalidSpendScript",
-	ErrTreasuryBaseInvalidTxVersion:    "ErrTreasuryBaseInvalidTxVersion",
-	ErrTreasuryBaseInvalidCount:        "ErrTreasuryBaseInvalidCount",
-	ErrTreasuryBaseInvalidLength:       "ErrTreasuryBaseInvalidLength",
-	ErrTreasuryBaseInvalidVersion:      "ErrTreasuryBaseInvalidVersion",
-	ErrTreasuryBaseInvalidOpcode0:      "ErrTreasuryBaseInvalidOpcode0",
-	ErrTreasuryBaseInvalidOpcode1:      "ErrTreasuryBaseInvalidOpcode1",
-	ErrTreasuryBaseInvalid:             "ErrTreasuryBaseInvalid",
+// Error satisfies the error interface and prints human-readable errors.
+func (e ErrorKind) Error() string {
+	return string(e)
 }
 
-// String returns the ErrorCode as a human-readable name.
-func (e ErrorCode) String() string {
-	if s := errorCodeStrings[e]; s != "" {
-		return s
-	}
-	return fmt.Sprintf("Unknown ErrorCode (%d)", int(e))
-}
-
-// RuleError identifies a rule violation.  It is used to indicate that
-// processing of a block or transaction failed due to one of the many validation
-// rules.  The caller can use type assertions to determine if a failure was
-// specifically due to a rule violation and access the ErrorCode field to
-// ascertain the specific reason for the rule violation.
+// RuleError identifies a rule violation related to stake transactions. It has
+// full support for errors.Is and errors.As, so the caller can ascertain the
+// specific reason for the error by checking the underlying error.
 type RuleError struct {
-	ErrorCode   ErrorCode // Describes the kind of error
-	Description string    // Human readable description of the issue
+	Description string
+	Err         error
 }
 
 // Error satisfies the error interface and prints human-readable errors.
@@ -393,12 +313,12 @@ func (e RuleError) Error() string {
 	return e.Description
 }
 
-// GetCode satisfies the error interface and prints human-readable errors.
-func (e RuleError) GetCode() ErrorCode {
-	return e.ErrorCode
+// Unwrap returns the underlying wrapped rule error.
+func (e RuleError) Unwrap() error {
+	return e.Err
 }
 
 // stakeRuleError creates a RuleError given a set of arguments.
-func stakeRuleError(c ErrorCode, desc string) RuleError {
-	return RuleError{ErrorCode: c, Description: desc}
+func stakeRuleError(kind ErrorKind, desc string) RuleError {
+	return RuleError{Err: kind, Description: desc}
 }

--- a/blockchain/stake/error_test.go
+++ b/blockchain/stake/error_test.go
@@ -3,98 +3,95 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package stake_test
+package stake
 
 import (
+	"errors"
+	"io"
 	"testing"
-
-	"github.com/decred/dcrd/blockchain/stake/v4"
 )
 
-// TestErrorCodeStringer tests the stringized output for the ErrorCode type.
-func TestErrorCodeStringer(t *testing.T) {
+// TestErrorKindStringer tests the stringized output for the ErrorKind type.
+func TestErrorKindStringer(t *testing.T) {
 	tests := []struct {
-		in   stake.ErrorCode
+		in   ErrorKind
 		want string
 	}{
-		{stake.ErrSStxTooManyInputs, "ErrSStxTooManyInputs"},
-		{stake.ErrSStxTooManyOutputs, "ErrSStxTooManyOutputs"},
-		{stake.ErrSStxNoOutputs, "ErrSStxNoOutputs"},
-		{stake.ErrSStxInvalidInputs, "ErrSStxInvalidInputs"},
-		{stake.ErrSStxInvalidOutputs, "ErrSStxInvalidOutputs"},
-		{stake.ErrSStxInOutProportions, "ErrSStxInOutProportions"},
-		{stake.ErrSStxBadCommitAmount, "ErrSStxBadCommitAmount"},
-		{stake.ErrSStxBadChangeAmts, "ErrSStxBadChangeAmts"},
-		{stake.ErrSStxVerifyCalcAmts, "ErrSStxVerifyCalcAmts"},
-		{stake.ErrSSGenWrongNumInputs, "ErrSSGenWrongNumInputs"},
-		{stake.ErrSSGenTooManyOutputs, "ErrSSGenTooManyOutputs"},
-		{stake.ErrSSGenNoOutputs, "ErrSSGenNoOutputs"},
-		{stake.ErrSSGenWrongIndex, "ErrSSGenWrongIndex"},
-		{stake.ErrSSGenWrongTxTree, "ErrSSGenWrongTxTree"},
-		{stake.ErrSSGenNoStakebase, "ErrSSGenNoStakebase"},
-		{stake.ErrSSGenNoReference, "ErrSSGenNoReference"},
-		{stake.ErrSSGenBadReference, "ErrSSGenBadReference"},
-		{stake.ErrSSGenNoVotePush, "ErrSSGenNoVotePush"},
-		{stake.ErrSSGenBadVotePush, "ErrSSGenBadVotePush"},
-		{stake.ErrSSGenInvalidDiscriminatorLength, "ErrSSGenInvalidDiscriminatorLength"},
-		{stake.ErrSSGenInvalidNullScript, "ErrSSGenInvalidNullScript"},
-		{stake.ErrSSGenInvalidTVLength, "ErrSSGenInvalidTVLength"},
-		{stake.ErrSSGenInvalidTreasuryVote, "ErrSSGenInvalidTreasuryVote"},
-		{stake.ErrSSGenDuplicateTreasuryVote, "ErrSSGenDuplicateTreasuryVote"},
-		{stake.ErrSSGenInvalidTxVersion, "ErrSSGenInvalidTxVersion"},
-		{stake.ErrSSGenUnknownDiscriminator, "ErrSSGenUnknownDiscriminator"},
-		{stake.ErrSSGenBadGenOuts, "ErrSSGenBadGenOuts"},
-		{stake.ErrSSRtxWrongNumInputs, "ErrSSRtxWrongNumInputs"},
-		{stake.ErrSSRtxTooManyOutputs, "ErrSSRtxTooManyOutputs"},
-		{stake.ErrSSRtxNoOutputs, "ErrSSRtxNoOutputs"},
-		{stake.ErrSSRtxWrongTxTree, "ErrSSRtxWrongTxTree"},
-		{stake.ErrSSRtxBadOuts, "ErrSSRtxBadOuts"},
-		{stake.ErrVerSStxAmts, "ErrVerSStxAmts"},
-		{stake.ErrVerifyInput, "ErrVerifyInput"},
-		{stake.ErrVerifyOutType, "ErrVerifyOutType"},
-		{stake.ErrVerifyTooMuchFees, "ErrVerifyTooMuchFees"},
-		{stake.ErrVerifySpendTooMuch, "ErrVerifySpendTooMuch"},
-		{stake.ErrVerifyOutputAmt, "ErrVerifyOutputAmt"},
-		{stake.ErrVerifyOutPkhs, "ErrVerifyOutPkhs"},
-		{stake.ErrDatabaseCorrupt, "ErrDatabaseCorrupt"},
-		{stake.ErrMissingDatabaseTx, "ErrMissingDatabaseTx"},
-		{stake.ErrMemoryCorruption, "ErrMemoryCorruption"},
-		{stake.ErrFindTicketIdxs, "ErrFindTicketIdxs"},
-		{stake.ErrMissingTicket, "ErrMissingTicket"},
-		{stake.ErrDuplicateTicket, "ErrDuplicateTicket"},
-		{stake.ErrUnknownTicketSpent, "ErrUnknownTicketSpent"},
-		{stake.ErrTAddInvalidTxVersion, "ErrTAddInvalidTxVersion"},
-		{stake.ErrTAddInvalidCount, "ErrTAddInvalidCount"},
-		{stake.ErrTAddInvalidVersion, "ErrTAddInvalidVersion"},
-		{stake.ErrTAddInvalidScriptLength, "ErrTAddInvalidScriptLength"},
-		{stake.ErrTAddInvalidLength, "ErrTAddInvalidLength"},
-		{stake.ErrTAddInvalidOpcode, "ErrTAddInvalidOpcode"},
-		{stake.ErrTAddInvalidChange, "ErrTAddInvalidChange"},
-		{stake.ErrTSpendInvalidTxVersion, "ErrTSpendInvalidTxVersion"},
-		{stake.ErrTSpendInvalidLength, "ErrTSpendInvalidLength"},
-		{stake.ErrTSpendInvalidVersion, "ErrTSpendInvalidVersion"},
-		{stake.ErrTSpendInvalidScriptLength, "ErrTSpendInvalidScriptLength"},
-		{stake.ErrTSpendInvalidPubkey, "ErrTSpendInvalidPubkey"},
-		{stake.ErrTSpendInvalidScript, "ErrTSpendInvalidScript"},
-		{stake.ErrTSpendInvalidTransaction, "ErrTSpendInvalidTransaction"},
-		{stake.ErrTSpendInvalidTGen, "ErrTSpendInvalidTGen"},
-		{stake.ErrTSpendInvalidSpendScript, "ErrTSpendInvalidSpendScript"},
-		{stake.ErrTreasuryBaseInvalidTxVersion, "ErrTreasuryBaseInvalidTxVersion"},
-		{stake.ErrTreasuryBaseInvalidCount, "ErrTreasuryBaseInvalidCount"},
-		{stake.ErrTreasuryBaseInvalidLength, "ErrTreasuryBaseInvalidLength"},
-		{stake.ErrTreasuryBaseInvalidVersion, "ErrTreasuryBaseInvalidVersion"},
-		{stake.ErrTreasuryBaseInvalidOpcode0, "ErrTreasuryBaseInvalidOpcode0"},
-		{stake.ErrTreasuryBaseInvalidOpcode1, "ErrTreasuryBaseInvalidOpcode1"},
-		{stake.ErrTreasuryBaseInvalid, "ErrTreasuryBaseInvalid"},
-		{0xffff, "Unknown ErrorCode (65535)"},
+		{ErrSStxTooManyInputs, "ErrSStxTooManyInputs"},
+		{ErrSStxTooManyOutputs, "ErrSStxTooManyOutputs"},
+		{ErrSStxNoOutputs, "ErrSStxNoOutputs"},
+		{ErrSStxInvalidInputs, "ErrSStxInvalidInputs"},
+		{ErrSStxInvalidOutputs, "ErrSStxInvalidOutputs"},
+		{ErrSStxInOutProportions, "ErrSStxInOutProportions"},
+		{ErrSStxBadCommitAmount, "ErrSStxBadCommitAmount"},
+		{ErrSStxBadChangeAmts, "ErrSStxBadChangeAmts"},
+		{ErrSStxVerifyCalcAmts, "ErrSStxVerifyCalcAmts"},
+		{ErrSSGenWrongNumInputs, "ErrSSGenWrongNumInputs"},
+		{ErrSSGenTooManyOutputs, "ErrSSGenTooManyOutputs"},
+		{ErrSSGenNoOutputs, "ErrSSGenNoOutputs"},
+		{ErrSSGenWrongIndex, "ErrSSGenWrongIndex"},
+		{ErrSSGenWrongTxTree, "ErrSSGenWrongTxTree"},
+		{ErrSSGenNoStakebase, "ErrSSGenNoStakebase"},
+		{ErrSSGenNoReference, "ErrSSGenNoReference"},
+		{ErrSSGenBadReference, "ErrSSGenBadReference"},
+		{ErrSSGenNoVotePush, "ErrSSGenNoVotePush"},
+		{ErrSSGenBadVotePush, "ErrSSGenBadVotePush"},
+		{ErrSSGenInvalidDiscriminatorLength, "ErrSSGenInvalidDiscriminatorLength"},
+		{ErrSSGenInvalidNullScript, "ErrSSGenInvalidNullScript"},
+		{ErrSSGenInvalidTVLength, "ErrSSGenInvalidTVLength"},
+		{ErrSSGenInvalidTreasuryVote, "ErrSSGenInvalidTreasuryVote"},
+		{ErrSSGenDuplicateTreasuryVote, "ErrSSGenDuplicateTreasuryVote"},
+		{ErrSSGenInvalidTxVersion, "ErrSSGenInvalidTxVersion"},
+		{ErrSSGenUnknownDiscriminator, "ErrSSGenUnknownDiscriminator"},
+		{ErrSSGenBadGenOuts, "ErrSSGenBadGenOuts"},
+		{ErrSSRtxWrongNumInputs, "ErrSSRtxWrongNumInputs"},
+		{ErrSSRtxTooManyOutputs, "ErrSSRtxTooManyOutputs"},
+		{ErrSSRtxNoOutputs, "ErrSSRtxNoOutputs"},
+		{ErrSSRtxWrongTxTree, "ErrSSRtxWrongTxTree"},
+		{ErrSSRtxBadOuts, "ErrSSRtxBadOuts"},
+		{ErrVerSStxAmts, "ErrVerSStxAmts"},
+		{ErrVerifyInput, "ErrVerifyInput"},
+		{ErrVerifyOutType, "ErrVerifyOutType"},
+		{ErrVerifyTooMuchFees, "ErrVerifyTooMuchFees"},
+		{ErrVerifySpendTooMuch, "ErrVerifySpendTooMuch"},
+		{ErrVerifyOutputAmt, "ErrVerifyOutputAmt"},
+		{ErrVerifyOutPkhs, "ErrVerifyOutPkhs"},
+		{ErrDatabaseCorrupt, "ErrDatabaseCorrupt"},
+		{ErrMissingDatabaseTx, "ErrMissingDatabaseTx"},
+		{ErrMemoryCorruption, "ErrMemoryCorruption"},
+		{ErrFindTicketIdxs, "ErrFindTicketIdxs"},
+		{ErrMissingTicket, "ErrMissingTicket"},
+		{ErrDuplicateTicket, "ErrDuplicateTicket"},
+		{ErrUnknownTicketSpent, "ErrUnknownTicketSpent"},
+		{ErrTAddInvalidTxVersion, "ErrTAddInvalidTxVersion"},
+		{ErrTAddInvalidCount, "ErrTAddInvalidCount"},
+		{ErrTAddInvalidVersion, "ErrTAddInvalidVersion"},
+		{ErrTAddInvalidScriptLength, "ErrTAddInvalidScriptLength"},
+		{ErrTAddInvalidLength, "ErrTAddInvalidLength"},
+		{ErrTAddInvalidOpcode, "ErrTAddInvalidOpcode"},
+		{ErrTAddInvalidChange, "ErrTAddInvalidChange"},
+		{ErrTSpendInvalidTxVersion, "ErrTSpendInvalidTxVersion"},
+		{ErrTSpendInvalidLength, "ErrTSpendInvalidLength"},
+		{ErrTSpendInvalidVersion, "ErrTSpendInvalidVersion"},
+		{ErrTSpendInvalidScriptLength, "ErrTSpendInvalidScriptLength"},
+		{ErrTSpendInvalidPubkey, "ErrTSpendInvalidPubkey"},
+		{ErrTSpendInvalidScript, "ErrTSpendInvalidScript"},
+		{ErrTSpendInvalidTransaction, "ErrTSpendInvalidTransaction"},
+		{ErrTSpendInvalidTGen, "ErrTSpendInvalidTGen"},
+		{ErrTSpendInvalidSpendScript, "ErrTSpendInvalidSpendScript"},
+		{ErrTreasuryBaseInvalidTxVersion, "ErrTreasuryBaseInvalidTxVersion"},
+		{ErrTreasuryBaseInvalidCount, "ErrTreasuryBaseInvalidCount"},
+		{ErrTreasuryBaseInvalidLength, "ErrTreasuryBaseInvalidLength"},
+		{ErrTreasuryBaseInvalidVersion, "ErrTreasuryBaseInvalidVersion"},
+		{ErrTreasuryBaseInvalidOpcode0, "ErrTreasuryBaseInvalidOpcode0"},
+		{ErrTreasuryBaseInvalidOpcode1, "ErrTreasuryBaseInvalidOpcode1"},
+		{ErrTreasuryBaseInvalid, "ErrTreasuryBaseInvalid"},
 	}
 
-	t.Logf("Running %d tests", len(tests))
 	for i, test := range tests {
-		result := test.in.String()
+		result := test.in.Error()
 		if result != test.want {
-			t.Errorf("String #%d\n got: %s want: %s", i, result,
-				test.want)
+			t.Errorf("%d: got: %s want: %s", i, result, test.want)
 			continue
 		}
 	}
@@ -103,23 +100,104 @@ func TestErrorCodeStringer(t *testing.T) {
 // TestRuleError tests the error output for the RuleError type.
 func TestRuleError(t *testing.T) {
 	tests := []struct {
-		in   stake.RuleError
+		in   RuleError
 		want string
-	}{
-		{stake.RuleError{Description: "duplicate block"},
-			"duplicate block",
-		},
-		{stake.RuleError{Description: "human-readable error"},
-			"human-readable error",
-		},
-	}
+	}{{
+		RuleError{Description: "duplicate block"},
+		"duplicate block",
+	}, {
+		RuleError{Description: "human-readable error"},
+		"human-readable error",
+	}}
 
-	t.Logf("Running %d tests", len(tests))
 	for i, test := range tests {
 		result := test.in.Error()
 		if result != test.want {
-			t.Errorf("Error #%d\n got: %s want: %s", i, result,
-				test.want)
+			t.Errorf("#%d: got: %s want: %s", i, result, test.want)
+			continue
+		}
+	}
+}
+
+// TestRuleErrorKindIsAs ensures both ErrorKind and RuleError can be
+// identified as being a specific error kind via errors.Is and unwrapped
+// via errors.As.
+func TestRuleErrorKindIsAs(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		target    error
+		wantMatch bool
+		wantAs    ErrorKind
+	}{{
+		name:      "ErrSStxTooManyInputs == ErrSStxTooManyInputs",
+		err:       ErrSStxTooManyInputs,
+		target:    ErrSStxTooManyInputs,
+		wantMatch: true,
+		wantAs:    ErrSStxTooManyInputs,
+	}, {
+		name:      "RuleError.ErrSStxTooManyInputs == ErrSStxTooManyInputs",
+		err:       stakeRuleError(ErrSStxTooManyInputs, ""),
+		target:    ErrSStxTooManyInputs,
+		wantMatch: true,
+		wantAs:    ErrSStxTooManyInputs,
+	}, {
+		name:      "RuleError.ErrSStxTooManyInputs == RuleError.ErrSStxTooManyInputs",
+		err:       stakeRuleError(ErrSStxTooManyInputs, ""),
+		target:    stakeRuleError(ErrSStxTooManyInputs, ""),
+		wantMatch: true,
+		wantAs:    ErrSStxTooManyInputs,
+	}, {
+		name:      "ErrSStxTooManyInputs != ErrSSGenNoOutputs",
+		err:       ErrSStxTooManyInputs,
+		target:    ErrSSGenNoOutputs,
+		wantMatch: false,
+		wantAs:    ErrSStxTooManyInputs,
+	}, {
+		name:      "RuleError.ErrSStxTooManyInputs != ErrSSGenNoOutputs",
+		err:       stakeRuleError(ErrSStxTooManyInputs, ""),
+		target:    ErrSSGenNoOutputs,
+		wantMatch: false,
+		wantAs:    ErrSStxTooManyInputs,
+	}, {
+		name:      "ErrSStxTooManyInputs != RuleError.ErrSSGenNoOutputs",
+		err:       ErrSStxTooManyInputs,
+		target:    stakeRuleError(ErrSSGenNoOutputs, ""),
+		wantMatch: false,
+		wantAs:    ErrSStxTooManyInputs,
+	}, {
+		name:      "RulError.ErrSStxTooManyInputs != RuleError.ErrSSGenNoOutputs",
+		err:       stakeRuleError(ErrSStxTooManyInputs, ""),
+		target:    stakeRuleError(ErrSSGenNoOutputs, ""),
+		wantMatch: false,
+		wantAs:    ErrSStxTooManyInputs,
+	}, {
+		name:      "RuleError.ErrDuplicateTicket != io.EOF",
+		err:       stakeRuleError(ErrDuplicateTicket, ""),
+		target:    io.EOF,
+		wantMatch: false,
+		wantAs:    ErrDuplicateTicket,
+	}}
+
+	for _, test := range tests {
+		// Ensure the error matches or not depending on the expected result.
+		result := errors.Is(test.err, test.target)
+		if result != test.wantMatch {
+			t.Errorf("%s: incorrect error identification -- got %v, want %v",
+				test.name, result, test.wantMatch)
+			continue
+		}
+
+		// Ensure the underlying error kind can be unwrapped is and is the
+		// expected kind.
+		var kind ErrorKind
+		if !errors.As(test.err, &kind) {
+			t.Errorf("%s: unable to unwrap to error kind", test.name)
+			continue
+		}
+		if kind != test.wantAs {
+			t.Errorf("%s: unexpected unwrapped error kind -- got %v, want %v",
+				test.name, kind, test.wantAs)
 			continue
 		}
 	}

--- a/blockchain/stake/staketx_test.go
+++ b/blockchain/stake/staketx_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package stake_test
+package stake
 
 import (
 	"bytes"
@@ -11,7 +11,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/decred/dcrd/blockchain/stake/v4"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/txscript/v4"
@@ -39,11 +38,11 @@ func TestSStx(t *testing.T) {
 	sstx.SetTree(wire.TxTreeStake)
 	sstx.SetIndex(0)
 
-	err := stake.CheckSStx(sstx.MsgTx())
+	err := CheckSStx(sstx.MsgTx())
 	if err != nil {
 		t.Errorf("CheckSStx: unexpected err: %v", err)
 	}
-	if !stake.IsSStx(sstx.MsgTx()) {
+	if !IsSStx(sstx.MsgTx()) {
 		t.Errorf("IsSStx claimed a valid sstx is invalid")
 	}
 
@@ -68,11 +67,11 @@ func TestSStx(t *testing.T) {
 	sstx.SetTree(wire.TxTreeStake)
 	sstx.SetIndex(0)
 
-	err = stake.CheckSStx(sstx.MsgTx())
+	err = CheckSStx(sstx.MsgTx())
 	if err != nil {
 		t.Errorf("CheckSStx: unexpected err: %v", err)
 	}
-	if !stake.IsSStx(sstx.MsgTx()) {
+	if !IsSStx(sstx.MsgTx()) {
 		t.Errorf("IsSStx claimed a valid sstx is invalid")
 	}
 }
@@ -96,13 +95,12 @@ func TestSSTxErrors(t *testing.T) {
 	sstxExtraInputs.SetTree(wire.TxTreeStake)
 	sstxExtraInputs.SetIndex(0)
 
-	var serr stake.RuleError
-	err = stake.CheckSStx(sstxExtraInputs.MsgTx())
-	if !errors.As(err, &serr) || serr.GetCode() != stake.ErrSStxTooManyInputs {
+	err = CheckSStx(sstxExtraInputs.MsgTx())
+	if !errors.Is(err, ErrSStxTooManyInputs) {
 		t.Errorf("CheckSStx should have returned %v but instead returned %v",
-			stake.ErrSStxTooManyInputs, err)
+			ErrSStxTooManyInputs, err)
 	}
-	if stake.IsSStx(sstxExtraInputs.MsgTx()) {
+	if IsSStx(sstxExtraInputs.MsgTx()) {
 		t.Errorf("IsSStx claimed an invalid sstx is valid")
 	}
 
@@ -113,12 +111,12 @@ func TestSSTxErrors(t *testing.T) {
 	sstxExtraOutputs.SetTree(wire.TxTreeStake)
 	sstxExtraOutputs.SetIndex(0)
 
-	err = stake.CheckSStx(sstxExtraOutputs.MsgTx())
-	if !errors.As(err, &serr) || serr.GetCode() != stake.ErrSStxTooManyOutputs {
+	err = CheckSStx(sstxExtraOutputs.MsgTx())
+	if !errors.Is(err, ErrSStxTooManyOutputs) {
 		t.Errorf("CheckSStx should have returned %v but instead returned %v",
-			stake.ErrSStxTooManyOutputs, err)
+			ErrSStxTooManyOutputs, err)
 	}
-	if stake.IsSStx(sstxExtraOutputs.MsgTx()) {
+	if IsSStx(sstxExtraOutputs.MsgTx()) {
 		t.Errorf("IsSStx claimed an invalid sstx is valid")
 	}
 
@@ -144,12 +142,12 @@ func TestSSTxErrors(t *testing.T) {
 	sstxUntaggedOut.SetTree(wire.TxTreeStake)
 	sstxUntaggedOut.SetIndex(0)
 
-	err = stake.CheckSStx(sstxUntaggedOut.MsgTx())
-	if !errors.As(err, &serr) || serr.GetCode() != stake.ErrSStxInvalidOutputs {
+	err = CheckSStx(sstxUntaggedOut.MsgTx())
+	if !errors.Is(err, ErrSStxInvalidOutputs) {
 		t.Errorf("CheckSStx should have returned %v but instead returned %v",
-			stake.ErrSStxInvalidOutputs, err)
+			ErrSStxInvalidOutputs, err)
 	}
-	if stake.IsSStx(sstxUntaggedOut.MsgTx()) {
+	if IsSStx(sstxUntaggedOut.MsgTx()) {
 		t.Errorf("IsSStx claimed an invalid sstx is valid")
 	}
 
@@ -160,12 +158,12 @@ func TestSSTxErrors(t *testing.T) {
 	sstxInsOutsMismatched.SetTree(wire.TxTreeStake)
 	sstxInsOutsMismatched.SetIndex(0)
 
-	err = stake.CheckSStx(sstxInsOutsMismatched.MsgTx())
-	if !errors.As(err, &serr) || serr.GetCode() != stake.ErrSStxInOutProportions {
+	err = CheckSStx(sstxInsOutsMismatched.MsgTx())
+	if !errors.Is(err, ErrSStxInOutProportions) {
 		t.Errorf("CheckSStx should have returned %v but instead returned %v",
-			stake.ErrSStxInOutProportions, err)
+			ErrSStxInOutProportions, err)
 	}
-	if stake.IsSStx(sstxInsOutsMismatched.MsgTx()) {
+	if IsSStx(sstxInsOutsMismatched.MsgTx()) {
 		t.Errorf("IsSStx claimed an invalid sstx is valid")
 	}
 
@@ -175,12 +173,12 @@ func TestSSTxErrors(t *testing.T) {
 	sstxBadVerOut.SetTree(wire.TxTreeStake)
 	sstxBadVerOut.SetIndex(0)
 
-	err = stake.CheckSStx(sstxBadVerOut.MsgTx())
-	if !errors.As(err, &serr) || serr.GetCode() != stake.ErrSStxInvalidOutputs {
+	err = CheckSStx(sstxBadVerOut.MsgTx())
+	if !errors.Is(err, ErrSStxInvalidOutputs) {
 		t.Errorf("CheckSStx should have returned %v but instead returned %v",
-			stake.ErrSStxInvalidOutputs, err)
+			ErrSStxInvalidOutputs, err)
 	}
-	if stake.IsSStx(sstxBadVerOut.MsgTx()) {
+	if IsSStx(sstxBadVerOut.MsgTx()) {
 		t.Errorf("IsSStx claimed an invalid sstx is valid")
 	}
 
@@ -191,12 +189,12 @@ func TestSSTxErrors(t *testing.T) {
 	sstxNoNullData.SetTree(wire.TxTreeStake)
 	sstxNoNullData.SetIndex(0)
 
-	err = stake.CheckSStx(sstxNoNullData.MsgTx())
-	if !errors.As(err, &serr) || serr.GetCode() != stake.ErrSStxInvalidOutputs {
+	err = CheckSStx(sstxNoNullData.MsgTx())
+	if !errors.Is(err, ErrSStxInvalidOutputs) {
 		t.Errorf("CheckSStx should have returned %v but instead returned %v",
-			stake.ErrSStxInvalidOutputs, err)
+			ErrSStxInvalidOutputs, err)
 	}
-	if stake.IsSStx(sstxNoNullData.MsgTx()) {
+	if IsSStx(sstxNoNullData.MsgTx()) {
 		t.Errorf("IsSStx claimed an invalid sstx is valid")
 	}
 
@@ -207,12 +205,12 @@ func TestSSTxErrors(t *testing.T) {
 	sstxNullDataMis.SetTree(wire.TxTreeStake)
 	sstxNullDataMis.SetIndex(0)
 
-	err = stake.CheckSStx(sstxNullDataMis.MsgTx())
-	if !errors.As(err, &serr) || serr.GetCode() != stake.ErrSStxInvalidOutputs {
+	err = CheckSStx(sstxNullDataMis.MsgTx())
+	if !errors.Is(err, ErrSStxInvalidOutputs) {
 		t.Errorf("CheckSStx should have returned %v but instead returned %v",
-			stake.ErrSStxInvalidOutputs, err)
+			ErrSStxInvalidOutputs, err)
 	}
-	if stake.IsSStx(sstxNullDataMis.MsgTx()) {
+	if IsSStx(sstxNullDataMis.MsgTx()) {
 		t.Errorf("IsSStx claimed an invalid sstx is valid")
 	}
 
@@ -243,12 +241,12 @@ func TestSSTxErrors(t *testing.T) {
 	sstxWrongPKHLength.SetTree(wire.TxTreeStake)
 	sstxWrongPKHLength.SetIndex(0)
 
-	err = stake.CheckSStx(sstxWrongPKHLength.MsgTx())
-	if !errors.As(err, &serr) || serr.GetCode() != stake.ErrSStxInvalidOutputs {
+	err = CheckSStx(sstxWrongPKHLength.MsgTx())
+	if !errors.Is(err, ErrSStxInvalidOutputs) {
 		t.Errorf("CheckSStx should have returned %v but instead returned %v",
-			stake.ErrSStxInvalidOutputs, err)
+			ErrSStxInvalidOutputs, err)
 	}
-	if stake.IsSStx(sstxWrongPKHLength.MsgTx()) {
+	if IsSStx(sstxWrongPKHLength.MsgTx()) {
 		t.Errorf("IsSStx claimed an invalid sstx is valid")
 	}
 
@@ -280,12 +278,12 @@ func TestSSTxErrors(t *testing.T) {
 	sstxWrongPrefix.SetTree(wire.TxTreeStake)
 	sstxWrongPrefix.SetIndex(0)
 
-	err = stake.CheckSStx(sstxWrongPrefix.MsgTx())
-	if !errors.As(err, &serr) || serr.GetCode() != stake.ErrSStxInvalidOutputs {
+	err = CheckSStx(sstxWrongPrefix.MsgTx())
+	if !errors.Is(err, ErrSStxInvalidOutputs) {
 		t.Errorf("CheckSStx should have returned %v but instead returned %v",
-			stake.ErrSStxInvalidOutputs, err)
+			ErrSStxInvalidOutputs, err)
 	}
-	if stake.IsSStx(sstxWrongPrefix.MsgTx()) {
+	if IsSStx(sstxWrongPrefix.MsgTx()) {
 		t.Errorf("IsSStx claimed an invalid sstx is valid")
 	}
 }
@@ -299,11 +297,11 @@ func TestSSGen(t *testing.T) {
 	ssgen.SetTree(wire.TxTreeStake)
 	ssgen.SetIndex(0)
 
-	err := stake.CheckSSGen(ssgen.MsgTx(), noTreasury)
+	err := CheckSSGen(ssgen.MsgTx(), noTreasury)
 	if err != nil {
 		t.Errorf("IsSSGen: unexpected err: %v", err)
 	}
-	if !stake.IsSSGen(ssgen.MsgTx(), noTreasury) {
+	if !IsSSGen(ssgen.MsgTx(), noTreasury) {
 		t.Errorf("IsSSGen claimed a valid ssgen is invalid")
 	}
 
@@ -327,11 +325,11 @@ func TestSSGen(t *testing.T) {
 	ssgen.SetIndex(0)
 	ssgen.MsgTx().TxOut[1].PkScript = biggestPush
 
-	err = stake.CheckSSGen(ssgen.MsgTx(), noTreasury)
+	err = CheckSSGen(ssgen.MsgTx(), noTreasury)
 	if err != nil {
 		t.Errorf("IsSSGen: unexpected err: %v", err)
 	}
-	if !stake.IsSSGen(ssgen.MsgTx(), noTreasury) {
+	if !IsSSGen(ssgen.MsgTx(), noTreasury) {
 		t.Errorf("IsSSGen claimed a valid ssgen is invalid")
 	}
 }
@@ -356,13 +354,12 @@ func TestSSGenErrors(t *testing.T) {
 	ssgenExtraInputs.SetTree(wire.TxTreeStake)
 	ssgenExtraInputs.SetIndex(0)
 
-	var serr stake.RuleError
-	err = stake.CheckSSGen(ssgenExtraInputs.MsgTx(), noTreasury)
-	if !errors.As(err, &serr) || serr.GetCode() != stake.ErrSSGenWrongNumInputs {
+	err = CheckSSGen(ssgenExtraInputs.MsgTx(), noTreasury)
+	if !errors.Is(err, ErrSSGenWrongNumInputs) {
 		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
-			stake.ErrSSGenWrongNumInputs, err)
+			ErrSSGenWrongNumInputs, err)
 	}
-	if stake.IsSSGen(ssgenExtraInputs.MsgTx(), noTreasury) {
+	if IsSSGen(ssgenExtraInputs.MsgTx(), noTreasury) {
 		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
@@ -373,12 +370,12 @@ func TestSSGenErrors(t *testing.T) {
 	ssgenExtraOutputs.SetTree(wire.TxTreeStake)
 	ssgenExtraOutputs.SetIndex(0)
 
-	err = stake.CheckSSGen(ssgenExtraOutputs.MsgTx(), noTreasury)
-	if !errors.As(err, &serr) || serr.GetCode() != stake.ErrSSGenTooManyOutputs {
+	err = CheckSSGen(ssgenExtraOutputs.MsgTx(), noTreasury)
+	if !errors.Is(err, ErrSSGenTooManyOutputs) {
 		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
-			stake.ErrSSGenTooManyOutputs, err)
+			ErrSSGenTooManyOutputs, err)
 	}
-	if stake.IsSSGen(ssgenExtraOutputs.MsgTx(), noTreasury) {
+	if IsSSGen(ssgenExtraOutputs.MsgTx(), noTreasury) {
 		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
@@ -389,12 +386,12 @@ func TestSSGenErrors(t *testing.T) {
 	ssgenStakeBaseWrong.SetTree(wire.TxTreeStake)
 	ssgenStakeBaseWrong.SetIndex(0)
 
-	err = stake.CheckSSGen(ssgenStakeBaseWrong.MsgTx(), noTreasury)
-	if !errors.As(err, &serr) || serr.GetCode() != stake.ErrSSGenNoStakebase {
+	err = CheckSSGen(ssgenStakeBaseWrong.MsgTx(), noTreasury)
+	if !errors.Is(err, ErrSSGenNoStakebase) {
 		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
-			stake.ErrSSGenNoStakebase, err)
+			ErrSSGenNoStakebase, err)
 	}
-	if stake.IsSSGen(ssgenStakeBaseWrong.MsgTx(), noTreasury) {
+	if IsSSGen(ssgenStakeBaseWrong.MsgTx(), noTreasury) {
 		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
@@ -421,12 +418,12 @@ func TestSSGenErrors(t *testing.T) {
 	ssgenWrongTreeIns.SetTree(wire.TxTreeStake)
 	ssgenWrongTreeIns.SetIndex(0)
 
-	err = stake.CheckSSGen(ssgenWrongTreeIns.MsgTx(), noTreasury)
-	if !errors.As(err, &serr) || serr.GetCode() != stake.ErrSSGenWrongTxTree {
+	err = CheckSSGen(ssgenWrongTreeIns.MsgTx(), noTreasury)
+	if !errors.Is(err, ErrSSGenWrongTxTree) {
 		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
-			stake.ErrSSGenWrongTxTree, err)
+			ErrSSGenWrongTxTree, err)
 	}
-	if stake.IsSSGen(ssgenWrongTreeIns.MsgTx(), noTreasury) {
+	if IsSSGen(ssgenWrongTreeIns.MsgTx(), noTreasury) {
 		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
@@ -436,12 +433,12 @@ func TestSSGenErrors(t *testing.T) {
 	ssgenTxBadVerOut.SetTree(wire.TxTreeStake)
 	ssgenTxBadVerOut.SetIndex(0)
 
-	err = stake.CheckSSGen(ssgenTxBadVerOut.MsgTx(), noTreasury)
-	if !errors.As(err, &serr) || serr.GetCode() != stake.ErrSSGenBadGenOuts {
+	err = CheckSSGen(ssgenTxBadVerOut.MsgTx(), noTreasury)
+	if !errors.Is(err, ErrSSGenBadGenOuts) {
 		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
-			stake.ErrSSGenBadGenOuts, err)
+			ErrSSGenBadGenOuts, err)
 	}
-	if stake.IsSSGen(ssgenTxBadVerOut.MsgTx(), noTreasury) {
+	if IsSSGen(ssgenTxBadVerOut.MsgTx(), noTreasury) {
 		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
@@ -452,12 +449,12 @@ func TestSSGenErrors(t *testing.T) {
 	ssgenWrongZeroethOut.SetTree(wire.TxTreeStake)
 	ssgenWrongZeroethOut.SetIndex(0)
 
-	err = stake.CheckSSGen(ssgenWrongZeroethOut.MsgTx(), noTreasury)
-	if !errors.As(err, &serr) || serr.GetCode() != stake.ErrSSGenNoReference {
+	err = CheckSSGen(ssgenWrongZeroethOut.MsgTx(), noTreasury)
+	if !errors.Is(err, ErrSSGenNoReference) {
 		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
-			stake.ErrSSGenNoReference, err)
+			ErrSSGenNoReference, err)
 	}
-	if stake.IsSSGen(ssgenWrongZeroethOut.MsgTx(), noTreasury) {
+	if IsSSGen(ssgenWrongZeroethOut.MsgTx(), noTreasury) {
 		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
@@ -494,12 +491,12 @@ func TestSSGenErrors(t *testing.T) {
 	ssgenWrongDataPush0Length.SetTree(wire.TxTreeStake)
 	ssgenWrongDataPush0Length.SetIndex(0)
 
-	err = stake.CheckSSGen(ssgenWrongDataPush0Length.MsgTx(), noTreasury)
-	if !errors.As(err, &serr) || serr.GetCode() != stake.ErrSSGenBadReference {
+	err = CheckSSGen(ssgenWrongDataPush0Length.MsgTx(), noTreasury)
+	if !errors.Is(err, ErrSSGenBadReference) {
 		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
-			stake.ErrSSGenBadReference, err)
+			ErrSSGenBadReference, err)
 	}
-	if stake.IsSSGen(ssgenWrongDataPush0Length.MsgTx(), noTreasury) {
+	if IsSSGen(ssgenWrongDataPush0Length.MsgTx(), noTreasury) {
 		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
@@ -536,12 +533,12 @@ func TestSSGenErrors(t *testing.T) {
 	ssgenWrongNullData0Prefix.SetTree(wire.TxTreeStake)
 	ssgenWrongNullData0Prefix.SetIndex(0)
 
-	err = stake.CheckSSGen(ssgenWrongNullData0Prefix.MsgTx(), noTreasury)
-	if !errors.As(err, &serr) || serr.GetCode() != stake.ErrSSGenBadReference {
+	err = CheckSSGen(ssgenWrongNullData0Prefix.MsgTx(), noTreasury)
+	if !errors.Is(err, ErrSSGenBadReference) {
 		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
-			stake.ErrSSGenBadReference, err)
+			ErrSSGenBadReference, err)
 	}
-	if stake.IsSSGen(ssgenWrongNullData0Prefix.MsgTx(), noTreasury) {
+	if IsSSGen(ssgenWrongNullData0Prefix.MsgTx(), noTreasury) {
 		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
@@ -552,12 +549,12 @@ func TestSSGenErrors(t *testing.T) {
 	ssgenWrongFirstOut.SetTree(wire.TxTreeStake)
 	ssgenWrongFirstOut.SetIndex(0)
 
-	err = stake.CheckSSGen(ssgenWrongFirstOut.MsgTx(), noTreasury)
-	if !errors.As(err, &serr) || serr.GetCode() != stake.ErrSSGenNoVotePush {
+	err = CheckSSGen(ssgenWrongFirstOut.MsgTx(), noTreasury)
+	if !errors.Is(err, ErrSSGenNoVotePush) {
 		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
-			stake.ErrSSGenNoVotePush, err)
+			ErrSSGenNoVotePush, err)
 	}
-	if stake.IsSSGen(ssgenWrongFirstOut.MsgTx(), noTreasury) {
+	if IsSSGen(ssgenWrongFirstOut.MsgTx(), noTreasury) {
 		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
@@ -583,12 +580,12 @@ func TestSSGenErrors(t *testing.T) {
 	ssgenWrongDataPush1Length.SetTree(wire.TxTreeStake)
 	ssgenWrongDataPush1Length.SetIndex(0)
 
-	err = stake.CheckSSGen(ssgenWrongDataPush1Length.MsgTx(), noTreasury)
-	if !errors.As(err, &serr) || serr.GetCode() != stake.ErrSSGenBadVotePush {
+	err = CheckSSGen(ssgenWrongDataPush1Length.MsgTx(), noTreasury)
+	if !errors.Is(err, ErrSSGenBadVotePush) {
 		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
-			stake.ErrSSGenBadVotePush, err)
+			ErrSSGenBadVotePush, err)
 	}
-	if stake.IsSSGen(ssgenWrongDataPush1Length.MsgTx(), noTreasury) {
+	if IsSSGen(ssgenWrongDataPush1Length.MsgTx(), noTreasury) {
 		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
@@ -615,12 +612,12 @@ func TestSSGenErrors(t *testing.T) {
 	ssgenWrongNullData1Prefix.SetTree(wire.TxTreeStake)
 	ssgenWrongNullData1Prefix.SetIndex(0)
 
-	err = stake.CheckSSGen(ssgenWrongNullData1Prefix.MsgTx(), noTreasury)
-	if !errors.As(err, &serr) || serr.GetCode() != stake.ErrSSGenBadVotePush {
+	err = CheckSSGen(ssgenWrongNullData1Prefix.MsgTx(), noTreasury)
+	if !errors.Is(err, ErrSSGenBadVotePush) {
 		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
-			stake.ErrSSGenBadVotePush, err)
+			ErrSSGenBadVotePush, err)
 	}
-	if stake.IsSSGen(ssgenWrongNullData1Prefix.MsgTx(), noTreasury) {
+	if IsSSGen(ssgenWrongNullData1Prefix.MsgTx(), noTreasury) {
 		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
@@ -647,12 +644,12 @@ func TestSSGenErrors(t *testing.T) {
 	ssgentestGenOutputUntagged.SetTree(wire.TxTreeStake)
 	ssgentestGenOutputUntagged.SetIndex(0)
 
-	err = stake.CheckSSGen(ssgentestGenOutputUntagged.MsgTx(), noTreasury)
-	if !errors.As(err, &serr) || serr.GetCode() != stake.ErrSSGenBadGenOuts {
+	err = CheckSSGen(ssgentestGenOutputUntagged.MsgTx(), noTreasury)
+	if !errors.Is(err, ErrSSGenBadGenOuts) {
 		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
-			stake.ErrSSGenBadGenOuts, err)
+			ErrSSGenBadGenOuts, err)
 	}
-	if stake.IsSSGen(ssgentestGenOutputUntagged.MsgTx(), noTreasury) {
+	if IsSSGen(ssgentestGenOutputUntagged.MsgTx(), noTreasury) {
 		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
@@ -664,13 +661,12 @@ func TestSSGenErrors(t *testing.T) {
 	ssgenNoDiscriminator.SetTree(wire.TxTreeStake)
 	ssgenNoDiscriminator.SetIndex(0)
 
-	err = stake.CheckSSGen(ssgenNoDiscriminator.MsgTx(), withTreasury)
-	if !errors.As(err, &serr) || serr.GetCode() !=
-		stake.ErrSSGenInvalidDiscriminatorLength {
+	err = CheckSSGen(ssgenNoDiscriminator.MsgTx(), withTreasury)
+	if !errors.Is(err, ErrSSGenInvalidDiscriminatorLength) {
 		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
-			stake.ErrSSGenInvalidDiscriminatorLength, err)
+			ErrSSGenInvalidDiscriminatorLength, err)
 	}
-	if stake.IsSSGen(ssgenNoDiscriminator.MsgTx(), withTreasury) {
+	if IsSSGen(ssgenNoDiscriminator.MsgTx(), withTreasury) {
 		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
@@ -679,13 +675,12 @@ func TestSSGenErrors(t *testing.T) {
 	ssgenInvalidDiscriminator.SetTree(wire.TxTreeStake)
 	ssgenInvalidDiscriminator.SetIndex(0)
 
-	err = stake.CheckSSGen(ssgenInvalidDiscriminator.MsgTx(), withTreasury)
-	if !errors.As(err, &serr) || serr.GetCode() !=
-		stake.ErrSSGenInvalidDiscriminatorLength {
+	err = CheckSSGen(ssgenInvalidDiscriminator.MsgTx(), withTreasury)
+	if !errors.Is(err, ErrSSGenInvalidDiscriminatorLength) {
 		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
-			stake.ErrSSGenInvalidDiscriminatorLength, err)
+			ErrSSGenInvalidDiscriminatorLength, err)
 	}
-	if stake.IsSSGen(ssgenInvalidDiscriminator.MsgTx(), withTreasury) {
+	if IsSSGen(ssgenInvalidDiscriminator.MsgTx(), withTreasury) {
 		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
@@ -694,13 +689,12 @@ func TestSSGenErrors(t *testing.T) {
 	ssgenInvalidDiscriminator2.SetTree(wire.TxTreeStake)
 	ssgenInvalidDiscriminator2.SetIndex(0)
 
-	err = stake.CheckSSGen(ssgenInvalidDiscriminator2.MsgTx(), withTreasury)
-	if !errors.As(err, &serr) || serr.GetCode() !=
-		stake.ErrSSGenUnknownDiscriminator {
+	err = CheckSSGen(ssgenInvalidDiscriminator2.MsgTx(), withTreasury)
+	if !errors.Is(err, ErrSSGenUnknownDiscriminator) {
 		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
-			stake.ErrSSGenUnknownDiscriminator, err)
+			ErrSSGenUnknownDiscriminator, err)
 	}
-	if stake.IsSSGen(ssgenInvalidDiscriminator2.MsgTx(), withTreasury) {
+	if IsSSGen(ssgenInvalidDiscriminator2.MsgTx(), withTreasury) {
 		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
@@ -709,19 +703,17 @@ func TestSSGenErrors(t *testing.T) {
 	ssgenInvalidDiscriminator3.SetTree(wire.TxTreeStake)
 	ssgenInvalidDiscriminator3.SetIndex(0)
 
-	err = stake.CheckSSGen(ssgenInvalidDiscriminator3.MsgTx(), withTreasury)
-	if !errors.As(err, &serr) || serr.GetCode() !=
-		stake.ErrSSGenBadGenOuts {
+	err = CheckSSGen(ssgenInvalidDiscriminator3.MsgTx(), withTreasury)
+	if !errors.Is(err, ErrSSGenBadGenOuts) {
 		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
-			stake.ErrSSGenBadGenOuts, err)
+			ErrSSGenBadGenOuts, err)
 	}
-	if stake.IsSSGen(ssgenInvalidDiscriminator3.MsgTx(), withTreasury) {
+	if IsSSGen(ssgenInvalidDiscriminator3.MsgTx(), withTreasury) {
 		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 	// Verify we don't crash in this case as well.
-	_, err = stake.GetSSGenTreasuryVotes(ssgenInvalidDiscriminator3.MsgTx().TxOut[4].PkScript)
-	if !errors.As(err, &serr) || serr.GetCode() !=
-		stake.ErrSSGenInvalidNullScript {
+	_, err = GetSSGenTreasuryVotes(ssgenInvalidDiscriminator3.MsgTx().TxOut[4].PkScript)
+	if !errors.Is(err, ErrSSGenInvalidNullScript) {
 		t.Error(err)
 	}
 
@@ -730,13 +722,12 @@ func TestSSGenErrors(t *testing.T) {
 	ssgenInvalidTVNoVote.SetTree(wire.TxTreeStake)
 	ssgenInvalidTVNoVote.SetIndex(0)
 
-	err = stake.CheckSSGen(ssgenInvalidTVNoVote.MsgTx(), withTreasury)
-	if !errors.As(err, &serr) || serr.GetCode() !=
-		stake.ErrSSGenInvalidTVLength {
+	err = CheckSSGen(ssgenInvalidTVNoVote.MsgTx(), withTreasury)
+	if !errors.Is(err, ErrSSGenInvalidTVLength) {
 		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
-			stake.ErrSSGenInvalidTVLength, err)
+			ErrSSGenInvalidTVLength, err)
 	}
-	if stake.IsSSGen(ssgenInvalidTVNoVote.MsgTx(), withTreasury) {
+	if IsSSGen(ssgenInvalidTVNoVote.MsgTx(), withTreasury) {
 		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
@@ -745,13 +736,12 @@ func TestSSGenErrors(t *testing.T) {
 	ssgenInvalidTVNoVote2.SetTree(wire.TxTreeStake)
 	ssgenInvalidTVNoVote2.SetIndex(0)
 
-	err = stake.CheckSSGen(ssgenInvalidTVNoVote2.MsgTx(), withTreasury)
-	if !errors.As(err, &serr) || serr.GetCode() !=
-		stake.ErrSSGenInvalidTVLength {
+	err = CheckSSGen(ssgenInvalidTVNoVote2.MsgTx(), withTreasury)
+	if !errors.Is(err, ErrSSGenInvalidTVLength) {
 		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
-			stake.ErrSSGenInvalidTVLength, err)
+			ErrSSGenInvalidTVLength, err)
 	}
-	if stake.IsSSGen(ssgenInvalidTVNoVote2.MsgTx(), withTreasury) {
+	if IsSSGen(ssgenInvalidTVNoVote2.MsgTx(), withTreasury) {
 		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
@@ -761,13 +751,12 @@ func TestSSGenErrors(t *testing.T) {
 	ssgenInvalidTVNoVote3.SetTree(wire.TxTreeStake)
 	ssgenInvalidTVNoVote3.SetIndex(0)
 
-	err = stake.CheckSSGen(ssgenInvalidTVNoVote3.MsgTx(), withTreasury)
-	if !errors.As(err, &serr) || serr.GetCode() !=
-		stake.ErrSSGenInvalidTVLength {
+	err = CheckSSGen(ssgenInvalidTVNoVote3.MsgTx(), withTreasury)
+	if !errors.Is(err, ErrSSGenInvalidTVLength) {
 		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
-			stake.ErrSSGenInvalidTVLength, err)
+			ErrSSGenInvalidTVLength, err)
 	}
-	if stake.IsSSGen(ssgenInvalidTVNoVote3.MsgTx(), withTreasury) {
+	if IsSSGen(ssgenInvalidTVNoVote3.MsgTx(), withTreasury) {
 		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
@@ -777,13 +766,12 @@ func TestSSGenErrors(t *testing.T) {
 	ssgenInvalidTVNoVote4.SetTree(wire.TxTreeStake)
 	ssgenInvalidTVNoVote4.SetIndex(0)
 
-	err = stake.CheckSSGen(ssgenInvalidTVNoVote4.MsgTx(), withTreasury)
-	if !errors.As(err, &serr) || serr.GetCode() !=
-		stake.ErrSSGenInvalidTVLength {
+	err = CheckSSGen(ssgenInvalidTVNoVote4.MsgTx(), withTreasury)
+	if !errors.Is(err, ErrSSGenInvalidTVLength) {
 		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
-			stake.ErrSSGenInvalidTVLength, err)
+			ErrSSGenInvalidTVLength, err)
 	}
-	if stake.IsSSGen(ssgenInvalidTVNoVote4.MsgTx(), withTreasury) {
+	if IsSSGen(ssgenInvalidTVNoVote4.MsgTx(), withTreasury) {
 		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
@@ -793,13 +781,12 @@ func TestSSGenErrors(t *testing.T) {
 	ssgenInvalidTVNoVote5.SetTree(wire.TxTreeStake)
 	ssgenInvalidTVNoVote5.SetIndex(0)
 
-	err = stake.CheckSSGen(ssgenInvalidTVNoVote5.MsgTx(), withTreasury)
-	if !errors.As(err, &serr) || serr.GetCode() !=
-		stake.ErrSSGenInvalidDiscriminatorLength {
+	err = CheckSSGen(ssgenInvalidTVNoVote5.MsgTx(), withTreasury)
+	if !errors.Is(err, ErrSSGenInvalidDiscriminatorLength) {
 		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
-			stake.ErrSSGenInvalidDiscriminatorLength, err)
+			ErrSSGenInvalidDiscriminatorLength, err)
 	}
-	if stake.IsSSGen(ssgenInvalidTVNoVote5.MsgTx(), withTreasury) {
+	if IsSSGen(ssgenInvalidTVNoVote5.MsgTx(), withTreasury) {
 		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
@@ -808,13 +795,12 @@ func TestSSGenErrors(t *testing.T) {
 	ssgenInvalidTVote.SetTree(wire.TxTreeStake)
 	ssgenInvalidTVote.SetIndex(0)
 
-	err = stake.CheckSSGen(ssgenInvalidTVote.MsgTx(), withTreasury)
-	if !errors.As(err, &serr) || serr.GetCode() !=
-		stake.ErrSSGenInvalidTreasuryVote {
+	err = CheckSSGen(ssgenInvalidTVote.MsgTx(), withTreasury)
+	if !errors.Is(err, ErrSSGenInvalidTreasuryVote) {
 		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
-			stake.ErrSSGenInvalidTreasuryVote, err)
+			ErrSSGenInvalidTreasuryVote, err)
 	}
-	if stake.IsSSGen(ssgenInvalidTVote.MsgTx(), withTreasury) {
+	if IsSSGen(ssgenInvalidTVote.MsgTx(), withTreasury) {
 		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
@@ -823,13 +809,12 @@ func TestSSGenErrors(t *testing.T) {
 	ssgenInvalidTVote2.SetTree(wire.TxTreeStake)
 	ssgenInvalidTVote2.SetIndex(0)
 
-	err = stake.CheckSSGen(ssgenInvalidTVote2.MsgTx(), withTreasury)
-	if !errors.As(err, &serr) || serr.GetCode() !=
-		stake.ErrSSGenInvalidTreasuryVote {
+	err = CheckSSGen(ssgenInvalidTVote2.MsgTx(), withTreasury)
+	if !errors.Is(err, ErrSSGenInvalidTreasuryVote) {
 		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
-			stake.ErrSSGenInvalidTreasuryVote, err)
+			ErrSSGenInvalidTreasuryVote, err)
 	}
-	if stake.IsSSGen(ssgenInvalidTVote2.MsgTx(), withTreasury) {
+	if IsSSGen(ssgenInvalidTVote2.MsgTx(), withTreasury) {
 		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
@@ -838,13 +823,12 @@ func TestSSGenErrors(t *testing.T) {
 	ssgenInvalidTVote3.SetTree(wire.TxTreeStake)
 	ssgenInvalidTVote3.SetIndex(0)
 
-	err = stake.CheckSSGen(ssgenInvalidTVote3.MsgTx(), withTreasury)
-	if !errors.As(err, &serr) || serr.GetCode() !=
-		stake.ErrSSGenDuplicateTreasuryVote {
+	err = CheckSSGen(ssgenInvalidTVote3.MsgTx(), withTreasury)
+	if !errors.Is(err, ErrSSGenDuplicateTreasuryVote) {
 		t.Errorf("CheckSSGen should have returned %v but instead returned %v",
-			stake.ErrSSGenDuplicateTreasuryVote, err)
+			ErrSSGenDuplicateTreasuryVote, err)
 	}
-	if stake.IsSSGen(ssgenInvalidTVote3.MsgTx(), withTreasury) {
+	if IsSSGen(ssgenInvalidTVote3.MsgTx(), withTreasury) {
 		t.Errorf("IsSSGen claimed an invalid ssgen is valid")
 	}
 
@@ -866,16 +850,16 @@ func TestSSGenTreasuryVotes(t *testing.T) {
 	}
 
 	// Make sure ssgen is valid.
-	if !stake.IsSSGen(ssgenValidVote.MsgTx(), withTreasury) {
+	if !IsSSGen(ssgenValidVote.MsgTx(), withTreasury) {
 		t.Error("IsSSGen claimed a valid ssgen is invalid")
 	}
-	err := stake.CheckSSGen(ssgenValidVote.MsgTx(), withTreasury)
+	err := CheckSSGen(ssgenValidVote.MsgTx(), withTreasury)
 	if err != nil {
 		t.Error(err)
 	}
 
 	// Pull out votes:
-	votes, err := stake.GetSSGenTreasuryVotes(lastTxOut.PkScript)
+	votes, err := GetSSGenTreasuryVotes(lastTxOut.PkScript)
 	if err != nil {
 		t.Error(err)
 	}
@@ -908,11 +892,11 @@ func TestSSRtx(t *testing.T) {
 	ssrtx.SetTree(wire.TxTreeStake)
 	ssrtx.SetIndex(0)
 
-	err := stake.CheckSSRtx(ssrtx.MsgTx())
+	err := CheckSSRtx(ssrtx.MsgTx())
 	if err != nil {
 		t.Errorf("IsSSRtx: unexpected err: %v", err)
 	}
-	if !stake.IsSSRtx(ssrtx.MsgTx()) {
+	if !IsSSRtx(ssrtx.MsgTx()) {
 		t.Errorf("IsSSRtx claimed a valid ssrtx is invalid")
 	}
 }
@@ -937,13 +921,12 @@ func TestIsSSRtxErrors(t *testing.T) {
 	ssrtxTooManyInputs.SetTree(wire.TxTreeStake)
 	ssrtxTooManyInputs.SetIndex(0)
 
-	var serr stake.RuleError
-	err = stake.CheckSSRtx(ssrtxTooManyInputs.MsgTx())
-	if !errors.As(err, &serr) || serr.GetCode() != stake.ErrSSRtxWrongNumInputs {
+	err = CheckSSRtx(ssrtxTooManyInputs.MsgTx())
+	if !errors.Is(err, ErrSSRtxWrongNumInputs) {
 		t.Errorf("CheckSSRtx should have returned %v but instead returned %v",
-			stake.ErrSSRtxWrongNumInputs, err)
+			ErrSSRtxWrongNumInputs, err)
 	}
-	if stake.IsSSRtx(ssrtxTooManyInputs.MsgTx()) {
+	if IsSSRtx(ssrtxTooManyInputs.MsgTx()) {
 		t.Errorf("IsSSRtx claimed an invalid ssrtx is valid")
 	}
 
@@ -954,12 +937,12 @@ func TestIsSSRtxErrors(t *testing.T) {
 	ssrtxTooManyOutputs.SetTree(wire.TxTreeStake)
 	ssrtxTooManyOutputs.SetIndex(0)
 
-	err = stake.CheckSSRtx(ssrtxTooManyOutputs.MsgTx())
-	if !errors.As(err, &serr) || serr.GetCode() != stake.ErrSSRtxTooManyOutputs {
+	err = CheckSSRtx(ssrtxTooManyOutputs.MsgTx())
+	if !errors.Is(err, ErrSSRtxTooManyOutputs) {
 		t.Errorf("CheckSSRtx should have returned %v but instead returned %v",
-			stake.ErrSSRtxTooManyOutputs, err)
+			ErrSSRtxTooManyOutputs, err)
 	}
-	if stake.IsSSRtx(ssrtxTooManyOutputs.MsgTx()) {
+	if IsSSRtx(ssrtxTooManyOutputs.MsgTx()) {
 		t.Errorf("IsSSRtx claimed an invalid ssrtx is valid")
 	}
 
@@ -969,12 +952,12 @@ func TestIsSSRtxErrors(t *testing.T) {
 	ssrtxTxBadVerOut.SetTree(wire.TxTreeStake)
 	ssrtxTxBadVerOut.SetIndex(0)
 
-	err = stake.CheckSSRtx(ssrtxTxBadVerOut.MsgTx())
-	if !errors.As(err, &serr) || serr.GetCode() != stake.ErrSSRtxBadOuts {
+	err = CheckSSRtx(ssrtxTxBadVerOut.MsgTx())
+	if !errors.Is(err, ErrSSRtxBadOuts) {
 		t.Errorf("CheckSSRtx should have returned %v but instead returned %v",
-			stake.ErrSSRtxBadOuts, err)
+			ErrSSRtxBadOuts, err)
 	}
-	if stake.IsSSRtx(ssrtxTxBadVerOut.MsgTx()) {
+	if IsSSRtx(ssrtxTxBadVerOut.MsgTx()) {
 		t.Errorf("IsSSRtx claimed an invalid ssrtx is valid")
 	}
 
@@ -1001,12 +984,12 @@ func TestIsSSRtxErrors(t *testing.T) {
 	ssrtxTestRevocOutputUntagged.SetTree(wire.TxTreeStake)
 	ssrtxTestRevocOutputUntagged.SetIndex(0)
 
-	err = stake.CheckSSRtx(ssrtxTestRevocOutputUntagged.MsgTx())
-	if !errors.As(err, &serr) || serr.GetCode() != stake.ErrSSRtxBadOuts {
+	err = CheckSSRtx(ssrtxTestRevocOutputUntagged.MsgTx())
+	if !errors.Is(err, ErrSSRtxBadOuts) {
 		t.Errorf("CheckSSRtx should have returned %v but instead returned %v",
-			stake.ErrSSRtxBadOuts, err)
+			ErrSSRtxBadOuts, err)
 	}
-	if stake.IsSSRtx(ssrtxTestRevocOutputUntagged.MsgTx()) {
+	if IsSSRtx(ssrtxTestRevocOutputUntagged.MsgTx()) {
 		t.Errorf("IsSSRtx claimed an invalid ssrtx is valid")
 	}
 
@@ -1032,12 +1015,12 @@ func TestIsSSRtxErrors(t *testing.T) {
 	ssrtxWrongTreeIns.SetTree(wire.TxTreeStake)
 	ssrtxWrongTreeIns.SetIndex(0)
 
-	err = stake.CheckSSRtx(ssrtxWrongTreeIns.MsgTx())
-	if !errors.As(err, &serr) || serr.GetCode() != stake.ErrSSRtxWrongTxTree {
+	err = CheckSSRtx(ssrtxWrongTreeIns.MsgTx())
+	if !errors.Is(err, ErrSSRtxWrongTxTree) {
 		t.Errorf("CheckSSRtx should have returned %v but instead returned %v",
-			stake.ErrSSGenWrongTxTree, err)
+			ErrSSGenWrongTxTree, err)
 	}
-	if stake.IsSSRtx(ssrtxWrongTreeIns.MsgTx()) {
+	if IsSSRtx(ssrtxWrongTreeIns.MsgTx()) {
 		t.Errorf("IsSSRtx claimed an invalid ssrtx is valid")
 	}
 }
@@ -1049,7 +1032,7 @@ func TestGetSSGenBlockVotedOn(t *testing.T) {
 	ssgen.SetTree(wire.TxTreeStake)
 	ssgen.SetIndex(0)
 
-	blockHash, height := stake.SSGenBlockVotedOn(ssgen.MsgTx())
+	blockHash, height := SSGenBlockVotedOn(ssgen.MsgTx())
 
 	correctBlockHash, _ := chainhash.NewHash(
 		[]byte{
@@ -1099,7 +1082,7 @@ func TestGetSStxStakeOutputInfo(t *testing.T) {
 	correctLimit := uint16(4)
 
 	typs, pkhs, amts, changeAmts, rules, limits :=
-		stake.TxSStxStakeOutputInfo(sstx.MsgTx())
+		TxSStxStakeOutputInfo(sstx.MsgTx())
 
 	if typs[2] != correctTyp {
 		t.Errorf("Error thrown on TestGetSStxStakeOutputInfo: Looking for "+
@@ -1139,7 +1122,7 @@ func TestGetSSGenVoteBits(t *testing.T) {
 
 	correctvbs := uint16(0x8c94)
 
-	votebits := stake.SSGenVoteBits(ssgen.MsgTx())
+	votebits := SSGenVoteBits(ssgen.MsgTx())
 
 	if correctvbs != votebits {
 		t.Errorf("Error thrown on TestGetSSGenVoteBits: Looking for "+
@@ -1150,8 +1133,8 @@ func TestGetSSGenVoteBits(t *testing.T) {
 func TestGetSSGenVersion(t *testing.T) {
 	var ssgen = ssgenMsgTx.Copy()
 
-	missingVersion := uint32(stake.VoteConsensusVersionAbsent)
-	version := stake.SSGenVersion(ssgen)
+	missingVersion := uint32(VoteConsensusVersionAbsent)
+	version := SSGenVersion(ssgen)
 	if version != missingVersion {
 		t.Errorf("Error thrown on TestGetSSGenVersion: Looking for "+
 			"version % x, got version % x", missingVersion, version)
@@ -1164,7 +1147,7 @@ func TestGetSSGenVersion(t *testing.T) {
 		t.Errorf("GenerateProvablyPruneableOut error %v", err)
 	}
 	ssgen.TxOut[1].PkScript = pkScript
-	version = stake.SSGenVersion(ssgen)
+	version = SSGenVersion(ssgen)
 
 	if version != expectedVersion {
 		t.Errorf("Error thrown on TestGetSSGenVersion: Looking for "+
@@ -1185,7 +1168,7 @@ func TestGetSStxNullOutputAmounts(t *testing.T) {
 	}
 	amtTicket := int64(0x9122e300)
 
-	_, _, err := stake.SStxNullOutputAmounts(
+	_, _, err := SStxNullOutputAmounts(
 		[]int64{
 			0x12000000,
 			0x12300000,
@@ -1201,7 +1184,7 @@ func TestGetSStxNullOutputAmounts(t *testing.T) {
 	}
 
 	// too small amount to commit
-	_, _, err = stake.SStxNullOutputAmounts(
+	_, _, err = SStxNullOutputAmounts(
 		commitAmts,
 		changeAmts,
 		int64(0x00000000))
@@ -1217,17 +1200,15 @@ func TestGetSStxNullOutputAmounts(t *testing.T) {
 		0x12300001,
 	}
 
-	var serr stake.RuleError
-	_, _, err = stake.SStxNullOutputAmounts(
+	_, _, err = SStxNullOutputAmounts(
 		commitAmts,
 		tooMuchChangeAmts,
 		int64(0x00000020))
-	if !errors.As(err, &serr) || serr.GetCode() != stake.ErrSStxBadChangeAmts {
+	if !errors.Is(err, ErrSStxBadChangeAmts) {
 		t.Errorf("TestGetSStxNullOutputAmounts unexpected error: %v", err)
 	}
 
-	fees, amts, err := stake.SStxNullOutputAmounts(commitAmts,
-		changeAmts,
+	fees, amts, err := SStxNullOutputAmounts(commitAmts, changeAmts,
 		amtTicket)
 
 	if err != nil {
@@ -1263,7 +1244,7 @@ func TestGetStakeRewards(t *testing.T) {
 	amountTicket := int64(42000000)
 	subsidy := int64(400000)
 
-	outAmts := stake.CalculateRewards(amounts, amountTicket, subsidy)
+	outAmts := CalculateRewards(amounts, amountTicket, subsidy)
 
 	// SSRtx example with 0 subsidy
 	expectedAmts := []int64{
@@ -1337,7 +1318,7 @@ func TestIsNullDataScript(t *testing.T) {
 				test.name, err)
 		}
 
-		result := stake.IsNullDataScript(test.version, script)
+		result := IsNullDataScript(test.version, script)
 		if result != test.expected {
 			t.Fatalf("%s: expected %v, got %v", test.name,
 				test.expected, result)

--- a/blockchain/stake/tickets_test.go
+++ b/blockchain/stake/tickets_test.go
@@ -28,10 +28,6 @@ import (
 const (
 	// testDbType is the database backend type to use for the tests.
 	testDbType = "ffldb"
-
-	// noTreasury signifies the treasury agenda should be treated as though it
-	// is inactive.  It is used to increase the readability of the tests.
-	noTreasury = false
 )
 
 // calcHash256PRNGIVFromHeader calculates the initialization vector for a
@@ -891,9 +887,9 @@ func TestTicketDBGeneral(t *testing.T) {
 	var rerr RuleError
 	_, err = n161Copy.ConnectNode(b162LotteryIV, n162Test.SpentByBlock(),
 		revokedTicketsInBlock(b162), n162Test.NewTickets())
-	if !errors.As(err, &rerr) || rerr.GetCode() != ErrMissingTicket {
-		t.Errorf("unexpected wrong or no error for "+
-			"Best node missing ticket in live ticket bucket to spend: %v", err)
+	if !errors.As(err, &rerr) || !errors.Is(rerr, ErrMissingTicket) {
+		t.Errorf("unexpected wrong or no error for best node missing ticket "+
+			"in live ticket bucket to spend: %v", err)
 	}
 
 	// Duplicate best winners.
@@ -904,9 +900,9 @@ func TestTicketDBGeneral(t *testing.T) {
 	spentInBlock[0] = spentInBlock[1]
 	_, err = n161Copy.ConnectNode(b162LotteryIV, spentInBlock,
 		revokedTicketsInBlock(b162), n162Test.NewTickets())
-	if !errors.As(err, &rerr) || rerr.GetCode() != ErrMissingTicket {
-		t.Errorf("unexpected wrong or no error for "+
-			"Best node missing ticket in live ticket bucket to spend: %v", err)
+	if !errors.As(err, &rerr) || !errors.Is(rerr, ErrMissingTicket) {
+		t.Errorf("unexpected wrong or no error for best node missing ticket "+
+			"in live ticket bucket to spend: %v", err)
 	}
 
 	// Test for corrupted spentInBlock.
@@ -915,7 +911,7 @@ func TestTicketDBGeneral(t *testing.T) {
 	spentInBlock[4] = someHash
 	_, err = nodesForward[161].ConnectNode(b162LotteryIV, spentInBlock,
 		revokedTicketsInBlock(b162), n162Test.NewTickets())
-	if !errors.As(err, &rerr) || rerr.GetCode() != ErrUnknownTicketSpent {
+	if !errors.As(err, &rerr) || !errors.Is(rerr, ErrUnknownTicketSpent) {
 		t.Errorf("unexpected wrong or no error for "+
 			"Test for corrupted spentInBlock: %v", err)
 	}
@@ -925,9 +921,8 @@ func TestTicketDBGeneral(t *testing.T) {
 	n161Copy.nextWinners[4] = someHash
 	_, err = n161Copy.ConnectNode(b162LotteryIV, spentInBlock,
 		revokedTicketsInBlock(b162), n162Test.NewTickets())
-	if !errors.As(err, &rerr) || rerr.GetCode() != ErrMissingTicket {
-		t.Errorf("unexpected wrong or no error for "+
-			"Corrupt winners: %v", err)
+	if !errors.As(err, &rerr) || !errors.Is(rerr, ErrMissingTicket) {
+		t.Errorf("unexpected wrong or no error for corrupt winners: %v", err)
 	}
 
 	// Unknown missed ticket.
@@ -935,9 +930,9 @@ func TestTicketDBGeneral(t *testing.T) {
 	spentInBlock = n162Copy.SpentByBlock()
 	_, err = nodesForward[161].ConnectNode(b162LotteryIV, spentInBlock,
 		append(revokedTicketsInBlock(b162), someHash), n162Copy.NewTickets())
-	if !errors.As(err, &rerr) || rerr.GetCode() != ErrMissingTicket {
-		t.Errorf("unexpected wrong or no error for "+
-			"Unknown missed ticket: %v", err)
+	if !errors.As(err, &rerr) || !errors.Is(rerr, ErrMissingTicket) {
+		t.Errorf("unexpected wrong or no error for unknown missed "+
+			"ticket: %v", err)
 	}
 
 	// Insert a duplicate new ticket.
@@ -945,9 +940,9 @@ func TestTicketDBGeneral(t *testing.T) {
 	newTicketsDup := []chainhash.Hash{someHash, someHash}
 	_, err = nodesForward[161].ConnectNode(b162LotteryIV, spentInBlock,
 		revokedTicketsInBlock(b162), newTicketsDup)
-	if !errors.As(err, &rerr) || rerr.GetCode() != ErrDuplicateTicket {
-		t.Errorf("unexpected wrong or no error for "+
-			"Insert a duplicate new ticket: %v", err)
+	if !errors.As(err, &rerr) || !errors.Is(rerr, ErrDuplicateTicket) {
+		t.Errorf("unexpected wrong or no error for insert a duplicate "+
+			"new ticket: %v", err)
 	}
 
 	// Impossible undo data for disconnecting.
@@ -986,9 +981,9 @@ func TestTicketDBGeneral(t *testing.T) {
 	n162Copy.databaseUndoUpdate[0].Revoked = false
 	_, err = n162Copy.DisconnectNode(b161LotteryIV, n161Copy.UndoData(),
 		n161Copy.NewTickets(), nil)
-	if !errors.As(err, &rerr) || rerr.GetCode() != ErrMissingTicket {
-		t.Errorf("unexpected wrong or no error for "+
-			"Unknown undo data for disconnecting (missing): %v", err)
+	if !errors.As(err, &rerr) || !errors.Is(rerr, ErrMissingTicket) {
+		t.Errorf("unexpected wrong or no error for unknown undo data for "+
+			"disconnecting (missing): %v", err)
 	}
 
 	// Unknown undo data hash when disconnecting (revoked).
@@ -1001,8 +996,8 @@ func TestTicketDBGeneral(t *testing.T) {
 	n162Copy.databaseUndoUpdate[0].Revoked = true
 	_, err = n162Copy.DisconnectNode(b161LotteryIV, n161Copy.UndoData(),
 		n161Copy.NewTickets(), nil)
-	if !errors.As(err, &rerr) || rerr.GetCode() != ErrMissingTicket {
-		t.Errorf("unexpected wrong or no error for "+
-			"Unknown undo data for disconnecting (revoked): %v", err)
+	if !errors.As(err, &rerr) || !errors.Is(rerr, ErrMissingTicket) {
+		t.Errorf("unexpected wrong or no error for unknown undo data for "+
+			"disconnecting (revoked): %v", err)
 	}
 }

--- a/blockchain/stake/treasury_test.go
+++ b/blockchain/stake/treasury_test.go
@@ -7,6 +7,7 @@ package stake
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
 	"math"
 	"math/rand"
 	"testing"
@@ -1061,77 +1062,77 @@ func TestTSpendErrors(t *testing.T) {
 		{
 			name:     "tspendInvalidOutCount",
 			tx:       tspendInvalidOutCount,
-			expected: RuleError{ErrorCode: ErrTSpendInvalidLength},
+			expected: ErrTSpendInvalidLength,
 		},
 		{
 			name:     "tspendInvalidInCount",
 			tx:       tspendInvalidInCount,
-			expected: RuleError{ErrorCode: ErrTSpendInvalidLength},
+			expected: ErrTSpendInvalidLength,
 		},
 		{
 			name:     "tspendInvalidVersion",
 			tx:       tspendInvalidVersion,
-			expected: RuleError{ErrorCode: ErrTSpendInvalidVersion},
+			expected: ErrTSpendInvalidVersion,
 		},
 		{
 			name:     "tspendInvalidSignature",
 			tx:       tspendInvalidSignature,
-			expected: RuleError{ErrorCode: ErrTSpendInvalidScript},
+			expected: ErrTSpendInvalidScript,
 		},
 		{
 			name:     "tspendInvalidSignature2",
 			tx:       tspendInvalidSignature2,
-			expected: RuleError{ErrorCode: ErrTSpendInvalidScript},
+			expected: ErrTSpendInvalidScript,
 		},
 		{
 			name:     "tspendInvalidOpcode",
 			tx:       tspendInvalidOpcode,
-			expected: RuleError{ErrorCode: ErrTSpendInvalidScript},
+			expected: ErrTSpendInvalidScript,
 		},
 		{
 			name:     "tspendInvalidPubkey",
 			tx:       tspendInvalidPubkey,
-			expected: RuleError{ErrorCode: ErrTSpendInvalidPubkey},
+			expected: ErrTSpendInvalidPubkey,
 		},
 		{
 			name:     "tspendInvalidTokenCount",
 			tx:       tspendInvalidTokenCount,
-			expected: RuleError{ErrorCode: ErrTSpendInvalidScript},
+			expected: ErrTSpendInvalidScript,
 		},
 		{
 			name:     "tspendInvalidTokenCount2",
 			tx:       tspendInvalidTokenCount2,
-			expected: RuleError{ErrorCode: ErrTSpendInvalidScript},
+			expected: ErrTSpendInvalidScript,
 		},
 		{
 			name:     "tspendInvalidTokenCount3",
 			tx:       tspendInvalidTokenCount3,
-			expected: RuleError{ErrorCode: ErrTSpendInvalidScript},
+			expected: ErrTSpendInvalidScript,
 		},
 		{
 			name:     "tspendInvalidScriptLength",
 			tx:       tspendInvalidScriptLength,
-			expected: RuleError{ErrorCode: ErrTSpendInvalidScriptLength},
+			expected: ErrTSpendInvalidScriptLength,
 		},
 		{
 			name:     "tspendInvalidTransaction",
 			tx:       tspendInvalidTransaction,
-			expected: RuleError{ErrorCode: ErrTSpendInvalidTransaction},
+			expected: ErrTSpendInvalidTransaction,
 		},
 		{
 			name:     "tspendInvalidTGen",
 			tx:       tspendInvalidTGen,
-			expected: RuleError{ErrorCode: ErrTSpendInvalidTGen},
+			expected: ErrTSpendInvalidTGen,
 		},
 		{
 			name:     "tspendInvalidP2SH",
 			tx:       tspendInvalidP2SH,
-			expected: RuleError{ErrorCode: ErrTSpendInvalidSpendScript},
+			expected: ErrTSpendInvalidSpendScript,
 		},
 		{
 			name:     "tspendInvalidTxVersion",
 			tx:       tspendInvalidTxVersion,
-			expected: RuleError{ErrorCode: ErrTSpendInvalidTxVersion},
+			expected: ErrTSpendInvalidTxVersion,
 		},
 	}
 	for i, tt := range tests {
@@ -1139,11 +1140,9 @@ func TestTSpendErrors(t *testing.T) {
 		test.SetTree(wire.TxTreeStake)
 		test.SetIndex(0)
 		err := checkTSpend(test.MsgTx())
-		if err.(RuleError).GetCode() != tt.expected.(RuleError).GetCode() {
+		if !errors.Is(err, tt.expected) {
 			t.Errorf("%v: checkTSpend should have returned %v but "+
-				"instead returned %v: %v",
-				tt.name, tt.expected.(RuleError).GetCode(),
-				err.(RuleError).GetCode(), err)
+				"instead returned %v", tt.name, tt.expected, err)
 		}
 		if IsTSpend(test.MsgTx()) {
 			t.Errorf("IsTSpend claimed an invalid tspend is valid"+
@@ -1306,47 +1305,47 @@ func TestTAddErrors(t *testing.T) {
 		{
 			name:     "taddInvalidOutCount",
 			tx:       taddInvalidOutCount,
-			expected: RuleError{ErrorCode: ErrTAddInvalidCount},
+			expected: ErrTAddInvalidCount,
 		},
 		{
 			name:     "taddInvalidOutCount2",
 			tx:       taddInvalidOutCount2,
-			expected: RuleError{ErrorCode: ErrTAddInvalidCount},
+			expected: ErrTAddInvalidCount,
 		},
 		{
 			name:     "taddInvalidOutCount3",
 			tx:       taddInvalidOutCount3,
-			expected: RuleError{ErrorCode: ErrTAddInvalidCount},
+			expected: ErrTAddInvalidCount,
 		},
 		{
 			name:     "taddInvalidVersion",
 			tx:       taddInvalidVersion,
-			expected: RuleError{ErrorCode: ErrTAddInvalidVersion},
+			expected: ErrTAddInvalidVersion,
 		},
 		{
 			name:     "taddInvalidScriptLength",
 			tx:       taddInvalidScriptLength,
-			expected: RuleError{ErrorCode: ErrTAddInvalidScriptLength},
+			expected: ErrTAddInvalidScriptLength,
 		},
 		{
 			name:     "taddInvalidLength",
 			tx:       taddInvalidLength,
-			expected: RuleError{ErrorCode: ErrTAddInvalidLength},
+			expected: ErrTAddInvalidLength,
 		},
 		{
 			name:     "taddInvalidOpcode",
 			tx:       taddInvalidOpcode,
-			expected: RuleError{ErrorCode: ErrTAddInvalidOpcode},
+			expected: ErrTAddInvalidOpcode,
 		},
 		{
 			name:     "taddInvalidChange",
 			tx:       taddInvalidChange,
-			expected: RuleError{ErrorCode: ErrTAddInvalidChange},
+			expected: ErrTAddInvalidChange,
 		},
 		{
 			name:     "taddInvalidTxVersion",
 			tx:       taddInvalidTxVersion,
-			expected: RuleError{ErrorCode: ErrTAddInvalidTxVersion},
+			expected: ErrTAddInvalidTxVersion,
 		},
 	}
 	for i, tt := range tests {
@@ -1354,11 +1353,9 @@ func TestTAddErrors(t *testing.T) {
 		test.SetTree(wire.TxTreeStake)
 		test.SetIndex(0)
 		err := checkTAdd(test.MsgTx())
-		if err.(RuleError).GetCode() != tt.expected.(RuleError).GetCode() {
+		if !errors.Is(err, tt.expected) {
 			t.Errorf("%v: checkTAdd should have returned %v but "+
-				"instead returned %v: %v",
-				tt.name, tt.expected.(RuleError).GetCode(),
-				err.(RuleError).GetCode(), err)
+				"instead returned %v", tt.name, tt.expected, err)
 		}
 		if IsTAdd(test.MsgTx()) {
 			t.Errorf("IsTAdd claimed an invalid tadd is valid"+
@@ -1664,62 +1661,62 @@ func TestTreasuryBaseErrors(t *testing.T) {
 		{
 			name:     "treasurybaseInvalidInCount",
 			tx:       treasurybaseInvalidInCount,
-			expected: RuleError{ErrorCode: ErrTreasuryBaseInvalidCount},
+			expected: ErrTreasuryBaseInvalidCount,
 		},
 		{
 			name:     "treasurybaseInvalidOutCount",
 			tx:       treasurybaseInvalidOutCount,
-			expected: RuleError{ErrorCode: ErrTreasuryBaseInvalidCount},
+			expected: ErrTreasuryBaseInvalidCount,
 		},
 		{
 			name:     "treasurybaseInvalidVersion",
 			tx:       treasurybaseInvalidVersion,
-			expected: RuleError{ErrorCode: ErrTreasuryBaseInvalidVersion},
+			expected: ErrTreasuryBaseInvalidVersion,
 		},
 		{
 			name:     "treasurybaseInvalidOpcode0",
 			tx:       treasurybaseInvalidOpcode0,
-			expected: RuleError{ErrorCode: ErrTreasuryBaseInvalidOpcode0},
+			expected: ErrTreasuryBaseInvalidOpcode0,
 		},
 		{
 			name:     "treasurybaseInvalidOpcode0Len",
 			tx:       treasurybaseInvalidOpcode0Len,
-			expected: RuleError{ErrorCode: ErrTreasuryBaseInvalidOpcode0},
+			expected: ErrTreasuryBaseInvalidOpcode0,
 		},
 		{
 			name:     "treasurybaseInvalidOpcode1",
 			tx:       treasurybaseInvalidOpcode1,
-			expected: RuleError{ErrorCode: ErrTreasuryBaseInvalidOpcode1},
+			expected: ErrTreasuryBaseInvalidOpcode1,
 		},
 		{
 			name:     "treasurybaseInvalidOpcode1Len",
 			tx:       treasurybaseInvalidOpcode1Len,
-			expected: RuleError{ErrorCode: ErrTreasuryBaseInvalidOpcode1},
+			expected: ErrTreasuryBaseInvalidOpcode1,
 		},
 		{
 			name:     "treasurybaseInvalidDataPush",
 			tx:       treasurybaseInvalidOpcodeDataPush,
-			expected: RuleError{ErrorCode: ErrTreasuryBaseInvalidOpcode1},
+			expected: ErrTreasuryBaseInvalidOpcode1,
 		},
 		{
 			name:     "treasurybaseInvalid",
 			tx:       treasurybaseInvalid,
-			expected: RuleError{ErrorCode: ErrTreasuryBaseInvalid},
+			expected: ErrTreasuryBaseInvalid,
 		},
 		{
 			name:     "treasurybaseInvalid2",
 			tx:       treasurybaseInvalid2,
-			expected: RuleError{ErrorCode: ErrTreasuryBaseInvalid},
+			expected: ErrTreasuryBaseInvalid,
 		},
 		{
 			name:     "treasurybaseInvalidTxVersion",
 			tx:       treasurybaseInvalidTxVersion,
-			expected: RuleError{ErrorCode: ErrTreasuryBaseInvalidTxVersion},
+			expected: ErrTreasuryBaseInvalidTxVersion,
 		},
 		{
 			name:     "treasurybaseInvalidLength",
 			tx:       treasurybaseInvalidLength,
-			expected: RuleError{ErrorCode: ErrTreasuryBaseInvalidLength},
+			expected: ErrTreasuryBaseInvalidLength,
 		},
 	}
 	for i, tt := range tests {
@@ -1727,11 +1724,9 @@ func TestTreasuryBaseErrors(t *testing.T) {
 		test.SetTree(wire.TxTreeStake)
 		test.SetIndex(0)
 		err := checkTreasuryBase(test.MsgTx())
-		if err.(RuleError).GetCode() != tt.expected.(RuleError).GetCode() {
+		if !errors.Is(err, tt.expected) {
 			t.Errorf("%v: checkTreasuryBase should have returned "+
-				"%v but instead returned %v: %v",
-				tt.name, tt.expected.(RuleError).GetCode(),
-				err.(RuleError).GetCode(), err)
+				"%v but instead returned %v", tt.name, tt.expected, err)
 		}
 		if IsTreasuryBase(test.MsgTx()) {
 			t.Errorf("IsTreasuryBase claimed an invalid treasury "+


### PR DESCRIPTION
This updates the stake error types to leverage go 1.13 errors.Is/As functionality as well as confirm to the error infrastructure best practices outlined in #2181.