### PR TITLE
multi: Remove notifystakedifficulty.

### DIFF
--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -2741,10 +2741,6 @@ user.  Click the method name for further details such as parameter and return in
 |Send notifications for all new tickets that have matured.
 |[[#newtickets|newtickets]]
 |-
-|[[#notifystakedifficulty|notifystakedifficulty]]
-|Send notifications whenever the stake difficulty is updated.
-|[[#stakedifficulty|stakedifficulty]]
-|-
 |[[#session|session]]
 |Return details regarding a websocket client's current connection.
 |None
@@ -3181,26 +3177,6 @@ NOTE: This is only required if an HTTP Authorization header is not being used.
 
 ----
 
-====notifystakedifficulty====
-{|
-!Method
-|notifystakedifficulty
-|-
-!Notifications
-|[[#stakedifficulty|stakedifficulty]]
-|-
-!Parameters
-|None
-|-
-!Description
-|Send a stakedifficulty notification when the stake difficulty is updated.
-|-
-!Returns
-|Nothing
-|}
-
-----
-
 ====session====
 {|
 !Method
@@ -3282,10 +3258,6 @@ The following is an overview of the JSON-RPC notifications used for Websocket co
 |[[#newtickets|newtickets]]
 |New tickets matured.
 |[[#notifynewtickets|notifynewtickets]]
-|-
-|[[#stakedifficulty|stakedifficulty]]
-|The stake difficulty was updated.
-|[[#notifystakedifficulty|notifystakedifficulty]]
 |-
 |[[#rescanprogress|rescanprogress]]
 |A rescan operation that is underway has made progress.
@@ -3576,29 +3548,6 @@ The redeemingtx notification for the same txout, after the spending transaction 
 : <code>{"jsonrpc": "1.0", "method": "newtickets", "params": ["00000044a6c0e2fb8f4feae2ac1133443859407abcf27d5d3a29d7d16eda8bc4", 479903, 9003800525, ["5297d32d5178c464c279711e771250f4f80a15830dfb89ae6bf414ee22613c88", "237c15fe027797d72c1ffd5aa3b3f9069b50352855bda5a9e7d0fa13d2299e32", "cd11ab320a543c946a021b37d5339a7f0ea72a6baf46fda455edf302165e812b", "eb82dba288e7af4a02a44818376f7228929c89a4fd51cf07ebdd825acc1c039d"]], "id": null}</code>
 |}
 
-----
-
-====stakedifficulty====
-{|
-!Method
-|stakedifficulty
-|-
-!Request
-|[[#notifystakedifficulty|notifystakedifficulty]]
-|-
-!Parameters
-|
-# <code>BlockHash</code>: <code>(string)</code> the hash of the block.
-# <code>BlockHeight</code>: <code>(numeric)</code> the height of the block.
-# <code>StakeDiff</code>: <code>(numeric)</code> the stake difficulty of the block.
-|-
-!Description
-|Notifies a client when the stake difficulty has been updated.
-|-
-!Example
-|Example stakedifficulty notification for block 479903 on testnet:
-: <code>{"jsonrpc": "1.0", "method": "stakedifficulty", "params": ["00000044a6c0e2fb8f4feae2ac1133443859407abcf27d5d3a29d7d16eda8bc4", 479903, 9003800525], "id": null}</code>
-|}
 ----
 
 ====rescanprogress====

--- a/internal/netsync/manager.go
+++ b/internal/netsync/manager.go
@@ -1042,16 +1042,6 @@ func (m *SyncManager) handleBlockMsg(bmsg *blockMsg) {
 			// Notify stake difficulty subscribers and prune invalidated
 			// transactions.
 			best := m.cfg.Chain.BestSnapshot()
-			if r := m.cfg.RpcServer(); r != nil {
-				// Update registered websocket clients on the
-				// current stake difficulty.
-				r.NotifyStakeDifficulty(
-					&rpcserver.StakeDifficultyNtfnData{
-						BlockHash:       best.Hash,
-						BlockHeight:     best.Height,
-						StakeDifficulty: best.NextStakeDiff,
-					})
-			}
 			m.cfg.TxMemPool.PruneStakeTx(best.NextStakeDiff, best.Height)
 			m.cfg.TxMemPool.PruneExpiredTx()
 
@@ -1613,17 +1603,8 @@ out:
 					msg.formerBest, msg.newBest)
 
 				if err == nil {
-					// Notify stake difficulty subscribers and prune
-					// invalidated transactions.
+					// Prune invalidated transactions.
 					best := m.cfg.Chain.BestSnapshot()
-					if r := m.cfg.RpcServer(); r != nil {
-						r.NotifyStakeDifficulty(
-							&rpcserver.StakeDifficultyNtfnData{
-								BlockHash:       best.Hash,
-								BlockHeight:     best.Height,
-								StakeDifficulty: best.NextStakeDiff,
-							})
-					}
 					m.cfg.TxMemPool.PruneStakeTx(best.NextStakeDiff,
 						best.Height)
 					m.cfg.TxMemPool.PruneExpiredTx()
@@ -1654,17 +1635,8 @@ out:
 
 				onMainChain := !isOrphan && forkLen == 0
 				if onMainChain {
-					// Notify stake difficulty subscribers and prune
-					// invalidated transactions.
+					// Prune invalidated transactions.
 					best := m.cfg.Chain.BestSnapshot()
-					if r := m.cfg.RpcServer(); r != nil {
-						r.NotifyStakeDifficulty(
-							&rpcserver.StakeDifficultyNtfnData{
-								BlockHash:       best.Hash,
-								BlockHeight:     best.Height,
-								StakeDifficulty: best.NextStakeDiff,
-							})
-					}
 					m.cfg.TxMemPool.PruneStakeTx(best.NextStakeDiff,
 						best.Height)
 					m.cfg.TxMemPool.PruneExpiredTx()

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -687,10 +687,6 @@ type NtfnManager interface {
 	// manager for processing.
 	NotifyNewTickets(tnd *blockchain.TicketNotificationsData)
 
-	// NotifyStakeDifficulty passes a new stake difficulty notification to the
-	// manager for processing.
-	NotifyStakeDifficulty(stnd *StakeDifficultyNtfnData)
-
 	// NotifyMempoolTx passes a transaction accepted by mempool to the
 	// manager for processing.
 	NotifyMempoolTx(tx *dcrutil.Tx, isNew bool)
@@ -745,14 +741,6 @@ type NtfnManager interface {
 	// UnregisterNewTickets removes spent/missed ticket notifications for
 	// the passed websocket client.
 	UnregisterNewTickets(wsc *wsClient)
-
-	// RegisterStakeDifficulty requests stake difficulty notifications
-	// to the passed websocket client.
-	RegisterStakeDifficulty(wsc *wsClient)
-
-	// UnregisterStakeDifficulty removes stake difficulty notifications for
-	// the passed websocket client.
-	UnregisterStakeDifficulty(wsc *wsClient)
 
 	// RegisterNewMempoolTxsUpdates requests notifications to the passed websocket
 	// client when new transactions are added to the memory pool.

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -5530,12 +5530,6 @@ func (s *Server) NotifyTSpend(tx *dcrutil.Tx) {
 	s.ntfnMgr.NotifyTSpend(tx)
 }
 
-// NotifyStakeDifficulty notifies websocket clients that have registered for
-// stake difficulty updates.
-func (s *Server) NotifyStakeDifficulty(stnd *StakeDifficultyNtfnData) {
-	s.ntfnMgr.NotifyStakeDifficulty(stnd)
-}
-
 // NotifyNewTickets notifies websocket clients that have registered for maturing
 // ticket updates.
 func (s *Server) NotifyNewTickets(tnd *blockchain.TicketNotificationsData) {

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -1122,10 +1122,6 @@ func (mgr *testNtfnManager) NotifySpentAndMissedTickets(tnd *blockchain.TicketNo
 // manager for processing.
 func (mgr *testNtfnManager) NotifyNewTickets(tnd *blockchain.TicketNotificationsData) {}
 
-// NotifyStakeDifficulty passes a new stake difficulty notification to the
-// manager for processing.
-func (mgr *testNtfnManager) NotifyStakeDifficulty(stnd *StakeDifficultyNtfnData) {}
-
 // NotifyMempoolTx passes a transaction accepted by mempool to the
 // manager for processing.
 func (mgr *testNtfnManager) NotifyMempoolTx(tx *dcrutil.Tx, isNew bool) {}

--- a/internal/rpcserver/rpcserverhelp.go
+++ b/internal/rpcserver/rpcserverhelp.go
@@ -828,9 +828,6 @@ var helpDescsEnUS = map[string]string{
 	// NotifyNewTicketsCmd help
 	"notifynewtickets--synopsis": "Request notifications for whenever new tickets are found.",
 
-	// NotifyStakeDifficultyCmd help
-	"notifystakedifficulty--synopsis": "Request notifications for whenever stake difficulty goes up.",
-
 	// NotifyWinningTicketsCmd help
 	"notifywinningtickets--synopsis": "Request notifications for whenever any tickets are chosen to vote.",
 
@@ -1074,7 +1071,6 @@ var rpcResultTypes = map[types.Method][]interface{}{
 	"notifywinningtickets":        nil,
 	"notifyspentandmissedtickets": nil,
 	"notifynewtickets":            nil,
-	"notifystakedifficulty":       nil,
 	"notifyblocks":                nil,
 	"notifywork":                  nil,
 	"notifytspend":                nil,

--- a/rpc/jsonrpc/types/chainsvrwscmds.go
+++ b/rpc/jsonrpc/types/chainsvrwscmds.go
@@ -111,17 +111,6 @@ func NewNotifyNewTicketsCmd() *NotifyNewTicketsCmd {
 	return &NotifyNewTicketsCmd{}
 }
 
-// NotifyStakeDifficultyCmd is a type handling custom marshaling and
-// unmarshaling of notifystakedifficulty JSON websocket extension
-// commands.
-type NotifyStakeDifficultyCmd struct {
-}
-
-// NewNotifyStakeDifficultyCmd creates a new NotifyStakeDifficultyCmd.
-func NewNotifyStakeDifficultyCmd() *NotifyStakeDifficultyCmd {
-	return &NotifyStakeDifficultyCmd{}
-}
-
 // RebroadcastMissedCmd is a type handling custom marshaling and
 // unmarshaling of rebroadcastmissed JSON RPC commands.
 type RebroadcastMissedCmd struct{}
@@ -228,12 +217,8 @@ func init() {
 	dcrjson.MustRegister(Method("notifytspend"), (*NotifyTSpendCmd)(nil), flags)
 	dcrjson.MustRegister(Method("notifynewtransactions"), (*NotifyNewTransactionsCmd)(nil), flags)
 	dcrjson.MustRegister(Method("notifynewtickets"), (*NotifyNewTicketsCmd)(nil), flags)
-	dcrjson.MustRegister(Method("notifyspentandmissedtickets"),
-		(*NotifySpentAndMissedTicketsCmd)(nil), flags)
-	dcrjson.MustRegister(Method("notifystakedifficulty"),
-		(*NotifyStakeDifficultyCmd)(nil), flags)
-	dcrjson.MustRegister(Method("notifywinningtickets"),
-		(*NotifyWinningTicketsCmd)(nil), flags)
+	dcrjson.MustRegister(Method("notifyspentandmissedtickets"), (*NotifySpentAndMissedTicketsCmd)(nil), flags)
+	dcrjson.MustRegister(Method("notifywinningtickets"), (*NotifyWinningTicketsCmd)(nil), flags)
 	dcrjson.MustRegister(Method("rebroadcastmissed"), (*RebroadcastMissedCmd)(nil), flags)
 	dcrjson.MustRegister(Method("rebroadcastwinners"), (*RebroadcastWinnersCmd)(nil), flags)
 	dcrjson.MustRegister(Method("session"), (*SessionCmd)(nil), flags)

--- a/rpc/jsonrpc/types/chainsvrwscmds_test.go
+++ b/rpc/jsonrpc/types/chainsvrwscmds_test.go
@@ -75,17 +75,6 @@ func TestChainSvrWsCmds(t *testing.T) {
 			unmarshalled: &NotifyNewTicketsCmd{},
 		},
 		{
-			name: "notifystakedifficulty",
-			newCmd: func() (interface{}, error) {
-				return dcrjson.NewCmd(Method("notifystakedifficulty"))
-			},
-			staticCmd: func() interface{} {
-				return NewNotifyStakeDifficultyCmd()
-			},
-			marshalled:   `{"jsonrpc":"1.0","method":"notifystakedifficulty","params":[],"id":1}`,
-			unmarshalled: &NotifyStakeDifficultyCmd{},
-		},
-		{
 			name: "notifyblocks",
 			newCmd: func() (interface{}, error) {
 				return dcrjson.NewCmd(Method("notifyblocks"))

--- a/rpc/jsonrpc/types/chainsvrwsntfns.go
+++ b/rpc/jsonrpc/types/chainsvrwsntfns.go
@@ -53,10 +53,6 @@ const (
 	// spentandmissedtickets notification.
 	SpentAndMissedTicketsNtfnMethod Method = "spentandmissedtickets"
 
-	// StakeDifficultyNtfnMethod is the method of the daemon stakedifficulty
-	// notification.
-	StakeDifficultyNtfnMethod Method = "stakedifficulty"
-
 	// WinningTicketsNtfnMethod is the method of the daemon winningtickets
 	// notification.
 	WinningTicketsNtfnMethod Method = "winningtickets"
@@ -177,23 +173,6 @@ func NewSpentAndMissedTicketsNtfn(hash string, height int32, stakeDiff int64, ti
 	}
 }
 
-// StakeDifficultyNtfn is a type handling custom marshaling and
-// unmarshaling of stakedifficulty JSON websocket notifications.
-type StakeDifficultyNtfn struct {
-	BlockHash   string
-	BlockHeight int32
-	StakeDiff   int64
-}
-
-// NewStakeDifficultyNtfn creates a new StakeDifficultyNtfn.
-func NewStakeDifficultyNtfn(hash string, height int32, stakeDiff int64) *StakeDifficultyNtfn {
-	return &StakeDifficultyNtfn{
-		BlockHash:   hash,
-		BlockHeight: height,
-		StakeDiff:   stakeDiff,
-	}
-}
-
 // TxAcceptedNtfn defines the txaccepted JSON-RPC notification.
 type TxAcceptedNtfn struct {
 	TxID   string  `json:"txid"`
@@ -266,6 +245,5 @@ func init() {
 	dcrjson.MustRegister(TxAcceptedVerboseNtfnMethod, (*TxAcceptedVerboseNtfn)(nil), flags)
 	dcrjson.MustRegister(RelevantTxAcceptedNtfnMethod, (*RelevantTxAcceptedNtfn)(nil), flags)
 	dcrjson.MustRegister(SpentAndMissedTicketsNtfnMethod, (*SpentAndMissedTicketsNtfn)(nil), flags)
-	dcrjson.MustRegister(StakeDifficultyNtfnMethod, (*StakeDifficultyNtfn)(nil), flags)
 	dcrjson.MustRegister(WinningTicketsNtfnMethod, (*WinningTicketsNtfn)(nil), flags)
 }

--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -282,9 +282,6 @@ func (c *Client) trackRegisteredNtfns(cmd interface{}) {
 	case *chainjson.NotifyNewTicketsCmd:
 		c.ntfnState.notifyNewTickets = true
 
-	case *chainjson.NotifyStakeDifficultyCmd:
-		c.ntfnState.notifyStakeDifficulty = true
-
 	case *chainjson.NotifyBlocksCmd:
 		c.ntfnState.notifyBlocks = true
 
@@ -598,14 +595,6 @@ func (c *Client) reregisterNtfns(ctx context.Context) error {
 	if stateCopy.notifyNewTickets {
 		log.Debugf("Reregistering [notifynewtickets]")
 		if err := c.NotifyNewTickets(ctx); err != nil {
-			return err
-		}
-	}
-
-	// Reregister notifystakedifficulty if needed.
-	if stateCopy.notifyStakeDifficulty {
-		log.Debugf("Reregistering [notifystakedifficulty]")
-		if err := c.NotifyStakeDifficulty(ctx); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This removes support from the RPC server for the `notifystakedifficulty` and related `stakedifficulty` notification.

This is being done because it really is not necessary, as evidenced by the fact that nothing actually uses it, and as further described below.

The only time the stake difficulty can change is when there is a new block that falls on a well defined interval, so all clients already know when it can possibly change and can make use of `getstakedifficulty` at the appropriate times if they really need access to it.

Moreover, since the activation of DCP0001, it became possible to independently calculate the stake difficulty from the headers alone, so SPV clients that don't rely on RPC, such as wallets, already calculate it themselves anyway.

In practice, wallets would be the only realistic potential consumer for such a notification, but for the aforementioned reasons, they really have no need for it.
    
Finally, I noticed that the current code was not even notifying under all of the correct circumstances.  So, rather than fixing and maintaining a bunch of code that isn't particularly useful, it's better to just remove it.

This is a breaking change to the RPC server API, but it has already had the major bumped since that last release, so it is not modified again.