### PR TITLE
multi: add getwork tests.

### DIFF
--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -478,6 +478,20 @@ type CPUMiner interface {
 	SetNumWorkers(numWorkers int32)
 }
 
+// TemplaterSubber represents a block template subscription.
+//
+// The interface contract requires that all these methods are safe for
+// concurrent access.
+type TemplateSubber interface {
+	// C returns a channel that produces a stream of block templates as
+	// each new template is generated.
+	C() <-chan *mining.TemplateNtfn
+
+	// Stop prevents any future template updates from being delivered and
+	// unsubscribes the associated subscription.
+	Stop()
+}
+
 // BlockTemplater represents a source of block templates for use with the
 // RPC server.
 //
@@ -491,7 +505,7 @@ type BlockTemplater interface {
 	// template subscription contains functions to retrieve a channel that produces
 	// the stream of block templates and to stop the stream when the caller no
 	// longer wishes to receive new templates.
-	Subscribe() *mining.TemplateSubscription
+	Subscribe() TemplateSubber
 
 	// CurrentTemplate returns the current template associated with the block
 	// templater along with any associated error.

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -3437,7 +3437,7 @@ func handleGetWorkSubmission(_ context.Context, s *Server, hexData string) (inte
 	if err != nil {
 		// Anything other than a rule violation is an unexpected error, so
 		// return that error as an internal error.
-		var rErr blockchain.RuleError
+		var rErr standalone.RuleError
 		if !errors.As(err, &rErr) {
 			context := "Unexpected error while checking proof of work"
 			return false, rpcInternalError(err.Error(), context)

--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -514,6 +514,13 @@ type rpcBlockTemplater struct {
 	*mining.BgBlkTmplGenerator
 }
 
+// Subscribe returns a TemplateSubber which has functions to retrieve
+// a channel that produces the stream of block templates and to stop
+// the stream when the caller no longer wishes to receive new templates.
+func (t *rpcBlockTemplater) Subscribe() rpcserver.TemplateSubber {
+	return t.BgBlkTmplGenerator.Subscribe()
+}
+
 // rpcCPUMiner provides a CPU miner for use with the RPC and implements the
 // rpcserver.CPUMiner interface.
 type rpcCPUMiner struct {


### PR DESCRIPTION
This adds rpc handler tests for `getwork`.

Work towards #2069.

