### PR TITLE
netsync: Split blockmanager into separate package.

### DIFF
--- a/blockdb.go
+++ b/blockdb.go
@@ -244,7 +244,7 @@ func dumpBlockChain(params *chaincfg.Params, b *blockchain.BlockChain) error {
 		progressLogger.LogBlockHeight(bl.MsgBlock(), tipHeight)
 	}
 
-	bmgrLog.Infof("Successfully dumped the blockchain (%v blocks) to %v.",
+	srvrLog.Infof("Successfully dumped the blockchain (%v blocks) to %v.",
 		tipHeight, cfg.DumpBlockchain)
 
 	return nil

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -2010,6 +2010,30 @@ func (b *blockManager) TicketPoolValue() (dcrutil.Amount, error) {
 	return b.cfg.Chain.TicketPoolValue()
 }
 
+// syncManager is a temporary interface to facilitate cleaner diffs when moving
+// the block manager to a new package, so none of its members are documented.
+// It will be removed in a future commit.
+type syncManager interface {
+	NewPeer(p *peerpkg.Peer)
+	IsCurrent() bool
+	TipGeneration() ([]chainhash.Hash, error)
+	RequestFromPeer(p *peerpkg.Peer, blocks, txs []*chainhash.Hash) error
+	QueueTx(tx *dcrutil.Tx, peer *peerpkg.Peer, done chan struct{})
+	QueueBlock(block *dcrutil.Block, peer *peerpkg.Peer, done chan struct{})
+	QueueInv(inv *wire.MsgInv, peer *peerpkg.Peer)
+	QueueHeaders(headers *wire.MsgHeaders, peer *peerpkg.Peer)
+	QueueNotFound(notFound *wire.MsgNotFound, peer *peerpkg.Peer)
+	DonePeer(peer *peerpkg.Peer)
+	Start()
+	Stop() error
+	ForceReorganization(formerBest, newBest chainhash.Hash) error
+	ProcessBlock(block *dcrutil.Block, flags blockchain.BehaviorFlags) (bool, error)
+	SyncPeerID() int32
+	SyncHeight() int64
+	ProcessTransaction(tx *dcrutil.Tx, allowOrphans bool, rateLimit bool,
+		allowHighFees bool, tag mempool.Tag) ([]*dcrutil.Tx, error)
+}
+
 // newBlockManager returns a new Decred block manager.
 // Use Start to begin processing asynchronous block and inv updates.
 func newBlockManager(config *blockManagerConfig) (*blockManager, error) {

--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -549,7 +549,7 @@ the method name for further details such as parameter and return information.
 : Dynamically changes the debug logging level.
 : The levelspec can either be a debug level or of the form <code><subsystem>=<level>,<subsystem2>=<level2>,...</code>
 : The valid debug levels are <code>trace</code>, <code>debug</code>, <code>info</code>, <code>warn</code>, <code>error</code>, and <code>critical</code>.
-: The valid subsystems are <code>AMGR</code>, <code>ADXR</code>, <code>BCDB</code>, <code>BMGR</code>, <code>DCRD</code>, <code>CHAN</code>, <code>DISC</code>, <code>PEER</code>, <code>RPCS</code>, <code>SCRP</code>, <code>SRVR</code>, and <code>TXMP</code>.
+: The valid subsystems are <code>AMGR</code>, <code>ADXR</code>, <code>BCDB</code>, <code>DCRD</code>, <code>CHAN</code>, <code>DISC</code>, <code>PEER</code>, <code>RPCS</code>, <code>SCRP</code>, <code>SRVR</code>, <code>SYNC</code>, and <code>TXMP</code>.
 : Additionally, the special keyword <code>show</code> can be used to get a list of the available subsystems.
 |-
 !Returns
@@ -559,7 +559,7 @@ the method name for further details such as parameter and return information.
 |<code>Done.</code>
 |-
 !Example <code>show</code> Return
-|<code>Supported subsystems [AMGR ADXR BCDB BMGR DCRD CHAN DISC PEER RPCS SCRP SRVR TXMP]</code>
+|<code>Supported subsystems [AMGR ADXR BCDB DCRD CHAN DISC PEER RPCS SCRP SRVR SYNC TXMP]</code>
 |}
 
 ----

--- a/internal/fees/estimator.go
+++ b/internal/fees/estimator.go
@@ -623,11 +623,11 @@ func (stats *Estimator) removeFromMemPool(blocksInMemPool int32, rate feeRate) {
 		// function but not on a previous newMemPoolTx. This leaves the fee db
 		// in an undefined state and should never happen in regular use. If this
 		// happens, then there is a logic or coding error somewhere, either in
-		// the estimator itself or on its hooking to the mempool/blockmanager.
-		// Either way, the easiest way to fix this is to completely delete the
-		// database and start again.
-		// During development, you can use a panic() here and we might return it
-		// after being confident that the estimator is completely bug free.
+		// the estimator itself or on its hooking to the mempool/network sync
+		// manager.  Either way, the easiest way to fix this is to completely
+		// delete the database and start again.  During development, you can use
+		// a panic() here and we might return it after being confident that the
+		// estimator is completely bug free.
 		log.Errorf("Transaction count in bucket index %d and confirmation "+
 			"index %d became < 0", bucketIdx, confirmIdx)
 	}

--- a/internal/mining/interface.go
+++ b/internal/mining/interface.go
@@ -67,7 +67,7 @@ type blockManagerFacade interface {
 	// best chain.
 	ForceReorganization(formerBest, newBest chainhash.Hash) error
 
-	// IsCurrent returns whether or not the block manager believes it is synced
-	// with the connected peers.
+	// IsCurrent returns whether or not the net sync manager believes it is
+	// synced with the connected peers.
 	IsCurrent() bool
 }

--- a/internal/netsync/README.md
+++ b/internal/netsync/README.md
@@ -1,0 +1,21 @@
+netsync
+=======
+
+[![Build Status](https://github.com/decred/dcrd/workflows/Build%20and%20Test/badge.svg)](https://github.com/decred/dcrd/actions)
+[![ISC License](https://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![Doc](https://img.shields.io/badge/doc-reference-blue.svg)](https://pkg.go.dev/github.com/decred/dcrd/internal/netsync)
+
+Package netsync implements a concurrency safe block syncing protocol.
+
+## Overview
+
+The provided implementation of SyncManager communicates with connected peers to
+perform an initial block download, keep the chain in sync, and announce new
+blocks connected to the chain. Currently the sync manager selects a single sync
+peer that it downloads all blocks from until it is up to date with the longest
+chain the sync peer is aware of.
+
+## License
+
+Package netsync is licensed under the [copyfree](http://copyfree.org) ISC
+License.

--- a/internal/netsync/doc.go
+++ b/internal/netsync/doc.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+/*
+Package netsync implements a concurrency safe block syncing protocol.
+
+The provided implementation of SyncManager communicates with connected peers to
+perform an initial block download, keep the chain in sync, and announce new
+blocks connected to the chain.  Currently the sync manager selects a single sync
+peer that it downloads all blocks from until it is up to date with the longest
+chain the sync peer is aware of.
+*/
+package netsync

--- a/internal/netsync/interface.go
+++ b/internal/netsync/interface.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package netsync
+
+import (
+	"github.com/decred/dcrd/blockchain/v4"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/dcrutil/v3"
+	"github.com/decred/dcrd/internal/mempool"
+	"github.com/decred/dcrd/peer/v2"
+	"github.com/decred/dcrd/wire"
+)
+
+// PeerNotifier provides an interface to notify peers of status changes related
+// to blocks and transactions.
+type PeerNotifier interface {
+	// AnnounceNewTransactions generates and relays inventory vectors and
+	// notifies websocket clients of the passed transactions.
+	AnnounceNewTransactions(txns []*dcrutil.Tx)
+
+	// UpdatePeerHeights updates the heights of all peers who have announced the
+	// latest connected main chain block, or a recognized orphan.
+	UpdatePeerHeights(latestBlkHash *chainhash.Hash, latestHeight int64, updateSource *peer.Peer)
+}
+
+// SyncManager is a temporary interface to facilitate cleaner diffs when moving
+// the block manager to a new package, so none of its members are documented.
+// It will be removed in a future commit.
+type SyncManager interface {
+	NewPeer(p *peer.Peer)
+	IsCurrent() bool
+	TipGeneration() ([]chainhash.Hash, error)
+	RequestFromPeer(p *peer.Peer, blocks, txs []*chainhash.Hash) error
+	QueueTx(tx *dcrutil.Tx, peer *peer.Peer, done chan struct{})
+	QueueBlock(block *dcrutil.Block, peer *peer.Peer, done chan struct{})
+	QueueInv(inv *wire.MsgInv, peer *peer.Peer)
+	QueueHeaders(headers *wire.MsgHeaders, peer *peer.Peer)
+	QueueNotFound(notFound *wire.MsgNotFound, peer *peer.Peer)
+	DonePeer(peer *peer.Peer)
+	Start()
+	Stop() error
+	ForceReorganization(formerBest, newBest chainhash.Hash) error
+	ProcessBlock(block *dcrutil.Block, flags blockchain.BehaviorFlags) (bool, error)
+	SyncPeerID() int32
+	SyncHeight() int64
+	ProcessTransaction(tx *dcrutil.Tx, allowOrphans bool, rateLimit bool,
+		allowHighFees bool, tag mempool.Tag) ([]*dcrutil.Tx, error)
+}

--- a/internal/netsync/interface.go
+++ b/internal/netsync/interface.go
@@ -5,12 +5,9 @@
 package netsync
 
 import (
-	"github.com/decred/dcrd/blockchain/v4"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil/v3"
-	"github.com/decred/dcrd/internal/mempool"
 	"github.com/decred/dcrd/peer/v2"
-	"github.com/decred/dcrd/wire"
 )
 
 // PeerNotifier provides an interface to notify peers of status changes related
@@ -23,28 +20,4 @@ type PeerNotifier interface {
 	// UpdatePeerHeights updates the heights of all peers who have announced the
 	// latest connected main chain block, or a recognized orphan.
 	UpdatePeerHeights(latestBlkHash *chainhash.Hash, latestHeight int64, updateSource *peer.Peer)
-}
-
-// SyncManager is a temporary interface to facilitate cleaner diffs when moving
-// the block manager to a new package, so none of its members are documented.
-// It will be removed in a future commit.
-type SyncManager interface {
-	NewPeer(p *peer.Peer)
-	IsCurrent() bool
-	TipGeneration() ([]chainhash.Hash, error)
-	RequestFromPeer(p *peer.Peer, blocks, txs []*chainhash.Hash) error
-	QueueTx(tx *dcrutil.Tx, peer *peer.Peer, done chan struct{})
-	QueueBlock(block *dcrutil.Block, peer *peer.Peer, done chan struct{})
-	QueueInv(inv *wire.MsgInv, peer *peer.Peer)
-	QueueHeaders(headers *wire.MsgHeaders, peer *peer.Peer)
-	QueueNotFound(notFound *wire.MsgNotFound, peer *peer.Peer)
-	DonePeer(peer *peer.Peer)
-	Start()
-	Stop() error
-	ForceReorganization(formerBest, newBest chainhash.Hash) error
-	ProcessBlock(block *dcrutil.Block, flags blockchain.BehaviorFlags) (bool, error)
-	SyncPeerID() int32
-	SyncHeight() int64
-	ProcessTransaction(tx *dcrutil.Tx, allowOrphans bool, rateLimit bool,
-		allowHighFees bool, tag mempool.Tag) ([]*dcrutil.Tx, error)
 }

--- a/internal/netsync/log.go
+++ b/internal/netsync/log.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package netsync
+
+import (
+	"github.com/decred/slog"
+)
+
+// log is a logger that is initialized with no output filters.  This
+// means the package will not perform any logging by default until the caller
+// requests it.
+// The default amount of logging is none.
+var log = slog.Disabled
+
+// UseLogger uses a specified Logger to output package logging info.
+// This should be used in preference to SetLogWriter if the caller is also
+// using slog.
+func UseLogger(logger slog.Logger) {
+	log = logger
+}

--- a/internal/rpcserver/rpcserverhelp.go
+++ b/internal/rpcserver/rpcserverhelp.go
@@ -22,7 +22,7 @@ var helpDescsEnUS = map[string]string{
 		"The levelspec can either a debug level or of the form:\n" +
 		"<subsystem>=<level>,<subsystem2>=<level2>,...\n" +
 		"The valid debug levels are trace, debug, info, warn, error, and critical.\n" +
-		"The valid subsystems are AMGR, ADXR, BCDB, BMGR, DCRD, CHAN, DISC, PEER, RPCS, SCRP, SRVR, and TXMP.\n" +
+		"The valid subsystems are AMGR, ADXR, BCDB, DCRD, CHAN, DISC, PEER, RPCS, SCRP, SRVR, SYNC, and TXMP.\n" +
 		"Finally the keyword 'show' will return a list of the available subsystems.",
 	"debuglevel-levelspec":   "The debug level(s) to use or the keyword 'show'",
 	"debuglevel--condition0": "levelspec!=show",

--- a/internal/rpcserver/rpcwebsocket.go
+++ b/internal/rpcserver/rpcwebsocket.go
@@ -2028,8 +2028,8 @@ var ErrClientQuit = errors.New("client quit")
 // QueueNotification queues the passed notification to be sent to the websocket
 // client.  This function, as the name implies, is only intended for
 // notifications since it has additional logic to prevent other subsystems, such
-// as the memory pool and block manager, from blocking even when the send
-// channel is full.
+// as the memory pool and sync manager, from blocking even when the send channel
+// is full.
 //
 // If the client is in the process of shutting down, this function returns
 // ErrClientQuit.  This is intended to be checked by long-running notification

--- a/log.go
+++ b/log.go
@@ -20,6 +20,7 @@ import (
 	"github.com/decred/dcrd/internal/mempool"
 	"github.com/decred/dcrd/internal/mining"
 	"github.com/decred/dcrd/internal/mining/cpuminer"
+	"github.com/decred/dcrd/internal/netsync"
 	"github.com/decred/dcrd/internal/rpcserver"
 	"github.com/decred/dcrd/peer/v2"
 	"github.com/decred/dcrd/txscript/v3"
@@ -92,6 +93,7 @@ func init() {
 	peer.UseLogger(peerLog)
 	rpcserver.UseLogger(rpcsLog)
 	stake.UseLogger(stkeLog)
+	netsync.UseLogger(syncLog)
 	txscript.UseLogger(scrpLog)
 }
 

--- a/log.go
+++ b/log.go
@@ -60,7 +60,6 @@ var (
 	adxrLog = backendLog.Logger("ADXR")
 	amgrLog = backendLog.Logger("AMGR")
 	bcdbLog = backendLog.Logger("BCDB")
-	bmgrLog = backendLog.Logger("BMGR")
 	chanLog = backendLog.Logger("CHAN")
 	cmgrLog = backendLog.Logger("CMGR")
 	dcrdLog = backendLog.Logger("DCRD")
@@ -73,6 +72,7 @@ var (
 	scrpLog = backendLog.Logger("SCRP")
 	srvrLog = backendLog.Logger("SRVR")
 	stkeLog = backendLog.Logger("STKE")
+	syncLog = backendLog.Logger("SYNC")
 	txmpLog = backendLog.Logger("TXMP")
 	trsyLog = backendLog.Logger("TRSY")
 )
@@ -100,7 +100,6 @@ var subsystemLoggers = map[string]slog.Logger{
 	"ADXR": adxrLog,
 	"AMGR": amgrLog,
 	"BCDB": bcdbLog,
-	"BMGR": bmgrLog,
 	"CHAN": chanLog,
 	"CMGR": cmgrLog,
 	"DCRD": dcrdLog,
@@ -113,6 +112,7 @@ var subsystemLoggers = map[string]slog.Logger{
 	"SCRP": scrpLog,
 	"SRVR": srvrLog,
 	"STKE": stkeLog,
+	"SYNC": syncLog,
 	"TXMP": txmpLog,
 	"TRSY": trsyLog,
 }

--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -310,7 +310,7 @@ func (*rpcConnManager) Lookup(host string) ([]net.IP, error) {
 // rpcserver.SyncManager interface.
 type rpcSyncMgr struct {
 	server  *server
-	syncMgr *blockManager
+	syncMgr syncManager
 }
 
 // Ensure rpcSyncMgr implements the rpcserver.SyncManager interface.

--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -19,6 +19,7 @@ import (
 	"github.com/decred/dcrd/internal/mempool"
 	"github.com/decred/dcrd/internal/mining"
 	"github.com/decred/dcrd/internal/mining/cpuminer"
+	"github.com/decred/dcrd/internal/netsync"
 	"github.com/decred/dcrd/internal/rpcserver"
 	"github.com/decred/dcrd/peer/v2"
 	"github.com/decred/dcrd/wire"
@@ -310,7 +311,7 @@ func (*rpcConnManager) Lookup(host string) ([]net.IP, error) {
 // rpcserver.SyncManager interface.
 type rpcSyncMgr struct {
 	server  *server
-	syncMgr syncManager
+	syncMgr netsync.SyncManager
 }
 
 // Ensure rpcSyncMgr implements the rpcserver.SyncManager interface.

--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -311,7 +311,7 @@ func (*rpcConnManager) Lookup(host string) ([]net.IP, error) {
 // rpcserver.SyncManager interface.
 type rpcSyncMgr struct {
 	server  *server
-	syncMgr netsync.SyncManager
+	syncMgr *netsync.SyncManager
 }
 
 // Ensure rpcSyncMgr implements the rpcserver.SyncManager interface.

--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -306,23 +306,23 @@ func (*rpcConnManager) Lookup(host string) ([]net.IP, error) {
 	return dcrdLookup(host)
 }
 
-// rpcSyncMgr provides a block manager for use with the RPC server and
-// implements the rpcserver.SyncManager interface.
+// rpcSyncMgr provides an adaptor for use with the RPC server and implements the
+// rpcserver.SyncManager interface.
 type rpcSyncMgr struct {
-	server   *server
-	blockMgr *blockManager
+	server  *server
+	syncMgr *blockManager
 }
 
 // Ensure rpcSyncMgr implements the rpcserver.SyncManager interface.
 var _ rpcserver.SyncManager = (*rpcSyncMgr)(nil)
 
-// IsCurrent returns whether or not the sync manager believes the chain is
+// IsCurrent returns whether or not the net sync manager believes the chain is
 // current as compared to the rest of the network.
 //
 // This function is safe for concurrent access and is part of the
 // rpcserver.SyncManager interface implementation.
 func (b *rpcSyncMgr) IsCurrent() bool {
-	return b.blockMgr.IsCurrent()
+	return b.syncMgr.IsCurrent()
 }
 
 // SubmitBlock submits the provided block to the network after processing it
@@ -331,7 +331,7 @@ func (b *rpcSyncMgr) IsCurrent() bool {
 // This function is safe for concurrent access and is part of the
 // rpcserver.SyncManager interface implementation.
 func (b *rpcSyncMgr) SubmitBlock(block *dcrutil.Block, flags blockchain.BehaviorFlags) (bool, error) {
-	return b.blockMgr.ProcessBlock(block, flags)
+	return b.syncMgr.ProcessBlock(block, flags)
 }
 
 // SyncPeer returns the id of the current peer being synced with.
@@ -339,7 +339,7 @@ func (b *rpcSyncMgr) SubmitBlock(block *dcrutil.Block, flags blockchain.Behavior
 // This function is safe for concurrent access and is part of the
 // rpcserver.SyncManager interface implementation.
 func (b *rpcSyncMgr) SyncPeerID() int32 {
-	return b.blockMgr.SyncPeerID()
+	return b.syncMgr.SyncPeerID()
 }
 
 // LocateBlocks returns the hashes of the blocks after the first known block in
@@ -355,19 +355,19 @@ func (b *rpcSyncMgr) LocateBlocks(locator blockchain.BlockLocator, hashStop *cha
 // TipGeneration returns the entire generation of blocks stemming from the
 // parent of the current tip.
 func (b *rpcSyncMgr) TipGeneration() ([]chainhash.Hash, error) {
-	return b.blockMgr.TipGeneration()
+	return b.syncMgr.TipGeneration()
 }
 
 // SyncHeight returns latest known block being synced to.
 func (b *rpcSyncMgr) SyncHeight() int64 {
-	return b.blockMgr.SyncHeight()
+	return b.syncMgr.SyncHeight()
 }
 
 // ProcessTransaction relays the provided transaction validation and insertion
 // into the memory pool.
 func (b *rpcSyncMgr) ProcessTransaction(tx *dcrutil.Tx, allowOrphans bool,
 	rateLimit bool, allowHighFees bool, tag mempool.Tag) ([]*dcrutil.Tx, error) {
-	return b.blockMgr.ProcessTransaction(tx, allowOrphans,
+	return b.syncMgr.ProcessTransaction(tx, allowOrphans,
 		rateLimit, allowHighFees, tag)
 }
 

--- a/server.go
+++ b/server.go
@@ -463,7 +463,7 @@ type server struct {
 	sigCache             *txscript.SigCache
 	subsidyCache         *standalone.SubsidyCache
 	rpcServer            *rpcserver.Server
-	syncManager          netsync.SyncManager
+	syncManager          *netsync.SyncManager
 	bg                   *mining.BgBlkTmplGenerator
 	chain                *blockchain.BlockChain
 	txMemPool            *mempool.TxPool

--- a/server.go
+++ b/server.go
@@ -2647,7 +2647,7 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 		// which could result in a deadlock.
 		block, ok := notification.Data.(*dcrutil.Block)
 		if !ok {
-			bmgrLog.Warnf("New tip block checked notification is not a block.")
+			syncLog.Warnf("New tip block checked notification is not a block.")
 			break
 		}
 
@@ -2671,7 +2671,7 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 
 		band, ok := notification.Data.(*blockchain.BlockAcceptedNtfnsData)
 		if !ok {
-			bmgrLog.Warnf("Chain accepted notification is not " +
+			syncLog.Warnf("Chain accepted notification is not " +
 				"BlockAcceptedNtfnsData.")
 			break
 		}
@@ -2715,7 +2715,7 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 			// blockchain.
 			wt, _, _, err := s.chain.LotteryDataForBlock(blockHash)
 			if err != nil {
-				bmgrLog.Errorf("Couldn't calculate winning tickets for "+
+				syncLog.Errorf("Couldn't calculate winning tickets for "+
 					"accepted block %v: %v", blockHash, err.Error())
 			} else {
 				// Notify registered websocket clients of newly eligible tickets
@@ -2760,8 +2760,8 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 	case blockchain.NTBlockConnected:
 		ntfn, ok := notification.Data.(*blockchain.BlockConnectedNtfnsData)
 		if !ok {
-			bmgrLog.Warnf("Block connected notification is not " +
-				"BlockConnectedNtfnsData.")
+			syncLog.Warnf("Block connected notification is not " +
+				"BlockConnectedNtfnsData")
 			break
 		}
 		block := ntfn.Block
@@ -2870,7 +2870,7 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 	case blockchain.NTSpentAndMissedTickets:
 		tnd, ok := notification.Data.(*blockchain.TicketNotificationsData)
 		if !ok {
-			bmgrLog.Warnf("Tickets connected notification is not " +
+			syncLog.Warnf("Tickets connected notification is not " +
 				"TicketNotificationsData")
 			break
 		}
@@ -2883,7 +2883,7 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 	case blockchain.NTNewTickets:
 		tnd, ok := notification.Data.(*blockchain.TicketNotificationsData)
 		if !ok {
-			bmgrLog.Warnf("Tickets connected notification is not " +
+			syncLog.Warnf("Tickets connected notification is not " +
 				"TicketNotificationsData")
 			break
 		}
@@ -2896,7 +2896,7 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 	case blockchain.NTBlockDisconnected:
 		ntfn, ok := notification.Data.(*blockchain.BlockDisconnectedNtfnsData)
 		if !ok {
-			bmgrLog.Warnf("Block disconnected notification is not " +
+			syncLog.Warnf("Block disconnected notification is not " +
 				"BlockDisconnectedNtfnsData.")
 			break
 		}
@@ -2989,7 +2989,7 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 	case blockchain.NTReorganization:
 		rd, ok := notification.Data.(*blockchain.ReorganizationNtfnsData)
 		if !ok {
-			bmgrLog.Warnf("Chain reorganization notification is malformed")
+			syncLog.Warnf("Chain reorganization notification is malformed")
 			break
 		}
 

--- a/server.go
+++ b/server.go
@@ -462,7 +462,7 @@ type server struct {
 	sigCache             *txscript.SigCache
 	subsidyCache         *standalone.SubsidyCache
 	rpcServer            *rpcserver.Server
-	syncManager          *blockManager
+	syncManager          syncManager
 	bg                   *mining.BgBlkTmplGenerator
 	chain                *blockchain.BlockChain
 	txMemPool            *mempool.TxPool

--- a/server.go
+++ b/server.go
@@ -42,6 +42,7 @@ import (
 	"github.com/decred/dcrd/internal/mempool"
 	"github.com/decred/dcrd/internal/mining"
 	"github.com/decred/dcrd/internal/mining/cpuminer"
+	"github.com/decred/dcrd/internal/netsync"
 	"github.com/decred/dcrd/internal/rpcserver"
 	"github.com/decred/dcrd/internal/version"
 	"github.com/decred/dcrd/lru"
@@ -462,7 +463,7 @@ type server struct {
 	sigCache             *txscript.SigCache
 	subsidyCache         *standalone.SubsidyCache
 	rpcServer            *rpcserver.Server
-	syncManager          syncManager
+	syncManager          netsync.SyncManager
 	bg                   *mining.BgBlkTmplGenerator
 	chain                *blockchain.BlockChain
 	txMemPool            *mempool.TxPool
@@ -3645,12 +3646,11 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 		},
 	}
 	s.txMemPool = mempool.New(&txC)
-	s.syncManager, err = newBlockManager(&blockManagerConfig{
+	s.syncManager, err = netsync.New(&netsync.Config{
 		PeerNotifier: &s,
 		Chain:        s.chain,
 		ChainParams:  s.chainParams,
 		SigCache:     s.sigCache,
-		SubsidyCache: s.subsidyCache,
 		TxMemPool:    s.txMemPool,
 		RpcServer: func() *rpcserver.Server {
 			return s.rpcServer


### PR DESCRIPTION
**This requires #2498 and #2499**.

This does the minimum work necessary to refactor the block manager into its own internal package named `netsync`.  The main motivation is that     separating this code into its own package will improve its testability and more cleanly split the details related to syncing with the network from consensus validation.

The API will certainly need some additional cleanup and changes to make it more usable outside of the specific circumstances it currently supports, however it is better to do that in future commits in order to keep the changeset as small as possible during this refactor.

It has been carefully crafted into a series of individual commits that make each step easier to review as it would be a giant blob of changes that would be very hard to review otherwise.  As a case in point, a temporary interface is introduced and then removed later to allow renaming to happen in a separate commit while ensuring every individual commit continues to build and work properly along the way.

Overview of the major changes:

- Rename server `blockManager` field to `syncManager`
- Rename `BMGR` logging subsystem to `SYNC`
- Update logging to use the new subsystem
- Create the new `netsync` package
- Add package logger
- Tie new package logger to `SYNC` subsystem logger
- Move `blockmanager.go` -> `internal/netsync/manager.go`
- Rename `blockManagerConfig` to `Config` (now `netsync.Config`)
- Move `peerNotifier` to `netsync/interface.go` (now `netsync.PeerNotifier`)
- Rename `newBlockManager` to `New` (now `netsync.New`)
- Rename `blockManager` to `SyncManager` (now `netsync.SyncManager`)
- Update all references to the block manager to use the package
- Add a skeleton `README.md`
- Add a skeleton `doc.go`


This is work towards #1145.