### PR TITLE
internal/ticketdb: update error types.

### DIFF
--- a/blockchain/stake/internal/ticketdb/chainio_test.go
+++ b/blockchain/stake/internal/ticketdb/chainio_test.go
@@ -107,28 +107,21 @@ func TestDbInfoDeserializeErrors(t *testing.T) {
 	tests := []struct {
 		name       string
 		serialized []byte
-		errCode    ErrorCode
+		err        error
 	}{
 		{
 			name:       "short read",
 			serialized: hexToBytes("0000"),
-			errCode:    ErrDatabaseInfoShortRead,
+			err:        ErrDatabaseInfoShortRead,
 		},
 	}
 
-	var ticketDBErr DBError
 	for _, test := range tests {
 		// Ensure the expected error type is returned.
 		_, err := deserializeDatabaseInfo(test.serialized)
-		if !errors.As(err, &ticketDBErr) {
-			t.Errorf("couldn't convert deserializeDatabaseInfo error "+
-				"to ticket db error (err: %v)", err)
-			continue
-		}
-		if ticketDBErr.GetCode() != test.errCode {
+		if !errors.Is(err, test.err) {
 			t.Errorf("deserializeDatabaseInfo (%s): expected error type "+
-				"does not match - got %v, want %v", test.name,
-				ticketDBErr.ErrorCode, test.errCode)
+				"does not match - got %v, want %v", test.name, err, test.err)
 			continue
 		}
 	}
@@ -200,28 +193,21 @@ func TestBestChainStateDeserializeErrors(t *testing.T) {
 	tests := []struct {
 		name       string
 		serialized []byte
-		errCode    ErrorCode
+		err        error
 	}{
 		{
 			name:       "short read",
 			serialized: hexToBytes("0000"),
-			errCode:    ErrChainStateShortRead,
+			err:        ErrChainStateShortRead,
 		},
 	}
 
-	var ticketDBErr DBError
 	for _, test := range tests {
 		// Ensure the expected error type is returned.
 		_, err := deserializeBestChainState(test.serialized)
-		if !errors.As(err, &ticketDBErr) {
-			t.Errorf("couldn't convert deserializeBestChainState error "+
-				"to ticket db error (err: %v)", err)
-			continue
-		}
-		if ticketDBErr.GetCode() != test.errCode {
+		if !errors.Is(err, test.err) {
 			t.Errorf("deserializeBestChainState (%s): expected error type "+
-				"does not match - got %v, want %v", test.name,
-				ticketDBErr.ErrorCode, test.errCode)
+				"does not match - got %v, want %v", test.name, err, test.err)
 			continue
 		}
 	}
@@ -293,33 +279,26 @@ func TestBlockUndoDataDeserializingErrors(t *testing.T) {
 	tests := []struct {
 		name       string
 		serialized []byte
-		errCode    ErrorCode
+		err        error
 	}{
 		{
 			name:       "short read",
 			serialized: hexToBytes("00"),
-			errCode:    ErrUndoDataShortRead,
+			err:        ErrUndoDataShortRead,
 		},
 		{
 			name:       "bad size",
 			serialized: hexToBytes("00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"),
-			errCode:    ErrUndoDataCorrupt,
+			err:        ErrUndoDataCorrupt,
 		},
 	}
 
-	var ticketDBErr DBError
 	for _, test := range tests {
 		// Ensure the expected error type is returned.
 		_, err := deserializeBlockUndoData(test.serialized)
-		if !errors.As(err, &ticketDBErr) {
-			t.Errorf("couldn't convert deserializeBlockUndoData error "+
-				"to ticket db error (err: %v)", err)
-			continue
-		}
-		if ticketDBErr.GetCode() != test.errCode {
+		if !errors.Is(err, test.err) {
 			t.Errorf("deserializeBlockUndoData (%s): expected error type "+
-				"does not match - got %v, want %v", test.name,
-				ticketDBErr.ErrorCode, test.errCode)
+				"does not match - got %v, want %v", test.name, err, test.err)
 			continue
 		}
 	}
@@ -382,33 +361,26 @@ func TestTicketHashesDeserializingErrors(t *testing.T) {
 	tests := []struct {
 		name       string
 		serialized []byte
-		errCode    ErrorCode
+		err        error
 	}{
 		{
 			name:       "short read",
 			serialized: hexToBytes("00"),
-			errCode:    ErrTicketHashesShortRead,
+			err:        ErrTicketHashesShortRead,
 		},
 		{
 			name:       "bad size",
 			serialized: hexToBytes("00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"),
-			errCode:    ErrTicketHashesCorrupt,
+			err:        ErrTicketHashesCorrupt,
 		},
 	}
 
-	var ticketDBErr DBError
 	for _, test := range tests {
 		// Ensure the expected error type is returned.
 		_, err := deserializeTicketHashes(test.serialized)
-		if !errors.As(err, &ticketDBErr) {
-			t.Errorf("couldn't convert deserializeTicketHashes error "+
-				"to ticket db error (err: %v)", err)
-			continue
-		}
-		if ticketDBErr.GetCode() != test.errCode {
+		if !errors.Is(err, test.err) {
 			t.Errorf("deserializeTicketHashes (%s): expected error type "+
-				"does not match - got %v, want %v", test.name,
-				ticketDBErr.ErrorCode, test.errCode)
+				"does not match - got %v, want %v", test.name, err, test.err)
 			continue
 		}
 	}

--- a/blockchain/stake/internal/ticketdb/error_test.go
+++ b/blockchain/stake/internal/ticketdb/error_test.go
@@ -3,63 +3,142 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package ticketdb_test
+package ticketdb
 
 import (
+	"errors"
+	"io"
 	"testing"
-
-	"github.com/decred/dcrd/blockchain/stake/v4/internal/ticketdb"
 )
 
-// TestErrorCodeStringer tests the stringized output for the ErrorCode type.
-func TestErrorCodeStringer(t *testing.T) {
+// TestErrorKindStringer tests the stringized output for the ErrorKind type.
+func TestErrorKindStringer(t *testing.T) {
 	tests := []struct {
-		in   ticketdb.ErrorCode
+		in   ErrorKind
 		want string
 	}{
-		{ticketdb.ErrUndoDataShortRead, "ErrUndoDataShortRead"},
-		{ticketdb.ErrUndoDataCorrupt, "ErrUndoDataCorrupt"},
-		{ticketdb.ErrTicketHashesShortRead, "ErrTicketHashesShortRead"},
-		{ticketdb.ErrTicketHashesCorrupt, "ErrTicketHashesCorrupt"},
-		{ticketdb.ErrUninitializedBucket, "ErrUninitializedBucket"},
-		{ticketdb.ErrMissingKey, "ErrMissingKey"},
-		{ticketdb.ErrChainStateShortRead, "ErrChainStateShortRead"},
-		{ticketdb.ErrDatabaseInfoShortRead, "ErrDatabaseInfoShortRead"},
-		{ticketdb.ErrLoadAllTickets, "ErrLoadAllTickets"},
-		{0xffff, "Unknown ErrorCode (65535)"},
-	}
-
-	t.Logf("Running %d tests", len(tests))
-	for i, test := range tests {
-		result := test.in.String()
-		if result != test.want {
-			t.Errorf("String #%d\n got: %s want: %s", i, result,
-				test.want)
-			continue
-		}
-	}
-}
-
-// TestRuleError tests the error output for the RuleError type.
-func TestRuleError(t *testing.T) {
-	tests := []struct {
-		in   ticketdb.DBError
-		want string
-	}{
-		{ticketdb.DBError{Description: "duplicate block"},
-			"duplicate block",
-		},
-		{ticketdb.DBError{Description: "human-readable error"},
-			"human-readable error",
-		},
+		{ErrUndoDataShortRead, "ErrUndoDataShortRead"},
+		{ErrUndoDataCorrupt, "ErrUndoDataCorrupt"},
+		{ErrTicketHashesShortRead, "ErrTicketHashesShortRead"},
+		{ErrTicketHashesCorrupt, "ErrTicketHashesCorrupt"},
+		{ErrUninitializedBucket, "ErrUninitializedBucket"},
+		{ErrMissingKey, "ErrMissingKey"},
+		{ErrChainStateShortRead, "ErrChainStateShortRead"},
+		{ErrDatabaseInfoShortRead, "ErrDatabaseInfoShortRead"},
+		{ErrLoadAllTickets, "ErrLoadAllTickets"},
 	}
 
 	t.Logf("Running %d tests", len(tests))
 	for i, test := range tests {
 		result := test.in.Error()
 		if result != test.want {
-			t.Errorf("Error #%d\n got: %s want: %s", i, result,
-				test.want)
+			t.Errorf("#%d: got: %s want: %s", i, result, test.want)
+			continue
+		}
+	}
+}
+
+// TestDBError tests the error output for the DBError type.
+func TestDBError(t *testing.T) {
+	tests := []struct {
+		in   DBError
+		want string
+	}{{
+		DBError{Description: "duplicate block"},
+		"duplicate block",
+	}, {
+		DBError{Description: "human-readable error"},
+		"human-readable error",
+	}}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		result := test.in.Error()
+		if result != test.want {
+			t.Errorf("#%d: got: %s want: %s", i, result, test.want)
+			continue
+		}
+	}
+}
+
+// TestErrorKindIsAs ensures both ErrorKind and Error can be identified as being
+// a specific error kind via errors.Is and unwrapped via errors.As.
+func TestErrorKindIsAs(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		target    error
+		wantMatch bool
+		wantAs    ErrorKind
+	}{{
+		name:      "ErrUndoDataShortRead == ErrUndoDataShortRead",
+		err:       ErrUndoDataShortRead,
+		target:    ErrUndoDataShortRead,
+		wantMatch: true,
+		wantAs:    ErrUndoDataShortRead,
+	}, {
+		name:      "DBError.ErrUndoDataShortRead == ErrUndoDataShortRead",
+		err:       ticketDBError(ErrUndoDataShortRead, ""),
+		target:    ErrUndoDataShortRead,
+		wantMatch: true,
+		wantAs:    ErrUndoDataShortRead,
+	}, {
+		name:      "DBError.ErrUndoDataShortRead == DBError.ErrUndoDataShortRead",
+		err:       ticketDBError(ErrUndoDataShortRead, ""),
+		target:    ticketDBError(ErrUndoDataShortRead, ""),
+		wantMatch: true,
+		wantAs:    ErrUndoDataShortRead,
+	}, {
+		name:      "ErrUndoDataShortRead != ErrUndoDataCorrupt",
+		err:       ErrUndoDataShortRead,
+		target:    ErrUndoDataCorrupt,
+		wantMatch: false,
+		wantAs:    ErrUndoDataShortRead,
+	}, {
+		name:      "DBError.ErrUndoDataShortRead != ErrUndoDataCorrupt",
+		err:       ticketDBError(ErrUndoDataShortRead, ""),
+		target:    ErrUndoDataCorrupt,
+		wantMatch: false,
+		wantAs:    ErrUndoDataShortRead,
+	}, {
+		name:      "ErrUndoDataShortRead != DBError.ErrUndoDataCorrupt",
+		err:       ErrUndoDataShortRead,
+		target:    ticketDBError(ErrUndoDataCorrupt, ""),
+		wantMatch: false,
+		wantAs:    ErrUndoDataShortRead,
+	}, {
+		name:      "DBError.ErrUndoDataShortRead != DBError.ErrUndoDataCorrupt",
+		err:       ticketDBError(ErrUndoDataShortRead, ""),
+		target:    ticketDBError(ErrUndoDataCorrupt, ""),
+		wantMatch: false,
+		wantAs:    ErrUndoDataShortRead,
+	}, {
+		name:      "DBError.ErrUndoDataShortRead != io.EOF",
+		err:       ticketDBError(ErrUndoDataShortRead, ""),
+		target:    io.EOF,
+		wantMatch: false,
+		wantAs:    ErrUndoDataShortRead,
+	}}
+
+	for _, test := range tests {
+		// Ensure the error matches or not depending on the expected result.
+		result := errors.Is(test.err, test.target)
+		if result != test.wantMatch {
+			t.Errorf("%s: incorrect error identification -- got %v, want %v",
+				test.name, result, test.wantMatch)
+			continue
+		}
+
+		// Ensure the underlying error kind can be unwrapped is and is the
+		// expected kind.
+		var kind ErrorKind
+		if !errors.As(test.err, &kind) {
+			t.Errorf("%s: unable to unwrap to error kind", test.name)
+			continue
+		}
+		if !errors.Is(kind, test.wantAs) {
+			t.Errorf("%s: unexpected unwrapped error kind -- got %v, want %v",
+				test.name, kind, test.wantAs)
 			continue
 		}
 	}


### PR DESCRIPTION
This updates the ticketdb error types to leverage go 1.13 errors.Is/As functionality as well as conform to the error infrastructure best practices outlined in #2181.
