### PR TITLE
netsync: Rework inventory announcement handling.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1886,11 +1886,11 @@ func (b *BlockChain) BlockLocatorFromHash(hash *chainhash.Hash) BlockLocator {
 // main (best) chain.
 //
 // This function is safe for concurrent access.
-func (b *BlockChain) LatestBlockLocator() (BlockLocator, error) {
+func (b *BlockChain) LatestBlockLocator() BlockLocator {
 	b.chainLock.RLock()
 	locator := b.bestChain.BlockLocator(nil)
 	b.chainLock.RUnlock()
-	return locator, nil
+	return locator
 }
 
 // extractDeploymentIDVersions returns a map of all deployment IDs within the

--- a/internal/netsync/manager.go
+++ b/internal/netsync/manager.go
@@ -362,12 +362,7 @@ func (m *SyncManager) startSync() {
 		// to send.
 		m.requestedBlocks = make(map[chainhash.Hash]struct{})
 
-		blkLocator, err := m.cfg.Chain.LatestBlockLocator()
-		if err != nil {
-			log.Errorf("Failed to get block locator for the latest block: %v",
-				err)
-			return
-		}
+		blkLocator := m.cfg.Chain.LatestBlockLocator()
 		locator := chainBlockLocatorToHashes(blkLocator)
 
 		log.Infof("Syncing to block height %d from peer %v",
@@ -1009,17 +1004,12 @@ func (m *SyncManager) handleBlockMsg(bmsg *blockMsg) {
 	onMainChain := !isOrphan && forkLen == 0
 	if isOrphan {
 		orphanRoot := m.orphanRoot(blockHash)
-		blkLocator, err := m.cfg.Chain.LatestBlockLocator()
+		blkLocator := m.cfg.Chain.LatestBlockLocator()
+		locator := chainBlockLocatorToHashes(blkLocator)
+		err := peer.PushGetBlocksMsg(locator, orphanRoot)
 		if err != nil {
-			log.Warnf("Failed to get block locator for the latest block: %v",
+			log.Warnf("Failed to push getblocksmsg for the latest block: %v",
 				err)
-		} else {
-			locator := chainBlockLocatorToHashes(blkLocator)
-			err = peer.PushGetBlocksMsg(locator, orphanRoot)
-			if err != nil {
-				log.Warnf("Failed to push getblocksmsg for the latest block: "+
-					"%v", err)
-			}
 		}
 	} else {
 		// When the block is not an orphan, log information about it and


### PR DESCRIPTION
**This is rebased on #2547**.

This modifies the way inventory announcements are handled to improve efficiency and readability.

Specifically, it switches to a more explicit approach that handles the specific recognized types (blocks and transactions) independently and now determines if they are needed with unique logic for each type as opposed to the more generic inventory-only based approach.

Next, and probably the most important change overall, is that recently confirmed transactions are now tracked by the server and the logic which determines if a transaction is needed now makes use of those tracked transactions as opposed to the previous rather expensive utxo-based query approach.

The reasoning for this change is that the only time honest nodes notify others about transactions are when they view those transactions as unconfirmed and they consider themselves to be current.  In practice this means the only duplicate announcements are for unconfirmed and recently confirmed transactions.  In the case of malicious nodes, the transactions are rejected (either the transactions are actually invalid or they are old transactions that were valid in the past but will now fail due to trying to spend outputs they already spent).
    
So, given the above discussion, there are 3 cases to handle:

1) Duplicate announcements for unconfirmed transactions
2) Duplicate announcements for txns that have already been rejected
3) Duplicate announcements for recently-confirmed transactions
    
For the first case, the duplicate request is filtered by the mempool since it already knows the unconfirmed transaction.  For the second case, rejected transactions are tracked separately and filtered.  Thus, only the third case of recently confirmed transactions remains.