### PR TITLE
netsync: Remove unneeded TipGeneration.

### DIFF
--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -158,10 +158,6 @@ type SyncManager interface {
 	LocateBlocks(locator blockchain.BlockLocator, hashStop *chainhash.Hash,
 		maxHashes uint32) []chainhash.Hash
 
-	// TipGeneration returns the entire generation of blocks stemming from the
-	// parent of the current tip.
-	TipGeneration() ([]chainhash.Hash, error)
-
 	// SyncHeight returns latest known block being synced to.
 	SyncHeight() int64
 

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -494,7 +494,6 @@ type testSyncManager struct {
 	submitBlockErr        error
 	syncPeerID            int32
 	locateBlocks          []chainhash.Hash
-	tipGeneration         []chainhash.Hash
 	syncHeight            int64
 	processTransaction    []*dcrutil.Tx
 	processTransactionErr error
@@ -522,12 +521,6 @@ func (s *testSyncManager) SyncPeerID() int32 {
 // the provided max number of block hashes.
 func (s *testSyncManager) LocateBlocks(locator blockchain.BlockLocator, hashStop *chainhash.Hash, maxHashes uint32) []chainhash.Hash {
 	return s.locateBlocks
-}
-
-// TipGeneration returns a mocked entire generation of blocks stemming from the
-// parent of the current tip.
-func (s *testSyncManager) TipGeneration() ([]chainhash.Hash, error) {
-	return s.tipGeneration, nil
 }
 
 // SyncHeight returns a mocked latest known block being synced to.

--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -353,12 +353,6 @@ func (b *rpcSyncMgr) LocateBlocks(locator blockchain.BlockLocator, hashStop *cha
 	return b.server.chain.LocateBlocks(locator, hashStop, maxHashes)
 }
 
-// TipGeneration returns the entire generation of blocks stemming from the
-// parent of the current tip.
-func (b *rpcSyncMgr) TipGeneration() ([]chainhash.Hash, error) {
-	return b.syncMgr.TipGeneration()
-}
-
 // SyncHeight returns latest known block being synced to.
 func (b *rpcSyncMgr) SyncHeight() int64 {
 	return b.syncMgr.SyncHeight()

--- a/server.go
+++ b/server.go
@@ -819,8 +819,7 @@ func (sp *serverPeer) OnGetMiningState(p *peer.Peer, msg *wire.MsgGetMiningState
 
 	// Obtain the entire generation of blocks stemming from the parent of
 	// the current tip.
-	sm := sp.server.syncManager
-	children, err := sm.TipGeneration()
+	children, err := sp.server.chain.TipGeneration()
 	if err != nil {
 		peerLog.Warnf("failed to access sync manager to get the generation "+
 			"for a mining state request (block: %v): %v", best.Hash, err)
@@ -909,8 +908,7 @@ func (sp *serverPeer) OnGetInitState(p *peer.Peer, msg *wire.MsgGetInitState) {
 	if wantBlocks || wantVotes {
 		// Obtain the entire generation of blocks stemming from the
 		// parent of the current tip.
-		sm := sp.server.syncManager
-		children, err := sm.TipGeneration()
+		children, err := sp.server.chain.TipGeneration()
 		if err != nil {
 			peerLog.Warnf("Failed to access sync manager to get the generation "+
 				"for a init state request (block: %v): %v", best.Hash, err)


### PR DESCRIPTION
**This requires #2518**.

This removes the `TipGeneration` method and infrastructure from the sync manager as it is no longer needed since the `blockchain` is safe for concurrent access.