### PR TITLE
standalone: Introduce CalcTSpendWindow.

### DIFF
--- a/blockchain/standalone/error.go
+++ b/blockchain/standalone/error.go
@@ -20,13 +20,9 @@ const (
 	// lower than the required target difficultly.
 	ErrHighHash = ErrorKind("ErrHighHash")
 
-	// ErrTSpendStartInvalidExpiry indicates that an invalid expiry was
-	// provided to calculate the start of a treasury spend vote window.
-	ErrTSpendStartInvalidExpiry = ErrorKind("ErrTSpendStartInvalidExpiry")
-
-	// ErrTSpendEndInvalidExpiry indicates that an invalid expiry was
-	// provided to calculate the end of a treasury spend vote window.
-	ErrTSpendEndInvalidExpiry = ErrorKind("ErrTSpendEndInvalidExpiry")
+	// ErrInvalidTSpendExpiry indicates that an invalid expiry was
+	// provided when calculating the treasury spend voting window.
+	ErrInvalidTSpendExpiry = ErrorKind("ErrInvalidTSpendExpiry")
 )
 
 // Error satisfies the error interface and prints human-readable errors.

--- a/blockchain/standalone/error_test.go
+++ b/blockchain/standalone/error_test.go
@@ -18,8 +18,7 @@ func TestErrorKindStringer(t *testing.T) {
 	}{
 		{ErrUnexpectedDifficulty, "ErrUnexpectedDifficulty"},
 		{ErrHighHash, "ErrHighHash"},
-		{ErrTSpendStartInvalidExpiry, "ErrTSpendStartInvalidExpiry"},
-		{ErrTSpendEndInvalidExpiry, "ErrTSpendEndInvalidExpiry"},
+		{ErrInvalidTSpendExpiry, "ErrInvalidTSpendExpiry"},
 	}
 
 	t.Logf("Running %d tests", len(tests))

--- a/blockchain/treasury.go
+++ b/blockchain/treasury.go
@@ -885,14 +885,9 @@ func (b *BlockChain) tSpendCountVotes(prevNode *blockNode, tspend *dcrutil.Tx) (
 	)
 
 	expiry := tspend.MsgTx().Expiry
