### PR TITLE
chaincfg: Prepare v3.0.0.

### DIFF
--- a/blockchain/go.mod
+++ b/blockchain/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200921173733-67245079e9fb
 	github.com/decred/dcrd/gcs/v2 v2.0.2-0.20200921173733-67245079e9fb
 	github.com/decred/dcrd/txscript/v3 v3.0.0-20200921173733-67245079e9fb
-	github.com/decred/dcrd/wire v1.3.1-0.20200921173733-67245079e9fb
+	github.com/decred/dcrd/wire v1.4.0
 	github.com/decred/slog v1.0.0
 )
 
@@ -25,5 +25,4 @@ replace (
 	github.com/decred/dcrd/dcrutil/v3 => ../dcrutil
 	github.com/decred/dcrd/gcs/v2 => ../gcs
 	github.com/decred/dcrd/txscript/v3 => ../txscript
-	github.com/decred/dcrd/wire => ../wire
 )

--- a/blockchain/go.sum
+++ b/blockchain/go.sum
@@ -30,6 +30,9 @@ github.com/decred/dcrd/dcrec/secp256k1/v2 v2.0.0 h1:3GIJYXQDAKpLEFriGFN8SbSffak1
 github.com/decred/dcrd/dcrec/secp256k1/v2 v2.0.0/go.mod h1:3s92l0paYkZoIHuj4X93Teg/HB7eGM9x/zokGw+u4mY=
 github.com/decred/dcrd/dcrutil/v2 v2.0.1 h1:aL+c7o7Q66HV1gIif+XkNYo9DeorN3l01Vns8mh0mqs=
 github.com/decred/dcrd/dcrutil/v2 v2.0.1/go.mod h1:JdEgF6eh0TTohPeiqDxqDSikTSvAczq0J7tFMyyeD+k=
+github.com/decred/dcrd/wire v1.3.0/go.mod h1:fnKGlUY2IBuqnpxx5dYRU5Oiq392OBqAuVjRVSkIoXM=
+github.com/decred/dcrd/wire v1.4.0 h1:KmSo6eTQIvhXS0fLBQ/l7hG7QLcSJQKSwSyzSqJYDk0=
+github.com/decred/dcrd/wire v1.4.0/go.mod h1:WxC/0K+cCAnBh+SKsRjIX9YPgvrjhmE+6pZlel1G7Ro=
 github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
 github.com/decred/slog v1.0.0/go.mod h1:zR98rEZHSnbZ4WHZtO0iqmSZjDLKhkXfrPTZQKtAonQ=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=

--- a/blockchain/stake/go.mod
+++ b/blockchain/stake/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0-20200215031403-6b2ce76f0986
 	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200215031403-6b2ce76f0986
 	github.com/decred/dcrd/txscript/v3 v3.0.0-20200215031403-6b2ce76f0986
-	github.com/decred/dcrd/wire v1.3.0
+	github.com/decred/dcrd/wire v1.4.0
 	github.com/decred/slog v1.0.0
 )
 
@@ -19,5 +19,4 @@ replace (
 	github.com/decred/dcrd/dcrec/secp256k1/v3 => ../../dcrec/secp256k1
 	github.com/decred/dcrd/dcrutil/v3 => ../../dcrutil
 	github.com/decred/dcrd/txscript/v3 => ../../txscript
-	github.com/decred/dcrd/wire => ../../wire
 )

--- a/blockchain/stake/go.sum
+++ b/blockchain/stake/go.sum
@@ -30,6 +30,9 @@ github.com/decred/dcrd/dcrec/secp256k1/v2 v2.0.0 h1:3GIJYXQDAKpLEFriGFN8SbSffak1
 github.com/decred/dcrd/dcrec/secp256k1/v2 v2.0.0/go.mod h1:3s92l0paYkZoIHuj4X93Teg/HB7eGM9x/zokGw+u4mY=
 github.com/decred/dcrd/dcrutil/v2 v2.0.1 h1:aL+c7o7Q66HV1gIif+XkNYo9DeorN3l01Vns8mh0mqs=
 github.com/decred/dcrd/dcrutil/v2 v2.0.1/go.mod h1:JdEgF6eh0TTohPeiqDxqDSikTSvAczq0J7tFMyyeD+k=
