### PR TITLE
netsync: Correct check for needTx.

### DIFF
--- a/internal/netsync/manager.go
+++ b/internal/netsync/manager.go
@@ -1245,7 +1245,7 @@ func (m *SyncManager) needTx(hash *chainhash.Hash) bool {
 		return false
 	}
 
-	return false
+	return true
 }
 
 // handleInvMsg handles inv messages from all peers.  This entails examining the


### PR DESCRIPTION
The transaction is needed if none of the things that disqualify it are true.