### PR TITLE
windows: Switch to os.Executable.

### DIFF
--- a/service_windows.go
+++ b/service_windows.go
@@ -8,7 +8,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"time"
 
 	"golang.org/x/sys/windows/svc/eventlog"
@@ -112,17 +111,10 @@ loop:
 // be done by the msi installer, but it is provided here since it can be useful
 // for development.
 func installService() error {
-	// Get the path of the current executable.  This is needed because
-	// os.Args[0] can vary depending on how the application was launched.
-	// For example, under cmd.exe it will only be the name of the app
-	// without the path or extension, but under mingw it will be the full
-	// path including the extension.
-	exePath, err := filepath.Abs(os.Args[0])
+	// The the full path to the current executable.
+	exePath, err := os.Executable()
 	if err != nil {
 		return err
-	}
-	if filepath.Ext(exePath) == "" {
-		exePath += ".exe"
 	}
 
 	// Connect to the windows service manager.


### PR DESCRIPTION
This switches the Windows service code to use os.Executable() to
determine the full path to the current executable instead of os.Args[0].

os.Args[0] is not stable across different execution contexts in Windows
(for example, cmd.exe will not return the path).

Originated by a comment in #2479 

Tested installing and removing on mingw, cmd.exe and powershell using the actual bin, a symlink and a hardlink.

In the {sym,hard}link cases, the service is installed pointing to the link itself instead of the link's target. The service runs as expected, but I'm not sure whether we want the default install action to point to the link or to the actual binary. I _think_ the current behaviour is the correct one, but I'm explicitly calling it out in the PR in case this isn't actually  expected.

Also, I noticed that installing the service from an elevated prompt, since the service runs without an user account and without arguments, it defaults to fetching config and data from `c:\windows\system32\config\systemprofile\AppData\Local\Dcrd`. I'm also not sure whether this is the expected location for the data or not.