+github.com/decred/dcrd/wire v1.3.0/go.mod h1:fnKGlUY2IBuqnpxx5dYRU5Oiq392OBqAuVjRVSkIoXM=
+github.com/decred/dcrd/wire v1.4.0 h1:KmSo6eTQIvhXS0fLBQ/l7hG7QLcSJQKSwSyzSqJYDk0=
+github.com/decred/dcrd/wire v1.4.0/go.mod h1:WxC/0K+cCAnBh+SKsRjIX9YPgvrjhmE+6pZlel1G7Ro=
 github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
 github.com/decred/slog v1.0.0/go.mod h1:zR98rEZHSnbZ4WHZtO0iqmSZjDLKhkXfrPTZQKtAonQ=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=

--- a/blockchain/standalone/go.mod
+++ b/blockchain/standalone/go.mod
@@ -6,10 +6,7 @@ require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0-20200608124004-b2f67c2dc475 // indirect
 	github.com/decred/dcrd/txscript/v3 v3.0.0-20200611204838-4c5825cf9054
-	github.com/decred/dcrd/wire v1.3.0
+	github.com/decred/dcrd/wire v1.4.0
 )
 
-replace (
-	github.com/decred/dcrd/txscript/v3 => ../../txscript
-	github.com/decred/dcrd/wire => ../../wire
-)
+replace github.com/decred/dcrd/txscript/v3 => ../../txscript

--- a/blockchain/standalone/go.sum
+++ b/blockchain/standalone/go.sum
@@ -27,5 +27,8 @@ github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0-20200608124004-b2f67c2dc475 h1:
 github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0-20200608124004-b2f67c2dc475/go.mod h1:J70FGZSbzsjecRTiTzER+3f1KZLNaXkuv+yeFTKoxM8=
 github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200215031403-6b2ce76f0986 h1:oT+4AnwK68i+xJlMUAh7G2wiazWY7ZaMWbBdXvV29mA=
 github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200215031403-6b2ce76f0986/go.mod h1:jFxEd2LWDLvrWlrIiyx9ZGTQjvoFHZ0OVfBdyIX7jSw=
+github.com/decred/dcrd/wire v1.3.0/go.mod h1:fnKGlUY2IBuqnpxx5dYRU5Oiq392OBqAuVjRVSkIoXM=
+github.com/decred/dcrd/wire v1.4.0 h1:KmSo6eTQIvhXS0fLBQ/l7hG7QLcSJQKSwSyzSqJYDk0=
+github.com/decred/dcrd/wire v1.4.0/go.mod h1:WxC/0K+cCAnBh+SKsRjIX9YPgvrjhmE+6pZlel1G7Ro=
 github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
 github.com/decred/slog v1.0.0/go.mod h1:zR98rEZHSnbZ4WHZtO0iqmSZjDLKhkXfrPTZQKtAonQ=

--- a/chaincfg/go.mod
+++ b/chaincfg/go.mod
@@ -5,5 +5,5 @@ go 1.11
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
-	github.com/decred/dcrd/wire v1.3.0
+	github.com/decred/dcrd/wire v1.4.0
 )

--- a/chaincfg/go.sum
+++ b/chaincfg/go.sum
@@ -4,5 +4,5 @@ github.com/decred/dcrd/chaincfg/chainhash v1.0.2 h1:rt5Vlq/jM3ZawwiacWjPa+smINyL
 github.com/decred/dcrd/chaincfg/chainhash v1.0.2/go.mod h1:BpbrGgrPTr3YJYRN3Bm+D9NuaFd+zGyNeIKgrhCXK60=
 github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
