### PR TITLE
netsync: Remove unused TicketPoolValue.

### DIFF
--- a/internal/netsync/manager.go
+++ b/internal/netsync/manager.go
@@ -1850,12 +1850,6 @@ func (m *SyncManager) IsCurrent() bool {
 	return isCurrent
 }
 
-// TicketPoolValue returns the current value of the total stake in the ticket
-// pool.
-func (m *SyncManager) TicketPoolValue() (dcrutil.Amount, error) {
-	return m.cfg.Chain.TicketPoolValue()
-}
-
 // Config holds the configuration options related to the network chain
 // synchronization manager.
 type Config struct {


### PR DESCRIPTION
This removes the `TicketPoolValue` method from the sync manager since it is no longer called by anything and also not necessary because it is available directly from the chain instance.