### PR TITLE
multi: Add gettreasuryspendvotes RPC command

### DIFF
--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -322,6 +322,10 @@ the method name for further details such as parameter and return information.
 |N
 |Returns the current value of all locked funds in the ticket pool.
 |-
+|[[#gettreasuryspendvotes|gettreasuryspendvotes]]
+|N
+|Returns the vote counts for mempool or mined treasury spend transactions.
+|-
 |[[#gettxout|gettxout]]
 |Y
 |Returns information about an unspent transaction output.
@@ -1899,6 +1903,37 @@ of the best block.
 |-
 !Example Return
 |<code>5214124.18608402</code>
+|}
+
+----
+
+====gettreasuryspendvotes====
+{|
+!Method
+|gettreasuryspendvotes
+|-
+!Parameters
+|
+# <code>blockhash</code>: <code>(string, optional)</code> Count treasury spend votes up to this block. If unspecified, the current chain tip is used.
+# <code>tspends</code>: <code>(json array of strings, optional)</code> A list of treasury spend transaction hashes for which to tally votes. All specified hashes must correspond to either mined or mempool residing tspends. If unspecified, defaults to tallying votes for all tspends currently in the mempool.
+|-
+!Description
+| Returns a tally of on-chain votes for treasury spend transactions.
+|-
+!Returns
+|<code>(json object)</code>
+| <code>hash</code>: <code>(string)</code> The block hash of the block up to which the votes were tallied.
+| <code>height</code>: <code>(numeric)</code> The block height of the block up to which the votes were tallied.
+| <code>votes</code>: <code>(json array of objects)</code> Per-tspend vote counts.
+|  <code>hash</code>: <code>(string)</code> Hash of the treasury spend transaction.
+|  <code>expiry</code>: <code>(numeric)</code> Expiry value for the tspend tx.
+|  <code>votestart</code>: <code>(numeric)</code> Block height at which voting for the tspend starts.
+|  <code>voteend</code>: <code>(numeric)</code> Block height at which voting for the tspend ends.
+|  <code>yesvotes</code>: <code>(numeric)</code> Number of <code>yes</code> votes the tspend received (up to the height returned in the main response object).
+|  <code>novotes</code>: <code>(numeric)</code> Number of <code>no</code> votes the tspend received (up to the height returned in the main response object).
+|-
+!Example Return
+|<code>{"hash": "00000000000000001605faff0827dafcea7d0986cf0aad06e87eccf9e02ff441","height":428944,"votes": [{"hash": "f9d40601f4156dbdf7b310da9f5751488d9e531cf26151782642cd47efa4b732","expiry": 432290,"votestart": 428832,"voteend": 432288,"yesvotes":392,"novotes":91}]}</code>
 |}
 
 ----

--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -322,6 +322,10 @@ the method name for further details such as parameter and return information.
 |N
 |Returns the current value of all locked funds in the ticket pool.
 |-
+|[[#gettreasurybalance|gettreasurybalance]]
+|Y
+|Returns the mature balance of the treasury account.
+|-
 |[[#gettreasuryspendvotes|gettreasuryspendvotes]]
 |N
 |Returns the vote counts for mempool or mined treasury spend transactions.
@@ -1903,6 +1907,31 @@ of the best block.
 |-
 !Example Return
 |<code>5214124.18608402</code>
+|}
+
+----
+
+====gettreasurybalance====
+{|
+!Method
+|gettreasurybalance
+|-
+!Parameters
+# <code>hash</code>: <code>(string, optional)</code> Return the treasury balance at the specified block. If unspecified, return the balance for the current tip block.
+# <code>verbose</code>: <code>(bool, optional)</code> Whether to fill the <code>updates</code> field of the response. Defaults to false.
+|-
+!Description
+| Returns the matured balance of the network's treasury account. It optionally also returns the individual balance-changing amounts (treasury base, add and spend transactions) for the block.
+|-
+!Returns
+|<code>(json object)</code>
+| <code>hash</code>: <code>(string)</code> Block hash for which the balance was fetched.
+| <code>height</code>: <code>(numeric)</code> Block height for which the balance was fetched.
+| <code>balance</code>: <code>(numeric)</code> Balance (in atoms) of mature funds of the treasury account.
+| <code>updates</code>: <code>(json array of numeric)</code>: Individual amounts that affect the treasury balance in the given block. Amounts corresponding to treasury spend transactions will be negative. Only filled if <code>verbose</code> is specified.
+|-
+!Example Return
+|<code>{"hash": "00000000000000001605faff0827dafcea7d0986cf0aad06e87eccf9e02ff441","height": 428944,"balance": 1923209183818,"updates":[157007970,19200000000,-1892811207]}</code>
 |}
 
 ----

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -410,6 +410,14 @@ type Chain interface {
 	// defined in DCP0006, has passed and is now active for the block AFTER the
 	// given block.
 	IsTreasuryAgendaActive(*chainhash.Hash) (bool, error)
+
+	// FetchTSpend returns all blocks where the treasury spend tx
+	// identified by the specified hash can be found.
+	FetchTSpend(chainhash.Hash) ([]chainhash.Hash, error)
+
+	// TSpendCountVotes returns the votes for the specified tspend up to
+	// the specified block.
+	TSpendCountVotes(*chainhash.Hash, *dcrutil.Tx) (int64, int64, error)
 }
 
 // Clock represents a clock for use with the RPC server. The purpose of this
@@ -604,6 +612,10 @@ type TxMempooler interface {
 	// transaction pool. This only fetches from the main transaction pool
 	// and does not include orphans.
 	FetchTransaction(txHash *chainhash.Hash) (*dcrutil.Tx, error)
+
+	// TSpendHashes returns the hashes of the treasury spend transactions
+	// currently in the mempool.
+	TSpendHashes() []chainhash.Hash
 }
 
 // AddrIndexer provides an interface for retrieving transactions for a given

--- a/internal/rpcserver/rpcserverhelp.go
+++ b/internal/rpcserver/rpcserverhelp.go
@@ -666,6 +666,26 @@ var helpDescsEnUS = map[string]string{
 	"gettreasurybalance--condition0": "verbose=false",
 	"gettreasurybalance--condition1": "verbose=true",
 
+	// TreasurySpendVotes help.
+	"treasuryspendvotes-hash":      "The hash of the tspend transaction",
+	"treasuryspendvotes-expiry":    "The block height when the tspend expires",
+	"treasuryspendvotes-votestart": "The block height when voting for the tspend starts",
+	"treasuryspendvotes-voteend":   "The block height when voting for the tspend ends",
+	"treasuryspendvotes-yesvotes":  "The number of yes votes the tspend received",
+	"treasuryspendvotes-novotes":   "The number of no votes the tspend received",
+
+	// GetTreasurySpendVotesResult help.
+	"gettreasuryspendvotesresult-hash":   "The block hash for the last block where votes were tallied",
+	"gettreasuryspendvotesresult-height": "The block height for the last block where votes were tallied",
+	"gettreasuryspendvotesresult-votes":  "Vote counts for each tspend",
+
+	// GetTreasurySpendCmd help.
+	"gettreasuryspendvotes--synopsis": "Returns a tally of votes for a list of treasury spend transactions.",
+	"gettreasuryspendvotes-block": "Count votes only up to the specified block.\n" +
+		"If empty, count up to the current mainchain tip.",
+	"gettreasuryspendvotes-tspends": "Count votes for the specified tspends.\n" +
+		"If empty, count votes for all tspends currently in the mempool.",
+
 	// GetTxOutResult help.
 	"gettxoutresult-bestblock":     "The block hash that contains the transaction output",
 	"gettxoutresult-confirmations": "The number of confirmations",
@@ -1018,6 +1038,7 @@ var rpcResultTypes = map[types.Method][]interface{}{
 	"getrawtransaction":     {(*string)(nil), (*types.TxRawResult)(nil)},
 	"getticketpoolvalue":    {(*float64)(nil)},
 	"gettreasurybalance":    {(*types.GetTreasuryBalanceResult)(nil)},
+	"gettreasuryspendvotes": {(*types.GetTreasurySpendVotesResult)(nil)},
 	"gettxout":              {(*types.GetTxOutResult)(nil)},
 	"gettxoutsetinfo":       {(*types.GetTxOutSetInfoResult)(nil)},
 	"getvoteinfo":           {(*types.GetVoteInfoResult)(nil)},

--- a/rpc/jsonrpc/types/chainsvrcmds.go
+++ b/rpc/jsonrpc/types/chainsvrcmds.go
@@ -823,6 +823,26 @@ func NewGetTreasuryBalanceCmd(hash *string) *GetTreasuryBalanceCmd {
 	}
 }
 
+// GetTreasurySpendVotesCmd returns the vote count for the specified treasury
+// spend transactions up to the specified block.
+//
+// If block is not specified, then the current best block is used. If no
+// tspends are specified, then the counts for all tspends currently in the
+// mempool are returned.
+type GetTreasurySpendVotesCmd struct {
+	Block   *string
+	TSpends *[]string
+}
+
+// NewGetTreasurySpendVotesCmd returns a new instance which can be used to
+// issue a JSON-RPC gettreasuryspendvotes command.
+func NewGetTreasurySpendVotesCmd(block *string, tspends *[]string) *GetTreasurySpendVotesCmd {
+	return &GetTreasurySpendVotesCmd{
+		Block:   block,
+		TSpends: tspends,
+	}
+}
+
 // GetWorkCmd defines the getwork JSON-RPC command.
 type GetWorkCmd struct {
 	Data *string
@@ -1180,6 +1200,7 @@ func init() {
 	dcrjson.MustRegister(Method("getstakeversions"), (*GetStakeVersionsCmd)(nil), flags)
 	dcrjson.MustRegister(Method("getticketpoolvalue"), (*GetTicketPoolValueCmd)(nil), flags)
 	dcrjson.MustRegister(Method("gettreasurybalance"), (*GetTreasuryBalanceCmd)(nil), flags)
+	dcrjson.MustRegister(Method("gettreasuryspendvotes"), (*GetTreasurySpendVotesCmd)(nil), flags)
 	dcrjson.MustRegister(Method("gettxout"), (*GetTxOutCmd)(nil), flags)
 	dcrjson.MustRegister(Method("gettxoutsetinfo"), (*GetTxOutSetInfoCmd)(nil), flags)
 	dcrjson.MustRegister(Method("getvoteinfo"), (*GetVoteInfoCmd)(nil), flags)

--- a/rpc/jsonrpc/types/chainsvrcmds_test.go
+++ b/rpc/jsonrpc/types/chainsvrcmds_test.go
@@ -693,6 +693,48 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 		},
 		{
+			name: "gettreasuryspendvotes",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd(Method("gettreasuryspendvotes"))
+			},
+			staticCmd: func() interface{} {
+				return NewGetTreasurySpendVotesCmd(nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"gettreasuryspendvotes","params":[],"id":1}`,
+			unmarshalled: &GetTreasurySpendVotesCmd{
+				Block:   nil,
+				TSpends: nil,
+			},
+		},
+		{
+			name: "gettreasuryspendvotes data",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd(Method("gettreasuryspendvotes"), "123", []string{"456"})
+			},
+			staticCmd: func() interface{} {
+				return NewGetTreasurySpendVotesCmd(dcrjson.String("123"), &[]string{"456"})
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"gettreasuryspendvotes","params":["123",["456"]],"id":1}`,
+			unmarshalled: &GetTreasurySpendVotesCmd{
+				Block:   dcrjson.String("123"),
+				TSpends: &[]string{"456"},
+			},
+		},
+		{
+			name: "gettreasuryspendvotes empty block",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd(Method("gettreasuryspendvotes"), "", []string{"456"})
+			},
+			staticCmd: func() interface{} {
+				return NewGetTreasurySpendVotesCmd(dcrjson.String(""), &[]string{"456"})
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"gettreasuryspendvotes","params":["",["456"]],"id":1}`,
+			unmarshalled: &GetTreasurySpendVotesCmd{
+				Block:   dcrjson.String(""),
+				TSpends: &[]string{"456"},
+			},
+		},
+		{
 			name: "getwork",
 			newCmd: func() (interface{}, error) {
 				return dcrjson.NewCmd(Method("getwork"))

--- a/rpc/jsonrpc/types/chainsvrresults.go
+++ b/rpc/jsonrpc/types/chainsvrresults.go
@@ -433,6 +433,25 @@ type GetTreasuryBalanceResult struct {
 	Updates []int64 `json:"updates,omitempty"`
 }
 
+// TreasurySpendVotes models the data returned for a single tspend returned by
+// gettreasuryspendvotes command.
+type TreasurySpendVotes struct {
+	Hash      string `json:"hash"`
+	Expiry    int64  `json:"expiry"`
+	VoteStart int64  `json:"votestart"`
+	VoteEnd   int64  `json:"voteend"`
+	YesVotes  int64  `json:"yesvotes"`
+	NoVotes   int64  `json:"novotes"`
+}
+
+// GetTreasurySpendVotesResult models the data returned from the
+// gettreasuryspendvotes command.
+type GetTreasurySpendVotesResult struct {
+	Hash   string               `json:"hash"`
+	Height int64                `json:"height"`
+	Votes  []TreasurySpendVotes `json:"votes"`
+}
+
 // GetWorkResult models the data from the getwork command.
 type GetWorkResult struct {
 	Data   string `json:"data"`


### PR DESCRIPTION
**Rebased on top of #2349**

_This is part of the treasury decentralization work._

closes #2326 

This adds a new RPC message named `gettreasuryspendvotes` and its corresponding server and client implementations.

This command can be used to tally the vote count of treasury spend transactions, for the purposes of tracking both ongoing and mined tspends.

The default parameters for this command (i.e. a future `dcrctl gettreasuryspendvotes`) returns the vote counts for all tspends currently in the node's mempool up to the current mainchain tip.

Clients may specify a block (`dcrctl gettreasuryspendvotes <blockhash>`) to verify the count up to some other previous block and may also specify a set of tspends (`dcrctl gettreasuryspendvotes <blockchash> '[<tspendhash1>, <tspendhash2>, ...]'` to perform a more specific or historical query.

Note that the current implementation can only query non-mempool tspends if they were eventually _mined_.

This work isn't strictly consensus-related and thus has been extracted from the main treasury PR to ease review by external developers.