### PR TITLE
mempool: Limit mempool ancestor stats.

### DIFF
--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -193,6 +193,9 @@ type TxDesc struct {
 
 	// TotalSigOps is the total signature operations for this transaction.
 	TotalSigOps int
+
+	// TxSize is the size of the transaction.
+	TxSize int64
 }
 
 // TxAncestorStats is a descriptor that stores aggregated statistics for the
@@ -209,6 +212,10 @@ type TxAncestorStats struct {
 
 	// NumAncestors is the total number of ancestors for a given transaction.
 	NumAncestors int
+
+	// NumDescendants is the total number of descendants that have ancestor
+	// statistics tracked for a given transaction.
+	NumDescendants int
 }
 
 // VoteDesc is a descriptor about a vote transaction in a transaction source


### PR DESCRIPTION
This change modifies the behavior of the mining view to not track ancestor stats for transactions that have too many unconfirmed ancestors in the mempool. Determining an accurate fee rate of all ancestors for a given transaction or aggregating accurate statistics for descendants of a set of transactions re-entering the mempool has polynomial complexity. Not bounding this problem opens the door to a number complexity attacks. By limiting the number of ancestors a transaction may have before ancestor statistics are no longer tracked, the performance of the block template generator should improve given large chains of unconfirmed transactions.

One example would be a “wide” transaction graph where a single base transaction with many outputs has descendants in the mempool where each redeemer has many outputs and a negligible fee. Unbounded, this would only be limited by the spendable amount in that transaction chain and the minimum fee allowed by the mempool.