### PR TITLE
contrib: Support MSYS2 in simnet setup script.

### DIFF
--- a/contrib/dcr_tmux_simnet_setup.sh
+++ b/contrib/dcr_tmux_simnet_setup.sh
@@ -32,6 +32,12 @@ WALLET_SEED="b280922d2cffda44648346412c5ec97f429938105003730414f10b01e1402eac"
 WALLET_MINING_ADDR="SspUvSyDGSzvPz2NfdZ5LW15uq6rmuGZyhL" # NOTE: This must be changed if the seed is changed.
 WALLET_XFER_ADDR="SsonWQK6xkLSYm7VttCddHWkWWhETFMdR4Y" # same as above
 
+# Workaround to allow input to work in MSYS2
+PTY_ADAPTOR=
+if [ "${MSYSTEM}" == "MSYS" ]; then
+	PTY_ADAPTOR=winpty
+fi
+
 if [ -d "${NODES_ROOT}" ] ; then
   rm -R "${NODES_ROOT}"
 fi
@@ -124,11 +130,12 @@ tmux split-window -v
 tmux select-pane -t 0
 tmux resize-pane -D 15
 tmux send-keys "cd ${NODES_ROOT}/${PRIMARY_WALLET_NAME}" C-m
-tmux send-keys "dcrwallet -C ../wallet.conf --create" C-m
+tmux send-keys "${PTY_ADAPTOR} dcrwallet -C ../wallet.conf --create; tmux wait-for -S ${PRIMARY_WALLET_NAME}" C-m
 sleep 2
 tmux send-keys "123" C-m "123" C-m "n" C-m "y" C-m
 sleep 1
 tmux send-keys "${WALLET_SEED}" C-m C-m
+tmux wait-for ${PRIMARY_WALLET_NAME}
 tmux send-keys "dcrwallet -C ../wallet.conf --enableticketbuyer --ticketbuyer.limit=10" C-m
 tmux select-pane -t 1
 tmux send-keys "cd ${NODES_ROOT}/${PRIMARY_WALLET_NAME}" C-m
@@ -218,11 +225,12 @@ tmux split-window -v
 tmux select-pane -t 0
 tmux resize-pane -D 15
 tmux send-keys "cd ${NODES_ROOT}/${SECONDARY_WALLET_NAME}" C-m
-tmux send-keys "dcrwallet -C ../wallet.conf --create" C-m
+tmux send-keys "${PTY_ADAPTOR} dcrwallet -C ../wallet.conf --create; tmux wait-for -S ${SECONDARY_WALLET_NAME}" C-m
 sleep 2
 tmux send-keys "123" C-m "123" C-m "n" C-m "y" C-m
 sleep 1
 tmux send-keys "${WALLET_SEED}" C-m C-m
+tmux wait-for ${SECONDARY_WALLET_NAME}
 tmux send-keys "dcrwallet -C ../wallet.conf --rpcconnect=${SECONDARY_DCRD_RPC} --rpclisten=${SECONDARY_WALLET_RPC} --nogrpc" C-m
 tmux select-pane -t 1
 tmux send-keys "cd ${NODES_ROOT}/${SECONDARY_WALLET_NAME}" C-m


### PR DESCRIPTION
This modifies the `simnet` environment setup script to make use of `winpty` when running under `MSYS2` so that it works properly there.