### PR TITLE
[release-v1.6] mining: Correct fee calculations during reorgs. 

### DIFF
--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -1110,6 +1110,9 @@ func NewBlkTmplGenerator(policy *Policy, txSource TxSource,
 // transaction and its ancestors into account.
 func calcFeePerKb(txDesc *TxDesc, ancestorStats *TxAncestorStats) float64 {
 	txSize := txDesc.Tx.MsgTx().SerializeSize()
+	if ancestorStats.Fees < 0 || ancestorStats.SizeBytes < 0 {
+		return (float64(txDesc.Fee) * float64(kilobyte)) / float64(txSize)
+	}
 	return (float64(txDesc.Fee+ancestorStats.Fees) * float64(kilobyte)) /
 		float64(int64(txSize)+ancestorStats.SizeBytes)
 }


### PR DESCRIPTION
This is a backport of #2530 to the 1.6 release branch.