### PR TITLE
mempool: Allow treasury txn vers as standard.

### DIFF
--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -783,7 +783,7 @@ func newPoolHarness(chainParams *chaincfg.Params) (*poolHarness, []spendableOutp
 		chain: chain,
 		txPool: New(&Config{
 			Policy: Policy{
-				MaxTxVersion:         3,
+				MaxTxVersion:         wire.TxVersionTreasury,
 				DisableRelayPriority: true,
 				FreeTxRelayLimit:     15.0,
 				MaxOrphanTxs:         5,

--- a/server.go
+++ b/server.go
@@ -3175,7 +3175,7 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 
 	txC := mempool.Config{
 		Policy: mempool.Policy{
-			MaxTxVersion:         2,
+			MaxTxVersion:         wire.TxVersionTreasury,
 			DisableRelayPriority: cfg.NoRelayPriority,
 			AcceptNonStd:         cfg.AcceptNonStd,
 			FreeTxRelayLimit:     cfg.FreeTxRelayLimit,


### PR DESCRIPTION
This updates the server configuration of the `mempool` to allow transactions with the treasury transaction version to ensure they are able to relay properly when/if the treasury agenda becomes active.

It also updates the test configuration to use the constant instead of a hard-coded number.