-github.com/decred/dcrd/wire v1.3.0 h1:X76I2/a8esUmxXmFpJpAvXEi014IA4twgwcOBeIS8lE=
-github.com/decred/dcrd/wire v1.3.0/go.mod h1:fnKGlUY2IBuqnpxx5dYRU5Oiq392OBqAuVjRVSkIoXM=
+github.com/decred/dcrd/wire v1.4.0 h1:KmSo6eTQIvhXS0fLBQ/l7hG7QLcSJQKSwSyzSqJYDk0=
+github.com/decred/dcrd/wire v1.4.0/go.mod h1:WxC/0K+cCAnBh+SKsRjIX9YPgvrjhmE+6pZlel1G7Ro=

--- a/database/go.mod
+++ b/database/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/chaincfg/v3 v3.0.0-20200215031403-6b2ce76f0986
 	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200215031403-6b2ce76f0986
-	github.com/decred/dcrd/wire v1.3.0
+	github.com/decred/dcrd/wire v1.4.0
 	github.com/decred/slog v1.0.0
 	github.com/golang/protobuf v1.3.2 // indirect
 	github.com/jessevdk/go-flags v1.4.0
@@ -21,5 +21,4 @@ replace (
 	github.com/decred/dcrd/dcrec/secp256k1/v3 => ../dcrec/secp256k1
 	github.com/decred/dcrd/dcrutil/v3 => ../dcrutil
 	github.com/decred/dcrd/txscript/v3 => ../txscript
-	github.com/decred/dcrd/wire => ../wire
 )

--- a/database/go.sum
+++ b/database/go.sum
@@ -14,6 +14,8 @@ github.com/decred/dcrd/dcrec v1.0.0 h1:W+z6Es+Rai3MXYVoPAxYr5U1DGis0Co33scJ6uH2J
 github.com/decred/dcrd/dcrec v1.0.0/go.mod h1:HIaqbEJQ+PDzQcORxnqen5/V1FR3B4VpIfmePklt8Q8=
 github.com/decred/dcrd/dcrec/edwards/v2 v2.0.0 h1:E5KszxGgpjpmW8vN811G6rBAZg0/S/DftdGqN4FW5x4=
 github.com/decred/dcrd/dcrec/edwards/v2 v2.0.0/go.mod h1:d0H8xGMWbiIQP7gN3v2rByWUcuZPm9YsgmnfoxgbINc=
+github.com/decred/dcrd/wire v1.4.0 h1:KmSo6eTQIvhXS0fLBQ/l7hG7QLcSJQKSwSyzSqJYDk0=
+github.com/decred/dcrd/wire v1.4.0/go.mod h1:WxC/0K+cCAnBh+SKsRjIX9YPgvrjhmE+6pZlel1G7Ro=
 github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
 github.com/decred/slog v1.0.0/go.mod h1:zR98rEZHSnbZ4WHZtO0iqmSZjDLKhkXfrPTZQKtAonQ=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=

--- a/dcrutil/go.mod
+++ b/dcrutil/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/decred/dcrd/dcrec v1.0.0
 	github.com/decred/dcrd/dcrec/edwards/v2 v2.0.0
 	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0-20200215031403-6b2ce76f0986
