### PR TITLE
blockchain: Decentralized Treasury db migration.

### DIFF
--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -74,11 +74,11 @@ var (
 
 	// spendJournalBucketName is the name of the db bucket used to house
 	// transactions outputs that are spent in each block.
-	spendJournalBucketName = []byte("spendjournal")
+	spendJournalBucketName = []byte("spendjournalv2")
 
 	// utxoSetBucketName is the name of the db bucket used to house the unspent
 	// transaction output set.
-	utxoSetBucketName = []byte("utxoset")
+	utxoSetBucketName = []byte("utxosetv2")
 
 	// blockIndexBucketName is the name of the db bucket used to house the block
 	// index which consists of metadata for all known blocks both in the main


### PR DESCRIPTION
**This requires PR #2170**.

### Testing Notes

As of this PR, the expected behavior is that there is a single migration that takes around 5 to 10 minutes to complete after which it will no longer be possible to downgrade.

As the warning above notes, if you try to run an older software version after this migration has completed, you will get an error message similar to `Unable to start server: the current blockchain database is no longer compatible with this version of the software (7 > 6)`

---

This adds code to migrate the database to the new schema required by the decentralized treasury implementation.

It involves updating the utxo set and spend journal entries to account for the change of the position of the fully spent bit within the flags from bit 4 to bit 6.  The process can be interrupted at any point and future invocations will resume from the point it was interrupted.
