### PR TITLE
multi: Round 5 prerel module release ver updates.

### DIFF
--- a/blockchain/go.mod
+++ b/blockchain/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/decred/dcrd/dcrec v1.0.0
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210127014238-b33b46cf1a24
 	github.com/decred/dcrd/dcrutil/v4 v4.0.0-20210129181600-6ae0142d3b28
-	github.com/decred/dcrd/gcs/v3 v3.0.0-20210129192908-660d0518b4cf
+	github.com/decred/dcrd/gcs/v3 v3.0.0-20210129195202-a4265d63b619
 	github.com/decred/dcrd/lru v1.1.0
 	github.com/decred/dcrd/txscript/v4 v4.0.0-20210129190127-4ebd135a82f1
 	github.com/decred/dcrd/wire v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/decred/dcrd/bech32 v1.1.1
 	github.com/decred/dcrd/blockchain/stake/v4 v4.0.0-20210129192908-660d0518b4cf
 	github.com/decred/dcrd/blockchain/standalone/v2 v2.0.0
-	github.com/decred/dcrd/blockchain/v4 v4.0.0-20210129192908-660d0518b4cf
+	github.com/decred/dcrd/blockchain/v4 v4.0.0-20210129195202-a4265d63b619
 	github.com/decred/dcrd/certgen v1.1.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/chaincfg/v3 v3.0.0
@@ -20,12 +20,12 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210127014238-b33b46cf1a24
 	github.com/decred/dcrd/dcrjson/v3 v3.1.0
 	github.com/decred/dcrd/dcrutil/v4 v4.0.0-20210129181600-6ae0142d3b28
-	github.com/decred/dcrd/gcs/v3 v3.0.0-20210129192908-660d0518b4cf
+	github.com/decred/dcrd/gcs/v3 v3.0.0-20210129195202-a4265d63b619
 	github.com/decred/dcrd/hdkeychain/v3 v3.0.1-0.20210129190127-4ebd135a82f1
 	github.com/decred/dcrd/lru v1.1.0
 	github.com/decred/dcrd/peer/v2 v2.2.1-0.20210129192908-660d0518b4cf
 	github.com/decred/dcrd/rpc/jsonrpc/types/v3 v3.0.0
-	github.com/decred/dcrd/rpcclient/v7 v7.0.0-20210129192908-660d0518b4cf
+	github.com/decred/dcrd/rpcclient/v7 v7.0.0-20210129195202-a4265d63b619
 	github.com/decred/dcrd/txscript/v4 v4.0.0-20210129190127-4ebd135a82f1
 	github.com/decred/dcrd/wire v1.4.0
 	github.com/decred/go-socks v1.1.0

--- a/rpcclient/go.mod
+++ b/rpcclient/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/dcrjson/v3 v3.1.0
 	github.com/decred/dcrd/dcrutil/v4 v4.0.0-20210129181600-6ae0142d3b28
-	github.com/decred/dcrd/gcs/v3 v3.0.0-20210129192908-660d0518b4cf
+	github.com/decred/dcrd/gcs/v3 v3.0.0-20210129195202-a4265d63b619
 	github.com/decred/dcrd/rpc/jsonrpc/types/v3 v3.0.0
 	github.com/decred/dcrd/wire v1.4.0
 	github.com/decred/go-socks v1.1.0


### PR DESCRIPTION
This modifies some recently-updated modules to use a valid prerelease version so they can be used in require statements in consumer code that is also under development.

Several commits are needed since there is a dependency chain that involves transitive deps.

The updated direct dependencies are as follows:

- github.com/decred/dcrd/blockchain/v4@v4.0.0-20210129195202-a4265d63b619
- github.com/decred/dcrd/gcs/v3@v3.0.0-20210129195202-a4265d63b619
- github.com/decred/dcrd/rpcclient/v7@v7.0.0-20210129195202-a4265d63b619