### PR TITLE
rpcserver: Update gettxout params and result.

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,7 +29,7 @@ import (
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/internal/mempool"
 	"github.com/decred/dcrd/internal/version"
-	"github.com/decred/dcrd/rpc/jsonrpc/types/v2"
+	"github.com/decred/dcrd/rpc/jsonrpc/types/v3"
 	"github.com/decred/dcrd/sampleconfig"
 	"github.com/decred/go-socks/socks"
 	"github.com/decred/slog"

--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -2065,6 +2065,7 @@ of the best block.
 |
 # <code>txid</code>: <code>(string, required)</code> The hash of the transaction.
 # <code>vout</code>: <code>(numeric, required)</code> The index of the output.
+# <code>tree</code>: <code>(numeric, required)</code> The tree of the transaction.
 # <code>includemempool</code>: <code>(string,default=true)</code> Include the mempool when true.
 |-
 !Description

--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -2078,11 +2078,10 @@ of the best block.
 : <code>confirmations</code>: <code>(numeric)</code> The number of confirmations.
 : <code>value</code>: <code>(numeric)</code> The transaction amount in DCR.
 : <code>scriptpubkey</code>: <code>(json object)</code> The public key script used to pay coins as a JSON object.
-: <code>version</code>: <code>(numeric)</code> The transaction version.
 : <code>coinbase</code>: <code>(numeric)</code> Whether or not the transaction is a coinbase.
 |-
 !Example Return
-|<code>{"bestblock": "00000000000000001914563fe4f93addae64cd2808a81835ae03b0947034843b","confirmations": 19,"value": 4.63835862,"scriptPubKey": {"asm": "OP_DUP OP_HASH160 f127302adf84741d28fa705a995dc827030077e5 OP_EQUALVERIFY OP_CHECKSIG","hex": "76a914f127302adf84741d28fa705a995dc827030077e588ac","reqSigs": 1,"type": "pubkeyhash","addresses": ["Dsnx1HW62otMif9zFyLzDnQdKuaV9cRNoyr"]},"version": 1,"coinbase": false}</code>
+|<code>{"bestblock": "00000000000000001914563fe4f93addae64cd2808a81835ae03b0947034843b","confirmations": 19,"value": 4.63835862,"scriptPubKey": {"asm": "OP_DUP OP_HASH160 f127302adf84741d28fa705a995dc827030077e5 OP_EQUALVERIFY OP_CHECKSIG","hex": "76a914f127302adf84741d28fa705a995dc827030077e588ac","reqSigs": 1,"type": "pubkeyhash","addresses": ["Dsnx1HW62otMif9zFyLzDnQdKuaV9cRNoyr"]},"coinbase": false}</code>
 |}
 
 ----

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/decred/dcrd/hdkeychain/v3 v3.0.0
 	github.com/decred/dcrd/lru v1.1.0
 	github.com/decred/dcrd/peer/v2 v2.2.0
-	github.com/decred/dcrd/rpc/jsonrpc/types/v2 v2.2.0
+	github.com/decred/dcrd/rpc/jsonrpc/types/v3 v3.0.0
 	github.com/decred/dcrd/rpcclient/v7 v7.0.0
 	github.com/decred/dcrd/txscript/v4 v4.0.0
 	github.com/decred/dcrd/wire v1.4.0
