### PR TITLE
multi: Remove unneeded ForceReorganization.

### DIFF
--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -132,8 +132,8 @@ type Config struct {
 	FetchUtxoViewParentTemplate func(block *wire.MsgBlock) (*blockchain.UtxoViewpoint, error)
 
 	// ForceHeadReorganization defines the function to use to force a
-	// reorganization of the block chain to the block hash requested, so long as it
-	// matches up with the current organization of the best chain.
+	// reorganization of the block chain to the block hash requested, so long as
+	// it matches up with the current organization of the best chain.
 	ForceHeadReorganization func(formerBest chainhash.Hash, newBest chainhash.Hash) error
 
 	// IsFinalizedTransaction defines the function to use to determine whether or
@@ -166,11 +166,6 @@ type Config struct {
 	// ValidateTransactionScripts defines the function to use to validate the
 	// scripts for the passed transaction.
 	ValidateTransactionScripts func(tx *dcrutil.Tx, utxoView *blockchain.UtxoViewpoint, flags txscript.ScriptFlags) error
-
-	// ForceReorganization forces a reorganization of the block chain to the
-	// block hash requested, so long as it matches up with the current
-	// organization of the best chain.
-	ForceReorganization func(formerBest, newBest chainhash.Hash) error
 }
 
 // TxDesc is a descriptor about a transaction in a transaction source along with
@@ -1096,7 +1091,7 @@ func (g *BlkTmplGenerator) NewBlockTemplate(payToAddress dcrutil.Address) (*Bloc
 		if eligibleParents[0] != prevHash {
 			for i := range eligibleParents {
 				newHead := &eligibleParents[i]
-				err := g.cfg.ForceReorganization(prevHash, *newHead)
+				err := g.cfg.ForceHeadReorganization(prevHash, *newHead)
 				if err != nil {
 					log.Errorf("failed to reorganize to new parent: %v", err)
 					continue

--- a/internal/mining/mining_harness_test.go
+++ b/internal/mining/mining_harness_test.go
@@ -1399,7 +1399,6 @@ func newMiningHarness(chainParams *chaincfg.Params) (*miningHarness, []spendable
 
 				return blockchain.ValidateTransactionScripts(tx, utxoView, flags, sigCache)
 			},
-			ForceReorganization: chain.ForceHeadReorganization,
 		}),
 	}
 

--- a/server.go
+++ b/server.go
@@ -3731,7 +3731,7 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 				return blockchain.ValidateTransactionScripts(tx, utxoView, flags,
 					s.sigCache)
 			},
-			ForceReorganization: s.syncManager.ForceReorganization,
+			ForceReorganization: s.chain.ForceHeadReorganization,
 		})
 
 		s.bg = mining.NewBgBlkTmplGenerator(&mining.BgBlkTmplConfig{

--- a/server.go
+++ b/server.go
@@ -3731,7 +3731,6 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 				return blockchain.ValidateTransactionScripts(tx, utxoView, flags,
 					s.sigCache)
 			},
-			ForceReorganization: s.chain.ForceHeadReorganization,
 		})
 
 		s.bg = mining.NewBgBlkTmplGenerator(&mining.BgBlkTmplConfig{


### PR DESCRIPTION
**This requires #2519**.

This removes the `ForceReorganization` method and infrastructure from the `netsync` sync manager as it is no longer needed since the blockchain is safe for concurrent access and the additional `mempool` pruning the version in sync manager currently does is not necessary since all siblings that could be the target of a head reorganization are necessarily at the same height and have the same stake difficulty.

It also removes the `ForceReorganization` method from the `mining.Config` struct in favor of the existing `ForceHeadReorganization` that does the same thing.