### PR TITLE
multi: Update README.md files for go modules.

### DIFF
--- a/bech32/README.md
+++ b/bech32/README.md
@@ -12,9 +12,8 @@ Test vectors from BIP 173 are added to ensure compatibility with the BIP.
 
 ## Installation and Updating
 
-```bash
-$ go get -u github.com/decred/dcrd/bech32
-```
+This package is part of the `github.com/decred/dcrd/bech32` module.  Use the
+standard go tooling for working with modules to incorporate it.
 
 ## Examples
 

--- a/blockchain/README.md
+++ b/blockchain/README.md
@@ -81,9 +81,8 @@ mean the block being processed is the one that failed validation.
 
 ## Installation and Updating
 
-```bash
-$ go get -u github.com/decred/dcrd/blockchain
-```
+This package is part of the `github.com/decred/dcrd/blockchain/v3` module.  Use
+the standard go tooling for working with modules to incorporate it.
 
 ## Examples
 

--- a/blockchain/chaingen/README.md
+++ b/blockchain/chaingen/README.md
@@ -30,11 +30,10 @@ functions.
   required first block and enough blocks to have mature coinbase outputs to
   work with along with asserting the generator state along the way.
 
-## Installation
+## Installation and Updating
 
-```bash
-$ go get -u github.com/decred/dcrd/blockchain/chaingen
-```
+This package is part of the `github.com/decred/dcrd/blockchain/v3` module.  Use
+the standard go tooling for working with modules to incorporate it.
 
 ## License
 

--- a/blockchain/fullblocktests/README.md
+++ b/blockchain/fullblocktests/README.md
@@ -19,9 +19,8 @@ of blocks that exercise the consensus validation rules.
 
 ## Installation and Updating
 
-```bash
-$ go get -u github.com/decred/dcrd/blockchain/fullblocktests
-```
+This package is part of the `github.com/decred/dcrd/blockchain/v3` module.  Use
+the standard go tooling for working with modules to incorporate it.
 
 ## License
 

--- a/blockchain/indexers/README.md
+++ b/blockchain/indexers/README.md
@@ -26,11 +26,10 @@ via an RPC interface.
   - Stores all committed filters and committed filter headers for all blocks in
     the main chain
 
-## Installation
+## Installation and Updating
 
-```bash
-$ go get -u github.com/decred/dcrd/blockchain/indexers
-```
+This package is part of the `github.com/decred/dcrd/blockchain/v3` module.  Use
+the standard go tooling for working with modules to incorporate it.
 
 ## License
 

