### PR TITLE
rpcserver: Correct getpeerinfo for peers w/o conn.

### DIFF
--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -44,7 +44,8 @@ type Peer interface {
 	// StatsSnapshot returns a snapshot of the current peer flags and statistics.
 	StatsSnapshot() *peer.StatsSnap
 
-	// LocalAddr returns the local address of the connection.
+	// LocalAddr returns the local address of the connection or nil if the peer
+	// is not currently connected.
 	LocalAddr() net.Addr
 
 	// LastPingNonce returns the last ping nonce of the remote peer.

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -2656,10 +2656,14 @@ func handleGetPeerInfo(_ context.Context, s *Server, cmd interface{}) (interface
 	infos := make([]*types.GetPeerInfoResult, 0, len(peers))
 	for _, p := range peers {
 		statsSnap := p.StatsSnapshot()
+		var addrLocalStr string
+		if addrLocal := p.LocalAddr(); addrLocal != nil {
+			addrLocalStr = addrLocal.String()
+		}
 		info := &types.GetPeerInfoResult{
 			ID:             statsSnap.ID,
 			Addr:           statsSnap.Addr,
-			AddrLocal:      p.LocalAddr().String(),
+			AddrLocal:      addrLocalStr,
 			Services:       fmt.Sprintf("%08d", uint64(statsSnap.Services)),
 			RelayTxes:      !p.IsTxRelayDisabled(),
 			LastSend:       statsSnap.LastSend.Unix(),

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -730,7 +730,8 @@ func (p *Peer) LastRecv() time.Time {
 	return time.Unix(atomic.LoadInt64(&p.lastRecv), 0)
 }
 
-// LocalAddr returns the local address of the connection.
+// LocalAddr returns the local address of the connection or nil if the peer is
+// not currently connected.
 //
 // This function is safe for concurrent access.
 func (p *Peer) LocalAddr() net.Addr {

--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -71,7 +71,8 @@ func (p *rpcPeer) StatsSnapshot() *peer.StatsSnap {
 	return (*serverPeer)(p).Peer.StatsSnapshot()
 }
 
-// LocalAddr returns the local address of the connection.
+// LocalAddr returns the local address of the connection or nil if the peer is
+// not currently connected.
 //
 // This function is safe for concurrent access and is part of the rpcserver.Peer
 // interface implementation.


### PR DESCRIPTION
This corrects the `getpeerinfo` RPC handler to avoid a panic when the local address is nil which is the case when a peer is not currently connected.  This can happen for cases such as permanent peers and during process shutdown as peers are disconnected and being cleaned up.

While here, it also updates the comments to specifically call out that the `LocalAddr` method returns `nil` when a peer is not connected to better inform callers they are expected to handle that condition.