### PR TITLE
rpcserver: Support getblockchaininfo genesis block.

### DIFF
--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -3606,7 +3606,8 @@ func TestHandleGetBlockchainInfo(t *testing.T) {
 		mockChain: func() *testRPCChain {
 			chain := defaultMockRPCChain()
 			chain.bestSnapshot = &blockchain.BestState{
-				Hash: *hash,
+				Hash:     *hash,
+				PrevHash: *prevHash,
 			}
 			chain.chainWork = big.NewInt(0).SetBytes([]byte{0x11, 0x5d, 0x28, 0x33, 0x84,
 				0x90, 0x90, 0xb0, 0x02, 0x65, 0x06})


### PR DESCRIPTION
This modifies the handler for `getblockchaininfo` to avoid calling the `MaxBlockSize` method with the zero hash which happens when queried at the genesis block because that is not supported and results in an error.