### PR TITLE
[release-v1.6] mempool: Limit ancestor tracking in mempool.

### DIFF
--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -65,6 +65,9 @@ type TxDesc struct {
 
 	// TotalSigOps is the total signature operations for this transaction.
 	TotalSigOps int
+
+	// TxSize is the size of the transaction.
+	TxSize int64
 }
 
 // TxAncestorStats is a descriptor that stores aggregated statistics for the
@@ -81,6 +84,10 @@ type TxAncestorStats struct {
 
 	// NumAncestors is the total number of ancestors for a given transaction.
 	NumAncestors int
+
+	// NumDescendants is the total number of descendants that have ancestor
+	// statistics tracked for a given transaction.
+	NumDescendants int
 }
 
 // TxMiningView is a snapshot of the tx source.


### PR DESCRIPTION
This is a backport of #2458 to the 1.6 release branch.