@@ -62,7 +62,7 @@ replace (
 	github.com/decred/dcrd/limits => ./limits
 	github.com/decred/dcrd/lru => ./lru
 	github.com/decred/dcrd/peer/v2 => ./peer
-	github.com/decred/dcrd/rpc/jsonrpc/types/v2 => ./rpc/jsonrpc/types
+	github.com/decred/dcrd/rpc/jsonrpc/types/v3 => ./rpc/jsonrpc/types
 	github.com/decred/dcrd/rpcclient/v7 => ./rpcclient
 	github.com/decred/dcrd/txscript/v4 => ./txscript
 	github.com/decred/dcrd/wire => ./wire

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -56,8 +56,8 @@ import (
 
 // API version constants
 const (
-	jsonrpcSemverMajor = 6
-	jsonrpcSemverMinor = 2
+	jsonrpcSemverMajor = 7
+	jsonrpcSemverMinor = 0
 	jsonrpcSemverPatch = 0
 )
 
@@ -3520,7 +3520,6 @@ func handleGetTxOut(_ context.Context, s *Server, cmd interface{}) (interface{},
 	// from there, otherwise attempt to fetch from the block database.
 	var bestBlockHash string
 	var confirmations int64
-	var txVersion uint16
 	var value int64
 	var scriptVersion uint16
 	var pkScript []byte
@@ -3561,7 +3560,6 @@ func handleGetTxOut(_ context.Context, s *Server, cmd interface{}) (interface{},
 
 		bestBlockHash = best.Hash.String()
 		confirmations = 0
-		txVersion = mtx.Version
 		value = txOut.Value
 		scriptVersion = txOut.Version
 		pkScript = txOut.PkScript
@@ -3598,7 +3596,6 @@ func handleGetTxOut(_ context.Context, s *Server, cmd interface{}) (interface{},
 
 		bestBlockHash = best.Hash.String()
 		confirmations = 1 + best.Height - entry.BlockHeight()
-		txVersion = entry.TxVersion()
 		value = entry.AmountByIndex(c.Vout)
 		scriptVersion = entry.ScriptVersionByIndex(c.Vout)
 		pkScript = entry.PkScriptByIndex(c.Vout)
@@ -3625,7 +3622,6 @@ func handleGetTxOut(_ context.Context, s *Server, cmd interface{}) (interface{},
 		BestBlock:     bestBlockHash,
 		Confirmations: confirmations,
 		Value:         dcrutil.Amount(value).ToUnit(dcrutil.AmountCoin),
-		Version:       int32(txVersion),
 		ScriptPubKey: types.ScriptPubKeyResult{
 			Asm:       disbuf,
 			Hex:       hex.EncodeToString(pkScript),

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -48,7 +48,7 @@ import (
 	"github.com/decred/dcrd/internal/mempool"
 	"github.com/decred/dcrd/internal/mining"
 	"github.com/decred/dcrd/internal/version"
-	"github.com/decred/dcrd/rpc/jsonrpc/types/v2"
+	"github.com/decred/dcrd/rpc/jsonrpc/types/v3"
 	"github.com/decred/dcrd/txscript/v4"
 	"github.com/decred/dcrd/wire"
 	"github.com/jrick/bitset"

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -40,7 +40,7 @@ import (
 	"github.com/decred/dcrd/internal/mining"
 	"github.com/decred/dcrd/internal/version"
 	"github.com/decred/dcrd/peer/v2"
-	"github.com/decred/dcrd/rpc/jsonrpc/types/v2"
+	"github.com/decred/dcrd/rpc/jsonrpc/types/v3"
 	"github.com/decred/dcrd/txscript/v4"
 	"github.com/decred/dcrd/wire"
 )

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -4951,7 +4951,6 @@ func TestHandleGetTxOut(t *testing.T) {
 			Type:      scriptClass.String(),
 			Addresses: addresses,
 		},
-		Version:  int32(msgTx.Version),
 		Coinbase: false,
 	}
 	txOutResultChain := txOutResultMempool

--- a/internal/rpcserver/rpcserverhelp.go
+++ b/internal/rpcserver/rpcserverhelp.go
@@ -702,6 +702,7 @@ var helpDescsEnUS = map[string]string{
 	"gettxout--synopsis":      "Returns information about an unspent transaction output.",
 	"gettxout-txid":           "The hash of the transaction",
 	"gettxout-vout":           "The index of the output",
+	"gettxout-tree":           "The tree of the transaction",
 	"gettxout-includemempool": "Include the mempool when true",
 
 	// GetTxOutSetInfoCmd help.

--- a/internal/rpcserver/rpcserverhelp.go
+++ b/internal/rpcserver/rpcserverhelp.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 
 	"github.com/decred/dcrd/dcrjson/v3"
-	"github.com/decred/dcrd/rpc/jsonrpc/types/v2"
+	"github.com/decred/dcrd/rpc/jsonrpc/types/v3"
 )
 
 // helpDescsEnUS defines the English descriptions used for the help strings.

--- a/internal/rpcserver/rpcwebsocket.go
+++ b/internal/rpcserver/rpcwebsocket.go
@@ -31,7 +31,7 @@ import (
 	"github.com/decred/dcrd/dcrjson/v3"
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/internal/mining"
-	"github.com/decred/dcrd/rpc/jsonrpc/types/v2"
+	"github.com/decred/dcrd/rpc/jsonrpc/types/v3"
 	"github.com/decred/dcrd/txscript/v4"
 	"github.com/decred/dcrd/wire"
 )

--- a/internal/rpcserver/treasury_test.go
+++ b/internal/rpcserver/treasury_test.go
@@ -514,7 +514,8 @@ func TestTreasury(t *testing.T) {
 
 	// Ensure the spending tx output is part of the utxo set and has 1
 	// confirmation.
-	utxo, err := hn.Node.GetTxOut(timeoutCtx(t, time.Second), spendTxHash, 0, false)
+	utxo, err := hn.Node.GetTxOut(timeoutCtx(t, time.Second), spendTxHash, 0,
+		wire.TxTreeRegular, false)
 	if err != nil {
 		t.Fatalf("unable to fetch spend tx utxo: %v", err)
 	}
@@ -528,7 +529,8 @@ func TestTreasury(t *testing.T) {
 	tspendAbstainHash := tspendAbstain.TxHash()
 	hashes := []*chainhash.Hash{&tspendLargeHash, &tspendNoHash, &tspendAbstainHash}
 	for i, h := range hashes {
-		utxo, err = hn.Node.GetTxOut(timeoutCtx(t, time.Second), h, 1, false)
+		utxo, err = hn.Node.GetTxOut(timeoutCtx(t, time.Second), h, 1,
+			wire.TxTreeRegular, false)
 		if err != nil {
 			t.Fatalf("unable to fetch tspend %d utxo: %v", i, err)
 		}

--- a/rpc/jsonrpc/types/README.md
+++ b/rpc/jsonrpc/types/README.md
@@ -3,7 +3,7 @@ jsonrpc/types
 
 [![Build Status](https://github.com/decred/dcrd/workflows/Build%20and%20Test/badge.svg)](https://github.com/decred/dcrd/actions)
 [![ISC License](https://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![Doc](https://img.shields.io/badge/doc-reference-blue.svg)](https://pkg.go.dev/github.com/decred/dcrd/rpc/jsonrpc/types/v2)
+[![Doc](https://img.shields.io/badge/doc-reference-blue.svg)](https://pkg.go.dev/github.com/decred/dcrd/rpc/jsonrpc/types/v3)
 
 Package types implements concrete types for marshalling to and from the dcrd
 JSON-RPC commands, return values, and notifications.  A comprehensive suite of

--- a/rpc/jsonrpc/types/chainsvrcmds.go
+++ b/rpc/jsonrpc/types/chainsvrcmds.go
@@ -772,6 +772,7 @@ func NewGetTicketPoolValueCmd() *GetTicketPoolValueCmd {
 type GetTxOutCmd struct {
 	Txid           string
 	Vout           uint32
+	Tree           int8
 	IncludeMempool *bool `jsonrpcdefault:"true"`
 }
 
@@ -780,10 +781,11 @@ type GetTxOutCmd struct {
 //
 // The parameters which are pointers indicate they are optional.  Passing nil
 // for optional parameters will use the default value.
-func NewGetTxOutCmd(txHash string, vout uint32, includeMempool *bool) *GetTxOutCmd {
+func NewGetTxOutCmd(txHash string, vout uint32, tree int8, includeMempool *bool) *GetTxOutCmd {
 	return &GetTxOutCmd{
 		Txid:           txHash,
 		Vout:           vout,
+		Tree:           tree,
 		IncludeMempool: includeMempool,
 	}
 }

--- a/rpc/jsonrpc/types/chainsvrcmds_test.go
+++ b/rpc/jsonrpc/types/chainsvrcmds_test.go
@@ -641,30 +641,32 @@ func TestChainSvrCmds(t *testing.T) {
 		{
 			name: "gettxout",
 			newCmd: func() (interface{}, error) {
-				return dcrjson.NewCmd(Method("gettxout"), "123", 1)
+				return dcrjson.NewCmd(Method("gettxout"), "123", 1, 0)
 			},
 			staticCmd: func() interface{} {
-				return NewGetTxOutCmd("123", 1, nil)
+				return NewGetTxOutCmd("123", 1, 0, nil)
 			},
-			marshalled: `{"jsonrpc":"1.0","method":"gettxout","params":["123",1],"id":1}`,
+			marshalled: `{"jsonrpc":"1.0","method":"gettxout","params":["123",1,0],"id":1}`,
 			unmarshalled: &GetTxOutCmd{
 				Txid:           "123",
 				Vout:           1,
+				Tree:           0,
 				IncludeMempool: dcrjson.Bool(true),
 			},
 		},
 		{
 			name: "gettxout optional",
 			newCmd: func() (interface{}, error) {
-				return dcrjson.NewCmd(Method("gettxout"), "123", 1, true)
+				return dcrjson.NewCmd(Method("gettxout"), "123", 1, 0, true)
 			},
 			staticCmd: func() interface{} {
-				return NewGetTxOutCmd("123", 1, dcrjson.Bool(true))
+				return NewGetTxOutCmd("123", 1, 0, dcrjson.Bool(true))
 			},
-			marshalled: `{"jsonrpc":"1.0","method":"gettxout","params":["123",1,true],"id":1}`,
+			marshalled: `{"jsonrpc":"1.0","method":"gettxout","params":["123",1,0,true],"id":1}`,
 			unmarshalled: &GetTxOutCmd{
 				Txid:           "123",
 				Vout:           1,
+				Tree:           0,
 				IncludeMempool: dcrjson.Bool(true),
 			},
 		},

--- a/rpc/jsonrpc/types/chainsvrresults.go
+++ b/rpc/jsonrpc/types/chainsvrresults.go
@@ -374,7 +374,6 @@ type GetTxOutResult struct {
 	Confirmations int64              `json:"confirmations"`
 	Value         float64            `json:"value"`
 	ScriptPubKey  ScriptPubKeyResult `json:"scriptPubKey"`
-	Version       int32              `json:"version"`
 	Coinbase      bool               `json:"coinbase"`
 }
 

--- a/rpc/jsonrpc/types/go.mod
+++ b/rpc/jsonrpc/types/go.mod
@@ -1,4 +1,4 @@
-module github.com/decred/dcrd/rpc/jsonrpc/types/v2
+module github.com/decred/dcrd/rpc/jsonrpc/types/v3
 
 go 1.11
 

--- a/rpcclient/chain.go
+++ b/rpcclient/chain.go
@@ -18,7 +18,7 @@ import (
 	"github.com/decred/dcrd/gcs/v3"
 	"github.com/decred/dcrd/gcs/v3/blockcf"
 	"github.com/decred/dcrd/gcs/v3/blockcf2"
-	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v2"
+	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v3"
 	"github.com/decred/dcrd/wire"
 )
 

--- a/rpcclient/chain.go
+++ b/rpcclient/chain.go
@@ -840,20 +840,20 @@ func (r *FutureGetTxOutResult) Receive() (*chainjson.GetTxOutResult, error) {
 // the returned instance.
 //
 // See GetTxOut for the blocking version and more details.
-func (c *Client) GetTxOutAsync(ctx context.Context, txHash *chainhash.Hash, index uint32, mempool bool) *FutureGetTxOutResult {
+func (c *Client) GetTxOutAsync(ctx context.Context, txHash *chainhash.Hash, index uint32, tree int8, mempool bool) *FutureGetTxOutResult {
 	hash := ""
 	if txHash != nil {
 		hash = txHash.String()
 	}
 
-	cmd := chainjson.NewGetTxOutCmd(hash, index, &mempool)
+	cmd := chainjson.NewGetTxOutCmd(hash, index, tree, &mempool)
 	return (*FutureGetTxOutResult)(c.sendCmd(ctx, cmd))
 }
 
 // GetTxOut returns the transaction output info if it's unspent and
 // nil, otherwise.
-func (c *Client) GetTxOut(ctx context.Context, txHash *chainhash.Hash, index uint32, mempool bool) (*chainjson.GetTxOutResult, error) {
-	return c.GetTxOutAsync(ctx, txHash, index, mempool).Receive()
+func (c *Client) GetTxOut(ctx context.Context, txHash *chainhash.Hash, index uint32, tree int8, mempool bool) (*chainjson.GetTxOutResult, error) {
+	return c.GetTxOutAsync(ctx, txHash, index, tree, mempool).Receive()
 }
 
 // FutureRescanResult is a future promise to deliver the result of a

--- a/rpcclient/extensions.go
+++ b/rpcclient/extensions.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil/v4"
-	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v2"
+	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v3"
 	"github.com/decred/dcrd/wire"
 )
 

--- a/rpcclient/go.mod
+++ b/rpcclient/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/decred/dcrd/dcrjson/v3 v3.1.0
 	github.com/decred/dcrd/dcrutil/v4 v4.0.0
 	github.com/decred/dcrd/gcs/v3 v3.0.0
-	github.com/decred/dcrd/rpc/jsonrpc/types/v2 v2.2.0
+	github.com/decred/dcrd/rpc/jsonrpc/types/v3 v3.0.0
 	github.com/decred/dcrd/wire v1.4.0
 	github.com/decred/go-socks v1.1.0
 	github.com/decred/slog v1.1.0
@@ -19,5 +19,6 @@ replace (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 => ../dcrec/secp256k1
 	github.com/decred/dcrd/dcrutil/v4 => ../dcrutil
 	github.com/decred/dcrd/gcs/v3 => ../gcs
+	github.com/decred/dcrd/rpc/jsonrpc/types/v3 => ../rpc/jsonrpc/types
 	github.com/decred/dcrd/txscript/v4 => ../txscript
 )

--- a/rpcclient/go.sum
+++ b/rpcclient/go.sum
@@ -26,8 +26,6 @@ github.com/decred/dcrd/dcrjson/v3 v3.1.0 h1:Y2VjCXCNWbNIa52wMKEuNiU+9rUgnjYb5c1J
 github.com/decred/dcrd/dcrjson/v3 v3.1.0/go.mod h1:fnTHev/ABGp8IxFudDhjGi9ghLiXRff1qZz/wvq12Mg=
 github.com/decred/dcrd/dcrutil/v3 v3.0.0 h1:n6uQaTQynIhCY89XsoDk2WQqcUcnbD+zUM9rnZcIOZo=
 github.com/decred/dcrd/dcrutil/v3 v3.0.0/go.mod h1:iVsjcqVzLmYFGCZLet2H7Nq+7imV9tYcuY+0lC2mNsY=
-github.com/decred/dcrd/rpc/jsonrpc/types/v2 v2.2.0 h1:8xxN/nKOO2yx29oZEL8METscZ3eJnvbl68oFiNg2+SI=
-github.com/decred/dcrd/rpc/jsonrpc/types/v2 v2.2.0/go.mod h1:krn89ZOgSa8yc7sA4WpDK95p61NnjNWFkNlMnGrKbMc=
 github.com/decred/dcrd/wire v1.4.0 h1:KmSo6eTQIvhXS0fLBQ/l7hG7QLcSJQKSwSyzSqJYDk0=
 github.com/decred/dcrd/wire v1.4.0/go.mod h1:WxC/0K+cCAnBh+SKsRjIX9YPgvrjhmE+6pZlel1G7Ro=
 github.com/decred/go-socks v1.1.0 h1:dnENcc0KIqQo3HSXdgboXAHgqsCIutkqq6ntQjYtm2U=

--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -28,7 +28,7 @@ import (
 	"github.com/gorilla/websocket"
 
 	"github.com/decred/dcrd/dcrjson/v3"
-	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v2"
+	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v3"
 	"github.com/decred/go-socks/socks"
 )
 

--- a/rpcclient/mining.go
+++ b/rpcclient/mining.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil/v4"
-	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v2"
+	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v3"
 )
 
 // FutureGenerateResult is a future promise to deliver the result of a

--- a/rpcclient/net.go
+++ b/rpcclient/net.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"encoding/json"
 
-	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v2"
+	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v3"
 )
 
 // AddNodeCommand enumerates the available commands that the AddNode function

--- a/rpcclient/notify.go
+++ b/rpcclient/notify.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil/v4"
-	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v2"
+	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v3"
 	"github.com/decred/dcrd/wire"
 )
 

--- a/rpcclient/rawtransactions.go
+++ b/rpcclient/rawtransactions.go
@@ -14,7 +14,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrjson/v3"
 	"github.com/decred/dcrd/dcrutil/v4"
-	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v2"
+	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v3"
 	"github.com/decred/dcrd/wire"
 )
 

--- a/rpctest/rpc_harness_test.go
+++ b/rpctest/rpc_harness_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/dcrutil/v4"
-	dcrdtypes "github.com/decred/dcrd/rpc/jsonrpc/types/v2"
+	dcrdtypes "github.com/decred/dcrd/rpc/jsonrpc/types/v3"
 	"github.com/decred/dcrd/txscript/v4"
 	"github.com/decred/dcrd/wire"
 

--- a/rpctest/utils.go
+++ b/rpctest/utils.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	dcrdtypes "github.com/decred/dcrd/rpc/jsonrpc/types/v2"
+	dcrdtypes "github.com/decred/dcrd/rpc/jsonrpc/types/v3"
 	"github.com/decred/dcrd/rpcclient/v7"
 )
 

--- a/rpctest/votingwallet.go
+++ b/rpctest/votingwallet.go
@@ -18,7 +18,7 @@ import (
 	"github.com/decred/dcrd/dcrec"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/dcrutil/v4"
-	dcrdtypes "github.com/decred/dcrd/rpc/jsonrpc/types/v2"
+	dcrdtypes "github.com/decred/dcrd/rpc/jsonrpc/types/v3"
 	"github.com/decred/dcrd/rpcclient/v7"
 	"github.com/decred/dcrd/txscript/v4"
 	"github.com/decred/dcrd/wire"


### PR DESCRIPTION
**This requires https://github.com/decred/dcrd/pull/2516.**

This updates the `gettxout` call to add a required `tree` parameter and remove `version` from the result.  The changes include:

- Starting the v3 module dev cycle for the `rpc/jsonrpc/types`.
- Bumping the RPC API version to 7.0.0.
- Removing `version` from the `gettxout` result.
  - It is being removed since upcoming changes will be modifying utxo entries to no longer store the tx version, and (per my understanding) the tx version is not really needed for anything by callers either.
- Adding a required `tree` param to `gettxout`.
  - Upcoming changes will be modifying utxo entries to be keyed by an outpoint which includes the `txhash`, `index`, and `tree`, which brought up the question of whether we want the server to check both trees in `gettxout` (as it does today) or require the client to pass the `tree`.
  - Based on some discussions, the `tree` should be known to the caller most of the time, and in the case where it is not, `gettxout` can be called with each tree to check both trees, so we will require the `tree` param.

Note: If testing with `dcrctl`, you'll want to add a replace directive to use the updated types module:
`go mod edit -replace=github.com/decred/dcrd/rpc/jsonrpc/types/v2=../dcrd/rpc/jsonrpc/types`