### PR TITLE
main: Unexport main package exports.

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -240,8 +240,8 @@ type headerNode struct {
 	hash   *chainhash.Hash
 }
 
-// PeerNotifier provides an interface for server peer notifications.
-type PeerNotifier interface {
+// peerNotifier provides an interface for server peer notifications.
+type peerNotifier interface {
 	// AnnounceNewTransactions generates and relays inventory vectors and
 	// notifies websocket clients of the passed transactions.
 	AnnounceNewTransactions(txns []*dcrutil.Tx)
@@ -261,7 +261,7 @@ type PeerNotifier interface {
 
 // blockManangerConfig is a configuration struct for a blockManager.
 type blockManagerConfig struct {
-	PeerNotifier PeerNotifier
+	PeerNotifier peerNotifier
 	TimeSource   blockchain.MedianTimeSource
 
 	// The following fields are for accessing the chain and its configuration.


### PR DESCRIPTION
This ensures that all code in the `main` package of root module is not exported since none of it should be accessed outside of the `main` package itself.

While here, it also updates the `NAT ` `discover` func to avoid using named variables which ensures error are not shadowed and eaten.