### PR TITLE
[release-v1.6] config: Use the P-256 curve by default for RPC.

### DIFF
--- a/config.go
+++ b/config.go
@@ -47,7 +47,7 @@ const (
 	defaultSigCacheMaxSize = 100000
 
 	// Defaults for RPC server options and policy.
-	defaultTLSCurve             = "P-521"
+	defaultTLSCurve             = "P-256"
 	defaultMaxRPCClients        = 10
 	defaultMaxRPCWebsockets     = 25
 	defaultMaxRPCConcurrentReqs = 20

--- a/doc.go
+++ b/doc.go
@@ -58,7 +58,7 @@ Application Options:
       --rpccert=               File containing the certificate file
       --rpckey=                File containing the certificate key
       --tlscurve=              Curve to use when generating the TLS keypair
-                               (default: P-521)
+                               (default: P-256)
       --altdnsnames            Specify additional dns names to use when
                                generating the rpc server certificate
                                [supports DCRD_ALT_DNSNAMES environment variable]


### PR DESCRIPTION
This is a backport of #2459 to the 1.6 release branch.