### PR TITLE
blockchain: Optimize chain tip tracking.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -365,12 +365,16 @@ func (b *BlockChain) ChainWork(hash *chainhash.Hash) (*big.Int, error) {
 //
 // The function is safe for concurrent access.
 func (b *BlockChain) TipGeneration() ([]chainhash.Hash, error) {
+	var nodeHashes []chainhash.Hash
 	b.chainLock.Lock()
 	b.index.RLock()
-	nodes := b.index.chainTips[b.bestChain.Tip().height]
-	nodeHashes := make([]chainhash.Hash, len(nodes))
-	for i, n := range nodes {
-		nodeHashes[i] = n.hash
+	entry := b.index.chainTips[b.bestChain.Tip().height]
+	if entry.tip != nil {
+		nodeHashes = make([]chainhash.Hash, 0, len(entry.otherTips)+1)
+		nodeHashes = append(nodeHashes, entry.tip.hash)
+		for _, n := range entry.otherTips {
+			nodeHashes = append(nodeHashes, n.hash)
+		}
 	}
 	b.index.RUnlock()
 	b.chainLock.Unlock()

--- a/blockchain/chainquery.go
+++ b/blockchain/chainquery.go
@@ -77,9 +77,12 @@ type ChainTipInfo struct {
 // known chain tips in the block index.
 func (b *BlockChain) ChainTips() []ChainTipInfo {
 	b.index.RLock()
-	var chainTips []*blockNode
-	for _, nodes := range b.index.chainTips {
-		chainTips = append(chainTips, nodes...)
+	chainTips := make([]*blockNode, 0, b.index.totalTips)
+	for _, entry := range b.index.chainTips {
+		chainTips = append(chainTips, entry.tip)
+		if len(entry.otherTips) > 0 {
+			chainTips = append(chainTips, entry.otherTips...)
+		}
 	}
 	b.index.RUnlock()
 


### PR DESCRIPTION
Part of adding nodes to the block index involves updating the current chain tip in order to be able to efficiently keep track of all known chain tips.

Since there can be multiple tips at a given height, the current code uses a slice for each height to track them.  However, this is wasteful since it is extremely rare for there to be more than one chain tip at the same height.

It is particularly notable at startup since the block index has to load up hundreds of thousands of nodes.

Given that, this modifies the chain tip tracking logic to avoid creating a slice unless it is actually needed by making use of an entry with a static field for the normal case and a dynamic slice for the case when more than 1 tip for the height actually exists.

It also keeps a running sum of the total number of known chips for use as a hint to further reduce allocations when serving up related data and updates the chain tip tests to ensure 100% branch coverage is maintained.

The end result is that  this reduces the total number of allocs at startup by around 1%, which results in faster startup, and also reduces the overall memory usage by a few MB for nodes that have a long running history of side chains.