### PR TITLE
config: Consolidate error reporting.

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -22,7 +23,9 @@ import (
 
 // TestLoadConfig ensures that basic configuration loading succeeds.
 func TestLoadConfig(t *testing.T) {
-	_, _, err := loadConfig()
+	appName := filepath.Base(os.Args[0])
+	appName = strings.TrimSuffix(appName, filepath.Ext(appName))
+	_, _, err := loadConfig(appName)
 	if err != nil {
 		t.Fatalf("Failed to load dcrd config: %s", err)
 	}
@@ -31,7 +34,9 @@ func TestLoadConfig(t *testing.T) {
 // TestDefaultAltDNSNames ensures that there are no additional hostnames added
 // by default during the configuration load phase.
 func TestDefaultAltDNSNames(t *testing.T) {
-	cfg, _, err := loadConfig()
+	appName := filepath.Base(os.Args[0])
+	appName = strings.TrimSuffix(appName, filepath.Ext(appName))
+	cfg, _, err := loadConfig(appName)
 	if err != nil {
 		t.Fatalf("Failed to load dcrd config: %s", err)
 	}
@@ -43,8 +48,10 @@ func TestDefaultAltDNSNames(t *testing.T) {
 // TestAltDNSNamesWithEnv ensures the DCRD_ALT_DNSNAMES environment variable is
 // parsed into a slice of additional hostnames as intended.
 func TestAltDNSNamesWithEnv(t *testing.T) {
+	appName := filepath.Base(os.Args[0])
+	appName = strings.TrimSuffix(appName, filepath.Ext(appName))
 	os.Setenv("DCRD_ALT_DNSNAMES", "hostname1,hostname2")
-	cfg, _, err := loadConfig()
+	cfg, _, err := loadConfig(appName)
 	if err != nil {
 		t.Fatalf("Failed to load dcrd config: %s", err)
 	}
@@ -58,9 +65,11 @@ func TestAltDNSNamesWithEnv(t *testing.T) {
 // TestAltDNSNamesWithArg ensures the altdnsnames configuration option parses
 // additional hostnames into a slice of hostnames as intended.
 func TestAltDNSNamesWithArg(t *testing.T) {
+	appName := filepath.Base(os.Args[0])
+	appName = strings.TrimSuffix(appName, filepath.Ext(appName))
 	old := os.Args
 	os.Args = append(os.Args, "--altdnsnames=\"hostname1,hostname2\"")
-	cfg, _, err := loadConfig()
+	cfg, _, err := loadConfig(appName)
 	if err != nil {
 		t.Fatalf("Failed to load dcrd config: %s", err)
 	}


### PR DESCRIPTION
This modifies the initial configuration error handling logic to avoid a bunch of duplicate code and fix some cases that were not logging the errors as expected.

It accomplishes this by consolidating the error reporting in a single place in the caller and introducing a custom error type which signals that the usage message should be suppressed in order to retain the primary behavior the originally was the reason for the prints being in the config function to begin with.

Also, the application name is passed into the function now since it is needed in both places.