### PR TITLE
blockmanager: Decouple from global config var.

### DIFF
--- a/blockdb.go
+++ b/blockdb.go
@@ -1,0 +1,250 @@
+// Copyright (c) 2013-2016 The btcsuite developers
+// Copyright (c) 2015-2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"encoding/binary"
+	"errors"
+	_ "net/http/pprof"
+	"os"
+	"path/filepath"
+
+	"github.com/decred/dcrd/blockchain/v4"
+	"github.com/decred/dcrd/chaincfg/v3"
+	"github.com/decred/dcrd/database/v2"
+)
+
+const (
+	// blockDbNamePrefix is the prefix for the block database name.  The
+	// database type is appended to this value to form the full block
+	// database name.
+	blockDbNamePrefix = "blocks"
+)
+
+// removeDB removes the database at the provided path.  The fi parameter MUST
+// agree with the provided path.
+func removeDB(dbPath string, fi os.FileInfo) error {
+	if fi.IsDir() {
+		return os.RemoveAll(dbPath)
+	}
+
+	return os.Remove(dbPath)
+}
+
+// removeRegressionDB removes the existing regression test database if running
+// in regression test mode and it already exists.
+func removeRegressionDB(dbPath string) error {
+	// Don't do anything if not in regression test mode.
+	if !cfg.RegNet {
+		return nil
+	}
+
+	// Remove the old regression test database if it already exists.
+	fi, err := os.Stat(dbPath)
+	if err == nil {
+		dcrdLog.Infof("Removing regression test database from '%s'", dbPath)
+		return removeDB(dbPath, fi)
+	}
+
+	return nil
+}
+
+// blockDbPath returns the path to the block database given a database type.
+func blockDbPath(dbType string) string {
+	// The database name is based on the database type.
+	dbName := blockDbNamePrefix + "_" + dbType
+	if dbType == "sqlite" {
+		dbName = dbName + ".db"
+	}
+	dbPath := filepath.Join(cfg.DataDir, dbName)
+	return dbPath
+}
+
+// warnMultipleDBs shows a warning if multiple block database types are detected.
+// This is not a situation most users want.  It is handy for development however
+// to support multiple side-by-side databases.
+func warnMultipleDBs() {
+	// This is intentionally not using the known db types which depend on the
+	// database types compiled into the binary since we want to detect legacy db
+	// types as well.
+	dbTypes := []string{"ffldb", "leveldb", "sqlite"}
+	duplicateDbPaths := make([]string, 0, len(dbTypes)-1)
+	for _, dbType := range dbTypes {
+		if dbType == cfg.DbType {
+			continue
+		}
+
+		// Store db path as a duplicate db if it exists.
+		dbPath := blockDbPath(dbType)
+		if fileExists(dbPath) {
+			duplicateDbPaths = append(duplicateDbPaths, dbPath)
+		}
+	}
+
+	// Warn if there are extra databases.
+	if len(duplicateDbPaths) > 0 {
+		selectedDbPath := blockDbPath(cfg.DbType)
+		dcrdLog.Warnf("WARNING: There are multiple block chain databases "+
+			"using different database types.\nYou probably don't want to "+
+			"waste disk space by having more than one.\nYour current database "+
+			"is located at [%v].\nThe additional database is located at %v",
+			selectedDbPath, duplicateDbPaths)
+	}
+}
+
+// loadBlockDB loads (or creates when needed) the block database taking into
+// account the selected database backend and returns a handle to it.  It also
+// contains additional logic such warning the user if there are multiple
+// databases which consume space on the file system and ensuring the regression
+// test database is clean when in regression test mode.
+func loadBlockDB(params *chaincfg.Params) (database.DB, error) {
+	// The memdb backend does not have a file path associated with it, so handle
+	// it uniquely.  We also don't want to worry about the multiple database
+	// type warnings when running with the memory database.
+	if cfg.DbType == "memdb" {
+		dcrdLog.Infof("Creating block database in memory.")
+		db, err := database.Create(cfg.DbType)
+		if err != nil {
+			return nil, err
+		}
+		return db, nil
+	}
+
+	warnMultipleDBs()
+
+	// The database name is based on the database type.
+	dbPath := blockDbPath(cfg.DbType)
+
+	// The regression test is special in that it needs a clean database for
+	// each run, so remove it now if it already exists.
+	removeRegressionDB(dbPath)
+
+	// createDB is a convenience func that creates the database with the type
+	// and network specified in the config at the path determined above while
+	// also creating any any intermediate directories in the configured data
+	// directory path as needed.
+	createDB := func() (database.DB, error) {
+		// Create the data dir if it does not exist.
+		err := os.MkdirAll(cfg.DataDir, 0700)
+		if err != nil {
+			return nil, err
+		}
+		return database.Create(cfg.DbType, dbPath, params.Net)
+	}
+
+	// Open the existing database or create a new one as needed.
+	dcrdLog.Infof("Loading block database from '%s'", dbPath)
+	db, err := database.Open(cfg.DbType, dbPath, params.Net)
+	if err != nil {
+		// Return the error if it's not because the database doesn't exist.
+		var dbErr database.Error
+		if !errors.As(err, &dbErr) || dbErr.ErrorCode !=
+			database.ErrDbDoesNotExist {
+
+			return nil, err
+		}
+
+		db, err = createDB()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Remove and recreate the blockchain database when it can no longer be
+	// upgraded due to being too old.
+	if err := blockchain.CheckDBTooOldToUpgrade(db); err != nil {
+		// Any errors other than the database being too old upgrade are
+		// unexpected.
+		if !errors.Is(err, blockchain.ErrDBTooOldToUpgrade) {
+			return nil, err
+		}
+		dcrdLog.Infof("Removing database from '%s': %v", dbPath, err)
+
+		// Close the database so it can be removed cleanly.
+		if err := db.Close(); err != nil {
+			return nil, err
+		}
+
+		// Remove the old database and create/open a new one.
+		fi, err := os.Stat(dbPath)
+		if err != nil {
+			return nil, err
+		}
+
+		err = removeDB(dbPath, fi)
+		if err != nil {
+			return nil, err
+		}
+
+		db, err = createDB()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	dcrdLog.Info("Block database loaded")
+	return db, nil
+}
+
+// dumpBlockChain dumps a map of the blockchain blocks as serialized bytes.
+func dumpBlockChain(params *chaincfg.Params, b *blockchain.BlockChain) error {
+	dcrdLog.Infof("Writing the blockchain to flat file %q.  This might take a "+
+		"while...", cfg.DumpBlockchain)
+
+	progressLogger := newBlockProgressLogger("Wrote", dcrdLog)
+
+	file, err := os.Create(cfg.DumpBlockchain)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	// Store the network ID in an array for later writing.
+	var net [4]byte
+	binary.LittleEndian.PutUint32(net[:], uint32(params.Net))
+
+	// Write the blocks sequentially, excluding the genesis block.
+	tipHeight := b.BestSnapshot().Height
+	var sz [4]byte
+	for i := int64(1); i <= tipHeight; i++ {
+		bl, err := b.BlockByHeight(i)
+		if err != nil {
+			return err
+		}
+
+		// Serialize the block for writing.
+		blB, err := bl.Bytes()
+		if err != nil {
+			return err
+		}
+
+		// Write the network ID first.
+		_, err = file.Write(net[:])
+		if err != nil {
+			return err
+		}
+
+		// Write the size of the block as a little endian uint32,
+		// then write the block itself serialized.
+		binary.LittleEndian.PutUint32(sz[:], uint32(len(blB)))
+		_, err = file.Write(sz[:])
+		if err != nil {
+			return err
+		}
+
+		_, err = file.Write(blB)
+		if err != nil {
+			return err
+		}
+
+		progressLogger.logBlockHeight(bl, tipHeight)
+	}
+
+	bmgrLog.Infof("Successfully dumped the blockchain (%v blocks) to %v.",
+		tipHeight, cfg.DumpBlockchain)
+
+	return nil
+}

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -7,11 +7,8 @@ package main
 
 import (
 	"container/list"
-	"encoding/binary"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -40,11 +37,6 @@ const (
 	// maxOrphanBlocks is the maximum number of orphan blocks that can be
 	// queued.
 	maxOrphanBlocks = 500
-
-	// blockDbNamePrefix is the prefix for the block database name.  The
-	// database type is appended to this value to form the full block
-	// database name.
-	blockDbNamePrefix = "blocks"
 
 	// maxRejectedTxns is the maximum number of rejected transactions
 	// hashes to store in memory.
@@ -2484,245 +2476,10 @@ func newBlockManager(config *blockManagerConfig) (*blockManager, error) {
 		bmgrLog.Info("Checkpoints are disabled")
 	}
 
-	// Dump the blockchain here if asked for it, and quit.
-	if cfg.DumpBlockchain != "" {
-		err := dumpBlockChain(bm.cfg.ChainParams, bm.cfg.Chain, best.Height)
-		if err != nil {
-			return nil, err
-		}
-
-		return nil, fmt.Errorf("closing after dumping blockchain")
-	}
-
 	bm.lotteryDataBroadcast = make(map[chainhash.Hash]struct{})
 	bm.syncHeightMtx.Lock()
 	bm.syncHeight = best.Height
 	bm.syncHeightMtx.Unlock()
 
 	return &bm, nil
-}
-
-// removeDB removes the database at the provided path.  The fi parameter MUST
-// agree with the provided path.
-func removeDB(dbPath string, fi os.FileInfo) error {
-	if fi.IsDir() {
-		return os.RemoveAll(dbPath)
-	}
-
-	return os.Remove(dbPath)
-}
-
-// removeRegressionDB removes the existing regression test database if running
-// in regression test mode and it already exists.
-func removeRegressionDB(dbPath string) error {
-	// Don't do anything if not in regression test mode.
-	if !cfg.RegNet {
-		return nil
-	}
-
-	// Remove the old regression test database if it already exists.
-	fi, err := os.Stat(dbPath)
-	if err == nil {
-		dcrdLog.Infof("Removing regression test database from '%s'", dbPath)
-		return removeDB(dbPath, fi)
-	}
-
-	return nil
-}
-
-// blockDbPath returns the path to the block database given a database type.
-func blockDbPath(dbType string) string {
-	// The database name is based on the database type.
-	dbName := blockDbNamePrefix + "_" + dbType
-	if dbType == "sqlite" {
-		dbName = dbName + ".db"
-	}
-	dbPath := filepath.Join(cfg.DataDir, dbName)
-	return dbPath
-}
-
-// warnMultipleDBs shows a warning if multiple block database types are detected.
-// This is not a situation most users want.  It is handy for development however
-// to support multiple side-by-side databases.
-func warnMultipleDBs() {
-	// This is intentionally not using the known db types which depend
-	// on the database types compiled into the binary since we want to
-	// detect legacy db types as well.
-	dbTypes := []string{"ffldb", "leveldb", "sqlite"}
-	duplicateDbPaths := make([]string, 0, len(dbTypes)-1)
-	for _, dbType := range dbTypes {
-		if dbType == cfg.DbType {
-			continue
-		}
-
-		// Store db path as a duplicate db if it exists.
-		dbPath := blockDbPath(dbType)
-		if fileExists(dbPath) {
-			duplicateDbPaths = append(duplicateDbPaths, dbPath)
-		}
-	}
-
-	// Warn if there are extra databases.
-	if len(duplicateDbPaths) > 0 {
-		selectedDbPath := blockDbPath(cfg.DbType)
-		dcrdLog.Warnf("WARNING: There are multiple block chain databases "+
-			"using different database types.\nYou probably don't "+
-			"want to waste disk space by having more than one.\n"+
-			"Your current database is located at [%v].\nThe "+
-			"additional database is located at %v", selectedDbPath,
-			duplicateDbPaths)
-	}
-}
-
-// loadBlockDB loads (or creates when needed) the block database taking into
-// account the selected database backend and returns a handle to it.  It also
-// contains additional logic such warning the user if there are multiple
-// databases which consume space on the file system and ensuring the regression
-// test database is clean when in regression test mode.
-func loadBlockDB(params *chaincfg.Params) (database.DB, error) {
-	// The memdb backend does not have a file path associated with it, so
-	// handle it uniquely.  We also don't want to worry about the multiple
-	// database type warnings when running with the memory database.
-	if cfg.DbType == "memdb" {
-		dcrdLog.Infof("Creating block database in memory.")
-		db, err := database.Create(cfg.DbType)
-		if err != nil {
-			return nil, err
-		}
-		return db, nil
-	}
-
-	warnMultipleDBs()
-
-	// The database name is based on the database type.
-	dbPath := blockDbPath(cfg.DbType)
-
-	// The regression test is special in that it needs a clean database for
-	// each run, so remove it now if it already exists.
-	removeRegressionDB(dbPath)
-
-	// createDB is a convenience func that creates the database with the type
-	// and network specified in the config at the path determined above while
-	// also creating any any intermediate directories in the configured data
-	// directory path as needed.
-	createDB := func() (database.DB, error) {
-		// Create the data dir if it does not exist.
-		err := os.MkdirAll(cfg.DataDir, 0700)
-		if err != nil {
-			return nil, err
-		}
-		return database.Create(cfg.DbType, dbPath, params.Net)
-	}
-
-	// Open the existing database or create a new one as needed.
-	dcrdLog.Infof("Loading block database from '%s'", dbPath)
-	db, err := database.Open(cfg.DbType, dbPath, params.Net)
-	if err != nil {
-		// Return the error if it's not because the database doesn't exist.
-		var dbErr database.Error
-		if !errors.As(err, &dbErr) || dbErr.ErrorCode !=
-			database.ErrDbDoesNotExist {
-
-			return nil, err
-		}
-
-		db, err = createDB()
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// Remove and recreate the blockchain database when it can no longer be
-	// upgraded due to being too old.
-	if err := blockchain.CheckDBTooOldToUpgrade(db); err != nil {
-		// Any errors other than the database being too old upgrade are
-		// unexpected.
-		if !errors.Is(err, blockchain.ErrDBTooOldToUpgrade) {
-			return nil, err
-		}
-		dcrdLog.Infof("Removing database from '%s': %v", dbPath, err)
-
-		// Close the database so it can be removed cleanly.
-		if err := db.Close(); err != nil {
-			return nil, err
-		}
-
-		// Remove the old database and create/open a new one.
-		fi, err := os.Stat(dbPath)
-		if err != nil {
-			return nil, err
-		}
-
-		err = removeDB(dbPath, fi)
-		if err != nil {
-			return nil, err
-		}
-
-		db, err = createDB()
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	dcrdLog.Info("Block database loaded")
-	return db, nil
-}
-
-// dumpBlockChain dumps a map of the blockchain blocks as serialized bytes.
-func dumpBlockChain(params *chaincfg.Params, b *blockchain.BlockChain, height int64) error {
-	bmgrLog.Infof("Writing the blockchain to disk as a flat file, " +
-		"please wait...")
-
-	progressLogger := newBlockProgressLogger("Written", bmgrLog)
-
-	file, err := os.Create(cfg.DumpBlockchain)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	// Store the network ID in an array for later writing.
-	var net [4]byte
-	binary.LittleEndian.PutUint32(net[:], uint32(params.Net))
-
-	// Write the blocks sequentially, excluding the genesis block.
-	var sz [4]byte
-	for i := int64(1); i <= height; i++ {
-		bl, err := b.BlockByHeight(i)
-		if err != nil {
-			return err
-		}
-
-		// Serialize the block for writing.
-		blB, err := bl.Bytes()
-		if err != nil {
-			return err
-		}
-
-		// Write the network ID first.
-		_, err = file.Write(net[:])
-		if err != nil {
-			return err
-		}
-
-		// Write the size of the block as a little endian uint32,
-		// then write the block itself serialized.
-		binary.LittleEndian.PutUint32(sz[:], uint32(len(blB)))
-		_, err = file.Write(sz[:])
-		if err != nil {
-			return err
-		}
-
-		_, err = file.Write(blB)
-		if err != nil {
-			return err
-		}
-
-		progressLogger.logBlockHeight(bl, height)
-	}
-
-	bmgrLog.Infof("Successfully dumped the blockchain (%v blocks) to %v.",
-		height, cfg.DumpBlockchain)
-
-	return nil
 }

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -250,7 +250,6 @@ type peerNotifier interface {
 // blockManangerConfig is a configuration struct for a blockManager.
 type blockManagerConfig struct {
 	PeerNotifier peerNotifier
-	TimeSource   blockchain.MedianTimeSource
 
 	// The following fields are for accessing the chain and its configuration.
 	Chain        *blockchain.BlockChain

--- a/server.go
+++ b/server.go
@@ -3253,6 +3253,16 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 		return nil, err
 	}
 
+	// Dump the blockchain and quit if requested.
+	if cfg.DumpBlockchain != "" {
+		err := dumpBlockChain(s.chainParams, s.chain)
+		if err != nil {
+			return nil, err
+		}
+
+		return nil, fmt.Errorf("closing after dumping blockchain")
+	}
+
 	// Create the background block template generator and CPU miner if the
 	// config has a mining address.
 	if len(cfg.miningAddrs) > 0 {

--- a/server.go
+++ b/server.go
@@ -3248,6 +3248,10 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 		RpcServer: func() *rpcserver.Server {
 			return s.rpcServer
 		},
+		DisableCheckpoints: cfg.DisableCheckpoints,
+		NoMiningStateSync:  cfg.NoMiningStateSync,
+		MaxPeers:           cfg.MaxPeers,
+		MaxOrphanTxs:       cfg.MaxOrphanTxs,
 	})
 	if err != nil {
 		return nil, err

--- a/server.go
+++ b/server.go
@@ -3236,7 +3236,6 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 		ChainParams:        s.chainParams,
 		SigCache:           s.sigCache,
 		SubsidyCache:       s.subsidyCache,
-		TimeSource:         s.timeSource,
 		FeeEstimator:       s.feeEstimator,
 		TxMemPool:          s.txMemPool,
 		BgBlkTmplGenerator: nil, // Created later.


### PR DESCRIPTION
This decouples the block manager from the global config variable as part of an overall effort to eventually split it into its own package.

It consists of three commits which:

- Remove an unused config field
- Decouples the code related to loading and dumping the block database from the block manager and moves it into a separate file
- Adds configuration parameters used by the block manager to its own config struct versus directly using the global config variable

This is work towards #1145.