### PR TITLE
mining: Remove leftover block manager facade iface.

### DIFF
--- a/internal/mining/interface.go
+++ b/internal/mining/interface.go
@@ -58,16 +58,3 @@ type TxSource interface {
 	// MiningView returns a snapshot of the underlying TxSource.
 	MiningView() *TxMiningView
 }
-
-// blockManagerFacade provides the mining package with a subset of
-// the methods originally defined in the blockManager.
-type blockManagerFacade interface {
-	// ForceReorganization forces a reorganization of the block chain to the block
-	// hash requested, so long as it matches up with the current organization of the
-	// best chain.
-	ForceReorganization(formerBest, newBest chainhash.Hash) error
-
-	// IsCurrent returns whether or not the net sync manager believes it is
-	// synced with the connected peers.
-	IsCurrent() bool
-}

--- a/internal/mining/mining_harness_test.go
+++ b/internal/mining/mining_harness_test.go
@@ -1369,7 +1369,6 @@ func newMiningHarness(chainParams *chaincfg.Params) (*miningHarness, []spendable
 			TimeSource:                 blockchain.NewMedianTime(),
 			SubsidyCache:               subsidyCache,
 			ChainParams:                chainParams,
-			BlockManager:               nil,
 			MiningTimeOffset:           0,
 			BestSnapshot:               chain.BestSnapshot,
 			BlockByHash:                chain.BlockByHash,
@@ -1400,6 +1399,7 @@ func newMiningHarness(chainParams *chaincfg.Params) (*miningHarness, []spendable
 
 				return blockchain.ValidateTransactionScripts(tx, utxoView, flags, sigCache)
 			},
+			ForceReorganization: chain.ForceHeadReorganization,
 		}),
 	}
 

--- a/server.go
+++ b/server.go
@@ -3698,7 +3698,6 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 			TimeSource:                 s.timeSource,
 			SubsidyCache:               s.subsidyCache,
 			ChainParams:                s.chainParams,
-			BlockManager:               s.syncManager,
 			MiningTimeOffset:           cfg.MiningTimeOffset,
 			BestSnapshot:               s.chain.BestSnapshot,
 			BlockByHash:                s.chain.BlockByHash,
@@ -3732,10 +3731,15 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 				return blockchain.ValidateTransactionScripts(tx, utxoView, flags,
 					s.sigCache)
 			},
+			ForceReorganization: s.syncManager.ForceReorganization,
 		})
 
-		s.bg = mining.NewBgBlkTmplGenerator(tg, cfg.miningAddrs,
-			cfg.AllowUnsyncedMining)
+		s.bg = mining.NewBgBlkTmplGenerator(&mining.BgBlkTmplConfig{
+			TemplateGenerator:   tg,
+			MiningAddrs:         cfg.miningAddrs,
+			AllowUnsyncedMining: cfg.AllowUnsyncedMining,
+			IsCurrent:           s.syncManager.IsCurrent,
+		})
 
 		s.cpuMiner = cpuminer.New(&cpuminer.Config{
 			ChainParams:                s.chainParams,


### PR DESCRIPTION
This reworks the mining template generator slightly to remove the leftover unexported block manager facade interface that was used as part of originally separating the code in a separate internal package.

The following is a high level overview of the changes:

- Introduces `BgBlkTmplConfig` for the background block template generator to mirror the standard approach used throughout the code
- Removes local fields that are now in the new config struct
- Removes `blockManagerFacade` interface which included:
  - `IsCurrent`
  - `ForceReorganization`
- Adds `IsCurrent` function to new `BgBlkTmplConfig` struct
- Adds `ForceReorganizion` to `Config`
- Updates all code to account for the changes