### PR TITLE
docs: JSON-RPC API Updates.

### DIFF
--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -2007,7 +2007,7 @@ of the best block.
 |None
 |-
 !Description
-| Returns information about an unspent transaction output.
+| Returns statistics on current unspent transaction output set.
 |-
 !Returns
 |<code>(json object)</code>

--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -2257,6 +2257,9 @@ of the best block.
 !Description
 |Returns raw data for transactions involving the passed address. Returned transactions are pulled from both the database, and transactions currently in the mempool. Transactions pulled from the mempool will have the <code>"confirmations"</code> field set to 0. Usage of this RPC requires the optional <code>--addrindex</code> flag to be activated, otherwise all responses will simply return with an error stating the address index has not yet been built up. Similarly, until the address index has caught up with the current best height, all requests will return an error response in order to avoid serving stale data.
 |-
+!Notes
+|Each request is limited to a maximum of 10000 transactions. Callers may use the <code>skip</code> parameter in subsequent requests to access additional data if access to more results is required.
+|-
 !Returns (verbose=0)
 |
 <code>(json array of strings)</code>

--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -1660,10 +1660,13 @@ of the best block.
 |-
 !Returns
 |<code>(json array)</code>
+: <code>id</code>: <code>(numeric)</code> a unique node ID.
 : <code>addr</code>: <code>(string)</code> the ip address and port of the peer.
+: <code>addrlocal</code>: <code>(string)</code> local address.
 : <code>services</code>: <code>(string)</code> the services supported by the peer.
-: <code>lastrecv</code>: <code>(numeric)</code> time the last message was received in seconds since 1 Jan 1970 GMT.
+: <code>relaytxes</code>: <code>(boolean)</code> peer has requested transactions be relayed to it.
 : <code>lastsend</code>: <code>(numeric)</code> time the last message was sent in seconds since 1 Jan 1970 GMT.
+: <code>lastrecv</code>: <code>(numeric)</code> time the last message was received in seconds since 1 Jan 1970 GMT.
 : <code>bytessent</code>: <code>(numeric)</code> total bytes sent.
 : <code>bytesrecv</code>: <code>(numeric)</code> total bytes received.
 : <code>conntime</code>: <code>(numeric)</code> time the connection was made in seconds since 1 Jan 1970 GMT.
@@ -1674,12 +1677,13 @@ of the best block.
 : <code>inbound</code>: <code>(boolean)</code> whether or not the peer is an inbound connection.
 : <code>startingheight</code>: <code>(numeric)</code> the latest block height the peer knew about when the connection was established.
 : <code>currentheight</code>: <code>(numeric)</code> the latest block height the peer is known to have relayed since connected.
+: <code>banscore</code>: <code>(numeric)</code> the ban score.
 : <code>syncnode</code>: <code>(boolean)</code> whether or not the peer is the sync peer.
 
-<code>[{"addr": "host:port", "services": "00000001", "lastrecv": n, "lastsend": n,  "bytessent": n, "bytesrecv": n, "conntime": n, "pingtime": n, "pingwait": n,  "version": n, "subver": "useragent", "inbound": true_or_false, "startingheight": n, "currentheight": n, "syncnode": true_or_false }, ...]</code>
+<code>[{"id": n, "addr": "host:port", "addrlocal": "host:port", "services": "00000001", "relaytxes": true_or_false, "lastsend": n, "lastrecv": n, "bytessent": n, "bytesrecv": n, "conntime": n, "pingtime": n.nnn, "pingwait": n.nnn,  "version": n, "subver": "useragent", "inbound": true_or_false, "startingheight": n, "currentheight": n, "banscore": n, "syncnode": true_or_false }, ...]</code>
 |-
 !Example Return
-|<code>[{"addr": "178.172.xxx.xxx:9108", "services": "00000001", "lastrecv": 1388183523, "lastsend": 1388185470, "bytessent": 287592965, "bytesrecv": 780340, "conntime": 1388182973, "pingtime": 405551, "pingwait": 183023, "version": 70001, "subver": "/dcrd:0.4.0/", "inbound": false, "startingheight": 276921, "currentheight": 276955, "syncnode": true }, ...]</code>
+|<code>[{"id": 1, "addr": "178.172.xxx.xxx:9108", "addrlocal": "192.168.x.x:54349", "services": "00000001", "relaytxes": true, "lastsend": 1388185470, "lastrecv": 1388183523, "bytessent": 287592965, "bytesrecv": 780340, "conntime": 1388182973, "pingtime": 405551, "pingwait": 183023, "version": 70001, "subver": "/dcrd:0.4.0/", "inbound": false, "startingheight": 276921, "currentheight": 276955, "banscore": 0, "syncnode": true }, ...]</code>
 |}
 
 ----

--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -1921,6 +1921,7 @@ of the best block.
 |gettreasurybalance
 |-
 !Parameters
