### PR TITLE
blockchain: Explicit hash in estimate stake diff.

### DIFF
--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -296,7 +296,7 @@ type Chain interface {
 	// interval unless the flag to use max tickets is set in which case it will use
 	// the max possible number of tickets that can be purchased in the remainder of
 	// the interval.
-	EstimateNextStakeDifficulty(newTickets int64, useMaxTickets bool) (int64, error)
+	EstimateNextStakeDifficulty(hash *chainhash.Hash, newTickets int64, useMaxTickets bool) (int64, error)
 
 	// FetchUtxoEntry loads and returns the unspent transaction output entry for the
 	// passed hash from the point of view of the end of the main chain.

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -148,7 +148,7 @@ type testRPCChain struct {
 	convertUtxosToMinimalOutputs  []*stake.MinimalOutput
 	countVoteVersion              uint32
 	countVoteVersionErr           error
-	estimateNextStakeDifficultyFn func(newTickets int64, useMaxTickets bool) (diff int64, err error)
+	estimateNextStakeDifficultyFn func(hash *chainhash.Hash, newTickets int64, useMaxTickets bool) (diff int64, err error)
 	fetchUtxoEntry                UtxoEntry
 	fetchUtxoEntryErr             error
 	fetchUtxoStats                *blockchain.UtxoStats
@@ -273,8 +273,8 @@ func (c *testRPCChain) CountVoteVersion(version uint32) (uint32, error) {
 }
 
 // EstimateNextStakeDifficulty returns a mocked estimated next stake difficulty.
-func (c *testRPCChain) EstimateNextStakeDifficulty(newTickets int64, useMaxTickets bool) (int64, error) {
-	return c.estimateNextStakeDifficultyFn(newTickets, useMaxTickets)
+func (c *testRPCChain) EstimateNextStakeDifficulty(hash *chainhash.Hash, newTickets int64, useMaxTickets bool) (int64, error) {
+	return c.estimateNextStakeDifficultyFn(hash, newTickets, useMaxTickets)
 }
 
 // FetchUtxoEntry returns a mocked UtxoEntry.
@@ -1407,7 +1407,7 @@ func defaultMockRPCChain() *testRPCChain {
 			Value:    0,
 			Version:  0,
 		}},
-		estimateNextStakeDifficultyFn: func(int64, bool) (int64, error) {
+		estimateNextStakeDifficultyFn: func(*chainhash.Hash, int64, bool) (int64, error) {
 			return 14336790201, nil
 		},
 		fetchUtxoEntry: &testRPCUtxoEntry{
@@ -2750,8 +2750,8 @@ func TestHandleEstimateStakeDiff(t *testing.T) {
 			&userQItem,
 		}
 	}
-	estimateFn := func(queue []*stakeDiffQueueItem) func(int64, bool) (int64, error) {
-		return func(int64, bool) (int64, error) {
+	estimateFn := func(queue []*stakeDiffQueueItem) func(*chainhash.Hash, int64, bool) (int64, error) {
+		return func(*chainhash.Hash, int64, bool) (int64, error) {
 			defer func() { queue = queue[1:] }()
 			return queue[0].diff, queue[0].err
 		}


### PR DESCRIPTION
**This requires #2518**.

This modifies `EstimateNextStakeDifficulty` to accept a hash instead of using the current chain tip as part of an overall effort to make the blockchain module more explicit and less reliant on the current state.

It also updates a few comments to match reality while here.
