### PR TITLE
rpctest: Don't use installed node.

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -14,13 +14,7 @@ set -ex
 # golangci-lint (github.com/golangci/golangci-lint) is used to run each
 # static checker.
 
-REPO=dcrd
-
 go version
-
-# binary needed for RPC tests
-env CC=gcc go build
-cp "$REPO" "$(go env GOPATH)/bin/"
 
 # run tests on all modules
 ROOTPATH=$(go list -m)


### PR DESCRIPTION
    Before these changes rpc tests would use whatever dcrd was installed on
    the system. For the run_tests script, this bin was prebuilt. Change
    every use of the rpc test harness to use an executable from a
    predetermined path, and build n node in a temporary path when not
    supplied. Remove building from run_tests.sh.

closes #2521 