### PR TITLE
contrib: Simnet setup script improvements.

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -32,5 +32,9 @@ network where the developer has full control since the difficulty levels are low
 enough to generate blocks on demand and the developer owns all of the tickets
 and votes on the private network.
 
+The environment will be housed in the `$HOME/dcrdsimnetnodes` directory by
+default.  This can be overridden with the `DCR_SIMNET_ROOT` environment variable
+if desired.
+
 See the full [Simulation Network Reference](../docs/simnet_environment.mediawiki)
 for more details.

--- a/contrib/dcr_tmux_simnet_setup.sh
+++ b/contrib/dcr_tmux_simnet_setup.sh
@@ -25,7 +25,7 @@
 set -e
 
 SESSION="dcrd-simnet-nodes"
-NODES_ROOT=~/dcrdsimnetnodes
+NODES_ROOT=${DCR_SIMNET_ROOT:-${HOME}/dcrdsimnetnodes}
 RPCUSER="USER"
 RPCPASS="PASS"
 WALLET_SEED="b280922d2cffda44648346412c5ec97f429938105003730414f10b01e1402eac"

--- a/contrib/dcr_tmux_simnet_setup.sh
+++ b/contrib/dcr_tmux_simnet_setup.sh
@@ -31,6 +31,11 @@ RPCPASS="PASS"
 WALLET_SEED="b280922d2cffda44648346412c5ec97f429938105003730414f10b01e1402eac"
 WALLET_MINING_ADDR="SspUvSyDGSzvPz2NfdZ5LW15uq6rmuGZyhL" # NOTE: This must be changed if the seed is changed.
 WALLET_XFER_ADDR="SsonWQK6xkLSYm7VttCddHWkWWhETFMdR4Y" # same as above
+WALLET_CREATE_CONFIG="y
+n
+y
+${WALLET_SEED}
+"
 
 if [ -d "${NODES_ROOT}" ] ; then
   rm -R "${NODES_ROOT}"
@@ -69,13 +74,6 @@ logdir=./log
 appdata=./data
 pass=123
 enablevoting=1
-EOF
-
-cat > "${NODES_ROOT}/wallet.answers" <<EOF
-y
-n
-y
-${WALLET_SEED}
 EOF
 
 cd ${NODES_ROOT} && tmux -2 new-session -d -s $SESSION
@@ -131,7 +129,7 @@ tmux split-window -v
 tmux select-pane -t 0
 tmux resize-pane -D 15
 tmux send-keys "cd ${NODES_ROOT}/${PRIMARY_WALLET_NAME}" C-m
-tmux send-keys "dcrwallet -C ../wallet.conf --create <../wallet.answers; tmux wait-for -S ${PRIMARY_WALLET_NAME}" C-m
+tmux send-keys "echo \"${WALLET_CREATE_CONFIG}\" | dcrwallet -C ../wallet.conf --create; tmux wait-for -S ${PRIMARY_WALLET_NAME}" C-m
 tmux wait-for ${PRIMARY_WALLET_NAME}
 tmux send-keys "dcrwallet -C ../wallet.conf --enableticketbuyer --ticketbuyer.limit=10" C-m
 tmux select-pane -t 1
@@ -222,7 +220,7 @@ tmux split-window -v
 tmux select-pane -t 0
 tmux resize-pane -D 15
 tmux send-keys "cd ${NODES_ROOT}/${SECONDARY_WALLET_NAME}" C-m
-tmux send-keys "dcrwallet -C ../wallet.conf --create <../wallet.answers; tmux wait-for -S ${SECONDARY_WALLET_NAME}" C-m
+tmux send-keys "echo \"${WALLET_CREATE_CONFIG}\" | dcrwallet -C ../wallet.conf --create; tmux wait-for -S ${SECONDARY_WALLET_NAME}" C-m
 tmux wait-for ${SECONDARY_WALLET_NAME}
 tmux send-keys "dcrwallet -C ../wallet.conf --rpcconnect=${SECONDARY_DCRD_RPC} --rpclisten=${SECONDARY_WALLET_RPC} --nogrpc" C-m
 tmux select-pane -t 1

--- a/docs/simnet_environment.mediawiki
+++ b/docs/simnet_environment.mediawiki
@@ -48,6 +48,10 @@ typically readily available on Unix and Linux platforms, to setup a
 self-contained environment with several terminal-based windows and panes with
 <code>dcrd</code> and <code>dcrwallet</code> already configured.
 
+The environment will be housed in the <code>$HOME/dcrdsimnetnodes</code>
+directory by default.  This can be overridden with the
+<code>DCR_SIMNET_ROOT</code> environment variable if desired.
+
 ===2.1 Preconfigured Environment Overview===
 
 The following provides an overview of how the environment that is automatically


### PR DESCRIPTION
This modifies the `dcr_tmux_simnet_setup.sh` script to set the root of all of the nodes to the environment variable `DCR_SIMNET_ROOT` when it is set and fallback to the existing path when it is not as well as to use a variable to consolidate wallet creation answers instead of a file so there are no artifacts left.

It also updates `contrib/README.md` and `docs/simnet_environment.mediawiki` to document the new capability.