### PR TITLE
rpcserver: Check unauthorized access in const time.

### DIFF
--- a/internal/rpcserver/rpcwebsocket.go
+++ b/internal/rpcserver/rpcwebsocket.go
@@ -1528,7 +1528,7 @@ out:
 				mac = c.rpcServer.authMAC(mac, []byte(auth))
 				cmp := subtle.ConstantTimeCompare(mac, c.rpcServer.authsha[:])
 				limitcmp := subtle.ConstantTimeCompare(mac, c.rpcServer.limitauthsha[:])
-				if cmp != 1 && limitcmp != 1 {
+				if cmp|limitcmp != 0 {
 					log.Warnf("Auth failure.")
 					break out
 				}


### PR DESCRIPTION
The comparisons of the hashed authentication details against the
expected values was constant time, but the checks for whether
successful auth matched the admin or limited privileges was not.
Correct this by performing the bitwise OR of each before comparing.