### PR TITLE
multi: Add initialstate peer messages.

### DIFF
--- a/peer/go.mod
+++ b/peer/go.mod
@@ -17,4 +17,5 @@ replace (
 	github.com/decred/dcrd/dcrec/secp256k1/v3 => ../dcrec/secp256k1
 	github.com/decred/dcrd/dcrutil/v3 => ../dcrutil
 	github.com/decred/dcrd/txscript/v3 => ../txscript
+	github.com/decred/dcrd/wire => ../wire
 )

--- a/peer/go.sum
+++ b/peer/go.sum
@@ -16,8 +16,6 @@ github.com/decred/dcrd/dcrec/edwards/v2 v2.0.0 h1:E5KszxGgpjpmW8vN811G6rBAZg0/S/
 github.com/decred/dcrd/dcrec/edwards/v2 v2.0.0/go.mod h1:d0H8xGMWbiIQP7gN3v2rByWUcuZPm9YsgmnfoxgbINc=
 github.com/decred/dcrd/lru v1.0.0 h1:Kbsb1SFDsIlaupWPwsPp+dkxiBY1frcS07PCPgotKz8=
 github.com/decred/dcrd/lru v1.0.0/go.mod h1:mxKOwFd7lFjN2GZYsiz/ecgqR6kkYAl+0pz0tEMk218=
-github.com/decred/dcrd/wire v1.3.0 h1:X76I2/a8esUmxXmFpJpAvXEi014IA4twgwcOBeIS8lE=
-github.com/decred/dcrd/wire v1.3.0/go.mod h1:fnKGlUY2IBuqnpxx5dYRU5Oiq392OBqAuVjRVSkIoXM=
 github.com/decred/go-socks v1.1.0 h1:dnENcc0KIqQo3HSXdgboXAHgqsCIutkqq6ntQjYtm2U=
 github.com/decred/go-socks v1.1.0/go.mod h1:sDhHqkZH0X4JjSa02oYOGhcGHYp12FsY1jQ/meV8md0=
 github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=

--- a/peer/log.go
+++ b/peer/log.go
@@ -190,6 +190,15 @@ func messageSummary(msg wire.Message) string {
 			summary += fmt.Sprintf(", hash %v", msg.Hash)
 		}
 		return summary
+
+	case *wire.MsgGetInitState:
+		return fmt.Sprintf("types %v", msg.Types)
+
+	case *wire.MsgInitState:
+		return fmt.Sprintf("blockHashes %d, voteHashes %d, tspendHashes %d",
+			len(msg.BlockHashes), len(msg.VoteHashes),
+			len(msg.TSpendHashes))
+
 	}
 
 	// No summary for other messages.

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// MaxProtocolVersion is the max protocol version the peer supports.
-	MaxProtocolVersion = wire.CFilterV2Version
+	MaxProtocolVersion = wire.InitStateVersion
 
 	// outputBufferSize is the number of elements the output channels use.
 	outputBufferSize = 5000
@@ -191,6 +191,13 @@ type MessageListeners struct {
 	// OnSendHeaders is invoked when a peer receives a sendheaders wire
 	// message.
 	OnSendHeaders func(p *Peer, msg *wire.MsgSendHeaders)
+
+	// OnGetInitState is invoked when a peer receives a getinitstate wire
+	// message.
+	OnGetInitState func(p *Peer, msg *wire.MsgGetInitState)
+
+	// OnInitState is invoked when a peer receives an initstate message.
+	OnInitState func(p *Peer, msg *wire.MsgInitState)
 
 	// OnRead is invoked when a peer receives a wire message.  It consists
 	// of the number of bytes read, the message, and whether or not an error
@@ -1112,6 +1119,9 @@ func (p *Peer) maybeAddDeadline(pendingResponses map[string]time.Time, msgCmd st
 
 	case wire.CmdGetMiningState:
 		pendingResponses[wire.CmdMiningState] = deadline
+
+	case wire.CmdGetInitState:
+		pendingResponses[wire.CmdInitState] = deadline
 	}
 }
 
@@ -1464,6 +1474,16 @@ out:
 		case *wire.MsgCFilterV2:
 			if p.cfg.Listeners.OnCFilterV2 != nil {
 				p.cfg.Listeners.OnCFilterV2(p, msg)
+			}
+
+		case *wire.MsgGetInitState:
+			if p.cfg.Listeners.OnGetInitState != nil {
+				p.cfg.Listeners.OnGetInitState(p, msg)
+			}
+
+		case *wire.MsgInitState:
+			if p.cfg.Listeners.OnInitState != nil {
+				p.cfg.Listeners.OnInitState(p, msg)
 			}
 
 		default:

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -405,6 +405,12 @@ func TestPeerListeners(t *testing.T) {
 			OnCFilterV2: func(p *Peer, msg *wire.MsgCFilterV2) {
 				ok <- msg
 			},
+			OnGetInitState: func(p *Peer, msg *wire.MsgGetInitState) {
+				ok <- msg
+			},
+			OnInitState: func(p *Peer, msg *wire.MsgInitState) {
+				ok <- msg
+			},
 		},
 		UserAgentName:    "peer",
 		UserAgentVersion: "1.0",
@@ -553,6 +559,14 @@ func TestPeerListeners(t *testing.T) {
 		{
 			"OnSendHeaders",
 			wire.NewMsgSendHeaders(),
+		},
+		{
+			"OnGetInitState",
+			wire.NewMsgGetInitState(),
+		},
+		{
+			"OnInitState",
+			wire.NewMsgInitState(),
 		},
 	}
 	t.Logf("Running %d tests", len(tests))

--- a/wire/error.go
+++ b/wire/error.go
@@ -121,6 +121,18 @@ const (
 	// ErrMalformedStrictString is returned when a string that has strict
 	// formatting requirements does not conform to the requirements.
 	ErrMalformedStrictString
+
+	// ErrTooManyInitialStateTypes is returned when the number of initial
+	// state types is larger than the maximum allowed by the protocol.
+	ErrTooManyInitStateTypes
+
+	// ErrInitialStateTypeTooLong is returned when an individual initial
+	// state type is longer than allowed by the protocol.
+	ErrInitStateTypeTooLong
+
+	// ErrTooManyTSpends is returned when the number of tspend hashes
+	// exceeds the maximum allowed.
+	ErrTooManyTSpends
 )
 
 // Map of ErrorCode values back to their constant names for pretty printing.
@@ -153,6 +165,9 @@ var errorCodeStrings = map[ErrorCode]string{
 	ErrUserAgentTooLong:              "ErrUserAgentTooLong",
 	ErrTooManyFilterHeaders:          "ErrTooManyFilterHeaders",
 	ErrMalformedStrictString:         "ErrMalformedStrictString",
+	ErrTooManyInitStateTypes:         "ErrTooManyInitStateTypes",
+	ErrInitStateTypeTooLong:          "ErrInitStateTypeTooLong",
+	ErrTooManyTSpends:                "ErrTooManyTSpends",
 }
 
 // String returns the ErrorCode as a human-readable name.

