### PR TITLE
dcrutil: Remove dependence on chaincfg.

### DIFF
--- a/dcrutil/example_test.go
+++ b/dcrutil/example_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/dcrec"
 	"github.com/decred/dcrd/dcrutil/v3"
 )
@@ -80,6 +79,74 @@ func ExampleAmount_unitConversions() {
 	// Atom to Atom: 44433322211100 Atom
 }
 
+// mockAddrParams implements the AddressParams interface and is used throughout
+// the tests to mock multiple networks.
+type mockAddrParams struct {
+	pubKeyID     [2]byte
+	pkhEcdsaID   [2]byte
+	pkhEd25519ID [2]byte
+	pkhSchnorrID [2]byte
+	scriptHashID [2]byte
+	privKeyID    [2]byte
+}
+
+// AddrIDPubKeyV0 returns the magic prefix bytes associated with the mock params
+// for version 0 pay-to-pubkey addresses.
+//
+// This is part of the AddressParams interface.
+func (p *mockAddrParams) AddrIDPubKeyV0() [2]byte {
+	return p.pubKeyID
+}
+
+// AddrIDPubKeyHashECDSAV0 returns the magic prefix bytes associated with the
+// mock params for version 0 pay-to-pubkey-hash addresses where the underlying
+// pubkey is secp256k1 and the signature algorithm is ECDSA.
+//
+// This is part of the AddressParams interface.
+func (p *mockAddrParams) AddrIDPubKeyHashECDSAV0() [2]byte {
+	return p.pkhEcdsaID
+}
+
+// AddrIDPubKeyHashEd25519V0 returns the magic prefix bytes associated with the
+// mock params for version 0 pay-to-pubkey-hash addresses where the underlying
+// pubkey and signature algorithm are Ed25519.
+//
+// This is part of the AddressParams interface.
+func (p *mockAddrParams) AddrIDPubKeyHashEd25519V0() [2]byte {
+	return p.pkhEd25519ID
+}
+
+// AddrIDPubKeyHashSchnorrV0 returns the magic prefix bytes associated with the
+// mock params for version 0 pay-to-pubkey-hash addresses where the underlying
+// pubkey is secp256k1 and the signature algorithm is Schnorr.
+//
+// This is part of the AddressParams interface.
+func (p *mockAddrParams) AddrIDPubKeyHashSchnorrV0() [2]byte {
+	return p.pkhSchnorrID
+}
+
+// AddrIDScriptHashV0 returns the magic prefix bytes associated with the mock
+// params for version 0 pay-to-script-hash addresses.
+//
+// This is part of the AddressParams interface.
+func (p *mockAddrParams) AddrIDScriptHashV0() [2]byte {
+	return p.scriptHashID
+}
+
+// mockMainNetParams returns mock mainnet address parameters to use throughout
+// the tests.  They match the Decred mainnet params as of the time this comment
+// was written.
+func mockMainNetParams() *mockAddrParams {
+	return &mockAddrParams{
+		pubKeyID:     [2]byte{0x13, 0x86}, // starts with Dk
+		pkhEcdsaID:   [2]byte{0x07, 0x3f}, // starts with Ds
+		pkhEd25519ID: [2]byte{0x07, 0x1f}, // starts with De
+		pkhSchnorrID: [2]byte{0x07, 0x01}, // starts with DS
+		scriptHashID: [2]byte{0x07, 0x1a}, // starts with Dc
+		privKeyID:    [2]byte{0x22, 0xde}, // starts with Pm
+	}
+}
+
 // This example demonstrates decoding addresses, determining their underlying
 // type, and displaying their associated underlying hash160 and digital
 // signature algorithm.
