### PR TITLE
rpcserver: Allow TLS client cert authentication

### DIFF
--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -5532,8 +5532,15 @@ func (s *Server) authMAC(dst, auth []byte) []byte {
 // of the server (true) or whether the user is limited (false). The second is
 // always false if the first is.
 func (s *Server) checkAuth(r *http.Request, require bool) (bool, bool, error) {
+	// If admin-level RPC user and pass options are not set, this always
+	// succeeds.  This will be the case when TLS client certificates are
+	// being used for authentication.
+	if s.authsha == ([32]byte{}) {
+		return true, true, nil
+	}
+
 	authhdr := r.Header["Authorization"]
-	if len(authhdr) <= 0 {
+	if len(authhdr) == 0 {
 		if require {
 			log.Warnf("RPC authentication failure from %s",
 				r.RemoteAddr)


### PR DESCRIPTION
This adds an alternative method for TLS clients to authenticate to the
server by presenting a client certificate in the TLS handshake.  In
order for dcrd to trust this client, the certificate authority must be
added as a trusted root (by default, in clients.pem in dcrd's
application data directory) as well as setting the config value
authtype=clientcerts.  HTTP POST and websocket clients need not
provide HTTP Basic authentication when client certificates are used.

In future changes, TLS client authentication may be used to limit
access to particular RPCs by various clients, which is possible now
that each client can present their own cryptographic identity.
However, at the moment, enabling TLS client authentication requires it
at the TLS listener level, and therefore breaks the
--rpclimituser/rpclimitpass mechanism to provide non-admin client
authentication.  Additional changes will be required to provide the
client identity through the request context in order to bring back
limited access for clients.  Users depending on the limited user
settings should avoid using client certificates in the meantime.