### PR TITLE
multi: Update for Go 1.15.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14
+FROM golang:1.15
 
 #
 # NOTE: The RPC server listens on localhost by default.

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,5 +1,5 @@
 # Build image
-FROM golang:1.14
+FROM golang:1.15
 
 #
 # NOTE: The RPC server listens on localhost by default.

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ https://decred.org/downloads/
 
 <details><summary><b>Install Dependencies</b></summary>
 
-- **Go 1.13 or 1.14**
+- **Go 1.14 or 1.15**
 
   Installation instructions can be found here: https://golang.org/doc/install.
   Ensure Go was installed properly and is a supported version:


### PR DESCRIPTION
This updates the `README.md` to require Go 1.14/1.15 as well as the docker files to use the `golang:1.15` image.