-	github.com/decred/dcrd/wire v1.3.0
+	github.com/decred/dcrd/wire v1.4.0
 )
 
 replace (

--- a/dcrutil/go.sum
+++ b/dcrutil/go.sum
@@ -14,5 +14,5 @@ github.com/decred/dcrd/dcrec v1.0.0 h1:W+z6Es+Rai3MXYVoPAxYr5U1DGis0Co33scJ6uH2J
 github.com/decred/dcrd/dcrec v1.0.0/go.mod h1:HIaqbEJQ+PDzQcORxnqen5/V1FR3B4VpIfmePklt8Q8=
 github.com/decred/dcrd/dcrec/edwards/v2 v2.0.0 h1:E5KszxGgpjpmW8vN811G6rBAZg0/S/DftdGqN4FW5x4=
 github.com/decred/dcrd/dcrec/edwards/v2 v2.0.0/go.mod h1:d0H8xGMWbiIQP7gN3v2rByWUcuZPm9YsgmnfoxgbINc=
-github.com/decred/dcrd/wire v1.3.0 h1:X76I2/a8esUmxXmFpJpAvXEi014IA4twgwcOBeIS8lE=
-github.com/decred/dcrd/wire v1.3.0/go.mod h1:fnKGlUY2IBuqnpxx5dYRU5Oiq392OBqAuVjRVSkIoXM=
+github.com/decred/dcrd/wire v1.4.0 h1:KmSo6eTQIvhXS0fLBQ/l7hG7QLcSJQKSwSyzSqJYDk0=
+github.com/decred/dcrd/wire v1.4.0/go.mod h1:WxC/0K+cCAnBh+SKsRjIX9YPgvrjhmE+6pZlel1G7Ro=

--- a/docs/README.md
+++ b/docs/README.md
@@ -202,7 +202,7 @@ The following versioned modules are provided by dcrd repository:
   Provides a database interface for the Decred block chain
 * [dcrutil/v2](https://github.com/decred/dcrd/tree/master/dcrutil) - Provides
   Decred-specific convenience functions and types
-* [chaincfg/v2](https://github.com/decred/dcrd/tree/master/chaincfg) - Defines
+* [chaincfg/v3](https://github.com/decred/dcrd/tree/master/chaincfg) - Defines
   chain configuration parameters for the standard Decred networks and allows
   callers to define their own custom Decred networks for testing puproses
   * [chainhash](https://github.com/decred/dcrd/tree/master/chaincfg/chainhash) -

--- a/docs/assets/module_hierarchy.gv
+++ b/docs/assets/module_hierarchy.gv
@@ -8,7 +8,7 @@ digraph {
 	types [label="rpc/jsonrpc/types" fillcolor=tomato]
 	wire [label="wire" fillcolor=coral]
 	addrmgr [label="addrmgr" fillcolor=lightsalmon]
-	chaincfg [label="chaincfg/v2" fillcolor=cadetblue]
+	chaincfg [label="chaincfg/v3" fillcolor=cadetblue]
 	connmgr [label="connmgr/v3" fillcolor=mistyrose]
 	dcrec [label="dcrec" fillcolor=mediumpurple]
 	edwards [label="dcrec/edwards/v2" fillcolor=lightseagreen]

--- a/docs/assets/module_hierarchy.svg
+++ b/docs/assets/module_hierarchy.svg
@@ -93,7 +93,7 @@
 <!-- chaincfg -->
 <g id="node7" class="node"><title>chaincfg</title>
 <path fill="cadetblue" stroke="black" d="M264,-540C264,-540 207,-540 207,-540 201,-540 195,-534 195,-528 195,-528 195,-516 195,-516 195,-510 201,-504 207,-504 207,-504 264,-504 264,-504 270,-504 276,-510 276,-516 276,-516 276,-528 276,-528 276,-534 270,-540 264,-540"/>
-<text text-anchor="middle" x="235.5" y="-518.3" font-family="Times New Roman,serif" font-size="14.00">chaincfg/v2</text>
+<text text-anchor="middle" x="235.5" y="-518.3" font-family="Times New Roman,serif" font-size="14.00">chaincfg/v3</text>
 </g>
 <!-- wire&#45;&gt;chaincfg -->
 <g id="edge4" class="edge"><title>wire&#45;&gt;chaincfg</title>

--- a/gcs/go.mod
+++ b/gcs/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/crypto/blake256 v1.0.0
 	github.com/decred/dcrd/txscript/v3 v3.0.0-20200215031403-6b2ce76f0986
-	github.com/decred/dcrd/wire v1.3.0
+	github.com/decred/dcrd/wire v1.4.0
 )
 
 replace (
@@ -17,5 +17,4 @@ replace (
 	github.com/decred/dcrd/dcrec/secp256k1/v3 => ../dcrec/secp256k1
 	github.com/decred/dcrd/dcrutil/v3 => ../dcrutil
 	github.com/decred/dcrd/txscript/v3 => ../txscript
-	github.com/decred/dcrd/wire => ../wire
 )

--- a/gcs/go.sum
+++ b/gcs/go.sum
@@ -30,6 +30,9 @@ github.com/decred/dcrd/dcrec/secp256k1/v2 v2.0.0 h1:3GIJYXQDAKpLEFriGFN8SbSffak1
 github.com/decred/dcrd/dcrec/secp256k1/v2 v2.0.0/go.mod h1:3s92l0paYkZoIHuj4X93Teg/HB7eGM9x/zokGw+u4mY=
 github.com/decred/dcrd/dcrutil/v2 v2.0.1 h1:aL+c7o7Q66HV1gIif+XkNYo9DeorN3l01Vns8mh0mqs=
 github.com/decred/dcrd/dcrutil/v2 v2.0.1/go.mod h1:JdEgF6eh0TTohPeiqDxqDSikTSvAczq0J7tFMyyeD+k=
+github.com/decred/dcrd/wire v1.3.0/go.mod h1:fnKGlUY2IBuqnpxx5dYRU5Oiq392OBqAuVjRVSkIoXM=
+github.com/decred/dcrd/wire v1.4.0 h1:KmSo6eTQIvhXS0fLBQ/l7hG7QLcSJQKSwSyzSqJYDk0=
+github.com/decred/dcrd/wire v1.4.0/go.mod h1:WxC/0K+cCAnBh+SKsRjIX9YPgvrjhmE+6pZlel1G7Ro=
 github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
 github.com/decred/slog v1.0.0/go.mod h1:zR98rEZHSnbZ4WHZtO0iqmSZjDLKhkXfrPTZQKtAonQ=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=

--- a/go.mod
+++ b/go.mod
@@ -28,9 +28,9 @@ require (
 	github.com/decred/dcrd/rpc/jsonrpc/types/v2 v2.0.1-0.20200503044000-76f6906e50e5
 	github.com/decred/dcrd/rpcclient/v6 v6.0.0-20200215031403-6b2ce76f0986
 	github.com/decred/dcrd/txscript/v3 v3.0.0
-	github.com/decred/dcrd/wire v1.3.1-0.20200921173733-67245079e9fb
+	github.com/decred/dcrd/wire v1.4.0
 	github.com/decred/go-socks v1.1.0
-	github.com/decred/slog v1.0.0
+	github.com/decred/slog v1.1.0
 	github.com/gorilla/websocket v1.4.2
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/jrick/bitset v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/decred/go-socks v1.1.0 h1:dnENcc0KIqQo3HSXdgboXAHgqsCIutkqq6ntQjYtm2U
 github.com/decred/go-socks v1.1.0/go.mod h1:sDhHqkZH0X4JjSa02oYOGhcGHYp12FsY1jQ/meV8md0=
 github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
 github.com/decred/slog v1.0.0/go.mod h1:zR98rEZHSnbZ4WHZtO0iqmSZjDLKhkXfrPTZQKtAonQ=
+github.com/decred/slog v1.1.0 h1:uz5ZFfmaexj1rEDgZvzQ7wjGkoSPjw2LCh8K+K1VrW4=
+github.com/decred/slog v1.1.0/go.mod h1:kVXlGnt6DHy2fV5OjSeuvCJ0OmlmTF6LFpEPMu/fOY0=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/hdkeychain/go.sum
+++ b/hdkeychain/go.sum
@@ -14,5 +14,5 @@ github.com/decred/dcrd/dcrec v1.0.0 h1:W+z6Es+Rai3MXYVoPAxYr5U1DGis0Co33scJ6uH2J
 github.com/decred/dcrd/dcrec v1.0.0/go.mod h1:HIaqbEJQ+PDzQcORxnqen5/V1FR3B4VpIfmePklt8Q8=
 github.com/decred/dcrd/dcrec/edwards/v2 v2.0.0 h1:E5KszxGgpjpmW8vN811G6rBAZg0/S/DftdGqN4FW5x4=
 github.com/decred/dcrd/dcrec/edwards/v2 v2.0.0/go.mod h1:d0H8xGMWbiIQP7gN3v2rByWUcuZPm9YsgmnfoxgbINc=
-github.com/decred/dcrd/wire v1.3.0 h1:X76I2/a8esUmxXmFpJpAvXEi014IA4twgwcOBeIS8lE=
-github.com/decred/dcrd/wire v1.3.0/go.mod h1:fnKGlUY2IBuqnpxx5dYRU5Oiq392OBqAuVjRVSkIoXM=
+github.com/decred/dcrd/wire v1.4.0 h1:KmSo6eTQIvhXS0fLBQ/l7hG7QLcSJQKSwSyzSqJYDk0=
+github.com/decred/dcrd/wire v1.4.0/go.mod h1:WxC/0K+cCAnBh+SKsRjIX9YPgvrjhmE+6pZlel1G7Ro=

--- a/peer/go.mod
+++ b/peer/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/lru v1.0.0
 	github.com/decred/dcrd/txscript/v3 v3.0.0-20200215031403-6b2ce76f0986
-	github.com/decred/dcrd/wire v1.3.0
+	github.com/decred/dcrd/wire v1.4.0
 	github.com/decred/go-socks v1.1.0
 	github.com/decred/slog v1.0.0
 )
@@ -17,5 +17,4 @@ replace (
 	github.com/decred/dcrd/dcrec/secp256k1/v3 => ../dcrec/secp256k1
 	github.com/decred/dcrd/dcrutil/v3 => ../dcrutil
 	github.com/decred/dcrd/txscript/v3 => ../txscript
-	github.com/decred/dcrd/wire => ../wire
 )

--- a/peer/go.sum
+++ b/peer/go.sum
@@ -18,6 +18,8 @@ github.com/decred/dcrd/dcrec/edwards/v2 v2.0.0 h1:E5KszxGgpjpmW8vN811G6rBAZg0/S/
 github.com/decred/dcrd/dcrec/edwards/v2 v2.0.0/go.mod h1:d0H8xGMWbiIQP7gN3v2rByWUcuZPm9YsgmnfoxgbINc=
 github.com/decred/dcrd/lru v1.0.0 h1:Kbsb1SFDsIlaupWPwsPp+dkxiBY1frcS07PCPgotKz8=
 github.com/decred/dcrd/lru v1.0.0/go.mod h1:mxKOwFd7lFjN2GZYsiz/ecgqR6kkYAl+0pz0tEMk218=
+github.com/decred/dcrd/wire v1.4.0 h1:KmSo6eTQIvhXS0fLBQ/l7hG7QLcSJQKSwSyzSqJYDk0=
+github.com/decred/dcrd/wire v1.4.0/go.mod h1:WxC/0K+cCAnBh+SKsRjIX9YPgvrjhmE+6pZlel1G7Ro=
 github.com/decred/go-socks v1.1.0 h1:dnENcc0KIqQo3HSXdgboXAHgqsCIutkqq6ntQjYtm2U=
 github.com/decred/go-socks v1.1.0/go.mod h1:sDhHqkZH0X4JjSa02oYOGhcGHYp12FsY1jQ/meV8md0=
 github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=

--- a/rpcclient/go.mod
+++ b/rpcclient/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200503044000-76f6906e50e5
 	github.com/decred/dcrd/gcs/v2 v2.0.1
 	github.com/decred/dcrd/rpc/jsonrpc/types/v2 v2.0.1-0.20200503044000-76f6906e50e5
-	github.com/decred/dcrd/wire v1.3.0
+	github.com/decred/dcrd/wire v1.4.0
 	github.com/decred/go-socks v1.1.0
 	github.com/decred/slog v1.0.0
 	github.com/gorilla/websocket v1.4.2

--- a/rpcclient/go.sum
+++ b/rpcclient/go.sum
@@ -40,6 +40,8 @@ github.com/decred/dcrd/txscript/v2 v2.1.0 h1:IKIpNm0lPmNQoaZ2zxZm1qMwfmLb/XXeahx
 github.com/decred/dcrd/txscript/v2 v2.1.0/go.mod h1:XaJAVrZU4NWRx4UEzTiDAs86op1m8GRJLz24SDBKOi0=
 github.com/decred/dcrd/wire v1.3.0 h1:X76I2/a8esUmxXmFpJpAvXEi014IA4twgwcOBeIS8lE=
 github.com/decred/dcrd/wire v1.3.0/go.mod h1:fnKGlUY2IBuqnpxx5dYRU5Oiq392OBqAuVjRVSkIoXM=
+github.com/decred/dcrd/wire v1.4.0 h1:KmSo6eTQIvhXS0fLBQ/l7hG7QLcSJQKSwSyzSqJYDk0=
+github.com/decred/dcrd/wire v1.4.0/go.mod h1:WxC/0K+cCAnBh+SKsRjIX9YPgvrjhmE+6pZlel1G7Ro=
 github.com/decred/go-socks v1.1.0 h1:dnENcc0KIqQo3HSXdgboXAHgqsCIutkqq6ntQjYtm2U=
 github.com/decred/go-socks v1.1.0/go.mod h1:sDhHqkZH0X4JjSa02oYOGhcGHYp12FsY1jQ/meV8md0=
 github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=

--- a/txscript/go.mod
+++ b/txscript/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/decred/dcrd/dcrec/edwards/v2 v2.0.0
 	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0-20200215031403-6b2ce76f0986
 	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200215031403-6b2ce76f0986
-	github.com/decred/dcrd/wire v1.3.0
+	github.com/decred/dcrd/wire v1.4.0
 	github.com/decred/slog v1.0.0
 )
 

--- a/txscript/go.sum
+++ b/txscript/go.sum
@@ -16,7 +16,7 @@ github.com/decred/dcrd/dcrec v1.0.0 h1:W+z6Es+Rai3MXYVoPAxYr5U1DGis0Co33scJ6uH2J
 github.com/decred/dcrd/dcrec v1.0.0/go.mod h1:HIaqbEJQ+PDzQcORxnqen5/V1FR3B4VpIfmePklt8Q8=
 github.com/decred/dcrd/dcrec/edwards/v2 v2.0.0 h1:E5KszxGgpjpmW8vN811G6rBAZg0/S/DftdGqN4FW5x4=
 github.com/decred/dcrd/dcrec/edwards/v2 v2.0.0/go.mod h1:d0H8xGMWbiIQP7gN3v2rByWUcuZPm9YsgmnfoxgbINc=
-github.com/decred/dcrd/wire v1.3.0 h1:X76I2/a8esUmxXmFpJpAvXEi014IA4twgwcOBeIS8lE=
-github.com/decred/dcrd/wire v1.3.0/go.mod h1:fnKGlUY2IBuqnpxx5dYRU5Oiq392OBqAuVjRVSkIoXM=
+github.com/decred/dcrd/wire v1.4.0 h1:KmSo6eTQIvhXS0fLBQ/l7hG7QLcSJQKSwSyzSqJYDk0=
+github.com/decred/dcrd/wire v1.4.0/go.mod h1:WxC/0K+cCAnBh+SKsRjIX9YPgvrjhmE+6pZlel1G7Ro=
 github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
 github.com/decred/slog v1.0.0/go.mod h1:zR98rEZHSnbZ4WHZtO0iqmSZjDLKhkXfrPTZQKtAonQ=


### PR DESCRIPTION
This updates the `chaincfg` module dependencies and serves as a base for `chaincfg/v3.0.0`.

The updated direct dependencies in this commit are as follows:

- github.com/decred/dcrd/wire@v1.4.0

The full list of updated direct dependencies since the previous `chaincfg/v2.3.0` release are as follows:

- github.com/decred/dcrd/wire@v1.4.0

Further, the following dependencies that were previously required in the previous `chaincfg/v2.3.0` release are no longer required:

- github.com/decred/dcrd/dcrec/edwards/v2
- github.com/decred/dcrd/dcrec/secp256k1/v2