### PR TITLE
rpcserver: Remove unused LocateBlocks iface method.

### DIFF
--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -152,12 +152,6 @@ type SyncManager interface {
 	// SyncPeerID returns the id of the current peer being synced with.
 	SyncPeerID() int32
 
-	// LocateBlocks returns the hashes of the blocks after the first known block
-	// in the locator until the provided stop hash is reached, or up to the
-	// provided max number of block hashes.
-	LocateBlocks(locator blockchain.BlockLocator, hashStop *chainhash.Hash,
-		maxHashes uint32) []chainhash.Hash
-
 	// SyncHeight returns latest known block being synced to.
 	SyncHeight() int64
 

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -493,7 +493,6 @@ type testSyncManager struct {
 	isOrphan              bool
 	submitBlockErr        error
 	syncPeerID            int32
-	locateBlocks          []chainhash.Hash
 	syncHeight            int64
 	processTransaction    []*dcrutil.Tx
 	processTransactionErr error
@@ -514,13 +513,6 @@ func (s *testSyncManager) SubmitBlock(block *dcrutil.Block, flags blockchain.Beh
 // SyncPeer returns a mocked id of the current peer being synced with.
 func (s *testSyncManager) SyncPeerID() int32 {
 	return s.syncPeerID
-}
-
-// LocateBlocks returns a mocked slice of hashes of the blocks after the first
-// known block in the locator until the provided stop hash is reached, or up to
-// the provided max number of block hashes.
-func (s *testSyncManager) LocateBlocks(locator blockchain.BlockLocator, hashStop *chainhash.Hash, maxHashes uint32) []chainhash.Hash {
-	return s.locateBlocks
 }
 
 // SyncHeight returns a mocked latest known block being synced to.

--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -343,16 +343,6 @@ func (b *rpcSyncMgr) SyncPeerID() int32 {
 	return b.syncMgr.SyncPeerID()
 }
 
-// LocateBlocks returns the hashes of the blocks after the first known block in
-// the locator until the provided stop hash is reached, or up to the provided
-// max number of block hashes.
-//
-// This function is safe for concurrent access and is part of the
-// rpcserver.SyncManager interface implementation.
-func (b *rpcSyncMgr) LocateBlocks(locator blockchain.BlockLocator, hashStop *chainhash.Hash, maxHashes uint32) []chainhash.Hash {
-	return b.server.chain.LocateBlocks(locator, hashStop, maxHashes)
-}
-
 // SyncHeight returns latest known block being synced to.
 func (b *rpcSyncMgr) SyncHeight() int64 {
 	return b.syncMgr.SyncHeight()


### PR DESCRIPTION
This removes the `LocateBlocks` method and related infrastructure from the rpcserver `SyncManager` interface since it is not used.