### PR TITLE
internal/mining: update mining error types.

### DIFF
--- a/blockchain/doc.go
+++ b/blockchain/doc.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -59,7 +59,7 @@ Errors returned by this package are either the raw errors provided by underlying
 calls or of type blockchain.RuleError.  This allows the caller to differentiate
 between unexpected errors, such as database errors, versus errors due to rule
 violations through type assertions.  In addition, callers can programmatically
-determine the specific rule violation by examining the ErrorCode field of the
+determine the specific rule violation by examining the Errorkind field of the
 type asserted blockchain.RuleError.
 */
 package blockchain

--- a/dcrec/secp256k1/ecdsa/doc.go
+++ b/dcrec/secp256k1/ecdsa/doc.go
@@ -34,9 +34,9 @@ Errors
 
 Errors returned by this package are of type ecdsa.Error and fully support the
 standard library errors.Is and errors.As functions.  This allows the caller to
-programmatically determine the specific error by examining the ErrorCode field
+programmatically determine the specific error by examining the ErrorKind field
 of the type asserted ecdsa.Error while still providing rich error messages with
-contextual information.  See ErrorCode in the package documentation for a full
+contextual information.  See ErrorKind in the package documentation for a full
 list.
 */
 package ecdsa

--- a/dcrec/secp256k1/ecdsa/error_test.go
+++ b/dcrec/secp256k1/ecdsa/error_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // TestErrorKindStringer tests the stringized output for the ErrorKind type.
-func TestErrorCodeStringer(t *testing.T) {
+func TestErrorKindStringer(t *testing.T) {
 	tests := []struct {
 		in   ErrorKind
 		want string

--- a/dcrec/secp256k1/schnorr/error_test.go
+++ b/dcrec/secp256k1/schnorr/error_test.go
@@ -61,7 +61,7 @@ func TestError(t *testing.T) {
 
 // TestErrorKindIsAs ensures both ErrorKind and Error can be identified
 // as being a specific error via errors.Is and unwrapped via errors.As.
-func TestErrorCodeIsAs(t *testing.T) {
+func TestErrorKindIsAs(t *testing.T) {
 	tests := []struct {
 		name      string
 		err       error

--- a/dcrjson/doc.go
+++ b/dcrjson/doc.go
@@ -122,7 +122,7 @@ returned from the various functions available in this package.  They identify
 issues such as unsupported field types, attempts to register malformed commands,
 and attempting to create a new command with an improper number of parameters.
 The specific reason for the error can be detected by type asserting it to a
-*dcrjson.Error and accessing the ErrorCode field.
+*dcrjson.Error and accessing the ErrorKind field.
 
 The second category of errors (type RPCError), on the other hand, are useful for
 returning errors to RPC clients.  Consequently, they are used in the previously

--- a/gcs/doc.go
+++ b/gcs/doc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019 The Decred developers
+// Copyright (c) 2018-2020 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -28,11 +28,10 @@ are parameterized by the following:
 Errors
 
 Errors returned by this package are of type gcs.Error.  This allows the caller
-to programmatically determine the specific error by examining the ErrorCode
+to programmatically determine the specific error by examining the ErrorKind
 field of the type asserted gcs.Error while still providing rich error messages
-with contextual information.  A convenience function named IsErrorCode is also
-provided to allow callers to easily check for a specific error code.  See
-ErrorCode in the package documentation for a full list.
+with contextual information.  See ErrorKind in the package documentation
+for a full list.
 
 GCS use in Decred
 

--- a/internal/mempool/doc.go
+++ b/internal/mempool/doc.go
@@ -80,6 +80,6 @@ consensus acceptance rules.  This allows the caller to easily differentiate
 between unexpected errors, such as database errors, versus errors due to rule
 violations through type assertions.  In addition, callers can programmatically
 determine the specific rule violation by type asserting the Err field to one of
-the aforementioned types and examining their underlying ErrorCode field.
+the aforementioned types and examining their underlying ErrorKind field.
 */
 package mempool

--- a/internal/mining/error.go
+++ b/internal/mining/error.go
@@ -4,100 +4,81 @@
 
 package mining
 
-import (
-	"fmt"
-)
-
-// MiningErrorCode identifies a kind of error.
-type MiningErrorCode int
+// ErrorKind identifies a mining of error.  It has full support for errors.Is
+// and errors.As, so the caller can directly check against an error kind
+// when determining the reason for an error.
+type ErrorKind string
 
 // These constants are used to identify a specific RuleError.
 const (
 	// ErrNotEnoughVoters indicates that there were not enough voters to
 	// build a block on top of HEAD.
-	ErrNotEnoughVoters MiningErrorCode = iota
+	ErrNotEnoughVoters = ErrorKind("ErrNotEnoughVoters")
 
 	// ErrFailedToGetGeneration specifies that the current generation for
 	// a block could not be obtained from blockchain.
-	ErrFailedToGetGeneration
+	ErrFailedToGetGeneration = ErrorKind("ErrFailedToGetGeneration")
 
-	// ErrGetStakeDifficulty indicates that the current top block of the
+	// ErrGetTopBlock indicates that the current top block of the
 	// blockchain could not be obtained.
-	ErrGetTopBlock
+	ErrGetTopBlock = ErrorKind("ErrGetTopBlock")
 
 	// ErrGettingDifficulty indicates that there was an error getting the
 	// PoW difficulty.
-	ErrGettingDifficulty
+	ErrGettingDifficulty = ErrorKind("ErrGettingDifficulty")
 
 	// ErrTransactionAppend indicates there was a problem adding a msgtx
 	// to a msgblock.
-	ErrTransactionAppend
+	ErrTransactionAppend = ErrorKind("ErrTransactionAppend")
 
 	// ErrTicketExhaustion indicates that there will not be enough mature
 	// tickets by the end of the next ticket maturity period to progress the
 	// chain.
-	ErrTicketExhaustion
+	ErrTicketExhaustion = ErrorKind("ErrTicketExhaustion")
 
 	// ErrCheckConnectBlock indicates that a newly created block template
 	// failed blockchain.CheckConnectBlock.
-	ErrCheckConnectBlock
+	ErrCheckConnectBlock = ErrorKind("ErrCheckConnectBlock")
 
 	// ErrFraudProofIndex indicates that there was an error finding the index
 	// for a fraud proof.
-	ErrFraudProofIndex
+	ErrFraudProofIndex = ErrorKind("ErrFraudProofIndex")
 
 	// ErrFetchTxStore indicates a transaction store failed to fetch.
-	ErrFetchTxStore
+	ErrFetchTxStore = ErrorKind("ErrFetchTxStore")
 
 	// ErrCalcCommitmentRoot indicates that creating the header commitments and
 	// calculating the associated commitment root for a newly created block
 	// template failed.
-	ErrCalcCommitmentRoot
+	ErrCalcCommitmentRoot = ErrorKind("ErrCalcCommitmentRoot")
 )
 
-// Map of MiningErrorCode values back to their constant names for pretty printing.
-var miningErrorCodeStrings = map[MiningErrorCode]string{
-	ErrNotEnoughVoters:       "ErrNotEnoughVoters",
-	ErrFailedToGetGeneration: "ErrFailedToGetGeneration",
-	ErrGetTopBlock:           "ErrGetTopBlock",
-	ErrGettingDifficulty:     "ErrGettingDifficulty",
-	ErrTransactionAppend:     "ErrTransactionAppend",
-	ErrTicketExhaustion:      "ErrTicketExhaustion",
-	ErrCheckConnectBlock:     "ErrCheckConnectBlock",
-	ErrFraudProofIndex:       "ErrFraudProofIndex",
-	ErrFetchTxStore:          "ErrFetchTxStore",
-	ErrCalcCommitmentRoot:    "ErrCalcCommitmentRoot",
+// Error satisfies the error interface and prints human-readable errors.
+func (e ErrorKind) Error() string {
+	return string(e)
 }
 
-// String returns the MiningErrorCode as a human-readable name.
-func (e MiningErrorCode) String() string {
-	if s := miningErrorCodeStrings[e]; s != "" {
-		return s
-	}
-	return fmt.Sprintf("Unknown MiningErrorCode (%d)", int(e))
-}
-
-// MiningRuleError identifies a rule violation.  It is used to indicate that
-// processing of a block or transaction failed due to one of the many validation
-// rules.  The caller can use type assertions to determine if a failure was
-// specifically due to a rule violation and access the MiningErrorCode field to
-// ascertain the specific reason for the rule violation.
-type MiningRuleError struct {
-	ErrorCode   MiningErrorCode // Describes the kind of error
-	Description string          // Human readable description of the issue
+// Error identifies a mining rule rule violation. It has full support for
+// errors.Is and errors.As, so the caller can ascertain the specific reason
+// for the error by checking the underlying error. It is used to indicate
+// that processing of a block or transaction failed due to one of the many
+// validation rules.
+type Error struct {
+	Err         error
+	Description string
 }
 
 // Error satisfies the error interface and prints human-readable errors.
-func (e MiningRuleError) Error() string {
+func (e Error) Error() string {
 	return e.Description
 }
 
-// GetCode satisfies the error interface and prints human-readable errors.
-func (e MiningRuleError) GetCode() MiningErrorCode {
-	return e.ErrorCode
+// Unwrap returns the underlying wrapped error.
+func (e Error) Unwrap() error {
+	return e.Err
 }
 
-// miningRuleError creates an RuleError given a set of arguments.
-func miningRuleError(c MiningErrorCode, desc string) MiningRuleError {
-	return MiningRuleError{ErrorCode: c, Description: desc}
+// makeError creates an Error given a set of arguments.
+func makeError(kind ErrorKind, desc string) Error {
+	return Error{Err: kind, Description: desc}
 }

--- a/internal/mining/error_test.go
+++ b/internal/mining/error_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package mining
+
+import (
+	"errors"
+	"io"
+	"testing"
+)
+
+// TestErrorKindStringer tests the stringized output for the ErrorKind type.
+func TestErrorKindStringer(t *testing.T) {
+	tests := []struct {
+		in   ErrorKind
+		want string
+	}{
+		{ErrNotEnoughVoters, "ErrNotEnoughVoters"},
+		{ErrFailedToGetGeneration, "ErrFailedToGetGeneration"},
+		{ErrGetTopBlock, "ErrGetTopBlock"},
+		{ErrGettingDifficulty, "ErrGettingDifficulty"},
+		{ErrTransactionAppend, "ErrTransactionAppend"},
+		{ErrTicketExhaustion, "ErrTicketExhaustion"},
+		{ErrCheckConnectBlock, "ErrCheckConnectBlock"},
+		{ErrFraudProofIndex, "ErrFraudProofIndex"},
+		{ErrFetchTxStore, "ErrFetchTxStore"},
+		{ErrCalcCommitmentRoot, "ErrCalcCommitmentRoot"},
+	}
+
+	for i, test := range tests {
+		result := test.in.Error()
+		if result != test.want {
+			t.Errorf("#%d: got: %s want: %s", i, result, test.want)
+			continue
+		}
+	}
+}
+
+// TestError tests the error output for the Error type.
+func TestError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   Error
+		want string
+	}{{
+		Error{Description: "some error"},
+		"some error",
+	}, {
+		Error{Description: "human-readable error"},
+		"human-readable error",
+	}}
+
+	for i, test := range tests {
+		result := test.in.Error()
+		if result != test.want {
+			t.Errorf("#%d: got: %s want: %s", i, result, test.want)
+			continue
+		}
+	}
+}
+
+// TestErrorKindIsAs ensures both ErrorKind and Error can be identified as being
+// a specific error kind via errors.Is and unwrapped via errors.As.
+func TestErrorKindIsAs(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		target    error
+		wantMatch bool
+		wantAs    ErrorKind
+	}{{
+		name:      "ErrNotEnoughVoters == ErrNotEnoughVoters",
+		err:       ErrNotEnoughVoters,
+		target:    ErrNotEnoughVoters,
+		wantMatch: true,
+		wantAs:    ErrNotEnoughVoters,
+	}, {
+		name:      "Error.ErrNotEnoughVoters == ErrNotEnoughVoters",
+		err:       makeError(ErrNotEnoughVoters, ""),
+		target:    ErrNotEnoughVoters,
+		wantMatch: true,
+		wantAs:    ErrNotEnoughVoters,
+	}, {
+		name:      "Error.ErrNotEnoughVoters == Error.ErrNotEnoughVoters",
+		err:       makeError(ErrNotEnoughVoters, ""),
+		target:    makeError(ErrNotEnoughVoters, ""),
+		wantMatch: true,
+		wantAs:    ErrNotEnoughVoters,
+	}, {
+		name:      "ErrNotEnoughVoters != ErrGetTopBlock",
+		err:       ErrNotEnoughVoters,
+		target:    ErrGetTopBlock,
+		wantMatch: false,
+		wantAs:    ErrNotEnoughVoters,
+	}, {
+		name:      "Error.ErrNotEnoughVoters != ErrGetTopBlock",
+		err:       makeError(ErrNotEnoughVoters, ""),
+		target:    ErrGetTopBlock,
+		wantMatch: false,
+		wantAs:    ErrNotEnoughVoters,
+	}, {
+		name:      "ErrNotEnoughVoters != Error.ErrGetTopBlock",
+		err:       ErrNotEnoughVoters,
+		target:    makeError(ErrGetTopBlock, ""),
+		wantMatch: false,
+		wantAs:    ErrNotEnoughVoters,
+	}, {
+		name:      "Error.ErrNotEnoughVoters != Error.ErrGetTopBlock",
+		err:       makeError(ErrNotEnoughVoters, ""),
+		target:    makeError(ErrGetTopBlock, ""),
+		wantMatch: false,
+		wantAs:    ErrNotEnoughVoters,
+	}, {
+		name:      "Error.ErrNotEnoughVoters != io.EOF",
+		err:       makeError(ErrNotEnoughVoters, ""),
+		target:    io.EOF,
+		wantMatch: false,
+		wantAs:    ErrNotEnoughVoters,
+	}}
+
+	for _, test := range tests {
+		// Ensure the error matches or not depending on the expected result.
+		result := errors.Is(test.err, test.target)
+		if result != test.wantMatch {
+			t.Errorf("%s: incorrect error identification -- got %v, want %v",
+				test.name, result, test.wantMatch)
+			continue
+		}
+
+		// Ensure the underlying error kind can be unwrapped is and is the
+		// expected kind.
+		var kind ErrorKind
+		if !errors.As(test.err, &kind) {
+			t.Errorf("%s: unable to unwrap to error kind", test.name)
+			continue
+		}
+		if kind != test.wantAs {
+			t.Errorf("%s: unexpected unwrapped error kind -- got %v, want %v",
+				test.name, kind, test.wantAs)
+			continue
+		}
+	}
+}


### PR DESCRIPTION
This updates the mining error types to leverage go 1.13 errors.Is/As functionality as well as conform to the error infrastructure best practices.