### PR TITLE
blockchain: Add invalidate/reconsider infrastructure.

### DIFF
--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -599,6 +599,10 @@ const (
 	// ErrNoTreasuryBalance indicates the treasury balance for a given block
 	// hash does not exist.
 	ErrNoTreasuryBalance = ErrorKind("ErrNoTreasuryBalance")
+
+	// ErrInvalidateGenesisBlock indicates an attempt to invalidate the genesis
+	// block which is not allowed.
+	ErrInvalidateGenesisBlock = ErrorKind("ErrInvalidateGenesisBlock")
 )
 
 // Error satisfies the error interface and prints human-readable errors.

--- a/blockchain/error_test.go
+++ b/blockchain/error_test.go
@@ -155,6 +155,7 @@ func TestErrorKindStringer(t *testing.T) {
 		{ErrUnknownBlock, "ErrUnknownBlock"},
 		{ErrNoFilter, "ErrNoFilter"},
 		{ErrNoTreasuryBalance, "ErrNoTreasuryBalance"},
+		{ErrInvalidateGenesisBlock, "ErrInvalidateGenesisBlock"},
 	}
 
 	t.Logf("Running %d tests", len(tests))

--- a/dcrjson/jsonrpcerr.go
+++ b/dcrjson/jsonrpcerr.go
@@ -77,6 +77,7 @@ const (
 	ErrRPCRawTxString       RPCErrorCode = -32602
 	ErrRPCDecodeHexString   RPCErrorCode = -22
 	ErrRPCDuplicateTx       RPCErrorCode = -40
+	ErrRPCReconsiderFailure RPCErrorCode = -50
 )
 
 // Errors that are specific to btcd.

--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -342,6 +342,10 @@ the method name for further details such as parameter and return information.
 |Y
 |Returns a list of all commands or help for a specified command.
 |-
