### PR TITLE
multi: Rework utxoset/view to use outpoints.

### DIFF
--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -392,11 +392,6 @@ const (
 	// more than it is allowed.
 	ErrBadStakebaseValue = ErrorKind("ErrBadStakebaseValue")
 
-	// ErrDiscordantTxTree specifies that a given origin tx's content
-	// indicated that it should exist in a different tx tree than the
-	// one given in the TxIn outpoint.
-	ErrDiscordantTxTree = ErrorKind("ErrDiscordantTxTree")
-
 	// ErrStakeFees indicates an error with the fees found in the stake
 	// transaction tree.
 	ErrStakeFees = ErrorKind("ErrStakeFees")

--- a/blockchain/error_test.go
+++ b/blockchain/error_test.go
@@ -102,7 +102,6 @@ func TestErrorKindStringer(t *testing.T) {
 		{ErrForceReorgWrongChain, "ErrForceReorgWrongChain"},
 		{ErrForceReorgMissingChild, "ErrForceReorgMissingChild"},
 		{ErrBadStakebaseValue, "ErrBadStakebaseValue"},
-		{ErrDiscordantTxTree, "ErrDiscordantTxTree"},
 		{ErrStakeFees, "ErrStakeFees"},
 		{ErrNoStakeTx, "ErrNoStakeTx"},
 		{ErrBadBlockHeight, "ErrBadBlockHeight"},

--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -2014,7 +2014,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 		tx.TxIn[0].PreviousOutPoint.Tree = wire.TxTreeStake
 		b.AddTransaction(tx)
 	})
-	rejected(blockchain.ErrDiscordantTxTree)
+	rejected(blockchain.ErrMissingTxOut)
 
 	// Create block with no dev subsidy for coinbase transaction.
 	//

--- a/blockchain/sequencelock.go
+++ b/blockchain/sequencelock.go
@@ -69,7 +69,7 @@ func (b *BlockChain) calcSequenceLock(node *blockNode, tx *dcrutil.Tx, view *Utx
 			continue
 		}
 
