### PR TITLE
netsync/server: Update peer heights directly.

### DIFF
--- a/internal/netsync/interface.go
+++ b/internal/netsync/interface.go
@@ -1,13 +1,11 @@
-// Copyright (c) 2020 The Decred developers
+// Copyright (c) 2020-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package netsync
 
 import (
-	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil/v4"
-	"github.com/decred/dcrd/peer/v2"
 )
 
 // PeerNotifier provides an interface to notify peers of status changes related
@@ -16,8 +14,4 @@ type PeerNotifier interface {
 	// AnnounceNewTransactions generates and relays inventory vectors and
 	// notifies websocket clients of the passed transactions.
 	AnnounceNewTransactions(txns []*dcrutil.Tx)
-
-	// UpdatePeerHeights updates the heights of all peers who have announced the
-	// latest connected main chain block, or a recognized orphan.
-	UpdatePeerHeights(latestBlkHash *chainhash.Hash, latestHeight int64, updateSource *peer.Peer)
 }


### PR DESCRIPTION
**This requires #2541**.

Now that the sync manager is aware of all peers, this modifies it to update their heights upon seeing the relevant announced blocks directly instead of threading back through the server via a callback that required a goroutine to avoid the otherwise circular lock.