### PR TITLE
peer: Add inv type summary to debug message.

### DIFF
--- a/peer/log.go
+++ b/peer/log.go
@@ -89,7 +89,18 @@ func invSummary(invList []*wire.InvVect) string {
 	}
 
 	// More than one inv item.
-	return fmt.Sprintf("size %d", invLen)
+	var numTxns, numBlocks uint64
+	for _, iv := range invList {
+		switch iv.Type {
+		case wire.InvTypeTx:
+			numTxns++
+		case wire.InvTypeBlock:
+			numBlocks++
+		}
+	}
+
+	diff := uint64(invLen) - (numTxns + numBlocks)
+	return fmt.Sprintf("txns %d, blocks %d, other %d", numTxns, numBlocks, diff)
 }
 
 // locatorSummary returns a block locator as a human-readable string.


### PR DESCRIPTION
This modifies the debug message summary for `inv` messages that contain a list with multiple items to include a count of the blocks and transactions as opposed to solely the size of the list.  This is useful information for the new sync model to help confirm there are no blocks in the `inv` messages.
