### PR TITLE
blockchain: Explicit hash in LN agenda active func.

### DIFF
--- a/blockchain/agendas_test.go
+++ b/blockchain/agendas_test.go
@@ -116,6 +116,7 @@ func testLNFeaturesDeployment(t *testing.T, params *chaincfg.Params) {
 					Bits:    yesChoice.Bits | 0x01,
 				})
 			}
+			bc.index.AddNode(node)
 			bc.bestChain.SetTip(node)
 			curTimestamp = curTimestamp.Add(time.Second)
 		}
@@ -136,7 +137,7 @@ func testLNFeaturesDeployment(t *testing.T, params *chaincfg.Params) {
 
 		// Ensure the agenda reports the expected activation status for
 		// the NEXT block
-		gotActive, err = bc.IsLNFeaturesAgendaActive()
+		gotActive, err = bc.IsLNFeaturesAgendaActive(&node.hash)
 		if err != nil {
 			t.Errorf("%s: unexpected err: %v", test.name, err)
 			continue

--- a/blockchain/thresholdstate.go
+++ b/blockchain/thresholdstate.go
@@ -626,12 +626,17 @@ func (b *BlockChain) isLNFeaturesAgendaActive(prevNode *blockNode) (bool, error)
 
 // IsLNFeaturesAgendaActive returns whether or not the LN features agenda vote,
 // as defined in DCP0002 and DCP0003 has passed and is now active for the block
-// AFTER the current best chain block.
+// AFTER the given block.
 //
 // This function is safe for concurrent access.
-func (b *BlockChain) IsLNFeaturesAgendaActive() (bool, error) {
+func (b *BlockChain) IsLNFeaturesAgendaActive(prevHash *chainhash.Hash) (bool, error) {
+	prevNode := b.index.LookupNode(prevHash)
+	if prevNode == nil || !b.index.NodeStatus(prevNode).HasValidated() {
+		return false, unknownBlockError(prevHash)
+	}
+
 	b.chainLock.Lock()
-	isActive, err := b.isLNFeaturesAgendaActive(b.bestChain.Tip())
+	isActive, err := b.isLNFeaturesAgendaActive(prevNode)
 	b.chainLock.Unlock()
 	return isActive, err
 }

--- a/server.go
+++ b/server.go
@@ -2917,9 +2917,9 @@ out:
 func standardScriptVerifyFlags(chain *blockchain.BlockChain) (txscript.ScriptFlags, error) {
 	scriptFlags := mempool.BaseStandardVerifyFlags
 
-	// Enable validation of OP_SHA256 if the stake vote for the agenda is
-	// active.
-	isActive, err := chain.IsLNFeaturesAgendaActive()
+	// Enable validation of OP_SHA256 when the associated agenda is active.
+	tipHash := &chain.BestSnapshot().Hash
+	isActive, err := chain.IsLNFeaturesAgendaActive(tipHash)
 	if err != nil {
 		return 0, err
 	}
@@ -2927,9 +2927,8 @@ func standardScriptVerifyFlags(chain *blockchain.BlockChain) (txscript.ScriptFla
 		scriptFlags |= txscript.ScriptVerifySHA256
 	}
 
-	// Enable validation of treasury-related opcodes when the associated
-	// agenda is active.
-	tipHash := &chain.BestSnapshot().Hash
+	// Enable validation of treasury-related opcodes when the associated agenda
+	// is active.
 	isActive, err = chain.IsTreasuryAgendaActive(tipHash)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
This modifies `IsLNAgendaActive` to accept a hash instead of using the current chain tip as part of an overall effort to make the blockchain module more explicit and less reliant on the current state.