### PR TITLE
rpcserver: Fix count tspend votes in mined block

### DIFF
--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -3210,11 +3210,11 @@ func handleGetTreasurySpendVotes(_ context.Context, s *Server, cmd interface{}) 
 				// Given this tspend was mined in the main
 				// chain, it doesn't make sense to count votes
 				// after it was mined. So stop early if the
-				// target block height is higher than the
-				// tspend's mined height. We need to count
-				// votes only up to the block _before_ the
-				// tspend was mined.
-				if blockHeight > int64(hdr.Height) {
+				// target block height is greater than or equal
+				// to the tspend's mined height. We need to
+				// count votes only up to the block _before_
+				// the tspend was mined.
+				if blockHeight >= int64(hdr.Height) {
 					endBlocks[hash] = hdr.PrevBlock
 				}
 


### PR DESCRIPTION
This fixes a bug where requesting the treasury spend vote counts on the
exact block where it was mined via the gettreasuryspendvotes rpc call
would fail with "tspend outside window".

Explicitly passing the block where the tspend was mined when that block
was the last possible block that particular tspend could be included in
the blockchain would fail because the votes on that block themselves
aren't counted towards determining tspend elligibility: votes are
tallied only up to its parent.

In essence, the test determining the cutoff height had an off-by-one by
using > instead of >= when a block was explicitly specified in the
request.

Before this fix:

```
$ dcrctl --testnet gettreasuryspendvotes "0000002fb43a19427c2c56764134bd1f4de64a5d5973ff4d38131dfa05431293" '["47de5efe98f073b6f33fbffb1743bacb850fbd8be5723195a744086061f5f0f2"]'
-32603: tspend outside of window: nextHeight 560881 start 560640 expiry 560882
```

After the fix:

```
$ dcrctl --testnet gettreasuryspendvotes "0000002fb43a19427c2c56764134bd1f4de64a5d5973ff4d38131dfa05431293" '["47de5efe98f073b6f33fbffb1743bacb850fbd8be5723195a744086061f5f0f2"]'
{
  "hash": "0000005b322a2c2ab15bdfd18464360c2db6d7ebd53737a3448c4cfbf43c82f3",
  "height": 560879,
  "votes": [
    {
      "hash": "47de5efe98f073b6f33fbffb1743bacb850fbd8be5723195a744086061f5f0f2",
      "expiry": 560882,
      "votestart": 560640,
      "voteend": 560880,
      "yesvotes": 380,
      "novotes": 65
    }
  ]
}
```

Props to @davecgh for noticing the issue.