### PR TITLE
standalone: Retain coinbase detection semantics.

### DIFF
--- a/blockchain/standalone/tx_test.go
+++ b/blockchain/standalone/tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 The Decred developers
+// Copyright (c) 2019-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -14,9 +14,10 @@ import (
 // TestIsCoinbaseTx ensures the coinbase identification works as intended.
 func TestIsCoinbaseTx(t *testing.T) {
 	tests := []struct {
-		name string // test description
-		tx   string // transaction to test
-		want bool   // expected coinbase test result
+		name         string // test description
+		tx           string // transaction to test
+		wantPreTrsy  bool   // expected coinbase result before treasury active
+		wantPostTrsy bool   // expected coinbase result after treasury active
 	}{{
 		name: "mainnet block 2 coinbase",
 		tx: "010000000100000000000000000000000000000000000000000000000000000" +
@@ -26,7 +27,28 @@ func TestIsCoinbaseTx(t *testing.T) {
 			"a6a9588edea1906f0000000000001976a9148ffe7a49ecf0f4858e7a5215530" +
 			"2177398d2296988ac000000000000000001d8bc28820000000000000000ffff" +
 			"ffff0800002f646372642f",
-		want: true,
+		wantPreTrsy:  true,
+		wantPostTrsy: false,
+	}, {
+		name: "modified mainnet block 2 coinbase: tx version 3",
+		tx: "030000000100000000000000000000000000000000000000000000000000000" +
+			"00000000000ffffffff00ffffffff02fa1a981200000000000017a914f59161" +
+			"58e3e2c4551c1796708db8367207ed13bb8700000000000000000000266a240" +
+			"2000000000000000000000000000000000000000000000000000000ffa310d9" +
+			"a6a9588e000000000000000001d8bc28820000000000000000ffffffff08000" +
+			"02f646372642f",
+		wantPreTrsy:  true,
+		wantPostTrsy: true,
+	}, {
+		name: "modified mainnet block 2 coinbase: tx version 3, no miner payout",
+		tx: "030000000100000000000000000000000000000000000000000000000000000" +
+			"00000000000ffffffff00ffffffff02fa1a981200000000000017a914f59161" +
+			"58e3e2c4551c1796708db8367207ed13bb8700000000000000000000266a240" +
+			"2000000000000000000000000000000000000000000000000000000ffa310d9" +
+			"a6a9588e000000000000000001d8bc28820000000000000000ffffffff08000" +
+			"02f646372642f",
+		wantPreTrsy:  true,
+		wantPostTrsy: true,
 	}, {
 		name: "mainnet block 3, tx[1] (one input), not coinbase",
 		tx: "0100000001e68bcb9222c7f6336e865c81d7fd3e4b3244cd83998ac9767efcb" +
@@ -36,7 +58,8 @@ func TestIsCoinbaseTx(t *testing.T) {
 			"97e0183a78bb4a656dcbcd293d29d91921a64c55af02203554e76f432f73862" +
 			"edd4f2ed80a4599141b13c6ac2406158b05a97c6867a1ba01210244709193c0" +
 			"5a649df0fb0a96180ec1a8e3cbcc478dc9c4a69a3ec5aba1e97a79",
-		want: false,
+		wantPreTrsy:  false,
+		wantPostTrsy: false,
 	}, {
 		name: "mainnet block 373, tx[5] (two inputs), not coinbase",
 		tx: "010000000201261057a5ecaf6edede86c5446c62f067f30d654117668325090" +
@@ -53,7 +76,50 @@ func TestIsCoinbaseTx(t *testing.T) {
 			"2206ba7e60f5ae9810794297359cc883e7ff97ecd21bc7177fcc668a84f64a4" +
 			"b9120121026a4151513b4e6650e3d213451037cd6b78ed829d12ed1d43d5d34" +
 			"ce0834831e9",
-		want: false,
+		wantPreTrsy:  false,
+		wantPostTrsy: false,
+	}, {
+		name: "simnet block 32 coinbase (treasury active)",
+		tx: "0300000001000000000000000000000000000000000000000000000000000000" +
+			"0000000000ffffffff00ffffffff02000000000000000000000e6a0c20000000" +
+			"93c1b2181e4cd3b100ac23fc0600000000001976a91423d4150eb4332733b5bf" +
+			"88e5d9cea3897bc09dbc88ac00000000000000000100ac23fc06000000000000" +
+			"00ffffffff0800002f646372642f",
+		wantPreTrsy:  true,
+		wantPostTrsy: true,
+	}, {
+		name: "modified simnet block 32 coinbase (treasury active): no miner payout",
+		tx: "030000000100000000000000000000000000000000000000000000000000000" +
+			"00000000000ffffffff00ffffffff01000000000000000000000e6a0c200000" +
+			"0093c1b2181e4cd3b100000000000000000100ac23fc0600000000000000fff" +
+			"fffff0800002f646372642f",
+		wantPreTrsy:  true,
+		wantPostTrsy: true,
+	}, {
+		name: "random simnet treasury spend",
+		tx: "030000000100000000000000000000000000000000000000000000000000000" +
+			"00000000000ffffffff00ffffffff0200000000000000000000226a20b63c13" +
+			"400000000045c279dd8870eff33bc219a4c9a39a9190960601d8fccdefc0321" +
+			"3400000000000001ac376a914c945ac8cdbf5e37ad4bfde5dc92f65e13ff5c6" +
+			"7488ac000000008201000001b63c13400000000000000000ffffffff6440650" +
+			"063174184d0438b26d05a2f6d3190d020994ef3c18ac110bf70df3d1ed7066c" +
+			"8c62c349b8ae86862d04ee94d2bddc42bd33d449c1ba53ed37a2c8d1e8f8f62" +
+			"102a36b785d584555696b69d1b2bbeff4010332b301e3edd316d79438554cac" +
+			"b3e7c2",
+		wantPreTrsy:  true,
+		wantPostTrsy: false,
+	}, {
+		// This is neither a valid coinbase nor a valid treasury spend, but
+		// since the coinbase identification function is only a fast heuristic,
+		// this is crafted to test that.
+		name: "modified random simnet treasury spend: missing signature script",
+		tx: "0300000001000000000000000000000000000000000000000000000000000000" +
+			"0000000000ffffffff00ffffffff0200000000000000000000226a20b63c1340" +
+			"0000000045c279dd8870eff33bc219a4c9a39a9190960601d8fccdefc0321340" +
+			"0000000000001ac376a914c945ac8cdbf5e37ad4bfde5dc92f65e13ff5c67488" +
+			"ac000000008201000001b63c13400000000000000000ffffffff00",
+		wantPreTrsy:  true,
+		wantPostTrsy: true,
 	}}
 
 	for _, test := range tests {
@@ -70,12 +136,20 @@ func TestIsCoinbaseTx(t *testing.T) {
 			continue
 		}
 
-		result := IsCoinBaseTx(&tx, false)
-		if result != test.want {
-			t.Errorf("%s: unexpected result -- got %v, want %v", test.name,
-				result, test.want)
+		result := IsCoinBaseTx(&tx, noTreasury)
+		if result != test.wantPreTrsy {
+			t.Errorf("%s: unexpected result pre treasury -- got %v, want %v",
+				test.name, result, test.wantPreTrsy)
 			continue
 		}
+
+		result = IsCoinBaseTx(&tx, withTreasury)
+		if result != test.wantPostTrsy {
+			t.Errorf("%s: unexpected result post treasury -- got %v, want %v",
+				test.name, result, test.wantPostTrsy)
+			continue
+		}
+
 	}
 }
 

--- a/blockchain/treasury_test.go
+++ b/blockchain/treasury_test.go
@@ -4213,7 +4213,7 @@ func TestTreasuryInRegularTree(t *testing.T) {
 	startTip := g.TipName()
 	g.NextBlock("tb0", nil, outs[1:], replaceTreasuryVersions, replaceCoinbase,
 		addTreasuryBaseRegular)
-	g.RejectTipBlock(ErrStakeTxInRegularTree)
+	g.RejectTipBlock(ErrMultipleCoinbases)
 
 	// ---------------------------------------------------------------------
 	// Append tadd to transactions


### PR DESCRIPTION
This modifies the `IsCoinBaseTx` function to retain the existing semantics regarding coinbase detection logic once the treasury agenda activates.

Specifically, the existing consensus logic regarding the fast heuristic for detecting whether or not a transaction is likely to be coinbase has no restrictions regarding the number of outputs nor the the lengths of the scripts.

Later, once a coinbase is actually validated by consensus, it is required to have a payout to the treasury as well as a provably-prunable output that identifies the block height.

This means that it is technically possible for a miner to create a coinbase that burns coins if they so choose, even though, in practice, it is exceedingly unlikely.

Since the new treasury spend transaction type looks similar enough to existing coinbase transactions, they are also detected as coinbases under the existing code.

To combat this, the new treasury code introduces logic which consists of exempting transactions that look like treasury spends from being identified as a coinbase.  Unfortunately, the logic reports that a transaction is not a coinbase when _any_ of the conditions that lead up to the transaction being identified as a treasury spend are met instead of when _all_ of the conditions are met. 

The result is that the aforementioned semantics are changed which should not be the case.

This resolves that by modifying the logic accordingly such that the heuristic retains the same semantics for all transactions that are not specifically identified to likely be a treasury spend.

It also adds tests to ensure the new behavior works as intended bringing the test coverage of the function back up to 100%.