### PR TITLE
simnet: force use of --rejectnonstd

### DIFF
--- a/contrib/dcr_tmux_simnet_setup.sh
+++ b/contrib/dcr_tmux_simnet_setup.sh
@@ -60,6 +60,7 @@ logdir=./log
 datadir=./data
 debuglevel=TXMP=debug,MINR=debug
 txindex=1
+rejectnonstd=1
 EOF
 
 cat > "${NODES_ROOT}/dcrctl.conf" <<EOF


### PR DESCRIPTION
A bug in server.go was not caught because we don't run dcrd on simnet with --rejectnonstd which is the default for mainnet. Force its use so that these bugs don't sneak in.