### PR TITLE
config: Use the P-256 curve by default for RPC.

### DIFF
--- a/config.go
+++ b/config.go
@@ -47,7 +47,7 @@ const (
 	defaultSigCacheMaxSize = 100000
 
 	// Defaults for RPC server options and policy.
-	defaultTLSCurve             = "P-521"
+	defaultTLSCurve             = "P-256"
 	defaultMaxRPCClients        = 10
 	defaultMaxRPCWebsockets     = 25
 	defaultMaxRPCConcurrentReqs = 20

--- a/doc.go
+++ b/doc.go
@@ -58,7 +58,7 @@ Application Options:
       --rpccert=               File containing the certificate file
       --rpckey=                File containing the certificate key
       --tlscurve=              Curve to use when generating the TLS keypair
-                               (default: P-521)
+                               (default: P-256)
       --altdnsnames            Specify additional dns names to use when
                                generating the rpc server certificate
                                [supports DCRD_ALT_DNSNAMES environment variable]


### PR DESCRIPTION
This modifies the default curve used to generate the RPC certificates to be P-256 instead of P-521.  While I very much prefer the stronger curve, unfortunately, Chromium removed support for P-521 and since that is what electron uses under the hood, Decrediton can no longer connect to dcrd RPC servers using a certificate with P-521.