--- a/wire/error_test.go
+++ b/wire/error_test.go
@@ -47,6 +47,10 @@ func TestMessageErrorCodeStringer(t *testing.T) {
 		{ErrUserAgentTooLong, "ErrUserAgentTooLong"},
 		{ErrTooManyFilterHeaders, "ErrTooManyFilterHeaders"},
 		{ErrMalformedStrictString, "ErrMalformedStrictString"},
+		{ErrTooManyInitStateTypes, "ErrTooManyInitStateTypes"},
+		{ErrInitStateTypeTooLong, "ErrInitStateTypeTooLong"},
+		{ErrTooManyTSpends, "ErrTooManyTSpends"},
+
 		{0xffff, "Unknown ErrorCode (65535)"},
 	}
 

--- a/wire/message.go
+++ b/wire/message.go
@@ -56,6 +56,8 @@ const (
 	CmdCFTypes        = "cftypes"
 	CmdGetCFilterV2   = "getcfilterv2"
 	CmdCFilterV2      = "cfilterv2"
+	CmdGetInitState   = "getinitstate"
+	CmdInitState      = "initstate"
 )
 
 // Message is an interface that describes a Decred message.  A type that
@@ -159,6 +161,12 @@ func makeEmptyMessage(command string) (Message, error) {
 
 	case CmdCFilterV2:
 		msg = &MsgCFilterV2{}
+
+	case CmdGetInitState:
+		msg = &MsgGetInitState{}
+
+	case CmdInitState:
+		msg = &MsgInitState{}
 
 	default:
 		str := fmt.Sprintf("unhandled command [%s]", command)

--- a/wire/message_test.go
+++ b/wire/message_test.go
@@ -78,6 +78,8 @@ func TestMessage(t *testing.T) {
 	msgCFHeaders := NewMsgCFHeaders()
 	msgCFTypes := NewMsgCFTypes([]FilterType{GCSFilterExtended})
 	msgReject := NewMsgReject("block", RejectDuplicate, "duplicate block")
+	msgGetInitState := NewMsgGetInitState()
+	msgInitState := NewMsgInitState()
 
 	tests := []struct {
 		in     Message     // Value to encode
@@ -108,6 +110,8 @@ func TestMessage(t *testing.T) {
 		{msgCFilter, msgCFilter, pver, MainNet, 65},           // [24]
 		{msgCFHeaders, msgCFHeaders, pver, MainNet, 58},       // [25]
 		{msgCFTypes, msgCFTypes, pver, MainNet, 26},           // [26]
+		{msgGetInitState, msgGetInitState, pver, MainNet, 25}, // [27]
+		{msgInitState, msgInitState, pver, MainNet, 27},       // [28]
 	}
 
 	t.Logf("Running %d tests", len(tests))

--- a/wire/msggetinitstate.go
+++ b/wire/msggetinitstate.go
@@ -1,0 +1,186 @@
+// Copyright (c) 2020 The decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"fmt"
+	"io"
+)
+
+const (
+	// MaxInitStateTypeLen is the maximum length allowable for an
+	// individual requested type.
+	MaxInitStateTypeLen = 32
+
+	// MaxInitStateTypes is the maximum number of individual types stored
+	// in a getinitialstate message.
+	MaxInitStateTypes = 32
+
+	// InitStateHeadBlocks is the init state type used to request head
+	// blocks for mining.
+	InitStateHeadBlocks = "headblocks"
+
+	// InitStateHeadBlockVotes is the init state type used to request votes
+	// for the head blocks for mining.
+	InitStateHeadBlockVotes = "headblockvotes"
+
+	// InitStateTSpends is the init state type used to request tpends for
+	// voting.
+	InitStateTSpends = "tspends"
+)
+
+// MsgGetInitState implements the Message interface and represents a
+// getinitstate message. It is used to request ephemeral, startup state from a
+// peer.
+//
+// The specific desired information is specified in individual entries in the
+// Types member.
+type MsgGetInitState struct {
+	Types []string
+}
+
+// AddType adds the specified type to the list of types stored in the message.
+// If an attempt to store more than MaxInitStateTypes is made, this function
+// returns an error.
+//
+// Only ascii strings up to MaxInitStateTypeLen may be stored.
+func (msg *MsgGetInitState) AddType(typ string) error {
+	const op = "MsgGetInitState.AddType"
+	lenTyp := len(typ)
+	if lenTyp > MaxInitStateTypeLen {
+		msg := fmt.Sprintf("individual initial state type is "+
+			"too long [len %d, max %d]", lenTyp,
+			MaxInitStateTypeLen)
+		return messageError(op, ErrInitStateTypeTooLong, msg)
+	}
+
+	if !isStrictAscii(typ) {
+		msg := "individual initial state type is not strict ASCII"
+		return messageError(op, ErrMalformedStrictString, msg)
+	}
+
+	nbTypes := uint64(len(msg.Types))
+	if nbTypes >= uint64(MaxInitStateTypes) {
+		msg := fmt.Sprintf("too many requested types for message "+
+			"[count %d, max %d]", nbTypes, MaxInitStateTypes)
+		return messageError(op, ErrTooManyInitStateTypes, msg)
+	}
+
+	msg.Types = append(msg.Types, typ)
+	return nil
+}
+
+// AddTypes adds all the specified types or returns the first error. See
+// AddType for limitations on individual type strings.
+func (msg *MsgGetInitState) AddTypes(types ...string) error {
+	for _, typ := range types {
+		if err := msg.AddType(typ); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// BtcDecode decodes r using the Decred protocol encoding into the receiver.
+// This is part of the Message interface implementation.
+func (msg *MsgGetInitState) BtcDecode(r io.Reader, pver uint32) error {
+	const op = "MsgGetInitState.BtcDecode"
+	if pver < InitStateVersion {
+		msg := fmt.Sprintf("%s message invalid for protocol version %d",
+			msg.Command(), pver)
+		return messageError(op, ErrMsgInvalidForPVer, msg)
+	}
+
+	nbTypes, err := ReadVarInt(r, pver)
+	if err != nil {
+		return err
+	}
+	if nbTypes > MaxInitStateTypes {
+		msg := fmt.Sprintf("too many types for message "+
+			"[count %d, max %d]", nbTypes, MaxInitStateTypes)
+		return messageError(op, ErrTooManyInitStateTypes, msg)
+	}
+
+	msg.Types = make([]string, nbTypes)
+	for i := 0; i < int(nbTypes); i++ {
+		msg.Types[i], err = ReadAsciiVarString(r, pver, MaxInitStateTypeLen)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// BtcEncode encodes the receiver to w using the Decred protocol encoding.
+// This is part of the Message interface implementation.
+func (msg *MsgGetInitState) BtcEncode(w io.Writer, pver uint32) error {
+	const op = "MsgGetInitState.BtcEncode"
+	if pver < InitStateVersion {
+		msg := fmt.Sprintf("%s message invalid for protocol version %d",
+			msg.Command(), pver)
+		return messageError(op, ErrMsgInvalidForPVer, msg)
+	}
+
+	nbTypes := uint64(len(msg.Types))
+	if nbTypes > uint64(MaxInitStateTypes) {
+		msg := fmt.Sprintf("too many requested types for message "+
+			"[count %d max %d]", nbTypes, MaxInitStateTypes)
+		return messageError(op, ErrTooManyInitStateTypes, msg)
+	}
+	err := WriteVarInt(w, pver, nbTypes)
+	if err != nil {
+		return err
+	}
+
+	for _, typ := range msg.Types {
+		lenTyp := len(typ)
+		if lenTyp > MaxInitStateTypeLen {
+			msg := fmt.Sprintf("individual initial state type is "+
+				"too long [len %d, max %d]", lenTyp,
+				MaxInitStateTypeLen)
+			return messageError(op, ErrInitStateTypeTooLong, msg)
+		}
+
+		if !isStrictAscii(typ) {
+			msg := "individual initial state type is not strict ASCII"
+			return messageError(op, ErrMalformedStrictString, msg)
+		}
+		err := WriteVarString(w, pver, typ)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Command returns the protocol command string for the message.  This is part
+// of the Message interface implementation.
+func (msg *MsgGetInitState) Command() string {
+	return CmdGetInitState
+}
+
+// MaxPayloadLength returns the maximum length the payload can be for the
+// receiver.  This is part of the Message interface implementation.
+func (msg *MsgGetInitState) MaxPayloadLength(pver uint32) uint32 {
+	if pver < InitStateVersion {
+		return 0
+	}
+
+	// maxLenType is the max length of a single serialized type.
+	maxLenType := VarIntSerializeSize(MaxInitStateTypeLen) +
+		MaxInitStateTypeLen
+	return uint32(VarIntSerializeSize(MaxInitStateTypes) +
+		MaxInitStateTypes*maxLenType)
+}
+
+// NewMsgGetInitState returns a new Decred getinitialstate message that
+// conforms to the Message interface.  See MsgGetInitState for details.
+func NewMsgGetInitState() *MsgGetInitState {
+	return &MsgGetInitState{
+		Types: make([]string, 0, MaxInitStateTypes),
+	}
+}

--- a/wire/msggetinitstate_test.go
+++ b/wire/msggetinitstate_test.go
@@ -1,0 +1,237 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+// TestGetInitState tests the MsgGetInitState API.
+func TestGetInitState(t *testing.T) {
+	pver := ProtocolVersion
+
+	// Ensure Command() returns the expected value.
+	wantCmd := "getinitstate"
+	msg := NewMsgGetInitState()
+	if cmd := msg.Command(); cmd != wantCmd {
+		t.Errorf("NewMsgInitMsg: wrong command - got %v, want %v",
+			cmd, wantCmd)
+	}
+
+	// Ensure max payload returns the expected value for latest protocol
+	// version. Num types (varInt) 1 byte + n var strings with max len.
+	wantPayload := uint32(1 + 32*(32+1))
+	maxPayload := msg.MaxPayloadLength(pver)
+	if maxPayload != wantPayload {
+		t.Errorf("MaxPayloadLength: wrong max payload length for "+
+			"protocol version %d - got %v, want %v", pver,
+			maxPayload, wantPayload)
+	}
+
+	// Ensure max payload length is not more than MaxMessagePayload.
+	if maxPayload > MaxMessagePayload {
+		t.Fatalf("MaxPayloadLength: payload length (%v) for protocol "+
+			"version %d exceeds MaxMessagePayload (%v).", maxPayload, pver,
+			MaxMessagePayload)
+	}
+
+	// Ensure AddType returns an error when trying to add an invalid type.
+	longType := strings.Repeat("x", 33)
+	if err := msg.AddType(longType); !errors.Is(err, ErrInitStateTypeTooLong) {
+		t.Fatalf("AddType: unexpeted error - got=%v, want %v",
+			err, ErrInitStateTypeTooLong)
+	}
+	nonAscii := "á"
+	if err := msg.AddType(nonAscii); !errors.Is(err, ErrMalformedStrictString) {
+		t.Fatalf("AddType: unexpeted error - got=%v, want=%v",
+			err, ErrMalformedStrictString)
+	}
+
+	// Ensure AddType adds up to the maximum allowed.
+	for i := 0; i < MaxInitStateTypes; i++ {
+		if err := msg.AddType(""); err != nil {
+			t.Fatalf("AddType: unable to add max number of entries: %v", err)
+		}
+	}
+
+	// Ensure AddType does _not_ add one more than the maximum allowed.
+	if err := msg.AddType(""); !errors.Is(err, ErrTooManyInitStateTypes) {
+		t.Fatalf("AddType: unexpected error - got=%v, want=%v",
+			err, ErrTooManyInitStateTypes)
+	}
+}
+
+// TestGetInitStateWire tests the MsgGetInitState wire encode and decode for
+// various numbers of types.
+func TestGetInitStateWire(t *testing.T) {
+	pver := ProtocolVersion
+
+	// MsgGetInitState message with no types.
+	noTypes := NewMsgGetInitState()
+	noTypesEncoded := []byte{
+		0x00, // Varint for number of types
+	}
+
+	// MsgGetInitState message with multiple types.
+	multiTypes := NewMsgGetInitState()
+	multiTypes.AddType("first")
+	multiTypes.AddType("second")
+	multiTypes.AddType("third")
+	multiTypesEncoded := []byte{
+		0x03, // Varint for number of types
+		0x05, // Varint for first type
+		'f', 'i', 'r', 's', 't',
+		0x06, // Varint for second type
+		's', 'e', 'c', 'o', 'n', 'd',
+		0x05, // Varint for third type
+		't', 'h', 'i', 'r', 'd',
+	}
+
+	tests := []struct {
+		in   *MsgGetInitState // Message to encode
+		out  *MsgGetInitState // Expected decoded message
+		buf  []byte           // Wire encoding
+		pver uint32           // Protocol version for wire encoding
+	}{{
+		in:   noTypes,
+		out:  noTypes,
+		buf:  noTypesEncoded,
+		pver: pver,
+	}, {
+		in:   multiTypes,
+		out:  multiTypes,
+		buf:  multiTypesEncoded,
+		pver: pver,
+	}}
+
+	for i, test := range tests {
+		// Encode the message to wire format.
+		var buf bytes.Buffer
+		err := test.in.BtcEncode(&buf, test.pver)
+		if err != nil {
+			t.Errorf("BtcEncode #%d error %v", i, err)
+			continue
+		}
+		if !bytes.Equal(buf.Bytes(), test.buf) {
+			t.Errorf("BtcEncode #%d - got %s, want: %s", i,
+				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
+			continue
+		}
+
+		// Decode the message from wire format.
+		var msg MsgGetInitState
+		rbuf := bytes.NewReader(test.buf)
+		err = msg.BtcDecode(rbuf, test.pver)
+		if err != nil {
+			t.Errorf("BtcDecode #%d error %v", i, err)
+			continue
+		}
+		if !reflect.DeepEqual(&msg, test.out) {
+			t.Errorf("BtcDecode #%d - got %s, want: %s", i,
+				spew.Sdump(&msg), spew.Sdump(test.out))
+			continue
+		}
+	}
+}
+
+// TestGetInitState performs negative tests against wire encode and decode of
+// MsgGetInitState to confirm error paths work correctly.
+func TestGetInitStateWireErrors(t *testing.T) {
+	pver := ProtocolVersion
+
+	baseMsg := NewMsgGetInitState()
+	baseMsg.AddType("first")
+	baseMsg.AddType("second")
+	baseMsg.AddType("third")
+	baseMsgEncoded := []byte{
+		0x03, // Varint for number of types
+		0x05, // Varint for first type
+		'f', 'i', 'r', 's', 't',
+		0x06, // Varint for second type
+		's', 'e', 'c', 'o', 'n', 'd',
+		0x05, // Varint for third type
+		't', 'h', 'i', 'r', 'd',
+	}
+
+	// Message that forces an error by having more than the max allowed
+	// number of types.
+	maxTypes := NewMsgGetInitState()
+	maxTypes.Types = make([]string, MaxInitStateTypes+1)
+	maxTypesEncoded := []byte{
+		0xfc, // Varint for number of types
+	}
+
+	// Message that forces an error by trying to encode a longer than
+	// allowed type.
+	longType := NewMsgGetInitState()
+	longType.Types = []string{strings.Repeat("a", MaxInitStateTypeLen+1)}
+	longTypeEncoded := []byte{
+		0x01, // Varint for number of types
+		0xfc, // Varint for first type
+	}
+
+	// Message that forces an error by trying to encode a type with invalid
+	// characters.
+	nonAsciiType := NewMsgGetInitState()
+	nonAsciiType.Types = []string{"á"}
+	nonAsciiTypeEncoded := []byte{
+		0x01, // Varint for number of types
+		0x01, // Varint for first type
+		'á',
+	}
+
+	tests := []struct {
+		in       *MsgGetInitState // Value to encode
+		buf      []byte           // Wire encoding
+		pver     uint32           // Protocol version for wire encoding
+		max      int              // Max size of fixed buffer to induce errors
+		writeErr error            // Expected write error
+		readErr  error            // Expected read error
+	}{
+		// Force error in number of types varint.
+		{baseMsg, baseMsgEncoded, pver, 0, io.ErrShortWrite, io.EOF},
+		// Force error in first var string len.
+		{baseMsg, baseMsgEncoded, pver, 1, io.ErrShortWrite, io.EOF},
+		// Force error in first string varint.
+		{baseMsg, baseMsgEncoded, pver, 3, io.ErrShortWrite, io.ErrUnexpectedEOF},
+		// Force error in first string.
+		{baseMsg, baseMsgEncoded, pver, 4, io.ErrShortWrite, io.ErrUnexpectedEOF},
+		// Force error with greater than allowed number of types.
+		{maxTypes, maxTypesEncoded, pver, 2, ErrTooManyInitStateTypes, ErrTooManyInitStateTypes},
+		// Force error with longer than allowed type.
+		{longType, longTypeEncoded, pver, 3, ErrInitStateTypeTooLong, ErrVarStringTooLong},
+		// Force error with non-ascii type.
+		{nonAsciiType, nonAsciiTypeEncoded, pver, 3, ErrMalformedStrictString, ErrMalformedStrictString},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		// Encode to wire format.
+		w := newFixedWriter(test.max)
+		err := test.in.BtcEncode(w, test.pver)
+		if !errors.Is(err, test.writeErr) {
+			t.Errorf("BtcEncode #%d wrong error - got %v, want: %v", i, err,
+				test.writeErr)
+			continue
+		}
+
+		// Decode from wire format.
+		var msg MsgGetInitState
+		r := newFixedReader(test.max, test.buf)
+		err = msg.BtcDecode(r, test.pver)
+		if !errors.Is(err, test.readErr) {
+			t.Errorf("BtcDecode #%d wrong error - got %v, want: %v", i, err,
+				test.readErr)
+			continue
+		}
+	}
+}

--- a/wire/msginitstate.go
+++ b/wire/msginitstate.go
@@ -1,0 +1,290 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/decred/dcrd/chaincfg/chainhash"
+)
+
+// MaxISBlocksAtHeadPerMsg is the maximum number of block hashes allowed per
+// message.
+const MaxISBlocksAtHeadPerMsg = 8
+
+// MaxISVotesAtHeadPerMsg is the maximum number of votes at head per message.
+const MaxISVotesAtHeadPerMsg = 40 // 8 * 5
+
+// MaxISTSpendsAtHeadPerMsg is the maximum number of tspends at head per
+// message.
+const MaxISTSpendsAtHeadPerMsg = 7
+
+// MsgInitState implements the Message interface and represents an initial
+// state message.  It is used to receive ephemeral startup information from a
+// remote peer, such as blocks that can be mined upon, votes for such blocks
+// and tspends.
+//
+// The content of such a message depends upon what the local peer requested
+// during a previous GetInitState msg.
+type MsgInitState struct {
+	BlockHashes  []chainhash.Hash
+	VoteHashes   []chainhash.Hash
+	TSpendHashes []chainhash.Hash
+}
+
+// AddBlockHash adds a new block hash to the message. Up to
+// MaxISBlocksAtHeadPerMsg may be added before this function errors out.
+func (msg *MsgInitState) AddBlockHash(hash *chainhash.Hash) error {
+	const op = "MsgInitState.AddBlockHash"
+	if len(msg.BlockHashes)+1 > MaxISBlocksAtHeadPerMsg {
+		msg := fmt.Sprintf("too many block hashes for message [max %v]",
+			MaxISBlocksAtHeadPerMsg)
+		return messageError(op, ErrTooManyHeaders, msg)
+	}
+
+	msg.BlockHashes = append(msg.BlockHashes, *hash)
+	return nil
+}
+
+// AddVoteHash adds a new vote hash to the message. Up to
+// MaxISVotesAtHeadPerMsg may be added before this function errors out.
+func (msg *MsgInitState) AddVoteHash(hash *chainhash.Hash) error {
+	const op = "MsgInitState.AddVoteHash"
+	if len(msg.VoteHashes)+1 > MaxISVotesAtHeadPerMsg {
+		msg := fmt.Sprintf("too many vote hashes for message [max %v]",
+			MaxISVotesAtHeadPerMsg)
+		return messageError(op, ErrTooManyVotes, msg)
+	}
+
+	msg.VoteHashes = append(msg.VoteHashes, *hash)
+	return nil
+}
+
+// AddTSpend adds a new tspend hash to the message. Up to
+// MaxISTSpendsAtHeadPerMsg may be added before this function errors out.
+func (msg *MsgInitState) AddTSpendHash(hash *chainhash.Hash) error {
+	const op = "MsgInitState.AddTSpendHash"
+	if len(msg.TSpendHashes)+1 > MaxISTSpendsAtHeadPerMsg {
+		msg := fmt.Sprintf("too many tspend hashes for message [max %v]",
+			MaxISTSpendsAtHeadPerMsg)
+		return messageError(op, ErrTooManyTSpends, msg)
+	}
+
+	msg.TSpendHashes = append(msg.TSpendHashes, *hash)
+	return nil
+}
+
+// BtcDecode decodes r using the protocol encoding into the receiver.
+// This is part of the Message interface implementation.
+func (msg *MsgInitState) BtcDecode(r io.Reader, pver uint32) error {
+	const op = "MsgInitState.BtcDecode"
+	if pver < InitStateVersion {
+		msg := fmt.Sprintf("%s message invalid for protocol version %d",
+			msg.Command(), pver)
+		return messageError(op, ErrMsgInvalidForPVer, msg)
+	}
+
+	// Read num block hashes and limit to max.
+	count, err := ReadVarInt(r, pver)
+	if err != nil {
+		return err
+	}
+	if count > MaxISBlocksAtHeadPerMsg {
+		msg := fmt.Sprintf("too many block hashes for message "+
+			"[count %v, max %v]", count, MaxISBlocksAtHeadPerMsg)
+		return messageError(op, ErrTooManyBlocks, msg)
+	}
+
+	msg.BlockHashes = make([]chainhash.Hash, count)
+	for i := uint64(0); i < count; i++ {
+		err := readElement(r, &msg.BlockHashes[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	// Read num vote hashes and limit to max.
+	count, err = ReadVarInt(r, pver)
+	if err != nil {
+		return err
+	}
+	if count > MaxISVotesAtHeadPerMsg {
+		msg := fmt.Sprintf("too many vote hashes for message "+
+			"[count %v, max %v]", count, MaxISVotesAtHeadPerMsg)
+		return messageError(op, ErrTooManyVotes, msg)
+	}
+
+	msg.VoteHashes = make([]chainhash.Hash, count)
+	for i := uint64(0); i < count; i++ {
+		err := readElement(r, &msg.VoteHashes[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	// Read num tspend hashes and limit to max.
+	count, err = ReadVarInt(r, pver)
+	if err != nil {
+		return err
+	}
+	if count > MaxISTSpendsAtHeadPerMsg {
+		msg := fmt.Sprintf("too many tspend hashes for message "+
+			"[count %v, max %v]", count, MaxISTSpendsAtHeadPerMsg)
+		return messageError(op, ErrTooManyTSpends, msg)
+	}
+
+	msg.TSpendHashes = make([]chainhash.Hash, count)
+	for i := uint64(0); i < count; i++ {
+		err := readElement(r, &msg.TSpendHashes[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// BtcEncode encodes the receiver to w using the protocol encoding.
+// This is part of the Message interface implementation.
+func (msg *MsgInitState) BtcEncode(w io.Writer, pver uint32) error {
+	const op = "MsgInitState.BtcEncode"
+	if pver < InitStateVersion {
+		msg := fmt.Sprintf("%s message invalid for protocol version %d",
+			msg.Command(), pver)
+		return messageError(op, ErrMsgInvalidForPVer, msg)
+	}
+
+	// Write block hashes.
+	count := len(msg.BlockHashes)
+	if count > MaxISBlocksAtHeadPerMsg {
+		msg := fmt.Sprintf("too many block hashes for message "+
+			"[count %v, max %v]", count, MaxISBlocksAtHeadPerMsg)
+		return messageError(op, ErrTooManyBlocks, msg)
+	}
+
+	err := WriteVarInt(w, pver, uint64(count))
+	if err != nil {
+		return err
+	}
+
+	for i := range msg.BlockHashes {
+		err = writeElement(w, &msg.BlockHashes[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	// Write vote hashes.
+	count = len(msg.VoteHashes)
+	if count > MaxISVotesAtHeadPerMsg {
+		msg := fmt.Sprintf("too many vote hashes for message "+
+			"[count %v, max %v]", count, MaxISVotesAtHeadPerMsg)
+		return messageError(op, ErrTooManyVotes, msg)
+	}
+
+	err = WriteVarInt(w, pver, uint64(count))
+	if err != nil {
+		return err
+	}
+
+	for i := range msg.VoteHashes {
+		err = writeElement(w, &msg.VoteHashes[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	// Write tspend hashes.
+	count = len(msg.TSpendHashes)
+	if count > MaxISTSpendsAtHeadPerMsg {
+		msg := fmt.Sprintf("too many tspend hashes for message "+
+			"[count %v, max %v]", count, MaxISTSpendsAtHeadPerMsg)
+		return messageError(op, ErrTooManyTSpends, msg)
+	}
+
+	err = WriteVarInt(w, pver, uint64(count))
+	if err != nil {
+		return err
+	}
+
+	for i := range msg.TSpendHashes {
+		err = writeElement(w, &msg.TSpendHashes[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Command returns the protocol command string for the message.  This is part
+// of the Message interface implementation.
+func (msg *MsgInitState) Command() string {
+	return CmdInitState
+}
+
+// MaxPayloadLength returns the maximum length the payload can be for the
+// receiver.  This is part of the Message interface implementation.
+func (msg *MsgInitState) MaxPayloadLength(pver uint32) uint32 {
+	if pver < InitStateVersion {
+		return 0
+	}
+
+	return uint32(VarIntSerializeSize(MaxISBlocksAtHeadPerMsg)) +
+		(MaxISBlocksAtHeadPerMsg * chainhash.HashSize) +
+		uint32(VarIntSerializeSize(MaxISVotesAtHeadPerMsg)) +
+		(MaxISVotesAtHeadPerMsg * chainhash.HashSize) +
+		uint32(VarIntSerializeSize(MaxISTSpendsAtHeadPerMsg)) +
+		(MaxISTSpendsAtHeadPerMsg * chainhash.HashSize)
+}
+
+// NewMsgInitState returns a new Decred initstate message that conforms to the
+// Message interface using the defaults for the fields.
+func NewMsgInitState() *MsgInitState {
+	return &MsgInitState{
+		BlockHashes:  make([]chainhash.Hash, 0, MaxISBlocksAtHeadPerMsg),
+		VoteHashes:   make([]chainhash.Hash, 0, MaxISVotesAtHeadPerMsg),
+		TSpendHashes: make([]chainhash.Hash, 0, MaxISTSpendsAtHeadPerMsg),
+	}
+}
+
+// NewMsgInitStateFilled returns a new Decred initstate message that conforms
+// to the Message interface and fills the message with the provided data. This
+// is useful in situations where the data slices are already built as it avoids
+// performing a second allocation and data copy.
+//
+// The provided slices are checked for their maximum length.
+func NewMsgInitStateFilled(blockHashes []chainhash.Hash, voteHashes []chainhash.Hash,
+	tspendHashes []chainhash.Hash) (*MsgInitState, error) {
+	const op = "NewMsgInitStateFilled"
+
+	count := len(blockHashes)
+	if count > MaxISBlocksAtHeadPerMsg {
+		msg := fmt.Sprintf("too many block hashes for message "+
+			"[count %v, max %v]", count, MaxISBlocksAtHeadPerMsg)
+		return nil, messageError(op, ErrTooManyBlocks, msg)
+	}
+
+	count = len(voteHashes)
+	if count > MaxISVotesAtHeadPerMsg {
+		msg := fmt.Sprintf("too many vote hashes for message "+
+			"[count %v, max %v]", count, MaxISVotesAtHeadPerMsg)
+		return nil, messageError(op, ErrTooManyVotes, msg)
+	}
+
+	count = len(tspendHashes)
+	if count > MaxISTSpendsAtHeadPerMsg {
+		msg := fmt.Sprintf("too many tspend hashes for message "+
+			"[count %v, max %v]", count, MaxISTSpendsAtHeadPerMsg)
+		return nil, messageError(op, ErrTooManyTSpends, msg)
+	}
+
+	return &MsgInitState{
+		BlockHashes:  blockHashes,
+		VoteHashes:   voteHashes,
+		TSpendHashes: tspendHashes,
+	}, nil
+}

--- a/wire/msginitstate_test.go
+++ b/wire/msginitstate_test.go
@@ -1,0 +1,386 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+)
+
+// TestInitState tests the MsgInitState API.
+func TestInitState(t *testing.T) {
+	pver := ProtocolVersion
+
+	// Ensure Command() returns the expected value.
+	wantCmd := "initstate"
+	msg := NewMsgInitState()
+	if cmd := msg.Command(); cmd != wantCmd {
+		t.Errorf("MsgInitMsg: wrong command - got %v, want %v",
+			cmd, wantCmd)
+	}
+
+	// Ensure max payload returns the expected value for latest protocol
+	// version. a var int and n * hashes for each of block, vote and tspend
+	// hashes.
+	wantPayload := uint32((1 + 32*8) + (1 + 32*40) + (1 + 32*7))
+	maxPayload := msg.MaxPayloadLength(pver)
+	if maxPayload != wantPayload {
+		t.Errorf("MaxPayloadLength: wrong max payload length for "+
+			"protocol version %d - got %v, want %v", pver,
+			maxPayload, wantPayload)
+	}
+
+	// Ensure max payload length is not more than MaxMessagePayload.
+	if maxPayload > MaxMessagePayload {
+		t.Fatalf("MaxPayloadLength: payload length (%v) for protocol "+
+			"version %d exceeds MaxMessagePayload (%v).", maxPayload, pver,
+			MaxMessagePayload)
+	}
+
+	var hash chainhash.Hash
+
+	// Ensure AddBlockHash adds up to the maximum allowed.
+	for i := 0; i < MaxISBlocksAtHeadPerMsg; i++ {
+		if err := msg.AddBlockHash(&hash); err != nil {
+			t.Fatalf("AddBlockHash: unable to add max number of entries: %v", err)
+		}
+	}
+
+	// Ensure AddBlockHash does _not_ add one more than the maximum
+	// allowed.
+	if err := msg.AddBlockHash(&hash); !errors.Is(err, ErrTooManyHeaders) {
+		t.Fatalf("AddBlockHash: unexpected error - got=%v, want=%v",
+			err, ErrTooManyHeaders)
+	}
+
+	// Ensure AddVoteHash adds up to the maximum allowed.
+	for i := 0; i < MaxISVotesAtHeadPerMsg; i++ {
+		if err := msg.AddVoteHash(&hash); err != nil {
+			t.Fatalf("AddVoteHash: unable to add max number of entries: %v", err)
+		}
+	}
+
+	// Ensure AddVoteHash does _not_ add one more than the maximum allowed.
+	if err := msg.AddVoteHash(&hash); !errors.Is(err, ErrTooManyVotes) {
+		t.Fatalf("AddVoteHash: unexpected error - got=%v, want=%v",
+			err, ErrTooManyVotes)
+	}
+
+	// Ensure AddTSpendHash adds up to the maximum allowed.
+	for i := 0; i < MaxISTSpendsAtHeadPerMsg; i++ {
+		if err := msg.AddTSpendHash(&hash); err != nil {
+			t.Fatalf("AddTSpendHash: unable to add max number of entries: %v", err)
+		}
+	}
+
+	// Ensure AddTSpendHash does _not_ add one more than the maximum
+	// allowed.
+	if err := msg.AddTSpendHash(&hash); !errors.Is(err, ErrTooManyTSpends) {
+		t.Fatalf("AddTSpendHash: unexpected error - got=%v, want=%v",
+			err, ErrTooManyTSpends)
+	}
+
+	// Ensure NewMsgInitStateFilled returns errors if more than the allowed
+	// for each type of response data is provided.
+	var maxHashes [41]chainhash.Hash
+	_, err := NewMsgInitStateFilled(maxHashes[:MaxISBlocksAtHeadPerMsg+1], nil, nil)
+	if !errors.Is(err, ErrTooManyBlocks) {
+		t.Fatalf("NewMsgInitStateFilled: unexpected error - got=%v, want=%v",
+			err, ErrTooManyBlocks)
+	}
+	_, err = NewMsgInitStateFilled(nil, maxHashes[:MaxISVotesAtHeadPerMsg+1], nil)
+	if !errors.Is(err, ErrTooManyVotes) {
+		t.Fatalf("NewMsgInitStateFilled: unexpected error - got=%v, want=%v",
+			err, ErrTooManyVotes)
+	}
+	_, err = NewMsgInitStateFilled(nil, nil, maxHashes[:MaxISTSpendsAtHeadPerMsg+1])
+	if !errors.Is(err, ErrTooManyTSpends) {
+		t.Fatalf("NewMsgInitStateFilled: unexpected error - got=%v, want=%v",
+			err, ErrTooManyTSpends)
+	}
+}
+
+// TestInitStateWire tests the MsgInitState wire encode and decode for various
+// numbers of responses.
+func TestInitStateWire(t *testing.T) {
+	pver := ProtocolVersion
+
+	// MsgInitState message with no response data.
+	emptyMsg := NewMsgInitState()
+	emptyMsgEncoded := []byte{
+		0x00, // Varint for number of blocks
+		0x00, // Varint for number of votes
+		0x00, // Varint for number of tspends
+	}
+
+	fakeBlock1, _ := chainhash.NewHashFromStr("4433221144332211443322114" +
+		"433221144332211443322114433221144332211")
+	fakeBlock2, _ := chainhash.NewHashFromStr("9300109283044211443383938" +
+		"912083481724918427109238198279148176817")
+	fakeVote1, _ := chainhash.NewHashFromStr("2222111122221111222211112" +
+		"222111122221111222211112222111122221111")
+	fakeVote2, _ := chainhash.NewHashFromStr("4444333344443333444433334" +
+		"444333344443333444433334444333344443333")
+	fakeVote3, _ := chainhash.NewHashFromStr("6666555566665555666655556" +
+		"666555566665555666655556666555566665555")
+	fakeTSpend1, _ := chainhash.NewHashFromStr("88888888888888828282888" +
+		"888888888888888888888888222888831888888")
+	fakeTSpend2, _ := chainhash.NewHashFromStr("9999999999929929999999" +
+		"999999999999999999991199999999999999919")
+	fakeTSpend3, _ := chainhash.NewHashFromStr("aaaaaaaaaaaa9200aaaaaa" +
+		"aaaaaaaaaaaaaaaaaaa9a9a9aaaaaaaaaaaaaaa")
+
+	// MsgInitState message with multiple values for each hash.
+	multiData := NewMsgInitState()
+	multiData.AddBlockHash(fakeBlock1)
+	multiData.AddBlockHash(fakeBlock2)
+	multiData.AddVoteHash(fakeVote1)
+	multiData.AddVoteHash(fakeVote2)
+	multiData.AddVoteHash(fakeVote3)
+	multiData.AddTSpendHash(fakeTSpend1)
+	multiData.AddTSpendHash(fakeTSpend2)
+	multiData.AddTSpendHash(fakeTSpend3)
+
+	multiDataEncoded := []byte{
+		0x02,                                           // Varint for number of block hashes
+		0x11, 0x22, 0x33, 0x44, 0x11, 0x22, 0x33, 0x44, // Fake block 1
+		0x11, 0x22, 0x33, 0x44, 0x11, 0x22, 0x33, 0x44,
+		0x11, 0x22, 0x33, 0x44, 0x11, 0x22, 0x33, 0x44,
+		0x11, 0x22, 0x33, 0x44, 0x11, 0x22, 0x33, 0x44,
+		0x17, 0x68, 0x17, 0x48, 0x91, 0x27, 0x98, 0x81, // Fake block 2
+		0x23, 0x09, 0x71, 0x42, 0x18, 0x49, 0x72, 0x81,
+		0x34, 0x08, 0x12, 0x89, 0x93, 0x83, 0x33, 0x44,
+		0x11, 0x42, 0x04, 0x83, 0x92, 0x10, 0x00, 0x93,
+		0x03,                                           // Varint for number of vote hashes
+		0x11, 0x11, 0x22, 0x22, 0x11, 0x11, 0x22, 0x22, // Fake vote 1
+		0x11, 0x11, 0x22, 0x22, 0x11, 0x11, 0x22, 0x22,
+		0x11, 0x11, 0x22, 0x22, 0x11, 0x11, 0x22, 0x22,
+		0x11, 0x11, 0x22, 0x22, 0x11, 0x11, 0x22, 0x22,
+		0x33, 0x33, 0x44, 0x44, 0x33, 0x33, 0x44, 0x44, // Fake vote 2
+		0x33, 0x33, 0x44, 0x44, 0x33, 0x33, 0x44, 0x44,
+		0x33, 0x33, 0x44, 0x44, 0x33, 0x33, 0x44, 0x44,
+		0x33, 0x33, 0x44, 0x44, 0x33, 0x33, 0x44, 0x44,
+		0x55, 0x55, 0x66, 0x66, 0x55, 0x55, 0x66, 0x66, // Fake vote 3
+		0x55, 0x55, 0x66, 0x66, 0x55, 0x55, 0x66, 0x66,
+		0x55, 0x55, 0x66, 0x66, 0x55, 0x55, 0x66, 0x66,
+		0x55, 0x55, 0x66, 0x66, 0x55, 0x55, 0x66, 0x66,
+		0x03,                                           // Varint for number of tspend hashes
+		0x88, 0x88, 0x88, 0x31, 0x88, 0x88, 0x22, 0x82, // Fake tspend 1
+		0x88, 0x88, 0x88, 0x88, 0x88, 0x88, 0x88, 0x88,
+		0x88, 0x88, 0x88, 0x88, 0x88, 0x82, 0x82, 0x82,
+		0x88, 0x88, 0x88, 0x88, 0x88, 0x88, 0x88, 0x00,
+		0x19, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, // Fake tspend 2
+		0x19, 0x91, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99,
+		0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x92,
+		0x29, 0x99, 0x99, 0x99, 0x99, 0x99, 0x09, 0x00,
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0x9a, // Fake tspend 3
+		0x9a, 0x9a, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0x0a, 0x20,
+		0xa9, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0x0a, 0x00,
+	}
+
+	tests := []struct {
+		in   *MsgInitState // Message to encode
+		out  *MsgInitState // Expected decoded message
+		buf  []byte        // Wire encoding
+		pver uint32        // Protocol version for wire encoding
+	}{{
+		in:   emptyMsg,
+		out:  emptyMsg,
+		buf:  emptyMsgEncoded,
+		pver: pver,
+	}, {
+		in:   multiData,
+		out:  multiData,
+		buf:  multiDataEncoded,
+		pver: pver,
+	}}
+
+	for i, test := range tests {
+		// Encode the message to wire format.
+		var buf bytes.Buffer
+		err := test.in.BtcEncode(&buf, test.pver)
+		if err != nil {
+			t.Errorf("BtcEncode #%d error %v", i, err)
+			continue
+		}
+		if !bytes.Equal(buf.Bytes(), test.buf) {
+			t.Errorf("BtcEncode #%d - got %s, want: %s", i,
+				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
+			continue
+		}
+
+		// Decode the message from wire format.
+		var msg MsgInitState
+		rbuf := bytes.NewReader(test.buf)
+		err = msg.BtcDecode(rbuf, test.pver)
+		if err != nil {
+			t.Errorf("BtcDecode #%d error %v", i, err)
+			continue
+		}
+		if !reflect.DeepEqual(&msg, test.out) {
+			t.Errorf("BtcDecode #%d - got: %s want: %s", i,
+				spew.Sdump(&msg), spew.Sdump(test.out))
+			continue
+		}
+	}
+}
+
+// TestInitState performs negative tests against wire encode and decode of
+// MsgInitState to confirm error paths work correctly.
+func TestInitStateWireErrors(t *testing.T) {
+	pver := ProtocolVersion
+
+	fakeBlock1, _ := chainhash.NewHashFromStr("4433221144332211443322114" +
+		"433221144332211443322114433221144332211")
+	fakeBlock2, _ := chainhash.NewHashFromStr("9300109283044211443383938" +
+		"912083481724918427109238198279148176817")
+	fakeVote1, _ := chainhash.NewHashFromStr("2222111122221111222211112" +
+		"222111122221111222211112222111122221111")
+	fakeVote2, _ := chainhash.NewHashFromStr("4444333344443333444433334" +
+		"444333344443333444433334444333344443333")
+	fakeVote3, _ := chainhash.NewHashFromStr("6666555566665555666655556" +
+		"666555566665555666655556666555566665555")
+	fakeTSpend1, _ := chainhash.NewHashFromStr("88888888888888828282888" +
+		"888888888888888888888888222888831888888")
+	fakeTSpend2, _ := chainhash.NewHashFromStr("9999999999929929999999" +
+		"999999999999999999991199999999999999919")
+	fakeTSpend3, _ := chainhash.NewHashFromStr("aaaaaaaaaaaa9200aaaaaa" +
+		"aaaaaaaaaaaaaaaaaaa9a9a9aaaaaaaaaaaaaaa")
+
+	// MsgInitState message with multiple values for each hash.
+	baseMsg := NewMsgInitState()
+	baseMsg.AddBlockHash(fakeBlock1)
+	baseMsg.AddBlockHash(fakeBlock2)
+	baseMsg.AddVoteHash(fakeVote1)
+	baseMsg.AddVoteHash(fakeVote2)
+	baseMsg.AddVoteHash(fakeVote3)
+	baseMsg.AddTSpendHash(fakeTSpend1)
+	baseMsg.AddTSpendHash(fakeTSpend2)
+	baseMsg.AddTSpendHash(fakeTSpend3)
+
+	baseMsgEncoded := []byte{
+		0x02,                                           // Varint for number of block hashes
+		0x11, 0x22, 0x33, 0x44, 0x11, 0x22, 0x33, 0x44, // Fake block 1
+		0x11, 0x22, 0x33, 0x44, 0x11, 0x22, 0x33, 0x44,
+		0x11, 0x22, 0x33, 0x44, 0x11, 0x22, 0x33, 0x44,
+		0x11, 0x22, 0x33, 0x44, 0x11, 0x22, 0x33, 0x44,
+		0x17, 0x68, 0x17, 0x48, 0x91, 0x27, 0x98, 0x81, // Fake block 2
+		0x23, 0x09, 0x71, 0x42, 0x18, 0x49, 0x72, 0x81,
+		0x34, 0x08, 0x12, 0x89, 0x93, 0x83, 0x33, 0x44,
+		0x11, 0x42, 0x04, 0x83, 0x92, 0x10, 0x00, 0x93,
+		0x03,                                           // Varint for number of vote hashes
+		0x11, 0x11, 0x22, 0x22, 0x11, 0x11, 0x22, 0x22, // Fake vote 1
+		0x11, 0x11, 0x22, 0x22, 0x11, 0x11, 0x22, 0x22,
+		0x11, 0x11, 0x22, 0x22, 0x11, 0x11, 0x22, 0x22,
+		0x11, 0x11, 0x22, 0x22, 0x11, 0x11, 0x22, 0x22,
+		0x33, 0x33, 0x44, 0x44, 0x33, 0x33, 0x44, 0x44, // Fake vote 2
+		0x33, 0x33, 0x44, 0x44, 0x33, 0x33, 0x44, 0x44,
+		0x33, 0x33, 0x44, 0x44, 0x33, 0x33, 0x44, 0x44,
+		0x33, 0x33, 0x44, 0x44, 0x33, 0x33, 0x44, 0x44,
+		0x55, 0x55, 0x66, 0x66, 0x55, 0x55, 0x66, 0x66, // Fake vote 3
+		0x55, 0x55, 0x66, 0x66, 0x55, 0x55, 0x66, 0x66,
+		0x55, 0x55, 0x66, 0x66, 0x55, 0x55, 0x66, 0x66,
+		0x55, 0x55, 0x66, 0x66, 0x55, 0x55, 0x66, 0x66,
+		0x03,                                           // Varint for number of tspend hashes
+		0x88, 0x88, 0x88, 0x31, 0x88, 0x88, 0x22, 0x82, // Fake tspend 1
+		0x88, 0x88, 0x88, 0x88, 0x88, 0x88, 0x88, 0x88,
+		0x88, 0x88, 0x88, 0x88, 0x88, 0x82, 0x82, 0x82,
+		0x88, 0x88, 0x88, 0x88, 0x88, 0x88, 0x88, 0x00,
+		0x19, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, // Fake tspend 2
+		0x19, 0x91, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99,
+		0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x92,
+		0x29, 0x99, 0x99, 0x99, 0x99, 0x99, 0x09, 0x00,
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0x9a, // Fake tspend 3
+		0x9a, 0x9a, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0x0a, 0x20,
+		0xa9, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0x0a, 0x00,
+	}
+
+	// Message that forces an error by having more than the max allowed
+	// number of block hashes.
+	maxBlockHashes := NewMsgInitState()
+	maxBlockHashes.BlockHashes = make([]chainhash.Hash, MaxISBlocksAtHeadPerMsg+1)
+	maxBlockHashesEncoded := []byte{
+		0xfc, // Varint for number of block hashes
+	}
+
+	// Message that forces an error by having more than the max allowed
+	// number of vote hashes.
+	maxVoteHashes := NewMsgInitState()
+	maxVoteHashes.VoteHashes = make([]chainhash.Hash, MaxISVotesAtHeadPerMsg+1)
+	maxVoteHashesEncoded := []byte{
+		0x00, // Varint for number of block hashes
+		0xfc, // Varint for number of vote hashes
+	}
+
+	// Message that forces an error by having more than the max allowed
+	// number of tspend hashes.
+	maxTSpendHashes := NewMsgInitState()
+	maxTSpendHashes.TSpendHashes = make([]chainhash.Hash, MaxISTSpendsAtHeadPerMsg+1)
+	maxTSpendHashesEncoded := []byte{
+		0x00, // Varint for number of block hashes
+		0x00, // Varint for number of vote hashes
+		0xfc, // Varint for number of tspend hashes
+	}
+
+	tests := []struct {
+		in       *MsgInitState // Value to encode
+		buf      []byte        // Wire encoding
+		pver     uint32        // Protocol version for wire encoding
+		max      int           // Max size of fixed buffer to induce errors
+		writeErr error         // Expected write error
+		readErr  error         // Expected read error
+	}{
+		// Force error in number of blockHashes varint.
+		{baseMsg, baseMsgEncoded, pver, 0, io.ErrShortWrite, io.EOF},
+		// Force error in first block hash.
+		{baseMsg, baseMsgEncoded, pver, 1, io.ErrShortWrite, io.EOF},
+		// Force error in number of vote hashes varint.
+		{baseMsg, baseMsgEncoded, pver, 1 + 32*2, io.ErrShortWrite, io.EOF},
+		// Force error in first vote.
+		{baseMsg, baseMsgEncoded, pver, 1 + 32*2 + 1, io.ErrShortWrite, io.EOF},
+		// Force error in number of tspend hashes varint.
+		{baseMsg, baseMsgEncoded, pver, 1 + 32*2 + 1 + 32*3, io.ErrShortWrite, io.EOF},
+		// Force error in first tspend.
+		{baseMsg, baseMsgEncoded, pver, 1 + 32*2 + 1 + 32*3 + 1, io.ErrShortWrite, io.EOF},
+		// Force error with greater than allowed number of block
+		// hashes.
+		{maxBlockHashes, maxBlockHashesEncoded, pver, 2, ErrTooManyBlocks, ErrTooManyBlocks},
+		// Force error with greater than allowed number of vote hashes.
+		{maxVoteHashes, maxVoteHashesEncoded, pver, 2, ErrTooManyVotes, ErrTooManyVotes},
+		// Force error with greater than allowed number of tspend
+		// hashes.
+		{maxTSpendHashes, maxTSpendHashesEncoded, pver, 3, ErrTooManyTSpends, ErrTooManyTSpends},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		// Encode to wire format.
+		w := newFixedWriter(test.max)
+		err := test.in.BtcEncode(w, test.pver)
+		if !errors.Is(err, test.writeErr) {
+			t.Errorf("BtcEncode #%d wrong error - got: %v, want: %v", i, err,
+				test.writeErr)
+			continue
+		}
+
+		// Decode from wire format.
+		var msg MsgInitState
+		r := newFixedReader(test.max, test.buf)
+		err = msg.BtcDecode(r, test.pver)
+		if !errors.Is(err, test.readErr) {
+			t.Errorf("BtcDecode #%d wrong error - got: %v, want: %v", i, err,
+				test.readErr)
+			continue
+		}
+	}
+}

--- a/wire/protocol.go
+++ b/wire/protocol.go
@@ -17,7 +17,7 @@ const (
 	InitialProcotolVersion uint32 = 1
 
 	// ProtocolVersion is the latest protocol version this package supports.
-	ProtocolVersion uint32 = 7
+	ProtocolVersion uint32 = 8
 
 	// NodeBloomVersion is the protocol version which added the SFNodeBloom
 	// service flag (unused).
@@ -43,6 +43,10 @@ const (
 	// CFilterV2Version is the protocol version which adds the getcfilterv2 and
 	// cfiltverv2 messages.
 	CFilterV2Version uint32 = 7
+
+	// InitStateVersion is the protocol version which adds the initstate
+	// and getinitstate messages.
+	InitStateVersion uint32 = 8
 )
 
 // ServiceFlag identifies services supported by a Decred peer.


### PR DESCRIPTION
**Rebased on top of ~#2170~ #2350**

~**Includes #2348**~

_This is part of the treasury decentralization work._

This adds a new pair of messages to the peer protocol named `getinitstate/initstate`. These messages are meant to be used as replacements for the `getminingstate/miningstate` messages.

The new messages are more generic and meant to be used for both the existing mining information (head blocks and votes) and other ephemeral data that nodes of the peer network might need. The initial implementation in dcrd additionally offers and responds with treasury spend transactions.

tpends are special transactions in that they are meant to be long-lived in the mempool and not only miner nodes but also voting wallet nodes need to discover them in a timely manner. Thus we introduce this new set of messages in order to relay them in the network as nodes startup.

This work isn't strictly consensus-related and thus has been extracted from the main treasury PR to ease review by external developers.
