### PR TITLE
mining: Unexport TxMiningView methods.

### DIFF
--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -879,7 +879,7 @@ func (mp *TxPool) removeTransaction(tx *dcrutil.Tx, removeRedeemers bool, isTrea
 		// If redeeming transactions are going to be removed from the
 		// graph, then do not update their stats.
 		updateDescendantStats := !removeRedeemers
-		mp.miningView.Remove(tx.Hash(), updateDescendantStats)
+		mp.miningView.RemoveTransaction(tx.Hash(), updateDescendantStats)
 
 		delete(mp.pool, *txHash)
 

--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -399,7 +399,7 @@ type BlockTemplate struct {
 	ValidPayAddress bool
 }
 
-// mergeUtxoView adds all of the entries in view to viewA.  The result is that
+// mergeUtxoView adds all of the entries in viewB to viewA.  The result is that
 // viewA will contain all of its original entries plus all of the entries
 // in viewB.  It will replace any entries in viewB which also exist in viewA
 // if the entry in viewA is fully spent.

--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -1607,7 +1607,7 @@ nextPriorityQueueItem:
 			// Remove transaction from mining view since it's been added to the
 			// block template.
 			bundledTxDeps := miningView.Children(bundledTxHash)
-			miningView.Remove(bundledTxHash, false)
+			miningView.RemoveTransaction(bundledTxHash, false)
 
 			// Add transactions which depend on this one (and also do not
 			// have any other unsatisfied dependencies) to the priority

--- a/internal/mining/mining_harness_test.go
+++ b/internal/mining/mining_harness_test.go
@@ -560,7 +560,7 @@ func (p *fakeTxSource) RemoveTransaction(tx *dcrutil.Tx, removeRedeemers bool, i
 		// If redeeming transactions are going to be removed from the graph, then do
 		// not update their stats.
 		updateDescendantStats := !removeRedeemers
-		p.miningView.Remove(tx.Hash(), updateDescendantStats)
+		p.miningView.RemoveTransaction(tx.Hash(), updateDescendantStats)
 
 		delete(p.pool, *txHash)
 

--- a/internal/mining/mining_view.go
+++ b/internal/mining/mining_view.go
@@ -449,12 +449,13 @@ func (mv *TxMiningView) AddTransaction(txDesc *TxDesc, findTx TxDescFind) {
 	}
 }
 
-// Remove stops tracking the transaction in the mining view if it exists.  If
-// updateDescendantStats is true, then the statistics for all descendant
-// transactions are updated to account for the removal of an ancestor.
+// RemoveTransaction stops tracking the transaction in the mining view if it
+// exists.  If updateDescendantStats is true, then the statistics for all
+// descendant transactions are updated to account for the removal of an
+// ancestor.
 //
 // This function is NOT safe for concurrent access.
-func (mv *TxMiningView) Remove(txHash *chainhash.Hash, updateDescendantStats bool) {
+func (mv *TxMiningView) RemoveTransaction(txHash *chainhash.Hash, updateDescendantStats bool) {
 	if mv.trackAncestorStats && updateDescendantStats {
 		txDesc := mv.txGraph.find(txHash)
 		if txDesc != nil {
@@ -476,11 +477,11 @@ func (mv *TxMiningView) Remove(txHash *chainhash.Hash, updateDescendantStats boo
 func (mv *TxMiningView) Reject(txHash *chainhash.Hash) {
 	seen := make(map[chainhash.Hash]struct{})
 	mv.txGraph.forEachDescendant(txHash, seen, func(descendant *TxDesc) {
-		mv.Remove(descendant.Tx.Hash(), false)
+		mv.RemoveTransaction(descendant.Tx.Hash(), false)
 		mv.rejected[*descendant.Tx.Hash()] = struct{}{}
 	})
 
-	mv.Remove(txHash, false)
+	mv.RemoveTransaction(txHash, false)
 	mv.rejected[*txHash] = struct{}{}
 }
 

--- a/internal/mining/mining_view_test.go
+++ b/internal/mining/mining_view_test.go
@@ -284,7 +284,7 @@ func TestMiningView(t *testing.T) {
 		// ancestor after removal.
 		removalMiningView := harness.txSource.MiningView()
 		if children := removalMiningView.Children(txHash); len(children) > 0 {
-			removalMiningView.Remove(txHash, false)
+			removalMiningView.RemoveTransaction(txHash, false)
 			child := children[0]
 			siblings := removalMiningView.Parents(child.Tx.Hash())
 
@@ -320,7 +320,7 @@ func TestMiningView(t *testing.T) {
 		// have the fee removed for this transaction when calling Remove with the
 		// option to do so.
 		removalMiningView = harness.txSource.MiningView()
-		removalMiningView.Remove(txHash, true)
+		removalMiningView.RemoveTransaction(txHash, true)
 
 		for _, descendant := range descendants {
 			oldStat, hasStats := miningView.AncestorStats(descendant)


### PR DESCRIPTION
**This is rebased on https://github.com/decred/dcrd/pull/2480**.

This unexports the TxMiningView methods and fields that don't need to be exposed outside of the mining package and additionally renames the Remove method of the TxMiningView type to RemoveTransaction for naming consistency with the AddTransaction method that it also provides.

I was originally going to create an interface in `mempool` for this but decided against it for a few reasons:
- It leads to an awkward interface usage due to how the mining view is used.
  - `mempool` has its own instance of a `TxMiningView` and returns a copy of it when requested by `mining` through the `MiningView` method in `mempool`.
  - If `mempool` is updated to use an interface, and the `MiningView` `mempool` method is updated to return that interface, this requires `mining` to type cast to the actual `TxMiningView` type to access the methods/fields that it needs.
- It's not really needed at this time.
  - There is not a need for `mempool` to use an alternate mining view implementation at this time, so it can just use the actual mining view (including within test code).  Unexporting the things that shouldn't be needed outside of the `mining` package, as this PR does, makes this usage clearer as an interface would.
  - `mempool` already depends on several `mining` types (`mining.TxDesc`, `mining.VoteDesc`, etc.).  If we decide that we want to remove the dependency that `mempool` has on `mining`, it would be worth revisiting this.