### PR TITLE
mempool: Store staged transactions as TxDesc

### DIFF
--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -578,8 +578,8 @@ type TxMempooler interface {
 	Count() int
 
 	// FetchTransaction returns the requested transaction from the
-	// transaction pool. This only fetches from the main transaction pool
-	// and does not include orphans.
+	// transaction pool. This only fetches from the main and stage transaction
+	// pools and does not include orphans.
 	FetchTransaction(txHash *chainhash.Hash) (*dcrutil.Tx, error)
 
 	// TSpendHashes returns the hashes of the treasury spend transactions


### PR DESCRIPTION
This optimization modifies the mempool to store staged transactions as a *TxDesc rather than a *dcrutil.Tx. The advantage of doing this is to avoid recalculating transaction types through stake.DetermineTxType since this would have been cached in a TxDesc when the transaction initially entered the mempool.

This concern was raised by @davecgh in #1852 (https://github.com/decred/dcrd/pull/1852#discussion_r379311798). 

