### PR TITLE
upnp: Don't return loopback IPs in getOurIP.

### DIFF
--- a/upnp.go
+++ b/upnp.go
@@ -40,7 +40,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -200,11 +199,14 @@ func getChildService(d *device, serviceType string) *service {
 
 // getOurIP returns a best guess at what the local IP is.
 func getOurIP() (ip string, err error) {
-	hostname, err := os.Hostname()
-	if err != nil {
-		return
+	addrs, err := net.InterfaceAddrs()
+	for _, addr := range addrs {
+		ip, _, _ := net.ParseCIDR(addr.String())
+		if !ip.IsLoopback() {
+			return ip.String(), nil
+		}
 	}
-	return net.LookupCNAME(hostname)
+	return
 }
 
 // getServiceURL parses the xml description at the given root url to find the


### PR DESCRIPTION
Fixes #1620

`net.LookupCNAME` resolved to a loopback IP for me (127.0.1.1). The router can't port forward to this IP.

before
```
$ ./dcrd --upnp | grep -E "Successfully bound via UPnP|can't add UPnP port mapping"
-8: [WRN] SRVR: can't add UPnP port mapping: error 500 for AddPortMapping
```

after
```
$ git stash pop
$ go build
$ ./dcrd --upnp | grep -E "Successfully bound via UPnP|can't add UPnP port mapping"
-8: [WRN] SRVR: Successfully bound via UPnP to x.x.x.x:9108
```