### PR TITLE
dcrjson: Reject dup method type registrations.

### DIFF
--- a/dcrjson/register.go
+++ b/dcrjson/register.go
@@ -168,13 +168,16 @@ func Register(method interface{}, params interface{}, flags UsageFlag) error {
 		return makeError(ErrInvalidType, str)
 	}
 
+	if _, ok := methodToConcreteType[method]; ok {
+		str := fmt.Sprintf("method %q is already registered for type %[1]T",
+			method)
+		return makeError(ErrDuplicateMethod, str)
+	}
+
 	rtp := reflect.TypeOf(params)
-	if paramsType, ok := methodToConcreteType[method]; ok {
-		if rtp == paramsType {
-			return nil
-		}
-		str := fmt.Sprintf("method %q is already registered for "+
-			"type %T", method, paramsType)
+	if registeredMethod, ok := concreteTypeToMethod[rtp]; ok {
+		str := fmt.Sprintf("param type %T is already registered for method %q",
+			params, registeredMethod)
 		return makeError(ErrDuplicateMethod, str)
 	}
 


### PR DESCRIPTION
This modifies the registration function to return an error as expected in the case the same method type is registered more than once and adds code to return an error when the parameter type is already registered for some other method type.

The current code allowed the same method type to be registered again so long as it had the same parameter type associated with it, which is not desirable since it might have been registered with a different set of flags and the new registration would simply be ignored.
