### PR TITLE
blockchain: No context checks in sanity/positional.

### DIFF
--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -248,10 +248,6 @@ const (
 	// is not a coinbase transaction.
 	ErrFirstTxNotCoinbase = ErrorKind("ErrFirstTxNotCoinbase")
 
-	// ErrFirstTxNotOpReturn indicates the first transaction in a block
-	// is not an OP_RETURN.
-	ErrFirstTxNotOpReturn = ErrorKind("ErrFirstTxNotOpReturn")
-
 	// ErrCoinbaseHeight indicates that the encoded height in the coinbase
 	// is incorrect.
 	ErrCoinbaseHeight = ErrorKind("ErrCoinbaseHeight")

--- a/blockchain/error_test.go
+++ b/blockchain/error_test.go
@@ -52,7 +52,6 @@ func TestErrorKindStringer(t *testing.T) {
 		{ErrBadFees, "ErrBadFees"},
 		{ErrTooManySigOps, "ErrTooManySigOps"},
 		{ErrFirstTxNotCoinbase, "ErrFirstTxNotCoinbase"},
-		{ErrFirstTxNotOpReturn, "ErrFirstTxNotOpReturn"},
 		{ErrCoinbaseHeight, "ErrCoinbaseHeight"},
 		{ErrMultipleCoinbases, "ErrMultipleCoinbases"},
 		{ErrStakeTxInRegularTree, "ErrStakeTxInRegularTree"},

--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -2123,7 +2123,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 		ticket.TxOut[0], ticket.TxOut[2] = ticket.TxOut[2], ticket.TxOut[0]
 		b.AddSTransaction(ticket)
 	})
-	rejected(blockchain.ErrRegTxCreateStakeOut)
+	rejected(blockchain.ErrRegTxInStakeTree)
 
 	// Create block with scripts that do not involve p2pkh or p2sh addresses
 	// for a ticket purchase.
@@ -2139,7 +2139,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 		ticket.TxOut[0].PkScript = opTrueScript
 		b.AddSTransaction(ticket)
 	})
-	rejected(blockchain.ErrRegTxCreateStakeOut)
+	rejected(blockchain.ErrRegTxInStakeTree)
 
 	// ---------------------------------------------------------------------
 	// Block header median time tests.
@@ -2676,7 +2676,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	g.NextBlock("bsc2", outs[19], ticketOuts[19],
 		replaceSpendScript(tooManySigOps))
 	g.AssertTipBlockSigOpsCount(maxBlockSigOps + 1)
-	rejected(blockchain.ErrScriptMalformed)
+	rejected(blockchain.ErrTooManySigOps)
 
 	// ---------------------------------------------------------------------
 	// Dead execution path tests.

--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -2123,7 +2123,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 		ticket.TxOut[0], ticket.TxOut[2] = ticket.TxOut[2], ticket.TxOut[0]
 		b.AddSTransaction(ticket)
 	})
-	rejected(blockchain.ErrRegTxInStakeTree)
+	rejected(blockchain.ErrRegTxCreateStakeOut)
 
 	// Create block with scripts that do not involve p2pkh or p2sh addresses
 	// for a ticket purchase.
@@ -2139,7 +2139,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 		ticket.TxOut[0].PkScript = opTrueScript
 		b.AddSTransaction(ticket)
 	})
-	rejected(blockchain.ErrRegTxInStakeTree)
+	rejected(blockchain.ErrRegTxCreateStakeOut)
 
 	// ---------------------------------------------------------------------
 	// Block header median time tests.

--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -2676,7 +2676,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	g.NextBlock("bsc2", outs[19], ticketOuts[19],
 		replaceSpendScript(tooManySigOps))
 	g.AssertTipBlockSigOpsCount(maxBlockSigOps + 1)
-	rejected(blockchain.ErrTooManySigOps)
+	rejected(blockchain.ErrScriptMalformed)
 
 	// ---------------------------------------------------------------------
 	// Dead execution path tests.

