### PR TITLE
multi: update blockchain/standalone error types.

### DIFF
--- a/blockchain/standalone/pow_test.go
+++ b/blockchain/standalone/pow_test.go
@@ -5,6 +5,7 @@
 package standalone
 
 import (
+	"errors"
 	"math/big"
 	"testing"
 
@@ -248,17 +249,17 @@ func TestCheckProofOfWorkRange(t *testing.T) {
 		name:     "zero",
 		bits:     0,
 		powLimit: mockMainNetPowLimit(),
-		err:      ruleError(ErrUnexpectedDifficulty, ""),
+		err:      ErrUnexpectedDifficulty,
 	}, {
 		name:     "negative",
 		bits:     0x1810000,
 		powLimit: mockMainNetPowLimit(),
-		err:      ruleError(ErrUnexpectedDifficulty, ""),
+		err:      ErrUnexpectedDifficulty,
 	}, {
 		name:     "pow limit + 1",
 		bits:     0x1d010000,
 		powLimit: mockMainNetPowLimit(),
-		err:      ruleError(ErrUnexpectedDifficulty, ""),
+		err:      ErrUnexpectedDifficulty,
 	}}
 
 	for _, test := range tests {
@@ -269,15 +270,9 @@ func TestCheckProofOfWorkRange(t *testing.T) {
 		}
 
 		err := CheckProofOfWorkRange(test.bits, powLimit)
-		if test.err == nil && err != nil {
-			t.Errorf("%q: unexpected err -- got %v, want nil", test.name, err)
-			continue
-		} else if test.err != nil {
-			if !IsErrorCode(err, test.err.(RuleError).ErrorCode) {
-				t.Errorf("%q: unexpected err -- got %v, want %v",
-					test.name, err, test.err.(RuleError).ErrorCode)
-				continue
-			}
+		if !errors.Is(err, test.err) {
+			t.Errorf("%q: unexpected err -- got %v, want %v", test.name, err,
+				test.err)
 			continue
 		}
 	}
@@ -316,25 +311,25 @@ func TestCheckProofOfWork(t *testing.T) {
 		hash:     "000000000001ffff000000000000000000000000000000000000000000000001",
 		bits:     0x1b01ffff,
 		powLimit: mockMainNetPowLimit(),
-		err:      ruleError(ErrHighHash, ""),
+		err:      ErrHighHash,
 	}, {
 		name:     "hash satisfies target, but target too high at pow limit + 1",
 		hash:     "0000000000000000000000000000000000000000000000000000000000000001",
 		bits:     0x1d010000,
 		powLimit: mockMainNetPowLimit(),
-		err:      ruleError(ErrUnexpectedDifficulty, ""),
+		err:      ErrUnexpectedDifficulty,
 	}, {
 		name:     "zero target difficulty",
 		hash:     "0000000000000000000000000000000000000000000000000000000000000001",
 		bits:     0,
 		powLimit: mockMainNetPowLimit(),
-		err:      ruleError(ErrUnexpectedDifficulty, ""),
+		err:      ErrUnexpectedDifficulty,
 	}, {
 		name:     "negative target difficulty",
 		hash:     "0000000000000000000000000000000000000000000000000000000000000001",
 		bits:     0x1810000,
 		powLimit: mockMainNetPowLimit(),
-		err:      ruleError(ErrUnexpectedDifficulty, ""),
+		err:      ErrUnexpectedDifficulty,
 	}}
 
 	for _, test := range tests {
@@ -351,15 +346,9 @@ func TestCheckProofOfWork(t *testing.T) {
 		}
 
 		err = CheckProofOfWork(hash, test.bits, powLimit)
-		if test.err == nil && err != nil {
-			t.Errorf("%q: unexpected err -- got %v, want nil", test.name, err)
-			continue
-		} else if test.err != nil {
-			if !IsErrorCode(err, test.err.(RuleError).ErrorCode) {
-				t.Errorf("%q: unexpected err -- got %v, want %v",
-					test.name, err, test.err.(RuleError).ErrorCode)
-				continue
-			}
+		if !errors.Is(err, test.err) {
+			t.Errorf("%q: unexpected err -- got %v, want %v", test.name, err,
+				test.err)
 			continue
 		}
 	}

--- a/blockchain/standalone/treasury.go
+++ b/blockchain/standalone/treasury.go
@@ -29,8 +29,8 @@ func IsTreasuryVoteInterval(height, tvi uint64) bool {
 // this function is only called with an expiry that *IS* on a TVI.
 func CalculateTSpendWindowStart(expiry uint32, tvi, multiplier uint64) (uint32, error) {
 	if !IsTreasuryVoteInterval(uint64(expiry-2), tvi) {
-		return 0, RuleError{ErrTSpendStartInvalidExpiry,
-			fmt.Sprintf("invalid start expiry: %v", expiry)}
+		return 0, ruleError(ErrTSpendStartInvalidExpiry,
+			fmt.Sprintf("invalid start expiry: %v", expiry))
 	}
 	return expiry - uint32(tvi*multiplier) - 2, nil
 }
@@ -40,8 +40,8 @@ func CalculateTSpendWindowStart(expiry uint32, tvi, multiplier uint64) (uint32, 
 // this function is only called with an expiry that *IS* on a TVI.
 func CalculateTSpendWindowEnd(expiry uint32, tvi uint64) (uint32, error) {
 	if !IsTreasuryVoteInterval(uint64(expiry-2), tvi) {
-		return 0, RuleError{ErrTSpendEndInvalidExpiry,
-			fmt.Sprintf("invalid end expiry: %v", expiry)}
+		return 0, ruleError(ErrTSpendEndInvalidExpiry,
+			fmt.Sprintf("invalid end expiry: %v", expiry))
 	}
 	return expiry - 2, nil
 }

--- a/blockchain/standalone/treasury_test.go
+++ b/blockchain/standalone/treasury_test.go
@@ -4,25 +4,24 @@
 
 package standalone
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestTSpendExpiryNegative(t *testing.T) {
 	// 5 is not a valid start for a tvi of 11 with a mul of 3.
 	_, err := CalculateTSpendWindowStart(5, 11, 3)
-	if e, ok := err.(RuleError); !ok {
-		t.Fatal(err)
-	} else if e.ErrorCode != ErrTSpendStartInvalidExpiry {
+	if !errors.Is(err, ErrTSpendStartInvalidExpiry) {
 		t.Fatalf("expected %v got %v",
-			ErrTSpendStartInvalidExpiry, e.ErrorCode)
+			ErrTSpendStartInvalidExpiry, err)
 	}
 
 	// 5 is not a valid end for a tvi of 11.
 	_, err = CalculateTSpendWindowEnd(5, 11)
-	if e, ok := err.(RuleError); !ok {
-		t.Fatal(err)
-	} else if e.ErrorCode != ErrTSpendEndInvalidExpiry {
+	if !errors.Is(err, ErrTSpendEndInvalidExpiry) {
 		t.Fatalf("expected %v got %v",
-			ErrTSpendEndInvalidExpiry, e.ErrorCode)
+			ErrTSpendEndInvalidExpiry, err)
 	}
 }
 

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -529,15 +529,15 @@ func CheckProofOfStake(block *dcrutil.Block, posLimit int64) error {
 }
 
 // standaloneToChainRuleError attempts to convert the passed error from a
-// standalone.RuleError to a blockchain.RuleError with the equivalent code.  The
-// error is simply passed through without modification if it is not a
-// standalone.RuleError, not one of the specifically recognized error codes, or
-// nil.
+// standalone.RuleError to a blockchain.RuleError with the equivalent error
+// kind.  The error is simply passed through without modification if it is
+// not a standalone.RuleError, not one of the specifically recognized
+// error codes, or nil.
 func standaloneToChainRuleError(err error) error {
 	// Convert standalone package rule errors to blockchain rule errors.
 	var rErr standalone.RuleError
 	if errors.As(err, &rErr) {
-		switch rErr.ErrorCode {
+		switch rErr.Err {
 		case standalone.ErrUnexpectedDifficulty:
 			return ruleError(ErrUnexpectedDifficulty, rErr.Description)
 		case standalone.ErrHighHash:


### PR DESCRIPTION
This updates the standalone error types to leverage go 1.13 errors.Is/As functionality as well as conform to the error infrastructure best practices outlined in #2181.