@@ -87,7 +154,12 @@ func ExampleDecodeAddress() {
 	// Ordinarily addresses would be read from the user or the result of a
 	// derivation, but they are hard coded here for the purposes of this
 	// example.
-	mainNetParmas := chaincfg.MainNetParams()
+	//
+	// Also, the caller would ordinarily want to use parameters from chaincfg
+	// such as chaincfg.MainNetParams(), but mock parameters are used here for
+	// the purposes of this example to avoid an otherwise unnecessary dependency
+	// on the chaincfg module.
+	mainNetParmas := mockMainNetParams()
 	addrsToDecode := []string{
 		"DsRUvfCwTMrKz29dDiQBJhZii9GDN3bVx6Q", // pay-to-pubkey-hash ecdsa
 		"DSpf9Sru9MarMKQQnuzTiQ9tjWVJA3KSm2d", // pay-to-pubkey-hash schnorr

--- a/dcrutil/go.mod
+++ b/dcrutil/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/base58 v1.0.3
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
-	github.com/decred/dcrd/chaincfg/v3 v3.0.0-20200215031403-6b2ce76f0986
 	github.com/decred/dcrd/crypto/ripemd160 v1.0.0
 	github.com/decred/dcrd/dcrec v1.0.0
 	github.com/decred/dcrd/dcrec/edwards/v2 v2.0.0
@@ -14,7 +13,4 @@ require (
 	github.com/decred/dcrd/wire v1.4.0
 )
 
-replace (
-	github.com/decred/dcrd/chaincfg/v3 => ../chaincfg
-	github.com/decred/dcrd/dcrec/secp256k1/v3 => ../dcrec/secp256k1
-)
+replace github.com/decred/dcrd/dcrec/secp256k1/v3 => ../dcrec/secp256k1

--- a/dcrutil/util_test.go
+++ b/dcrutil/util_test.go
@@ -6,36 +6,51 @@ package dcrutil
 
 import (
 	"testing"
-
-	"github.com/decred/dcrd/chaincfg/v3"
 )
 
+// TestVerifyMessage ensures the verifying a message works as intended.
 func TestVerifyMessage(t *testing.T) {
+	mainNetParams := mockMainNetParams()
+	testNetParams := mockTestNetParams()
+
 	msg := "verifymessage test"
 
 	var tests = []struct {
+		name    string
 		addr    string
 		sig     string
 		params  AddressParams
 		isValid bool
-	}{
-		// valid
-		{"TsdbYVDoh3JsyP6oEg2aHVoTjsFuHzUgGKv", "IITPXfmkfLPULbX9Im3XIyHAKiXRw5N9j6P7qf0MdEP9YQinn51lWjS+8jbTceRxCWckKKssu3ZpQm1xCWKz9GA=", chaincfg.TestNet3Params(), true},
+	}{{
+		name:    "valid",
+		addr:    "TsdbYVDoh3JsyP6oEg2aHVoTjsFuHzUgGKv",
+		sig:     "IITPXfmkfLPULbX9Im3XIyHAKiXRw5N9j6P7qf0MdEP9YQinn51lWjS+8jbTceRxCWckKKssu3ZpQm1xCWKz9GA=",
+		params:  testNetParams,
+		isValid: true,
+	}, {
+		name:    "wrong address",
+		addr:    "TsWeG3TJzucZgYyMfZFC2GhBvbeNfA48LTo",
+		sig:     "IITPXfmkfLPULbX9Im3XIyHAKiXRw5N9j6P7qf0MdEP9YQinn51lWjS+8jbTceRxCWckKKssu3ZpQm1xCWKz9GA=",
+		params:  testNetParams,
+		isValid: false,
+	}, {
+		name:    "wrong signature",
+		addr:    "TsdbYVDoh3JsyP6oEg2aHVoTjsFuHzUgGKv",
+		sig:     "HxzZggzHMljSWpKHnw1Dow84KGWvTRBCG2JqBM5W4Q7iePW0dirZXCggSeXHVQ26D0MbDFffi3yw+x2Z5nQ94gg=",
+		params:  testNetParams,
+		isValid: false,
+	}, {
+		name:    "wrong params",
+		addr:    "TsdbYVDoh3JsyP6oEg2aHVoTjsFuHzUgGKv",
+		sig:     "IITPXfmkfLPULbX9Im3XIyHAKiXRw5N9j6P7qf0MdEP9YQinn51lWjS+8jbTceRxCWckKKssu3ZpQm1xCWKz9GA=",
+		params:  mainNetParams,
+		isValid: false,
+	}}
 
-		// wrong address
-		{"TsWeG3TJzucZgYyMfZFC2GhBvbeNfA48LTo", "IITPXfmkfLPULbX9Im3XIyHAKiXRw5N9j6P7qf0MdEP9YQinn51lWjS+8jbTceRxCWckKKssu3ZpQm1xCWKz9GA=", chaincfg.TestNet3Params(), false},
-
-		// wrong signature
-		{"TsdbYVDoh3JsyP6oEg2aHVoTjsFuHzUgGKv", "HxzZggzHMljSWpKHnw1Dow84KGWvTRBCG2JqBM5W4Q7iePW0dirZXCggSeXHVQ26D0MbDFffi3yw+x2Z5nQ94gg=", chaincfg.TestNet3Params(), false},
-
-		// wrong params
-		{"TsdbYVDoh3JsyP6oEg2aHVoTjsFuHzUgGKv", "IITPXfmkfLPULbX9Im3XIyHAKiXRw5N9j6P7qf0MdEP9YQinn51lWjS+8jbTceRxCWckKKssu3ZpQm1xCWKz9GA=", chaincfg.MainNetParams(), false},
-	}
-
-	for i, test := range tests {
+	for _, test := range tests {
 		err := VerifyMessage(test.addr, test.sig, msg, test.params)
 		if (test.isValid && err != nil) || (!test.isValid && err == nil) {
-			t.Fatalf("VerifyMessage test #%d failed", i+1)
+			t.Fatalf("%s: failed", test.name)
 		}
 	}
 }


### PR DESCRIPTION
**This is rebased on #2381**.

This consists of two commits which result in removal of the `chaincfg` dependency through the use of mock parameters instead.

The first commit cleans up the tests for verify message and also modifies them to use the available mock parameters to avoid an otherwise unnecessary dep on `chaincfg`.

This second commit modifies the example to make use of mock parameters instead of actual parameters from `chaincfg` in order to avoid the otherwise unnecessary dependency on it.

