### PR TITLE
lru: Fix lookup race on small caches.

### DIFF
--- a/lru/kv.go
+++ b/lru/kv.go
@@ -34,19 +34,17 @@ type KVCache struct {
 //
 // This function is safe for concurrent access.
 func (m *KVCache) Lookup(key interface{}) (interface{}, bool) {
+	var value interface{}
 	m.mtx.Lock()
 	node, exists := m.cache[key]
 	if exists {
 		m.list.MoveToFront(node)
+		pair := node.Value.(*kv)
+		value = pair.value
 	}
 	m.mtx.Unlock()
 
-	if !exists {
-		return nil, exists
-	}
-
-	pair := node.Value.(*kv)
-	return pair.value, exists
+	return value, exists
 }
 
 // Contains returns whether or not the passed key is a member of the cache.


### PR DESCRIPTION
This fixes a possible race condition that could happen between the Add()
and Lookup() calls when the cache size was small.

When an entry was found in the cache during a Lookup() call, its value
was feched from the internal list node outside the mutex lock. This
could race with a corresponding Add() call when the node was actually
the LRU node and was about to be overwritten.

This could manifest as a race specially when using caches with a very
small size, since it becomes more likely to perform a lookup on an entry
that is about to be concurrently overwritten.

This fixes the issue by moving the code that extracts the value from the
node to be performed with the lock held.

Here's a test that can usually trigger the race detector on my machine. Run it with `go test -race -run TestPossibleRaceSmallCache`

```
func TestPossibleRaceSmallCache(t *testing.T) {
	cache := NewKVCache(1)
	for i := 0; i < 1000; i++ {
		i := i
		go func() {
			cache.Add(i, i)
			cache.Lookup(i)
		}()
	}
}
```