--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -1077,7 +1077,9 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	//                 \-> bv2(9)
 	g.SetTip("bsl5")
 	g.NextBlock("bv2", outs[9], ticketOuts[9], func(b *wire.MsgBlock) {
-		b.STransactions[0] = b.Transactions[0]
+		txCopy := b.Transactions[1].Copy()
+		txCopy.TxOut[1].PkScript = chaingen.UniqueOpReturnScript()
+		b.AddSTransaction(txCopy)
 	})
 	rejected(blockchain.ErrRegTxInStakeTree)
 
@@ -1852,7 +1854,9 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	//                  \-> bmf16(15)
 	g.SetTip("brs3")
 	g.NextBlock("bmf16", outs[15], ticketOuts[15], func(b *wire.MsgBlock) {
-		b.AddTransaction(b.STransactions[1])
+		txCopy := b.STransactions[1].Copy()
+		txCopy.TxOut[1].PkScript = chaingen.UniqueOpReturnScript()
+		b.AddTransaction(txCopy)
 	})
 	rejected(blockchain.ErrStakeTxInRegularTree)
 
@@ -2118,12 +2122,11 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 		ticket := g.CreateTicketPurchaseTx(&spendOut, ticketPrice, lowFee)
 		ticket.TxOut[0], ticket.TxOut[2] = ticket.TxOut[2], ticket.TxOut[0]
 		b.AddSTransaction(ticket)
-		b.Header.FreshStake++
 	})
 	rejected(blockchain.ErrRegTxCreateStakeOut)
 
-	// Create block with scripts that do not involve p2pkh or
-	// p2sh addresses for a ticket purchase.
+	// Create block with scripts that do not involve p2pkh or p2sh addresses
+	// for a ticket purchase.
 	//
 	//   ... -> brs3(14)
 	//                  \-> bmf37(15)
@@ -2135,7 +2138,6 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 		ticket := g.CreateTicketPurchaseTx(&spendOut, ticketPrice, lowFee)
 		ticket.TxOut[0].PkScript = opTrueScript
 		b.AddSTransaction(ticket)
-		b.Header.FreshStake++
 	})
 	rejected(blockchain.ErrRegTxCreateStakeOut)
 

--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -1069,7 +1069,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 			Tree:  wire.TxTreeRegular,
 		}
 	})
-	rejected(blockchain.ErrBadTxInput)
+	rejected(blockchain.ErrDuplicateTxInputs)
 
 	// Attempt to add block with a regular tx in the stake tree.
 	//

--- a/blockchain/process.go
+++ b/blockchain/process.go
@@ -66,7 +66,7 @@ func (b *BlockChain) ProcessBlock(block *dcrutil.Block, flags BehaviorFlags) (in
 	}
 
 	// Perform preliminary sanity checks on the block and its transactions.
-	err := checkBlockSanityContextFree(block, b.timeSource, flags, b.chainParams)
+	err := checkBlockSanity(block, b.timeSource, flags, b.chainParams)
 	if err != nil {
 		return 0, err
 	}
@@ -79,23 +79,6 @@ func (b *BlockChain) ProcessBlock(block *dcrutil.Block, flags BehaviorFlags) (in
 		// not connect to the best chain.
 		str := fmt.Sprintf("previous block %s is not known", prevHash)
 		return 0, ruleError(ErrMissingParent, str)
-	}
-
-	// Perform preliminary sanity checks on the block and its transactions that
-	// depend on the state of the treasury agenda.  Note that these checks
-	// really ultimately need to be done later in the context-dependent block
-	// checking, however, they are done here for now as a stop gap to ensure
-	// they are not applied to orphan blocks from further in the chain which may
-	// have the new rules active before the local chain is far enough along for
-	// them to be active.
-	isTreasuryEnabled, err := b.isTreasuryAgendaActiveByHash(prevHash)
-	if err != nil {
-		return 0, err
-	}
-	err = checkBlockSanityContextual(block, b.timeSource, flags, b.chainParams,
-		isTreasuryEnabled)
-	if err != nil {
-		return 0, err
 	}
 
 	// The block has passed all context independent checks and appears sane

