### PR TITLE
jsonrpc/types: Register rebroadcast as websocket.

### DIFF
--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -358,14 +358,6 @@ the method name for further details such as parameter and return information.
 |N
 |Queues a ping to be sent to each connected peer.
 |-
-|[[#rebroadcastmissed|rebroadcastmissed]]
-|Y
-|Asks the daemon to rebroadcast missed votes.
-|-
-|[[#rebroadcastwinners|rebroadcastwinners]]
-|Y
-|Asks the daemon to rebroadcast the winners of the voting lottery.
-|-
 |[[#regentemplate|regentemplate]]
 |Y
 |Asks the daemon to regenerate the mining block template.
@@ -2158,42 +2150,6 @@ of the best block.
 
 ----
 
-====rebroadcastmissed====
-{|
-!Method
-|rebroadcastmissed
-|-
-!Parameters
-|None
-|-
-!Description
-|Asks the daemon to rebroadcast missed votes.
-|-
-!Returns
-|Nothing
-|-
-|}
-
-----
-
-====rebroadcastwinners====
-{|
-!Method
-|rebroadcastwinners
-|-
-!Parameters
-|None
-|-
-!Description
-|Asks the daemon to rebroadcast the winners of the voting lottery.
-|-
-!Returns
-|Nothing
-|-
-|}
-
-----
-
 ====regentemplate====
 {|
 !Method
@@ -2633,6 +2589,14 @@ user.  Click the method name for further details such as parameter and return in
 |Load, add to, or reload a websocket client's transaction filter for mempool transactions, new blocks and rescanblocks.
 |[[#relevanttxaccepted|relevanttxaccepted]]
 |-
+|[[#rebroadcastmissed|rebroadcastmissed]]
+|Asks the daemon to rebroadcast missed votes.
+|[[#spentandmissedtickets|spentandmissedtickets]]
+|-
+|[[#rebroadcastwinners|rebroadcastwinners]]
+|Asks the daemon to rebroadcast the winners of the voting lottery.
+|[[#winningtickets|winningtickets]]
+|-
 |[[#rescan|rescan]]
 |Rescan block chain for transactions to addresses and spent transaction outpoints.
 |[[#recvtx|recvtx]], [[#redeemingtx|redeemingtx]], [[#rescanprogress|rescanprogress]], and [[#rescanfinished|rescanfinished]]
@@ -2886,6 +2850,42 @@ NOTE: This is only required if an HTTP Authorization header is not being used.
 |-
 !Returns
 |Nothing
+|}
+
+----
+
+====rebroadcastmissed====
+{|
+!Method
+|rebroadcastmissed
+|-
+!Parameters
+|None
+|-
+!Description
+|Asks the daemon to rebroadcast missed votes via a [[#spentandmissedtickets|spentandmissedtickets]] notification.
+|-
+!Returns
+|Nothing
+|-
+|}
+
+----
+
+====rebroadcastwinners====
+{|
+!Method
+|rebroadcastwinners
+|-
+!Parameters
+|None
+|-
+!Description
+|Asks the daemon to rebroadcast the winners of the voting lottery via a [[#winningtickets|winningtickets]] notification.
+|-
+!Returns
+|Nothing
+|-
 |}
 
 ----

--- a/rpc/jsonrpc/types/chainsvrcmds.go
+++ b/rpc/jsonrpc/types/chainsvrcmds.go
@@ -895,26 +895,6 @@ func NewPingCmd() *PingCmd {
 	return &PingCmd{}
 }
 
-// RebroadcastMissedCmd is a type handling custom marshaling and
-// unmarshaling of rebroadcastmissed JSON RPC commands.
-type RebroadcastMissedCmd struct{}
-
-// NewRebroadcastMissedCmd returns a new instance which can be used to
-// issue a JSON-RPC rebroadcastmissed command.
-func NewRebroadcastMissedCmd() *RebroadcastMissedCmd {
-	return &RebroadcastMissedCmd{}
-}
-
-// RebroadcastWinnersCmd is a type handling custom marshaling and
-// unmarshaling of rebroadcastwinners JSON RPC commands.
-type RebroadcastWinnersCmd struct{}
-
-// NewRebroadcastWinnersCmd returns a new instance which can be used to
-// issue a JSON-RPC rebroadcastwinners command.
-func NewRebroadcastWinnersCmd() *RebroadcastWinnersCmd {
-	return &RebroadcastWinnersCmd{}
-}
-
 // SearchRawTransactionsCmd defines the searchrawtransactions JSON-RPC command.
 type SearchRawTransactionsCmd struct {
 	Address     string
@@ -1190,8 +1170,6 @@ func init() {
 	dcrjson.MustRegister(Method("missedtickets"), (*MissedTicketsCmd)(nil), flags)
 	dcrjson.MustRegister(Method("node"), (*NodeCmd)(nil), flags)
 	dcrjson.MustRegister(Method("ping"), (*PingCmd)(nil), flags)
-	dcrjson.MustRegister(Method("rebroadcastmissed"), (*RebroadcastMissedCmd)(nil), flags)
-	dcrjson.MustRegister(Method("rebroadcastwinners"), (*RebroadcastWinnersCmd)(nil), flags)
 	dcrjson.MustRegister(Method("regentemplate"), (*RegenTemplateCmd)(nil), flags)
 	dcrjson.MustRegister(Method("searchrawtransactions"), (*SearchRawTransactionsCmd)(nil), flags)
 	dcrjson.MustRegister(Method("sendrawtransaction"), (*SendRawTransactionCmd)(nil), flags)

--- a/rpc/jsonrpc/types/chainsvrwscmds.go
+++ b/rpc/jsonrpc/types/chainsvrwscmds.go
@@ -113,6 +113,26 @@ func NewNotifyStakeDifficultyCmd() *NotifyStakeDifficultyCmd {
 	return &NotifyStakeDifficultyCmd{}
 }
 
+// RebroadcastMissedCmd is a type handling custom marshaling and
+// unmarshaling of rebroadcastmissed JSON RPC commands.
+type RebroadcastMissedCmd struct{}
+
+// NewRebroadcastMissedCmd returns a new instance which can be used to
+// issue a JSON-RPC rebroadcastmissed command.
+func NewRebroadcastMissedCmd() *RebroadcastMissedCmd {
+	return &RebroadcastMissedCmd{}
+}
+
+// RebroadcastWinnersCmd is a type handling custom marshaling and
+// unmarshaling of rebroadcastwinners JSON RPC commands.
+type RebroadcastWinnersCmd struct{}
+
+// NewRebroadcastWinnersCmd returns a new instance which can be used to
+// issue a JSON-RPC rebroadcastwinners command.
+func NewRebroadcastWinnersCmd() *RebroadcastWinnersCmd {
+	return &RebroadcastWinnersCmd{}
+}
+
 // StopNotifyBlocksCmd defines the stopnotifyblocks JSON-RPC command.
 type StopNotifyBlocksCmd struct{}
 
@@ -195,6 +215,8 @@ func init() {
 		(*NotifyStakeDifficultyCmd)(nil), flags)
 	dcrjson.MustRegister(Method("notifywinningtickets"),
 		(*NotifyWinningTicketsCmd)(nil), flags)
+	dcrjson.MustRegister(Method("rebroadcastmissed"), (*RebroadcastMissedCmd)(nil), flags)
+	dcrjson.MustRegister(Method("rebroadcastwinners"), (*RebroadcastWinnersCmd)(nil), flags)
 	dcrjson.MustRegister(Method("session"), (*SessionCmd)(nil), flags)
 	dcrjson.MustRegister(Method("stopnotifyblocks"), (*StopNotifyBlocksCmd)(nil), flags)
 	dcrjson.MustRegister(Method("stopnotifywork"), (*StopNotifyWorkCmd)(nil), flags)


### PR DESCRIPTION
This consists of two commits.

The first oen moves the `rebroadcastmissed` and `rebroadcastwinners` commands from the regular chain server file to the websocket chain server file so they are only registered as available to websocket clients, and 



The second one updates the `rebroadcastmissed` and `rebroadcastwinners` entries in the JSON-RPC API docs to be properly categorized under the Websocket Methods section and updates them to properly call out the associated notifications they generate.


