### PR TITLE
mining: Move txMiningView from mempool package.

### DIFF
--- a/internal/mining/interface.go
+++ b/internal/mining/interface.go
@@ -22,54 +22,6 @@ type PriorityInputser interface {
 	PriorityInput(prevOut *wire.OutPoint) (blockHeight int64, amount int64, ok bool)
 }
 
-// TxMiningView is a snapshot of the tx source.
-type TxMiningView interface {
-	// TxDescs returns a slice of mining descriptors for all minable
-	// transactions in the source pool.
-	TxDescs() []*TxDesc
-
-	// AncestorStats returns the last known ancestor stats for the provided
-	// transaction hash, and a boolean indicating whether ancestors are being
-	// tracked for it.
-	//
-	// Calling Ancestors will update the value returned by this function to
-	// reflect the newly calculated statistics for those ancestors.
-	AncestorStats(txHash *chainhash.Hash) (*TxAncestorStats, bool)
-
-	// Ancestors returns all transactions in the mining view that the provided
-	// transaction hash depends on.
-	Ancestors(txHash *chainhash.Hash) []*TxDesc
-
-	// HasParents returns true if the provided transaction hash has any
-	// ancestors known to the view.
-	HasParents(txHash *chainhash.Hash) bool
-
-	// Parents returns a set of transactions in the graph that the provided
-	// transaction hash spends from in the view. The order of elements
-	// returned is not guaranteed.
-	Parents(txHash *chainhash.Hash) []*TxDesc
-
-	// Children returns a set of transactions in the graph that spend
-	// from the provided transaction hash. The order of elements
-	// returned is not guaranteed.
-	Children(txHash *chainhash.Hash) []*TxDesc
-
-	// Remove causes the provided transaction to be removed from the view, if
-	// it exists. The updateDescendantStats parameter indicates whether the
-	// descendent transactions of the provided txHash should have their ancestor
-	// stats updated within the view to account for the removal of this
-	// transaction.
-	Remove(txHash *chainhash.Hash, updateDescendantStats bool)
-
-	// Reject removes and flags the provided transaction hash and all of its
-	// descendants in the view as rejected.
-	Reject(txHash *chainhash.Hash)
-
-	// IsRejected checks to see if a transaction that once existed in the view
-	// has been rejected.
-	IsRejected(txHash *chainhash.Hash) bool
-}
-
 // TxSource represents a source of transactions to consider for inclusion in
 // new blocks.
 //
@@ -104,7 +56,7 @@ type TxSource interface {
 	IsRegTxTreeKnownDisapproved(hash *chainhash.Hash) bool
 
 	// MiningView returns a snapshot of the underlying TxSource.
-	MiningView() TxMiningView
+	MiningView() *TxMiningView
 }
 
 // blockManagerFacade provides the mining package with a subset of

