### PR TITLE
cpuminer: Rework to use bg template generator.

### DIFF
--- a/config.go
+++ b/config.go
@@ -1062,7 +1062,7 @@ func loadConfig() (*config, []string, error) {
 
 	// Ensure there is at least one mining address when the generate flag is
 	// set.
-	if cfg.Generate && len(cfg.MiningAddrs) == 0 {
+	if cfg.Generate && len(cfg.miningAddrs) == 0 {
 		str := "%s: the generate flag is set, but there are no mining " +
 			"addresses specified "
 		err := fmt.Errorf(str, funcName)
@@ -1080,8 +1080,8 @@ func loadConfig() (*config, []string, error) {
 		return nil, nil, err
 	}
 
-	// Always allow unsynchronized mining on simnet.
-	if cfg.SimNet {
+	// Always allow unsynchronized mining on simnet and regnet.
+	if cfg.SimNet || cfg.RegNet {
 		cfg.AllowUnsyncedMining = true
 	}
 

--- a/internal/mining/cpuminer/cpuminer.go
+++ b/internal/mining/cpuminer/cpuminer.go
@@ -9,8 +9,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
-	"fmt"
-	"math/rand"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -39,16 +38,19 @@ const (
 	// keep track of the hashes per second.
 	hashUpdateSecs = 15
 
-	// maxSimnetToMine is the maximum number of blocks to mine on HEAD~1
-	// for simnet so that you don't run out of memory if tickets for
-	// some reason run out during simulations.
+	// maxSimnetToMine is the maximum number of blocks mined on HEAD~1 for
+	// simnet that fail to submit to avoid pointlessly mining blocks in
+	// situations such as tickets running out during simulations.
 	maxSimnetToMine uint8 = 4
 )
 
 var (
-	// defaultNumWorkers is the default number of workers to use for mining
-	// and is based on the number of processor cores.  This helps ensure the
+	// MaxNumWorkers is the maximum number of workers that will be allowed for
+	// mining and is based on the number of processor cores.  This helps ensure
 	// system stays reasonably responsive under heavy load.
+	MaxNumWorkers = uint32(runtime.NumCPU() * 2)
+
+	// defaultNumWorkers is the default number of workers to use for mining.
 	defaultNumWorkers = uint32(1)
 
 	// littleEndian is a convenience variable since binary.LittleEndian is
@@ -74,18 +76,18 @@ func (s *speedStats) AddTotalHashes(numHashes uint64) {
 	s.Unlock()
 }
 
-// Config is a descriptor containing the cpu miner configuration.
+// Config is a descriptor containing the CPU miner configuration.
 type Config struct {
-	// ChainParams identifies which chain parameters the cpu miner is
+	// ChainParams identifies which chain parameters the CPU miner is
 	// associated with.
 	ChainParams *chaincfg.Params
 
-	// PermitConnectionlessMining allows single node mining on simnet.
+	// PermitConnectionlessMining allows single node mining.
 	PermitConnectionlessMining bool
 
-	// BlockTemplateGenerator identifies the instance to use in order to
+	// BgBlkTmplGenerator identifies the instance to use in order to
 	// generate block templates that the miner will attempt to solve.
-	BlockTemplateGenerator *mining.BlkTmplGenerator
+	BgBlkTmplGenerator *mining.BgBlkTmplGenerator
 
 	// MiningAddrs is a list of payment addresses to use for the generated
 	// blocks.  Each generated block will randomly choose one of them.
@@ -113,20 +115,27 @@ type Config struct {
 	IsCurrent func() bool
 }
 
-// CPUMiner provides facilities for solving blocks (mining) using the CPU in
-// a concurrency-safe manner.  It consists of two main goroutines -- a speed
-// monitor and a controller for worker goroutines which generate and solve
-// blocks.  The number of goroutines can be set via the SetMaxGoRoutines
-// function, but the default is based on the number of processor cores in the
-// system which is typically sufficient.
+// CPUMiner provides facilities for solving blocks (mining) using the CPU in a
+// concurrency-safe manner.  It consists of two main modes -- a normal mining
+// mode that tries to solve blocks continuously and a discrete mining mode,
+// which is accessible via GenerateNBlocks, that generates a specific number of
+// blocks that extend the main chain.
+//
+// The normal mining mode consists of two main goroutines -- a speed monitor and
+// a controller for additional worker goroutines that generate and solve blocks.
+//
+// When the CPU miner is first started via the Run method, it will not have any
+// workers which means it will be idle.  The number of worker goroutines for the
+// normal mining mode can be set via the SetNumWorkers method.
 type CPUMiner struct {
 	numWorkers uint32 // update atomically
 
 	sync.Mutex
-	g                 *mining.BlkTmplGenerator
+	g                 *mining.BgBlkTmplGenerator
 	cfg               *Config
-	started           bool
+	normalMining      bool
 	discreteMining    bool
+	discretePrevHash  chainhash.Hash
 	submitBlockLock   sync.Mutex
 	wg                sync.WaitGroup
 	workerWg          sync.WaitGroup
@@ -144,8 +153,8 @@ type CPUMiner struct {
 
 // speedMonitor handles tracking the number of hashes per second the mining
 // process is performing.  It must be run as a goroutine.
-func (m *CPUMiner) speedMonitor() {
-	log.Tracef("CPU miner speed monitor started")
+func (m *CPUMiner) speedMonitor(ctx context.Context) {
+	log.Trace("CPU miner speed monitor started")
 
 	var hashesPerSec float64
 	ticker := time.NewTicker(time.Second * hpsUpdateSecs)
@@ -174,13 +183,13 @@ out:
 		case m.queryHashesPerSec <- hashesPerSec:
 			// Nothing to do.
 
-		case <-m.quit:
+		case <-ctx.Done():
 			break out
 		}
 	}
 
 	m.wg.Done()
-	log.Tracef("CPU miner speed monitor done")
+	log.Trace("CPU miner speed monitor done")
 }
 
 // submitBlock submits the passed block to network after ensuring it passes all
@@ -201,15 +210,20 @@ func (m *CPUMiner) submitBlock(block *dcrutil.Block) bool {
 				"CPU miner: %v", err)
 			return false
 		}
-		// Occasionally errors are given out for timing errors with
-		// ReduceMinDifficulty and high block works that is above
-		// the target. Feed these to debug.
+
+		// When the reduce min difficulty option is set it is possible that the
+		// required difficulty changed while a block was being solved and will
+		// therefore result in an error due to having the incorrect required
+		// difficulty set in the header.  In that case, only log the error as
+		// debug since it is expected to happen from time to time and not really
+		// an error.
 		if m.cfg.ChainParams.ReduceMinDifficulty &&
 			rErr.ErrorCode == blockchain.ErrHighHash {
 			log.Debugf("Block submitted via CPU miner rejected because of "+
 				"ReduceMinDifficulty time sync failure: %v", err)
 			return false
 		}
+
 		// Other rule errors should be reported.
 		log.Errorf("Block submitted via CPU miner rejected: %v", err)
 		return false
@@ -233,15 +247,14 @@ func (m *CPUMiner) submitBlock(block *dcrutil.Block) bool {
 }
 
 // solveBlock attempts to find some combination of a nonce, extra nonce, and
-// current timestamp which makes the passed block hash to a value less than the
-// target difficulty.  The timestamp is updated periodically and the passed
-// block is modified with all tweaks during this process.  This means that
-// when the function returns true, the block is ready for submission.
+// current timestamp which makes the passed block header hash to a value less
+// than the target difficulty.  The timestamp is updated periodically and the
+// passed block header is modified with all tweaks during this process.  This
+// means that when the function returns true, the block is ready for submission.
 //
-// This function will return early with false when conditions that trigger a
-// stale block such as a new block showing up or periodically when there are
-// new transactions and enough time has elapsed without finding a solution.
-func (m *CPUMiner) solveBlock(ctx context.Context, msgBlock *wire.MsgBlock, stats *speedStats, ticker *time.Ticker) bool {
+// This function will return early with false when the provided context is
+// cancelled or an unexpected error happens.
+func (m *CPUMiner) solveBlock(ctx context.Context, header *wire.BlockHeader, stats *speedStats, ticker *time.Ticker) bool {
 	// Choose a random extra nonce offset for this block template and
 	// worker.
 	enOffset, err := wire.RandomUint64()
@@ -252,12 +265,9 @@ func (m *CPUMiner) solveBlock(ctx context.Context, msgBlock *wire.MsgBlock, stat
 	}
 
 	// Create some convenience variables.
-	header := &msgBlock.Header
 	targetDifficulty := standalone.CompactToBig(header.Bits)
 
 	// Initial state.
-	lastGenerated := time.Now()
-	lastTxUpdate := m.g.TxSource().LastUpdated()
 	hashesCompleted := uint64(0)
 
 	// Note that the entire extra nonce range is iterated and the offset is
@@ -290,17 +300,6 @@ func (m *CPUMiner) solveBlock(ctx context.Context, msgBlock *wire.MsgBlock, stat
 				stats.AddTotalHashes(hashesCompleted)
 				hashesCompleted = 0
 
-				// The current block is stale if the memory pool
-				// has been updated since the block template was
-				// generated and it has been at least 3 seconds,
-				// or if it's been one minute.
-				now := time.Now()
-				if (lastTxUpdate != m.g.TxSource().LastUpdated() &&
-					now.After(lastGenerated.Add(3*time.Second))) ||
-					now.After(lastGenerated.Add(60*time.Second)) {
-					return false
-				}
-
 				err = m.g.UpdateBlockTime(header)
 				if err != nil {
 					log.Warnf("CPU miner unable to update block template "+
@@ -331,125 +330,168 @@ func (m *CPUMiner) solveBlock(ctx context.Context, msgBlock *wire.MsgBlock, stat
 	}
 }
 
-// generateBlocks is a worker that is controlled by the miningWorkerController.
-// It is self contained in that it creates block templates and attempts to solve
-// them while detecting when it is performing stale work and reacting
-// accordingly by generating a new block template.  When a block is solved, it
-// is submitted.
+// solver is a worker that is controlled by a given generateBlocks goroutine.
+//
+// It attempts to solve the provided block template and submit the resulting
+// solved block.  It also contains some additional logic to handle various
+// corner cases such as waiting for connections when connectionless mining is
+// disabled and exiting if too many failed blocks building on the same parent
+// are mined when on the simulation network.
 //
 // It must be run as a goroutine.
-func (m *CPUMiner) generateBlocks(ctx context.Context) {
-	log.Tracef("Starting generate blocks worker")
-
-	// Start a ticker which is used to signal checks for stale work and
-	// updates to the speed monitor.
-	ticker := time.NewTicker(333 * time.Millisecond)
-	defer ticker.Stop()
+func (m *CPUMiner) solver(ctx context.Context, template *mining.BlockTemplate, ticker *time.Ticker) {
+	defer m.workerWg.Done()
 
 	for {
-		// Quit when the miner is stopped.
 		if ctx.Err() != nil {
-			break
+			return
 		}
 
-		// If not in connectionless mode, wait until there is a connection to
-		// at least one other peer since there is no way to relay a found
-		// block or receive transactions to work on when there are no
-		// connected peers.
-		if !m.cfg.PermitConnectionlessMining && m.cfg.ConnectedCount() == 0 {
-			time.Sleep(time.Second)
-			continue
+		// Wait until there is a connection to at least one other peer when not
+		// in connectionless mode since there is no way to relay a found block
+		// or receive transactions to work on when there are no connected peers.
+		prevBlock := template.Block.Header.PrevBlock
+		for !m.cfg.PermitConnectionlessMining && m.cfg.ConnectedCount() == 0 {
+			select {
+			case <-time.After(time.Second):
+			case <-ctx.Done():
+				return
+			}
 		}
 
-		// No point in searching for a solution before the chain is
-		// synced.  Also, grab the same lock as used for block
-		// submission, since the current block will be changing and
-		// this would otherwise end up building a new block template on
-		// a block that is in the process of becoming stale.
-		m.submitBlockLock.Lock()
-		curHeight := m.g.BestSnapshot().Height
-		if curHeight != 0 && !m.cfg.IsCurrent() {
-			m.submitBlockLock.Unlock()
-			time.Sleep(time.Second)
-			continue
-		}
-
-		// Choose a payment address at random.
-		rand.Seed(time.Now().UnixNano())
-		payToAddr := m.cfg.MiningAddrs[rand.Intn(len(m.cfg.MiningAddrs))]
-
-		// Create a new block template using the available transactions
-		// in the memory pool as a source of transactions to potentially
-		// include in the block.
-		template, err := m.g.NewBlockTemplate(payToAddr)
-		m.submitBlockLock.Unlock()
-		if err != nil {
-			errStr := fmt.Sprintf("Failed to create new block template: %v",
-				err)
-			log.Errorf(errStr)
-			continue
-		}
-
-		// Not enough voters.
-		if template == nil {
-			continue
-		}
-
-		// This prevents you from causing memory exhaustion issues
-		// when mining aggressively in a simulation network.
+		// Don't try to mine any more blocks when in connectionless mode and the
+		// maximum number of alternatives building on the current parent that
+		// fail to submit has been reached.  This avoids pointlessly mining
+		// blocks in situations such as tickets running out during simulations.
 		if m.cfg.PermitConnectionlessMining {
-			prevBlock := template.Block.Header.PrevBlock
 			m.Lock()
 			maxBlocksOnParent := m.minedOnParents[prevBlock] >= maxSimnetToMine
 			m.Unlock()
 			if maxBlocksOnParent {
-				log.Tracef("too many blocks mined on parent, stopping until " +
+				log.Infof("too many blocks mined on parent, stopping until " +
 					"there are enough votes on these to make a new block")
-				continue
+				return
 			}
 		}
 
-		// Attempt to solve the block.  The function will exit early
-		// with false when conditions that trigger a stale block, so
-		// a new block template can be generated.  When the return is
-		// true a solution was found, so submit the solved block.
-		if m.solveBlock(ctx, template.Block, &m.speedStats, ticker) {
-			block := dcrutil.NewBlock(template.Block)
-			m.submitBlock(block)
+		// Attempt to solve the block.
+		//
+		// The function will exit with false if the block was not solved for any
+		// reason such as the context being cancelled or an unexpected error, so
+		// allow it to loop around to potentially try again in that case.
+		//
+		// When the return is true, a solution was found, so attempt to submit
+		// the solved block and return from the worker if successful since it is
+		// done.  In the case the solved block fails to submit, keep track of
+		// how many blocks have failed to submit for its parent and try to find
+		// another solution.
+		//
+		// The block in the template is shallow copied to avoid mutating the
+		// data of the shared template.
+		shallowBlockCopy := *template.Block
+		if m.solveBlock(ctx, &shallowBlockCopy.Header, &m.speedStats, ticker) {
+			block := dcrutil.NewBlock(&shallowBlockCopy)
+			if !m.submitBlock(block) {
+				m.Lock()
+				m.minedOnParents[prevBlock]++
+				m.Unlock()
+				continue
+			}
 
-			m.Lock()
-			m.minedOnParents[template.Block.Header.PrevBlock]++
-			m.Unlock()
+			return
 		}
 	}
+}
 
-	m.workerWg.Done()
-	log.Tracef("Generate blocks worker done")
+// generateBlocks is a worker that is controlled by the miningWorkerController.
+//
+// It is self contained in that it registers for block template updates from the
+// background block template generator and launches a goroutine that attempts to
+// solve them while automatically switching to new templates as they become
+// available.  When a block is solved, it is submitted.
+//
+// A separate goroutine for the solving is used to ensure template notifications
+// can be serviced immediately without slowing down the main mining loop.
+//
+// It must be run as a goroutine.
+func (m *CPUMiner) generateBlocks(ctx context.Context) {
+	log.Trace("Starting generate blocks worker")
+	defer func() {
+		m.workerWg.Done()
+		log.Trace("Generate blocks worker done")
+	}()
+
+	// Subscribe for block template updates and ensure the subscription is
+	// stopped along with the worker.
+	templateSub := m.g.Subscribe()
+	defer templateSub.Stop()
+
+	// Start a ticker which is used to signal updates to the speed monitor.
+	ticker := time.NewTicker(time.Second * hashUpdateSecs)
+	defer ticker.Stop()
+
+	var solverCtx context.Context
+	var solverCancel context.CancelFunc
+	for {
+		select {
+		case templateNtfn := <-templateSub.C():
+			// Clean up the map that tracks the number of blocks mined on a
+			// given parent whenever a template is received due to a new parent.
+			if m.cfg.PermitConnectionlessMining {
+				if templateNtfn.Reason == mining.TURNewParent {
+					prevHash := templateNtfn.Template.Block.Header.PrevBlock
+					m.Lock()
+					for k := range m.minedOnParents {
+						if k != prevHash {
+							delete(m.minedOnParents, k)
+						}
+					}
+					m.Unlock()
+				}
+			}
+
+			// Ensure the previous solver goroutine (if any) is stopped and
+			// start another one for the new template.
+			if solverCancel != nil {
+				solverCancel()
+			}
+			solverCtx, solverCancel = context.WithCancel(ctx)
+			m.workerWg.Add(1)
+			go m.solver(solverCtx, templateNtfn.Template, ticker)
+
+		case <-ctx.Done():
+			// Ensure resources associated with the solver goroutine context are
+			// freed as needed.
+			if solverCancel != nil {
+				solverCancel()
+			}
+
+			return
+		}
+	}
 }
 
 // miningWorkerController launches the worker goroutines that are used to
-// generate block templates and solve them.  It also provides the ability to
-// dynamically adjust the number of running worker goroutines.
+// subscribe for template updates and solve them.  It also provides the ability
+// to dynamically adjust the number of running worker goroutines.
 //
 // It must be run as a goroutine.
 func (m *CPUMiner) miningWorkerController(ctx context.Context) {
-	// launchWorkers groups common code to launch a specified number of
-	// workers for generating blocks.
-	var runningWorkers []context.CancelFunc
-	launchWorkers := func(numWorkers uint32) {
-		for i := uint32(0); i < numWorkers; i++ {
-			wCtx, wCancel := context.WithCancel(ctx)
-			runningWorkers = append(runningWorkers, wCancel)
-
-			m.workerWg.Add(1)
-			go m.generateBlocks(wCtx)
-		}
+	// launchWorker groups common code to launch a worker for subscribing for
+	// template updates and solving blocks.
+	type workerState struct {
+		cancel context.CancelFunc
 	}
+	var runningWorkers []workerState
+	launchWorker := func() {
+		wCtx, wCancel := context.WithCancel(ctx)
+		runningWorkers = append(runningWorkers, workerState{
+			cancel: wCancel,
+		})
 
-	// Launch the current number of workers by default.
-	numWorkers := atomic.LoadUint32(&m.numWorkers)
-	runningWorkers = make([]context.CancelFunc, 0, numWorkers)
-	launchWorkers(numWorkers)
+		m.workerWg.Add(1)
+		go m.generateBlocks(wCtx)
+	}
 
 out:
 	for {
@@ -466,20 +508,31 @@ out:
 
 			// Add new workers.
 			if numWorkers > numRunning {
-				launchWorkers(numWorkers - numRunning)
+				numToLaunch := numWorkers - numRunning
+				for i := uint32(0); i < numToLaunch; i++ {
+					launchWorker()
+				}
+				log.Debugf("Launched %d %s (%d total running)", numToLaunch,
+					pickNoun(uint64(numToLaunch), "worker", "workers"),
+					numWorkers)
 				continue
 			}
 
 			// Signal the most recently created goroutines to exit.
-			for i := numRunning - 1; i >= numWorkers; i-- {
-				runningWorkers[i]()
-				runningWorkers[i] = nil
-				runningWorkers = runningWorkers[:i]
+			numToStop := numRunning - numWorkers
+			for i := uint32(0); i < numToStop; i++ {
+				finalWorkerIdx := numRunning - 1 - i
+				runningWorkers[finalWorkerIdx].cancel()
+				runningWorkers[finalWorkerIdx].cancel = nil
+				runningWorkers = runningWorkers[:finalWorkerIdx]
 			}
+			log.Debugf("Stopped %d %s (%d total running)", numToStop,
+				pickNoun(uint64(numToStop), "worker", "workers"), numWorkers)
 
-		case <-m.quit:
-			for _, wCancel := range runningWorkers {
-				wCancel()
+		case <-ctx.Done():
+			// Signal all of the workers to shut down.
+			for _, state := range runningWorkers {
+				state.cancel()
 			}
 			break out
 		}
@@ -490,212 +543,235 @@ out:
 	m.wg.Done()
 }
 
-// Start begins the CPU mining process as well as the speed monitor used to
-// track hashing metrics.  Calling this function when the CPU miner has
-// already been started will have no effect.
+// Run starts the CPU miner with zero workers which means it will be idle. It
+// blocks until the provided context is cancelled.
 //
-// This function is safe for concurrent access.
-func (m *CPUMiner) Start() {
-	m.Lock()
-	defer m.Unlock()
+// Use the SetNumWorkers method to start solving blocks in the normal mining
+// mode.
+func (m *CPUMiner) Run(ctx context.Context) {
+	log.Trace("Starting CPU miner in idle state")
 
-	// Nothing to do if the miner is already running or if running in discrete
-	// mode (using GenerateNBlocks).
-	if m.started || m.discreteMining {
-		return
-	}
+	m.wg.Add(3)
+	go m.speedMonitor(ctx)
+	go m.miningWorkerController(ctx)
+	go func(ctx context.Context) {
+		<-ctx.Done()
+		close(m.quit)
+		m.wg.Done()
+	}(ctx)
 
-	m.quit = make(chan struct{})
-	m.wg.Add(2)
-	go m.speedMonitor()
-	go m.miningWorkerController(context.TODO())
-
-	m.started = true
-	log.Infof("CPU miner started")
-}
-
-// Wait blocks until the CPU miner finishes shutting down.
-func (m *CPUMiner) Wait() {
 	m.wg.Wait()
+	log.Trace("CPU miner stopped")
 }
 
-// Stop gracefully stops the mining process by signalling all workers, and the
-// speed monitor to quit.  Calling this function when the CPU miner has not
-// already been started will have no effect.
-//
-// This function is safe for concurrent access.
-func (m *CPUMiner) Stop() {
-	m.Lock()
-	defer m.Unlock()
-
-	// Nothing to do if the miner is not currently running or if running in
-	// discrete mode (using GenerateNBlocks).
-	if !m.started || m.discreteMining {
-		return
-	}
-
-	close(m.quit)
-	m.wg.Wait()
-	m.started = false
-	log.Infof("CPU miner stopped")
-}
-
-// IsMining returns whether or not the CPU miner has been started and is
-// therefore currently mining.
+// IsMining returns whether or not the CPU miner is currently mining in either
+// the normal or discrete mining modes.
 //
 // This function is safe for concurrent access.
 func (m *CPUMiner) IsMining() bool {
 	m.Lock()
 	defer m.Unlock()
 
-	return m.started
+	return m.normalMining || m.discreteMining
 }
 
-// HashesPerSecond returns the number of hashes per second the mining process
-// is performing.  0 is returned if the miner is not currently running.
+// HashesPerSecond returns the number of hashes per second the normal mode
+// mining process is performing.  0 is returned if the miner is not currently
+// mining anything in normal mining mode.
 //
 // This function is safe for concurrent access.
 func (m *CPUMiner) HashesPerSecond() float64 {
 	m.Lock()
 	defer m.Unlock()
 
-	// Nothing to do if the miner is not currently running.
-	if !m.started {
+	// Nothing to do if the miner is not currently mining anything.
+	if !m.normalMining {
 		return 0
 	}
 
-	return <-m.queryHashesPerSec
+	var hashesPerSec float64
+	select {
+	case hps := <-m.queryHashesPerSec:
+		hashesPerSec = hps
+	case <-m.quit:
+	}
+
+	return hashesPerSec
 }
 
-// SetNumWorkers sets the number of workers to create which solve blocks.  Any
-// negative values will cause a default number of workers to be used which is
-// based on the number of processor cores in the system.  A value of 0 will
-// cause all CPU mining to be stopped.
+// SetNumWorkers sets the number of workers to create for solving blocks in the
+// normal mining mode.  Negative values cause the default number of workers to
+// be used, values larger than the max allowed are limited to the max, and a
+// value of 0 causes all normal mode CPU mining to be stopped.
+//
+// NOTE: This will have no effect if discrete mining mode is currently active
+// via GenerateNBlocks.
 //
 // This function is safe for concurrent access.
 func (m *CPUMiner) SetNumWorkers(numWorkers int32) {
-	if numWorkers == 0 {
-		m.Stop()
+	m.Lock()
+	defer m.Unlock()
+
+	// Ignore when the miner is in discrete mode
+	if m.discreteMining {
+		return
 	}
 
-	// Use default if provided value is negative.
+	// Use default number of workers if the provided value is negative or limit
+	// it to the maximum allowed if needed.
+	targetNumWorkers := uint32(numWorkers)
 	if numWorkers < 0 {
-		atomic.StoreUint32(&m.numWorkers, defaultNumWorkers)
+		targetNumWorkers = defaultNumWorkers
+	} else if targetNumWorkers > MaxNumWorkers {
+		targetNumWorkers = MaxNumWorkers
+	}
+	atomic.StoreUint32(&m.numWorkers, targetNumWorkers)
+
+	// Set the normal mining state accordingly.
+	if targetNumWorkers != 0 {
+		m.normalMining = true
 	} else {
-		atomic.StoreUint32(&m.numWorkers, uint32(numWorkers))
+		m.normalMining = false
 	}
 
-	// When the miner is already running, notify the controller about the
-	// the change.
-	if m.started {
-		m.updateNumWorkers <- struct{}{}
+	// Notify the controller about the the change.
+	select {
+	case m.updateNumWorkers <- struct{}{}:
+	case <-m.quit:
 	}
 }
 
-// NumWorkers returns the number of workers which are running to solve blocks.
+// NumWorkers returns the number of workers which are running to solve blocks
+// in the normal mining mode.
 //
 // This function is safe for concurrent access.
 func (m *CPUMiner) NumWorkers() int32 {
 	return int32(atomic.LoadUint32(&m.numWorkers))
 }
 
-// GenerateNBlocks generates the requested number of blocks. It is self
-// contained in that it creates block templates and attempts to solve them while
-// detecting when it is performing stale work and reacting accordingly by
-// generating a new block template.  When a block is solved, it is submitted.
-// The function returns a list of the hashes of generated blocks.
+// GenerateNBlocks generates the requested number of blocks in the discrete
+// mining mode and returns a list of the hashes of generated blocks that were
+// added to the main chain.
+//
+// It makes use of a subscription to the background block template generator to
+// obtain the templates and attempts to solve them while automatically switching
+// to new templates as they become available as needed.  As a result, it
+// supports many of the nice features of the template subscriptions such as
+// giving all votes a chance to arrive.
+//
+// Note that, as the above implies, this will only consider blocks successfully
+// added to the main chain in the overall count, so, upon returning, the list of
+// hashes will only contain the hashes of those blocks.  This distinction is
+// important because it is sometimes possible for a block to be rejected or be
+// added to a side chain if it happens to be solved around the same time another
+// one shows up.
 func (m *CPUMiner) GenerateNBlocks(ctx context.Context, n uint32) ([]*chainhash.Hash, error) {
+	// Nothing to do.
+	if n == 0 {
+		return nil, nil
+	}
+
 	// Respond with an error if server is already mining.
 	m.Lock()
-	if m.started || m.discreteMining {
+	if m.normalMining || m.discreteMining {
 		m.Unlock()
 		return nil, errors.New("server is already CPU mining. Please call " +
 			"`setgenerate 0` before calling discrete `generate` commands")
 	}
 
-	m.started = true
 	m.discreteMining = true
 	m.Unlock()
 
 	log.Tracef("Generating %d blocks", n)
 
-	i := uint32(0)
-	blockHashes := make([]*chainhash.Hash, n)
-
 	// Start a ticker which is used to signal checks for stale work.
 	ticker := time.NewTicker(time.Second * hashUpdateSecs)
 	defer ticker.Stop()
 
+	templateSub := m.g.Subscribe()
+	defer templateSub.Stop()
+
+	blockHashes := make([]*chainhash.Hash, 0, n)
+	var stats speedStats
+out:
 	for {
-		// Read updateNumWorkers in case someone tries a `setgenerate` while
-		// we're generating. We can ignore it as the `generate` RPC call only
-		// uses 1 worker.
+		// Wait for a new template update notification or early shutdown.
+		var templateNtfn *mining.TemplateNtfn
 		select {
-		case <-m.updateNumWorkers:
-		default:
+		case <-ctx.Done():
+			break out
+		case <-m.quit:
+			break out
+		case templateNtfn = <-templateSub.C():
 		}
 
-		// Grab the lock used for block submission, since the current block will
-		// be changing and this would otherwise end up building a new block
-		// template on a block that is in the process of becoming stale.
-		m.submitBlockLock.Lock()
-
-		// Choose a payment address at random.
-		rand.Seed(time.Now().UnixNano())
-		payToAddr := m.cfg.MiningAddrs[rand.Intn(len(m.cfg.MiningAddrs))]
-
-		// Create a new block template using the available transactions
-		// in the memory pool as a source of transactions to potentially
-		// include in the block.
-		template, err := m.g.NewBlockTemplate(payToAddr)
-		m.submitBlockLock.Unlock()
-		if err != nil {
-			errStr := fmt.Sprintf("Failed to create new block "+
-				"template: %v", err)
-			log.Errorf(errStr)
-			continue
-		}
-		if template == nil {
-			errStr := fmt.Sprintf("Not enough voters on parent block " +
-				"and failed to pull parent template")
-			log.Debugf(errStr)
+		// Since callers might call this method in rapid succession and the
+		// subscription immediately sends the current template, the template
+		// might not have been updated yet (for example, it might be waiting on
+		// votes).  In that case, wait for the updated template.
+		m.Lock()
+		discretePrev := m.discretePrevHash
+		m.Unlock()
+		if templateNtfn.Template.Block.Header.PrevBlock == discretePrev {
 			continue
 		}
 
-		// Attempt to solve the block.  The function will exit early
-		// with false when conditions that trigger a stale block, so
-		// a new block template can be generated.  When the return is
-		// true a solution was found, so submit the solved block.
-		var stats speedStats
-		if m.solveBlock(ctx, template.Block, &stats, ticker) {
-			block := dcrutil.NewBlock(template.Block)
-			m.submitBlock(block)
-			blockHashes[i] = block.Hash()
-			i++
-			if i == n {
-				log.Tracef("Generated %d blocks", i)
-				m.wg.Wait()
+		// Attempt to solve the block.
+		//
+		// The function will exit with false if the block was not solved for any
+		// reason such as the context being cancelled or an unexpected error.
+		//
+		// When the return is true, a solution was found, so attempt to submit
+		// the solved block.  Notice that this only records the hash of the
+		// block if it was successfully submitted to the main chain.  This means
+		// it is theoretically possible for more blocks than requested to be
+		// mined if any of them fail to submit, but it results in better
+		// behavior that lines up with what a caller would expect such that the
+		// requested number of blocks are mined and added to the main chain.
+		//
+		// The block in the template is shallow copied to avoid mutating the
+		// data of the shared template.
+		shallowBlockCopy := *templateNtfn.Template.Block
+		if m.solveBlock(ctx, &shallowBlockCopy.Header, &stats, ticker) {
+			block := dcrutil.NewBlock(&shallowBlockCopy)
+			if m.submitBlock(block) {
 				m.Lock()
-				m.started = false
-				m.discreteMining = false
+				m.discretePrevHash = shallowBlockCopy.Header.PrevBlock
 				m.Unlock()
-				return blockHashes, nil
+				blockHashes = append(blockHashes, block.Hash())
 			}
 		}
+
+		// Done when the requested number of blocks are mined.
+		if uint32(len(blockHashes)) == n {
+			break out
+		}
 	}
+
+	// Disable discrete mining mode and return the results.
+	log.Tracef("Generated %d blocks", len(blockHashes))
+	m.Lock()
+	m.discreteMining = false
+	m.Unlock()
+	return blockHashes, nil
 }
 
-// New returns a new instance of a CPU miner for the provided server.
+// New returns a new instance of a CPU miner for the provided configuration
+// options.
 //
-// Use Start to begin the mining process.  See the documentation for CPUMiner
-// type for more details.
+// Use Run to initialize the CPU miner and then either use SetNumWorkers with a
+// non-zero value to start the normal continuous mining mode or use
+// GenerateNBlocks to mine a discrete number of blocks.
+//
+// See the documentation for CPUMiner type for more details.
 func New(cfg *Config) *CPUMiner {
 	return &CPUMiner{
-		g:                 cfg.BlockTemplateGenerator,
+		g:                 cfg.BgBlkTmplGenerator,
 		cfg:               cfg,
 		numWorkers:        defaultNumWorkers,
 		updateNumWorkers:  make(chan struct{}),
 		queryHashesPerSec: make(chan float64),
 		minedOnParents:    make(map[chainhash.Hash]uint8),
+		quit:              make(chan struct{}),
 	}
 }

--- a/internal/mining/cpuminer/log.go
+++ b/internal/mining/cpuminer/log.go
@@ -20,3 +20,12 @@ var log = slog.Disabled
 func UseLogger(logger slog.Logger) {
 	log = logger
 }
+
+// pickNoun returns the singular or plural form of a noun depending
+// on the count n.
+func pickNoun(n uint64, singular, plural string) string {
+	if n == 1 {
+		return singular
+	}
+	return plural
+}

--- a/rpctest/node.go
+++ b/rpctest/node.go
@@ -129,6 +129,8 @@ func (n *nodeConfig) arguments() []string {
 		// --debuglevel
 		args = append(args, fmt.Sprintf("--debuglevel=%s", n.debugLevel))
 	}
+	// --allowunsyncedmining
+	args = append(args, "--allowunsyncedmining")
 	args = append(args, n.extra...)
 	return args
 }


### PR DESCRIPTION
**This requires #2276**.
 
This significantly reworks the CPU miner to make use of the background block template generator that was introduced in the previous release as well as to convert its lifecycle to use the expected pattern for running subsystems based on contexts.

The switch to using the background block template generator provides all the benefits it offers to miners such as:

- Intelligent vote propagation handling
- Improved handling of chain reorganizations necessary when the current tip is unable to obtain enough votes
- Current state synchronization
- Near elimination of stale templates when new blocks and votes are received

This is particularly important in testing scenarios, such as when using the simulation network, since the difficulty is so low that the code this is replacing is often able to mine blocks so fast it ends up mining multiple alternative blocks while waiting for the votes to show up which makes testing with it more difficult.

This is no longer an issue when requesting template updates since the background block template generator has logic to provide the votes a chance to arrive before building and notifying the template.

Another modification this makes is to also make use of template notifications when mining blocks mined via the discrete mining mode and to only count blocks if they successfully extend the main chain.  This also significantly helps in testing scenarios since it means the testing code and/or testers using the simulation test network can rely on the requested number of blocks actually being added to the main chain even if more need to be generated to make that happen.

Along similar lines, one area this change does not address, but does pave the way to support and would be useful in the future for the simulation test network is to add some additional logic to provide ticket purchases a chance to arrive when prior to stake validation height, since that is another area that often complicates testing.

In terms of the lifecycle changes, this replaces the `Start`, `Stop`, and `Wait` methods with a single method named `Run` and arranges for it to block until the provided context is cancelled.  This is more flexible for the caller since it can easily turn blocking code into async code while the reverse is not true.

The new `Run` method waits for all goroutines that it starts to shutdown before returning to help ensure an orderly shutdown.

In addition, the semantics of `Run` are different from `Start`/`Stop` in that the `Start` method launched the default number of mining worker goroutines whereas `Run` only starts the CPU miner with the main infrastructure goroutines and zero workers, meaning it will be idle until explicitly requested to mine by the caller setting the number of workers to use.

Since there are exported methods that send messages to the CPU miner infrastructure goroutines via a channel and those goroutines are stopped during the shutdown process, all sends select across both the channel in question as well as a `quit` channel which is closed when the context is canceled.  This ensures callers can't end up blocking on send to a goroutine that is no longer running without needing additional mutexes.

As part of the conversion, it improves a lot of the comments to better describe the expected behavior and further integrates the context to support cancellation where it previously was not supported.

Finally, all callers are updated to use the new API and the server is modified to take advantage of the new lifecycle semantics by taking ownership of the CPU miner code directly in its Run method where it more logically makes sense and only creating the template generate and CPU miner infrastructure if needed based on the configuration options.
