### PR TITLE
blockchain: Fix stxo deserialization for indexing.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1961,7 +1961,7 @@ func stxosToScriptSource(block *dcrutil.Block, stxos []spentTxOut, isTreasuryEna
 			prevOut := &txIn.PreviousOutPoint
 			source[*prevOut] = scriptSourceEntry{
 				version: stxo.scriptVersion,
-				script:  decompressScript(stxo.pkScript),
+				script:  stxo.pkScript,
 			}
 		}
 	}
@@ -1983,7 +1983,7 @@ func stxosToScriptSource(block *dcrutil.Block, stxos []spentTxOut, isTreasuryEna
 			prevOut := &txIn.PreviousOutPoint
 			source[*prevOut] = scriptSourceEntry{
 				version: stxo.scriptVersion,
-				script:  decompressScript(stxo.pkScript),
+				script:  stxo.pkScript,
 			}
 		}
 	}


### PR DESCRIPTION
This fixes an issue that was introduced by https://github.com/decred/dcrd/pull/2540:

- blockchain: Fix incorrect decompressScript calls.
    - This removes calls to decompressScript on scripts that are already decompressed.  The scripts are already decompressed when loaded for V3 spend journal and utxo set entries.
- blockchain: Fix V3 spend journal migration.
    - This fixes an issue with the V3 spend journal migration for a case where the ticket minimal outputs will be incorrectly missing in some migrated entries.
    - The issue is that when the utxoset is migrated from V2 to V3, the ticket minimal outputs are only kept for ticket submission outputs (output 0).  Additionally, the V2 spend journal only stores the ticket minimal outputs in the last spent entry.  Therefore, for example, in the case where a ticket has output 0 spent, and output 2 unspent, the ticket minimal output data will be lost once the utxoset is migrated from V2 to V3 (since it won't be stored for the unspent output 2, and additionally it won't be stored for the spent output 0 in the V2 spend journal since it is not fully spent).
    - This fixes the issue by migrating the spend journal first using the V2 utxo set where the ticket minimal output data will be available for all transaction output indexes.

**Note**: Anyone that has already run the latest on `master` to upgrade to database version `9` will need to drop their data directory, as it is corrupted due to missing info.

On the plus side, this does appear to speed up the migration quite a bit since looking up utxo entries in the V2 utxo set for the migration is faster due to the smaller number of entries (since V2 only had an entry per tx, and V3 has an entry per output).

Testing:
- Tested fully syncing the chain with the tx and address indexes enabled (both with a migrated database and fresh database).
- Re-tested invalidating/reconsidering a block deep within the migrated data to ensure spent tx outs are resurrected properly.