--- a/internal/mining/mining_view.go
+++ b/internal/mining/mining_view.go
@@ -1,0 +1,490 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package mining
+
+import (
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/dcrutil/v3"
+)
+
+const (
+	// AncestorTrackingLimit is the maximum number of ancestors a transaction
+	// can have ancestor stats calculated for.
+	AncestorTrackingLimit = 25
+)
+
+// defaultAncestorStats is the default-state of ancestor stats for a transaction
+// that has no ancestors.
+var defaultAncestorStats = TxAncestorStats{}
+
+// TxMiningView represents a snapshot of all transactions, as well as the
+// hierarchy of transactions, that are ready to be mined.
+type TxMiningView struct {
+	rejected           map[chainhash.Hash]struct{}
+	txGraph            *txDescGraph
+	txDescs            []*TxDesc
+	trackAncestorStats bool
+	ancestorStats      map[chainhash.Hash]*TxAncestorStats
+}
+
+// NewTxMiningView creates a new mining view instance.  The forEachRedeemer
+// parameter should define the function to be used for finding transactions that
+// spend a given transaction.
+func NewTxMiningView(enableAncestorTracking bool,
+	forEachRedeemer func(tx *dcrutil.Tx, f func(redeemerTx *TxDesc))) *TxMiningView {
+
+	return &TxMiningView{
+		rejected:           make(map[chainhash.Hash]struct{}),
+		txGraph:            newTxDescGraph(forEachRedeemer),
+		txDescs:            nil,
+		trackAncestorStats: enableAncestorTracking,
+		ancestorStats:      make(map[chainhash.Hash]*TxAncestorStats),
+	}
+}
+
+// addAncestorTo modifies the TxAncestorStats instance to include the provided
+// TxDesc's statistics.
+func addAncestorTo(stats *TxAncestorStats, txDesc *TxDesc) {
+	stats.Fees += txDesc.Fee
+	stats.SizeBytes += txDesc.TxSize
+	stats.TotalSigOps += txDesc.TotalSigOps
+	stats.NumAncestors++
+}
+
+// addDescendantTo modifies the TxAncestorStats instance to account for the
+// addition of a newly tracked descendant.
+func addDescendantTo(stats *TxAncestorStats) {
+	stats.NumDescendants++
+}
+
+// removeAncestorFrom modifies the TxAncestorStats instance to stop storing
+// the statistics of the provided TxDesc.
+func removeAncestorFrom(stats *TxAncestorStats, txDesc *TxDesc) {
+	stats.Fees -= txDesc.Fee
+	stats.SizeBytes -= txDesc.TxSize
+	stats.TotalSigOps -= txDesc.TotalSigOps
+	stats.NumAncestors--
+}
+
+// removeDescendantFrom modifies the TxAncestorStats instance to account for
+// the removal of a descendant.
+func removeDescendantFrom(stats *TxAncestorStats) {
+	stats.NumDescendants--
+}
+
+// Ancestors returns a collection of all transactions in the graph that the
+// provided transaction hash depends on, and its ancestors' bundle stats.
+//
+// This function is NOT safe for concurrent access.
+func (mv *TxMiningView) Ancestors(txHash *chainhash.Hash) []*TxDesc {
+	if !mv.trackAncestorStats {
+		return nil
+	}
+
+	ancestors := make([]*TxDesc, 0, AncestorTrackingLimit)
+	var baseTxStats *TxAncestorStats
+	if oldStats, hadStats := mv.ancestorStats[*txHash]; hadStats {
+		// If the transaction had statistics tracked already, then we should
+		// copy the number of descendants since that value is up to date. Use
+		// a new instance of TxAncestorStats to avoid mutating references
+		// that may be held between calls to this function.
+		baseTxStats = &TxAncestorStats{}
+		baseTxStats.NumDescendants = oldStats.NumDescendants
+	}
+
+	seen := make(map[chainhash.Hash]struct{}, AncestorTrackingLimit)
+	mv.txGraph.forEachAncestor(txHash, seen, func(txDesc *TxDesc) {
+		if baseTxStats == nil {
+			baseTxStats = &TxAncestorStats{}
+		}
+
+		addAncestorTo(baseTxStats, txDesc)
+		ancestors = append(ancestors, txDesc)
+	})
+
+	if baseTxStats == nil {
+		delete(mv.ancestorStats, *txHash)
+	} else {
+		// Update the cache.
+		mv.ancestorStats[*txHash] = baseTxStats
+	}
+
+	return ancestors
+}
+
+// AncestorStats returns the view's cached statistics for all of the provided
+// transaction's ancestors.
+//
+// This function is NOT safe for concurrent access.
+func (mv *TxMiningView) AncestorStats(txHash *chainhash.Hash) (*TxAncestorStats, bool) {
+	if !mv.trackAncestorStats {
+		return &defaultAncestorStats, false
+	}
+
+	if stats, exists := mv.ancestorStats[*txHash]; exists {
+		return stats, exists
+	}
+
+	return &defaultAncestorStats, false
+}
+
+// Children returns a set of transactions in the graph that spend from the
+// provided transaction hash. The order of elements returned is not guaranteed.
+//
+// This function is NOT safe for concurrent access.
+func (mv *TxMiningView) Children(txHash *chainhash.Hash) []*TxDesc {
+	childrenOf := mv.txGraph.childrenOf[*txHash]
+	if len(childrenOf) == 0 {
+		return nil
+	}
+
+	children := make([]*TxDesc, 0, len(childrenOf))
+	for _, tx := range childrenOf {
+		children = append(children, tx)
+	}
+
+	return children
+}
+
+// Clone makes a deep copy of the mining view and underlying transaction graph.
+// fetchTx is the locator functon that is used to find transactions that should
+// be included in the mining view.
+//
+// This function is NOT safe for concurrent access.
+func (mv *TxMiningView) Clone(txDescs []*TxDesc, fetchTx TxDescFind) *TxMiningView {
+	view := &TxMiningView{
+		rejected:           make(map[chainhash.Hash]struct{}),
+		txGraph:            mv.txGraph.clone(fetchTx),
+		txDescs:            txDescs,
+		trackAncestorStats: mv.trackAncestorStats,
+		ancestorStats: make(map[chainhash.Hash]*TxAncestorStats,
+			len(mv.ancestorStats)),
+	}
+
+	for key, value := range mv.ancestorStats {
+		view.ancestorStats[key] = &TxAncestorStats{
+			Fees:           value.Fees,
+			SizeBytes:      value.SizeBytes,
+			TotalSigOps:    value.TotalSigOps,
+			NumAncestors:   value.NumAncestors,
+			NumDescendants: value.NumDescendants,
+		}
+	}
+
+	return view
+}
+
+// Descendants returns a collection of transactions in the mining view that
+// depend on the provided transaction hash.
+//
+// This function is NOT safe for concurrent access.
+func (mv *TxMiningView) Descendants(txHash *chainhash.Hash) []*chainhash.Hash {
+	seen := map[chainhash.Hash]struct{}{}
+	descendants := make([]*chainhash.Hash, 0)
+	mv.txGraph.forEachDescendant(txHash, seen, func(descendant *TxDesc) {
+		descendants = append(descendants, descendant.Tx.Hash())
+	})
+	return descendants
+}
+
+// HasParents returns true if the provided transaction hash spends from another
+// transaction in the mining view.
+//
+// This function is NOT safe for concurrent access.
+func (mv *TxMiningView) HasParents(txHash *chainhash.Hash) bool {
+	return len(mv.txGraph.parentsOf[*txHash]) > 0
+}
+
+// IsRejected returns true if the given hash has been passed to Reject
+// on this instance of the view.
+//
+// This function is NOT safe for concurrent access.
+func (mv *TxMiningView) IsRejected(txHash *chainhash.Hash) bool {
+	_, exist := mv.rejected[*txHash]
+	return exist
+}
+
+// Parents returns a set of transactions in the graph that the provided
+// transaction hash spends from in the view. The order of elements
+// returned is not guaranteed.
+//
+// This function is NOT safe for concurrent access.
+func (mv *TxMiningView) Parents(txHash *chainhash.Hash) []*TxDesc {
+	parentsOf := mv.txGraph.parentsOf[*txHash]
+	if len(parentsOf) == 0 {
+		return nil
+	}
+
+	parents := make([]*TxDesc, 0, len(parentsOf))
+	for _, tx := range parentsOf {
+		parents = append(parents, tx)
+	}
+
+	return parents
+}
+
+// maybeUpdateAncestorStats attempts to update the ancestor stats for a given
+// transaction. It walks the graph for all ancestors of the provided transaction
+// and aggregates statistics for its ancestors. It also accepts a hash for
+// an ancestor that should be treated as though it does not exist in the
+// graph.
+func (mv *TxMiningView) maybeUpdateAncestorStats(txDesc *TxDesc,
+	ignoreTxHash *chainhash.Hash) bool {
+
+	baseTxHash := txDesc.Tx.Hash()
+	canTrackAncestors := true
+	seenAncestors := make(map[chainhash.Hash]*TxDesc,
+		AncestorTrackingLimit)
+	mv.txGraph.forEachAncestorPreOrder(baseTxHash, seenAncestors,
+		func(ancestorTxDesc *TxDesc) bool {
+			if !canTrackAncestors {
+				// Short circuit the below checks if we know that the provided
+				// transaction cannot have ancestor stats aggregated. This also
+				// stops adding transactions to the seenAncestors map.
+				return false
+			}
+
+			ancestorTxHash := *ancestorTxDesc.Tx.Hash()
+			if ancestorTxHash == *ignoreTxHash {
+				// Skip this ancestor but continue walking others.
+				// This accounts for a scenario where a transaction that will be
+				// removed from the miningView should cause descendants on the
+				// outer edge of the ancestor limit to potentially have ancestor
+				// stats calculated. However, in order to walk descendants of
+				// the transaction pending removal, it must exist in the graph
+				// so ignore it.
+				return false
+			}
+
+			if len(seenAncestors) >= AncestorTrackingLimit {
+				// A transaction with too many ancestors should not have
+				// ancestor stats cached.
+				canTrackAncestors = false
+				return false
+			}
+
+			// If any ancestor transaction does not have stats, then the
+			// provided one should not either.
+			ancestorStats, exists := mv.ancestorStats[ancestorTxHash]
+			if !exists {
+				canTrackAncestors = false
+				return false
+			}
+
+			// If any ancestor plus its respective ancestors would exceed the
+			// limit for this transaction, then do not track stats.
+			if ancestorStats.NumAncestors+1 > AncestorTrackingLimit {
+				canTrackAncestors = false
+				return false
+			}
+
+			// If tracking this transaction would cause any ancestor to have
+			// more descendants than the tracking limit, then stats should not
+			// be tracked for the base transaction.
+			if ancestorStats.NumDescendants+1 > AncestorTrackingLimit {
+				canTrackAncestors = false
+				return false
+			}
+			return true
+		})
+
+	if !canTrackAncestors {
+		delete(mv.ancestorStats, *baseTxHash)
+		return false
+	}
+
+	// The transaction has passed all checks and will have ancestor statistics
+	// tracked and updated. All elements of the seenAncestors map will have
+	// ancestor statistics tracked. This is guaranteed by a check performed
+	// during a prior walk that limits what enters the seenAncestors map.
+	baseTxnAncestorStats := &TxAncestorStats{}
+	for ancestorTxHash, ancestorTxDesc := range seenAncestors {
+		addAncestorTo(baseTxnAncestorStats, ancestorTxDesc)
+		addDescendantTo(mv.ancestorStats[ancestorTxHash])
+	}
+	mv.ancestorStats[*baseTxHash] = baseTxnAncestorStats
+	return true
+}
+
+// updateStatsDescendantsAdded adds the provided transaction's stats
+// to all transactions in the graph that depend on it.
+func (mv *TxMiningView) updateStatsDescendantsAdded(baseTxDesc *TxDesc) {
+	if len(mv.txGraph.childrenOf[*baseTxDesc.Tx.Hash()]) == 0 {
+		// Return early if the base transaction has no descendants.
+		return
+	}
+
+	baseTxHash := baseTxDesc.Tx.Hash()
+	baseTxStats, baseTxHasStats := mv.ancestorStats[*baseTxHash]
+	seenDescendants := make(map[chainhash.Hash]struct{},
+		AncestorTrackingLimit+1)
+
+	mv.txGraph.forEachDescendantPreOrder(baseTxHash, seenDescendants,
+		func(descendant *TxDesc) bool {
+			descendantTxHash := *descendant.Tx.Hash()
+			descendantStats, descendantHasStats :=
+				mv.ancestorStats[descendantTxHash]
+			if !descendantHasStats {
+				// Cannot update ancestor stats for a transaction or its
+				// descendants if it does not have ancestor stats tracked.
+				return false
+			}
+
+			if !baseTxHasStats {
+				// If the base tx does not have ancestor stats, then remove them
+				// for all of its descendants. This can happen during a reorg or
+				// disapproval event when two transaction chains are joined by
+				// the base transaction.
+				delete(mv.ancestorStats, descendantTxHash)
+				return true
+			}
+
+			if baseTxStats.NumDescendants+1 > AncestorTrackingLimit {
+				// The base transaction has enough tracked descendants. Stop
+				// tracking this descendant and its descendants.
+				delete(mv.ancestorStats, descendantTxHash)
+				return true
+			}
+
+			if descendantStats.NumAncestors+1 > AncestorTrackingLimit {
+				// The descendant has too many tracked ancestors. Stop
+				// tracking this descendant and its descendants.
+				delete(mv.ancestorStats, descendantTxHash)
+				return true
+			}
+
+			// Update the stats for this descendant since it is allowed to have
+			// ancestor statistics tracked. Also add the descendant to the
+			// statistics of the base transaction.
+			addAncestorTo(descendantStats, baseTxDesc)
+			addDescendantTo(baseTxStats)
+			return true
+		})
+}
+
+// updateStatsDescendantsRemoved removes the provided transaction's stats
+// from all descendant transactions.
+func (mv *TxMiningView) updateStatsDescendantsRemoved(baseTxDesc *TxDesc) {
+	baseTxHash := baseTxDesc.Tx.Hash()
+	if _, hasStats := mv.ancestorStats[*baseTxHash]; !hasStats {
+		// If the transaction does not have ancestor tracking enabled, then
+		// none of its descendants should either.
+		return
+	}
+
+	numUntrackedDescendants := 0
+	seenDescendants := make(map[chainhash.Hash]struct{}, AncestorTrackingLimit)
+	mv.txGraph.forEachDescendantPreOrder(baseTxHash, seenDescendants,
+		func(descendantTxDesc *TxDesc) bool {
+			descendantTxHash := *descendantTxDesc.Tx.Hash()
+			descendantStats, hasStats := mv.ancestorStats[descendantTxHash]
+
+			// Attempt to track the descendant's ancestor stats if it was not
+			// tracked previously. This scenario applies to a transaction
+			// that once had too many ancestors, but is now eligible to
+			// have stats tracked.
+			// A check is also performed to avoid testing too many descendants
+			// for eligibility to be included in the tracked set, since no
+			// descendant can know if any one of its ancestors has too many
+			// descendants tracked without visiting the ancestor. Note that
+			// although this has a non-ideal behavior of potentially skipping
+			// transactions that would otherwise be eligible to have stats
+			// tracked, it bounds the number of times ancestors are walked.
+			if !hasStats && numUntrackedDescendants < AncestorTrackingLimit {
+				numUntrackedDescendants++
+
+				// Note that this call retrieves ancestors while walking
+				// descendants of another transaction, and that the time
+				// complexity is bound by the maximum number of ancestors
+				// allowed to be tracked in the graph and the maximum
+				// number of descendants allowed to have ancestor stats tracked.
+				mv.maybeUpdateAncestorStats(descendantTxDesc, baseTxHash)
+
+				// Do not walk descendants of this descendant if it did not
+				// have ancestor stats previously because it was on the edge of
+				// the ancestor limit. Any transactions that descend from it
+				// would exceed the limit by at least one.
+				return false
+			}
+
+			if hasStats {
+				removeAncestorFrom(descendantStats, baseTxDesc)
+				return true
+			}
+
+			// If the transaction does not have statistics tracked then none of
+			// its descendants will either.
+			return false
+		})
+
+	// Update all ancestors to account for the removal of a descendant.
+	seenAncestors := make(map[chainhash.Hash]*TxDesc, AncestorTrackingLimit)
+	mv.txGraph.forEachAncestorPreOrder(baseTxHash, seenAncestors,
+		func(ancestorTxDesc *TxDesc) bool {
+			ancestorStats, exists := mv.ancestorStats[*ancestorTxDesc.Tx.Hash()]
+			if exists {
+				removeDescendantFrom(ancestorStats)
+			}
+			return true
+		})
+}
+
+// AddTransaction inserts a TxDesc into the mining view if it has a parent
+// or child in the view, or has a relationship with another transaction through
+// findTx.
+//
+// This function is NOT safe for concurrent access.
+func (mv *TxMiningView) AddTransaction(txDesc *TxDesc, findTx TxDescFind) {
+	// Track the txn in the graph and attempt to relate it to at least one other
+	// transaction.
+	mv.txGraph.insert(txDesc, findTx)
+
+	if mv.trackAncestorStats {
+		mv.maybeUpdateAncestorStats(txDesc, &zeroHash)
+		// When a transaction is added back to the view, update the stats of its
+		// descendants.
+		mv.updateStatsDescendantsAdded(txDesc)
+	}
+}
+
+// Remove stops tracking the transaction in the mining view if it exists.  If
+// updateDescendantStats is true, then the statistics for all descendant
+// transactions are updated to account for the removal of an ancestor.
+//
+// This function is NOT safe for concurrent access.
+func (mv *TxMiningView) Remove(txHash *chainhash.Hash, updateDescendantStats bool) {
+	if mv.trackAncestorStats && updateDescendantStats {
+		txDesc := mv.txGraph.find(txHash)
+		if txDesc != nil {
+			mv.updateStatsDescendantsRemoved(txDesc)
+		}
+	}
+
+	mv.txGraph.remove(txHash)
+	delete(mv.ancestorStats, *txHash)
+}
+
+// Reject stops tracking the transaction in the view, if it exists, and all
+// of its descendants.  Also flags the provided transaction as rejected and
+// tracks the hash as rejected in this instance of the mining view. Rejected
+// transactions are not shared between mining view instances, and a new
+// mining view is always initialized with an empty set of rejected transactions.
+//
+// This function is NOT safe for concurrent access.
+func (mv *TxMiningView) Reject(txHash *chainhash.Hash) {
+	seen := make(map[chainhash.Hash]struct{})
+	mv.txGraph.forEachDescendant(txHash, seen, func(descendant *TxDesc) {
+		mv.Remove(descendant.Tx.Hash(), false)
+		mv.rejected[*descendant.Tx.Hash()] = struct{}{}
+	})
+
+	mv.Remove(txHash, false)
+	mv.rejected[*txHash] = struct{}{}
+}
+
+// TxDescs returns a collection of all transactions available in the view.
+func (mv *TxMiningView) TxDescs() []*TxDesc {
+	return mv.txDescs
+}