-		utxo := view.LookupEntry(&txIn.PreviousOutPoint.Hash)
+		utxo := view.LookupEntry(txIn.PreviousOutPoint)
 		if utxo == nil {
 			str := fmt.Sprintf("output %v referenced from "+
 				"transaction %s:%d either does not exist or "+

--- a/blockchain/utxoviewpoint_test.go
+++ b/blockchain/utxoviewpoint_test.go
@@ -55,8 +55,8 @@ func TestFetchUtxoView(t *testing.T) {
 
 		for txInIdx, txIn := range tx.MsgTx().TxIn {
 			prevOut := &txIn.PreviousOutPoint
-			entry := view.LookupEntry(&prevOut.Hash)
-			gotSpent := entry == nil || entry.IsOutputSpent(prevOut.Index)
+			entry := view.LookupEntry(*prevOut)
+			gotSpent := entry == nil || entry.IsSpent()
 			if gotSpent != spent {
 				t.Fatalf("unexpected spent state for txo %s referenced by "+
 					"input %d -- got %v, want %v", prevOut, txInIdx,

--- a/gcs/blockcf2/blockcf.go
+++ b/gcs/blockcf2/blockcf.go
@@ -376,8 +376,8 @@ func Regular(block *wire.MsgBlock, prevScripts PrevScripter) (*gcs.FilterV2, err
 
 				// Commit to the change outputs with the exception of those that
 				// are provably unspendable.
-				isChangeOuput := txOutIdx%2 == 0
-				if isChangeOuput {
+				isChangeOutput := txOutIdx%2 == 0
+				if isChangeOutput {
 					if txOut.Value == 0 {
 						continue
 					}

--- a/internal/mempool/policy.go
+++ b/internal/mempool/policy.go
@@ -124,10 +124,9 @@ func checkInputsStandard(tx *dcrutil.Tx, txType stake.TxType, utxoView *blockcha
 		// It is safe to elide existence and index checks here since
 		// they have already been checked prior to calling this
 		// function.
-		prevOut := txIn.PreviousOutPoint
-		entry := utxoView.LookupEntry(&prevOut.Hash)
-		originPkScriptVer := entry.ScriptVersionByIndex(prevOut.Index)
-		originPkScript := entry.PkScriptByIndex(prevOut.Index)
+		entry := utxoView.LookupEntry(txIn.PreviousOutPoint)
+		originPkScriptVer := entry.ScriptVersion()
+		originPkScript := entry.PkScript()
 		switch txscript.GetScriptClass(originPkScriptVer,
 			originPkScript, isTreasuryEnabled) {
 		case txscript.ScriptHashTy:

--- a/internal/mining/mining_view_test.go
+++ b/internal/mining/mining_view_test.go
@@ -497,7 +497,8 @@ func TestAncestorTrackingLimits(t *testing.T) {
 	for index := len(allTxns) - 1; index >= 0; index-- {
 		tx := allTxns[index]
 		txHash := tx.Hash()
-		harness.chain.utxos.LookupEntry(txHash).SpendOutput(0)
+		outpoint := wire.OutPoint{Hash: *txHash, Index: 0, Tree: wire.TxTreeRegular}
+		harness.chain.utxos.LookupEntry(outpoint).Spend()
 		_, err = harness.AddTransactionToTxSource(tx)
 		if err != nil {
 			t.Fatalf("unable to add transaction to the tx source: %v", err)

--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"time"
 
-	"github.com/decred/dcrd/blockchain/stake/v4"
 	"github.com/decred/dcrd/blockchain/v4"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v3"
@@ -379,25 +378,18 @@ type rpcChain struct {
 // Ensure rpcChain implements the rpcserver.Chain interface.
 var _ rpcserver.Chain = (*rpcChain)(nil)
 
-// ConvertUtxosToMinimalOutputs converts the contents of a UTX to a series of
-// minimal outputs. It does this so that these can be passed to stake subpackage
-// functions, where they will be evaluated for correctness.
-func (c *rpcChain) ConvertUtxosToMinimalOutputs(entry rpcserver.UtxoEntry) []*stake.MinimalOutput {
-	return blockchain.ConvertUtxosToMinimalOutputs(entry.ToUtxoEntry())
-}
-
-// FetchUtxoEntry loads and returns the unspent transaction output entry for the
-// passed hash from the point of view of the end of the main chain.
+// FetchUtxoEntry loads and returns the requested unspent transaction output
+// from the point of view of the main chain tip.
 //
-// NOTE: Requesting a hash for which there is no data will NOT return an error.
-// Instead both the entry and the error will be nil.  This is done to allow
-// pruning of fully spent transactions.  In practice this means the caller must
-// check if the returned entry is nil before invoking methods on it.
+// NOTE: Requesting an output for which there is no data will NOT return an
+// error.  Instead both the entry and the error will be nil.  This is done to
+// allow pruning of spent transaction outputs.  In practice this means the
+// caller must check if the returned entry is nil before invoking methods on it.
 //
 // This function is safe for concurrent access however the returned entry (if
 // any) is NOT.
-func (c *rpcChain) FetchUtxoEntry(txHash *chainhash.Hash) (rpcserver.UtxoEntry, error) {
-	utxo, err := c.BlockChain.FetchUtxoEntry(txHash)
+func (c *rpcChain) FetchUtxoEntry(outpoint wire.OutPoint) (rpcserver.UtxoEntry, error) {
+	utxo, err := c.BlockChain.FetchUtxoEntry(outpoint)
 	if utxo == nil || err != nil {
 		return nil, err
 	}

--- a/server.go
+++ b/server.go
@@ -855,7 +855,7 @@ func (sp *serverPeer) OnGetMiningState(p *peer.Peer, msg *wire.MsgGetMiningState
 // requests the data advertised in the message from the peer.
 func (sp *serverPeer) OnMiningState(p *peer.Peer, msg *wire.MsgMiningState) {
 	err := sp.server.syncManager.RequestFromPeer(sp.Peer, msg.BlockHashes,
-		msg.VoteHashes)
+		msg.VoteHashes, nil)
 	if err != nil {
 		peerLog.Warnf("couldn't handle mining state message: %v",
 			err.Error())
@@ -947,20 +947,21 @@ func (sp *serverPeer) OnGetInitState(p *peer.Peer, msg *wire.MsgGetInitState) {
 // requests the data advertised in the message from the peer.
 func (sp *serverPeer) OnInitState(p *peer.Peer, msg *wire.MsgInitState) {
 	blockHashes := make([]*chainhash.Hash, 0, len(msg.BlockHashes))
-	txHashes := make([]*chainhash.Hash, 0, len(msg.VoteHashes)+len(msg.TSpendHashes))
+	voteHashes := make([]*chainhash.Hash, 0, len(msg.VoteHashes))
+	tSpendHashes := make([]*chainhash.Hash, 0, len(msg.TSpendHashes))
 
 	for i := range msg.BlockHashes {
 		blockHashes = append(blockHashes, &msg.BlockHashes[i])
 	}
 	for i := range msg.VoteHashes {
-		txHashes = append(txHashes, &msg.VoteHashes[i])
+		voteHashes = append(voteHashes, &msg.VoteHashes[i])
 	}
 	for i := range msg.TSpendHashes {
-		txHashes = append(txHashes, &msg.TSpendHashes[i])
+		tSpendHashes = append(tSpendHashes, &msg.TSpendHashes[i])
 	}
 
 	err := sp.server.syncManager.RequestFromPeer(sp.Peer, blockHashes,
-		txHashes)
+		voteHashes, tSpendHashes)
 	if err != nil {
 		peerLog.Warnf("couldn't handle init state message: %v", err)
 	}


### PR DESCRIPTION
**NOTE: This contains a database migration, so if you plan to test it, please make a copy of your data directory first.**

---

This modifies the utxoset in the database and related `UtxoViewpoint` to store and work with unspent transaction outputs on a per-output basis instead of at a transaction level.  This is a port of https://github.com/btcsuite/btcd/pull/1045 with some significant differences due to the stake tree and transactions in Decred.

The primary motivation is to simplify the code, pave the way for a utxo cache, and generally focus on optimizing runtime performance.

The tradeoff is that this approach does somewhat increase the size of the serialized utxoset since it means that the transaction hash is duplicated for each output as a part of the key and some additional details are duplicated in each output.  The details duplicated in each output include flags encoded into a single byte that specify whether the containing transaction is a coinbase, whether the containing transaction has an expiry, and the transaction type.  Additionally, the containing block height and index are stored in each output.

However, in practice, the size difference isn't all that large, disk space is relatively cheap, certainly cheaper than memory, and it is much more important to provide more efficient runtime operation since that is the ultimate purpose of the daemon.

While performing this conversion, it also simplifies the code to remove the transaction version information from the utxoset as well as the spend journal.  The logic for only serializing it under certain circumstances is complicated, and it was only used for the `gettxout` RPC, where it has already been removed.

The utxo set and spend journal in the database are automatically migrated to the new format with this commit and it is possible to interrupt and resume the migration process.

Finally, it also updates all references and tests that previously dealt with transaction hashes to use outpoints instead.

An overview of the changes are as follows:

- Remove transaction version from both spent and unspent output entries
  - Update utxo serialization format to exclude the version
  - Update spend journal serialization format to exclude the version
- Convert `UtxoEntry` to represent a specific utxo instead of a transaction with all remaining utxos
  - Optimize for memory usage with an eye toward a utxo cache
    - Combine fields such as whether the containing transaction is a coinbase, whether the containing transaction has an expiry, and the transaction type, into a single byte
    - Align entry fields to eliminate extra padding since ultimately there will be a lot of these in memory
    - Introduce a free list for serializing an outpoint to the database key format to significantly reduce pressure on the GC
  - Update entries to be keyed by a `<hash><tree><output index>` outpoint rather than just a tx hash
  - Update all related functions that previously dealt with transaction hashes to accept outpoints instead
  - Update all callers accordingly
  - Only add individually requested outputs from the mempool when constructing a mempool view
- Modify the spend journal to always store the encoded flags with every spent txout
  - Combine fields such as whether the containing transaction is a coinbase, whether the containing transaction has an expiry, and the transaction type into a single byte
    - Use 4 bits instead of 3 for the transaction type to be consistent with utxos. The extra bit was already unused so this doesn't take any additional space
  - Remove the fully spent flag
- Introduce `ticketMinOuts` in place of `stakeExtra`
  - Renamed `stakeExtra` as `ticketMinOuts` and updated all comments to make the purpose of the field clearer
  - Only store `ticketMinOuts` for ticket submission outputs
  - Add `TicketMinimalOutputs` function on `UtxoEntry` in place of `ConvertUtxosToMinimalOutputs`
- Always decompress data loaded from the database now that a utxo entry only consists of a specific output
- Introduce upgrade code to migrate the utxo set and spend journal to the new format
  - Update current database version to 9
  - Update current utxo set version to 3
  - Update current spend journal version to 3
  - Introduce the ability to run upgrades after the block index has been loaded
- Update all tests to expect the correct encodings, remove tests that no longer apply, and add new ones for the new expected behavior
  - Convert old tests for the legacy utxo format deserialization code to test the new function that is used during upgrade
- Introduce a few new functions on `UtxoViewpoint`
  - `AddTxOut` for adding an individual txout versus all of them
  - `addTxOut` to handle the common code between the new `AddTxOut` and existing `AddTxOuts`
  - `RemoveEntry` for removing an individual txout
- Remove the `ErrDiscordantTxTree` error
  - Since utxos are now retrieved using an outpoint, which includes the tree, it is no longer possible to hit this error path

---

A couple other notes on the implementation:

- Unfortunately, it wasn't really possible to break this into smaller working commits, so these changes are all in one large commit.
- The spend journal migration does take awhile to run (~20 mins, due to the fact that it needs to read all block entries).

---

**Part of https://github.com/decred/dcrd/issues/1145.**