### PR TITLE
rpcserver: Add TxMempooler interface and TestHandleExistsMempoolTxs.

### DIFF
--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -566,3 +566,32 @@ type ExistsAddresser interface {
 	// addresses has been seen before.
 	ExistsAddresses(addrs []dcrutil.Address) ([]bool, error)
 }
+
+// TxMempooler represents a source of mempool transaction data for the RPC
+// server. Methods assume the existence of a main pool and an orphans pool.
+//
+// The interface contract requires that all of these methods are safe for
+// concurrent access.
+type TxMempooler interface {
+	// HaveTransactions returns whether or not the passed transactions
+	// already exist in the main pool or in the orphan pool.
+	HaveTransactions(hashes []*chainhash.Hash) []bool
+
+	// TxDescs returns a slice of descriptors for all the transactions in
+	// the pool. The descriptors must be treated as read only.
+	TxDescs() []*mempool.TxDesc
+
+	// VerboseTxDescs returns a slice of verbose descriptors for all the
+	// transactions in the pool. The descriptors must be treated as read
+	// only.
+	VerboseTxDescs() []*mempool.VerboseTxDesc
+
+	// Count returns the number of transactions in the main pool. It does
+	// not include the orphan pool.
+	Count() int
+
+	// FetchTransaction returns the requested transaction from the
+	// transaction pool. This only fetches from the main transaction pool
+	// and does not include orphans.
+	FetchTransaction(txHash *chainhash.Hash) (*dcrutil.Tx, error)
+}

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -2745,6 +2745,51 @@ func TestHandleExistsLiveTickets(t *testing.T) {
 	}})
 }
 
+func TestHandleExistsMempoolTxs(t *testing.T) {
+	t.Parallel()
+
+	defaultCmdTxHashes := []string{
+		"1189cbe656c2ef1e0fcb91f107624d9aa8f0db7b28e6a86f694a4cf49abc5e39",
+		"2189cbe656c2ef1e0fcb91f107624d9aa8f0db7b28e6a86f694a4cf49abc5e39",
+	}
+	testRPCServerHandler(t, []rpcTest{{
+		name:    "handleExistsMempoolTxs: ok",
+		handler: handleExistsMempoolTxs,
+		cmd: &types.ExistsMempoolTxsCmd{
+			TxHashes: defaultCmdTxHashes,
+		},
+		mockTxMempooler: func() *testTxMempooler {
+			mp := defaultMockTxMempooler()
+			mp.haveTransactions = []bool{false, true}
+			return mp
+		}(),
+		result: "02",
+	}, {
+		name:    "handleExistsMempoolTxs: invalid hash",
+		handler: handleExistsMempoolTxs,
+		cmd: &types.ExistsMempoolTxsCmd{
+			TxHashes: []string{
+				"g189cbe656c2ef1e0fcb91f107624d9aa8f0db7b28e6a86f694a4cf49abc5e39",
+			},
+		},
+		wantErr: true,
+		errCode: dcrjson.ErrRPCDecodeHexString,
+	}, {
+		name:    "handleExistsMempoolTxs: have transaction count different than number of args",
+		handler: handleExistsMempoolTxs,
+		cmd: &types.ExistsMempoolTxsCmd{
+			TxHashes: defaultCmdTxHashes,
+		},
+		mockTxMempooler: func() *testTxMempooler {
+			mp := defaultMockTxMempooler()
+			mp.haveTransactions = []bool{false}
+			return mp
+		}(),
+		wantErr: true,
+		errCode: dcrjson.ErrRPCInternal.Code,
+	}})
+}
+
 func TestHandleExistsMissedTickets(t *testing.T) {
 	t.Parallel()
 

--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -597,15 +597,15 @@ type rpcFiltererV2 struct {
 // Ensure rpcFiltererV2 implements the rpcserver.FiltererV2 interface.
 var _ rpcserver.FiltererV2 = (*rpcFiltererV2)(nil)
 
-// Ensure rpcExistsAddresser implements the rpcserver.ExistsAddresser interface.
-var _ rpcserver.ExistsAddresser = (*rpcExistsAddresser)(nil)
-
 // rpcExistsAddresser provides exists address methods for use with the RPC
 // server and implements the rpcserver.ExistsAddresser interface. It should be
 // constructed by calling newRPCExistsAddresser.
 type rpcExistsAddresser struct {
-	existsAddrIndex *indexers.ExistsAddrIndex
+	*indexers.ExistsAddrIndex
 }
+
+// Ensure rpcExistsAddresser implements the rpcserver.ExistsAddresser interface.
+var _ rpcserver.ExistsAddresser = (*rpcExistsAddresser)(nil)
 
 // newRPCExistsAddresser is a constructor for a new rpcserver.ExistsAddresser
 // that wraps *rpcExistsAddresser. If the server's existsAddrIndex is nil, nil
@@ -618,13 +618,11 @@ func newRPCExistsAddresser(e *indexers.ExistsAddrIndex) rpcserver.ExistsAddresse
 	return &rpcExistsAddresser{e}
 }
 
-// ExistsAddress returns whether or not an address has been seen before.
-func (e *rpcExistsAddresser) ExistsAddress(addr dcrutil.Address) (bool, error) {
-	return e.existsAddrIndex.ExistsAddress(addr)
+// rpcTxMempooler provides a mempool transaction data source for use with the
+// RPC server and implements the rpcserver.TxMempooler interface.
+type rpcTxMempooler struct {
+	*mempool.TxPool
 }
 
-// ExistsAddresses returns whether or not each address in a slice of addresses
-// has been seen before.
-func (e *rpcExistsAddresser) ExistsAddresses(addrs []dcrutil.Address) ([]bool, error) {
-	return e.existsAddrIndex.ExistsAddresses(addrs)
-}
+// Ensure rpcTxMempooler implements the rpcserver.TxMempooler interface.
+var _ rpcserver.TxMempooler = (*rpcTxMempooler)(nil)

--- a/server.go
+++ b/server.go
@@ -3279,7 +3279,7 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 			ChainParams:     chainParams,
 			SanityChecker:   &rpcSanityChecker{s.timeSource, chainParams},
 			DB:              db,
-			TxMemPool:       s.txMemPool,
+			TxMempooler:     &rpcTxMempooler{s.txMemPool},
 			BlockTemplater: func() rpcserver.BlockTemplater {
 				if s.bg == nil {
 					return nil


### PR DESCRIPTION
    rpcserver: Add TxMempooler interface.
    
    In order to allow tests to use mocked mempool transaction data, replace
    the RPC server's TxMemPool with an interface that satisfies what is
    needed for the server.

    rpcserver: Add handleExistsMempoolTxs test.