### PR TITLE
txscript: Optimize trace logging.

### DIFF
--- a/txscript/log.go
+++ b/txscript/log.go
@@ -19,16 +19,3 @@ var log = slog.Disabled
 func UseLogger(logger slog.Logger) {
 	log = logger
 }
-
-// LogClosure is a closure that can be printed with %v to be used to
-// generate expensive-to-create data for a detailed log level and avoid doing
-// the work if the data isn't printed.
-type logClosure func() string
-
-func (c logClosure) String() string {
-	return c()
-}
-
-func newLogClosure(c func() string) logClosure {
-	return logClosure(c)
-}


### PR DESCRIPTION
After recent optimizations, the current next biggest offender of more allocations than would be expected revealed by profiling is due to the trace logging closures for the scripting engine execution.

Once upon a time, there was no way to check the current logging level with the logging infrastructure at the time and thus a logging closure was used to defer the fairly expensive construction of the trace logging information until it was actually invoked (meaning tracing is enabled).

However, those closures come at the cost of allocations, and since script execution is something that happens non-stop during normal operation, those allocations really add up, as the profiling shows.

As some point, the logging infrastructure was changed out, and it is now possible to determine the logging level, so this updates the code to take advantage of that and avoid the closures while still only performing the fairly expensive construction of trace logging information when tracing is enabled. In other words, with this change there is zero cost (other than the conditional check, of course) when tracing is not enabled.

Finally, this also removes the no longer necessary code related to creating the logging closures.

Relevant portion of the **before** profile:

```
github.com/decred/dcrd/txscript/v3.(*Engine).Execute
  Total:     6520930   13079822 (flat, cum) 19.23%
    588            .          .           	done := false 
    589            .          .           	for !done { 
    590      3309618    3309618           		log.Tracef("%v", newLogClosure(func() string { 
    591            .          .           			dis, err := vm.DisasmPC() 
    592            .          .           			if err != nil { 
    593            .          .           				return fmt.Sprintf("stepping - failed to disasm pc: %v", err) 
    594            .          .           			} 
    595            .          .           			return fmt.Sprintf("stepping %v", dis) 
    596            .          .           		})) 
    597            .          .            
    598            .    6558892           		done, err = vm.Step() 
    599            .          .           		if err != nil { 
    600            .          .           			return err 
    601            .          .           		} 
    602      3211312    3211312           		log.Tracef("%v", newLogClosure(func() string { 
    603            .          .           			var dstr, astr string 
    604            .          .            
```

Those logging sections are zero after this PR as expected.