--- a/blockchain/standalone/README.md
+++ b/blockchain/standalone/README.md
@@ -3,7 +3,7 @@ standalone
 
 [![Build Status](https://github.com/decred/dcrd/workflows/Build%20and%20Test/badge.svg)](https://github.com/decred/dcrd/actions)
 [![ISC License](https://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![Doc](https://img.shields.io/badge/doc-reference-blue.svg)](https://pkg.go.dev/github.com/decred/dcrd/blockchain/standalone)
+[![Doc](https://img.shields.io/badge/doc-reference-blue.svg)](https://pkg.go.dev/github.com/decred/dcrd/blockchain/standalone/v2)
 
 Package standalone provides standalone functions useful for working with the
 Decred blockchain consensus rules.
@@ -37,9 +37,8 @@ The provided functions fall into the following categories:
 
 ## Installation and Updating
 
-```bash
-$ go get -u github.com/decred/dcrd/blockchain/standalone
-```
+This package is part of the `github.com/decred/dcrd/blockchain/standalone/v2`
+module.  Use the standard go tooling for working with modules to incorporate it.
 
 ## Examples
 

--- a/certgen/README.md
+++ b/certgen/README.md
@@ -16,9 +16,8 @@ this package additionally includes support for Ed25519 certificates.
 
 ## Installation and Updating
 
-```bash
-$ go get -u github.com/decred/dcrd/certgen
-```
+This package is part of the `github.com/decred/dcrd/certgen` module.  Use the
+standard go tooling for working with modules to incorporate it.
 
 ## License
 

--- a/chaincfg/README.md
+++ b/chaincfg/README.md
@@ -54,9 +54,8 @@ func main() {
 
 ## Installation and Updating
 
-```bash
-$ go get -u github.com/decred/dcrd/chaincfg
-```
+This package is part of the `github.com/decred/dcrd/chaincfg/v3` module.  Use
+the standard go tooling for working with modules to incorporate it.
 
 ## License
 

--- a/chaincfg/chainhash/README.md
+++ b/chaincfg/chainhash/README.md
@@ -8,11 +8,10 @@ chainhash
 chainhash provides a generic hash type and associated functions that allows the
 specific hash algorithm to be abstracted.
 
-## Installation and updating
+## Installation and Updating
 
-```bash
-$ go get -u github.com/decred/dcrd/chaincfg/chainhash
-```
+This package is part of the `github.com/decred/dcrd/chaincfg/chainhash` module.
+Use the standard go tooling for working with modules to incorporate it.
 
 ## License
 

--- a/connmgr/README.md
+++ b/connmgr/README.md
@@ -28,9 +28,8 @@ In addition the connection manager provides the following utilities:
 
 ## Installation and Updating
 
-```bash
-$ go get -u github.com/decred/dcrd/connmgr
-```
+This package is part of the `github.com/decred/dcrd/connmgr/v3` module.  Use the
+standard go tooling for working with modules to incorporate it.
 
 ## License
 

--- a/dcrec/secp256k1/README.md
+++ b/dcrec/secp256k1/README.md
@@ -57,9 +57,8 @@ defined by the secp256k1 domain parameters.
 
 ## Installation and Updating
 
-```bash
-$ go get -u github.com/decred/dcrd/dcrec/secp256k1/v3
-```
+This package is part of the `github.com/decred/dcrd/dcrec/secp256k1/v3` module.
+Use the standard go tooling for working with modules to incorporate it.
 
 ## Examples
 

--- a/dcrec/secp256k1/ecdsa/README.md
+++ b/dcrec/secp256k1/ecdsa/README.md
@@ -34,9 +34,8 @@ key without actually revealing it.
 
 ## Installation and Updating
 
-```bash
-$ go get -u github.com/decred/dcrd/dcrec/secp25k1/v3/ecdsa
-```
+This package is part of the `github.com/decred/dcrd/dcrec/secp256k1/v3` module.
+Use the standard go tooling for working with modules to incorporate it.
 
 ## Examples
 

--- a/dcrec/secp256k1/schnorr/README.md
+++ b/dcrec/secp256k1/schnorr/README.md
@@ -314,9 +314,8 @@ standardization attempts:
 
 ## Installation and Updating
 
-```bash
-$ go get -u github.com/decred/dcrd/dcrec/secp25k1/v3/schnorr
-```
+This package is part of the `github.com/decred/dcrd/dcrec/secp256k1/v3` module.
+Use the standard go tooling for working with modules to incorporate it.
 
 ## Examples
 

--- a/dcrjson/README.md
+++ b/dcrjson/README.md
@@ -24,9 +24,8 @@ ints, etc) to higher-level types with many nice and useful properties.
 
 ## Installation and Updating
 
-```bash
-$ go get -u github.com/decred/dcrd/dcrjson
-```
+This package is part of the `github.com/decred/dcrd/dcrjson/v3` module.  Use the
+standard go tooling for working with modules to incorporate it.
 
 ## Examples
 

--- a/dcrutil/README.md
+++ b/dcrutil/README.md
@@ -16,9 +16,8 @@ standalone package for any projects needing the functionality provided.
 
 ## Installation and Updating
 
-```bash
-$ go get -u github.com/decred/dcrd/dcrutil
-```
+This package is part of the `github.com/decred/dcrd/dcrutil/v3` module.  Use the
+standard go tooling for working with modules to incorporate it.
 
 ## License
 

--- a/dcrutil/txsort/README.md
+++ b/dcrutil/txsort/README.md
@@ -28,9 +28,8 @@ A comprehensive suite of tests is provided to ensure proper functionality.
 
 ## Installation and Updating
 
-```bash
-$ go get -u github.com/decred/dcrd/dcrutil/txsort
-```
+This package is part of the `github.com/decred/dcrd/dcrutil/v3` module.  Use the
+standard go tooling for working with modules to incorporate it.
 
 ## License
 

--- a/gcs/README.md
+++ b/gcs/README.md
@@ -42,9 +42,8 @@ DCP0005](https://github.com/decred/dcps/blob/master/dcp-0005/dcp-0005.mediawiki#
 
 ## Installation and Updating
 
-```bash
-$ go get -u github.com/decred/dcrd/gcs
-```
+This package is part of the `github.com/decred/dcrd/gcs/v2` module.  Use the
+standard go tooling for working with modules to incorporate it.
 
 ## License
 

--- a/hdkeychain/README.md
+++ b/hdkeychain/README.md
@@ -35,9 +35,8 @@ A comprehensive suite of tests is provided to ensure proper functionality.
 
 ## Installation and Updating
 
-```bash
-$ go get -u github.com/decred/dcrd/hdkeychain
-```
+This package is part of the `github.com/decred/dcrd/hdkeychain/v3` module.  Use
+the standard go tooling for working with modules to incorporate it.
 
 ## Examples
 

--- a/lru/README.md
+++ b/lru/README.md
@@ -25,9 +25,8 @@ lookups, inserts, and deletions.
 
 ## Installation and Updating
 
-```bash
-$ go get -u github.com/decred/dcrd/lru
-```
+This package is part of the `github.com/decred/dcrd/lru` module.  Use the
+standard go tooling for working with modules to incorporate it.
 
 ## Examples
 

--- a/peer/README.md
+++ b/peer/README.md
@@ -53,9 +53,8 @@ A quick overview of the major features peer provides are as follows:
 
 ## Installation and Updating
 
-```bash
-$ go get -u github.com/decred/dcrd/peer
-```
+This package is part of the `github.com/decred/dcrd/peer/v2` module.  Use the
+standard go tooling for working with modules to incorporate it.
 
 ## Examples
 

--- a/rpc/jsonrpc/types/README.md
+++ b/rpc/jsonrpc/types/README.md
@@ -17,9 +17,8 @@ projects needing to marshal to and from dcrd JSON-RPC requests and responses.
 
 ## Installation and Updating
 
-```bash
-$ go get -u github.com/decred/dcrd/rpc/jsonrpc/types
-```
+This package is part of the `github.com/decred/dcrd/rpc/jsonrpc/types/v2`
+module.  Use the standard go tooling for working with modules to incorporate it.
 
 ## License
 

--- a/rpcclient/README.md
+++ b/rpcclient/README.md
@@ -36,11 +36,10 @@ implement and the API is not stable yet.
   * Registered notifications are automatically reregistered
   * Back-off support on reconnect attempts
 
-## Installation
+## Installation and Updating
 
-```bash
-$ go get -u github.com/decred/dcrd/rpcclient
-```
+This package is part of the `github.com/decred/dcrd/rpcclient/v6` module.  Use
+the standard go tooling for working with modules to incorporate it.
 
 ## License
 

--- a/rpcclient/examples/dcrdwebsockets/README.md
+++ b/rpcclient/examples/dcrdwebsockets/README.md
@@ -10,24 +10,17 @@ demonstrate clean shutdown.
 
 ## Running the Example
 
-The first step is to use `go get` to download and install the rpcclient package:
-
-```bash
-$ go get -u github.com/decred/dcrd/rpcclient
-```
-
-Next, modify the `main.go` source to specify the correct RPC username and
-password for the RPC server:
+After obtaining the source code, modify the `main.go` source to specify the
+correct RPC username and password for the RPC server:
 
 ```Go
 	User: "yourrpcuser",
 	Pass: "yourrpcpass",
 ```
 
-Finally, navigate to the example's directory and run it with:
+Then, navigate to the example's directory and run it with:
 
 ```bash
-$ cd $GOPATH/src/github.com/decred/dcrd/rpcclient/examples/dcrdwebsockets
 $ go run *.go
 ```
 

--- a/rpctest/README.md
+++ b/rpctest/README.md
@@ -19,9 +19,8 @@ systems/integration tests.
 
 ## Installation and Updating
 
-```bash
-$ go get -u github.com/decred/dcrd/rpctest
-```
+This package is part of the `github.com/decred/dcrd` module.  Use the standard
+go tooling for working with modules to incorporate it.
 
 ## License
 

--- a/sampleconfig/README.md
+++ b/sampleconfig/README.md
@@ -13,9 +13,8 @@ samples of other configuration options.
 
 ## Installation and Updating
 
-```bash
-$ go get -u github.com/decred/dcrd/sampleconfig
-```
+This package is part of the `github.com/decred/dcrd` module.  Use the standard
+go tooling for working with modules to incorporate it.
 
 ## License
 

--- a/txscript/README.md
+++ b/txscript/README.md
@@ -13,15 +13,14 @@ package for any projects needing to use or validate Decred transaction scripts.
 
 ## Decred Scripts
 
-Decred provides a stack-based, FORTH-like language for the scripts in
-the Decred transactions.  This language is not turing complete
-although it is still fairly powerful.
+Decred provides a stack-based, FORTH-like language for the scripts in the Decred
+transactions.  This language is not Turing complete although it is still fairly
+powerful.
 
 ## Installation and Updating
 
-```bash
-$ go get -u github.com/decred/dcrd/txscript
-```
+This package is part of the `github.com/decred/dcrd/txscript/v3` module.  Use
+the standard go tooling for working with modules to incorporate it.
 
 ## Examples
 

--- a/wire/README.md
+++ b/wire/README.md
@@ -14,9 +14,8 @@ protocol level.
 
 ## Installation and Updating
 
-```bash
-$ go get -u github.com/decred/dcrd/wire
-```
+This package is part of the `github.com/decred/dcrd/wire` module.  Use the
+standard go tooling for working with modules to incorporate it.
 
 ## Decred Message Overview
 


### PR DESCRIPTION
This updates the installation and updating section of the `README.md` files in the various packages to call out the module they are a part of and instruct the consumer to use the standard go tooling instead of the old, and no longer correct, package-based 'go get -u' instructions.

Closes #2557.