### PR TITLE
blockchain: Explicit hash in max block size func.

### DIFF
--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -371,8 +371,8 @@ type Chain interface {
 	MainChainHasBlock(hash *chainhash.Hash) bool
 
 	// MaxBlockSize returns the maximum permitted block size for the block AFTER
-	// the end of the current best chain.
-	MaxBlockSize() (int64, error)
+	// the provided block hash.
+	MaxBlockSize(hash *chainhash.Hash) (int64, error)
 
 	// MissedTickets returns all currently missed tickets.
 	MissedTickets() ([]chainhash.Hash, error)

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -2033,7 +2033,7 @@ func handleGetBlockchainInfo(_ context.Context, s *Server, cmd interface{}) (int
 	}
 
 	// Fetch the maximum allowed block size.
-	maxBlockSize, err := chain.MaxBlockSize()
+	maxBlockSize, err := chain.MaxBlockSize(&best.PrevHash)
 	if err != nil {
 		return nil, rpcInternalError(err.Error(),
 			"Could not fetch max block size.")

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -343,8 +343,8 @@ func (c *testRPCChain) MainChainHasBlock(hash *chainhash.Hash) bool {
 }
 
 // MaxBlockSize returns a mocked maximum permitted block size for the block
-// AFTER the end of the current best chain.
-func (c *testRPCChain) MaxBlockSize() (int64, error) {
+// AFTER the provided block hash.
+func (c *testRPCChain) MaxBlockSize(hash *chainhash.Hash) (int64, error) {
 	return c.maxBlockSize, c.maxBlockSizeErr
 }
 


### PR DESCRIPTION
This modifies `MaxBlockSize` to accept a hash instead of using the current chain tip as part of an overall effort to make the blockchain module more explicit and less reliant on the current state.