### PR TITLE
blockchain: Optimize stake node pruning.

### DIFF
--- a/blockchain/prune.go
+++ b/blockchain/prune.go
@@ -4,22 +4,20 @@ import (
 	"time"
 )
 
-// pruningIntervalInMinutes is the interval in which to prune the blockchain's
-// nodes and restore memory to the garbage collector.
-const pruningIntervalInMinutes = 5
-
 // chainPruner is used to occasionally prune the blockchain of old nodes that
 // can be freed to the garbage collector.
 type chainPruner struct {
-	chain         *BlockChain
-	lastPruneTime time.Time
+	chain           *BlockChain
+	lastPruneTime   time.Time
+	pruningInterval time.Duration
 }
 
 // newChainPruner returns a new chain pruner.
 func newChainPruner(chain *BlockChain) *chainPruner {
 	return &chainPruner{
-		chain:         chain,
-		lastPruneTime: time.Now(),
+		chain:           chain,
+		lastPruneTime:   time.Now(),
+		pruningInterval: chain.chainParams.TargetTimePerBlock,
 	}
 }
 
@@ -30,7 +28,7 @@ func newChainPruner(chain *BlockChain) *chainPruner {
 func (c *chainPruner) pruneChainIfNeeded() {
 	now := time.Now()
 	duration := now.Sub(c.lastPruneTime)
-	if duration < time.Minute*pruningIntervalInMinutes {
+	if duration < c.pruningInterval {
 		return
 	}
 

--- a/blockchain/prune.go
+++ b/blockchain/prune.go
@@ -1,8 +1,33 @@
 package blockchain
 
 import (
+	"math"
 	"time"
 )
+
+// poissonConfidenceSecs returns the number of seconds it will take to produce
+// an event at the provided confidence level given a Poisson distribution with 1
+// event ocurring in the given target interval.
+func poissonConfidenceSecs(targetIntervalSecs int64, confidence float64) int64 {
+	// The waiting times between events in a Poisson distribution are
+	// exponentially distributed and the CDF for an exponential distribution is:
+	//
+	// x = 1 - e^-λt
+	//
+	// Since the goal rate is 1 event per target and time is in terms of
+	// targetIntervalSecs, let λ = 1, i = targetIntervalSecs, t = s/i, and x =
+	// confidence:
+	//   => x = 1 - e^-(s/i)
+	//
+	// Solve for s:
+	//   => e^-(s/i) = 1 - x
+	//   => -(s/i) = ln(1 - x)
+	//   => s = ln(1 - x) * -i
+	//   => s = ln1p(-confidence) * -targetIntervalSecs
+	//
+	// Extra 0.5 to round up.
+	return int64(math.Log1p(-confidence)*-float64(targetIntervalSecs) + 0.5)
+}
 
 // chainPruner is used to occasionally prune the blockchain of old nodes that
 // can be freed to the garbage collector.
@@ -10,14 +35,38 @@ type chainPruner struct {
 	chain           *BlockChain
 	lastPruneTime   time.Time
 	pruningInterval time.Duration
+
+	// prunedPerIntervalHint is the maximum expected number of nodes that will
+	// be pruned per pruning interval with a high degree of confidence.
+	prunedPerIntervalHint int64
 }
 
 // newChainPruner returns a new chain pruner.
 func newChainPruner(chain *BlockChain) *chainPruner {
+	// Set the pruning interval to match the target time per block.
+	targetTimePerBlock := chain.chainParams.TargetTimePerBlock
+	pruningInterval := targetTimePerBlock
+	pruningIntervalSecs := int64(pruningInterval.Seconds())
+
+	// Calculate the maximum expected number of nodes that will be pruned per
+	// interval with a 99% confidence level to use as a hint for reducing the
+	// number of allocations.
+	//
+	// Note that as long as the pruning interval is the same as the target block
+	// interval, this will always result in the same value for all networks,
+	// but it's better to calculate it properly so it remains accurate if the
+	// pruning interval is changed.
+	const confidence = 0.99
+	targetTimePerBlockSecs := int64(targetTimePerBlock.Seconds())
+	confidenceSecs := poissonConfidenceSecs(targetTimePerBlockSecs, confidence)
+	pruneHintFloat := float64(confidenceSecs) / float64(pruningIntervalSecs)
+	pruneHint := int64(math.Round(pruneHintFloat))
+
 	return &chainPruner{
-		chain:           chain,
-		lastPruneTime:   time.Now(),
-		pruningInterval: chain.chainParams.TargetTimePerBlock,
+		chain:                 chain,
+		lastPruneTime:         time.Now(),
+		pruningInterval:       pruningInterval,
+		prunedPerIntervalHint: pruneHint,
 	}
 }
 

--- a/blockchain/prune.go
+++ b/blockchain/prune.go
@@ -11,15 +11,15 @@ const pruningIntervalInMinutes = 5
 // chainPruner is used to occasionally prune the blockchain of old nodes that
 // can be freed to the garbage collector.
 type chainPruner struct {
-	chain              *BlockChain
-	lastNodeInsertTime time.Time
+	chain         *BlockChain
+	lastPruneTime time.Time
 }
 
 // newChainPruner returns a new chain pruner.
 func newChainPruner(chain *BlockChain) *chainPruner {
 	return &chainPruner{
-		chain:              chain,
-		lastNodeInsertTime: time.Now(),
+		chain:         chain,
+		lastPruneTime: time.Now(),
 	}
 }
 
@@ -29,11 +29,11 @@ func newChainPruner(chain *BlockChain) *chainPruner {
 // pruneChainIfNeeded must be called with the chainLock held for writes.
 func (c *chainPruner) pruneChainIfNeeded() {
 	now := time.Now()
-	duration := now.Sub(c.lastNodeInsertTime)
+	duration := now.Sub(c.lastPruneTime)
 	if duration < time.Minute*pruningIntervalInMinutes {
 		return
 	}
 
-	c.lastNodeInsertTime = now
+	c.lastPruneTime = now
 	c.chain.pruneStakeNodes()
 }


### PR DESCRIPTION
Profiling revealed that the number one cause of allocations in blockchain is currently due to stake node pruning, which definitely should not be the case.

Upon closer examination, the culprit is that every single time the stake nodes are pruned the entire ancestry of nodes prior to the prune height, including those that have already been pruned, are appended to the list of nodes to prune.  In practice, this amounts to hundreds of thousands of nodes and thus the slice is resized multiple times (likely around 18 times per run given the current runtime semantics).

 This remedies that by ensuring that only the nodes that actually need to be pruned are added to the relevant slice and also preallocating space per a hint that will handle the number of nodes expected to be pruned with a 99% confidence level to further reduce allocations when more than a single node needs to be pruned.

It also renames the slice to reflect what it actually does.

Finally, this renames the field used to track the last pruning time to more accurately reflect its purpose


Relevant portion of the **before** profile:
```
github.com/decred/dcrd/blockchain/v3.(*BlockChain).pruneStakeNodes
src\github.com\decred\dcrd\blockchain\chain.go
  Total:    654.60MB   654.60MB (flat, cum) 19.97%
    458            .          .           	var deleteNodes []*blockNode 
    459            .          .           	for node := pruneToNode.parent; node != nil; node = node.parent { 
    460     654.60MB   654.60MB           		deleteNodes = append(deleteNodes, node) 
    461            .          .           	} 
    462            .          .            
```

It does not even show up in the profile with this PR.