### PR TITLE
rpcserver: Add handleGetHeaders test.

### DIFF
--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -4245,6 +4245,61 @@ func TestHandleGetHashesPerSec(t *testing.T) {
 	}})
 }
 
+func TestHandleGetHeaders(t *testing.T) {
+	t.Parallel()
+
+	hash32 := "349b3e23b64cb4b71d09b9be4652c9e02e73430daee1285ea03d92aa437dcf37"
+	headerBytes, err := block432100.Header.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	header := hex.EncodeToString(headerBytes)
+	chain := defaultMockRPCChain()
+	chain.locateHeaders = []wire.BlockHeader{block432100.Header, block432100.Header}
+
+	testRPCServerHandler(t, []rpcTest{{
+		name:      "handleGetHeaders: ok with hashstop",
+		handler:   handleGetHeaders,
+		mockChain: chain,
+		cmd: &types.GetHeadersCmd{
+			BlockLocators: []string{hash32, hash32},
+			HashStop:      hash32,
+		},
+		result: &types.GetHeadersResult{
+			Headers: []string{header, header},
+		},
+	}, {
+		name:      "handleGetHeaders: ok no hashstop",
+		handler:   handleGetHeaders,
+		mockChain: chain,
+		cmd: &types.GetHeadersCmd{
+			BlockLocators: []string{hash32, hash32},
+		},
+		result: &types.GetHeadersResult{
+			Headers: []string{header, header},
+		},
+	}, {
+		name:      "handleGetHeaders: bad locator",
+		handler:   handleGetHeaders,
+		mockChain: chain,
+		cmd: &types.GetHeadersCmd{
+			BlockLocators: []string{hash32, "bad hex"},
+		},
+		wantErr: true,
+		errCode: dcrjson.ErrRPCDecodeHexString,
+	}, {
+		name:      "handleGetHeaders: bad hashstop",
+		handler:   handleGetHeaders,
+		mockChain: chain,
+		cmd: &types.GetHeadersCmd{
+			BlockLocators: []string{hash32, hash32},
+			HashStop:      "bad hex",
+		},
+		wantErr: true,
+		errCode: dcrjson.ErrRPCInvalidParameter,
+	}})
+}
+
 func TestHandleGetInfo(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Work towards #2069 

```
$ go test -run="TestHandleGetHeaders" -coverprofile=cov.out && go tool cover -func=cov.out | grep -E "handleGetHeaders"
PASS
coverage: 1.3% of statements
ok      github.com/decred/dcrd/internal/rpcserver       0.017s
github.com/decred/dcrd/internal/rpcserver/rpcserver.go:2347:            handleGetHeaders                95.8%
```

I don't believe it is possible to cause the blockheader serializations to fail.