-	t.start, err = standalone.CalculateTSpendWindowStart(expiry,
+	t.start, t.end, err = standalone.CalcTSpendWindow(expiry,
 		b.chainParams.TreasuryVoteInterval,
 		b.chainParams.TreasuryVoteIntervalMultiplier)
-	if err != nil {
-		return nil, err
-	}
-	t.end, err = standalone.CalculateTSpendWindowEnd(expiry,
-		b.chainParams.TreasuryVoteInterval)
 	if err != nil {
 		return nil, err
 	}

--- a/blockchain/treasury_test.go
+++ b/blockchain/treasury_test.go
@@ -523,11 +523,7 @@ func TestTSpendVoteCount(t *testing.T) {
 	tspendFee := 100
 	expiry := standalone.CalculateTSpendExpiry(int64(nextBlockHeight), tvi,
 		mul)
-	start, err := standalone.CalculateTSpendWindowStart(expiry, tvi, mul)
-	if err != nil {
-		t.Fatal(err)
-	}
-	end, err := standalone.CalculateTSpendWindowEnd(expiry, tvi)
+	start, end, err := standalone.CalcTSpendWindow(expiry, tvi, mul)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -738,7 +734,7 @@ func TestTSpendVoteCount(t *testing.T) {
 	// Use exact hight to validate that tspend starts on next tvi.
 	expiry = standalone.CalculateTSpendExpiry(int64(g.Tip().Header.Height),
 		tvi, mul)
-	start, err = standalone.CalculateTSpendWindowStart(expiry, tvi, mul)
+	start, _, err = standalone.CalcTSpendWindow(expiry, tvi, mul)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -946,7 +942,7 @@ func TestTSpendEmptyTreasury(t *testing.T) {
 	nextBlockHeight := g.Tip().Header.Height + 1
 	expiry := standalone.CalculateTSpendExpiry(int64(nextBlockHeight), tvi,
 		mul)
-	start, err := standalone.CalculateTSpendWindowStart(expiry, tvi, mul)
+	start, _, err := standalone.CalcTSpendWindow(expiry, tvi, mul)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1170,7 +1166,7 @@ func TestTSpendExpendituresPolicy(t *testing.T) {
 	nextBlockHeight := g.Tip().Header.Height + 1
 	expiry := standalone.CalculateTSpendExpiry(int64(nextBlockHeight), tvi,
 		mul)
-	start, err := standalone.CalculateTSpendWindowStart(expiry, tvi, mul)
+	start, _, err := standalone.CalcTSpendWindow(expiry, tvi, mul)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1661,7 +1657,7 @@ func TestExpendituresReorg(t *testing.T) {
 
 	nextBlockHeight := g.Tip().Header.Height + 1
 	expiry := standalone.CalculateTSpendExpiry(int64(nextBlockHeight), tvi, mul)
-	start, err := standalone.CalculateTSpendWindowStart(expiry, tvi, mul)
+	start, _, err := standalone.CalcTSpendWindow(expiry, tvi, mul)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1869,7 +1865,7 @@ func TestSpendableTreasuryTxs(t *testing.T) {
 	nextBlockHeight := g.Tip().Header.Height + 1
 	expiry := standalone.CalculateTSpendExpiry(int64(nextBlockHeight), tvi,
 		mul)
-	start, err := standalone.CalculateTSpendWindowStart(expiry, tvi, mul)
+	start, _, err := standalone.CalcTSpendWindow(expiry, tvi, mul)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2164,7 +2160,7 @@ func TestTSpendDupVote(t *testing.T) {
 	// ---------------------------------------------------------------------
 	nextBlockHeight := g.Tip().Header.Height + 1
 	expiry := standalone.CalculateTSpendExpiry(int64(nextBlockHeight), tvi, mul)
-	start, err := standalone.CalculateTSpendWindowStart(expiry, tvi, mul)
+	start, _, err := standalone.CalcTSpendWindow(expiry, tvi, mul)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2306,7 +2302,7 @@ func TestTSpendTooManyTSpend(t *testing.T) {
 	nextBlockHeight := g.Tip().Header.Height + 1
 	expiry := standalone.CalculateTSpendExpiry(int64(nextBlockHeight), tvi,
 		mul)
-	start, err := standalone.CalculateTSpendWindowStart(expiry, tvi, mul)
+	start, _, err := standalone.CalcTSpendWindow(expiry, tvi, mul)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2423,7 +2419,7 @@ func TestTSpendWindow(t *testing.T) {
 	nextBlockHeight := g.Tip().Header.Height + uint32(tvi*mul*4) + 1
 	expiry := standalone.CalculateTSpendExpiry(int64(nextBlockHeight), tvi,
 		mul)
-	start, err := standalone.CalculateTSpendWindowStart(expiry, tvi, mul)
+	start, _, err := standalone.CalcTSpendWindow(expiry, tvi, mul)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2547,7 +2543,7 @@ func TestTSpendSignature(t *testing.T) {
 	nextBlockHeight := g.Tip().Header.Height //+ uint32(tvi*mul*4) + 1
 	expiry := standalone.CalculateTSpendExpiry(int64(nextBlockHeight), tvi,
 		mul)
-	start, err := standalone.CalculateTSpendWindowStart(expiry, tvi, mul)
+	start, _, err := standalone.CalcTSpendWindow(expiry, tvi, mul)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2767,7 +2763,7 @@ func TestTSpendSignatureInvalid(t *testing.T) {
 	nextBlockHeight := g.Tip().Header.Height //+ uint32(tvi*mul*4) + 1
 	expiry := standalone.CalculateTSpendExpiry(int64(nextBlockHeight), tvi,
 		mul)
-	start, err := standalone.CalculateTSpendWindowStart(expiry, tvi, mul)
+	start, _, err := standalone.CalcTSpendWindow(expiry, tvi, mul)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2965,7 +2961,7 @@ func TestTSpendExists(t *testing.T) {
 	nextBlockHeight := g.Tip().Header.Height + 1
 	expiry := standalone.CalculateTSpendExpiry(int64(nextBlockHeight), tvi,
 		mul)
-	start, err := standalone.CalculateTSpendWindowStart(expiry, tvi, mul)
+	start, _, err := standalone.CalcTSpendWindow(expiry, tvi, mul)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3870,7 +3866,7 @@ func TestTSpendCorners(t *testing.T) {
 	tspendFee := 100
 	expiry := standalone.CalculateTSpendExpiry(int64(nextBlockHeight), tvi,
 		mul)
-	start, err := standalone.CalculateTSpendWindowStart(expiry, tvi, mul)
+	start, _, err := standalone.CalcTSpendWindow(expiry, tvi, mul)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3958,11 +3954,7 @@ func TestTSpendFirstTVICorner(t *testing.T) {
 	// total of 55 possible.  That easily is voted in since 60% is 33 yes
 	// votes.
 	expiry := standalone.CalculateTSpendExpiry(140, tvi, mul)
-	start, err := standalone.CalculateTSpendWindowStart(expiry, tvi, mul)
-	if err != nil {
-		t.Fatal(err)
-	}
-	end, err := standalone.CalculateTSpendWindowEnd(expiry, tvi)
+	start, end, err := standalone.CalcTSpendWindow(expiry, tvi, mul)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4250,11 +4242,7 @@ func TestTSpendVoteCountSynthetic(t *testing.T) {
 	tpb := params.TicketsPerBlock
 
 	expiry := standalone.CalculateTSpendExpiry(int64(tmh), tvi, mul)
-	start, err := standalone.CalculateTSpendWindowStart(expiry, tvi, mul)
-	if err != nil {
-		t.Fatal(err)
-	}
-	end, err := standalone.CalculateTSpendWindowEnd(expiry, tvi)
+	start, end, err := standalone.CalcTSpendWindow(expiry, tvi, mul)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -3432,20 +3432,15 @@ func (b *BlockChain) tspendChecks(prevNode *blockNode, block *dcrutil.Block) err
 			return ruleError(ErrNotTVI, str)
 		}
 
-		// Assert that the tspend is inside the correct window.
+		// Assert that the treasury spend is inside the correct window.
 		exp := stx.MsgTx().Expiry
 		if !standalone.InsideTSpendWindow(blockHeight,
 			exp, b.chainParams.TreasuryVoteInterval,
 			b.chainParams.TreasuryVoteIntervalMultiplier) {
-			s, _ := standalone.CalculateTSpendWindowStart(exp,
-				b.chainParams.TreasuryVoteInterval,
-				b.chainParams.TreasuryVoteIntervalMultiplier)
 
-			str := fmt.Sprintf("block contains TSpend "+
-				"transaction (%v) that is outside "+
-				"of the valid window: height %v "+
-				"start %v expiry %v",
-				stx.Hash(), block.Height(), s, exp)
+			str := fmt.Sprintf("block at height %d contains treasury spend "+
+				"transaction %v with expiry %v that is outside of the valid "+
+				"window", blockHeight, stx.Hash(), exp)
 			return ruleError(ErrInvalidTSpendWindow, str)
 		}
 

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -1630,8 +1630,7 @@ func (mp *TxPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit, allow
 		// its voting is supposed to start. We arbitrarily define as
 		// "too far in the future" as the vote starting greater than or
 		// equal to two full voting windows in the future.
-		voteStart, err := standalone.CalculateTSpendWindowStart(msgTx.Expiry,
-			tvi, mul)
+		voteStart, _, err := standalone.CalcTSpendWindow(msgTx.Expiry, tvi, mul)
 		if err != nil {
 			str := fmt.Sprintf("Invalid tspend expiry %d: %v ",
 				msgTx.Expiry, err)

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -2613,7 +2613,7 @@ func TestHandlesTSpends(t *testing.T) {
 	// when voting ends and advance the fake chain to just before that
 	// height. The tspend can be mined on the block the vote ends, which is
 	// a TVI block.
-	endVote, err := standalone.CalculateTSpendWindowEnd(expiry, tvi)
+	_, endVote, err := standalone.CalcTSpendWindow(expiry, tvi, mul)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -1461,13 +1461,9 @@ mempoolLoop:
 				exp, g.chainParams.TreasuryVoteInterval,
 				g.chainParams.TreasuryVoteIntervalMultiplier) {
 
-				s, _ := standalone.CalculateTSpendWindowStart(exp,
-					g.chainParams.TreasuryVoteInterval,
-					g.chainParams.TreasuryVoteIntervalMultiplier)
-				log.Tracef("Skipping tspend %v because it is "+
-					"outside of the window: height %v "+
-					"start %v expiry %v reason %v",
-					tx.Hash(), nextBlockHeight, s, exp, err)
+				log.Tracef("Skipping treasury spend %v at height %d because it "+
+					"has an expiry of %d that is outside of the voting window",
+					tx.Hash(), nextBlockHeight, exp)
 				continue
 			}
 

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -3323,10 +3323,9 @@ func handleGetTreasurySpendVotes(_ context.Context, s *Server, cmd interface{}) 
 			}
 		}
 
-		// The following errors can be ignored because we checked the
-		// expiry is in a TVI earlier.
-		start, _ := standalone.CalculateTSpendWindowStart(expiry, tvi, mul)
-		end, _ := standalone.CalculateTSpendWindowEnd(expiry, tvi)
+		// The following error can be ignored because the expiry was verified to
+		// be in a TVI earlier.
+		start, end, _ := standalone.CalcTSpendWindow(expiry, tvi, mul)
 
 		votes[i] = types.TreasurySpendVotes{
 			Hash:      txHash.String(),


### PR DESCRIPTION
**This requires #2388**.

This existing code for calculating treasury spend window values, namely `CalculateTSpendWindowStart` and `CalculateTSpendWindowEnd`, has a couple of footguns:

- The starting value calculation returns totally invalid values without an error when provided with a expiry that is prior to the first voting window
- Expiry values that are invalid for the start calc are valid for the end calc even though they should not be

As a result, the code for handling the error paths in the rpc server and mining code produces error messages that don't make sense in some cases because they blindly print the start value without checking the error.

To remove the aforementioned footguns and also address the incorrect error messages, the following overview of changes are made:

- Replaces the `CalculateTSpendWindowStart` and `CalculateTSpendWindowEnd` functions with a single combined `CalcTSpendWindow` function that properly checks for expiries before the first possible voting interval
- Modifies the returned errors to match the new reality
- Shortens the prefix to `Calc` to match the rest of the function names in the package
- Updates the incorrect error handling paths to avoid reporting the values that are not guaranteed to be meaningful and modifies the error messages to be more consistent
- Adds a comprehensive set of tests for the new function

Note that in addition to addressing the aforementioned issues, this approach has at least a couple of other benefits:

- It is more efficient to have a single function with a single bounds check
- Almost all callers outside of the tests need both the start and end value anyway, so it allows more compact code

Finally, this updates all callers in the repository accordingly.
