### PR TITLE
blockchain: Update unreleased requires to master

### DIFF
--- a/blockchain/go.mod
+++ b/blockchain/go.mod
@@ -3,17 +3,17 @@ module github.com/decred/dcrd/blockchain/v3
 go 1.13
 
 require (
-	github.com/decred/dcrd/blockchain/stake/v3 v3.0.0-20200215031403-6b2ce76f0986
-	github.com/decred/dcrd/blockchain/standalone/v2 v2.0.0
+	github.com/decred/dcrd/blockchain/stake/v3 v3.0.0-20200921173733-67245079e9fb
+	github.com/decred/dcrd/blockchain/standalone/v2 v2.0.0-20200921173733-67245079e9fb
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
-	github.com/decred/dcrd/chaincfg/v3 v3.0.0-20200215031403-6b2ce76f0986
+	github.com/decred/dcrd/chaincfg/v3 v3.0.0-20200921173733-67245079e9fb
 	github.com/decred/dcrd/database/v2 v2.0.1
 	github.com/decred/dcrd/dcrec v1.0.0
-	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0-20200608124004-b2f67c2dc475
-	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200215031403-6b2ce76f0986
-	github.com/decred/dcrd/gcs/v2 v2.0.0
-	github.com/decred/dcrd/txscript/v3 v3.0.0-20200611204838-4c5825cf9054
-	github.com/decred/dcrd/wire v1.3.0
+	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0-20200921173733-67245079e9fb
+	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200921173733-67245079e9fb
+	github.com/decred/dcrd/gcs/v2 v2.0.2-0.20200921173733-67245079e9fb
+	github.com/decred/dcrd/txscript/v3 v3.0.0-20200921173733-67245079e9fb
+	github.com/decred/dcrd/wire v1.3.1-0.20200921173733-67245079e9fb
 	github.com/decred/slog v1.0.0
 )
 


### PR DESCRIPTION
This should fix consumers requiring the blockchain module at dcrd
master.  Previously, this would fail, due to an invalid require on the
released v2.0.0 version of standalone/v2, which has not yet been
released.