### PR TITLE
mining: Move block chain functions to Config.

### DIFF
--- a/blockchain/stakeversion.go
+++ b/blockchain/stakeversion.go
@@ -311,7 +311,7 @@ func (b *BlockChain) calcStakeVersionByHash(hash *chainhash.Hash) (uint32, error
 }
 
 // CalcStakeVersionByHash calculates the expected stake version for the block
-// AFTER provided block hash.
+// AFTER the provided block hash.
 //
 // This function is safe for concurrent access.
 func (b *BlockChain) CalcStakeVersionByHash(hash *chainhash.Hash) (uint32, error) {

--- a/server.go
+++ b/server.go
@@ -3282,9 +3282,17 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 				return standardScriptVerifyFlags(s.chain)
 			},
 		}
-		tg := mining.NewBlkTmplGenerator(&policy, s.txMemPool, s.timeSource,
-			s.sigCache, s.subsidyCache, s.chainParams, s.chain, s.blockManager,
-			cfg.MiningTimeOffset)
+		tg := mining.NewBlkTmplGenerator(&mining.Config{
+			Policy:           &policy,
+			TxSource:         s.txMemPool,
+			TimeSource:       s.timeSource,
+			SigCache:         s.sigCache,
+			SubsidyCache:     s.subsidyCache,
+			ChainParams:      s.chainParams,
+			Chain:            s.chain,
+			BlockManager:     s.blockManager,
+			MiningTimeOffset: cfg.MiningTimeOffset,
+		})
 
 		s.bg = mining.NewBgBlkTmplGenerator(tg, cfg.miningAddrs,
 			cfg.AllowUnsyncedMining)


### PR DESCRIPTION
This updates mining to take in the block chain related functions that it requires rather than requiring a blockchain.BlockChain instance.

This allows for alternate implementations to be provided for these functions, such as for testing.

Some of the functions, such as `BlockByHash(hash *chainhash.Hash)`, are only used for the tip and therefore _could_ have been defined as something like `BestBlock()` instead (which would internally call `BestSnapshot` and pass that hash to `BlockByHash`).  I decided against this since mining already has already fetched `blockchain.BestState` in most cases, so it would be a bit less efficient to be calling `BestSnapshot` again within these functions.