### PR TITLE
multi: Fix treasury comments

### DIFF
--- a/gcs/blockcf2/blockcf.go
+++ b/gcs/blockcf2/blockcf.go
@@ -319,6 +319,7 @@ func Regular(block *wire.MsgBlock, prevScripts PrevScripter) (*gcs.FilterV2, err
 	//
 	// - Treasury add:
 	//   - Input scripts that are payments to the treasury
+	//   - Output script for the second output if it exists (tadd change)
 	//
 	// - Treasury spends:
 	//   - Output scripts that make payments


### PR DESCRIPTION
This fixes a few treasury-related comments throughout the codebase.

It also has a commit to fix a possible race in an exported function due to missing RLock call.