### PR TITLE
dcrjson: update error types.

### DIFF
--- a/dcrjson/cmdinfo_test.go
+++ b/dcrjson/cmdinfo_test.go
@@ -1,11 +1,12 @@
 // Copyright (c) 2015 The btcsuite developers
-// Copyright (c) 2015-2019 The Decred developers
+// Copyright (c) 2015-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package dcrjson
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 )
@@ -24,7 +25,7 @@ func TestCmdMethod(t *testing.T) {
 		{
 			name: "unregistered type",
 			cmd:  (*int)(nil),
-			err:  Error{Code: ErrUnregisteredMethod},
+			err:  ErrUnregisteredMethod,
 		},
 		{
 			name:   "nil pointer of registered type",
@@ -41,21 +42,10 @@ func TestCmdMethod(t *testing.T) {
 	t.Logf("Running %d tests", len(tests))
 	for i, test := range tests {
 		method, err := CmdMethod(test.cmd)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.err) {
-			t.Errorf("Test #%d (%s) wrong error - got %T (%[3]v), "+
-				"want %T", i, test.name, err, test.err)
-			continue
-		}
-		if err != nil {
-			gotErrorCode := err.(Error).Code
-			if gotErrorCode != test.err.(Error).Code {
-				t.Errorf("Test #%d (%s) mismatched error code "+
-					"- got %v (%v), want %v", i, test.name,
-					gotErrorCode, err,
-					test.err.(Error).Code)
-				continue
-			}
-
+		// Ensure the error is of the expected type.
+		if !errors.Is(err, test.err) {
+			t.Errorf("Test #%d (%s): mismatched error - got %v, "+
+				"want %v", i, test.name, err, test.err)
 			continue
 		}
 
@@ -82,7 +72,7 @@ func TestMethodUsageFlags(t *testing.T) {
 		{
 			name:   "unregistered type",
 			method: "bogusmethod",
-			err:    Error{Code: ErrUnregisteredMethod},
+			err:    ErrUnregisteredMethod,
 		},
 		{
 			name:   "getblock",
@@ -99,21 +89,9 @@ func TestMethodUsageFlags(t *testing.T) {
 	t.Logf("Running %d tests", len(tests))
 	for i, test := range tests {
 		flags, err := MethodUsageFlags(test.method)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.err) {
-			t.Errorf("Test #%d (%s) wrong error - got %T (%[3]v), "+
-				"want %T", i, test.name, err, test.err)
-			continue
-		}
-		if err != nil {
-			gotErrorCode := err.(Error).Code
-			if gotErrorCode != test.err.(Error).Code {
-				t.Errorf("Test #%d (%s) mismatched error code "+
-					"- got %v (%v), want %v", i, test.name,
-					gotErrorCode, err,
-					test.err.(Error).Code)
-				continue
-			}
-
+		if !errors.Is(err, test.err) {
+			t.Errorf("Test #%d (%s): mismatched error - got %v, "+
+				"want %v", i, test.name, err, test.err)
 			continue
 		}
 
@@ -140,7 +118,7 @@ func TestMethodUsageText(t *testing.T) {
 		{
 			name:   "unregistered type",
 			method: "bogusmethod",
-			err:    Error{Code: ErrUnregisteredMethod},
+			err:    ErrUnregisteredMethod,
 		},
 		{
 			name:     "getblockcount",
@@ -157,21 +135,9 @@ func TestMethodUsageText(t *testing.T) {
 	t.Logf("Running %d tests", len(tests))
 	for i, test := range tests {
 		usage, err := MethodUsageText(test.method)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.err) {
-			t.Errorf("Test #%d (%s) wrong error - got %T (%[3]v), "+
-				"want %T", i, test.name, err, test.err)
-			continue
-		}
-		if err != nil {
-			gotErrorCode := err.(Error).Code
-			if gotErrorCode != test.err.(Error).Code {
-				t.Errorf("Test #%d (%s) mismatched error code "+
-					"- got %v (%v), want %v", i, test.name,
-					gotErrorCode, err,
-					test.err.(Error).Code)
-				continue
-			}
-
+		if !errors.Is(err, test.err) {
+			t.Errorf("Test #%d (%s): mismatched error - got %v, "+
+				"want %v", i, test.name, err, test.err)
 			continue
 		}
 
@@ -184,7 +150,7 @@ func TestMethodUsageText(t *testing.T) {
 
 		// Get the usage again to exercise caching.
 		usage, err = MethodUsageText(test.method)
-		if err != nil {
+		if !errors.Is(err, test.err) {
 			t.Errorf("Test #%d (%s) unexpected error: %v", i,
 				test.name, err)
 			continue

--- a/dcrjson/jsonerr.go
+++ b/dcrjson/jsonerr.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 Conformal Systems LLC.
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -7,23 +7,23 @@ package dcrjson
 
 // Standard JSON-RPC 2.0 errors
 var (
-	ErrInvalidRequest = Error{
+	ErrInvalidRequest = RPCError{
 		Code:    -32600,
 		Message: "Invalid request",
 	}
-	ErrMethodNotFound = Error{
+	ErrMethodNotFound = RPCError{
 		Code:    -32601,
 		Message: "Method not found",
 	}
-	ErrInvalidParams = Error{
+	ErrInvalidParams = RPCError{
 		Code:    -32602,
 		Message: "Invalid parameters",
 	}
-	ErrInternal = Error{
+	ErrInternal = RPCError{
 		Code:    -32603,
 		Message: "Internal error",
 	}
-	ErrParse = Error{
+	ErrParse = RPCError{
 		Code:    -32700,
 		Message: "Parse error",
 	}
@@ -31,35 +31,35 @@ var (
 
 // General application defined JSON errors
 var (
-	ErrMisc = Error{
+	ErrMisc = RPCError{
 		Code:    -1,
 		Message: "Miscellaneous error",
 	}
-	ErrForbiddenBySafeMode = Error{
+	ErrForbiddenBySafeMode = RPCError{
 		Code:    -2,
 		Message: "Server is in safe mode, and command is not allowed in safe mode",
 	}
-	ErrType = Error{
+	ErrType = RPCError{
 		Code:    -3,
 		Message: "Unexpected type was passed as parameter",
 	}
-	ErrInvalidAddressOrKey = Error{
+	ErrInvalidAddressOrKey = RPCError{
 		Code:    -5,
 		Message: "Invalid address or key",
 	}
-	ErrOutOfMemory = Error{
+	ErrOutOfMemory = RPCError{
 		Code:    -7,
 		Message: "Ran out of memory during operation",
 	}
-	ErrInvalidParameter = Error{
+	ErrInvalidParameter = RPCError{
 		Code:    -8,
 		Message: "Invalid, missing or duplicate parameter",
 	}
-	ErrDatabase = Error{
+	ErrDatabase = RPCError{
 		Code:    -20,
 		Message: "Database error",
 	}
-	ErrDeserialization = Error{
+	ErrDeserialization = RPCError{
 		Code:    -22,
 		Message: "Error parsing or validating structure in raw format",
 	}
@@ -67,11 +67,11 @@ var (
 
 // Peer-to-peer client errors
 var (
-	ErrClientNotConnected = Error{
+	ErrClientNotConnected = RPCError{
 		Code:    -9,
 		Message: "dcrd is not connected",
 	}
-	ErrClientInInitialDownload = Error{
+	ErrClientInInitialDownload = RPCError{
 		Code:    -10,
 		Message: "dcrd is downloading blocks...",
 	}
@@ -79,39 +79,39 @@ var (
 
 // Wallet JSON errors
 var (
-	ErrWallet = Error{
+	ErrWallet = RPCError{
 		Code:    -4,
 		Message: "Unspecified problem with wallet",
 	}
-	ErrWalletInsufficientFunds = Error{
+	ErrWalletInsufficientFunds = RPCError{
 		Code:    -6,
 		Message: "Not enough funds in wallet or account",
 	}
-	ErrWalletInvalidAccountName = Error{
+	ErrWalletInvalidAccountName = RPCError{
 		Code:    -11,
 		Message: "Invalid account name",
 	}
-	ErrWalletKeypoolRanOut = Error{
+	ErrWalletKeypoolRanOut = RPCError{
 		Code:    -12,
 		Message: "Keypool ran out, call keypoolrefill first",
 	}
-	ErrWalletUnlockNeeded = Error{
+	ErrWalletUnlockNeeded = RPCError{
 		Code:    -13,
 		Message: "Enter the wallet passphrase with walletpassphrase first",
 	}
-	ErrWalletPassphraseIncorrect = Error{
+	ErrWalletPassphraseIncorrect = RPCError{
 		Code:    -14,
 		Message: "The wallet passphrase entered was incorrect",
 	}
-	ErrWalletWrongEncState = Error{
+	ErrWalletWrongEncState = RPCError{
 		Code:    -15,
 		Message: "Command given in wrong wallet encryption state",
 	}
-	ErrWalletEncryptionFailed = Error{
+	ErrWalletEncryptionFailed = RPCError{
 		Code:    -16,
 		Message: "Failed to encrypt the wallet",
 	}
-	ErrWalletAlreadyUnlocked = Error{
+	ErrWalletAlreadyUnlocked = RPCError{
 		Code:    -17,
 		Message: "Wallet is already unlocked",
 	}
@@ -121,43 +121,43 @@ var (
 // server are most likely to see.  Generally, the codes should match one of the
 // more general errors above.
 var (
-	ErrBlockNotFound = Error{
+	ErrBlockNotFound = RPCError{
 		Code:    -5,
 		Message: "Block not found",
 	}
-	ErrBlockCount = Error{
+	ErrBlockCount = RPCError{
 		Code:    -5,
 		Message: "Error getting block count",
 	}
-	ErrBestBlockHash = Error{
+	ErrBestBlockHash = RPCError{
 		Code:    -5,
 		Message: "Error getting best block hash",
 	}
-	ErrDifficulty = Error{
+	ErrDifficulty = RPCError{
 		Code:    -5,
 		Message: "Error getting difficulty",
 	}
-	ErrOutOfRange = Error{
+	ErrOutOfRange = RPCError{
 		Code:    -1,
 		Message: "Block number out of range",
 	}
-	ErrNoTxInfo = Error{
+	ErrNoTxInfo = RPCError{
 		Code:    -5,
 		Message: "No information available about transaction",
 	}
-	ErrNoNewestBlockInfo = Error{
+	ErrNoNewestBlockInfo = RPCError{
 		Code:    -5,
 		Message: "No information about newest block",
 	}
-	ErrInvalidTxVout = Error{
+	ErrInvalidTxVout = RPCError{
 		Code:    -5,
 		Message: "Output index number (vout) does not exist for transaction.",
 	}
-	ErrRawTxString = Error{
+	ErrRawTxString = RPCError{
 		Code:    -32602,
 		Message: "Raw tx is not a string",
 	}
-	ErrDecodeHexString = Error{
+	ErrDecodeHexString = RPCError{
 		Code:    -22,
 		Message: "Unable to decode hex string",
 	}
@@ -165,11 +165,11 @@ var (
 
 // Errors that are specific to dcrd.
 var (
-	ErrNoWallet = Error{
+	ErrNoWallet = RPCError{
 		Code:    -1,
 		Message: "This implementation does not implement wallet commands",
 	}
-	ErrUnimplemented = Error{
+	ErrUnimplemented = RPCError{
 		Code:    -1,
 		Message: "Command unimplemented",
 	}

--- a/dcrjson/jsonrpc_test.go
+++ b/dcrjson/jsonrpc_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -7,6 +7,7 @@ package dcrjson
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
 	"testing"
 )
@@ -108,9 +109,9 @@ func TestMiscErrors(t *testing.T) {
 
 	// Force an error in MarshalResponse by giving it an id type that is not
 	// supported.
-	wantErr := Error{Code: ErrInvalidType}
+	wantErr := ErrInvalidType
 	_, err = MarshalResponse("", make(chan int), nil, nil)
-	if jerr, ok := err.(Error); !ok || jerr.Code != wantErr.Code {
+	if !errors.Is(err, wantErr) {
 		t.Errorf("MarshalResult: did not receive expected error - got "+
 			"%v (%[1]T), want %v (%[2]T)", err, wantErr)
 		return

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -5684,8 +5684,7 @@ func parseCmd(request *dcrjson.Request) *parsedRPCCmd {
 		// Produce a relevant error when the requested method is not registered
 		// depending on whether or not it is recognized as being a wallet
 		// command, recognized as unimplemented, or completely unrecognized.
-		var jerr dcrjson.Error
-		if errors.As(err, &jerr) && jerr.Code == dcrjson.ErrUnregisteredMethod {
+		if errors.Is(err, dcrjson.ErrUnregisteredMethod) {
 			parsedCmd.err = dcrjson.ErrRPCMethodNotFound
 			if _, ok := rpcAskWallet[request.Method]; ok {
 				parsedCmd.err = ErrRPCNoWallet


### PR DESCRIPTION
This updates the dcrjson error types to leverage go 1.13 errors.Is/As functionality as well as confirm to the error infrastructure best practices outlined in #2181.