### PR TITLE
mining: Prevent panic in child prio item handling.

### DIFF
--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -1317,7 +1317,7 @@ nextPriorityQueueItem:
 			// If the fee decreased due to ancestors being included in the
 			// template and the transaction has no parents, then enqueue it one
 			// more time with an accurate feePerKb.
-			heap.Push(priorityQueue, prioItemMap[*tx.Hash()])
+			heap.Push(priorityQueue, prioItem)
 			prioritizedTxns[*tx.Hash()] = struct{}{}
 			continue
 		}
@@ -1506,11 +1506,15 @@ nextPriorityQueueItem:
 					continue
 				}
 
-				// Add the transaction to the priority queue if there
-				// are no more dependencies after this one.
+				// Add the transaction to the priority queue if there are no
+				// more dependencies after this one and the priority item for it
+				// already exists.
 				if !miningView.HasParents(childTxHash) {
-					heap.Push(priorityQueue, prioItemMap[*childTxHash])
-					prioritizedTxns[*childTxHash] = struct{}{}
+					childPrioItem := prioItemMap[*childTxHash]
+					if childPrioItem != nil {
+						heap.Push(priorityQueue, childPrioItem)
+						prioritizedTxns[*childTxHash] = struct{}{}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This prevents an issue with the way that children are added to the priority queue when building mining templates.  In particular, it
ensures the child has already had priority item built for it before adding to the prioirty queue since it is possible that the child has not yet been seen under certain circumstances such as when there are complicated transaction graphs of unconfirmed transactions.