### PR TITLE
blockchain: Clear failed block flags for HF.

### DIFF
--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -28,7 +28,7 @@ import (
 const (
 	// currentDatabaseVersion indicates what the current database
 	// version is.
-	currentDatabaseVersion = 7
+	currentDatabaseVersion = 8
 
 	// currentBlockIndexVersion indicates what the current block index
 	// database version.


### PR DESCRIPTION
**This is rebased on top of #2449**.

### Testing Notes

As of this PR, the expected behavior is that there is a single migration that takes around 30 seconds to complete after which it will no longer be possible to downgrade.

As the warning above notes, if you try to run an older software version after this migration has completed, you will get an error message similar to `Unable to start server: the current blockchain database is no longer compatible with this version of the software (8 > 7)`

---

Since the next release of the software will include a vote to change the consensus rules, this unmarks all blocks previously marked as having failed validation so they are eligible for validation again under what will likely become new consensus rules.  This ensures clients that did not update prior to new rules activating are able to automatically recover under the new rules without having to download the entire chain again.

This really should have been done as a part of the version 7 upgrade, but it wasn't, so this bumps the database version accordingly.

Also, since the version has to be bumped, this also takes the opportunity to roll the fix to ensure the treasury buckets that weren't created in the v7 upgrade in the original RC into the v8 upgrade.
