### PR TITLE
multi: Add TAdd support to getrawmempool

### DIFF
--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -2714,12 +2714,15 @@ func handleGetRawMempool(_ context.Context, s *Server, cmd interface{}) (interfa
 		case types.GRMTSpend:
 			filterType = new(stake.TxType)
 			*filterType = stake.TxTypeTSpend
+		case types.GRMTAdd:
+			filterType = new(stake.TxType)
+			*filterType = stake.TxTypeTAdd
 		case types.GRMAll:
 			// Nothing to do
 		default:
 			supported := []types.GetRawMempoolTxTypeCmd{types.GRMRegular,
 				types.GRMTickets, types.GRMVotes, types.GRMRevocations,
-				types.GRMAll}
+				types.GRMTSpend, types.GRMTAdd, types.GRMAll}
 			return nil, rpcInvalidError("Invalid transaction type: %s -- "+
 				"supported types: %v", *c.TxType, supported)
 		}

--- a/rpc/jsonrpc/types/chainsvrcmds.go
+++ b/rpc/jsonrpc/types/chainsvrcmds.go
@@ -675,6 +675,9 @@ const (
 
 	// GRMTSpend indicates that only tspends should be returned.
 	GRMTSpend GetRawMempoolTxTypeCmd = "tspend"
+
+	// GRMTAdd indicates that only tadds should be returned.
+	GRMTAdd GetRawMempoolTxTypeCmd = "tadd"
 )
 
 // GetRawMempoolCmd defines the getmempool JSON-RPC command.


### PR DESCRIPTION
This adds support to querying specifically for tadds when using the
getrawmempool rpc call.

It also adds the missing tspend to the help command when using an
invalid txtype argument to getrawmempool.

