### PR TITLE
chaincfg: Make simnet votes standard txs

### DIFF
--- a/chaincfg/simnetparams.go
+++ b/chaincfg/simnetparams.go
@@ -174,7 +174,7 @@ func SimNetParams() *Params {
 		MaxFreshStakePerBlock:   20,            // 4*TicketsPerBlock
 		StakeEnabledHeight:      16 + 16,       // CoinbaseMaturity + TicketMaturity
 		StakeValidationHeight:   16 + (64 * 2), // CoinbaseMaturity + TicketPoolSize*2
-		StakeBaseSigScript:      []byte{0xDE, 0xAD, 0xBE, 0xEF},
+		StakeBaseSigScript:      []byte{0x00, 0x00},
 		StakeMajorityMultiplier: 3,
 		StakeMajorityDivisor:    4,
 


### PR DESCRIPTION
This allows simnet nodes to run with --rejectnonstd and still receive
votes and advance the network past SVH.

Previously the simnet used a non-push-only signature script, so this
conflicted with the --rejectnonstd mempool policy.

Note that after this change, a corresponding bump in dcrwallet's go.mod is needed to run simnet setups that advance past SVH. A dcrwallet PR will be provided once a final version of this PR is merged.