### PR TITLE
rpcclient: Prepare v6.0.2.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/decred/dcrd/hdkeychain/v3 v3.0.0
 	github.com/decred/dcrd/lru v1.1.0
 	github.com/decred/dcrd/peer/v2 v2.2.0
-	github.com/decred/dcrd/rpc/jsonrpc/types/v2 v2.2.0
+	github.com/decred/dcrd/rpc/jsonrpc/types/v2 v2.3.0
 	github.com/decred/dcrd/rpcclient/v6 v6.0.0
 	github.com/decred/dcrd/txscript/v3 v3.0.0
 	github.com/decred/dcrd/wire v1.4.0

--- a/rpcclient/go.mod
+++ b/rpcclient/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/decred/dcrd/dcrjson/v3 v3.1.0
 	github.com/decred/dcrd/dcrutil/v3 v3.0.0
 	github.com/decred/dcrd/gcs/v2 v2.1.0
-	github.com/decred/dcrd/rpc/jsonrpc/types/v2 v2.2.0
+	github.com/decred/dcrd/rpc/jsonrpc/types/v2 v2.3.0
 	github.com/decred/dcrd/wire v1.4.0
 	github.com/decred/go-socks v1.1.0
 	github.com/decred/slog v1.1.0

--- a/rpcclient/go.sum
+++ b/rpcclient/go.sum
@@ -30,8 +30,8 @@ github.com/decred/dcrd/dcrutil/v3 v3.0.0 h1:n6uQaTQynIhCY89XsoDk2WQqcUcnbD+zUM9r
 github.com/decred/dcrd/dcrutil/v3 v3.0.0/go.mod h1:iVsjcqVzLmYFGCZLet2H7Nq+7imV9tYcuY+0lC2mNsY=
 github.com/decred/dcrd/gcs/v2 v2.1.0 h1:foECqwfE3UJztU4CYtqUYqvR254x1Z9clXVfNdOjBQ8=
 github.com/decred/dcrd/gcs/v2 v2.1.0/go.mod h1:MbnJOINFcp42NMRAQ+CjX/xGz+53AwNgMzKZhwBibdM=
-github.com/decred/dcrd/rpc/jsonrpc/types/v2 v2.2.0 h1:8xxN/nKOO2yx29oZEL8METscZ3eJnvbl68oFiNg2+SI=
-github.com/decred/dcrd/rpc/jsonrpc/types/v2 v2.2.0/go.mod h1:krn89ZOgSa8yc7sA4WpDK95p61NnjNWFkNlMnGrKbMc=
+github.com/decred/dcrd/rpc/jsonrpc/types/v2 v2.3.0 h1:KZ2zihwY5Mx6EeYwEA3bL3k+qDXdCraQL+iDIG1BP5k=
+github.com/decred/dcrd/rpc/jsonrpc/types/v2 v2.3.0/go.mod h1:krn89ZOgSa8yc7sA4WpDK95p61NnjNWFkNlMnGrKbMc=
 github.com/decred/dcrd/txscript/v3 v3.0.0 h1:74NmirXAIskbGP0g9OWtrmN7OxDbWJ9G73a5uoxTkcM=
 github.com/decred/dcrd/txscript/v3 v3.0.0/go.mod h1:pdvnlD4KGdDoc09cvWRJ8EoRQUaiUz41uDevOWuEfII=
 github.com/decred/dcrd/wire v1.4.0 h1:KmSo6eTQIvhXS0fLBQ/l7hG7QLcSJQKSwSyzSqJYDk0=


### PR DESCRIPTION
**NOTE: This is rebased on top of `rpcclient/v6.0.1` since master has moved on to the rpcclient/v7 development cycle.**

This updates the `rpcclient` module dependencies and serves as a base for `rpcclient/v6.0.2`.

The updated direct dependencies in this commit are as follows:

- github.com/decred/dcrd/rpc/jsonrpc/types/v2@v2.3.0

The full list of updated direct dependencies since the previous `rpcclient/v6.0.1` release are as follows:

- github.com/decred/dcrd/rpc/jsonrpc/types/v2@v2.3.0

Finally, all modules in the repository are tidied to ensure they are updated to use the latest versions hoisted forward as a result.