### PR TITLE
rpcserver: Update getrawmempool txtype help.

### DIFF
--- a/internal/rpcserver/rpcserverhelp.go
+++ b/internal/rpcserver/rpcserverhelp.go
@@ -636,7 +636,7 @@ var helpDescsEnUS = map[string]string{
 	// GetRawMempoolCmd help.
 	"getrawmempool--synopsis":   "Returns information about all of the transactions currently in the memory pool.",
 	"getrawmempool-verbose":     "Returns JSON object when true or an array of transaction hashes when false",
-	"getrawmempool-txtype":      "Type of tx to return. (all/regular/tickets/votes/revocations)",
+	"getrawmempool-txtype":      "Type of tx to return (regular/tickets/votes/revocations/tspend/tadd/all)",
 	"getrawmempool--condition0": "verbose=false",
 	"getrawmempool--condition1": "verbose=true",
 	"getrawmempool--result0":    "Array of transaction hashes",


### PR DESCRIPTION
This updates the help for the `getrawmempool` `txtype` parameters to specify the new supported treasury types.