### PR TITLE
multi: Handle chain ntfn callback in server.

### DIFF
--- a/server.go
+++ b/server.go
@@ -813,7 +813,7 @@ func (sp *serverPeer) OnGetMiningState(p *peer.Peer, msg *wire.MsgGetMiningState
 	// mining state message.  There is nothing to send when there are no
 	// eligible blocks.
 	blockHashes := mining.SortParentsByVotes(mp, best.Hash, children,
-		bm.cfg.ChainParams)
+		sp.server.chainParams)
 	numBlocks := len(blockHashes)
 	if numBlocks == 0 {
 		return
@@ -904,7 +904,7 @@ func (sp *serverPeer) OnGetInitState(p *peer.Peer, msg *wire.MsgGetInitState) {
 		// block hashes per init state message.  There is nothing to
 		// send when there are no eligible blocks.
 		blockHashes = mining.SortParentsByVotes(mp, best.Hash, children,
-			bm.cfg.ChainParams)
+			sp.server.chainParams)
 		if len(blockHashes) > wire.MaxISBlocksAtHeadPerMsg {
 			blockHashes = blockHashes[:wire.MaxISBlocksAtHeadPerMsg]
 		}


### PR DESCRIPTION
**This requires #2497**.

This further decouples the block manager from the server by reworking thelogic that determines whether or not the block manager believes the chain is current (synced) and moving the chain callback code from the block manager to server where it more naturally belongs since it is not directly related to sync, rather it is in response to it.

The logic to determine if the block manager believes the chain is current now uses a flag that is protected by a separate mutex and is updated on the fly versus needing to go through a channel and using the current sync peer.

This also has the benefit of much faster state querying and allowing looser coupling of block processing without the potential of deadlocks.

The following is a high level overview of the changes:

- Avoid using unexported block manager cfg variable from server
- Rework chain currency determination logic
  - Introduce a new `isCurrent` flag protected by `isCurrentMtx` to the block manager
  - Update the flag on the fly as blocks are received versus determining it via the sync peer on every invocation
- Move blockchain notification callback to server
  - Use instance vars and methods directly on server
- Move funcs and consts only used by callback from `blockmanager.go` to `server.go`
- Remove no longer needed methods from `peerNotifier` interface
  - `RelayInventory`
  - `TransactionConfirmed`
- Remove no longer needed fields from `blockManagerConfig` struct
  - `FeeEstimator`
  - `BgBlkTmplGenerator`
  - `NotifyWinningTickets`
  - `PruneRebroadcastInventory`
- Move lottery data duplicate filter state to server
- Move block announce duplicate filter state to server
- Misc consistency nits

This is a part of the overall effort to decouple the block manager from the server so it can be split out into a separate internal `netsync` package.


This is work towards #1145.