--- a/blockchain/stake/staketx.go
+++ b/blockchain/stake/staketx.go
@@ -868,8 +868,6 @@ func GetSSGenTreasuryVotes(PkScript []byte) ([]TreasuryVoteTuple, error) {
 // For example: OP_RETURN OP_DATA_X 'T','V' <N hashvote_tuple>
 func CheckSSGenVotes(tx *wire.MsgTx, isTreasuryEnabled bool) ([]TreasuryVoteTuple, error) {
 	// Check to make sure there aren't too many inputs.
-	// CheckTransactionSanity already makes sure that number of inputs is
-	// greater than 0, so no need to check that.
 	if len(tx.TxIn) != NumInputsPerSSGen {
 		return nil, stakeRuleError(ErrSSGenWrongNumInputs,
 			"SSgen tx has an invalid number of inputs")
@@ -1087,8 +1085,6 @@ func IsSSGen(tx *wire.MsgTx, isTreasuryEnabled bool) bool {
 //     MaxInputsPerSStx [index MaxOutputsPerSSRtx - 1]
 func CheckSSRtx(tx *wire.MsgTx) error {
 	// Check to make sure there is the correct number of inputs.
-	// CheckTransactionSanity already makes sure that number of inputs is
-	// greater than 0, so no need to check that.
 	if len(tx.TxIn) != NumInputsPerSSRtx {
 		return stakeRuleError(ErrSSRtxWrongNumInputs, "SSRtx has an "+
 			"invalid number of inputs")

--- a/blockchain/treasury_test.go
+++ b/blockchain/treasury_test.go
@@ -3757,7 +3757,7 @@ func TestTreasuryBaseCorners(t *testing.T) {
 	g.SetTip(startTip)
 	g.NextBlock("length0", nil, outs[1:], replaceTreasuryVersions,
 		replaceCoinbase, corruptLengthTreasurybase)
-	g.RejectTipBlock(ErrFirstTxNotTreasurybase)
+	g.RejectTipBlock(ErrRegTxInStakeTree)
 
 	// ---------------------------------------------------------------------
 	// Only treasury base.
@@ -3784,8 +3784,8 @@ func TestTreasuryBaseCorners(t *testing.T) {
 	g.RejectTipBlock(ErrTreasurybaseOutValue)
 
 	// Note we can't hit the following errors in consensus:
-	// * ErrErrFirstTxNotOpReturn (missing OP_RETURN)
-	// * ErrErrFirstTxNotOpReturn (version)
+	// * ErrFirstTxNotTreasurybase (missing OP_RETURN)
+	// * ErrFirstTxNotTreasurybase (version)
 	// * ErrTreasurybaseTxNotOpReturn
 	// * ErrInvalidTreasurybaseTxOutputs
 	// * ErrInvalidTreasurybaseVersion

--- a/blockchain/treasury_test.go
+++ b/blockchain/treasury_test.go
@@ -3631,15 +3631,19 @@ func TestTreasuryBaseCorners(t *testing.T) {
 	}
 
 	// removeStakeTxns is a munge function which modifies the provided block by
-	// removing all stake transactions.
+	// removing all stake transactions other than votes.
 	removeStakeTxns := func(b *wire.MsgBlock) {
-		b.STransactions = nil
+		b.Header.FreshStake = 0
+		b.Header.Revocations = 0
+		b.STransactions = b.STransactions[1:6]
 	}
 
 	// dupTreasurybase is a munge function which modifies the provided block by
 	// adding a duplicate treasurybase at the end of the stake tree.
 	dupTreasurybase := func(b *wire.MsgBlock) {
-		b.STransactions = append(b.STransactions, b.STransactions[0])
+		txCopy := b.STransactions[0].Copy()
+		txCopy.TxOut[1].PkScript[len(txCopy.TxOut[1].PkScript)-1] ^= 0x55
+		b.AddSTransaction(txCopy)
 	}
 
 	// flipTreasurybase is a munge function which modifies the provided block by
@@ -4143,7 +4147,9 @@ func TestTreasuryInRegularTree(t *testing.T) {
 	// addTreasuryBaseRegular is a munge function which modifies the provided
 	// block to add a treasurybase to the regular transaction tree.
 	addTreasuryBaseRegular := func(b *wire.MsgBlock) {
-		b.Transactions = append(b.Transactions, b.STransactions[0])
+		txCopy := b.STransactions[0].Copy()
+		txCopy.TxOut[1].PkScript[len(txCopy.TxOut[1].PkScript)-1] ^= 0x55
+		b.AddTransaction(txCopy)
 	}
 
 	// moveTAddRegular is a munge function which modifies the provided block by

--- a/blockchain/treasury_test.go
+++ b/blockchain/treasury_test.go
@@ -2211,7 +2211,7 @@ func TestTSpendDupVote(t *testing.T) {
 				stake.TreasuryVoteYes,
 			},
 			voteCount, true))
-	g.RejectTipBlock(ErrRegTxInStakeTree)
+	g.RejectTipBlock(ErrBadTxInput)
 
 	// ---------------------------------------------------------------------
 	// Invalid treasury spend tx vote bits are illegal and therefore the tx
@@ -2232,7 +2232,7 @@ func TestTSpendDupVote(t *testing.T) {
 				0x04, // Invalid bits
 			},
 			voteCount, true))
-	g.RejectTipBlock(ErrRegTxInStakeTree)
+	g.RejectTipBlock(ErrBadTxInput)
 }
 
 func TestTSpendTooManyTSpend(t *testing.T) {
@@ -2346,7 +2346,7 @@ func TestTSpendTooManyTSpend(t *testing.T) {
 	g.NextBlock("bdv0", nil, outs[1:], replaceTreasuryVersions,
 		replaceCoinbase,
 		addTSpendVotes(t, tspendHashes, tspendVotes, voteCount, true))
-	g.RejectTipBlock(ErrRegTxInStakeTree)
+	g.RejectTipBlock(ErrBadTxInput)
 }
 
 func TestTSpendWindow(t *testing.T) {
@@ -3757,7 +3757,7 @@ func TestTreasuryBaseCorners(t *testing.T) {
 	g.SetTip(startTip)
 	g.NextBlock("length0", nil, outs[1:], replaceTreasuryVersions,
 		replaceCoinbase, corruptLengthTreasurybase)
-	g.RejectTipBlock(ErrRegTxInStakeTree)
+	g.RejectTipBlock(ErrFirstTxNotTreasurybase)
 
 	// ---------------------------------------------------------------------
 	// Only treasury base.

--- a/blockchain/treasury_test.go
+++ b/blockchain/treasury_test.go
@@ -2190,8 +2190,11 @@ func TestTSpendDupVote(t *testing.T) {
 	}
 
 	// ---------------------------------------------------------------------
+	// Duplicate votes on the same treasury spend tx hash illegal and
+	// therefore the tx is NOT recognized as a vote.
+	//
 	//   ... -> pretvi1
-	//       \-> bdv0
+	//                 \-> bdv0
 	// ---------------------------------------------------------------------
 
 	startTip := g.TipName()
@@ -2208,11 +2211,14 @@ func TestTSpendDupVote(t *testing.T) {
 				stake.TreasuryVoteYes,
 			},
 			voteCount, true))
-	g.RejectTipBlock(ErrBadTxInput)
+	g.RejectTipBlock(ErrRegTxInStakeTree)
 
 	// ---------------------------------------------------------------------
+	// Invalid treasury spend tx vote bits are illegal and therefore the tx
+	// is NOT recognized as a vote.
+	//
 	//   ... -> pretvi1
-	//       \-> bdv1
+	//                 \-> bdv1
 	// ---------------------------------------------------------------------
 
 	g.SetTip(startTip)
@@ -2226,7 +2232,7 @@ func TestTSpendDupVote(t *testing.T) {
 				0x04, // Invalid bits
 			},
 			voteCount, true))
-	g.RejectTipBlock(ErrBadTxInput)
+	g.RejectTipBlock(ErrRegTxInStakeTree)
 }
 
 func TestTSpendTooManyTSpend(t *testing.T) {
@@ -2330,19 +2336,17 @@ func TestTSpendTooManyTSpend(t *testing.T) {
 	}
 
 	// ---------------------------------------------------------------------
-	// 8 votes is illegal and therefore this SSGEN is NOT recognized as a
-	// vote and therefore it falls through the type if/else case in
-	// validate.go CheckTransactionSanity.
+	// 8 votes is illegal and therefore the tx is NOT recognized as a vote.
 	//
 	//   ... -> pretvi1
-	//       \-> bdv0
+	//                 \-> bdv0
 	// ---------------------------------------------------------------------
 
 	voteCount := params.TicketsPerBlock
 	g.NextBlock("bdv0", nil, outs[1:], replaceTreasuryVersions,
 		replaceCoinbase,
 		addTSpendVotes(t, tspendHashes, tspendVotes, voteCount, true))
-	g.RejectTipBlock(ErrBadTxInput)
+	g.RejectTipBlock(ErrRegTxInStakeTree)
 }
 
 func TestTSpendWindow(t *testing.T) {

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -668,31 +668,12 @@ func checkBlockHeaderSanity(header *wire.BlockHeader, timeSource MedianTimeSourc
 }
 
 // checkBlockSanity performs some preliminary checks on a block to ensure it is
-// sane before continuing with block processing.  These checks are supposed to
-// be context free but are not due to the treasury agenda.
+// sane before continuing with block processing.  These checks are context
+// free.
 //
 // The flags do not modify the behavior of this function directly, however they
 // are needed to pass along to checkBlockHeaderSanity.
-//
-// Note that this is a giant hack to separate the original context free
-// function into two functions due to the treasury agenda induced contextual
-// isTreasuryEnabled flag.  The contextual checks have been pulled out in order
-// to maintain order and assumptions without having to discard the
-// isTreasuryEnabled checks from the function.
-func checkBlockSanity(block *dcrutil.Block, timeSource MedianTimeSource, flags BehaviorFlags, chainParams *chaincfg.Params, isTreasuryEnabled bool) error {
-	err := checkBlockSanityContextFree(block, timeSource, flags,
-		chainParams)
-	if err != nil {
-		return err
-	}
-	return checkBlockSanityContextual(block, timeSource, flags,
-		chainParams, isTreasuryEnabled)
-}
-
-// checkBlockSanityContextFree performs some preliminary checks on a block to
-// ensure it is sane before continuing with block processing.  These checks are
-// context free.
-func checkBlockSanityContextFree(block *dcrutil.Block, timeSource MedianTimeSource, flags BehaviorFlags, chainParams *chaincfg.Params) error {
+func checkBlockSanity(block *dcrutil.Block, timeSource MedianTimeSource, flags BehaviorFlags, chainParams *chaincfg.Params) error {
 	msgBlock := block.MsgBlock()
 	header := &msgBlock.Header
 	err := checkBlockHeaderSanity(header, timeSource, flags, chainParams)
@@ -813,18 +794,11 @@ func checkBlockSanityContextFree(block *dcrutil.Block, timeSource MedianTimeSour
 	return nil
 }
 
-// checkBlockSanityContextual performs some preliminary checks on a block to
-// ensure it is sane before continuing with block processing.  These checks are
-// contextual.
-func checkBlockSanityContextual(block *dcrutil.Block, timeSource MedianTimeSource, flags BehaviorFlags, chainParams *chaincfg.Params, isTreasuryEnabled bool) error {
-	return nil
-}
-
 // CheckBlockSanity performs some preliminary checks on a block to ensure it is
 // sane before continuing with block processing.  These checks are context
 // free.
-func CheckBlockSanity(block *dcrutil.Block, timeSource MedianTimeSource, chainParams *chaincfg.Params, isTreasuryEnabled bool) error {
-	return checkBlockSanity(block, timeSource, BFNone, chainParams, isTreasuryEnabled)
+func CheckBlockSanity(block *dcrutil.Block, timeSource MedianTimeSource, chainParams *chaincfg.Params) error {
+	return checkBlockSanity(block, timeSource, BFNone, chainParams)
 }
 
 // checkBlockHeaderPositional performs several validation checks on the block
@@ -3795,8 +3769,7 @@ func (b *BlockChain) CheckConnectBlockTemplate(block *dcrutil.Block) error {
 	if err != nil {
 		return err
 	}
-	err = checkBlockSanity(block, b.timeSource, flags, b.chainParams,
-		isTreasuryEnabled)
+	err = checkBlockSanity(block, b.timeSource, flags, b.chainParams)
 	if err != nil {
 		return err
 	}

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -532,7 +532,7 @@ func TestCheckBlockSanity(t *testing.T) {
 	params := chaincfg.RegNetParams()
 	timeSource := NewMedianTime()
 	block := dcrutil.NewBlock(&badBlock)
-	err := CheckBlockSanity(block, timeSource, params, noTreasury)
+	err := CheckBlockSanity(block, timeSource, params)
 	if err == nil {
 		t.Fatalf("block should fail.\n")
 	}

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -601,7 +601,7 @@ func TestTxValidationErrors(t *testing.T) {
 	}
 
 	// Ensure transaction is rejected due to being too large.
-	err := CheckTransactionSanity(tx, chaincfg.MainNetParams(), noTreasury)
+	err := CheckTransactionSanity(tx, chaincfg.MainNetParams())
 	if !errors.Is(err, ErrTxTooBig) {
 		t.Fatalf("CheckTransactionSanity: unexpected error for transaction "+
 			"that is too large -- got %v, want %v", err, ErrTxTooBig)

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -1192,11 +1192,14 @@ func (mp *TxPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit, allow
 		return nil, txRuleError(ErrDuplicate, str)
 	}
 
-	// Perform preliminary sanity checks on the transaction.  This makes
-	// use of blockchain which contains the invariant rules for what
-	// transactions are allowed into blocks.
-	err := blockchain.CheckTransactionSanity(msgTx, mp.cfg.ChainParams,
-		isTreasuryEnabled)
+	// Perform preliminary validation checks on the transaction.  This makes use
+	// of blockchain which contains the invariant rules for what transactions
+	// are allowed into blocks.
+	checkTxFlags := blockchain.AFNone
+	if isTreasuryEnabled {
+		checkTxFlags |= blockchain.AFTreasuryEnabled
+	}
+	err := blockchain.CheckTransaction(msgTx, mp.cfg.ChainParams, checkTxFlags)
 	if err != nil {
 		var cerr blockchain.RuleError
 		if errors.As(err, &cerr) {

--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -483,14 +483,7 @@ var _ rpcserver.SanityChecker = (*rpcSanityChecker)(nil)
 //
 // This function is part of the rpcserver.SanityChecker interface implementation.
 func (s *rpcSanityChecker) CheckBlockSanity(block *dcrutil.Block) error {
-	pHash := &block.MsgBlock().Header.PrevBlock
-	isTreasuryEnabled, err := s.chain.IsTreasuryAgendaActive(pHash)
-	if err != nil {
-		return err
-	}
-
-	return blockchain.CheckBlockSanity(block, s.timeSource, s.chainParams,
-		isTreasuryEnabled)
+	return blockchain.CheckBlockSanity(block, s.timeSource, s.chainParams)
 }
 
 // rpcBlockTemplater provides a block template generator for use with the


### PR DESCRIPTION
The sanity functions, as their comments indicate, are supposed to be context free since they are used on blocks and transactions regardless of their position within the chain.  Further, the positional functions, as their comments also indicate, are supposed to only rely on the position of the block within the chain and having the headers of all ancestors available, but NOT the full block data of all ancestors available.  These restrictions are important for planned future work which intends to decouple the processing order from the download order.

Unfortunately, the decentralized treasury work ignored the intended purpose and introduced context to both the sanity and positional functions.

This restores the intended restrictions by moving all of the checks that depend on the result of the treasury vote to the proper intended locations.

Since this is all consensus code, and it is a fairly non-trivial task due to assumptions in the code about the order of the checks, this has been split into a series of commits that each individually pass all tests and maintain proper functionality to make it reasonable to review for correctness.  Each commit more fully describes the changes in a logical order.

It should be noted that some of the intermediate commits necessarily update the expected error codes due to the change in order resulting in different error conditions being hit and then end up restoring the original error code later once the overall order is restored.  When taken as a whole, all of the full block tests end up testing for the same errors they did prior to these changes.