### PR TITLE
run_tests.sh: Avoid command substitution.

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -ex
 
@@ -48,7 +48,7 @@ for module in $MODPATHS; do
     go mod tidy
     UPDATED_MOD_STATUS=$(git status --porcelain go.mod go.sum)
     if [ "$UPDATED_MOD_STATUS" != "$MOD_STATUS" ]; then
-      echo "Running `go mod tidy` modified go.mod and/or go.sum"
+      echo 'Running `go mod tidy` modified go.mod and/or go.sum'
       exit 1
     fi
 


### PR DESCRIPTION
This string is meant to describe the command that was run, not
substitute the output of the command into the error message.

While here, use /bin/sh in the shebang instead of bash, as this script
does not use or need any bashisms.