### PR TITLE
blockchain: Error type consolidation.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -257,7 +257,7 @@ func (b *BlockChain) GetStakeVersions(hash *chainhash.Hash, count int32) ([]Stak
 	// efficiently determine that state.
 	startNode := b.index.LookupNode(hash)
 	if startNode == nil || !b.index.NodeStatus(startNode).HasValidated() {
-		return nil, fmt.Errorf("block %s is not known", hash)
+		return nil, unknownBlockError(hash)
 	}
 
 	// Nothing to do if no count requested.
@@ -354,7 +354,7 @@ func (b *BlockChain) HaveBlock(hash *chainhash.Hash) bool {
 func (b *BlockChain) ChainWork(hash *chainhash.Hash) (*big.Int, error) {
 	node := b.index.LookupNode(hash)
 	if node == nil {
-		return nil, fmt.Errorf("block %s is not known", hash)
+		return nil, unknownBlockError(hash)
 	}
 
 	return node.workSum, nil
@@ -1592,7 +1592,7 @@ func (b *BlockChain) MaxBlockSize() (int64, error) {
 func (b *BlockChain) HeaderByHash(hash *chainhash.Hash) (wire.BlockHeader, error) {
 	node := b.index.LookupNode(hash)
 	if node == nil {
-		return wire.BlockHeader{}, fmt.Errorf("block %s is not known", hash)
+		return wire.BlockHeader{}, unknownBlockError(hash)
 	}
 
 	return node.Header(), nil
@@ -1620,7 +1620,7 @@ func (b *BlockChain) HeaderByHeight(height int64) (wire.BlockHeader, error) {
 func (b *BlockChain) BlockByHash(hash *chainhash.Hash) (*dcrutil.Block, error) {
 	node := b.index.LookupNode(hash)
 	if node == nil || !b.index.NodeStatus(node).HaveData() {
-		return nil, fmt.Errorf("block %s is not known", hash)
+		return nil, unknownBlockError(hash)
 	}
 
 	// Return the block from either cache or the database.

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -301,13 +301,13 @@ type VoteInfo struct {
 	AgendaStatus []ThresholdStateTuple
 }
 
-// GetVoteInfo returns information on consensus deployment agendas
-// and their respective states at the provided hash, for the provided
-// deployment version.
+// GetVoteInfo returns information on consensus deployment agendas and their
+// respective states at the provided hash, for the provided deployment version.
 func (b *BlockChain) GetVoteInfo(hash *chainhash.Hash, version uint32) (*VoteInfo, error) {
 	deployments, ok := b.chainParams.Deployments[version]
 	if !ok {
-		return nil, VoteVersionError(version)
+		str := fmt.Sprintf("stake version %d does not exist", version)
+		return nil, contextError(ErrUnknownDeploymentVersion, str)
 	}
 
 	vi := VoteInfo{
@@ -1921,7 +1921,9 @@ func extractDeploymentIDVersions(params *chaincfg.Params) (map[string]uint32, er
 		for _, deployment := range deployments {
 			id := deployment.Vote.Id
 			if _, ok := deploymentVers[id]; ok {
-				return nil, DuplicateDeploymentError(id)
+				str := fmt.Sprintf("deployment ID %s exists in more than one "+
+					"deployment", id)
+				return nil, contextError(ErrDuplicateDeployment, str)
 			}
 			deploymentVers[id] = version
 		}

--- a/blockchain/difficulty.go
+++ b/blockchain/difficulty.go
@@ -208,7 +208,7 @@ func (b *BlockChain) calcNextRequiredDifficulty(curNode *blockNode, newBlockTime
 func (b *BlockChain) CalcNextRequiredDifficulty(hash *chainhash.Hash, timestamp time.Time) (uint32, error) {
 	node := b.index.LookupNode(hash)
 	if node == nil {
-		return 0, fmt.Errorf("block %s is not known", hash)
+		return 0, unknownBlockError(hash)
 	}
 
 	b.chainLock.Lock()

--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -11,26 +11,6 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 )
 
-// UnknownBlockError identifies an error that indicates a requested block
-// does not exist.
-type UnknownBlockError chainhash.Hash
-
-// Error returns the error as a human-readable string and satisfies the error
-// interface.
-func (e UnknownBlockError) Error() string {
-	return fmt.Sprintf("block %s is not known", chainhash.Hash(e))
-}
-
-// HashError identifies an error that indicates a hash was specified that does
-// not exist.
-type HashError string
-
-// Error returns the error as a human-readable string and satisfies the error
-// interface.
-func (e HashError) Error() string {
-	return fmt.Sprintf("hash %v does not exist", string(e))
-}
-
 // NoFilterError identifies an error that indicates a filter for a given block
 // hash does not exist.
 type NoFilterError string
@@ -616,6 +596,9 @@ const (
 	// ErrDuplicateDeployment indicates a duplicate deployment id exists in the
 	// network parameter deployment definitions.
 	ErrDuplicateDeployment = ErrorKind("ErrDuplicateDeployment")
+
+	// ErrUnknownBlock indicates a requested block does not exist.
+	ErrUnknownBlock = ErrorKind("ErrUnknownBlock")
 )
 
 // Error satisfies the error interface and prints human-readable errors.
@@ -644,6 +627,13 @@ func (e ContextError) Unwrap() error {
 // ruleError creates a ContextError given a set of arguments.
 func contextError(kind ErrorKind, desc string) ContextError {
 	return ContextError{Err: kind, Description: desc}
+}
+
+// unknownBlockError create a ContextError with the kind of error set to
+// ErrUnknownBlock and a description that includes the provided hash.
+func unknownBlockError(hash *chainhash.Hash) ContextError {
+	str := fmt.Sprintf("block %s is not known", hash)
+	return contextError(ErrUnknownBlock, str)
 }
 
 // RuleError identifies a rule violation.  It is used to indicate that

--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -11,16 +11,6 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 )
 
-// NoTreasuryError identifies an error that indicates the treasury balance for a
-// given block hash does not exist.
-type NoTreasuryError string
-
-// Error returns the error as a human-readable string and satisfies the error
-// interface.
-func (e NoTreasuryError) Error() string {
-	return fmt.Sprintf("treasury balance not available for block %s", string(e))
-}
-
 // AssertError identifies an error that indicates an internal code consistency
 // issue and should be treated as a critical and unrecoverable error.
 type AssertError string
@@ -592,6 +582,10 @@ const (
 
 	// ErrNoFilter indicates a filter for a given block hash does not exist.
 	ErrNoFilter = ErrorKind("ErrNoFilter")
+
+	// ErrNoTreasuryBalance indicates the treasury balance for a given block
+	// hash does not exist.
+	ErrNoTreasuryBalance = ErrorKind("ErrNoTreasuryBalance")
 )
 
 // Error satisfies the error interface and prints human-readable errors.

--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -11,16 +11,6 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 )
 
-// NoFilterError identifies an error that indicates a filter for a given block
-// hash does not exist.
-type NoFilterError string
-
-// Error returns the error as a human-readable string and satisfies the error
-// interface.
-func (e NoFilterError) Error() string {
-	return fmt.Sprintf("no filter available for block %s", string(e))
-}
-
 // NoTreasuryError identifies an error that indicates the treasury balance for a
 // given block hash does not exist.
 type NoTreasuryError string
@@ -599,6 +589,9 @@ const (
 
 	// ErrUnknownBlock indicates a requested block does not exist.
 	ErrUnknownBlock = ErrorKind("ErrUnknownBlock")
+
+	// ErrNoFilter indicates a filter for a given block hash does not exist.
+	ErrNoFilter = ErrorKind("ErrNoFilter")
 )
 
 // Error satisfies the error interface and prints human-readable errors.

--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -21,16 +21,6 @@ func (e UnknownBlockError) Error() string {
 	return fmt.Sprintf("block %s is not known", chainhash.Hash(e))
 }
 
-// VoteVersionError identifies an error that indicates a vote version was
-// specified that does not exist.
-type VoteVersionError uint32
-
-// Error returns the assertion error as a human-readable string and satisfies
-// the error interface.
-func (e VoteVersionError) Error() string {
-	return fmt.Sprintf("stake version %v does not exist", uint32(e))
-}
-
 // HashError identifies an error that indicates a hash was specified that does
 // not exist.
 type HashError string
@@ -39,27 +29,6 @@ type HashError string
 // interface.
 func (e HashError) Error() string {
 	return fmt.Sprintf("hash %v does not exist", string(e))
-}
-
-// DeploymentError identifies an error that indicates a deployment ID was
-// specified that does not exist.
-type DeploymentError string
-
-// Error returns the assertion error as a human-readable string and satisfies
-// the error interface.
-func (e DeploymentError) Error() string {
-	return fmt.Sprintf("deployment ID %v does not exist", string(e))
-}
-
-// DuplicateDeploymentError identifies an error that indicates a duplicate
-// deployment ID was specified in the network parameter deployment definitions.
-type DuplicateDeploymentError string
-
-// Error returns the assertion error as a human-readable string and satisfies
-// the error interface.
-func (e DuplicateDeploymentError) Error() string {
-	return fmt.Sprintf("deployment ID %v exists in more than one deployment",
-		string(e))
 }
 
 // NoFilterError identifies an error that indicates a filter for a given block
@@ -636,6 +605,17 @@ const (
 	// ErrDBTooOldToUpgrade indicates the database version is prior to the
 	// minimum supported version for which upgrades are supported.
 	ErrDBTooOldToUpgrade = ErrorKind("ErrDBTooOldToUpgrade")
+
+	// ErrUnknownDeploymentID indicates a deployment id does not exist.
+	ErrUnknownDeploymentID = ErrorKind("ErrUnknownDeploymentID")
+
+	// ErrUnknownDeploymentVersion indicates a version for a given deployment id
+	// was specified that does not exist.
+	ErrUnknownDeploymentVersion = ErrorKind("ErrUnknownDeploymentVersion")
+
+	// ErrDuplicateDeployment indicates a duplicate deployment id exists in the
+	// network parameter deployment definitions.
+	ErrDuplicateDeployment = ErrorKind("ErrDuplicateDeployment")
 )
 
 // Error satisfies the error interface and prints human-readable errors.

--- a/blockchain/error_test.go
+++ b/blockchain/error_test.go
@@ -150,6 +150,7 @@ func TestErrorKindStringer(t *testing.T) {
 		{ErrUnknownDeploymentID, "ErrUnknownDeploymentID"},
 		{ErrUnknownDeploymentVersion, "ErrUnknownDeploymentVersion"},
 		{ErrDuplicateDeployment, "ErrDuplicateDeployment"},
+		{ErrUnknownBlock, "ErrUnknownBlock"},
 	}
 
 	t.Logf("Running %d tests", len(tests))

--- a/blockchain/error_test.go
+++ b/blockchain/error_test.go
@@ -147,6 +147,9 @@ func TestErrorKindStringer(t *testing.T) {
 		{ErrTooManyTAdds, "ErrTooManyTAdds"},
 		{ErrTicketExhaustion, "ErrTicketExhaustion"},
 		{ErrDBTooOldToUpgrade, "ErrDBTooOldToUpgrade"},
+		{ErrUnknownDeploymentID, "ErrUnknownDeploymentID"},
+		{ErrUnknownDeploymentVersion, "ErrUnknownDeploymentVersion"},
+		{ErrDuplicateDeployment, "ErrDuplicateDeployment"},
 	}
 
 	t.Logf("Running %d tests", len(tests))

--- a/blockchain/error_test.go
+++ b/blockchain/error_test.go
@@ -152,6 +152,7 @@ func TestErrorKindStringer(t *testing.T) {
 		{ErrDuplicateDeployment, "ErrDuplicateDeployment"},
 		{ErrUnknownBlock, "ErrUnknownBlock"},
 		{ErrNoFilter, "ErrNoFilter"},
+		{ErrNoTreasuryBalance, "ErrNoTreasuryBalance"},
 	}
 
 	t.Logf("Running %d tests", len(tests))

--- a/blockchain/error_test.go
+++ b/blockchain/error_test.go
@@ -151,6 +151,7 @@ func TestErrorKindStringer(t *testing.T) {
 		{ErrUnknownDeploymentVersion, "ErrUnknownDeploymentVersion"},
 		{ErrDuplicateDeployment, "ErrDuplicateDeployment"},
 		{ErrUnknownBlock, "ErrUnknownBlock"},
+		{ErrNoFilter, "ErrNoFilter"},
 	}
 
 	t.Logf("Running %d tests", len(tests))

--- a/blockchain/headercmt.go
+++ b/blockchain/headercmt.go
@@ -128,8 +128,8 @@ func (b *BlockChain) FetchUtxoViewParentTemplate(block *wire.MsgBlock) (*UtxoVie
 // when it exists.  This function returns the filters regardless of whether or
 // not their associated block is part of the main chain.
 //
-// An error of type NoFilterError will be returned when the filter for the given
-// block hash does not exist.
+// An error that wraps ErrNoFilter will be returned when the filter for the
+// given block hash does not exist.
 //
 // This function is safe for concurrent access.
 func (b *BlockChain) FilterByBlockHash(hash *chainhash.Hash) (*gcs.FilterV2, error) {
@@ -140,7 +140,8 @@ func (b *BlockChain) FilterByBlockHash(hash *chainhash.Hash) (*gcs.FilterV2, err
 		return err
 	})
 	if err == nil && filter == nil {
-		err = NoFilterError(hash.String())
+		str := fmt.Sprintf("no filter available for block %s", hash)
+		err = contextError(ErrNoFilter, str)
 	}
 	return filter, err
 }

--- a/blockchain/stakeext.go
+++ b/blockchain/stakeext.go
@@ -6,8 +6,6 @@
 package blockchain
 
 import (
-	"fmt"
-
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/database/v2"
 	"github.com/decred/dcrd/dcrutil/v3"
@@ -54,7 +52,7 @@ func (b *BlockChain) lotteryDataForNode(node *blockNode) ([]chainhash.Hash, int,
 func (b *BlockChain) lotteryDataForBlock(hash *chainhash.Hash) ([]chainhash.Hash, int, [6]byte, error) {
 	node := b.index.LookupNode(hash)
 	if node == nil {
-		return nil, 0, [6]byte{}, fmt.Errorf("block %s is not known", hash)
+		return nil, 0, [6]byte{}, unknownBlockError(hash)
 	}
 
 	winningTickets, poolSize, finalState, err := b.lotteryDataForNode(node)

--- a/blockchain/thresholdstate.go
+++ b/blockchain/thresholdstate.go
@@ -461,7 +461,8 @@ func (b *BlockChain) deploymentState(prevNode *blockNode, version uint32, deploy
 		State:  ThresholdInvalid,
 		Choice: invalidChoice,
 	}
-	return invalidState, DeploymentError(deploymentID)
+	str := fmt.Sprintf("deployment ID %s does not exist", deploymentID)
+	return invalidState, contextError(ErrUnknownDeploymentID, str)
 }
 
 // stateLastChanged returns the node at which the provided consensus deployment
@@ -874,7 +875,8 @@ func (b *BlockChain) GetVoteCounts(version uint32, deploymentID string) (VoteCou
 			return counts, err
 		}
 	}
-	return VoteCounts{}, DeploymentError(deploymentID)
+	str := fmt.Sprintf("deployment ID %s does not exist", deploymentID)
+	return VoteCounts{}, contextError(ErrUnknownDeploymentID, str)
 }
 
 // CountVoteVersion returns the total number of version votes for the current

--- a/blockchain/thresholdstate.go
+++ b/blockchain/thresholdstate.go
@@ -530,7 +530,7 @@ func (b *BlockChain) StateLastChangedHeight(hash *chainhash.Hash, version uint32
 	// efficiently determine that state.
 	node := b.index.LookupNode(hash)
 	if node == nil || !b.index.NodeStatus(node).HasValidated() {
-		return 0, HashError(hash.String())
+		return 0, unknownBlockError(hash)
 	}
 
 	// Fetch the threshold state cache for the provided deployment id as well as
@@ -584,7 +584,7 @@ func (b *BlockChain) NextThresholdState(hash *chainhash.Hash, version uint32, de
 			State:  ThresholdInvalid,
 			Choice: invalidChoice,
 		}
-		return invalidState, HashError(hash.String())
+		return invalidState, unknownBlockError(hash)
 	}
 
 	b.chainLock.Lock()
@@ -723,7 +723,7 @@ func (b *BlockChain) IsHeaderCommitmentsAgendaActive(prevHash *chainhash.Hash) (
 	// efficiently determine that state.
 	node := b.index.LookupNode(prevHash)
 	if node == nil || !b.index.NodeStatus(node).HasValidated() {
-		return false, HashError(prevHash.String())
+		return false, unknownBlockError(prevHash)
 	}
 
 	b.chainLock.Lock()
@@ -796,7 +796,7 @@ func (b *BlockChain) isTreasuryAgendaActiveByHash(prevHash *chainhash.Hash) (boo
 func (b *BlockChain) IsTreasuryAgendaActive(prevHash *chainhash.Hash) (bool, error) {
 	prevNode := b.index.LookupNode(prevHash)
 	if prevNode == nil || !b.index.NodeStatus(prevNode).HasValidated() {
-		return false, HashError(prevHash.String())
+		return false, unknownBlockError(prevHash)
 	}
 
 	b.chainLock.Lock()

--- a/blockchain/treasury.go
+++ b/blockchain/treasury.go
@@ -525,7 +525,8 @@ func (b *BlockChain) TreasuryBalance(hash *chainhash.Hash) (*TreasuryBalanceInfo
 
 	// Treasury agenda is never active for the genesis block.
 	if node.parent == nil {
-		return nil, NoTreasuryError(hash.String())
+		str := fmt.Sprintf("treasury balance not available for block %s", hash)
+		return nil, contextError(ErrNoTreasuryBalance, str)
 	}
 
 	// Ensure the treasury agenda is active as of the requested block.
@@ -537,7 +538,8 @@ func (b *BlockChain) TreasuryBalance(hash *chainhash.Hash) (*TreasuryBalanceInfo
 		return nil, err
 	}
 	if !isActive {
-		return nil, NoTreasuryError(hash.String())
+		str := fmt.Sprintf("treasury balance not available for block %s", hash)
+		return nil, contextError(ErrNoTreasuryBalance, str)
 	}
 
 	// Load treasury balance information.

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -3922,7 +3922,7 @@ func (b *BlockChain) checkTicketExhaustion(prevNode *blockNode, ticketPurchases 
 func (b *BlockChain) CheckTicketExhaustion(hash *chainhash.Hash, ticketPurchases uint8) error {
 	node := b.index.LookupNode(hash)
 	if node == nil || !b.index.NodeStatus(node).HaveData() {
-		return UnknownBlockError(*hash)
+		return unknownBlockError(hash)
 	}
 
 	return b.checkTicketExhaustion(node, ticketPurchases)

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -559,11 +559,11 @@ type Filterer interface {
 // The interface contract requires that all of these methods are safe for
 // concurrent access.
 type FiltererV2 interface {
-	// FilterByBlockHash returns the version 2 GCS filter for the given block hash
-	// when it exists.  This function returns the filters regardless of whether or
-	// not their associated block is part of the main chain.
+	// FilterByBlockHash returns the version 2 GCS filter for the given block
+	// hash when it exists.  This function returns the filters regardless of
+	// whether or not their associated block is part of the main chain.
 	//
-	// An error of type blockchain.NoFilterError must be returned when the filter
+	// An error of type blockchain.ErrNoFilter must be returned when the filter
 	// for the given block hash does not exist.
 	FilterByBlockHash(hash *chainhash.Hash) (*gcs.FilterV2, error)
 }

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -3410,8 +3410,7 @@ func handleGetVoteInfo(_ context.Context, s *Server, cmd interface{}) (interface
 
 	vi, err := chain.GetVoteInfo(&snapshot.Hash, c.Version)
 	if err != nil {
-		var vErr blockchain.VoteVersionError
-		if errors.As(err, &vErr) {
+		if errors.Is(err, blockchain.ErrUnknownDeploymentVersion) {
 			return nil, rpcInvalidError("%d: unrecognized vote version",
 				c.Version)
 		}

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -3147,7 +3147,6 @@ func handleGetTreasuryBalance(_ context.Context, s *Server, cmd interface{}) (in
 
 	balanceInfo, err := s.cfg.Chain.TreasuryBalance(&hash)
 	if err != nil {
-		var nErr blockchain.NoTreasuryError
 		switch {
 		case errors.Is(err, blockchain.ErrUnknownBlock):
 			return nil, &dcrjson.RPCError{
@@ -3155,7 +3154,7 @@ func handleGetTreasuryBalance(_ context.Context, s *Server, cmd interface{}) (in
 				Message: fmt.Sprintf("Block not found: %s", hash),
 			}
 
-		case errors.As(err, &nErr):
+		case errors.Is(err, blockchain.ErrNoTreasuryBalance):
 			return nil, &dcrjson.RPCError{
 				Code:    dcrjson.ErrRPCNoTreasury,
 				Message: fmt.Sprintf("Treasury inactive for block %s", hash),

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -2444,8 +2444,7 @@ func handleGetCFilterV2(_ context.Context, s *Server, cmd interface{}) (interfac
 
 	filter, err := s.cfg.FiltererV2.FilterByBlockHash(hash)
 	if err != nil {
-		var nErr blockchain.NoFilterError
-		if errors.As(err, &nErr) {
+		if errors.Is(err, blockchain.ErrNoFilter) {
 			return nil, &dcrjson.RPCError{
 				Code:    dcrjson.ErrRPCBlockNotFound,
 				Message: fmt.Sprintf("Block not found: %v", hash),

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -4863,7 +4863,7 @@ func TestHandleGetTreasuryBalance(t *testing.T) {
 		cmd:     &types.GetTreasuryBalanceCmd{},
 		mockChain: func() *testRPCChain {
 			chain := defaultMockRPCChain()
-			chain.treasuryBalanceErr = blockchain.NoTreasuryError(blkHashString)
+			chain.treasuryBalanceErr = blockchain.ErrNoTreasuryBalance
 			return chain
 		}(),
 		wantErr: true,

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -6988,7 +6988,7 @@ func TestHandleGetVoteInfo(t *testing.T) {
 		},
 		mockChain: func() *testRPCChain {
 			chain := defaultMockRPCChain()
-			chain.getVoteInfoErr = blockchain.VoteVersionError(v7)
+			chain.getVoteInfoErr = blockchain.ErrUnknownDeploymentVersion
 			return chain
 		}(),
 		wantErr: true,

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -4251,7 +4251,6 @@ func TestHandleGetCFilterV2(t *testing.T) {
 
 	blkHashString := block432100.BlockHash().String()
 	filter := hex.EncodeToString(defaultMockFiltererV2().filterByBlockHash.Bytes())
-	var noFilterErr blockchain.NoFilterError
 	testRPCServerHandler(t, []rpcTest{{
 		name:    "handleGetCFilterV2: ok",
 		handler: handleGetCFilterV2,
@@ -4280,7 +4279,7 @@ func TestHandleGetCFilterV2(t *testing.T) {
 		},
 		mockFiltererV2: func() *testFiltererV2 {
 			testFiltererV2 := defaultMockFiltererV2()
-			testFiltererV2.filterByBlockHashErr = noFilterErr
+			testFiltererV2.filterByBlockHashErr = blockchain.ErrNoFilter
 			return testFiltererV2
 		}(),
 		wantErr: true,

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -4853,7 +4853,7 @@ func TestHandleGetTreasuryBalance(t *testing.T) {
 		cmd:     &types.GetTreasuryBalanceCmd{},
 		mockChain: func() *testRPCChain {
 			chain := defaultMockRPCChain()
-			chain.treasuryBalanceErr = blockchain.UnknownBlockError(blkHash)
+			chain.treasuryBalanceErr = blockchain.ErrUnknownBlock
 			return chain
 		}(),
 		wantErr: true,


### PR DESCRIPTION
**This is rebased on #2481**.

This removes several of the error type definitions from `blockchain` in favor of the context error type wrapping an
error kind that can be detected by `errors.Is`.

This is more in line with the new approach to errors as of the introduction of `errors.Is` and `errors.As` and also has another nice benefit of reducing the amount of code related to errors.

It also updates all callers in the repository to account for the changes.