### PR TITLE
sampleconfig: Make constant a function instead.

### DIFF
--- a/config.go
+++ b/config.go
@@ -456,7 +456,7 @@ func createDefaultConfigFile(destPath string) error {
 	// file contents with their generated values.
 	rpcUserRE := regexp.MustCompile(`(?m)^;\s*rpcuser=[^\s]*$`)
 	rpcPassRE := regexp.MustCompile(`(?m)^;\s*rpcpass=[^\s]*$`)
-	s := rpcUserRE.ReplaceAllString(sampleconfig.FileContents, rpcUserLine)
+	s := rpcUserRE.ReplaceAllString(sampleconfig.FileContents(), rpcUserLine)
 	s = rpcPassRE.ReplaceAllString(s, rpcPassLine)
 
 	// Create config file at the provided path.

--- a/sampleconfig/README.md
+++ b/sampleconfig/README.md
@@ -5,7 +5,7 @@ sampleconfig
 [![ISC License](https://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
 [![Doc](https://img.shields.io/badge/doc-reference-blue.svg)](https://pkg.go.dev/github.com/decred/dcrd/sampleconfig)
 
-Package sampleconfig provides a single constant that contains the contents of
+Package sampleconfig provides a single function that returns the contents of
 the sample configuration file for dcrd.  This is provided for tools that perform
 automatic configuration and would like to ensure the generated configuration
 file not only includes the specifically configured values, but also provides

--- a/sampleconfig/doc.go
+++ b/sampleconfig/doc.go
@@ -1,9 +1,9 @@
-// Copyright (c) 2017 The Decred developers
+// Copyright (c) 2017-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 /*
-Package sampleconfig provides a single constant that contains the contents of
+Package sampleconfig provides a single function that returns the contents of
 the sample configuration file for dcrd.  This is provided for tools that perform
 automatic configuration and would like to ensure the generated configuration
 file not only includes the specifically configured values, but also provides

--- a/sampleconfig/sampleconfig.go
+++ b/sampleconfig/sampleconfig.go
@@ -1,11 +1,11 @@
-// Copyright (c) 2017 The Decred developers
+// Copyright (c) 2017-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package sampleconfig
 
-// FileContents is a string containing the commented example config for dcrd.
-const FileContents = `[Application Options]
+// fileContents is a string containing the commented example config for dcrd.
+const fileContents = `[Application Options]
 
 ; ------------------------------------------------------------------------------
 ; Data settings
@@ -411,3 +411,9 @@ const DcrctlSampleConfig = `[Application Options]
 ; RPC server certificate chain file for validation
 ; rpccert=~/.dcrd/rpc.cert
 `
+
+// FileContents returns a string containing the commented example config for
+// dcrd.
+func FileContents() string {
+	return fileContents
+}


### PR DESCRIPTION
This modifies the `sampleconfig` package to contain a single function named `FileContents` instead of a constant.

This is being done because changing a constant is technically a major semver breaking change while changing the contents returned by a function is not and the goal is to ultimately make the root module semver compliant.