### PR TITLE
gencerts: Use the P-256 curve by default.

### DIFF
--- a/cmd/gencerts/gencerts.go
+++ b/cmd/gencerts/gencerts.go
@@ -46,7 +46,7 @@ type config struct {
 
 func main() {
 	cfg := config{
-		Algo:  "P-521",
+		Algo:  "P-256",
 		Years: 10,
 		Org:   "gencerts",
 	}


### PR DESCRIPTION
This modifies the default curve used to generate the certificates by the `gencerts` utility to be P-256 instead of P-521 to match a recent similar change made to the RPC server automatic generation logic.

Unfortunately, Chromium removed support for P-521 and since that is what electron uses under the hood, Decrediton can no longer connect to dcrd RPC servers using a certificate with P-521.

Thus, given the `gencerts` utility is used in various scenarios which involve interop with the aforementioned software, update it as well.