### PR TITLE
blockchain/mempool: Update for recent err convrsn.

### DIFF
--- a/blockchain/common_test.go
+++ b/blockchain/common_test.go
@@ -558,7 +558,7 @@ func (g *chaingenHarness) RejectBlock(blockName string, kind ErrorKind) {
 }
 
 // RejectTipBlock expects the current tip block associated with the harness
-// generator to be rejected with the provided error code.
+// generator to be rejected with the provided error kind.
 func (g *chaingenHarness) RejectTipBlock(kind ErrorKind) {
 	g.t.Helper()
 

--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -643,9 +643,10 @@ func (e ErrorKind) Error() string {
 	return string(e)
 }
 
-// RuleError identifies a rule violation related to blocks. It has
-// full support for errors.Is and errors.As, so the caller can ascertain the
-// specific reason for the error by checking the underlying error.
+// RuleError identifies a rule violation.  It is used to indicate that
+// processing of a block or transaction failed due to one of the many validation
+// rules.  It has full support for errors.Is and errors.As, so the caller can
+// ascertain the specific reason for the rule violation.
 type RuleError struct {
 	Err         error
 	Description string

--- a/blockchain/error_test.go
+++ b/blockchain/error_test.go
@@ -153,8 +153,7 @@ func TestErrorKindStringer(t *testing.T) {
 	for i, test := range tests {
 		result := test.in.Error()
 		if result != test.want {
-			t.Errorf("#%d: got: %s want: %s", i, result,
-				test.want)
+			t.Errorf("#%d: got: %s want: %s", i, result, test.want)
 			continue
 		}
 	}
@@ -165,23 +164,19 @@ func TestRuleError(t *testing.T) {
 	tests := []struct {
 		in   RuleError
 		want string
-	}{
-		{
-			RuleError{Description: "duplicate block"},
-			"duplicate block",
-		},
-		{
-			RuleError{Description: "human-readable error"},
-			"human-readable error",
-		},
-	}
+	}{{
+		RuleError{Description: "duplicate block"},
+		"duplicate block",
+	}, {
+		RuleError{Description: "human-readable error"},
+		"human-readable error",
+	}}
 
 	t.Logf("Running %d tests", len(tests))
 	for i, test := range tests {
 		result := test.in.Error()
 		if result != test.want {
-			t.Errorf("Error #%d: got: %s want: %s", i, result,
-				test.want)
+			t.Errorf("#%d: got: %s want: %s", i, result, test.want)
 			continue
 		}
 	}

--- a/blockchain/fullblocks_test.go
+++ b/blockchain/fullblocks_test.go
@@ -192,8 +192,8 @@ func TestFullBlocks(t *testing.T) {
 				blockHeight)
 		}
 
-		// Ensure the error code is of the expected type and the reject
-		// code matches the value specified in the test instance.
+		// Ensure the error reject kind matches the value specified in the test
+		// instance.
 		if !errors.Is(err, item.RejectKind) {
 			t.Fatalf("block %q (hash %s, height %d) does not have "+
 				"expected reject code -- got %v, want %v",
@@ -237,9 +237,9 @@ func TestFullBlocks(t *testing.T) {
 
 		_, err := chain.ProcessBlock(block, blockchain.BFNone)
 		if err != nil {
-			// Ensure the error code is of the expected type.  Note
-			// that orphans are rejected with ErrMissingParent, so
-			// this check covers both conditions.
+			// Ensure the error is of the expected type.  Note that orphans are
+			// rejected with ErrMissingParent, so this check covers both
+			// conditions.
 			var rerr blockchain.RuleError
 			if !errors.As(err, &rerr) {
 				t.Fatalf("block %q (hash %s, height %d) "+

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -532,7 +532,7 @@ func CheckProofOfStake(block *dcrutil.Block, posLimit int64) error {
 // standalone.RuleError to a blockchain.RuleError with the equivalent error
 // kind.  The error is simply passed through without modification if it is
 // not a standalone.RuleError, not one of the specifically recognized
-// error codes, or nil.
+// error kinds, or nil.
 func standaloneToChainRuleError(err error) error {
 	// Convert standalone package rule errors to blockchain rule errors.
 	var rErr standalone.RuleError

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -603,9 +603,8 @@ func TestTxValidationErrors(t *testing.T) {
 	// Ensure transaction is rejected due to being too large.
 	err := CheckTransactionSanity(tx, chaincfg.MainNetParams(), noTreasury)
 	if !errors.Is(err, ErrTxTooBig) {
-		t.Fatalf("CheckTransactionSanity: unexpected error code for "+
-			"transaction that is too large -- got %v, want %v",
-			err, ErrTxTooBig)
+		t.Fatalf("CheckTransactionSanity: unexpected error for transaction "+
+			"that is too large -- got %v, want %v", err, ErrTxTooBig)
 	}
 }
 
@@ -647,7 +646,7 @@ func TestCheckConnectBlockTemplate(t *testing.T) {
 	// template.
 	//
 	// rejectedBlockTemplate expects the block to be considered an invalid
-	// block template due to the provided error code.
+	// block template due to the provided error kind.
 	acceptedBlockTemplate := func() {
 		msgBlock := g.Tip()
 		blockHeight := msgBlock.Header.Height
@@ -676,8 +675,8 @@ func TestCheckConnectBlockTemplate(t *testing.T) {
 				blockHeight)
 		}
 
-		// Ensure the error code is of the expected type and the reject
-		// code matches the value specified in the test instance.
+		// Ensure the error reject kind matches the value specified in the test
+		// instance.
 		if !errors.Is(err, kind) {
 			t.Fatalf("block template %q (hash %s, height %d) does "+
 				"not have expected reject code -- got %v, want %v",

--- a/internal/mempool/policy_test.go
+++ b/internal/mempool/policy_test.go
@@ -556,7 +556,7 @@ func TestCheckTransactionStandard(t *testing.T) {
 			continue
 		}
 
-		// Ensure the error code is the expected one.
+		// Ensure the error is the expected one.
 		if !errors.Is(err, test.err) {
 			t.Errorf("checkTransactionStandard (%s): unexpected error -- got "+
 				"%v, want %v", test.name, err, test.err)


### PR DESCRIPTION
This updates the blockchain and mempool packages for the recent conversion to the new preferred error infrastructure to finish a TODO that was mean to take advantage of it as well as address some other nits such as comments that weren't updated properly and test formatting.