### PR TITLE
cpuminer: Refactor code to its own package.

### DIFF
--- a/internal/mining/cpuminer/README.md
+++ b/internal/mining/cpuminer/README.md
@@ -1,0 +1,21 @@
+
+cpuminer
+========
+
+[![Build Status](https://github.com/decred/dcrd/workflows/Build%20and%20Test/badge.svg)](https://github.com/decred/dcrd/actions)
+[![ISC License](https://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![Doc](https://img.shields.io/badge/doc-reference-blue.svg)](https://pkg.go.dev/github.com/decred/dcrd/internal/mining/cpuminer)
+
+Package cpuminer provides facilities for solving blocks (mining) using the CPU.
+
+## Overview
+
+This package is currently a work in progress.  It works without issue since it
+is used in several of the integration tests, but the API is not really ready for
+public consumption as it has simply been refactored out of the main codebase for
+now.
+
+## License
+
+Package cpuminer is licensed under the [copyfree](http://copyfree.org) ISC
+License.

--- a/internal/mining/cpuminer/cpuminer.go
+++ b/internal/mining/cpuminer/cpuminer.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package mining
+package cpuminer
 
 import (
 	"context"
@@ -20,6 +20,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/dcrutil/v3"
+	"github.com/decred/dcrd/internal/mining"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -73,8 +74,8 @@ func (s *speedStats) AddTotalHashes(numHashes uint64) {
 	s.Unlock()
 }
 
-// CPUMinerConfig is a descriptor containing the cpu miner configuration.
-type CPUMinerConfig struct {
+// Config is a descriptor containing the cpu miner configuration.
+type Config struct {
 	// ChainParams identifies which chain parameters the cpu miner is
 	// associated with.
 	ChainParams *chaincfg.Params
@@ -84,7 +85,7 @@ type CPUMinerConfig struct {
 
 	// BlockTemplateGenerator identifies the instance to use in order to
 	// generate block templates that the miner will attempt to solve.
-	BlockTemplateGenerator *BlkTmplGenerator
+	BlockTemplateGenerator *mining.BlkTmplGenerator
 
 	// MiningAddrs is a list of payment addresses to use for the generated
 	// blocks.  Each generated block will randomly choose one of them.
@@ -122,8 +123,8 @@ type CPUMiner struct {
 	numWorkers uint32 // update atomically
 
 	sync.Mutex
-	g                 *BlkTmplGenerator
-	cfg               *CPUMinerConfig
+	g                 *mining.BlkTmplGenerator
+	cfg               *Config
 	started           bool
 	discreteMining    bool
 	submitBlockLock   sync.Mutex
@@ -166,8 +167,7 @@ out:
 			}
 			hashesPerSec = (hashesPerSec + curHashesPerSec) / 2
 			if hashesPerSec != 0 {
-				log.Debugf("Hash speed: %6.0f kilohashes/s",
-					hashesPerSec/1000)
+				log.Debugf("Hash speed: %6.0f kilohashes/s", hashesPerSec/1000)
 			}
 
 		// Request for the number of hashes per second.
@@ -197,8 +197,8 @@ func (m *CPUMiner) submitBlock(block *dcrutil.Block) bool {
 		// so log that error as an internal error.
 		var rErr blockchain.RuleError
 		if !errors.As(err, &rErr) {
-			log.Errorf("Unexpected error while processing "+
-				"block submitted via CPU miner: %v", err)
+			log.Errorf("Unexpected error while processing block submitted via "+
+				"CPU miner: %v", err)
 			return false
 		}
 		// Occasionally errors are given out for timing errors with
@@ -206,9 +206,8 @@ func (m *CPUMiner) submitBlock(block *dcrutil.Block) bool {
 		// the target. Feed these to debug.
 		if m.cfg.ChainParams.ReduceMinDifficulty &&
 			rErr.ErrorCode == blockchain.ErrHighHash {
-			log.Debugf("Block submitted via CPU miner rejected "+
-				"because of ReduceMinDifficulty time sync failure: %v",
-				err)
+			log.Debugf("Block submitted via CPU miner rejected because of "+
+				"ReduceMinDifficulty time sync failure: %v", err)
 			return false
 		}
 		// Other rule errors should be reported.
@@ -216,8 +215,8 @@ func (m *CPUMiner) submitBlock(block *dcrutil.Block) bool {
 		return false
 	}
 	if isOrphan {
-		log.Errorf("Block submitted via CPU miner is an orphan building "+
-			"on parent %v", block.MsgBlock().Header.PrevBlock)
+		log.Errorf("Block submitted via CPU miner is an orphan building on "+
+			"parent %v", block.MsgBlock().Header.PrevBlock)
 		return false
 	}
 
@@ -227,8 +226,8 @@ func (m *CPUMiner) submitBlock(block *dcrutil.Block) bool {
 	for _, out := range coinbaseTxOuts {
 		coinbaseTxGenerated += out.Value
 	}
-	log.Infof("Block submitted via CPU miner accepted (hash %s, "+
-		"height %v, amount %v)", block.Hash(), block.Height(),
+	log.Infof("Block submitted via CPU miner accepted (hash %s, height %v, "+
+		"amount %v)", block.Hash(), block.Height(),
 		dcrutil.Amount(coinbaseTxGenerated))
 	return true
 }
@@ -247,18 +246,18 @@ func (m *CPUMiner) solveBlock(ctx context.Context, msgBlock *wire.MsgBlock, stat
 	// worker.
 	enOffset, err := wire.RandomUint64()
 	if err != nil {
-		log.Errorf("Unexpected error while generating random "+
-			"extra nonce offset: %v", err)
+		log.Errorf("Unexpected error while generating random extra nonce "+
+			"offset: %v", err)
 		enOffset = 0
 	}
 
-	// Create a couple of convenience variables.
+	// Create some convenience variables.
 	header := &msgBlock.Header
 	targetDifficulty := standalone.CompactToBig(header.Bits)
 
 	// Initial state.
 	lastGenerated := time.Now()
-	lastTxUpdate := m.g.txSource.LastUpdated()
+	lastTxUpdate := m.g.TxSource().LastUpdated()
 	hashesCompleted := uint64(0)
 
 	// Note that the entire extra nonce range is iterated and the offset is
@@ -296,7 +295,7 @@ func (m *CPUMiner) solveBlock(ctx context.Context, msgBlock *wire.MsgBlock, stat
 				// generated and it has been at least 3 seconds,
 				// or if it's been one minute.
 				now := time.Now()
-				if (lastTxUpdate != m.g.txSource.LastUpdated() &&
+				if (lastTxUpdate != m.g.TxSource().LastUpdated() &&
 					now.After(lastGenerated.Add(3*time.Second))) ||
 					now.After(lastGenerated.Add(60*time.Second)) {
 					return false
@@ -368,7 +367,7 @@ func (m *CPUMiner) generateBlocks(ctx context.Context) {
 		// this would otherwise end up building a new block template on
 		// a block that is in the process of becoming stale.
 		m.submitBlockLock.Lock()
-		curHeight := m.g.chain.BestSnapshot().Height
+		curHeight := m.g.BestSnapshot().Height
 		if curHeight != 0 && !m.cfg.IsCurrent() {
 			m.submitBlockLock.Unlock()
 			time.Sleep(time.Second)
@@ -385,8 +384,8 @@ func (m *CPUMiner) generateBlocks(ctx context.Context) {
 		template, err := m.g.NewBlockTemplate(payToAddr)
 		m.submitBlockLock.Unlock()
 		if err != nil {
-			errStr := fmt.Sprintf("Failed to create new block "+
-				"template: %v", err)
+			errStr := fmt.Sprintf("Failed to create new block template: %v",
+				err)
 			log.Errorf(errStr)
 			continue
 		}
@@ -404,9 +403,8 @@ func (m *CPUMiner) generateBlocks(ctx context.Context) {
 			maxBlocksOnParent := m.minedOnParents[prevBlock] >= maxSimnetToMine
 			m.Unlock()
 			if maxBlocksOnParent {
-				log.Tracef("too many blocks mined on parent, stopping " +
-					"until there are enough votes on these to make a new " +
-					"block")
+				log.Tracef("too many blocks mined on parent, stopping until " +
+					"there are enough votes on these to make a new block")
 				continue
 			}
 		}
@@ -516,8 +514,7 @@ func (m *CPUMiner) Start() {
 	log.Infof("CPU miner started")
 }
 
-// Wait blocks until the WaitGroup counters added to by a call to
-// Start() are zero.
+// Wait blocks until the CPU miner finishes shutting down.
 func (m *CPUMiner) Wait() {
 	m.wg.Wait()
 }
@@ -688,10 +685,11 @@ func (m *CPUMiner) GenerateNBlocks(ctx context.Context, n uint32) ([]*chainhash.
 	}
 }
 
-// NewCPUMiner returns a new instance of a CPU miner for the provided server.
+// New returns a new instance of a CPU miner for the provided server.
+//
 // Use Start to begin the mining process.  See the documentation for CPUMiner
 // type for more details.
-func NewCPUMiner(cfg *CPUMinerConfig) *CPUMiner {
+func New(cfg *Config) *CPUMiner {
 	return &CPUMiner{
 		g:                 cfg.BlockTemplateGenerator,
 		cfg:               cfg,

--- a/internal/mining/cpuminer/doc.go
+++ b/internal/mining/cpuminer/doc.go
@@ -1,0 +1,8 @@
+// Copyright (c) 2016-2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+/*
+Package cpuminer provides facilities for solving blocks (mining) using the CPU.
+*/
+package cpuminer

--- a/internal/mining/cpuminer/log.go
+++ b/internal/mining/cpuminer/log.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package cpuminer
+
+import (
+	"github.com/decred/slog"
+)
+
+// log is a logger that is initialized with no output filters.  This
+// means the package will not perform any logging by default until the caller
+// requests it.
+// The default amount of logging is none.
+var log = slog.Disabled
+
+// UseLogger uses a specified Logger to output package logging info.
+// This should be used in preference to SetLogWriter if the caller is also
+// using slog.
+func UseLogger(logger slog.Logger) {
+	log = logger
+}

--- a/internal/mining/doc.go
+++ b/internal/mining/doc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 The Decred developers
+// Copyright (c) 2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -1979,6 +1979,23 @@ func (g *BlkTmplGenerator) UpdateBlockTime(header *wire.BlockHeader) error {
 	return nil
 }
 
+// BestSnapshot returns information about the current best chain block and
+// related state as of the current point in time using the chain instance
+// associated with the block template generator.  The returned state must be
+// treated as immutable since it is shared by all callers.
+//
+// This function is safe for concurrent access.
+func (g *BlkTmplGenerator) BestSnapshot() *blockchain.BestState {
+	return g.chain.BestSnapshot()
+}
+
+// TxSource returns the associated transaction source.
+//
+// This function is safe for concurrent access.
+func (g *BlkTmplGenerator) TxSource() TxSource {
+	return g.txSource
+}
+
 // regenEventType represents the type of a template regeneration event message.
 type regenEventType int
 

--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -1951,12 +1951,13 @@ mempoolLoop:
 	return blockTemplate, nil
 }
 
-// UpdateBlockTime updates the timestamp in the header of the passed block to
-// the current time while taking into account the median time of the last
-// several blocks to ensure the new time is after that time per the chain
-// consensus rules.  Finally, it will update the target difficulty if needed
-// based on the new time for the test networks since their target difficulty can
-// change based upon time.
+// UpdateBlockTime updates the timestamp in the passed header to the current
+// time while taking into account the median time of the last several blocks to
+// ensure the new time is after that time per the chain consensus rules.
+//
+// Finally, it will update the target difficulty if needed based on the new time
+// for the test networks since their target difficulty can change based upon
+// time.
 func (g *BlkTmplGenerator) UpdateBlockTime(header *wire.BlockHeader) error {
 	// The new timestamp is potentially adjusted to ensure it comes after
 	// the median time of the last several blocks per the chain consensus
@@ -1976,12 +1977,6 @@ func (g *BlkTmplGenerator) UpdateBlockTime(header *wire.BlockHeader) error {
 	}
 
 	return nil
-}
-
-// UpdateBlockTime invokes `UpdateBlockTime` on the underlying
-// BgBlkTmplGenerator.
-func (g *BgBlkTmplGenerator) UpdateBlockTime(header *wire.BlockHeader) error {
-	return g.tg.UpdateBlockTime(header)
 }
 
 // regenEventType represents the type of a template regeneration event message.
@@ -2230,6 +2225,17 @@ func NewBgBlkTmplGenerator(tg *BlkTmplGenerator, addrs []dcrutil.Address, allowU
 		regenEventMsgs:      make(chan regenEvent),
 		cancelTemplate:      func() {},
 	}
+}
+
+// UpdateBlockTime updates the timestamp in the passed header to the current
+// time while taking into account the median time of the last several blocks to
+// ensure the new time is after that time per the chain consensus rules.
+//
+// Finally, it will update the target difficulty if needed based on the new time
+// for the test networks since their target difficulty can change based upon
+// time.
+func (g *BgBlkTmplGenerator) UpdateBlockTime(header *wire.BlockHeader) error {
+	return g.tg.UpdateBlockTime(header)
 }
 
 // sendQueueRegenEvent sends the provided regen event on the internal queue

--- a/log.go
+++ b/log.go
@@ -19,6 +19,7 @@ import (
 	"github.com/decred/dcrd/fees/v2"
 	"github.com/decred/dcrd/internal/mempool"
 	"github.com/decred/dcrd/internal/mining"
+	"github.com/decred/dcrd/internal/mining/cpuminer"
 	"github.com/decred/dcrd/internal/rpcserver"
 	"github.com/decred/dcrd/peer/v2"
 	"github.com/decred/dcrd/txscript/v3"
@@ -85,6 +86,7 @@ func init() {
 	indexers.UseLogger(indxLog)
 	mempool.UseLogger(txmpLog)
 	mining.UseLogger(minrLog)
+	cpuminer.UseLogger(minrLog)
 	peer.UseLogger(peerLog)
 	rpcserver.UseLogger(rpcsLog)
 	stake.UseLogger(stkeLog)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -48,6 +48,7 @@ import (
 	"github.com/decred/dcrd/dcrutil/v3"
 	"github.com/decred/dcrd/internal/mempool"
 	"github.com/decred/dcrd/internal/mining"
+	"github.com/decred/dcrd/internal/mining/cpuminer"
 	"github.com/decred/dcrd/internal/rpcserver"
 	"github.com/decred/dcrd/internal/version"
 	"github.com/decred/dcrd/rpc/jsonrpc/types/v2"
@@ -5575,7 +5576,7 @@ type rpcserverConfig struct {
 	// solves templates using the CPU.  CPU mining is typically only useful
 	// for test purposes when doing regression or simulation testing.
 	BgBlkTmplGenerator func() *mining.BgBlkTmplGenerator
-	CPUMiner           *mining.CPUMiner
+	CPUMiner           *cpuminer.CPUMiner
 
 	// These fields define any optional indexes the RPC server can make use
 	// of to provide additional data when queried.

--- a/server.go
+++ b/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/decred/dcrd/gcs/v2/blockcf"
 	"github.com/decred/dcrd/internal/mempool"
 	"github.com/decred/dcrd/internal/mining"
+	"github.com/decred/dcrd/internal/mining/cpuminer"
 	"github.com/decred/dcrd/internal/version"
 	"github.com/decred/dcrd/lru"
 	"github.com/decred/dcrd/peer/v2"
@@ -446,7 +447,7 @@ type server struct {
 	chain                *blockchain.BlockChain
 	txMemPool            *mempool.TxPool
 	feeEstimator         *fees.Estimator
-	cpuMiner             *mining.CPUMiner
+	cpuMiner             *cpuminer.CPUMiner
 	modifyRebroadcastInv chan interface{}
 	newPeers             chan *serverPeer
 	donePeers            chan *serverPeer
@@ -3131,7 +3132,7 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 		s.blockManager.cfg.BgBlkTmplGenerator = s.bg
 	}
 
-	s.cpuMiner = mining.NewCPUMiner(&mining.CPUMinerConfig{
+	s.cpuMiner = cpuminer.New(&cpuminer.Config{
 		ChainParams:                s.chainParams,
 		PermitConnectionlessMining: cfg.SimNet,
 		BlockTemplateGenerator:     tg,


### PR DESCRIPTION
**This requires #2275**.

This does the minimum work necessary to refactor the CPU miner code into its own internal package.  The idea is that separating this code into its own package will improve its testability and ultimately be useful to other parts of the codebase such as the various tests which currently effectively have their own stripped-down versions of this code.

The API will certainly need some additional cleanup and changes to make it more usable outside of the specific circumstances it was originally designed to support (namely the generate RPC), however it is better to do that in future commits in order to keep the changeset as small as possible during this refactor.

Overview of the major changes:

- Create the new package
- Move `internal/mining/cpuminer.go` -> `internal/mining/cpuminer/cpuminer.go`
- Update mining logging to use the new `cpuminer` package logger
- Rename `CPUMinerConfig` to `Config` (so it's now `cpuminer.Config`)
- Rename `NewCPUMiner` to `New` (so it's now `cpuminer.New`)
- Add exported `BestSnapshot` method to `mining.BlkTmplGenerator`
- Add exported `TxSource` method to `mining.BlkTmplGenerator`
- Update all references to the `cpuminer` to use the package
- Add a skeleton `README.md`
- Add a skeleton `doc.go`
