### PR TITLE
multi: Add ticket exhaustion check.

### DIFF
--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -632,6 +632,10 @@ const (
 	// block is larger than the maximum allowed.
 	ErrTooManyTAdds
 
+	// ErrTicketExhaustion indicates extending a given block with another one
+	// would result in an unrecoverable chain due to ticket exhaustion.
+	ErrTicketExhaustion
+
 	// numErrorCodes is the maximum error code number used in tests.
 	numErrorCodes
 )
@@ -767,6 +771,7 @@ var errorCodeStrings = map[ErrorCode]string{
 	ErrInvalidTemplateParent:        "ErrInvalidTemplateParent",
 	ErrInvalidTAddChange:            "ErrInvalidTAddChange",
 	ErrTooManyTAdds:                 "ErrTooManyTAdds",
+	ErrTicketExhaustion:             "ErrTicketExhaustion",
 }
 
 // String returns the ErrorCode as a human-readable name.

--- a/blockchain/error_test.go
+++ b/blockchain/error_test.go
@@ -144,6 +144,7 @@ func TestErrorCodeStringer(t *testing.T) {
 		{ErrBadTSpendScriptLen, "ErrBadTSpendScriptLen"},
 		{ErrInvalidTAddChange, "ErrInvalidTAddChange"},
 		{ErrTooManyTAdds, "ErrTooManyTAdds"},
+		{ErrTicketExhaustion, "ErrTicketExhaustion"},
 		{0xffff, "Unknown ErrorCode (65535)"},
 	}
 

--- a/internal/mining/error.go
+++ b/internal/mining/error.go
@@ -33,6 +33,11 @@ const (
 	// to a msgblock.
 	ErrTransactionAppend
 
+	// ErrTicketExhaustion indicates that there will not be enough mature
+	// tickets by the end of the next ticket maturity period to progress the
+	// chain.
+	ErrTicketExhaustion
+
 	// ErrCheckConnectBlock indicates that a newly created block template
 	// failed blockchain.CheckConnectBlock.
 	ErrCheckConnectBlock
@@ -57,6 +62,7 @@ var miningErrorCodeStrings = map[MiningErrorCode]string{
 	ErrGetTopBlock:           "ErrGetTopBlock",
 	ErrGettingDifficulty:     "ErrGettingDifficulty",
 	ErrTransactionAppend:     "ErrTransactionAppend",
+	ErrTicketExhaustion:      "ErrTicketExhaustion",
 	ErrCheckConnectBlock:     "ErrCheckConnectBlock",
 	ErrFraudProofIndex:       "ErrFraudProofIndex",
 	ErrFetchTxStore:          "ErrFetchTxStore",

--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -1843,6 +1843,14 @@ mempoolLoop:
 		}
 	}
 
+	// Ensure that mining the block would not cause the chain to become
+	// unrecoverable due to ticket exhaustion.
+	err = g.chain.CheckTicketExhaustion(&best.Hash, uint8(freshStake))
+	if err != nil {
+		log.Debug(err)
+		return nil, miningRuleError(ErrTicketExhaustion, err.Error())
+	}
+
 	// Get the ticket revocations (SSRtx tx) and store them and their
 	// number.
 	revocations := 0


### PR DESCRIPTION
This is an alternative approach to #2090 which resolves several of the issues it had and is originally based of an idea mentioned by @matheusd in #2047.

---

This modifies the mining template creation logic to prevent creation of templates that would result in an unrecoverable chain     due to inevitable ticket exhaustion.

It is split into two individual commits as follows:

The first commit adds a new function named `checkTicketExhaustion` to `blockchain` which will return a new rule error if extending a given block with another block that contains a specified number of tickets will result in an unrecoverable chain due to inevitable ticket exhaustion along with tests to ensure proper functionality.

The approach taken is such that it should be easy to use in a future consensus change gated behind a vote if that is ultimately desired, which I personally think would be a good idea.

An exported variant is also provided that takes the hash of the block to extend for use by external callers such as the mining template code.

The second commit modifies the mining template creation logic to make use of the new ability along with returning an associated new mining rule error.

