### PR TITLE
multi: add BlockTemplater interface.

### DIFF
--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -18,6 +18,7 @@ import (
 	"github.com/decred/dcrd/dcrutil/v3"
 	"github.com/decred/dcrd/gcs/v2"
 	"github.com/decred/dcrd/internal/mempool"
+	"github.com/decred/dcrd/internal/mining"
 	"github.com/decred/dcrd/peer/v2"
 	"github.com/decred/dcrd/wire"
 )
@@ -490,4 +491,28 @@ type CPUMiner interface {
 
 	// SetNumWorkers sets the number of workers to create which solve blocks.
 	SetNumWorkers(numWorkers int32)
+}
+
+// BlockTemplater represents a source of block templates for use with the
+// RPC server.
+//
+// The interface contract requires that all of these methods are safe for
+// concurrent access.
+type BlockTemplater interface {
+	// ForceRegen asks the block templater to generate a new template immediately.
+	ForceRegen()
+
+	// Subscribe subscribes a client for block template updates.  The returned
+	// template subscription contains functions to retrieve a channel that produces
+	// the stream of block templates and to stop the stream when the caller no
+	// longer wishes to receive new templates.
+	Subscribe() *mining.TemplateSubscription
+
+	// CurrentTemplate returns the current template associated with the block
+	// templater along with any associated error.
+	CurrentTemplate() (*mining.BlockTemplate, error)
+
+	// UpdateBlockTime updates the timestamp in the passed header to the current
+	// time while taking into account the consensus rules.
+	UpdateBlockTime(header *wire.BlockHeader) error
 }

--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -18,6 +18,7 @@ import (
 	"github.com/decred/dcrd/dcrutil/v3"
 	"github.com/decred/dcrd/internal/fees"
 	"github.com/decred/dcrd/internal/mempool"
+	"github.com/decred/dcrd/internal/mining"
 	"github.com/decred/dcrd/internal/rpcserver"
 	"github.com/decred/dcrd/peer/v2"
 	"github.com/decred/dcrd/wire"
@@ -515,4 +516,13 @@ var _ rpcserver.SanityChecker = (*rpcSanityChecker)(nil)
 // This function is part of the rpcserver.SanityChecker interface implementation.
 func (s *rpcSanityChecker) CheckBlockSanity(block *dcrutil.Block) error {
 	return blockchain.CheckBlockSanity(block, s.timeSource, s.chainParams)
+}
+
+// Ensure rpcBlockTemplater implements the rpcserver.BlockTemplater interface.
+var _ rpcserver.BlockTemplater = (*rpcBlockTemplater)(nil)
+
+// rpcBlockTemplater provides a block template generator for use with the
+// RPC server and implements the rpcserver.BlockTemplater interface.
+type rpcBlockTemplater struct {
+	*mining.BgBlkTmplGenerator
 }

--- a/server.go
+++ b/server.go
@@ -3279,9 +3279,12 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 			SanityChecker: &rpcSanityChecker{s.timeSource, chainParams},
 			DB:            db,
 			TxMemPool:     s.txMemPool,
-			BgBlkTmplGenerator: func() *mining.BgBlkTmplGenerator {
-				return s.bg
-			},
+			BlockTemplater: func() rpcserver.BlockTemplater {
+				if s.bg == nil {
+					return nil
+				}
+				return &rpcBlockTemplater{s.bg}
+			}(),
 			CPUMiner:             s.cpuMiner,
 			TxIndex:              s.txIndex,
 			AddrIndex:            s.addrIndex,


### PR DESCRIPTION
This adds the `BlockTemplater` interface to the `rpcserver` package. Its corresponding adapter has also been added.