### PR TITLE
blockchain: Add test func to remove deployment.

### DIFF
--- a/blockchain/common_test.go
+++ b/blockchain/common_test.go
@@ -253,7 +253,7 @@ func findDeployment(params *chaincfg.Params, voteID string) (uint32, *chaincfg.C
 		}
 	}
 
-	return 0, nil, fmt.Errorf("unable to find deployement for id %q", voteID)
+	return 0, nil, fmt.Errorf("unable to find deployment for id %q", voteID)
 }
 
 // findDeploymentChoice finds the provided choice ID within the given
@@ -268,6 +268,33 @@ func findDeploymentChoice(deployment *chaincfg.ConsensusDeployment, choiceID str
 	}
 
 	return nil, fmt.Errorf("unable to find vote choice for id %q", choiceID)
+}
+
+// Make the linter happy.  This should be removed once the function is actually
+// used.
+var _ = removeDeployment
+
+// removeDeployment modifies the passed parameters to remove all deployments for
+// the provided vote ID.  An error is returned when not found.
+func removeDeployment(params *chaincfg.Params, voteID string) error {
+	// Remove the deployment(s) for the passed vote ID.
+	var found bool
+	for version, deployments := range params.Deployments {
+		for i, deployment := range deployments {
+			if deployment.Vote.Id == voteID {
+				copy(deployments[i:], deployments[i+1:])
+				deployments[len(deployments)-1] = chaincfg.ConsensusDeployment{}
+				deployments = deployments[:len(deployments)-1]
+				params.Deployments[version] = deployments
+				found = true
+			}
+		}
+	}
+	if found {
+		return nil
+	}
+
+	return fmt.Errorf("unable to find deployment for id %q", voteID)
 }
 
 // removeDeploymentTimeConstraints modifies the passed deployment to remove the


### PR DESCRIPTION
This adds a function to the common test infrastructure to remove deployments for a given vote ID from parameters for use in testing cases where it is useful to ensure behavior is correct on networks for which an agenda is already active before heights that are not possible to hit when the agenda has to be voted in.

Note that it is intentionally unused at this point, but future commits will make use of it.

