### PR TITLE
rpcserver: Add tests for cfilter handlers.

### DIFF
--- a/blockchain/indexers/cfindex.go
+++ b/blockchain/indexers/cfindex.go
@@ -255,6 +255,9 @@ func (idx *CFIndex) DisconnectBlock(dbTx database.Tx, block, parent *dcrutil.Blo
 
 // FilterByBlockHash returns the serialized contents of a block's basic or
 // extended committed filter.
+//
+// Deprecated: This will be removed in the next major version.  Use
+// blockchain.FilterByBlockHash instead.
 func (idx *CFIndex) FilterByBlockHash(h *chainhash.Hash, filterType wire.FilterType) ([]byte, error) {
 	if uint8(filterType) > maxFilterType {
 		return nil, errors.New("unsupported filter type")
@@ -270,6 +273,9 @@ func (idx *CFIndex) FilterByBlockHash(h *chainhash.Hash, filterType wire.FilterT
 
 // FilterHeaderByBlockHash returns the serialized contents of a block's basic
 // or extended committed filter header.
+//
+// Deprecated: This will be removed in the next major version.  Use
+// blockchain.FilterByBlockHash instead.
 func (idx *CFIndex) FilterHeaderByBlockHash(h *chainhash.Hash, filterType wire.FilterType) ([]byte, error) {
 	if uint8(filterType) > maxFilterType {
 		return nil, errors.New("unsupported filter type")

--- a/config.go
+++ b/config.go
@@ -174,8 +174,8 @@ type config struct {
 	DropAddrIndex        bool          `long:"dropaddrindex" description:"Deletes the address-based transaction index from the database on start up and then exits."`
 	NoExistsAddrIndex    bool          `long:"noexistsaddrindex" description:"Disable the exists address index, which tracks whether or not an address has even been used."`
 	DropExistsAddrIndex  bool          `long:"dropexistsaddrindex" description:"Deletes the exists address index from the database on start up and then exits."`
-	NoCFilters           bool          `long:"nocfilters" description:"Disable compact filtering (CF) support"`
-	DropCFIndex          bool          `long:"dropcfindex" description:"Deletes the index used for compact filtering (CF) support from the database on start up and then exits."`
+	NoCFilters           bool          `long:"nocfilters" description:"(Deprecated) Disable compact filtering (CF) support"`
+	DropCFIndex          bool          `long:"dropcfindex" description:"(Deprecated) Deletes the index used for compact filtering (CF) support from the database on start up and then exits."`
 	PipeRx               uint          `long:"piperx" description:"File descriptor of read end pipe to enable parent -> child process communication"`
 	PipeTx               uint          `long:"pipetx" description:"File descriptor of write end pipe to enable parent <- child process communication"`
 	LifetimeEvents       bool          `long:"lifetimeevents" description:"Send lifetime notifications over the TX pipe"`

--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -1227,7 +1227,9 @@ of the best block.
 # <code>filtertype</code>: <code>(string, required)</code> The type of committed filter to return.
 |-
 !Description
-|Returns the committed filter for a block.
+|
+: Returns the committed filter for a block.
+: Deprecated: This will be removed in the next major version.  Use [[#getcfilterv2|getcfilterv2]] instead.
 |-
 !Returns
 |<code>string</code> The hex encoded committed filter.
@@ -1253,7 +1255,9 @@ of the best block.
 # <code>filtertype</code>: <code>(string, required)</code> The type of committed filter header to return.
 |-
 !Description
-|Returns the committed filter header for a block.
+|
+: Returns the committed filter header for a block.
+: Deprecated: This will be removed in the next major version.  Use [[#getcfilterv2|getcfilterv2]] instead.
 |-
 !Returns
 |<code>string</code> The hex encoded committed filter header.

--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -230,6 +230,10 @@ the method name for further details such as parameter and return information.
 |Y
 |Returns the committed filter for a block.
 |-
+|[[#getcfilterheader|getcfilterheader]]
+|Y
+|Returns the committed filter header for a block.
+|-
 |[[#getcfilterv2|getcfilterv2]]
 |Y
 |Returns the version 2 block filter for the given block along with a proof that can be used to prove the filter is committed to by the block header.
@@ -1234,6 +1238,29 @@ of the best block.
 :<code>0000002305d72c4c0f6e3d19783a59f26cef1fab1ec21585f8016a22a43762cd2edbda7a1fba</code>
 :<code>596d06e092c6ec2f651d5242074fd063918741f4492dd0dd889f6909fd3028e04fa1e84259c4</code>
 :<code>1088aea6fa0cd0cb162daaa4afb05de43718914a7e04</code>
+|}
+
+----
+
+====getcfilterheader====
+{|
+!Method
+|getcfilterheader
+|-
+!Parameters
+|
+# <code>hash</code>: <code>(string, required)</code> The block hash of the filter header being queried.
+# <code>filtertype</code>: <code>(string, required)</code> The type of committed filter header to return.
+|-
+!Description
+|Returns the committed filter header for a block.
+|-
+!Returns
+|<code>string</code> The hex encoded committed filter header.
+|-
+!Example Return
+|
+<code>bd60b439d72fad354acc4b47d374ec34b0cca3bb25994b459f01f6f84ad6b478</code>
 |}
 
 ----

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -159,9 +159,6 @@ type SyncManager interface {
 	// ExistsAddrIndex returns the address index.
 	ExistsAddrIndex() *indexers.ExistsAddrIndex
 
-	// CFIndex returns the committed filter (cf) by hash index.
-	CFIndex() *indexers.CFIndex
-
 	// TipGeneration returns the entire generation of blocks stemming from the
 	// parent of the current tip.
 	TipGeneration() ([]chainhash.Hash, error)
@@ -317,14 +314,6 @@ type Chain interface {
 
 	// FetchUtxoStats returns statistics on the current utxo set.
 	FetchUtxoStats() (*blockchain.UtxoStats, error)
-
-	// FilterByBlockHash returns the version 2 GCS filter for the given block hash
-	// when it exists.  This function returns the filters regardless of whether or
-	// not their associated block is part of the main chain.
-	//
-	// An error of type blockchain.NoFilterError must be returned when the filter
-	// for the given block hash does not exist.
-	FilterByBlockHash(hash *chainhash.Hash) (*gcs.FilterV2, error)
 
 	// GetStakeVersions returns a cooked array of StakeVersions.  We do this in
 	// order to not bloat memory by returning raw blocks.
@@ -515,4 +504,34 @@ type BlockTemplater interface {
 	// UpdateBlockTime updates the timestamp in the passed header to the current
 	// time while taking into account the consensus rules.
 	UpdateBlockTime(header *wire.BlockHeader) error
+}
+
+// Filterer provides an interface for retrieving a block's committed filter or
+// committed filter header.
+//
+// The interface contract requires that all of these methods are safe for
+// concurrent access.
+type Filterer interface {
+	// FilterByBlockHash returns the serialized contents of a block's regular or
+	// extended committed filter.
+	FilterByBlockHash(h *chainhash.Hash, filterType wire.FilterType) ([]byte, error)
+
+	// FilterHeaderByBlockHash returns the serialized contents of a block's regular
+	// or extended committed filter header.
+	FilterHeaderByBlockHash(h *chainhash.Hash, filterType wire.FilterType) ([]byte, error)
+}
+
+// FiltererV2 provides an interface for retrieving a block's version 2 GCS
+// filter.
+//
+// The interface contract requires that all of these methods are safe for
+// concurrent access.
+type FiltererV2 interface {
+	// FilterByBlockHash returns the version 2 GCS filter for the given block hash
+	// when it exists.  This function returns the filters regardless of whether or
+	// not their associated block is part of the main chain.
+	//
+	// An error of type blockchain.NoFilterError must be returned when the filter
+	// for the given block hash does not exist.
+	FilterByBlockHash(hash *chainhash.Hash) (*gcs.FilterV2, error)
 }

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -511,6 +511,9 @@ type BlockTemplater interface {
 //
 // The interface contract requires that all of these methods are safe for
 // concurrent access.
+//
+// Deprecated: This will be removed in the next major version.  Use FiltererV2
+// instead.
 type Filterer interface {
 	// FilterByBlockHash returns the serialized contents of a block's regular or
 	// extended committed filter.

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -2196,6 +2196,9 @@ func handleGetHashesPerSec(_ context.Context, s *Server, cmd interface{}) (inter
 }
 
 // handleGetCFilter implements the getcfilter command.
+//
+// Deprecated: This will be removed in the next major version.  Use
+// handleGetCFilterV2 instead.
 func handleGetCFilter(_ context.Context, s *Server, cmd interface{}) (interface{}, error) {
 	if s.cfg.Filterer == nil {
 		return nil, &dcrjson.RPCError{
@@ -2238,6 +2241,9 @@ func handleGetCFilter(_ context.Context, s *Server, cmd interface{}) (interface{
 }
 
 // handleGetCFilterHeader implements the getcfilterheader command.
+//
+// Deprecated: This will be removed in the next major version.  Use
+// handleGetCFilterV2 instead.
 func handleGetCFilterHeader(_ context.Context, s *Server, cmd interface{}) (interface{}, error) {
 	if s.cfg.Filterer == nil {
 		return nil, &dcrjson.RPCError{

--- a/internal/rpcserver/rpcserverhelp.go
+++ b/internal/rpcserver/rpcserverhelp.go
@@ -377,13 +377,15 @@ var helpDescsEnUS = map[string]string{
 	"getblocksubsidyresult-total":     "The total subsidy",
 
 	// GetCFilterCmd help.
-	"getcfilter--synopsis":  "Returns the committed filter for a block",
+	"getcfilter--synopsis": "Returns the committed filter for a block.\n\n" +
+		"Deprecated: Use handleGetCFilterV2 instead.",
 	"getcfilter--result0":   "The committed filter serialized with the N value and encoded as a hex string",
 	"getcfilter-hash":       "The block hash of the filter being queried",
 	"getcfilter-filtertype": "The type of committed filter to return",
 
 	// GetCFilterHeaderCmd help.
-	"getcfilterheader--synopsis":  "Returns the filter header hash committing to all filters in the chain up through a block",
+	"getcfilterheader--synopsis": "Returns the filter header hash committing to all filters in the chain up through a block.\n\n" +
+		"Deprecated: Use handleGetCFilterV2 instead.",
 	"getcfilterheader--result0":   "The filter header commitment hash",
 	"getcfilterheader-hash":       "The block hash of the filter header being queried",
 	"getcfilterheader-filtertype": "The type of committed filter to return the header commitment for",

--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -371,14 +371,6 @@ func (b *rpcSyncMgr) ExistsAddrIndex() *indexers.ExistsAddrIndex {
 	return b.server.existsAddrIndex
 }
 
-// CFIndex returns the committed filter (cf) by hash index.
-//
-// This function is safe for concurrent access and is part of the
-// rpcserver.SyncManager interface implementation.
-func (b *rpcSyncMgr) CFIndex() *indexers.CFIndex {
-	return b.server.cfIndex
-}
-
 // TipGeneration returns the entire generation of blocks stemming from the
 // parent of the current tip.
 func (b *rpcSyncMgr) TipGeneration() ([]chainhash.Hash, error) {
@@ -584,3 +576,21 @@ func (c *rpcCPUMiner) SetNumWorkers(numWorkers int32) {
 		c.miner.SetNumWorkers(numWorkers)
 	}
 }
+
+// rpcFilterer provides methods for retrieving a block's committed filter or
+// committed filter header and implements the rpcserver.Filterer interface.
+type rpcFilterer struct {
+	*indexers.CFIndex
+}
+
+// Ensure rpcFilterer implements the rpcserver.Filterer interface.
+var _ rpcserver.Filterer = (*rpcFilterer)(nil)
+
+// rpcFiltererV2 provides methods for retrieving a block's version 2 GCS filter
+// and implements the rpcserver.FiltererV2 interface.
+type rpcFiltererV2 struct {
+	*blockchain.BlockChain
+}
+
+// Ensure rpcFiltererV2 implements the rpcserver.FiltererV2 interface.
+var _ rpcserver.FiltererV2 = (*rpcFiltererV2)(nil)

--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -579,6 +579,9 @@ func (c *rpcCPUMiner) SetNumWorkers(numWorkers int32) {
 
 // rpcFilterer provides methods for retrieving a block's committed filter or
 // committed filter header and implements the rpcserver.Filterer interface.
+//
+// Deprecated: This will be removed in the next major version.  Use
+// rpcFiltererV2 instead.
 type rpcFilterer struct {
 	*indexers.CFIndex
 }

--- a/server.go
+++ b/server.go
@@ -3304,6 +3304,13 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 			MaxProtocolVersion:   maxProtocolVersion,
 			UserAgentVersion:     userAgentVersion,
 			LogManager:           &rpcLogManager{},
+			Filterer: func() rpcserver.Filterer {
+				if s.cfIndex == nil {
+					return nil
+				}
+				return &rpcFilterer{s.cfIndex}
+			}(),
+			FiltererV2: &rpcFiltererV2{s.chain},
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This adds full test coverage for the following rpcserver handlers:
- `handleGetCFilter`
- `handleGetCFilterHeader`
- `handleGetCFilterV2`

```
go test -run="TestHandleGetCFilter" -coverprofile=cov.out &&
go tool cover -func=cov.out | grep -E "handleGetCFilter"

github.com/decred/dcrd/internal/rpcserver/rpcserver.go:2199:		handleGetCFilter		100.0%
github.com/decred/dcrd/internal/rpcserver/rpcserver.go:2241:		handleGetCFilterHeader		100.0%
github.com/decred/dcrd/internal/rpcserver/rpcserver.go:2331:		handleGetCFilterV2		100.0%
```

Part of https://github.com/decred/dcrd/issues/2069

Closes #2313.