### PR TITLE
rpcserver: Add --rejectnonstd to rpctest

### DIFF
--- a/internal/rpcserver/treasury_test.go
+++ b/internal/rpcserver/treasury_test.go
@@ -217,6 +217,7 @@ func TestTreasury(t *testing.T) {
 	// Setup the log dir for tests to ease debugging after failures.
 	logDir := ".dcrdlogs"
 	extraArgs := []string{
+		"--rejectnonstd",
 		"--debuglevel=MINR=trace,TRSY=trace",
 		"--logdir=" + logDir,
 	}


### PR DESCRIPTION
Previously you couldn't run simnet without --rejectnonstd so the rpctest
harness setup was left without this.

This ended up letting a bug slip through that would prevent tadds being
added to mempools and relayed through the network.

