### PR TITLE
blockchain: Whitelist DCP0005 violations.

### DIFF
--- a/blockchain/blockindex_test.go
+++ b/blockchain/blockindex_test.go
@@ -10,23 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/wire"
 )
-
-// mustParseHash converts the passed big-endian hex string into a
-// chainhash.Hash and will panic if there is an error.  It only differs from the
-// one available in chainhash in that it will panic so errors in the source code
-// be detected.  It will only (and must only) be called with hard-coded, and
-// therefore known good, hashes.
-func mustParseHash(s string) *chainhash.Hash {
-	hash, err := chainhash.NewHashFromStr(s)
-	if err != nil {
-		panic("invalid hash in source file: " + s)
-	}
-	return hash
-}
 
 // TestBlockNodeHeader ensures that block nodes reconstruct the correct header
 // and fetching the header from the chain reconstructs it from memory.

--- a/blockchain/chainio_test.go
+++ b/blockchain/chainio_test.go
@@ -21,15 +21,6 @@ import (
 	"github.com/decred/dcrd/wire"
 )
 
-// newHashFromStr converts the passed big-endian hex string into a
-// chainhash.Hash.  It only differs from the one available in chainhash in that
-// it ignores the error since it will only (and must only) be called with
-// hard-coded, and therefore known good, hashes.
-func newHashFromStr(hexStr string) *chainhash.Hash {
-	hash, _ := chainhash.NewHashFromStr(hexStr)
-	return hash
-}
-
 // hexToFinalState converts the passed hex string into an array of 6 bytes and
 // will panic if there is an error.  This is only provided for the hard-coded
 // constants so errors in the source code can be detected. It will only (and
