### PR TITLE
blockchain: Handle db upgrade paths for ver < 5.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -2198,12 +2198,6 @@ func New(ctx context.Context, config *Config) (*BlockChain, error) {
 		}
 	}
 
-	// The version 5 database upgrade requires a full reindex.  Perform, or
-	// resume, the reindex as needed.
-	if err := b.maybeFinishV5Upgrade(ctx); err != nil {
-		return nil, err
-	}
-
 	log.Infof("Blockchain database version info: chain: %d, compression: "+
 		"%d, block index: %d", b.dbInfo.version, b.dbInfo.compVer,
 		b.dbInfo.bidxVer)

--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -97,7 +97,7 @@ func (e AssertError) Error() string {
 // determining the reason for an error.
 type ErrorKind string
 
-// These constants are used to identify a specific RuleError.
+// These constants are used to identify a specific ErrorKind.
 const (
 	// ErrDuplicateBlock indicates a block with the same hash already
 	// exists.
@@ -636,11 +636,38 @@ const (
 	// ErrTicketExhaustion indicates extending a given block with another one
 	// would result in an unrecoverable chain due to ticket exhaustion.
 	ErrTicketExhaustion = ErrorKind("ErrTicketExhaustion")
+
+	// ErrDBTooOldToUpgrade indicates the database version is prior to the
+	// minimum supported version for which upgrades are supported.
+	ErrDBTooOldToUpgrade = ErrorKind("ErrDBTooOldToUpgrade")
 )
 
 // Error satisfies the error interface and prints human-readable errors.
 func (e ErrorKind) Error() string {
 	return string(e)
+}
+
+// ContextError wraps an error with additional context.  It has full support for
+// errors.Is and errors.As, so the caller can ascertain the specific wrapped
+// error.
+type ContextError struct {
+	Err         error
+	Description string
+}
+
+// Error satisfies the error interface and prints human-readable errors.
+func (e ContextError) Error() string {
+	return e.Description
+}
+
+// Unwrap returns the underlying wrapped error.
+func (e ContextError) Unwrap() error {
+	return e.Err
+}
+
+// ruleError creates a ContextError given a set of arguments.
+func contextError(kind ErrorKind, desc string) ContextError {
+	return ContextError{Err: kind, Description: desc}
 }
 
 // RuleError identifies a rule violation.  It is used to indicate that

--- a/blockchain/error_test.go
+++ b/blockchain/error_test.go
@@ -147,6 +147,7 @@ func TestErrorKindStringer(t *testing.T) {
 		{ErrInvalidTAddChange, "ErrInvalidTAddChange"},
 		{ErrTooManyTAdds, "ErrTooManyTAdds"},
 		{ErrTicketExhaustion, "ErrTicketExhaustion"},
+		{ErrDBTooOldToUpgrade, "ErrDBTooOldToUpgrade"},
 	}
 
 	t.Logf("Running %d tests", len(tests))
@@ -169,6 +170,29 @@ func TestRuleError(t *testing.T) {
 		"duplicate block",
 	}, {
 		RuleError{Description: "human-readable error"},
+		"human-readable error",
+	}}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		result := test.in.Error()
+		if result != test.want {
+			t.Errorf("#%d: got: %s want: %s", i, result, test.want)
+			continue
+		}
+	}
+}
+
+// TestContextError tests the error output for the ContextError type.
+func TestContextError(t *testing.T) {
+	tests := []struct {
+		in   ContextError
+		want string
+	}{{
+		ContextError{Description: "duplicate block"},
+		"duplicate block",
+	}, {
+		ContextError{Description: "human-readable error"},
 		"human-readable error",
 	}}
 
@@ -239,6 +263,42 @@ func TestErrorKindIsAs(t *testing.T) {
 		target:    io.EOF,
 		wantMatch: false,
 		wantAs:    ErrDuplicateBlock,
+	}, {
+		name:      "ContextError.ErrDBTooOldToUpgrade == ErrDBTooOldToUpgrade",
+		err:       contextError(ErrDBTooOldToUpgrade, ""),
+		target:    ErrDBTooOldToUpgrade,
+		wantMatch: true,
+		wantAs:    ErrDBTooOldToUpgrade,
+	}, {
+		name:      "ContextError.ErrDBTooOldToUpgrade == ContextError.ErrDBTooOldToUpgrade",
+		err:       contextError(ErrDBTooOldToUpgrade, ""),
+		target:    contextError(ErrDBTooOldToUpgrade, ""),
+		wantMatch: true,
+		wantAs:    ErrDBTooOldToUpgrade,
+	}, {
+		name:      "ContextError.ErrDBTooOldToUpgrade != ErrMissingParent",
+		err:       contextError(ErrDBTooOldToUpgrade, ""),
+		target:    ErrMissingParent,
+		wantMatch: false,
+		wantAs:    ErrDBTooOldToUpgrade,
+	}, {
+		name:      "ErrDBTooOldToUpgrade != ContextError.ErrMissingParent",
+		err:       ErrDBTooOldToUpgrade,
+		target:    contextError(ErrMissingParent, ""),
+		wantMatch: false,
+		wantAs:    ErrDBTooOldToUpgrade,
+	}, {
+		name:      "ContextError.ErrDBTooOldToUpgrade != ContextError.ErrMissingParent",
+		err:       contextError(ErrDBTooOldToUpgrade, ""),
+		target:    contextError(ErrMissingParent, ""),
+		wantMatch: false,
+		wantAs:    ErrDBTooOldToUpgrade,
+	}, {
+		name:      "ContextError.ErrDBTooOldToUpgrade != io.EOF",
+		err:       contextError(ErrDBTooOldToUpgrade, ""),
+		target:    io.EOF,
+		wantMatch: false,
+		wantAs:    ErrDBTooOldToUpgrade,
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
**This requires #2446**.

This removes all code related to upgrading old databases prior to version 5 and adds code so the main dcrd block loading logic is able to query the blockchain if the database is too old to be upgraded and then automatically handle removing and recreating the database when it is.

In other words, there is no manual intervention required by the user as it will behave the same as if the user had manually removed the database and thus redownload the chain from scratch as normal.

Since the blockchain package is used by other callers and utilities as well, the upgrade path is also updated to detect the situation and return an appropriate error along with additional information informing the caller that the version is no longer supported and the database must be removed.

While it would be nice to continue to support upgrading from super old versions, there was a major overhaul from v4 to v5 such that an entire reindex that needs to be tightly integrated with the code was required.
    
Since the aforementioned code has continued to change since that time, attempting to continue to support this now would require reimplementing a massive amount of code solely to support upgrading nodes that are woefully out of data at this point and have long since been hard forked from the network.

Upgrades starting from v5 are still supported.
    
Finally, in order to make the error detection more ergonomic, this introduces a new `ContextError` type which can be used to wrap any error with additional context such that errors.Is is able to detect the underlying wrapped error.  Ideally, the other error types would be consolidated in the future to make use to the new `ContextError` type instead to provide the additional context, but since that would be a breaking change the API, it will need to be done in a new major version.