### PR TITLE
rpcserver: Add handleGet{NetworkHashPS,MiningInfo} tests.

### DIFF
--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -2512,7 +2512,7 @@ func handleGetMempoolInfo(_ context.Context, s *Server, cmd interface{}) (interf
 
 // handleGetMiningInfo implements the getmininginfo command. We only return the
 // fields that are not related to wallet functionality.
-func handleGetMiningInfo(ctx context.Context, s *Server, cmd interface{}) (interface{}, error) {
+func handleGetMiningInfo(ctx context.Context, s *Server, _ interface{}) (interface{}, error) {
 	// Create a default getnetworkhashps command to use defaults and make
 	// use of the existing getnetworkhashps handler.
 	gnhpsCmd := types.NewGetNetworkHashPSCmd(nil, nil)

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -4496,6 +4496,32 @@ func TestHandleGetMempoolInfo(t *testing.T) {
 	}})
 }
 
+func TestHandleGetMiningInfo(t *testing.T) {
+	t.Parallel()
+
+	testRPCServerHandler(t, []rpcTest{{
+		name:    "handleGetMiningInfo: ok",
+		handler: handleGetMiningInfo,
+		result: &types.GetMiningInfoResult{
+			Blocks:           432100,
+			CurrentBlockSize: 2782,
+			CurrentBlockTx:   7,
+			Difficulty:       2.8147398026656624e+10,
+			StakeDifficulty:  14428162590,
+		},
+	}, {
+		name:    "handleGetMiningInfo: invalid network hashes per sec",
+		handler: handleGetMiningInfo,
+		mockChain: func() *testRPCChain {
+			chain := defaultMockRPCChain()
+			chain.headerByHashErr = errors.New("")
+			return chain
+		}(),
+		wantErr: true,
+		errCode: dcrjson.ErrRPCInternal.Code,
+	}})
+}
+
 func TestHandleGetNetTotals(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This adds tests for `handleGetNetworkHashPS` and `handleGetMiningInfo`.
    
Because the test blockchain `HeaderByHash` must return different timestamps, use a function for `testRPCChain.headerByHash` that can return varying results.

