### PR TITLE
blockchain: Upgrade simplification refactor.

### DIFF
--- a/blockchain/upgrade.go
+++ b/blockchain/upgrade.go
@@ -1355,26 +1355,34 @@ func migrateSpendJournalVersion1To2(ctx context.Context, db database.DB) error {
 	// a single database transaction could result in massive memory usage and
 	// could potentially crash on many systems due to ulimits.
 	//
-	// It returns the number of entries processed.
+	// It returns whether or not all entries have been updated.
 	const maxEntries = 20000
 	var resumeOffset uint32
-	doBatch := func(dbTx database.Tx) (uint32, error) {
+	var totalMigrated uint64
+	doBatch := func(dbTx database.Tx) (bool, error) {
 		meta := dbTx.Metadata()
 		v1Bucket := meta.Bucket(v1BucketName)
 		if v1Bucket == nil {
-			return 0, fmt.Errorf("bucket %s does not exist", v1BucketName)
+			return false, fmt.Errorf("bucket %s does not exist", v1BucketName)
 		}
 
 		v2Bucket := meta.Bucket(v2BucketName)
 		if v2Bucket == nil {
-			return 0, fmt.Errorf("bucket %s does not exist", v2BucketName)
+			return false, fmt.Errorf("bucket %s does not exist", v2BucketName)
 		}
 
 		// Migrate spend journal entries so long as the max number of entries
 		// for this batch has not been exceeded.
+		var logProgress bool
 		var numMigrated, numIterated uint32
 		err := v1Bucket.ForEach(func(key, oldSerialized []byte) error {
+			if interruptRequested(ctx) {
+				logProgress = true
+				return errInterruptRequested
+			}
+
 			if numMigrated >= maxEntries {
+				logProgress = true
 				return errBatchFinished
 			}
 
@@ -1518,47 +1526,20 @@ func migrateSpendJournalVersion1To2(ctx context.Context, db database.DB) error {
 			}
 
 			numMigrated++
-
-			if interruptRequested(ctx) {
-				return errInterruptRequested
-			}
-
 			return nil
 		})
-		return numMigrated, err
+		isFullyDone := err == nil
+		if (isFullyDone || logProgress) && numMigrated > 0 {
+			totalMigrated += uint64(numMigrated)
+			log.Infof("Migrated %d entries (%d total)", numMigrated,
+				totalMigrated)
+		}
+		return isFullyDone, err
 	}
 
 	// Migrate all entries in batches for the reasons mentioned above.
-	var totalMigrated uint64
-	for {
-		var numMigrated uint32
-		err := db.Update(func(dbTx database.Tx) error {
-			var err error
-			numMigrated, err = doBatch(dbTx)
-			if errors.Is(err, errInterruptRequested) ||
-				errors.Is(err, errBatchFinished) {
-				// No error here so the database transaction is not cancelled
-				// and therefore outstanding work is written to disk.  The outer
-				// function will exit with an interrupted error below due to
-				// another interrupted check.
-				err = nil
-			}
-			return err
-		})
-		if err != nil {
-			return err
-		}
-
-		if interruptRequested(ctx) {
-			return errInterruptRequested
-		}
-
-		if numMigrated == 0 {
-			break
-		}
-
-		totalMigrated += uint64(numMigrated)
-		log.Infof("Migrated %d entries (%d total)", numMigrated, totalMigrated)
+	if err := batchedUpdate(ctx, db, doBatch); err != nil {
+		return err
 	}
 
 	elapsed := time.Since(start).Round(time.Millisecond)

--- a/blockchain/upgrade.go
+++ b/blockchain/upgrade.go
@@ -1034,26 +1034,34 @@ func migrateBlockIndexVersion2To3(ctx context.Context, db database.DB, dbInfo *d
 	// a single database transaction could result in massive memory usage and
 	// could potentially crash on many systems due to ulimits.
 	//
-	// It returns the number of entries processed.
+	// It returns whether or not all entries have been updated.
 	const maxEntries = 20000
 	var resumeOffset uint32
-	doBatch := func(dbTx database.Tx) (uint32, error) {
+	var totalMigrated uint64
+	doBatch := func(dbTx database.Tx) (bool, error) {
 		meta := dbTx.Metadata()
 		v2BlockIdxBucket := meta.Bucket(v2BucketName)
 		if v2BlockIdxBucket == nil {
-			return 0, fmt.Errorf("bucket %s does not exist", v2BucketName)
+			return false, fmt.Errorf("bucket %s does not exist", v2BucketName)
 		}
 
 		v3BlockIdxBucket := meta.Bucket(v3BucketName)
 		if v3BlockIdxBucket == nil {
-			return 0, fmt.Errorf("bucket %s does not exist", v3BucketName)
+			return false, fmt.Errorf("bucket %s does not exist", v3BucketName)
 		}
 
 		// Migrate block index entries so long as the max number of entries for
 		// this batch has not been exceeded.
+		var logProgress bool
 		var numMigrated, numIterated uint32
 		err := v2BlockIdxBucket.ForEach(func(key, oldSerialized []byte) error {
+			if interruptRequested(ctx) {
+				logProgress = true
+				return errInterruptRequested
+			}
+
 			if numMigrated >= maxEntries {
+				logProgress = true
 				return errBatchFinished
 			}
 
@@ -1093,47 +1101,20 @@ func migrateBlockIndexVersion2To3(ctx context.Context, db database.DB, dbInfo *d
 			}
 
 			numMigrated++
-
-			if interruptRequested(ctx) {
-				return errInterruptRequested
-			}
-
 			return nil
 		})
-		return numMigrated, err
+		isFullyDone := err == nil
+		if (isFullyDone || logProgress) && numMigrated > 0 {
+			totalMigrated += uint64(numMigrated)
+			log.Infof("Migrated %d entries (%d total)", numMigrated,
+				totalMigrated)
+		}
+		return isFullyDone, err
 	}
 
 	// Migrate all entries in batches for the reasons mentioned above.
-	var totalMigrated uint64
-	for {
-		var numMigrated uint32
-		err := db.Update(func(dbTx database.Tx) error {
-			var err error
-			numMigrated, err = doBatch(dbTx)
-			if errors.Is(err, errInterruptRequested) ||
-				errors.Is(err, errBatchFinished) {
-				// No error here so the database transaction is not cancelled
-				// and therefore outstanding work is written to disk.  The outer
-				// function will exit with an interrupted error below due to
-				// another interrupted check.
-				err = nil
-			}
-			return err
-		})
-		if err != nil {
-			return err
-		}
-
-		if interruptRequested(ctx) {
-			return errInterruptRequested
-		}
-
-		if numMigrated == 0 {
-			break
-		}
-
-		totalMigrated += uint64(numMigrated)
-		log.Infof("Migrated %d entries (%d total)", numMigrated, totalMigrated)
+	if err := batchedUpdate(ctx, db, doBatch); err != nil {
+		return err
 	}
 
 	elapsed := time.Since(start).Round(time.Millisecond)


### PR DESCRIPTION
This modifies the upgrade logic in `blockchain` to simplify it, avoid some otherwise unnecessary code duplication, and also make it faster to write upgrade code in the future.

It accomplishes this introducing a couple of new functions described below.

It is also split into several commits which further describe each change to ease the review process.

---
The first new function consolidates the logic for the upgrade code that avoids running a single stage again in the case of interrupted upgrades by accepting a callback and key name to use for tracking.

The net effect is that the individual functions that handle whatever migration is necessary by that stage can focus specifically on that logic and the caller then handles whether or not to apply the stage completion tracking by simply wrapping it with the new func.

This also allows a case of tracking that wasn't actually needed but was originally made a part of the migration function since it is intended to be called by future upgrades which might consist of multiple stages.

The updated approach handles that type of situation much more cleanly.

---
The second new function consolidates the logic for handling repeatedly calling a provided batch function which, as the name implies, performs database updates and migrations in batches.

The logic for handling this is currently used several times throughout the upgrade code and will very likely continue to be used in the future, so, rather than repeating it multiple times with slight variations as is currently required, the approach introduced here allows the batch function to signal when it should no longer be invoked due to finishing the final batch and passed into the new function which handles the common transaction updating and looping logic.

