### PR TITLE
rpcclient:  Update unreleased requires to master

### DIFF
--- a/rpcclient/go.mod
+++ b/rpcclient/go.mod
@@ -5,12 +5,12 @@ go 1.13
 require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/dcrjson/v3 v3.1.0
-	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200503044000-76f6906e50e5
+	github.com/decred/dcrd/dcrutil/v3 v3.0.0
 	github.com/decred/dcrd/gcs/v2 v2.0.1
-	github.com/decred/dcrd/rpc/jsonrpc/types/v2 v2.0.1-0.20200503044000-76f6906e50e5
+	github.com/decred/dcrd/rpc/jsonrpc/types/v2 v2.1.0
 	github.com/decred/dcrd/wire v1.4.0
 	github.com/decred/go-socks v1.1.0
-	github.com/decred/slog v1.0.0
+	github.com/decred/slog v1.1.0
 	github.com/gorilla/websocket v1.4.2
 )
 

--- a/rpcclient/go.sum
+++ b/rpcclient/go.sum
@@ -50,6 +50,8 @@ github.com/decred/go-socks v1.1.0 h1:dnENcc0KIqQo3HSXdgboXAHgqsCIutkqq6ntQjYtm2U
 github.com/decred/go-socks v1.1.0/go.mod h1:sDhHqkZH0X4JjSa02oYOGhcGHYp12FsY1jQ/meV8md0=
 github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
 github.com/decred/slog v1.0.0/go.mod h1:zR98rEZHSnbZ4WHZtO0iqmSZjDLKhkXfrPTZQKtAonQ=
+github.com/decred/slog v1.1.0 h1:uz5ZFfmaexj1rEDgZvzQ7wjGkoSPjw2LCh8K+K1VrW4=
+github.com/decred/slog v1.1.0/go.mod h1:kVXlGnt6DHy2fV5OjSeuvCJ0OmlmTF6LFpEPMu/fOY0=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=


### PR DESCRIPTION
This should fix consumers requiring the rpcclient module at dcrd
master.  Previously, this would fail, due to various undefined
treasury types, which has not been released.
