### PR TITLE
docs: Update for dcrec/secp256k1/v3 module.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -194,7 +194,7 @@ The following versioned modules are provided by dcrd repository:
   Implements the Decred transaction scripting language
 * [dcrec](https://github.com/decred/dcrd/tree/master/dcrec) - Provides constants
   for the supported cryptographic signatures supported by Decred scripts
-  * [secp256k1/v2](https://github.com/decred/dcrd/tree/master/dcrec/secp256k1) -
+  * [secp256k1/v3](https://github.com/decred/dcrd/tree/master/dcrec/secp256k1) -
     Implements the secp256k1 elliptic curve
   * [edwards/v2](https://github.com/decred/dcrd/tree/master/dcrec/edwards) -
     Implements the edwards25519 twisted Edwards curve

--- a/docs/assets/module_hierarchy.gv
+++ b/docs/assets/module_hierarchy.gv
@@ -12,7 +12,7 @@ digraph {
 	connmgr [label="connmgr/v3" fillcolor=mistyrose]
 	dcrec [label="dcrec" fillcolor=mediumpurple]
 	edwards [label="dcrec/edwards/v2" fillcolor=lightseagreen]
-	secp256k1 [label="dcrec/secp256k1/v2" fillcolor=mediumvioletred]
+	secp256k1 [label="dcrec/secp256k1/v3" fillcolor=mediumvioletred]
 	dcrutil [label="dcrutil/v2" fillcolor=burlywood]
 	database [label="database/v2" fillcolor=dodgerblue]
 	hdkeychain [label="hdkeychain/v2" fillcolor=deepskyblue]

--- a/docs/assets/module_hierarchy.svg
+++ b/docs/assets/module_hierarchy.svg
@@ -53,7 +53,7 @@
 <!-- secp256k1 -->
 <g id="node11" class="node"><title>secp256k1</title>
 <path fill="mediumvioletred" stroke="black" d="M487,-612C487,-612 382,-612 382,-612 376,-612 370,-606 370,-600 370,-600 370,-588 370,-588 370,-582 376,-576 382,-576 382,-576 487,-576 487,-576 493,-576 499,-582 499,-588 499,-588 499,-600 499,-600 499,-606 493,-612 487,-612"/>
-<text text-anchor="middle" x="434.5" y="-590.3" font-family="Times New Roman,serif" font-size="14.00">dcrec/secp256k1/v2</text>
+<text text-anchor="middle" x="434.5" y="-590.3" font-family="Times New Roman,serif" font-size="14.00">dcrec/secp256k1/v3</text>
 </g>
 <!-- chainhash&#45;&gt;secp256k1 -->
 <g id="edge6" class="edge"><title>chainhash&#45;&gt;secp256k1</title>


### PR DESCRIPTION
This updates the `docs/README.md` file, module hierarchy graphviz, and module hierarchy diagram to reflect the new module version.