### PR TITLE
rpcserver: Add searchrawtransactions count limit.

### DIFF
--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -2242,7 +2242,7 @@ of the best block.
 # <code>address</code>: <code>(string, required)</code> Decred address.
 # <code>verbose</code>: <code>(int, optional, default=true)</code> specifies the transaction is returned as a JSON object instead of hex-encoded string.
 # <code>skip</code>: <code>(int, optional, default=0)</code> the number of leading transactions to leave out of the final response.
-# <code>count</code>: <code>(int, optional, default=100)</code> the maximum number of transactions to return.
+# <code>count</code>: <code>(int, optional, default=100, max=10000)</code> the maximum number of transactions to return.
 # <code>vinextra</code>: <code>(int, optional, default=0)</code> specify that extra data from previous output will be returned in vin.
 # <code>reverse</code>: <code>(boolean, optional, default=false)</code> specify that the transactions should be returned in reverse chronological order.
 # <code>filteraddrs</code>: <code>(json array of strings, optional)</code> specify that only inputs or outputs with matching addresses should be returned.

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -4263,8 +4263,11 @@ func handleSearchRawTransactions(_ context.Context, s *Server, cmd interface{}) 
 	numRequested := 100
 	if c.Count != nil {
 		numRequested = *c.Count
+		maxCount := 10000
 		if numRequested < 0 {
 			numRequested = 1
+		} else if numRequested > maxCount {
+			numRequested = maxCount
 		}
 	}
 	if numRequested == 0 {

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -5090,6 +5090,21 @@ func TestHandleSearchRawTransactions(t *testing.T) {
 			tx0TestTx.hex,
 		},
 	}, {
+		name:    "handleSearchRawTransactions: ok with count greater than limit",
+		handler: handleSearchRawTransactions,
+		cmd: &types.SearchRawTransactionsCmd{
+			Address:  address,
+			VinExtra: dcrjson.Int(1),
+			Verbose:  dcrjson.Int(0),
+			Count:    dcrjson.Int(42949673333394),
+		},
+		mockAddrIndexer: addrIndexer,
+		mockDB:          db,
+		result: []string{
+			tx0TestTx.hex,
+			tx1TestTx.hex,
+		},
+	}, {
 		name:    "handleSearchRawTransactions: ok with skip < 0",
 		handler: handleSearchRawTransactions,
 		cmd: &types.SearchRawTransactionsCmd{


### PR DESCRIPTION
This adds a reasonable limit to the maximum number of transactions that can be requested through searchrawtransactions.

10,000 seems like a reasonable max to me, especially given that results can be paginated using the `skip` param, but if anyone is aware of a case where client are expecting to fetch more than 10,000 transactions in one call we can increase this.

Closes https://github.com/decred/dcrd/issues/2372