### PR TITLE
multi: use EstimateSmartFeeResult.

### DIFF
--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -152,7 +152,7 @@ the method name for further details such as parameter and return information.
 |-
 |[[#estimatesmartfee|estimatesmartfee]]
 |Y
-|Returns the estimated fee using the historical fee data in dcr/kb.
+|Returns the estimated fee using the historical fee data in dcr/kb and the block number where the estimate was found.
 |-
 |[[#estimatestakediff|estimatestakediff]]
 |Y
@@ -737,10 +737,13 @@ the method name for further details such as parameter and return information.
 # <code>mode</code>: <code>(string)</code> The only supported mode for the moment is 'conservative'.
 |-
 !Description
-|Returns the estimated fee using the historical fee data in dcr/kb.
+|Returns the estimated fee using the historical fee data in dcr/kb and the block number where the estimate was found.
 |-
 !Returns
-|<code>numeric</code>
+|<code>{json object}</code>
+: <code>fee</code>: <code>(numeric)</code> The estimated fee.
+: <code>errors</code>: <code>(json array)</code> Unused.
+: <code>blocks</code>: <code>(numeric)</code> The block number where the estimate was found.
 |-
 !Example Return
 |

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -1420,7 +1420,10 @@ func handleEstimateSmartFee(_ context.Context, s *Server, cmd interface{}) (inte
 		return nil, rpcInternalError(err.Error(), "Could not estimate fee")
 	}
 
-	return fee.ToCoin(), nil
+	return &types.EstimateSmartFeeResult{
+		FeeRate: fee.ToCoin(),
+		Blocks:  c.Confirmations,
+	}, nil
 }
 
 // handleEstimateStakeDiff implements the estimatestakediff command.

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -2708,7 +2708,9 @@ func TestHandleEstimateSmartFee(t *testing.T) {
 	economical := types.EstimateSmartFeeEconomical
 	validFeeEstimator := defaultMockFeeEstimator()
 	validFeeEstimator.estimateFeeAmt = 123456789
-	validFee := float64(1.23456789)
+	result := &types.EstimateSmartFeeResult{
+		FeeRate: float64(1.23456789),
+	}
 	testRPCServerHandler(t, []rpcTest{{
 		name:    "handleEstimateSmartFee: ok with mode",
 		handler: handleEstimateSmartFee,
@@ -2717,13 +2719,13 @@ func TestHandleEstimateSmartFee(t *testing.T) {
 			Mode:          &conservative,
 		},
 		mockFeeEstimator: validFeeEstimator,
-		result:           validFee,
+		result:           result,
 	}, {
 		name:             "handleEstimateSmartFee: ok no mode",
 		handler:          handleEstimateSmartFee,
 		cmd:              &types.EstimateSmartFeeCmd{},
 		mockFeeEstimator: validFeeEstimator,
-		result:           validFee,
+		result:           result,
 	}, {
 		name:    "handleEstimateSmartFee: not conservative mode",
 		handler: handleEstimateSmartFee,

--- a/internal/rpcserver/rpcserverhelp.go
+++ b/internal/rpcserver/rpcserverhelp.go
@@ -885,7 +885,9 @@ var helpDescsEnUS = map[string]string{
 	"estimatesmartfee--synopsis":     "Returns the estimated fee using the historical fee data in dcr/kb.",
 	"estimatesmartfee-confirmations": "Estimate the fee rate a transaction requires so that it is mined in up to this number of blocks.",
 	"estimatesmartfee-mode":          "The only supported mode for the moment is 'conservative'.",
-	"estimatesmartfee--result0":      "Estimated fee rate (in DCR/KB).",
+	"estimatesmartfeeresult-feerate": "The Estimated fee rate (in DCR/KB).",
+	"estimatesmartfeeresult-errors":  "Unused.",
+	"estimatesmartfeeresult-blocks":  "The block number where the estimate was found.",
 
 	// EstimateStakeDiff help.
 	"estimatestakediff--synopsis":      "Estimate the next minimum, maximum, expected, and user-specified stake difficulty",
@@ -1000,7 +1002,7 @@ var rpcResultTypes = map[types.Method][]interface{}{
 	"decoderawtransaction":  {(*types.TxRawDecodeResult)(nil)},
 	"decodescript":          {(*types.DecodeScriptResult)(nil)},
 	"estimatefee":           {(*float64)(nil)},
-	"estimatesmartfee":      {(*float64)(nil)},
+	"estimatesmartfee":      {(*types.EstimateSmartFeeResult)(nil)},
 	"estimatestakediff":     {(*types.EstimateStakeDiffResult)(nil)},
 	"existsaddress":         {(*bool)(nil)},
 	"existsaddresses":       {(*string)(nil)},

--- a/rpc/jsonrpc/types/chainsvrresults.go
+++ b/rpc/jsonrpc/types/chainsvrresults.go
@@ -28,14 +28,9 @@ type DecodeScriptResult struct {
 
 // EstimateSmartFeeResult models the data returned from the estimatesmartfee
 // command.
-//
-// NOTE: EstimateSmartFee currently returns a float. This result type is
-// unused.
-//
-// TODO: Rework EstimateSmartFee to return this result type.
 type EstimateSmartFeeResult struct {
 	FeeRate float64  `json:"feerate"`
-	Errors  []string `json:"errors"`
+	Errors  []string `json:"errors,omitempty"`
 	Blocks  int64    `json:"blocks"`
 }
 


### PR DESCRIPTION
This updates `EstimateSmartFee` to return `EstimateSmartFeeResult` and updates associated documentation and tests.

Resolves #2268.