### PR TITLE
[release-v1.6] release: Bump for 1.6.0.

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2018 The Decred developers
+// Copyright (c) 2015-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -37,14 +37,14 @@ var (
 	// '-ldflags "-X github.com/decred/dcrd/internal/version.PreRelease=foo"'
 	// if needed.  It MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.
-	PreRelease = "pre"
+	PreRelease = ""
 
 	// BuildMetadata is defined as a variable so it can be overridden during the
 	// build process with:
 	// '-ldflags "-X github.com/decred/dcrd/internal/version.BuildMetadata=foo"'
 	// if needed.  It MUST only contain characters from semanticBuildAlphabet
 	// per the semantic versioning spec.
-	BuildMetadata = ""
+	BuildMetadata = "release.local"
 )
 
 // String returns the application version as a properly formed string per the


### PR DESCRIPTION
**This requires #2428**.

This clears the `PreRelease` and sets the `BuildMetadata` to `release.local` on the release branch so that anyone building the release branch will end up with version "1.6.0+release.local" indicating it was a local build as opposed to a reproducible release build.