+|
 # <code>hash</code>: <code>(string, optional)</code> Return the treasury balance at the specified block. If unspecified, return the balance for the current tip block.
 # <code>verbose</code>: <code>(bool, optional)</code> Whether to fill the <code>updates</code> field of the response. Defaults to false.
 |-
@@ -1928,11 +1929,12 @@ of the best block.
 | Returns the matured balance of the network's treasury account. It optionally also returns the individual balance-changing amounts (treasury base, add and spend transactions) for the block.
 |-
 !Returns
-|<code>(json object)</code>
-| <code>hash</code>: <code>(string)</code> Block hash for which the balance was fetched.
-| <code>height</code>: <code>(numeric)</code> Block height for which the balance was fetched.
-| <code>balance</code>: <code>(numeric)</code> Balance (in atoms) of mature funds of the treasury account.
-| <code>updates</code>: <code>(json array of numeric)</code>: Individual amounts that affect the treasury balance in the given block. Amounts corresponding to treasury spend transactions will be negative. Only filled if <code>verbose</code> is specified.
+|
+<code>(json object)</code>
+: <code>hash</code>: <code>(string)</code> Block hash for which the balance was fetched.
+: <code>height</code>: <code>(numeric)</code> Block height for which the balance was fetched.
+: <code>balance</code>: <code>(numeric)</code> Balance (in atoms) of mature funds of the treasury account.
+: <code>updates</code>: <code>(json array of numeric)</code>: Individual amounts that affect the treasury balance in the given block. Amounts corresponding to treasury spend transactions will be negative. Only filled if <code>verbose</code> is specified.
 |-
 !Example Return
 |<code>{"hash": "00000000000000001605faff0827dafcea7d0986cf0aad06e87eccf9e02ff441","height": 428944,"balance": 1923209183818,"updates":[157007970,19200000000,-1892811207]}</code>

--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -1956,16 +1956,17 @@ of the best block.
 | Returns a tally of on-chain votes for treasury spend transactions.
 |-
 !Returns
-|<code>(json object)</code>
-| <code>hash</code>: <code>(string)</code> The block hash of the block up to which the votes were tallied.
-| <code>height</code>: <code>(numeric)</code> The block height of the block up to which the votes were tallied.
-| <code>votes</code>: <code>(json array of objects)</code> Per-tspend vote counts.
-|  <code>hash</code>: <code>(string)</code> Hash of the treasury spend transaction.
-|  <code>expiry</code>: <code>(numeric)</code> Expiry value for the tspend tx.
-|  <code>votestart</code>: <code>(numeric)</code> Block height at which voting for the tspend starts.
-|  <code>voteend</code>: <code>(numeric)</code> Block height at which voting for the tspend ends.
-|  <code>yesvotes</code>: <code>(numeric)</code> Number of <code>yes</code> votes the tspend received (up to the height returned in the main response object).
-|  <code>novotes</code>: <code>(numeric)</code> Number of <code>no</code> votes the tspend received (up to the height returned in the main response object).
+|
+<code>(json object)</code>
+: <code>hash</code>: <code>(string)</code> The block hash of the block up to which the votes were tallied.
+: <code>height</code>: <code>(numeric)</code> The block height of the block up to which the votes were tallied.
+: <code>votes</code>: <code>(json array of objects)</code> Per-tspend vote counts.
+:  <code>hash</code>: <code>(string)</code> Hash of the treasury spend transaction.
+:  <code>expiry</code>: <code>(numeric)</code> Expiry value for the tspend tx.
+:  <code>votestart</code>: <code>(numeric)</code> Block height at which voting for the tspend starts.
+:  <code>voteend</code>: <code>(numeric)</code> Block height at which voting for the tspend ends.
+:  <code>yesvotes</code>: <code>(numeric)</code> Number of <code>yes</code> votes the tspend received (up to the height returned in the main response object).
+:  <code>novotes</code>: <code>(numeric)</code> Number of <code>no</code> votes the tspend received (up to the height returned in the main response object).
 |-
 !Example Return
 |<code>{"hash": "00000000000000001605faff0827dafcea7d0986cf0aad06e87eccf9e02ff441","height":428944,"votes": [{"hash": "f9d40601f4156dbdf7b310da9f5751488d9e531cf26151782642cd47efa4b732","expiry": 432290,"votestart": 428832,"voteend": 432288,"yesvotes":392,"novotes":91}]}</code>


### PR DESCRIPTION
This addresses several issues with the JSON-RPC API documentation.  It is split into several commits to easy the review process.


- docs: Fix JSON-RPC API gettxoutsetinfo description.
- docs: Add JSON-RPC API getpeerinfo missing fields.
- docs: Fix JSON-RPC API gettreasurybalance fmt.
- docs: Fix JSON-RPC API gettreasuryspendvotes fmt.
- docs: Add JSON-RPC API searchrawtxns req limit. 

Closes #2437
Closes #2438
Closes #2439
Closes #2440
Closes #2442

