### PR TITLE
txscript: Optimize alt stack drop.

### DIFF
--- a/txscript/stack.go
+++ b/txscript/stack.go
@@ -201,14 +201,10 @@ func (s *stack) Tuck() error {
 // DropN removes the top N items from the stack.
 //
 // Stack transformation:
+// DropN(0): [... x1 x2] -> [... x1 x2] (aka NOP)
 // DropN(1): [... x1 x2] -> [... x1]
 // DropN(2): [... x1 x2] -> [...]
 func (s *stack) DropN(n int32) error {
-	if n < 1 {
-		str := fmt.Sprintf("attempt to drop %d items from stack", n)
-		return scriptError(ErrInvalidStackOperation, str)
-	}
-
 	for ; n > 0; n-- {
 		_, err := s.PopByteArray()
 		if err != nil {

--- a/txscript/stack_test.go
+++ b/txscript/stack_test.go
@@ -567,6 +567,15 @@ func TestStack(t *testing.T) {
 			nil,
 		},
 		{
+			"drop 0",
+			[][]byte{{1}, {2}, {3}, {4}},
+			func(s *stack) error {
+				return s.DropN(0)
+			},
+			nil,
+			[][]byte{{1}, {2}, {3}, {4}},
+		},
+		{
 			"drop 1",
 			[][]byte{{1}, {2}, {3}, {4}},
 			func(s *stack) error {
@@ -607,15 +616,6 @@ func TestStack(t *testing.T) {
 			[][]byte{{1}, {2}, {3}, {4}},
 			func(s *stack) error {
 				return s.DropN(5)
-			},
-			ErrInvalidStackOperation,
-			nil,
-		},
-		{
-			"drop invalid",
-			[][]byte{{1}, {2}, {3}, {4}},
-			func(s *stack) error {
-				return s.DropN(0)
 			},
 			ErrInvalidStackOperation,
 			nil,


### PR DESCRIPTION
Profiling shows that approximately 0.67% of the total allocations are coming from `DropN` even though it should realistically be zero.

The cause is that `DropN` returns an error if it is called with 0 and the code that drops the alternate data stack in between scripts calls it with the depth of the alternate data stack, which is almost always zero.

The call has no observable effect on the result of the script execution in that case since the error is intentionally ignored, there is nothing to be dropped, and is therefore correct semantically, however, it is wasteful to generate and throw away the error.

There really is no good reason for the internal stack implementation to return an error from `DropN` when called with 0 since it equivalent to a NOP.

I have done a careful analysis of all call sites to ensure the change will break any observable semantics.

Thus, this modifies `DropN` to remove the unnecessary error condition and updates the associated internal stack implementation test accordingly.

Relevant portion of the **before** profile:
```
      flat  flat%   sum%        cum   cum%
    327690  0.67% 77.75%     958489  1.96%  github.com/decred/dcrd/txscript/v3.(*stack).DropN
```

It does not show up in the profile with this PR as expected.