### PR TITLE
chaincfg: Add extra seeders.

### DIFF
--- a/chaincfg/mainnetparams.go
+++ b/chaincfg/mainnetparams.go
@@ -418,6 +418,9 @@ func MainNetParams() *Params {
 		seeders: []string{
 			"mainnet-seed-1.decred.org",
 			"mainnet-seed-2.decred.org",
+			"mainnet-seed.planetdecred.org",
+			"mainnet-seed.dcrdata.org",
+			"mainnet-seed.jamieholdstock.com",
 		},
 	}
 }

--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -306,6 +306,9 @@ func TestNet3Params() *Params {
 		seeders: []string{
 			"testnet-seed-1.decred.org",
 			"testnet-seed-2.decred.org",
+			"testnet-seed.planetdecred.org",
+			"testnet-seed.dcrdata.org",
+			"testnet-seed.jamieholdstock.com",
 		},
 	}
 }


### PR DESCRIPTION
Adds additional seeders for both mainnet and testnet. This will help to
reduce dependency on the decred.org domain, and gives users some
alternatives if they don't want to use the decred.org seeders for whatever
reason.

FYI: @raedah @chappjc 