### PR TITLE
rpcserver: Add handleEstimateStakeDiff test.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/btcsuite/winsvc v1.0.0
+	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/base58 v1.0.3
 	github.com/decred/dcrd/addrmgr v1.1.0
 	github.com/decred/dcrd/bech32 v1.0.0


### PR DESCRIPTION
Because handleEstimateStakeDiff calls chain.EstimateNextStakeDifficulty
up to four times, change testRPCChain.estimateNextStakeDifficulty to a
function so that handlers can specify more complex return values. In
TestHandleExtimateStakeDiff, have the test RPC chain return functions
that return results from a queue, allowing for multiple calls with
varying results.

Use go-spew to print test result equality errors so that values of
pointers are also printed.