### PR TITLE
txscript: Check equality via secp256k1 methods.

### DIFF
--- a/txscript/sigcache.go
+++ b/txscript/sigcache.go
@@ -6,7 +6,6 @@
 package txscript
 
 import (
-	"bytes"
 	"sync"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
@@ -63,10 +62,7 @@ func (s *SigCache) Exists(sigHash chainhash.Hash, sig *ecdsa.Signature, pubKey *
 	entry, ok := s.validSigs[sigHash]
 	s.RUnlock()
 
-	return ok &&
-		bytes.Equal(entry.pubKey.SerializeCompressed(),
-			pubKey.SerializeCompressed()) &&
-		bytes.Equal(entry.sig.Serialize(), sig.Serialize())
+	return ok && entry.pubKey.IsEqual(pubKey) && entry.sig.IsEqual(sig)
 }
 
 // Add adds an entry for a signature over 'sigHash' under public key 'pubKey'


### PR DESCRIPTION
This modifies the signature cache `Exists` method to make use of the new efficient equality testing methods provided by the `secp256k1` types versus indirectly checking their equality via their serializations.

The following benchmark shows a before and after comparison of a typical signature cache exists check:

```
name             old time/op     new time/op     delta
-------------------------------------------------------------------------
SigCacheExists   400ns ± 0%      62ns ± 0%       -84.54%  (p=0.000 n=5+5)

name             old alloc/op    new alloc/op    delta
--------------------------------------------------------------------------
SigCacheExists   256B ± 0%       0B              -100.00%  (p=0.008 n=5+5)

name             old allocs/op   new allocs/op   delta
--------------------------------------------------------------------------
SigCacheExists   4.00 ± 0%       0.00            -100.00%  (p=0.008 n=5+5)
```