--- a/internal/mining/tx_desc_graph.go
+++ b/internal/mining/tx_desc_graph.go
@@ -1,0 +1,242 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package mining
+
+import (
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/dcrutil/v3"
+)
+
+// txDescGraph relates a set of transactions to their respective descendants and
+// ancestors. It only stores transactions that have at least one edge relating
+// to another.
+type txDescGraph struct {
+	forEachRedeemer func(tx *dcrutil.Tx, f func(redeemerTx *TxDesc))
+	childrenOf      map[chainhash.Hash]map[chainhash.Hash]*TxDesc
+	parentsOf       map[chainhash.Hash]map[chainhash.Hash]*TxDesc
+}
+
+// TxDescFind is used to inject a transaction repository into the mining view.
+// This might either come from the mempool's outpoint map or from the mining
+// view itself.
+type TxDescFind func(txHash *chainhash.Hash) *TxDesc
+
+// newTxDescGraph creates a new transaction graph instance.  The forEachRedeemer
+// parameter should define the function to be used for finding transactions that
+// spend a given transaction.
+func newTxDescGraph(forEachRedeemer func(tx *dcrutil.Tx, f func(redeemerTx *TxDesc))) *txDescGraph {
+	return &txDescGraph{
+		forEachRedeemer: forEachRedeemer,
+		childrenOf:      make(map[chainhash.Hash]map[chainhash.Hash]*TxDesc),
+		parentsOf:       make(map[chainhash.Hash]map[chainhash.Hash]*TxDesc),
+	}
+}
+
+// addChild adds a child transaction to the graph as a dependent of the
+// provided transaction tx.
+func (g *txDescGraph) addChild(tx *TxDesc, child *TxDesc) {
+	txHash := *tx.Tx.Hash()
+	if _, exists := g.childrenOf[txHash]; !exists {
+		g.childrenOf[txHash] = make(map[chainhash.Hash]*TxDesc,
+			len(tx.Tx.MsgTx().TxOut))
+	}
+
+	g.childrenOf[txHash][*child.Tx.Hash()] = child
+}
+
+// addParent adds a parent transaction to the graph as a dependency of the
+// provided transaction tx.
+func (g *txDescGraph) addParent(tx *TxDesc, parent *TxDesc) {
+	txHash := *tx.Tx.Hash()
+	if _, exists := g.parentsOf[txHash]; !exists {
+		g.parentsOf[txHash] = make(map[chainhash.Hash]*TxDesc,
+			len(tx.Tx.MsgTx().TxIn))
+	}
+
+	g.parentsOf[txHash][*parent.Tx.Hash()] = parent
+}
+
+// find returns the TxDesc stored in the graph by its hash. If the transaction
+// is not in the graph, then a nil pointer is returned. Since each transaction
+// in the graph must have at least one edge connecting it to another
+// transaction, scanning for a known hash as a child or parent is sufficient
+// to recover its pointer.
+func (g *txDescGraph) find(txHash *chainhash.Hash) *TxDesc {
+	for parentHash := range g.parentsOf[*txHash] {
+		return g.childrenOf[parentHash][*txHash]
+	}
+
+	for childHash := range g.childrenOf[*txHash] {
+		return g.parentsOf[childHash][*txHash]
+	}
+
+	return nil
+}
+
+// forEachAncestor iterates over all transactions in the graph that txHash
+// depends on and invokes the function f for each transaction,
+// in topological order.
+func (g *txDescGraph) forEachAncestor(txHash *chainhash.Hash,
+	seen map[chainhash.Hash]struct{}, f func(tx *TxDesc)) {
+
+	for parent, parentDesc := range g.parentsOf[*txHash] {
+		if _, saw := seen[parent]; saw {
+			continue
+		}
+
+		seen[parent] = struct{}{}
+		g.forEachAncestor(&parent, seen, f)
+		f(parentDesc)
+	}
+}
+
+// forEachAncestorPreOrder iterates over all transactions in the graph that
+// txHash depends on and invokes the function f for each, in pre-order.
+// If the provided function f returns true then it continues to walk ancestors
+// of the respective ancestor. If it returns false, then no additional parents
+// of the provided transaction will be visited and the transaction passed to f
+// will not be added to the seen map.
+func (g *txDescGraph) forEachAncestorPreOrder(txHash *chainhash.Hash,
+	seen map[chainhash.Hash]*TxDesc, f func(tx *TxDesc) bool) {
+
+	for parentHash, parentTxDesc := range g.parentsOf[*txHash] {
+		if _, saw := seen[parentHash]; saw {
+			continue
+		}
+
+		moveNext := f(parentTxDesc)
+		if !moveNext {
+			return
+		}
+
+		seen[parentHash] = parentTxDesc
+		g.forEachAncestorPreOrder(&parentHash, seen, f)
+	}
+}
+
+// forEachDescendant iterates depth-first over all transactions that depend on
+// the provided transaction hash and invokes function f with each in post-order.
+func (g *txDescGraph) forEachDescendant(txHash *chainhash.Hash,
+	seen map[chainhash.Hash]struct{}, f func(*TxDesc)) {
+
+	for child, childDesc := range g.childrenOf[*txHash] {
+		if _, saw := seen[child]; saw {
+			continue
+		}
+
+		seen[child] = struct{}{}
+		g.forEachDescendant(&child, seen, f)
+		f(childDesc)
+	}
+}
+
+// forEachDescendantPreOrder attempts to walk all transactions that depend on
+// the provided transaction hash by invoking the function f with each in
+// pre-order. If the provided function f returns true then the traversal will
+// walk descendants of the provided transaction's respective child.
+func (g *txDescGraph) forEachDescendantPreOrder(txHash *chainhash.Hash,
+	seen map[chainhash.Hash]struct{}, f func(*TxDesc) bool) {
+
+	for child, childDesc := range g.childrenOf[*txHash] {
+		if _, saw := seen[child]; saw {
+			continue
+		}
+
+		seen[child] = struct{}{}
+		if f(childDesc) {
+			g.forEachDescendantPreOrder(&child, seen, f)
+		}
+	}
+}
+
+// insert adds a transaction to the graph and creates a 2-way association
+// between itself and its parents.
+func (g *txDescGraph) insert(txDesc *TxDesc, findTx TxDescFind) {
+	seen := make(map[chainhash.Hash]struct{})
+
+	// Fetch transactions that spend this one from the graph.
+	g.forEachRedeemer(txDesc.Tx, func(child *TxDesc) {
+		g.addChild(txDesc, child)
+		g.addParent(child, txDesc)
+	})
+
+	// Relate self with direct ancestors.
+	for _, txIn := range txDesc.Tx.MsgTx().TxIn {
+		parentHash := txIn.PreviousOutPoint.Hash
+		if _, saw := seen[parentHash]; saw {
+			continue
+		}
+
+		seen[parentHash] = struct{}{}
+
+		// Find parents using the provided locator function and add them to the graph.
+		if parentTx := findTx(&parentHash); parentTx != nil {
+			g.addParent(txDesc, parentTx)
+			g.addChild(parentTx, txDesc)
+		}
+	}
+}
+
+// remove deletes the provided txn hash from the graph. If it is the only
+// relationship held by a related transaction in the graph, that related
+// transaction is also removed.
+func (g *txDescGraph) remove(txHash *chainhash.Hash) {
+	// Remove references to tx from all children.
+	for childHash := range g.childrenOf[*txHash] {
+		delete(g.parentsOf[childHash], *txHash)
+
+		// If the child has no more parents, remove reference.
+		if len(g.parentsOf[childHash]) == 0 {
+			delete(g.parentsOf, childHash)
+		}
+	}
+
+	// Remove references to tx from all parents.
+	for parentHash := range g.parentsOf[*txHash] {
+		delete(g.childrenOf[parentHash], *txHash)
+
+		// If the parent has no more children, remove reference.
+		if len(g.childrenOf[parentHash]) == 0 {
+			delete(g.childrenOf, parentHash)
+		}
+	}
+
+	// Remove reference since we don't need to track this txn's
+	// parents or children
+	delete(g.parentsOf, *txHash)
+	delete(g.childrenOf, *txHash)
+}
+
+// clone returns a copy of the current graph.
+func (g *txDescGraph) clone(fetchTx TxDescFind) *txDescGraph {
+	graph := &txDescGraph{
+		parentsOf: make(map[chainhash.Hash]map[chainhash.Hash]*TxDesc,
+			len(g.parentsOf)),
+		childrenOf: make(map[chainhash.Hash]map[chainhash.Hash]*TxDesc,
+			len(g.childrenOf)),
+	}
+
+	// Source transactions from within the graph to decouple the cloned
+	// mining view instance from the original transaction source.
+	graph.forEachRedeemer = func(tx *dcrutil.Tx, f func(redeemerTx *TxDesc)) {
+		for _, childTx := range graph.childrenOf[*tx.Hash()] {
+			f(childTx)
+		}
+	}
+
+	// Copy parents and children. Anything tracked by the graph
+	// will either be a child or parent of another element in the graph.
+	for txHash := range g.parentsOf {
+		txDesc := fetchTx(&txHash)
+		graph.insert(txDesc, fetchTx)
+	}
+
+	for txHash := range g.childrenOf {
+		txDesc := fetchTx(&txHash)
+		graph.insert(txDesc, fetchTx)
+	}
+
+	return graph
+}


