### PR TITLE
rpcserver: Add handleExistsAddress(es) tests.

### DIFF
--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -13,7 +13,6 @@ import (
 	"github.com/decred/dcrd/addrmgr"
 	"github.com/decred/dcrd/blockchain/stake/v3"
 	"github.com/decred/dcrd/blockchain/v3"
-	"github.com/decred/dcrd/blockchain/v3/indexers"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil/v3"
 	"github.com/decred/dcrd/gcs/v2"
@@ -155,9 +154,6 @@ type SyncManager interface {
 	// provided max number of block hashes.
 	LocateBlocks(locator blockchain.BlockLocator, hashStop *chainhash.Hash,
 		maxHashes uint32) []chainhash.Hash
-
-	// ExistsAddrIndex returns the address index.
-	ExistsAddrIndex() *indexers.ExistsAddrIndex
 
 	// TipGeneration returns the entire generation of blocks stemming from the
 	// parent of the current tip.
@@ -537,4 +533,22 @@ type FiltererV2 interface {
 	// An error of type blockchain.NoFilterError must be returned when the filter
 	// for the given block hash does not exist.
 	FilterByBlockHash(hash *chainhash.Hash) (*gcs.FilterV2, error)
+}
+
+// ExistsAddresser represents a source of exists address methods for the RPC
+// server. These methods return whether or not an address or addresses have
+// been seen on the blockchain.
+//
+// The interface contract requires that all of these methods are safe for
+// concurrent access.
+//
+// ExistsAddresser may be nil. The RPC server must check for the presence of an
+// ExistsAddresser before calling methods associated with it.
+type ExistsAddresser interface {
+	// ExistsAddress returns whether or not an address has been seen before.
+	ExistsAddress(addr dcrutil.Address) (bool, error)
+
+	// ExistsAddresses returns whether or not each address in a slice of
+	// addresses has been seen before.
+	ExistsAddresses(addrs []dcrutil.Address) ([]bool, error)
 }

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -1458,6 +1458,9 @@ func handleExistsAddress(_ context.Context, s *Server, cmd interface{}) (interfa
 }
 
 // handleExistsAddresses implements the existsaddresses command.
+//
+// TODO: Add an upper bound to the number of addresses that can be checked.
+// This will come with a major RPC version bump.
 func handleExistsAddresses(_ context.Context, s *Server, cmd interface{}) (interface{}, error) {
 	if s.cfg.ExistsAddresser == nil {
 		return nil, rpcInternalError("Exists address index disabled",
@@ -1523,6 +1526,9 @@ func decodeHashPointers(strs []string) ([]*chainhash.Hash, error) {
 }
 
 // handleExistsMissedTickets implements the existsmissedtickets command.
+//
+// TODO: Add an upper bound to the number of hashes that can be checked. This
+// will come with a major RPC version bump.
 func handleExistsMissedTickets(_ context.Context, s *Server, cmd interface{}) (interface{}, error) {
 	c := cmd.(*types.ExistsMissedTicketsCmd)
 
@@ -1549,6 +1555,9 @@ func handleExistsMissedTickets(_ context.Context, s *Server, cmd interface{}) (i
 }
 
 // handleExistsExpiredTickets implements the existsexpiredtickets command.
+//
+// TODO: Add an upper bound to the number of hashes that can be checked. This
+// will come with a major RPC version bump.
 func handleExistsExpiredTickets(_ context.Context, s *Server, cmd interface{}) (interface{}, error) {
 	c := cmd.(*types.ExistsExpiredTicketsCmd)
 
@@ -1587,6 +1596,9 @@ func handleExistsLiveTicket(_ context.Context, s *Server, cmd interface{}) (inte
 }
 
 // handleExistsLiveTickets implements the existslivetickets command.
+//
+// TODO: Add an upper bound to the number of hashes that can be checked. This
+// will come with a major RPC version bump.
 func handleExistsLiveTickets(_ context.Context, s *Server, cmd interface{}) (interface{}, error) {
 	c := cmd.(*types.ExistsLiveTicketsCmd)
 
@@ -1613,6 +1625,9 @@ func handleExistsLiveTickets(_ context.Context, s *Server, cmd interface{}) (int
 }
 
 // handleExistsMempoolTxs implements the existsmempooltxs command.
+//
+// TODO: Add an upper bound to the number of hashes that can be checked. This
+// will come with a major RPC version bump.
 func handleExistsMempoolTxs(_ context.Context, s *Server, cmd interface{}) (interface{}, error) {
 	c := cmd.(*types.ExistsMempoolTxsCmd)
 

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -1434,8 +1434,7 @@ func handleEstimateStakeDiff(_ context.Context, s *Server, cmd interface{}) (int
 
 // handleExistsAddress implements the existsaddress command.
 func handleExistsAddress(_ context.Context, s *Server, cmd interface{}) (interface{}, error) {
-	existsAddrIndex := s.cfg.SyncMgr.ExistsAddrIndex()
-	if existsAddrIndex == nil {
+	if s.cfg.ExistsAddresser == nil {
 		return nil, rpcInternalError("Exists address index disabled",
 			"Configuration")
 	}
@@ -1450,7 +1449,7 @@ func handleExistsAddress(_ context.Context, s *Server, cmd interface{}) (interfa
 			err)
 	}
 
-	exists, err := existsAddrIndex.ExistsAddress(addr)
+	exists, err := s.cfg.ExistsAddresser.ExistsAddress(addr)
 	if err != nil {
 		return nil, rpcInvalidError("Could not query address: %v", err)
 	}
@@ -1460,8 +1459,7 @@ func handleExistsAddress(_ context.Context, s *Server, cmd interface{}) (interfa
 
 // handleExistsAddresses implements the existsaddresses command.
 func handleExistsAddresses(_ context.Context, s *Server, cmd interface{}) (interface{}, error) {
-	existsAddrIndex := s.cfg.SyncMgr.ExistsAddrIndex()
-	if existsAddrIndex == nil {
+	if s.cfg.ExistsAddresser == nil {
 		return nil, rpcInternalError("Exists address index disabled",
 			"Configuration")
 	}
@@ -1478,7 +1476,7 @@ func handleExistsAddresses(_ context.Context, s *Server, cmd interface{}) (inter
 		addresses[i] = addr
 	}
 
-	exists, err := existsAddrIndex.ExistsAddresses(addresses)
+	exists, err := s.cfg.ExistsAddresser.ExistsAddresses(addresses)
 	if err != nil {
 		return nil, rpcInvalidError("Could not query address: %v", err)
 	}
@@ -5593,6 +5591,10 @@ type Config struct {
 
 	// SyncMgr defines the sync manager for the RPC server to use.
 	SyncMgr SyncManager
+
+	// ExistsAddresser defines the exist addresser for the RPC server to
+	// use.
+	ExistsAddresser ExistsAddresser
 
 	// These fields allow the RPC server to interface with the local block
 	// chain data and state.

--- a/server.go
+++ b/server.go
@@ -3265,20 +3265,21 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 		}
 
 		s.rpcServer, err = rpcserver.New(&rpcserver.Config{
-			Listeners:     rpcListeners,
-			ConnMgr:       &rpcConnManager{&s},
-			SyncMgr:       &rpcSyncMgr{&s, s.blockManager},
-			FeeEstimator:  &rpcFeeEstimator{s.feeEstimator},
-			TimeSource:    s.timeSource,
-			Services:      s.services,
-			AddrManager:   &rpcAddrManager{s.addrManager},
-			Clock:         &rpcClock{},
-			SubsidyCache:  s.subsidyCache,
-			Chain:         &rpcChain{s.chain},
-			ChainParams:   chainParams,
-			SanityChecker: &rpcSanityChecker{s.timeSource, chainParams},
-			DB:            db,
-			TxMemPool:     s.txMemPool,
+			Listeners:       rpcListeners,
+			ConnMgr:         &rpcConnManager{&s},
+			SyncMgr:         &rpcSyncMgr{server: &s, blockMgr: s.blockManager},
+			ExistsAddresser: newRPCExistsAddresser(s.existsAddrIndex),
+			FeeEstimator:    &rpcFeeEstimator{s.feeEstimator},
+			TimeSource:      s.timeSource,
+			Services:        s.services,
+			AddrManager:     &rpcAddrManager{s.addrManager},
+			Clock:           &rpcClock{},
+			SubsidyCache:    s.subsidyCache,
+			Chain:           &rpcChain{s.chain},
+			ChainParams:     chainParams,
+			SanityChecker:   &rpcSanityChecker{s.timeSource, chainParams},
+			DB:              db,
+			TxMemPool:       s.txMemPool,
 			BlockTemplater: func() rpcserver.BlockTemplater {
 				if s.bg == nil {
 					return nil


### PR DESCRIPTION
    rpcserver: Add handleExistsAddress test.
    This removes the ExistsAddrIndex method from the SyncManager interface
    and replaces it with a new interface ExistsAddresser that supplies the
    two methods used by the rpcserver, ExistsAddress and ExistsAddresses.

    rpcserver: Add handleExistsAddresses test.

    rpcserver: Add exists upper bounds TODOs.
    Although permissioned, the RPC server will allow for checking any number
    of values for its various exists commands. It would be reasonable to
    limit unreasonable requests that could exhaust dcrd's available memory
    and cause node failure. Changes will come with a major RPC version bump.