+|[[#invalidateblock|invalidateblock]]
+|N
+|Permanently invalidates a block as if it had violated consensus rules.
+|-
 |[[#livetickets|livetickets]]
 |Y
 |Returns live ticket hashes from the ticket database.
@@ -357,6 +361,10 @@ the method name for further details such as parameter and return information.
 |[[#ping|ping]]
 |N
 |Queues a ping to be sent to each connected peer.
+|-
+|[[#reconsiderblock|reconsiderblock]]
+|N
+|Reconsiders a block for validation and best chain selection by removing any invalid status from it and its ancestors.  Any descendants that are neither themselves marked as having failed validation, nor descendants of another such block, are also made eligibile for best chain selection.
 |-
 |[[#regentemplate|regentemplate]]
 |Y
@@ -2161,6 +2169,26 @@ of the best block.
 
 ----
 
+====invalidateblock====
+{|
+!Method
+|invalidateblock
+|-
+!Parameters
+|
+# <code>block hash</code>: <code>(string, required)</code> the hash of the block to invalidate
+|-
+!Description
+|
+: Permanently invalidates a block as if it had violated consensus rules.
+: Use [[#reconsiderblock|reconsiderblock]] to remove the invalid status.
+|-
+!Returns
+|Nothing
+|}
+
+----
+
 ====livetickets====
 {|
 !Method
@@ -2239,6 +2267,26 @@ of the best block.
 !Returns
 |Nothing
 |-
+|}
+
+----
+
+====reconsiderblock====
+{|
+!Method
+|reconsiderblock
+|-
+!Parameters
+|
+# <code>block hash</code>: <code>(string, required)</code> the hash of the block to reconsider
+|-
+!Description
+|
+: Reconsiders a block for validation and best chain selection by removing any invalid status from it and its ancestors.
+: Any descendants that are neither themselves marked as having failed validation, nor descendants of another such block, are also made eligibile for best chain selection.
+|-
+!Returns
+|Nothing
 |}
 
 ----

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -408,6 +408,23 @@ type Chain interface {
 	// TSpendCountVotes returns the votes for the specified tspend up to
 	// the specified block.
 	TSpendCountVotes(*chainhash.Hash, *dcrutil.Tx) (int64, int64, error)
+
+	// InvalidateBlock manually invalidates the provided block as if the block
+	// had violated a consensus rule and marks all of its descendants as having
+	// a known invalid ancestor.  It then reorganizes the chain as necessary so
+	// the branch with the most cumulative proof of work that is still valid
+	// becomes the main chain.
+	InvalidateBlock(*chainhash.Hash) error
+
+	// ReconsiderBlock removes the known invalid status of the provided block
+	// and all of its ancestors along with the known invalid ancestor status
+	// from all of its descendants that are neither themselves marked as having
+	// failed validation nor descendants of another such block.  Therefore, it
+	// allows the affected blocks to be reconsidered under the current consensus
+	// rules.  It then potentially reorganizes the chain as necessary so the
+	// block with the most cumulative proof of work that is valid becomes the
+	// tip of the main chain.
+	ReconsiderBlock(*chainhash.Hash) error
 }
 
 // Clock represents a clock for use with the RPC server. The purpose of this

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -163,6 +163,7 @@ type testRPCChain struct {
 	headerByHeight                wire.BlockHeader
 	headerByHeightErr             error
 	heightRangeFn                 func(startHeight, endHeight int64) ([]chainhash.Hash, error)
+	invalidateBlockErr            error
 	isCurrent                     bool
 	liveTickets                   []chainhash.Hash
 	liveTicketsErr                error
@@ -176,6 +177,7 @@ type testRPCChain struct {
 	missedTicketsErr              error
 	nextThresholdState            blockchain.ThresholdStateTuple
 	nextThresholdStateErr         error
+	reconsiderBlockErr            error
 	stateLastChangedHeight        int64
 	stateLastChangedHeightErr     error
 	ticketPoolValue               dcrutil.Amount
@@ -321,6 +323,12 @@ func (c *testRPCChain) HeightRange(startHeight, endHeight int64) ([]chainhash.Ha
 	return c.heightRangeFn(startHeight, endHeight)
 }
 
+// InvalidateBlock returns a mocked error from manually invalidating a given
+// block.
+func (c *testRPCChain) InvalidateBlock(hash *chainhash.Hash) error {
+	return c.invalidateBlockErr
+}
+
 // IsCurrent returns a mocked bool representing whether or not the chain
 // believes it is current.
 func (c *testRPCChain) IsCurrent() bool {
@@ -366,6 +374,12 @@ func (c *testRPCChain) MissedTickets() ([]chainhash.Hash, error) {
 // the given deployment ID for the block AFTER the provided block hash.
 func (c *testRPCChain) NextThresholdState(hash *chainhash.Hash, version uint32, deploymentID string) (blockchain.ThresholdStateTuple, error) {
 	return c.nextThresholdState, c.nextThresholdStateErr
+}
+
+// ReconsiderBlock returns a mocked error from manually reconsidering a given
+// block.
+func (c *testRPCChain) ReconsiderBlock(hash *chainhash.Hash) error {
+	return c.reconsiderBlockErr
 }
 
 // StateLastChangedHeight returns a mocked height at which the provided

--- a/internal/rpcserver/rpcserverhelp.go
+++ b/internal/rpcserver/rpcserverhelp.go
@@ -724,15 +724,25 @@ var helpDescsEnUS = map[string]string{
 	"help--result0":    "List of commands",
 	"help--result1":    "Help for specified command",
 
+	// InvalidateBlockCmd help.
+	"invalidateblock--synopsis": "Permanently invalidates a block as if it had violated consensus rules.\n" +
+		"Use reconsiderblock to remove the invalid status.",
+	"invalidateblock-blockhash": "The hash of the block to invalidate",
+
 	// PingCmd help.
 	"ping--synopsis": "Queues a ping to be sent to each connected peer.\n" +
 		"Ping times are provided by getpeerinfo via the pingtime and pingwait fields.",
 
 	// RebroadcastMissed help.
-	"rebroadcastmissed--synopsis": "Asks the daemon to rebroadcast missed votes.\n",
+	"rebroadcastmissed--synopsis": "Asks the daemon to rebroadcast missed votes.",
 
-	// RebroadcastWinnerCmd help.
-	"rebroadcastwinners--synopsis": "Asks the daemon to rebroadcast the winners of the voting lottery.\n",
+	// RebroadcastWinnersCmd help.
+	"rebroadcastwinners--synopsis": "Asks the daemon to rebroadcast the winners of the voting lottery.",
+
+	// ReconsiderBlockCmd help.
+	"reconsiderblock--synopsis": "Reconsiders a block for validation and best chain selection by removing any invalid status from it and its ancestors.\n" +
+		"Any descendants that are neither themselves marked as having failed validation, nor descendants of another such block, are also made eligibile for best chain selection.",
+	"reconsiderblock-blockhash": "The hash of the block to reconsider",
 
 	// SearchRawTransactionsCmd help.
 	"searchrawtransactions--synopsis": "Returns raw data for transactions involving the passed address.\n" +
@@ -1033,10 +1043,12 @@ var rpcResultTypes = map[types.Method][]interface{}{
 	"getwork":               {(*types.GetWorkResult)(nil), (*bool)(nil)},
 	"getcoinsupply":         {(*int64)(nil)},
 	"help":                  {(*string)(nil), (*string)(nil)},
+	"invalidateblock":       nil,
 	"livetickets":           {(*types.LiveTicketsResult)(nil)},
 	"missedtickets":         {(*types.MissedTicketsResult)(nil)},
 	"node":                  nil,
 	"ping":                  nil,
+	"reconsiderblock":       nil,
 	"regentemplate":         nil,
 	"searchrawtransactions": {(*string)(nil), (*[]types.SearchRawTransactionsResult)(nil)},
 	"sendrawtransaction":    {(*string)(nil)},

--- a/rpc/jsonrpc/types/chainsvrcmds.go
+++ b/rpc/jsonrpc/types/chainsvrcmds.go
@@ -859,6 +859,19 @@ func NewHelpCmd(command *string) *HelpCmd {
 	}
 }
 
+// InvalidateBlockCmd defines the invalidateblock JSON-RPC command.
+type InvalidateBlockCmd struct {
+	BlockHash string
+}
+
+// NewInvalidateBlockCmd returns a new instance which can be used to issue an
+// invalidateblock JSON-RPC command.
+func NewInvalidateBlockCmd(hash string) *InvalidateBlockCmd {
+	return &InvalidateBlockCmd{
+		BlockHash: hash,
+	}
+}
+
 // LiveTicketsCmd is a type handling custom marshaling and
 // unmarshaling of livetickets JSON RPC commands.
 type LiveTicketsCmd struct{}
@@ -906,6 +919,19 @@ type PingCmd struct{}
 // command.
 func NewPingCmd() *PingCmd {
 	return &PingCmd{}
+}
+
+// ReconsiderBlockCmd defines the reconsiderblock JSON-RPC command.
+type ReconsiderBlockCmd struct {
+	BlockHash string
+}
+
+// NewReconsiderBlockCmd returns a new instance which can be used to issue a
+// reconsiderblock JSON-RPC command.
+func NewReconsiderBlockCmd(hash string) *ReconsiderBlockCmd {
+	return &ReconsiderBlockCmd{
+		BlockHash: hash,
+	}
 }
 
 // SearchRawTransactionsCmd defines the searchrawtransactions JSON-RPC command.
@@ -1179,10 +1205,12 @@ func init() {
 	dcrjson.MustRegister(Method("getvoteinfo"), (*GetVoteInfoCmd)(nil), flags)
 	dcrjson.MustRegister(Method("getwork"), (*GetWorkCmd)(nil), flags)
 	dcrjson.MustRegister(Method("help"), (*HelpCmd)(nil), flags)
+	dcrjson.MustRegister(Method("invalidateblock"), (*InvalidateBlockCmd)(nil), flags)
 	dcrjson.MustRegister(Method("livetickets"), (*LiveTicketsCmd)(nil), flags)
 	dcrjson.MustRegister(Method("missedtickets"), (*MissedTicketsCmd)(nil), flags)
 	dcrjson.MustRegister(Method("node"), (*NodeCmd)(nil), flags)
 	dcrjson.MustRegister(Method("ping"), (*PingCmd)(nil), flags)
+	dcrjson.MustRegister(Method("reconsiderblock"), (*ReconsiderBlockCmd)(nil), flags)
 	dcrjson.MustRegister(Method("regentemplate"), (*RegenTemplateCmd)(nil), flags)
 	dcrjson.MustRegister(Method("searchrawtransactions"), (*SearchRawTransactionsCmd)(nil), flags)
 	dcrjson.MustRegister(Method("sendrawtransaction"), (*SendRawTransactionCmd)(nil), flags)


### PR DESCRIPTION
**This requires #2518**.

This adds infrastructure to support invalidating arbitrary blocks as if they had violated a consensus rule as well as reconsidering arbitrary blocks for validation under the current consensus rules and includes comprehensive tests to ensure proper functionality.

It also adds two new rpc commands `invalidateblock` and `reconsiderblock` to expose the new functionality and updates the JSON-RPC API documentation accordingly.

Example use cases this enables:

- Revalidating blocks under new consensus rules 
  - Consider the case of old software rejecting blocks due to new consensus rules activating on the network and then upgrading to a new version that supports the new rules
- Possibility of manually generating snapshots of historical state such as live tickets and available utxos
- Manually recovering from unexpected circumstances
- Easier chain reorganization testing

---

## Testing notes:

In order to make the new commands available to `dcrctl`, a replace directive to use the updated and unreleased `types` module is needed.  The following command from the `dcrctl` directory will accomplish that:

> go mod edit -replace=github.com/decred/dcrd/rpc/jsonrpc/types/v2=../dcrd/rpc/jsonrpc/types