### PR DESCRIPTION
Requires https://github.com/decred/dcrd/pull/2458

This moves txMiningView and txDescGraph to the mining package. This reduces the coupling between the mempool and mining packages and allows mining tests to use the actual txMiningView and txDescGraph implementations.

---

The more immediate reason I am looking to bring this in is that I am working toward adding a mining test harness. In its current state, most/all of the `txMiningView` and `txDescGraph` functionality would need to be duplicated in the test code.

Summary of the changes (unfortunately, this couldn't really be split into multiple commits since the intermediate steps would be in a non-working state):

- Moved the `txMiningView` type and methods to `mining/mining_view.go`.
  - Removed `mining.*` everywhere in this file.
- Moved the `txDescGraph` type and methods to `mining/tx_desc_graph.go`.
  - Removed `mining.*` everywhere in this file.
  - Nothing is exported within this file, `txDescGraph` is only used internally by `txMiningView`.
- Updated `TxMiningView` to be exported and updated all references accordingly.
- Updated `AddTransaction` to be exported and updated all references accordingly.
- Removed `TxMiningView` interface and updated `mempool` to use the exported `mining.TxMiningView` type and methods.
  - I didn't see a need for this interface at this point.  If `mempool` wanted to use an alternative mining view implementation (for testing or other purposes), it could make sense to have a mining view interface defined in `mempool`.
  - `mempool` is only using `AddTransaction`, `Remove`, and `Clone` from `TxMiningView`. However, `mempool_test` uses quite a few other `TxMiningView` methods since it is validating that the internals of `TxMiningView` are set correctly.  Testing these internals could be moved to `mining` in the future, and then those other methods could be unexported.
- Added `mining.NewTxMiningView` and `mining.TxMiningView` `Clone` methods for `mempool` to use instead of handling that logic directly.


