### PR TITLE
rpcserver: Sort getpeerinfo results by ID

### DIFF
--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -2616,6 +2616,9 @@ func handleGetPeerInfo(_ context.Context, s *Server, cmd interface{}) (interface
 		}
 		infos = append(infos, info)
 	}
+	sort.Slice(infos, func(i, j int) bool {
+		return infos[i].ID < infos[j].ID
+	})
 	return infos, nil
 }
 


### PR DESCRIPTION
The IDs are assigned in increasing order, so this has the net effect
of peer results returned in the order they were connected.  It also
keeps the order the same across multiple calls.

This matches the behavior of the current pull request implementing
getpeerinfo in dcrwallet.