### PR TITLE
mempool: Improve tspend tracking and add tests

### DIFF
--- a/internal/mempool/error.go
+++ b/internal/mempool/error.go
@@ -53,6 +53,9 @@ const (
 	ErrInsufficientPriority
 	ErrFeeTooHigh
 	ErrOrphan
+	ErrTooManyTSpends
+	ErrTSpendMinedOnAncestor
+	ErrTSpendInvalidExpiry
 )
 
 // TxRuleError identifies a rule violation.  It is used to indicate that

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -1240,8 +1240,12 @@ func (mp *TxPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit, allow
 	// Reject votes before stake validation height.
 	stakeValidationHeight := mp.cfg.ChainParams.StakeValidationHeight
 	if (isVote || isTSpend) && nextBlockHeight < stakeValidationHeight {
-		str := fmt.Sprintf("votes are not valid until block height %d (next "+
-			"block height %d)", stakeValidationHeight, nextBlockHeight)
+		strType := "votes"
+		if isTSpend {
+			strType = "tspends"
+		}
+		str := fmt.Sprintf("%s are not valid until block height %d (next "+
+			"block height %d)", strType, stakeValidationHeight, nextBlockHeight)
 		return nil, txRuleError(ErrInvalid, str)
 	}
 

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -1628,7 +1628,7 @@ func (mp *TxPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit, allow
 		if expiry != msgTx.Expiry {
 			str := fmt.Sprintf("Invalid TSPEND Expiry must be %v "+
 				"got %v", expiry, msgTx.Expiry)
-			return nil, txRuleError(ErrInvalid, str)
+			return nil, txRuleError(ErrTSpendInvalidExpiry, str)
 		}
 
 		// Only allow up to MempoolMaxConcurrentTSpends TSpends in the
@@ -1638,7 +1638,7 @@ func (mp *TxPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit, allow
 			str := fmt.Sprintf("Mempool can only hold %v "+
 				"concurrent TSpend transactions",
 				MempoolMaxConcurrentTSpends)
-			return nil, txRuleError(ErrInvalid, str)
+			return nil, txRuleError(ErrTooManyTSpends, str)
 		}
 
 		// Verify that this TSpend uses a well-known Pi key and that
@@ -1663,7 +1663,7 @@ func (mp *TxPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit, allow
 		// ancestor block yet.
 		if err := mp.cfg.TSpendMinedOnAncestor(*txHash); err != nil {
 			// err is descriptive and only needs to be wrapped.
-			return nil, txRuleError(ErrInvalid, err.Error())
+			return nil, txRuleError(ErrTSpendMinedOnAncestor, err.Error())
 		}
 
 		// Notify that we accepted a TSpend.


### PR DESCRIPTION
**Rebased on top of #2170**

_This is part of the treasury decentralization work._

This PR adds separate tracking for tspends in the mempool and adds unit tests in the mempool package for tspend and tadd handling.

Separately tracking tspends is needed in order to provide them to other nodes during startup, which will be done by a new set of messages introduced in a future PR.

Since this work isn't strictly consensus-related it has been split from the main treasury PR.