### PR TITLE
multi: Subscribe for work ntfns in rpcserver.

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -359,14 +359,6 @@ func (b *blockManager) resetHeaderState(newestHash *chainhash.Hash, newestHeight
 	}
 }
 
-// NotifyWork passes new mining work to the notification manager
-// for block notification processing.
-func (b *blockManager) NotifyWork(templateNtfn *mining.TemplateNtfn) {
-	if r := b.cfg.RpcServer(); r != nil {
-		r.NotifyWork(templateNtfn)
-	}
-}
-
 // SyncHeight returns latest known block being synced to.
 func (b *blockManager) SyncHeight() int64 {
 	b.syncHeightMtx.Lock()

--- a/internal/mining/bgblktmplgenerator.go
+++ b/internal/mining/bgblktmplgenerator.go
@@ -465,8 +465,6 @@ func (g *BgBlkTmplGenerator) notifySubscribersHandler(ctx context.Context) {
 	for {
 		select {
 		case templateNtfn := <-g.notifySubscribers:
-			g.tg.cfg.BlockManager.NotifyWork(templateNtfn)
-
 			g.subscriptionMtx.Lock()
 			for subscription := range g.subscriptions {
 				subscription.publishTemplateNtfn(templateNtfn)

--- a/internal/mining/interface.go
+++ b/internal/mining/interface.go
@@ -70,8 +70,4 @@ type blockManagerFacade interface {
 	// IsCurrent returns whether or not the block manager believes it is synced
 	// with the connected peers.
 	IsCurrent() bool
-
-	// NotifyWork passes new mining work to the notification manager for block
-	// notification processing.
-	NotifyWork(templateNtfn *TemplateNtfn)
 }

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -665,8 +665,7 @@ type NtfnManager interface {
 	// for processing.
 	NotifyBlockDisconnected(block *dcrutil.Block)
 
-	// NotifyWork passes new mining work to the manager for
-	// processing.
+	// NotifyWork passes new mining work to the manager for processing.
 	NotifyWork(templateNtfn *mining.TemplateNtfn)
 
 	// NotifyTSpend passes new tspends to the manager for processing.

--- a/internal/rpcserver/rpcwebsocket.go
+++ b/internal/rpcserver/rpcwebsocket.go
@@ -885,8 +885,7 @@ func updateReasonToWorkNtfnString(reason mining.TemplateUpdateReason) string {
 
 // notifyWork notifies websocket clients that have registered for template
 // updates when a new block template is generated.
-func (m *wsNotificationManager) notifyWork(clients map[chan struct{}]*wsClient,
-	templateNtfn *mining.TemplateNtfn) {
+func (m *wsNotificationManager) notifyWork(clients map[chan struct{}]*wsClient, templateNtfn *mining.TemplateNtfn) {
 	// Skip notification creation if no clients have requested work
 	// notifications.
 	if len(clients) == 0 {


### PR DESCRIPTION
This modifies the RPC server to subscribe to the background block template generator when it is enabled instead of passing a callback through several layers.