### PR TITLE
mining: Correct fee calculations during reorgs.

### DIFF
--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -931,6 +931,9 @@ func NewBlkTmplGenerator(cfg *Config) *BlkTmplGenerator {
 // transaction and its ancestors into account.
 func calcFeePerKb(txDesc *TxDesc, ancestorStats *TxAncestorStats) float64 {
 	txSize := txDesc.Tx.MsgTx().SerializeSize()
+	if ancestorStats.Fees < 0 || ancestorStats.SizeBytes < 0 {
+		return (float64(txDesc.Fee) * float64(kilobyte)) / float64(txSize)
+	}
 	return (float64(txDesc.Fee+ancestorStats.Fees) * float64(kilobyte)) /
 		float64(int64(txSize)+ancestorStats.SizeBytes)
 }


### PR DESCRIPTION
This change modifies the block template generator to account for some ancestor statistics not being updated correctly during a reorg, which could lead to some transactions being considered lower priority than expected during block template inclusion. In the interest of keeping the scope of this PR as small and focused as possible, obvious optimizations such as using the cached `txDesc.TxSize` rather than recalculating the tx size multiple times throughout the block template generator have not been applied.