### PR TITLE
rpcserver: Add handleGetStakeVersion tests.

### DIFF
--- a/rpcserverhandlers_test.go
+++ b/rpcserverhandlers_test.go
@@ -150,6 +150,7 @@ type testRPCChain struct {
 	stateLastChangedHeight          int64
 	stateLastChangedHeightErr       error
 	ticketPoolValue                 dcrutil.Amount
+	ticketPoolValueErr              error
 	ticketsWithAddress              []chainhash.Hash
 	tipGeneration                   []chainhash.Hash
 }
@@ -347,7 +348,7 @@ func (c *testRPCChain) StateLastChangedHeight(hash *chainhash.Hash, version uint
 // TicketPoolValue returns a mocked current value of all the locked funds in the
 // ticket pool.
 func (c *testRPCChain) TicketPoolValue() (dcrutil.Amount, error) {
-	return c.ticketPoolValue, nil
+	return c.ticketPoolValue, c.ticketPoolValueErr
 }
 
 // TicketsWithAddress returns a mocked slice of ticket hashes that are currently
@@ -3132,6 +3133,28 @@ func TestHandleGetPeerInfo(t *testing.T) {
 			BanScore:       int32(0),
 			SyncNode:       false,
 		}},
+	}})
+}
+
+func TestHandleGetTicketPoolValue(t *testing.T) {
+	t.Parallel()
+
+	testRPCServerHandler(t, []rpcTest{{
+		name:    "handleGetTicketPoolValue: ok",
+		handler: handleGetTicketPoolValue,
+		cmd:     &types.GetTicketPoolValueCmd{},
+		result:  defaultMockRPCChain().ticketPoolValue.ToCoin(),
+	}, {
+		name:    "handleGetTicketPoolValue: could not obtain ticket pool value",
+		handler: handleGetTicketPoolValue,
+		cmd:     &types.GetTicketPoolValueCmd{},
+		mockChain: func() *testRPCChain {
+			chain := defaultMockRPCChain()
+			chain.ticketPoolValueErr = errors.New("could not obtain ticket pool value")
+			return chain
+		}(),
+		wantErr: true,
+		errCode: dcrjson.ErrRPCInternal.Code,
 	}})
 }
 

--- a/rpcserverhandlers_test.go
+++ b/rpcserverhandlers_test.go
@@ -3137,6 +3137,124 @@ func TestHandleGetPeerInfo(t *testing.T) {
 	}})
 }
 
+func TestHandleGetStakeVersionInfo(t *testing.T) {
+	t.Parallel()
+
+	blk := dcrutil.NewBlock(&block432100)
+	blkHashString := blk.Hash().String()
+	blkHeight := blk.Height()
+	blk2000Hash := mustParseHash("0000000000000c8a886e3f7c32b1bb08422066dcfd008de596471f11a5aff475")
+	mockVersionCount := []types.VersionCount{{
+		Version: 7,
+		Count:   1,
+	}}
+	defaultChain := defaultMockRPCChain()
+	testRPCServerHandler(t, []rpcTest{{
+		name:    "handleGetStakeVersionInfo: ok without specifying count",
+		handler: handleGetStakeVersionInfo,
+		cmd:     &types.GetStakeVersionInfoCmd{},
+		result: types.GetStakeVersionInfoResult{
+			CurrentHeight: blkHeight,
+			Hash:          blkHashString,
+			Intervals: []types.VersionInterval{{
+				StartHeight:  defaultChain.calcWantHeight + 1,
+				EndHeight:    blkHeight,
+				PoSVersions:  mockVersionCount,
+				VoteVersions: mockVersionCount,
+			}},
+		},
+	}, {
+		name:    "handleGetStakeVersionInfo: ok with count 2",
+		handler: handleGetStakeVersionInfo,
+		cmd: &types.GetStakeVersionInfoCmd{
+			Count: dcrjson.Int32(2),
+		},
+		result: types.GetStakeVersionInfoResult{
+			CurrentHeight: blkHeight,
+			Hash:          blkHashString,
+			Intervals: []types.VersionInterval{{
+				StartHeight:  defaultChain.calcWantHeight + 1,
+				EndHeight:    blkHeight,
+				PoSVersions:  mockVersionCount,
+				VoteVersions: mockVersionCount,
+			}, {
+				StartHeight: defaultChain.calcWantHeight + 1 -
+					defaultChainParams.StakeVersionInterval,
+				EndHeight:    defaultChain.calcWantHeight + 1,
+				PoSVersions:  mockVersionCount,
+				VoteVersions: mockVersionCount,
+			}},
+		},
+	}, {
+		name:    "handleGetStakeVersionInfo: invalid count",
+		handler: handleGetStakeVersionInfo,
+		cmd: &types.GetStakeVersionInfoCmd{
+			Count: dcrjson.Int32(-1),
+		},
+		wantErr: true,
+		errCode: dcrjson.ErrRPCInvalidParameter,
+	}, {
+		name:    "handleGetStakeVersionInfo: ok with count > max intervals",
+		handler: handleGetStakeVersionInfo,
+		cmd: &types.GetStakeVersionInfoCmd{
+			Count: dcrjson.Int32(5),
+		},
+		mockChain: func() *testRPCChain {
+			chain := defaultMockRPCChain()
+			chain.bestSnapshot.Hash = *blk2000Hash
+			chain.bestSnapshot.Height = 2000
+			chain.calcWantHeight = 0
+			return chain
+		}(),
+		result: types.GetStakeVersionInfoResult{
+			CurrentHeight: 2000,
+			Hash:          blk2000Hash.String(),
+			Intervals: []types.VersionInterval{{
+				StartHeight:  1,
+				EndHeight:    2000,
+				PoSVersions:  mockVersionCount,
+				VoteVersions: mockVersionCount,
+			}},
+		},
+	}, {
+		name:    "handleGetStakeVersionInfo: ok with startHeight - endHeight == 0",
+		handler: handleGetStakeVersionInfo,
+		cmd:     &types.GetStakeVersionInfoCmd{},
+		mockChain: func() *testRPCChain {
+			chain := defaultMockRPCChain()
+			chain.calcWantHeight = blkHeight
+			return chain
+		}(),
+		result: types.GetStakeVersionInfoResult{
+			CurrentHeight: blkHeight,
+			Hash:          blkHashString,
+			Intervals:     []types.VersionInterval{},
+		},
+	}, {
+		name:    "handleGetStakeVersionInfo: failed to get stake versions",
+		handler: handleGetStakeVersionInfo,
+		cmd:     &types.GetStakeVersionInfoCmd{},
+		mockChain: func() *testRPCChain {
+			chain := defaultMockRPCChain()
+			chain.getStakeVersionsErr = errors.New("failed to get stake versions")
+			return chain
+		}(),
+		wantErr: true,
+		errCode: dcrjson.ErrRPCInternal.Code,
+	}, {
+		name:    "handleGetStakeVersionInfo: failed to get block hash",
+		handler: handleGetStakeVersionInfo,
+		cmd:     &types.GetStakeVersionInfoCmd{},
+		mockChain: func() *testRPCChain {
+			chain := defaultMockRPCChain()
+			chain.blockHashByHeightErr = errors.New("failed to get block hash")
+			return chain
+		}(),
+		wantErr: true,
+		errCode: dcrjson.ErrRPCInternal.Code,
+	}})
+}
+
 func TestHandleGetStakeVersions(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This is part of https://github.com/decred/dcrd/issues/2069 and adds tests for the following rpcserver handler functions:

- handleGetTicketPoolValue
- handleGetStakeVersions
- handleGetStakeVersionInfo