@@ -104,9 +95,9 @@ func TestBlockIndexSerialization(t *testing.T) {
 	// for the various tests below.
 	baseHeader := wire.BlockHeader{
 		Version:      4,
-		PrevBlock:    *newHashFromStr("000000000000016916671ae225343a5ee131c999d5cadb6348805db25737731f"),
-		MerkleRoot:   *newHashFromStr("5ef2bb79795d7503c0ccc5cb6e0d4731992fc8c8c5b332c1c0e2c687d864c666"),
-		StakeRoot:    *newHashFromStr("022965059b7527dc2bc18daaa533f806eda1f96fd0b04bbda2381f5552d7c2de"),
+		PrevBlock:    *mustParseHash("000000000000016916671ae225343a5ee131c999d5cadb6348805db25737731f"),
+		MerkleRoot:   *mustParseHash("5ef2bb79795d7503c0ccc5cb6e0d4731992fc8c8c5b332c1c0e2c687d864c666"),
+		StakeRoot:    *mustParseHash("022965059b7527dc2bc18daaa533f806eda1f96fd0b04bbda2381f5552d7c2de"),
 		VoteBits:     0x0001,
 		FinalState:   hexToFinalState("313e16e64c0b"),
 		Voters:       4,
@@ -597,7 +588,7 @@ func TestSpendJournalSerialization(t *testing.T) {
 				Version: 1,
 				TxIn: []*wire.TxIn{{
 					PreviousOutPoint: wire.OutPoint{
-						Hash:  *newHashFromStr("0437cd7f8525ceed2324359c2d0ba26006d92d856a9c20fa0241106ee5a597c9"),
+						Hash:  *mustParseHash("0437cd7f8525ceed2324359c2d0ba26006d92d856a9c20fa0241106ee5a597c9"),
 						Index: 0,
 						Tree:  0,
 					},
@@ -650,7 +641,7 @@ func TestSpendJournalSerialization(t *testing.T) {
 				Version: 1,
 				TxIn: []*wire.TxIn{{
 					PreviousOutPoint: wire.OutPoint{
-						Hash:  *newHashFromStr("c0ed017828e59ad5ed3cf70ee7c6fb0f426433047462477dc7a5d470f987a537"),
+						Hash:  *mustParseHash("c0ed017828e59ad5ed3cf70ee7c6fb0f426433047462477dc7a5d470f987a537"),
 						Index: 1,
 						Tree:  0,
 					},
@@ -676,7 +667,7 @@ func TestSpendJournalSerialization(t *testing.T) {
 				Version: 1,
 				TxIn: []*wire.TxIn{{
 					PreviousOutPoint: wire.OutPoint{
-						Hash:  *newHashFromStr("92fbe1d4be82f765dfabc9559d4620864b05cc897c4db0e29adac92d294e52b7"),
+						Hash:  *mustParseHash("92fbe1d4be82f765dfabc9559d4620864b05cc897c4db0e29adac92d294e52b7"),
 						Index: 0,
 						Tree:  0,
 					},
@@ -699,7 +690,7 @@ func TestSpendJournalSerialization(t *testing.T) {
 				Expiry:   0,
 			}},
 			utxoView: &UtxoViewpoint{entries: map[chainhash.Hash]*UtxoEntry{
-				*newHashFromStr("c0ed017828e59ad5ed3cf70ee7c6fb0f426433047462477dc7a5d470f987a537"): {
+				*mustParseHash("c0ed017828e59ad5ed3cf70ee7c6fb0f426433047462477dc7a5d470f987a537"): {
 					txVersion:  1,
 					isCoinBase: false,
 					hasExpiry:  false,
@@ -739,7 +730,7 @@ func TestSpendJournalSerialization(t *testing.T) {
 				Version: 1,
 				TxIn: []*wire.TxIn{{
 					PreviousOutPoint: wire.OutPoint{
-						Hash:  *newHashFromStr("c0ed017828e59ad5ed3cf70ee7c6fb0f426433047462477dc7a5d470f987a537"),
+						Hash:  *mustParseHash("c0ed017828e59ad5ed3cf70ee7c6fb0f426433047462477dc7a5d470f987a537"),
 						Index: 1,
 					},
 					SignatureScript: hexToBytes(""),
@@ -749,7 +740,7 @@ func TestSpendJournalSerialization(t *testing.T) {
 					ValueIn:         159747816,
 				}, {
 					PreviousOutPoint: wire.OutPoint{
-						Hash:  *newHashFromStr("c0ed017828e59ad5ed3cf70ee7c6fb0f426433047462477dc7a5d470f987a537"),
+						Hash:  *mustParseHash("c0ed017828e59ad5ed3cf70ee7c6fb0f426433047462477dc7a5d470f987a537"),
 						Index: 2,
 					},
 					SignatureScript: hexToBytes(""),
@@ -771,7 +762,7 @@ func TestSpendJournalSerialization(t *testing.T) {
 				Expiry:   0,
 			}},
 			utxoView: &UtxoViewpoint{entries: map[chainhash.Hash]*UtxoEntry{
-				*newHashFromStr("c0ed017828e59ad5ed3cf70ee7c6fb0f426433047462477dc7a5d470f987a537"): {
+				*mustParseHash("c0ed017828e59ad5ed3cf70ee7c6fb0f426433047462477dc7a5d470f987a537"): {
 					txVersion:  1,
 					isCoinBase: false,
 					hasExpiry:  false,
@@ -844,7 +835,7 @@ func TestSpendJournalErrors(t *testing.T) {
 				Version: 1,
 				TxIn: []*wire.TxIn{{
 					PreviousOutPoint: wire.OutPoint{
-						Hash:  *newHashFromStr("0437cd7f8525ceed2324359c2d0ba26006d92d856a9c20fa0241106ee5a597c9"),
+						Hash:  *mustParseHash("0437cd7f8525ceed2324359c2d0ba26006d92d856a9c20fa0241106ee5a597c9"),
 						Index: 0,
 					},
 					SignatureScript: hexToBytes("47304402204e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd410220181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d0901"),
@@ -862,7 +853,7 @@ func TestSpendJournalErrors(t *testing.T) {
 				Version: 1,
 				TxIn: []*wire.TxIn{{
 					PreviousOutPoint: wire.OutPoint{
-						Hash:  *newHashFromStr("0437cd7f8525ceed2324359c2d0ba26006d92d856a9c20fa0241106ee5a597c9"),
+						Hash:  *mustParseHash("0437cd7f8525ceed2324359c2d0ba26006d92d856a9c20fa0241106ee5a597c9"),
 						Index: 0,
 					},
 					SignatureScript: hexToBytes("47304402204e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd410220181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d0901"),
@@ -1373,7 +1364,7 @@ func TestBestChainStateSerialization(t *testing.T) {
 		{
 			name: "genesis",
 			state: bestChainState{
-				hash:         *newHashFromStr("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
+				hash:         *mustParseHash("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
 				height:       0,
 				totalTxns:    1,
 				totalSubsidy: 0,
@@ -1387,7 +1378,7 @@ func TestBestChainStateSerialization(t *testing.T) {
 		{
 			name: "block 1",
 			state: bestChainState{
-				hash:         *newHashFromStr("00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048"),
+				hash:         *mustParseHash("00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048"),
 				height:       1,
 				totalTxns:    2,
 				totalSubsidy: 123456789,

--- a/blockchain/upgrade_test.go
+++ b/blockchain/upgrade_test.go
@@ -169,9 +169,9 @@ func TestBlockIndexSerializationV2(t *testing.T) {
 	// for the various tests below.
 	baseHeader := wire.BlockHeader{
 		Version:      4,
-		PrevBlock:    *newHashFromStr("000000000000016916671ae225343a5ee131c999d5cadb6348805db25737731f"),
-		MerkleRoot:   *newHashFromStr("5ef2bb79795d7503c0ccc5cb6e0d4731992fc8c8c5b332c1c0e2c687d864c666"),
-		StakeRoot:    *newHashFromStr("022965059b7527dc2bc18daaa533f806eda1f96fd0b04bbda2381f5552d7c2de"),
+		PrevBlock:    *mustParseHash("000000000000016916671ae225343a5ee131c999d5cadb6348805db25737731f"),
+		MerkleRoot:   *mustParseHash("5ef2bb79795d7503c0ccc5cb6e0d4731992fc8c8c5b332c1c0e2c687d864c666"),
+		StakeRoot:    *mustParseHash("022965059b7527dc2bc18daaa533f806eda1f96fd0b04bbda2381f5552d7c2de"),
 		VoteBits:     0x0001,
 		FinalState:   hexToFinalState("313e16e64c0b"),
 		Voters:       4,
@@ -188,14 +188,14 @@ func TestBlockIndexSerializationV2(t *testing.T) {
 		StakeVersion: 4,
 	}
 	baseTicketsVoted := []chainhash.Hash{
-		*newHashFromStr("8b62a877544753ea80a822142a48ec066170e9381d21a9e8a84bc7373f0f9b2e"),
-		*newHashFromStr("4427a003a7aceb1404ffd9072e9aff1e128a24333a543332030e91668a389db7"),
-		*newHashFromStr("4415b88ac74881d7b6b15d41df465257cd1cc92d55e95f1b648434aef3a2110b"),
-		*newHashFromStr("9d2621b57352088809d3a069b04b76c832f30a76da14e56aece72208b3e5b87a"),
+		*mustParseHash("8b62a877544753ea80a822142a48ec066170e9381d21a9e8a84bc7373f0f9b2e"),
+		*mustParseHash("4427a003a7aceb1404ffd9072e9aff1e128a24333a543332030e91668a389db7"),
+		*mustParseHash("4415b88ac74881d7b6b15d41df465257cd1cc92d55e95f1b648434aef3a2110b"),
+		*mustParseHash("9d2621b57352088809d3a069b04b76c832f30a76da14e56aece72208b3e5b87a"),
 	}
 	baseTicketsRevoked := []chainhash.Hash{
-		*newHashFromStr("8146f01b8ffca8008ebc80293d2978d63b1dffa5c456a73e7b39a9b1e695e8eb"),
-		*newHashFromStr("2292ff2461e725c58cc6e2051eac2a10e6ee6d1f62327ed676b7a196fb94be0c"),
+		*mustParseHash("8146f01b8ffca8008ebc80293d2978d63b1dffa5c456a73e7b39a9b1e695e8eb"),
+		*mustParseHash("2292ff2461e725c58cc6e2051eac2a10e6ee6d1f62327ed676b7a196fb94be0c"),
 	}
 	baseVoteInfo := []stake.VoteVersionTuple{
 		{Version: 4, Bits: 0x0001},

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -100,6 +100,19 @@ const (
 	checkForDuplicateHashes = false
 )
 
+// mustParseHash converts the passed big-endian hex string into a
+// chainhash.Hash and will panic if there is an error.  It only differs from the
+// one available in chainhash in that it will panic so errors in the source code
+// be detected.  It will only (and must only) be called with hard-coded, and
+// therefore known good, hashes.
+func mustParseHash(s string) *chainhash.Hash {
+	hash, err := chainhash.NewHashFromStr(s)
+	if err != nil {
+		panic("invalid hash in source file: " + s)
+	}
+	return hash
+}
+
 var (
 	// zeroHash is the zero value for a chainhash.Hash and is defined as a
 	// package level variable to avoid the need to create a new instance
@@ -109,6 +122,17 @@ var (
 	// earlyFinalState is the only value of the final state allowed in a
 	// block header before stake validation height.
 	earlyFinalState = [6]byte{0x00}
+
+	// The following blocks violate DCP0005 as they were submitted with an old
+	// version after the majority of the network had upgraded.  See
+	// isDCP0005Violation for more details.  They are defined as package level
+	// variables to avoid the need to create new instances every time a check is
+	// needed.
+	block413762Hash = mustParseHash("00000000000000002086ed61f62a546f3bfa8f3e567b003f097efa982008c47b")
+	block414036Hash = mustParseHash("0000000000000000194fa59310b9e988ecb23de0c716d6e8f1b2aa31d9592387")
+	block424011Hash = mustParseHash("0000000000000000317fc6c7a8a6578be7dfa9c96eb81d620050a3732b02d572")
+	block428809Hash = mustParseHash("00000000000000003147798ccffcecaa420fb1c7934d8f4e33809a871ee34aaa")
+	block430191Hash = mustParseHash("00000000000000002127ad6d4cb30cc16f6344589b417e42650388bb0690a88e")
 )
 
 // voteBitsApproveParent returns whether or not the passed vote bits indicate
@@ -821,6 +845,44 @@ func CheckBlockSanity(block *dcrutil.Block, timeSource MedianTimeSource, chainPa
 	return checkBlockSanity(block, timeSource, BFNone, chainParams)
 }
 
+// isDCP0005Violation returns whether or not the block is known to violate
+// DCP0005.  Due to a bug that has since been fixed, some blocks were accepted
+// that violated DCP0005 by still being submitted on an old block version
+// (version 6 on mainnet) when the majority of the network had already upgraded
+// to the new version specified by DCP0005 (version 7 on mainnet).
+//
+// The blocks that violated DCP0005 due to specifying the old version were
+// otherwise valid and are whitelisted by this function so that they will be
+// accepted when fully syncing the chain without checkpoints.
+func isDCP0005Violation(network wire.CurrencyNet, header *wire.BlockHeader, blockHash *chainhash.Hash) bool {
+	switch network {
+	case wire.MainNet:
+		// 430191 is the height of the last block on mainnet that violated
+		// DCP0005, so return false immediately if the height is greater than
+		// that.
+		if header.Height > 430191 {
+			return false
+		}
+
+		// Return whether or not the block is any of the following 5 mainnet
+		// blocks that are known to violate DCP0005.
+		return header.Height == 413762 && *blockHash == *block413762Hash ||
+			header.Height == 414036 && *blockHash == *block414036Hash ||
+			header.Height == 424011 && *blockHash == *block424011Hash ||
+			header.Height == 428809 && *blockHash == *block428809Hash ||
+			header.Height == 430191 && *blockHash == *block430191Hash
+
+	case wire.TestNet3:
+		// 323282 is the height of the last block on testnet that violated
+		// DCP0005.  Return true if the height is less than or equal to 323282
+		// so that the DCP0005 version check is not enforced until after that
+		// point.
+		return header.Height <= 323282
+	}
+
+	return false
+}
+
 // checkBlockHeaderPositional performs several validation checks on the block
 // header which depend on its position within the block chain and having the
 // headers of all ancestors available.  These checks do not, and must not, rely
@@ -900,10 +962,20 @@ func (b *BlockChain) checkBlockHeaderPositional(header *wire.BlockHeader, prevNo
 		// Note that the latest block version for all networks other than the
 		// main network is one higher.
 		latestBlockVersion := int32(8)
+		dcp0005Version := int32(7)
 		if b.chainParams.Net != wire.MainNet {
 			latestBlockVersion++
+			dcp0005Version++
 		}
 		for version := latestBlockVersion; version > 1; version-- {
+			// Skip the version check for blocks that are known to violate DCP0005.
+			// See isDCP0005Violation for more details.
+			if version == dcp0005Version &&
+				isDCP0005Violation(b.chainParams.Net, header, &blockHash) {
+
+				continue
+			}
+
 			if header.Version < version && b.isMajorityVersion(version,
 				prevNode, b.chainParams.BlockRejectNumRequired) {
 

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -613,7 +613,7 @@ func TestTxValidationErrors(t *testing.T) {
 var badBlock = wire.MsgBlock{
 	Header: wire.BlockHeader{
 		Version:      1,
-		MerkleRoot:   *newHashFromStr("66aa7491b9adce110585ccab7e3fb5fe280de174530cca10eba2c6c3df01c10d"),
+		MerkleRoot:   *mustParseHash("66aa7491b9adce110585ccab7e3fb5fe280de174530cca10eba2c6c3df01c10d"),
 		VoteBits:     uint16(0x0000),
 		FinalState:   [6]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 		Voters:       uint16(0x0000),


### PR DESCRIPTION
This updates the block header positional checks to skip the version check for blocks that are known to violate DCP0005.

Due to a bug that has since been fixed, some blocks were accepted that violated DCP0005 by still being submitted on an old block version (version 6 on mainnet) when the majority of the network had already upgraded to the new version specified by DCP0005 (version 7 on mainnet).

The blocks that violated DCP0005 due to specifying the old version were otherwise valid and are now whitelisted so that they will be accepted when fully syncing the chain without checkpoints.

The logic for the old version checks has since been simplified [in this commit](https://github.com/decred/dcrd/commit/f1e004695ec5d40dc05ee62e741528248ededce6) to take all versions into account with a loop so that this can't be easily missed moving forward.

Tested a full sync with checkpoints disabled on mainnet and testnet, and it worked as expected. 

