### PR TITLE
contrib: Update simnet script for dcrwallet master

### DIFF
--- a/contrib/dcr_tmux_simnet_setup.sh
+++ b/contrib/dcr_tmux_simnet_setup.sh
@@ -32,12 +32,6 @@ WALLET_SEED="b280922d2cffda44648346412c5ec97f429938105003730414f10b01e1402eac"
 WALLET_MINING_ADDR="SspUvSyDGSzvPz2NfdZ5LW15uq6rmuGZyhL" # NOTE: This must be changed if the seed is changed.
 WALLET_XFER_ADDR="SsonWQK6xkLSYm7VttCddHWkWWhETFMdR4Y" # same as above
 
-# Workaround to allow input to work in MSYS2
-PTY_ADAPTOR=
-if [ "${MSYSTEM}" == "MSYS" ]; then
-	PTY_ADAPTOR=winpty
-fi
-
 if [ -d "${NODES_ROOT}" ] ; then
   rm -R "${NODES_ROOT}"
 fi
@@ -75,6 +69,13 @@ logdir=./log
 appdata=./data
 pass=123
 enablevoting=1
+EOF
+
+cat > "${NODES_ROOT}/wallet.answers" <<EOF
+y
+n
+y
+${WALLET_SEED}
 EOF
 
 cd ${NODES_ROOT} && tmux -2 new-session -d -s $SESSION
@@ -130,11 +131,7 @@ tmux split-window -v
 tmux select-pane -t 0
 tmux resize-pane -D 15
 tmux send-keys "cd ${NODES_ROOT}/${PRIMARY_WALLET_NAME}" C-m
-tmux send-keys "${PTY_ADAPTOR} dcrwallet -C ../wallet.conf --create; tmux wait-for -S ${PRIMARY_WALLET_NAME}" C-m
-sleep 2
-tmux send-keys "123" C-m "123" C-m "n" C-m "y" C-m
-sleep 1
-tmux send-keys "${WALLET_SEED}" C-m C-m
+tmux send-keys "dcrwallet -C ../wallet.conf --create <../wallet.answers; tmux wait-for -S ${PRIMARY_WALLET_NAME}" C-m
 tmux wait-for ${PRIMARY_WALLET_NAME}
 tmux send-keys "dcrwallet -C ../wallet.conf --enableticketbuyer --ticketbuyer.limit=10" C-m
 tmux select-pane -t 1
@@ -225,11 +222,7 @@ tmux split-window -v
 tmux select-pane -t 0
 tmux resize-pane -D 15
 tmux send-keys "cd ${NODES_ROOT}/${SECONDARY_WALLET_NAME}" C-m
-tmux send-keys "${PTY_ADAPTOR} dcrwallet -C ../wallet.conf --create; tmux wait-for -S ${SECONDARY_WALLET_NAME}" C-m
-sleep 2
-tmux send-keys "123" C-m "123" C-m "n" C-m "y" C-m
-sleep 1
-tmux send-keys "${WALLET_SEED}" C-m C-m
+tmux send-keys "dcrwallet -C ../wallet.conf --create <../wallet.answers; tmux wait-for -S ${SECONDARY_WALLET_NAME}" C-m
 tmux wait-for ${SECONDARY_WALLET_NAME}
 tmux send-keys "dcrwallet -C ../wallet.conf --rpcconnect=${SECONDARY_DCRD_RPC} --rpclisten=${SECONDARY_WALLET_RPC} --nogrpc" C-m
 tmux select-pane -t 1


### PR DESCRIPTION
The prompts when creating the wallet were changed when the wallet
passphrase was part of the application configuration, which caused the
script to hang.  This fixes the hang by replying to the additional
prompt, and updates the script to pipe input to dcrwallet's stdin to
reply to the prompts, rather than using tmux to send keys.