### PR TITLE
chaincfg: Update min known chain work for release.

### DIFF
--- a/chaincfg/mainnetparams.go
+++ b/chaincfg/mainnetparams.go
@@ -147,9 +147,9 @@ func MainNetParams() *Params {
 		// chain at a given point in time.  This is intended to be updated
 		// periodically with new releases.
 		//
-		// Block 00000000000000001c654e2935e7722ddae8277da482e31557ac5c70ec101792
-		// Height: 395000
-		MinKnownChainWork: hexToBigInt("0000000000000000000000000000000000000000000ae01920a7ee4b769cc620"),
+		// Block 00000000000000000b639b99ec8b3097ed3dac076c455d30139db0d5958d4c4a
+		// Height: 487720
+		MinKnownChainWork: hexToBigInt("00000000000000000000000000000000000000000013e6909b5a73128d52fc6f"),
 
 		// The miner confirmation window is defined as:
 		//   target proof of work timespan / target proof of work spacing

--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -120,9 +120,9 @@ func TestNet3Params() *Params {
 		// chain at a given point in time.  This is intended to be updated
 		// periodically with new releases.
 		//
-		// Block 0000004ce20783706c005901e44b984d8d0f9d62855f266f064a25f8131f84e4
-		// Height: 301000
-		MinKnownChainWork: hexToBigInt("0000000000000000000000000000000000000000000000005df2701ec6263182"),
+		// Block 000000097a93845014d7865997154cc186be0435742e0d3c37c019ff118493fa
+		// Height: 519845
+		MinKnownChainWork: hexToBigInt("000000000000000000000000000000000000000000000000e41955f181d00f59"),
 
 		// Consensus rule change deployments.
 		//


### PR DESCRIPTION
This updates the minimum known chain work values for the main and test
networks as follows:

> mainnet: 0x00000000000000000000000000000000000000000013e6909b5a73128d52fc6f
> testnet: 0x000000000000000000000000000000000000000000000000e41955f181d00f59
