### PR TITLE
[release-v1.6] gencerts: Use the P-256 curve by default.

### DIFF
--- a/cmd/gencerts/gencerts.go
+++ b/cmd/gencerts/gencerts.go
@@ -46,7 +46,7 @@ type config struct {
 
 func main() {
 	cfg := config{
-		Algo:  "P-521",
+		Algo:  "P-256",
 		Years: 10,
 		Org:   "gencerts",
 	}


### PR DESCRIPTION
This is a backport of #2461 to the 1.6 release branch.