### PR TITLE
multi: add rpcCPUMiner adaptor.

### DIFF
--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -4227,9 +4227,7 @@ func handleSetGenerate(_ context.Context, s *Server, cmd interface{}) (interface
 
 	if !generate {
 		// Stop CPU mining by setting the number of workers to zero, if needed.
-		if s.cfg.CPUMiner != nil {
-			s.cfg.CPUMiner.SetNumWorkers(0)
-		}
+		s.cfg.CPUMiner.SetNumWorkers(0)
 	} else {
 		// Respond with an error if there are no addresses to pay the
 		// created blocks to.

--- a/server.go
+++ b/server.go
@@ -3285,7 +3285,7 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 				}
 				return &rpcBlockTemplater{s.bg}
 			}(),
-			CPUMiner:             s.cpuMiner,
+			CPUMiner:             &rpcCPUMiner{s.cpuMiner},
 			TxIndex:              s.txIndex,
 			AddrIndex:            s.addrIndex,
 			NetInfo:              cfg.generateNetworkInfo(),


### PR DESCRIPTION
This adds an rpc adaptor for cpu miner, handling cases where the underlining miner being passed is nil.