### PR TITLE
apbf: Introduce Age-Partitioned Bloom Filters.

### DIFF
--- a/container/apbf/README.md
+++ b/container/apbf/README.md
@@ -1,0 +1,170 @@
+apbf
+====
+
+[![Build Status](https://github.com/decred/dcrd/workflows/Build%20and%20Test/badge.svg)](https://github.com/decred/dcrd/actions)
+[![ISC License](https://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![Doc](https://img.shields.io/badge/doc-reference-blue.svg)](https://pkg.go.dev/github.com/decred/dcrd/container/apbf)
+
+## Age-Partitioned Bloom Filter (APBF)
+
+An [Age-Partitioned Bloom Filter](https://arxiv.org/pdf/2001.03147.pdf) is a
+probabilistic data structure suitable for processing unbounded data streams
+where more recent items are more significant than older ones and some false
+positives are acceptable.  It has similar computational costs as traditional
+Bloom filters and provides space efficiency that is competitive with the current
+best-known, and more complex, Dictionary approaches.
+
+Similar to classic Bloom filters, APBFs have a non-zero probability of false
+positives that can be tuned via parameters and are free from false negatives up
+to the capacity of the filter.  However, unlike classic Bloom filters, where the
+false positive rate climbs as items are added until all queries are a false
+positive, APBFs provide a configurable upper bound on the false positive rate
+for an unbounded number of additions.
+
+The unbounded property is achieved by adding and retiring disjoint segments over
+time where each segment is a slice of a partitioned Bloom filter.  The slices
+are conceptually aged over time as new items are added by shifting them and
+discarding the oldest one.
+
+An ideal use case for APBFs is efficiently deduplicating a continuous and
+unbounded event stream with a tunable upper bound on the false positive rate.
+
+### Additional Implementation Details
+
+This implementation deviates from the original paper in at least a couple of
+important ways:
+
+- It uses Dillinger-Manolis enhanced double hashing instead of the more
+  traditional Kirsch-Mitzenmacher double hashing since the latter imposes an
+  observable accuracy limit on the filter while the former comes much closer to
+  the theoretical limit of two-index fingerprinting
+- Every filter is given a unique key for the internal hashing logic so each one
+  will have a unique set of false positives and that key is automatically
+  changed when the filter is manually reset by the caller
+
+## Choosing Parameters
+
+The API provides two different mechanisms for creating an APBF with the desired properties:
+
+- The `NewFilter` method
+
+  This is the recommended approach for most applications. It is parameterized by
+  the number of most-recently added items that must always return true and the
+  target false positive rate to maintain.
+
+  For most applications, the values chosen by this option will be perfectly
+  acceptable, however, applications that desire greater control over the tuning
+  can make use of the second method instead.
+
+- The `NewFilterKL` method
+
+  This provides applications with greater control over the tradeoff between
+  overall filter size and computational speed.  It is parameterized by the
+  number of most-recently added items that must always return true, the number
+  slices which need consecutive matches, `K`, and the number of additional
+  slices, `L`, to reach a desired target false positive rate to maintain.
+
+  For convenience, the `go generate` command may be used in the code directory
+  to generate a table of `K` and `L` combinations along with the false positive
+  rate they maintain and average expected number of accesses for false queries
+  to help select appropriate values.
+
+## Accuracy Under Workloads
+
+The following details the results of experimental validation of this
+implementation with respect to false positive rate of filters with various
+capacities and target false positive rates.
+
+The methodology used for this analysis is to subject each filter to
+`10*capacity` distinct additions and to probe each filter with
+`capacity*(1/false positive rate)` distinct items that were never added.  For
+example, in the case of a capacity of `1000` and target false positive rate of
+`0.001`, ten thousand items are added and one million items that were never
+added are probed.
+
+It is also worth noting that this analysis uses the `NewFilter` method, as
+described above, for the parameter selection.
+
+Capacity | Target FP | Actual Observed FP
+---------|-----------|-------------------
+1000     |   0.1%    | 0.099%
+10000    |   0.1%    | 0.096%
+10000000 |   0.1%    | 0.1%
+1000     |   1.0%    | 0.948%
+10000    |   1.0%    | 0.868%
+10000000 |   1.0%    | 0.857%
+1000     |   2.0%    | 1.448%
+10000    |   2.0%    | 1.47%
+10000000 |   2.0%    | 1.46%
+1000     |  10.0%    | 6.74%
+10000    |  10.0%    | 6.834%
+10000000 |  10.0%    | 7.027%
+
+## Memory Usage
+
+The total space (in bytes) used by a filter that can hold `n` items with a false
+positive rate of `fpRate` is approximately `1.3n * -log(fpRate)`, where log is
+base 10.
+
+Here is a table of measured usage for some common values for convenience:
+
+Capacity | Target FP | Size
+---------|-----------|-----------
+1000     |   1.0%    | 2.78 KiB
+10000    |   1.0%    | 27.19 KiB
+100000   |   1.0%    | 271.28 KiB
+1000     |   0.1%    | 4.10 KiB
+10000    |   0.1%    | 40.34 KiB
+100000   |   0.1%    | 402.62 KiB
+
+## Benchmarks
+
+The following results demonstrate the performance of the primary filter
+operations.  The benchmarks are from a Ryzen 7 1700 processor.
+
+### `Add`
+
+Capacity | Target FP |  Time / Op  | Allocs / Op
+---------|-----------|-------------|------------
+1000     | 0.1%      | 159ns ± 5%  | 0
+1000     | 0.01%     | 208ns ± 0%  | 0
+1000     | 0.001%    | 245ns ± 0%  | 0
+100000   | 0.01%     | 198ns ± 3%  | 0
+100000   | 0.0001%   | 271ns ± 2%  | 0
+1000000  | 0.00001%  | 496ns ± 7%  | 0
+
+### `Contains` (item matches filter, worst case)
+
+Capacity | Target FP |  Time / Op  | Allocs / Op
+---------|-----------|-------------|------------
+1000     | 0.1%      | 175ns ± 1%  | 0
+1000     | 0.01%     | 228ns ± 1%  | 0
+1000     | 0.001%    | 267ns ± 1%  | 0
+100000   | 0.01%     | 211ns ± 1%  | 0
+100000   | 0.0001%   | 282ns ± 1%  | 0
+
+### `Contains` (item does NOT match filter)
+
+Capacity | Target FP |  Time / Op  | Allocs / Op
+---------|-----------|-------------|------------
+1000     | 0.1%      | 45.4ns ± 0% | 0
+1000     | 0.01%     | 57.6ns ±21% | 0
+1000     | 0.001%    | 56.2ns ±19% | 0
+100000   | 0.01%     | 48.7ns ±15% | 0
+100000   | 0.0001%   | 49.6ns ±19% | 0
+
+## Installation and Updating
+
+This package is part of the `github.com/decred/dcrd/container/apbf` module.  Use
+the standard go tooling for working with modules to incorporate it.
+
+## Examples
+
+* [Basic Usage](https://pkg.go.dev/github.com/decred/dcrd/container/apbf#example-package-BasicUsage)  
+  Demonstrates creating a new APBF, adding items to it up to the maximum
+  capacity, querying the oldest item, then adding more items to it in order to
+  cause the older items to be evicted.
+
+## License
+
+Package apbf is licensed under the [copyfree](http://copyfree.org) ISC License.

--- a/container/apbf/bench_test.go
+++ b/container/apbf/bench_test.go
@@ -1,0 +1,227 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package apbf
+
+import (
+	"encoding/binary"
+	"fmt"
+	"testing"
+)
+
+// BenchmarkAdd benchmarks adding items to an APBF for various capacities and
+// false positive rates.
+func BenchmarkAdd(b *testing.B) {
+	benches := []struct {
+		capacity uint32  // target capacity
+		fpRate   float64 // target false positive rate
+	}{{
+		capacity: 1000,
+		fpRate:   0.001,
+	}, {
+		capacity: 1000,
+		fpRate:   0.0001,
+	}, {
+		capacity: 1000,
+		fpRate:   0.00001,
+	}, {
+		capacity: 100000,
+		fpRate:   0.0001,
+	}, {
+		capacity: 100000,
+		fpRate:   0.000001,
+	}, {
+		capacity: 1000000,
+		fpRate:   0.0000001,
+	}}
+
+	for benchIdx := range benches {
+		bench := benches[benchIdx]
+		benchName := fmt.Sprintf("capacity=%d/fprate=%0.7f", bench.capacity,
+			bench.fpRate)
+		b.Run(benchName, func(b *testing.B) {
+			filter := NewFilter(bench.capacity, bench.fpRate)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			var data [4]byte
+			for i := 0; i < b.N; i++ {
+				binary.LittleEndian.PutUint32(data[:], uint32(i))
+				filter.Add(data[:])
+			}
+		})
+	}
+}
+
+// BenchmarkContainsTrue benchmarks membership queries on an APBF for various
+// capacities and false positive rates when the item exists in the filter and
+// is near worst case performance.
+func BenchmarkContainsTrue(b *testing.B) {
+	benches := []struct {
+		capacity uint32  // target capacity
+		fpRate   float64 // target false positive rate
+	}{{
+		capacity: 1000,
+		fpRate:   0.001,
+	}, {
+		capacity: 1000,
+		fpRate:   0.0001,
+	}, {
+		capacity: 1000,
+		fpRate:   0.00001,
+	}, {
+		capacity: 100000,
+		fpRate:   0.0001,
+	}, {
+		capacity: 100000,
+		fpRate:   0.000001,
+	}}
+
+	for benchIdx := range benches {
+		bench := benches[benchIdx]
+		benchName := fmt.Sprintf("capacity=%d/fprate=%0.6f", bench.capacity,
+			bench.fpRate)
+		b.Run(benchName, func(b *testing.B) {
+			// Load the filter so the benchmark is with a max capacity filter.
+			filter := NewFilter(bench.capacity, bench.fpRate)
+			var data [4]byte
+			for i := uint32(0); i < filter.Capacity(); i++ {
+				binary.LittleEndian.PutUint32(data[:], i)
+				filter.Add(data[:])
+			}
+			binary.LittleEndian.PutUint32(data[:], filter.Capacity()/2)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				filter.Contains(data[:])
+			}
+		})
+	}
+}
+
+// BenchmarkContainsFalse benchmarks membership queries on an APBF for various
+// capacities and false positive rates when the item does not exist in the
+// filter.
+func BenchmarkContainsFalse(b *testing.B) {
+	benches := []struct {
+		capacity uint32  // target capacity
+		fpRate   float64 // target false positive rate
+	}{{
+		capacity: 1000,
+		fpRate:   0.001,
+	}, {
+		capacity: 1000,
+		fpRate:   0.0001,
+	}, {
+		capacity: 1000,
+		fpRate:   0.00001,
+	}, {
+		capacity: 100000,
+		fpRate:   0.0001,
+	}, {
+		capacity: 100000,
+		fpRate:   0.000001,
+	}}
+
+	for benchIdx := range benches {
+		bench := benches[benchIdx]
+		benchName := fmt.Sprintf("capacity=%d/fprate=%0.6f", bench.capacity,
+			bench.fpRate)
+		b.Run(benchName, func(b *testing.B) {
+			// Load the filter so the benchmark is with a max capacity filter.
+			filter := NewFilter(bench.capacity, bench.fpRate)
+			var data [4]byte
+			for i := uint32(0); i < filter.Capacity(); i++ {
+				binary.LittleEndian.PutUint32(data[:], i)
+				filter.Add(data[:])
+			}
+			binary.LittleEndian.PutUint32(data[:], filter.Capacity()+1)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				filter.Contains(data[:])
+			}
+		})
+	}
+}
+
+// BenchmarkReset benchmarks resetting an APBF for various capacities and false
+// positive rates.
+func BenchmarkReset(b *testing.B) {
+	benches := []struct {
+		capacity uint32  // target capacity
+		fpRate   float64 // target false positive rate
+	}{{
+		capacity: 1000,
+		fpRate:   0.001,
+	}, {
+		capacity: 1000,
+		fpRate:   0.0001,
+	}, {
+		capacity: 1000,
+		fpRate:   0.00001,
+	}, {
+		capacity: 10000,
+		fpRate:   0.00001,
+	}, {
+		capacity: 100000,
+		fpRate:   0.000001,
+	}}
+
+	for benchIdx := range benches {
+		bench := benches[benchIdx]
+		benchName := fmt.Sprintf("capacity=%d/fprate=%0.6f", bench.capacity,
+			bench.fpRate)
+		b.Run(benchName, func(b *testing.B) {
+			filter := NewFilter(bench.capacity, bench.fpRate)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				filter.Reset()
+			}
+		})
+	}
+}
+
+// BenchmarkNewFilter benchmarks creating a new APBF for various capacities and
+// false positive rates.
+func BenchmarkNewFilter(b *testing.B) {
+	benches := []struct {
+		capacity uint32  // target capacity
+		fpRate   float64 // target false positive rate
+	}{{
+		capacity: 1000,
+		fpRate:   0.001,
+	}, {
+		capacity: 1000,
+		fpRate:   0.0001,
+	}, {
+		capacity: 1000,
+		fpRate:   0.00001,
+	}, {
+		capacity: 10000,
+		fpRate:   0.00001,
+	}, {
+		capacity: 100000,
+		fpRate:   0.000001,
+	}}
+
+	var noElide *Filter
+	for benchIdx := range benches {
+		bench := benches[benchIdx]
+		benchName := fmt.Sprintf("capacity=%d/fprate=%0.6f", bench.capacity,
+			bench.fpRate)
+		b.Run(benchName, func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				noElide = NewFilter(bench.capacity, bench.fpRate)
+			}
+		})
+	}
+	_ = noElide
+}

--- a/container/apbf/example_test.go
+++ b/container/apbf/example_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package apbf_test
+
+import (
+	"fmt"
+
+	"github.com/decred/dcrd/container/apbf"
+)
+
+// This example demonstrates creating a new APBF, adding items to it up to the
+// maximum capacity, querying the oldest item, then adding more items to it in
+// order to cause the older items to be evicted.
+func Example_basicUsage() {
+	// Create a new filter that will always return true for the most-recent 1000
+	// items and maintains a false positive rate on items that were never added
+	// of 0.01% (1 in 10,000).
+	const maxItems = 1000
+	const fpRate = 0.0001
+	filter := apbf.NewFilter(maxItems, fpRate)
+
+	// Add items to the filter.
+	for i := 0; i < maxItems; i++ {
+		item := fmt.Sprintf("item %d", i)
+		filter.Add([]byte(item))
+	}
+
+	// At this point, the maximum number of items guaranteed to return true has
+	// been reached, so the first entry will still be a member.
+	if !filter.Contains([]byte("item 0")) {
+		fmt.Println("filter does not contain expected item 0")
+		return
+	}
+
+	// Adding more items will eventually evict the oldest items.
+	for i := 0; i < maxItems; i++ {
+		item := fmt.Sprintf("item %d", i+maxItems)
+		filter.Add([]byte(item))
+	}
+	if filter.Contains([]byte("item 0")) {
+		fmt.Println("filter contains unexpected item 0")
+		return
+	}
+
+	// Output:
+	//
+}

--- a/container/apbf/filter.go
+++ b/container/apbf/filter.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
+//go:generate go run generateapbftable.go
+
 // Package apbf implements an optimized Age-Partitioned Bloom Filter.
 package apbf
 
@@ -486,6 +488,11 @@ func (f *Filter) Reset() {
 // Applications might prefer using NewFilter to specify the max capacity and a
 // target false positive rate unless they specifically require the additional
 // fine tuning provided here.
+//
+// For convenience, the 'go generate' command may be used in the code directory
+// to generate a table of k and l combinations along with the false positive
+// rate they maintain and average expected number of accesses for false queries
+// to help select appropriate parameters.
 //
 // Note that, due to rounding, the actual max number of items that can be added
 // to the filter before old entries are expired might actually be slightly

--- a/container/apbf/filter.go
+++ b/container/apbf/filter.go
@@ -1,0 +1,608 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+// Package apbf implements an optimized Age-Partitioned Bloom Filter.
+package apbf
+
+import (
+	"encoding/binary"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/dchest/siphash"
+)
+
+// References:
+//   [APBF] Age-Partitioned Bloom Filters (Shtul, Baquero, Almeida)
+//     https://arxiv.org/pdf/2001.03147.pdf
+//
+//   [LHSP] Less Hashing, Same Performance: Building a Better Bloom Filter
+//      (Kirsch, Mitzenmacher)
+//
+//   [BFPV] Bloom Filters in Probabilistic Verification (Dillinger, Manolis)
+
+// calcFPRateKey is used as the key when caching results for the false positive
+// calculations.
+type calcFPRateKey struct {
+	a, i uint16
+}
+
+// calcFPRateInternal calculates and returns the false positive rate for the
+// provided parameters using the given results map to cache intermediate
+// results.
+func calcFPRateInternal(results map[calcFPRateKey]float64, k, l uint8, a, i uint16) float64 {
+	// The false positive rate is calculated according to the following
+	// recursively-defined function provided in [APBF]:
+	//
+	//              {1                                        , if a = k
+	// F(k,l,a,i) = {0                                        , if i > l + a
+	//              {(r_i)F(k,l,a+1,i+1) + (1-r_i)F(k,l,0,i+1), otherwise
+
+	if a == uint16(k) {
+		return 1
+	} else if i > uint16(l)+a {
+		return 0
+	}
+
+	// Return stored results to avoid a bunch of duplicate work.
+	resultKey := calcFPRateKey{a, i}
+	if result, ok := results[resultKey]; ok {
+		return result
+	}
+
+	// Calculate the fill ratio for the slice.
+	fillRatio := float64(0.5)
+	if i < uint16(k) {
+		fillRatio = float64(i+1) / float64(2*k)
+	}
+
+	firstTerm := fillRatio * calcFPRateInternal(results, k, l, a+1, i+1)
+	secondTerm := (1 - fillRatio) * calcFPRateInternal(results, k, l, 0, i+1)
+	result := firstTerm + secondTerm
+	results[resultKey] = result
+	return result
+}
+
+// CalcFPRate calculates and returns the false positive rate for an APBF
+// created with the given parameters.
+//
+// NOTE: This involves allocations, so the result should be cached by the caller
+// if it intends to use it multiple times.
+//
+// This function is safe for concurrent access.
+func CalcFPRate(k, l uint8) float64 {
+	results := make(map[calcFPRateKey]float64, 2*uint16(k)*uint16(l))
+	return calcFPRateInternal(results, k, l, 0, 0)
+}
+
+// Filter implements an Age-Partitioned Bloom Filter (APBF) that is safe for
+// concurrent access.
+//
+// An APBF is a probabilistic data structure suitable for use in processing
+// unbounded data streams where more recent items are more significant than
+// older ones and some false positives are acceptable.  It has similar
+// computational costs as traditional Bloom filters and provides space
+// efficiency that is competitive with the current best-known, and more complex,
+// Dictionary approaches.
+//
+// Similar to classic Bloom filters, APBFs have a non-zero probability of false
+// positives that can be tuned via parameters and are free from false negatives
+// up to the capacity of the filter.  However, unlike classic Bloom filters,
+// where the false positive rate climbs as items are added until all queries are
+// a false positive, APBFs provide a configurable upper bound on the false
+// positive rate for an unbounded number of additions.
+//
+// The unbounded property is achieved by adding and retiring disjoint segments
+// over time where each segment is a slice of a partitioned Bloom filter.  The
+// slices are conceptually aged over time as new items are added by shifting
+// them and discarding the oldest one.
+//
+// See the NewFilter documentation for details regarding tuning parameters and
+// expected approximate total space usage.
+type Filter struct {
+	// k is the number of slices which need consecutive matches for an item to
+	// be considered in the filter.  This is similar to the k parameter of
+	// static bloom filters which use exactly k hash functions for k different
+	// slices, except here it is the number of consecutive matches in a larger
+	// sequence of distinct slices determined by this parameter along with the l
+	// parameter below to preserve the false positive rate.
+	k uint8
+
+	// l is the additional number of slices which comprise the region of items
+	// that are transitioning to expired.
+	//
+	// The sum of this parameter and k above determines the total number of
+	// slices, which in turn determines the false positive rate and also
+	// influences the filter capacity.
+	l uint8
+
+	// kPlusL is simply the sum of the k and l parameters and is stored to avoid
+	// calculating it repeatedly.  It is the total number of slices.
+	kPlusL uint16
+
+	// bitsPerSlice is the number of physical bits occupied by each slice that
+	// comprise the overall filter.
+	bitsPerSlice uint64
+
+	// itemsPerGeneration is the number of items per generation.  Conceptually,
+	// the slices are aged every time this number of items is inserted into the
+	// filter resulting in items inserted in older generations expiring.  In
+	// other words, the items are effectively partitioned by age.
+	itemsPerGeneration uint32
+
+	// ****************************************************************
+	// The fields below this point are protected by the embedded mutex.
+	// ****************************************************************
+
+	mtx sync.Mutex
+
+	// key0 and key1 are used to seed the hash function in order to ensure
+	// attackers are not able to intentionally grind false positives that would
+	// otherwise affect the entire network if all nodes were calculating the
+	// same hash values.
+	key0, key1 uint64
+
+	// itemsInCurGeneration is the number of items that have been added to the
+	// current generation.  The slices are aged once the number of items per
+	// generation is reached by conceptually shifting them to subsequent slices
+	// and throwing away the overflow from the final slice.  In practice, the
+	// shifting is done via logical shifts in a ring buffer by keeping track of
+	// the index of the first logical slice (called the base index).
+	itemsInCurGeneration uint32
+
+	// baseIndex is the index of the position of the first slice within the ring
+	// buffer.
+	baseIndex uint16
+
+	// data is the actual filter data implemented as a packed ring buffer where
+	// the individual filter slices (partitions) perform logical shifts.
+	data []byte
+}
+
+// Capacity returns the max number of items that were most recently added which
+// are guaranteed to return true.  Adding more items than the returned value
+// will cause the oldest items to be expired.
+//
+// This function is safe for concurrent access.
+func (f *Filter) Capacity() uint32 {
+	return uint32(f.l+1) * f.itemsPerGeneration
+}
+
+// FPRate calculates and returns the actual false positive rate for the filter.
+//
+// NOTE: This involves allocations, so the result should be cached by the caller
+// if it intends to use it multiple times.
+//
+// This function is safe for concurrent access.
+func (f *Filter) FPRate() float64 {
+	return CalcFPRate(f.k, f.l)
+}
+
+// Size returns the total bytes occupied by the filter data plus overhead.
+//
+// This function is safe for concurrent access.
+func (f *Filter) Size() int {
+	const overhead = 70
+	f.mtx.Lock()
+	result := len(f.data) + overhead
+	f.mtx.Unlock()
+	return result
+}
+
+// K returns the filter configuration parameter for the number of slices that
+// need consecutive matches.  It is one of the tunable parameters that determine
+// the overall capacity and false positive rate of the filter.
+//
+// This function is safe for concurrent access.
+func (f *Filter) K() uint8 {
+	return f.k
+}
+
+// L returns the filter configuration parameter for the number of additional
+// slices.  It is one of the tunable parameters that determine the overall
+// capacity and false positive rate of the filter.
+//
+// This function is safe for concurrent access.
+func (f *Filter) L() uint8 {
+	return f.l
+}
+
+// nextGeneration transitions the filter to the next generation which
+// effectively ages all items and potentially expires the oldest generation of
+// items.
+//
+// This function MUST be called with the filter mutex held.
+func (f *Filter) nextGeneration() {
+	// Shift the position of the first slice within the ring buffer to the left
+	// by one.
+	if f.baseIndex == 0 {
+		f.baseIndex = f.kPlusL
+	}
+	f.baseIndex--
+
+	// Clear the bits associated with the new logical slice.  Note that since
+	// the logical slice was just rotated once backwards around the ring buffer
+	// above, this clears what was previously the oldest slice so the new
+	// entries take its place.
+	startBit := uint64(f.baseIndex) * f.bitsPerSlice
+	endBit := startBit + f.bitsPerSlice
+
+	// Clear bits up to the next byte boundary.
+	byteIdx := startBit >> 3
+	if bit := startBit & 7; bit != 0 {
+		f.data[byteIdx] &= byte(1<<bit - 1)
+		byteIdx++
+	}
+
+	// Clear full bytes in one fell swoop when possible.
+	if endByteIdx := (endBit >> 3); endByteIdx > byteIdx {
+		fullBytes := endByteIdx - byteIdx
+		data := f.data[byteIdx : byteIdx+fullBytes]
+		for i := range data {
+			data[i] = 0
+		}
+		byteIdx += fullBytes
+	}
+
+	// Clear any remaining bits.
+	if byteIdx < uint64(len(f.data)) {
+		f.data[byteIdx] &^= byte(1<<(endBit&7) - 1)
+	}
+
+	f.itemsInCurGeneration = 0
+}
+
+// deriveIndex uses enhanced double hashing to calculate a unique index for the
+// given logical slice number using the closed formula.  In order to support
+// more efficient interleaving of the calculation while looping over several
+// slices, it also returns the intermediate accumulator which can be fed into
+// subsequent iterations of the algorithm to potentially provide significant
+// speed improvements.
+//
+// Note that each slice conceptually uses an independent hash function to
+// determine which bit to index.  However, rather than using the more
+// traditional approach of a distinct hash function for each one, enhanced
+// double hashing is used to effectively generate the necessary hash function
+// because it is significantly faster while still coming quite close to the
+// theoretical limit of two-index fingerprinting.
+//
+// It is defined as "f(i) = hash1 + i*hash2 + (i^3 - i)/6 (mod m)", where m is
+// the number of bits to index, however, this function does not perform the
+// modular reduction and instead leaves it up to the caller.
+//
+// It is also worth noting that enhanced double hashing is used in this
+// implementation over the more common double hashing referenced in [APBF], and
+// defined in [LHSP], which generates the necessary hash functions from a linear
+// combination of the two independent hash functions as "f(i) = hash1 + i*hash2
+// (mod m)" because, as pointed out in [BFPV], that construction results in
+// imposing an observable accuracy limit since there are no restrictions placed
+// on the second hash to ensure the resulting indices are (almost) all unique.
+// Namely, when the second hash function produces 0, all indices are the same,
+// and, similarly, when it produces a value that divides m, the number of
+// indices probed will be the minimum of the number of slices and the produced
+// value, which could be as small as 2.
+//
+// See section 5.2 of [BFPV] for further details, if desired.
+func deriveIndex(slice uint16, hash1, hash2 uint64) (uint64, uint64) {
+	s := uint64(slice)
+	z := (s*s + s) / 2
+	derivedIdx := hash1 + s*hash2 + (z*(s-1))/3
+	return derivedIdx, hash2 + z
+}
+
+// setBit unconditionally sets the bit at the provided absolute index in the
+// underlying filter data.
+//
+// This function MUST be called with the filter mutex held.
+func (f *Filter) setBit(bit uint64) {
+	f.data[bit>>3] |= 1 << (bit & 7)
+}
+
+// Add inserts the provided data into the filter.
+//
+// This function is safe for concurrent access.
+func (f *Filter) Add(data []byte) {
+	// Transition the filter to the next generation when adding the new item
+	// will exceed the number of items per generation.  This effectively ages
+	// all existing items and potentially expires the oldest generation of
+	// items.
+	f.mtx.Lock()
+	if f.itemsInCurGeneration == f.itemsPerGeneration {
+		f.nextGeneration()
+	}
+	f.itemsInCurGeneration++
+
+	// Set the relevant bits in the filter for 'k' slices, starting from the
+	// first slice (slice 0), as determined by the equivalent of a separate hash
+	// (index) function for each slice.  See the comments in deriveIndex for
+	// more details about the enhanced double hashing technique used.
+	//
+	// Note that this implementation uses a ring buffer where the position index
+	// of the first slice is modified to simulate shifting, so the code below
+	// uses logical slices to map to the correct physical location within the
+	// filter data.
+	//
+	// As a further optimization, rather than fully calculating each independent
+	// bit index for each slice via the closed formula for enhanced double
+	// hashing, this interleaves the calculation with the loop over the slices
+	// which benchmarking shows is about 30% faster.
+	logicalSlice := f.baseIndex
+	sliceBitOffset := uint64(logicalSlice) * f.bitsPerSlice
+	hash1, hash2 := siphash.Hash128(f.key0, f.key1, data)
+	derivedIdx, acc := deriveIndex(logicalSlice, hash1, hash2)
+	for i := uint8(0); i < f.k; i++ {
+		f.setBit(sliceBitOffset + derivedIdx%f.bitsPerSlice)
+
+		// Move to the next logical slice while wrapping around the ring buffer
+		// if needed.
+		logicalSlice++
+		if logicalSlice == f.kPlusL {
+			logicalSlice = 0
+			sliceBitOffset = 0
+
+			// Reset the derived bit index using enhanced double hashing
+			// accordingly.
+			derivedIdx, acc = hash1, hash2
+			continue
+		}
+		sliceBitOffset += f.bitsPerSlice
+
+		// Derive the next bit index using enhanced double hashing.
+		derivedIdx += acc
+		acc += uint64(logicalSlice)
+	}
+	f.mtx.Unlock()
+}
+
+// isBitSet returns whether or not the bit at the provided absolute index in the
+// underlying filter data is set.
+//
+// This function MUST be called with the filter mutex held.
+func (f *Filter) isBitSet(bit uint64) bool {
+	return f.data[bit>>3]&(1<<(bit&7)) != 0
+}
+
+// Contains returns the result of a probabilistic membership test of the
+// provided data such that there is a non-zero probability of false positives,
+// per the false positive rate of the filter, and a zero probability of false
+// negatives for the previous number of items supported by the max capacity of
+// the filter.
+//
+// In other words, the most recent max capacity number of items added to the
+// filter will always return true while items that were never added or have been
+// expired will only report true with the false positive rate of the filter.
+//
+// This function is safe for concurrent access.
+func (f *Filter) Contains(data []byte) bool {
+	// Attempt to find the required 'k' consecutive matches using an algorithm
+	// that reduces the average number of tests required.
+	//
+	// The algorithm works by choosing the starting position such that it leaves
+	// exactly 'k' consecutive slices to be tested, accumulates the matching
+	// sub sequences, and jumps backwards 'k' slices when a match fails.
+	//
+	// Recall that this implementation uses a ring buffer where the position
+	// index of the first slice is modified to simulate shifting, so the code
+	// below uses logical slices to map to the correct physical location within
+	// the filter data.
+	//
+	// As a further optimization, similar to when the items are added, rather
+	// than fully calculating each independent bit index for each slice via the
+	// closed formula for enhanced double hashing, this interleaves the
+	// calculation with the loop over the slices for consecutive matches which
+	// benchmarking shows is about 12% faster on average.
+	var result = false
+	f.mtx.Lock()
+	prevMatches, curMatches := uint8(0), uint8(0)
+	physicalSlice := uint16(f.l)
+	logicalSlice := (f.baseIndex + physicalSlice) % f.kPlusL
+	sliceBitOffset := uint64(logicalSlice) * f.bitsPerSlice
+	hash1, hash2 := siphash.Hash128(f.key0, f.key1, data)
+	derivedIdx, acc := deriveIndex(logicalSlice, hash1, hash2)
+	for {
+		if f.isBitSet(sliceBitOffset + derivedIdx%f.bitsPerSlice) {
+			// Successful query when the required number of consecutive matches
+			// is achieved.
+			curMatches++
+			if prevMatches+curMatches == f.k {
+				result = true
+				break
+			}
+
+			// Move to the next logical slice while wrapping around the ring
+			// buffer if needed.
+			physicalSlice++
+			logicalSlice++
+			if logicalSlice == f.kPlusL {
+				logicalSlice = 0
+				sliceBitOffset = 0
+
+				// Reset the derived bit index using enhanced double hashing
+				// accordingly.
+				derivedIdx, acc = hash1, hash2
+				continue
+			}
+			sliceBitOffset += f.bitsPerSlice
+
+			// Derive the next bit index using enhanced double hashing.
+			derivedIdx += acc
+			acc += uint64(logicalSlice)
+			continue
+		}
+
+		// Nothing more to do when there are not enough slices left to achieve
+		// the required number of consecutive matches.
+		if uint16(f.k) > physicalSlice {
+			break
+		}
+
+		// Skip back the required number of matches while accumulating any
+		// matching sub sequence.
+		physicalSlice -= uint16(f.k)
+		prevMatches = curMatches
+		curMatches = 0
+
+		// Reset logical slice and derive the associated bit index using
+		// enhanced double hashing.
+		logicalSlice = (f.baseIndex + physicalSlice) % f.kPlusL
+		sliceBitOffset = uint64(logicalSlice) * f.bitsPerSlice
+		derivedIdx, acc = deriveIndex(logicalSlice, hash1, hash2)
+	}
+	f.mtx.Unlock()
+
+	return result
+}
+
+// Reset clears the filter and changes the key used in the internal hashing
+// logic to ensure a unique set of false positives versus those prior to the
+// reset.
+//
+// This function is safe for concurrent access.
+func (f *Filter) Reset() {
+	f.mtx.Lock()
+	f.key0, f.key1 = siphash.Hash128(f.key0, f.key1, []byte("reset"))
+	f.baseIndex = 0
+	f.itemsInCurGeneration = 0
+	for i := range f.data {
+		f.data[i] = 0
+	}
+	f.mtx.Unlock()
+}
+
+// NewFilterKL returns an Age-Partitioned Bloom Filter (APBF) suitable for use
+// in processing unbounded data streams where more recent items are more
+// significant than older ones and some false positives are acceptable.  The
+// parameters specify the number of most-recently added items that must always
+// return true, the number slices which need consecutive matches, k, and the
+// number of additional slices, l, to reach a desired target false positive rate
+// to maintain.
+//
+// Every new filter uses a unique key for the internal hashing logic so that
+// each one will have a unique set of false positives.  The key is also
+// automatically changed by Reset.
+//
+// Applications might prefer using NewFilter to specify the max capacity and a
+// target false positive rate unless they specifically require the additional
+// fine tuning provided here.
+//
+// Note that, due to rounding, the actual max number of items that can be added
+// to the filter before old entries are expired might actually be slightly
+// higher than the specified target and can be obtained via the Capacity method
+// on the returned filter.
+//
+// The total space (in bytes) used by a filter that can hold 'n' items for the
+// given 'k' and 'l' is approximately:
+//
+//   ceil(ceil(1.44k * ceil(n / l+1)) * (k+l) / 8)
+func NewFilterKL(minCapacity uint32, k, l uint8) *Filter {
+	// Calculate the number of items per generation such that the maximum
+	// capacity (aka sliding window size) is at least the specified number of
+	// items.
+	//    w = g*(l+1)
+	// => g = w/(l+1)
+	// => g = ceil(w/(l+1))
+	g := uint32(math.Ceil(float64(minCapacity) / (float64(l) + 1)))
+
+	// Calculate the number of bits needed per slice based the number of items
+	// per generation and number of slices used for filter insertions.
+	//
+	// The fill ratio can be approximated by r = 1 - e^-(n/m), where n is the
+	// number of items and m is the bits per slice.  It is well known that
+	// optimal filter usage for partitioned bloom filters is asymptotically when
+	// r = 1/2.
+	//
+	// Thus solving r = 1/2 yields:
+	//    e^-(n/m) = 1/2
+	// => n/m = ln(2)
+	// => m = n / ln(2)
+	// => bitsPerSlice = k*g / ln(2)
+	bitsPerSlice := uint64(math.Ceil(float64(k) * float64(g) / math.Log(2)))
+
+	// The total filter size in bits is thus the total number of slices
+	// multiplied by the number of bits per slice.
+	kPlusL := uint16(k) + uint16(l)
+	filterBytes := ((bitsPerSlice * uint64(kPlusL)) + 7) / 8
+
+	// The key does not need to be cryptographically secure since its purpose is
+	// only to ensure filters created at different times (for example, as
+	// different nodes come online) produce a different set of false positives.
+	var seed [8]byte
+	s0 := uint64(time.Now().UnixNano())
+	s1 := s0 ^ 0xa5a5a5a5a5a5a5a5
+	binary.BigEndian.PutUint64(seed[:], s0^0x5a5a5a5a5a5a5a5a)
+	key0, key1 := siphash.Hash128(s0, s1, seed[:])
+	return &Filter{
+		key0:               key0,
+		key1:               key1,
+		k:                  k,
+		l:                  l,
+		kPlusL:             kPlusL,
+		bitsPerSlice:       bitsPerSlice,
+		itemsPerGeneration: g,
+		data:               make([]byte, filterBytes),
+	}
+}
+
+// nearOptimalK calculates a near optimal number of hash functions to use based
+// on the desired false positive rate and tradeoff versus the average number of
+// queries.  Since the actual false positive rate depends on both the number of
+// hash functions and an additional number of slices, the calculated value here
+// might be off by one from what is truly optimal, but the difference is minor.
+func nearOptimalK(fpRate float64) uint8 {
+	return uint8(math.Ceil(-math.Log2(fpRate)))
+}
+
+// nearOptimalL calculates a near optimal number of additional slices to use for
+// a given number of hash functions in order to maintain the desired false
+// positive rate.
+func nearOptimalL(k uint8, fpRate float64) uint8 {
+	// There is not currently a closed formula for calculating the false
+	// positive rate of an APBF, so just brute force it since it is only done
+	// once when the filter is created and it's fast enough anyway.
+	const maxL = 100
+	for l := uint8(1); l <= maxL; l++ {
+		result := CalcFPRate(k, l)
+		if result > fpRate {
+			return l - 1
+		}
+	}
+
+	return maxL
+}
+
+// NewFilter returns an Age-Partitioned Bloom Filter (APBF) suitable for use in
+// processing unbounded data streams where more recent items are more
+// significant than older ones and some false positives are acceptable.  The
+// parameters specify the number of most-recently added items that must always
+// return true and the target false positive rate to maintain.
+//
+// Every new filter uses a unique key for the internal hashing logic so that
+// each one will have a unique set of false positives.  The key is also
+// automatically changed by Reset.
+//
+// Note that, due to rounding, the actual max number of items that can be added
+// to the filter before old entries are expired might actually be slightly
+// higher than the specified target and can be obtained via the Capacity method
+// on the returned filter.
+//
+// Similarly, the actual false positive rate might be slightly better than the
+// target rate and can be obtained via the FPRate method on the returned filter.
+//
+// In other words, both parameters are treated as lower bounds so that the
+// returned filter has at least the requested target values.
+//
+// For most applications, the values will be perfectly acceptable, however,
+// applications that desire greater control over the tuning can make use of
+// NewFilterKL instead.
+//
+// The total space (in bytes) used by a filter that can hold 'n' items with a
+// false positive rate of 'fpRate' is approximately:
+//
+//   1.3n * -log(fpRate), where log is base 10
+func NewFilter(minCapacity uint32, fpRate float64) *Filter {
+	k := nearOptimalK(fpRate)
+	l := nearOptimalL(k, fpRate)
+	return NewFilterKL(minCapacity, k, l)
+}

--- a/container/apbf/filter_test.go
+++ b/container/apbf/filter_test.go
@@ -1,0 +1,410 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package apbf
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+)
+
+// TestFilterMembership ensures that the most recent items added to the filter
+// up to its capacity are always reported (zero false negatives) and that aging
+// the filter expires entries as expected.
+func TestFilterMembership(t *testing.T) {
+	tests := []struct {
+		name     string  // test description
+		capacity uint32  // target capacity
+		fpRate   float64 // target false positive rate
+	}{{
+		name:     "capacity 100, fpRate 0.1",
+		capacity: 100,
+		fpRate:   0.1,
+	}, {
+		name:     "capacity 100, fpRate 0.01",
+		capacity: 100,
+		fpRate:   0.01,
+	}, {
+		name:     "capacity 100, fpRate 0.001",
+		capacity: 100,
+		fpRate:   0.001,
+	}, {
+		name:     "capacity 1000, fpRate 0.1",
+		capacity: 1000,
+		fpRate:   0.1,
+	}}
+
+nextTest:
+	for _, test := range tests {
+		// Add twice the capacity of the filter to also test expiration and
+		// absence of false negatives.
+		const capacityMul = 2
+		var data [4]byte
+		filter := NewFilter(test.capacity, test.fpRate)
+		actualCapacity := filter.Capacity()
+		for i := uint32(0); i < actualCapacity*capacityMul; i++ {
+			binary.BigEndian.PutUint32(data[:], i)
+			filter.Add(data[:])
+
+			// Ensure the item that was just added is in the filter.
+			if !filter.Contains(data[:]) {
+				t.Errorf("%q: filter missing expected data %x", test.name, data)
+				continue nextTest
+			}
+		}
+
+		// Ensure there are no false negatives for the most recent items up to
+		// the filter capacity.
+		startVal := actualCapacity * (capacityMul - 1)
+		for i := startVal; i < actualCapacity*capacityMul; i++ {
+			binary.BigEndian.PutUint32(data[:], i)
+			if !filter.Contains(data[:]) {
+				t.Errorf("%q: filter missing expected data %x", test.name, data)
+				continue nextTest
+			}
+		}
+
+		// Force all items to be expired and ensure they are gone while
+		// accounting for the possibility of false positives even though there
+		// will typically be 0 since the filter will be totally clear.
+		var numFP uint32
+		for i := uint8(0); i <= filter.L(); i++ {
+			filter.nextGeneration()
+		}
+		for i := uint32(0); i < actualCapacity*capacityMul; i++ {
+			binary.BigEndian.PutUint32(data[:], i)
+			if filter.Contains(data[:]) {
+				numFP++
+			}
+		}
+		maxItemsPerFP := uint32(math.Ceil(1 / filter.FPRate()))
+		maxFP := (actualCapacity * capacityMul) / maxItemsPerFP
+		if numFP > maxFP {
+			t.Errorf("%q: items not expired -- max expected fp %d, got %d",
+				test.name, maxFP, numFP)
+			continue
+		}
+	}
+}
+
+// TestFalsePositives ensures that filters of various capacities and false
+// positive rates do not produce more false positives than the expected rate
+// after exceeding their capacity several times over.
+func TestFalsePositives(t *testing.T) {
+	tests := []struct {
+		name     string  // test description
+		capacity uint32  // target capacity
+		fpRate   float64 // target false positive rate
+	}{{
+		name:     "capacity 1000, fpRate 0.1",
+		capacity: 1000,
+		fpRate:   0.1,
+	}, {
+		name:     "capacity 1000, fpRate 0.01",
+		capacity: 1000,
+		fpRate:   0.01,
+	}, {
+		name:     "capacity 1000, fpRate 0.001",
+		capacity: 1000,
+		fpRate:   0.001,
+	}, {
+		name:     "capacity 10000, fpRate 0.1",
+		capacity: 10000,
+		fpRate:   0.1,
+	}}
+
+nextTest:
+	for _, test := range tests {
+		// Add several times the capacity of the filter.
+		const capacityMul = 4
+		var data [4]byte
+		filter := NewFilter(test.capacity, test.fpRate)
+		numToAdd := test.capacity * capacityMul
+		for i := uint32(0); i < numToAdd; i++ {
+			binary.BigEndian.PutUint32(data[:], i)
+			filter.Add(data[:])
+
+			// Ensure the item that was just added is in the filter.
+			if !filter.Contains(data[:]) {
+				t.Errorf("%q: filter missing expected data %x", test.name, data)
+				continue nextTest
+			}
+		}
+
+		// Test for items that were never added to the filter at 100 times the
+		// false positive rate and expect a max of one and half that number to
+		// ensure the rate is not significantly worse than expected and
+		// stablizes around the expected rate.
+		const fpRateMul = 100
+		var numFP uint32
+		numToProbe := uint32(math.Floor(1/test.fpRate) * fpRateMul)
+		for i := uint32(0); i < numToProbe; i++ {
+			val := i + numToAdd
+			binary.BigEndian.PutUint32(data[:], val)
+			if filter.Contains(data[:]) {
+				numFP++
+			}
+		}
+		maxFP := uint32(math.Ceil(fpRateMul * 1.5))
+		if numFP > maxFP {
+			t.Errorf("%q: expected a maximum of %d false positives, got %d",
+				test.name, maxFP, numFP)
+			continue
+		}
+	}
+}
+
+// TestFilterTargetCapacity ensures filters are created with a max capacity that
+// is at least the target capacity.
+func TestFilterTargetCapacity(t *testing.T) {
+	tests := []struct {
+		name    string  // test description
+		filter  *Filter // filter to test with
+		wantCap uint32  // expected actual capacity
+	}{{
+		name:    "capacity 100, fpRate 0.1",
+		filter:  NewFilter(100, 0.1),
+		wantCap: 102,
+	}, {
+		name:    "capacity 100, fpRate 0.01",
+		filter:  NewFilter(100, 0.01),
+		wantCap: 100,
+	}, {
+		name:    "capacity 100, fpRate 0.001",
+		filter:  NewFilter(100, 0.001),
+		wantCap: 105,
+	}, {
+		name:    "capacity 1000, fpRate 0.1",
+		filter:  NewFilter(1000, 0.1),
+		wantCap: 1002,
+	}, {
+		name:    "capacity 250, K 20, L 14",
+		filter:  NewFilterKL(250, 20, 14),
+		wantCap: 255,
+	}, {
+		name:    "capacity 500, K 17, L 12",
+		filter:  NewFilterKL(500, 17, 12),
+		wantCap: 507,
+	}}
+
+	for _, test := range tests {
+		if gotCap := test.filter.Capacity(); gotCap != test.wantCap {
+			t.Errorf("%q: unexpected capacity -- got %d, want %d", test.name,
+				gotCap, test.wantCap)
+			continue
+		}
+	}
+}
+
+// TestFilterKL ensures filters are created with the expected K and L params and
+// the associated methods return them as expected.
+func TestFilterKL(t *testing.T) {
+	tests := []struct {
+		name   string  // test description
+		filter *Filter // filter to test with
+		wantK  uint8   // expected K param
+		wantL  uint8   // expected L param
+	}{{
+		name:   "capacity 100, fpRate 0.1",
+		filter: NewFilter(100, 0.1),
+		wantK:  4,
+		wantL:  2,
+	}, {
+		name:   "capacity 100, fpRate 0.01",
+		filter: NewFilter(100, 0.01),
+		wantK:  7,
+		wantL:  4,
+	}, {
+		name:   "capacity 100, fpRate 0.001",
+		filter: NewFilter(100, 0.001),
+		wantK:  10,
+		wantL:  6,
+	}, {
+		name:   "capacity 1000, fpRate 0.1",
+		filter: NewFilter(1000, 0.1),
+		wantK:  4,
+		wantL:  2,
+	}, {
+		name:   "capacity 250, K 20, L 14",
+		filter: NewFilterKL(250, 20, 14),
+		wantK:  20,
+		wantL:  14,
+	}, {
+		name:   "capacity 500, K 17, L 12",
+		filter: NewFilterKL(500, 17, 12),
+		wantK:  17,
+		wantL:  12,
+	}}
+
+	for _, test := range tests {
+		if gotK := test.filter.K(); gotK != test.wantK {
+			t.Errorf("%q: unexpected K param -- got %d, want %d", test.name,
+				gotK, test.wantK)
+			continue
+		}
+
+		if gotL := test.filter.L(); gotL != test.wantL {
+			t.Errorf("%q: unexpected L param -- got %d, want %d", test.name,
+				gotL, test.wantL)
+			continue
+		}
+	}
+}
+
+// TestFilterSize ensures the filter size reports the expected values for a
+// variety of target capacities and false positive rates.
+func TestFilterSize(t *testing.T) {
+	tests := []struct {
+		name     string  // test description
+		capacity uint32  // target capacity
+		fpRate   float64 // target false positive rate
+		want     int     // expected size
+	}{{
+		name:     "capacity 1000, fpRate 0.1",
+		capacity: 1000,
+		fpRate:   0.1,
+		want:     1516,
+	}, {
+		name:     "capacity 1000, fpRate 0.01",
+		capacity: 1000,
+		fpRate:   0.01,
+		want:     2848,
+	}, {
+		name:     "capacity 1000, fpRate 0.001",
+		capacity: 1000,
+		fpRate:   0.001,
+		want:     4198,
+	}, {
+		name:     "capacity 1000, fpRate 0.0001",
+		capacity: 1000,
+		fpRate:   0.0001,
+		want:     5374,
+	}, {
+		name:     "capacity 10000, fpRate 0.1",
+		capacity: 10000,
+		fpRate:   0.1,
+		want:     14500,
+	}, {
+		name:     "capacity 10000, fpRate 0.01",
+		capacity: 10000,
+		fpRate:   0.01,
+		want:     27843,
+	}, {
+		name:     "capacity 10000, fpRate 0.001",
+		capacity: 10000,
+		fpRate:   0.001,
+		want:     41304,
+	}, {
+		name:     "capacity 10000, fpRate 0.0001",
+		capacity: 10000,
+		fpRate:   0.0001,
+		want:     52711,
+	}}
+
+	for _, test := range tests {
+		filter := NewFilter(test.capacity, test.fpRate)
+		if gotSize := filter.Size(); gotSize != test.want {
+			t.Errorf("%q: unexpected size -- got %d, want %d", test.name,
+				gotSize, test.want)
+		}
+	}
+}
+
+// TestReset ensures resetting a filter resets all state and changes the hash
+// key without disturbing the capacity or false positive rate.
+func TestReset(t *testing.T) {
+	tests := []struct {
+		name     string  // test description
+		capacity uint32  // target capacity
+		fpRate   float64 // target false positive rate
+	}{{
+		name:     "capacity 10, fpRate 0.1",
+		capacity: 10,
+		fpRate:   0.1,
+	}, {
+		name:     "capacity 20, fpRate 0.01",
+		capacity: 20,
+		fpRate:   0.01,
+	}}
+
+	for _, test := range tests {
+		// Create the filter per the test params and populate a bunch of data.
+		f := NewFilter(test.capacity, test.fpRate)
+		oldKey0, oldKey1 := f.key0, f.key1
+		oldK, oldL := f.K(), f.L()
+		oldCapacity, oldFPRate := f.Capacity(), f.FPRate()
+		oldSize := f.Size()
+
+		var data [8]byte
+		for i := 0; i < 1000; i++ {
+			binary.LittleEndian.PutUint64(data[:], uint64(i))
+			f.Add(data[:])
+		}
+
+		// Reset the filter and ensure all of the expected fields are cleared.
+		f.Reset()
+		if f.baseIndex != 0 {
+			t.Errorf("%q: base index is not zero -- got %d", test.name,
+				f.baseIndex)
+			continue
+		}
+		if f.itemsInCurGeneration != 0 {
+			t.Errorf("%q: current gen items is not zero -- got %d", test.name,
+				f.itemsInCurGeneration)
+			continue
+		}
+		for i, b := range f.data {
+			if b != 0 {
+				t.Errorf("%q: data at index %d is not zero -- got %d",
+					test.name, i, b)
+			}
+		}
+
+		// Ensure the key is reset.
+		if f.key0 == oldKey0 || f.key1 == oldKey1 {
+			t.Errorf("%q: unchanged key -- old (%d, %d), new (%d, %d)",
+				test.name, oldKey0, oldKey1, f.key0, f.key1)
+		}
+
+		// Ensure the K and L parameters are the same.
+		newK, newL := f.K(), f.L()
+		if newK != oldK {
+			t.Errorf("%q: K param mismatch -- got %d, want %d", test.name, newK,
+				oldK)
+		}
+		if newL != oldL {
+			t.Errorf("%q: L param mismatch -- got %d, want %d", test.name, newL,
+				oldL)
+		}
+
+		// Ensure the capacity and false positive rate are the same.
+		newCapacity, newFPRate := f.Capacity(), f.FPRate()
+		if newCapacity != oldCapacity {
+			t.Errorf("%q: capacity mismatch -- got %d, want %d", test.name,
+				newCapacity, oldCapacity)
+		}
+		if newFPRate != oldFPRate {
+			t.Errorf("%q: false positive rate mismatch -- got %f, want %f",
+				test.name, newFPRate, oldFPRate)
+		}
+
+		// Ensure the filter size is the same.
+		newSize := f.Size()
+		if newSize != oldSize {
+			t.Errorf("%q: size mismatch -- got %d, want %d", test.name, newSize,
+				oldSize)
+		}
+	}
+}
+
+// TestMaxNearOptimalL ensures that the function which attempts to determine a
+// near optimal L value caps out at the expected point.
+func TestMaxNearOptimalL(t *testing.T) {
+	const wantL = 100
+	if gotL := nearOptimalL(7, 0.35); gotL != wantL {
+		t.Fatalf("unexepected calaculated L value -- got %d, want %d", gotL,
+			wantL)
+	}
+}

--- a/container/apbf/generateapbftable.go
+++ b/container/apbf/generateapbftable.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+//+build ignore
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// calcRateKey is used as the key when caching results for the false positive
+// and query access calculations.
+type calcRateKey struct {
+	a, i uint16
+}
+
+// calcFPRateInternal calculates and returns the false positive rate for the
+// provided parameters using the given results map to cache intermediate
+// results.
+func calcFPRateInternal(results map[calcRateKey]float64, k, l uint8, a, i uint16) float64 {
+	// The false positive rate is calculated according to the following
+	// recursively-defined function provided in [APBF]:
+	//
+	//              {1                                        , if a = k
+	// F(k,l,a,i) = {0                                        , if i > l + a
+	//              {(r_i)F(k,l,a+1,i+1) + (1-r_i)F(k,l,0,i+1), otherwise
+
+	if a == uint16(k) {
+		return 1
+	} else if i > uint16(l)+a {
+		return 0
+	}
+
+	// Return stored results to avoid a bunch of duplicate work.
+	resultKey := calcRateKey{a, i}
+	if result, ok := results[resultKey]; ok {
+		return result
+	}
+
+	// Calculate the fill ratio for the slice.
+	fillRatio := float64(0.5)
+	if i < uint16(k) {
+		fillRatio = float64(i+1) / float64(2*k)
+	}
+
+	firstTerm := fillRatio * calcFPRateInternal(results, k, l, a+1, i+1)
+	secondTerm := (1 - fillRatio) * calcFPRateInternal(results, k, l, 0, i+1)
+	result := firstTerm + secondTerm
+	results[resultKey] = result
+	return result
+}
+
+// calcFPRate calculates and returns the false positive rate for an APBF
+// created with the given parameters.
+func calcFPRate(k, l uint8) float64 {
+	results := make(map[calcRateKey]float64, 2*uint16(k)*uint16(l))
+	return calcFPRateInternal(results, k, l, 0, 0)
+}
+
+// calcAvgAccessFalseInternal calculates and returns the average number of
+// accesses for false queries for the provided parameters using the given
+// results map to cache intermediate results.
+func calcAvgAccessFalseInternal(results map[calcRateKey]float64, k, l uint8, p, c, a uint16, i int16) float64 {
+	// The average expected number of accesses for false queries is calculated
+	// according to the following recursively-defined function provided in
+	// [APBF]:
+	//
+	//                  {a                                        , if i < 0
+	// A(k,l,p,c,a,i) = {0                                        , if p + c = k
+	//                  {(r_i)A(k,l,p,c+1,a+1,i+1) +
+	//                   (1-r_i)A(k,l,c,0,a+1,i-k)                , otherwise
+	//
+
+	if i < 0 {
+		return float64(a)
+	} else if p+c == uint16(k) {
+		return 0
+	}
+
+	// Return stored results to avoid a bunch of duplicate work.
+	resultKey := calcRateKey{a, uint16(i)}
+	if result, ok := results[resultKey]; ok {
+		return result
+	}
+
+	// Calculate the fill ratio for the slice.
+	fillRatio := float64(0.5)
+	if i < int16(k) {
+		fillRatio = float64(i+1) / float64(2*k)
+	}
+
+	firstTerm := fillRatio
+	firstTerm *= calcAvgAccessFalseInternal(results, k, l, p, c+1, a+1, i+1)
+	secondTerm := (1 - fillRatio)
+	secondTerm *= calcAvgAccessFalseInternal(results, k, l, c, 0, a+1, i-int16(k))
+	result := firstTerm + secondTerm
+	results[resultKey] = result
+	return result
+}
+
+// calcAvgAccessFalse calculates and returns the average number of accesses for
+// false queries for an APBF created with the given parameters.
+func calcAvgAccessFalse(k, l uint8) float64 {
+	results := make(map[calcRateKey]float64, 2*uint16(k)*uint16(l))
+	return calcAvgAccessFalseInternal(results, k, l, 0, 0, 0, int16(l)) /
+		(1 - calcFPRate(k, l))
+}
+
+func main() {
+	fi, err := os.Create("apbftable.md")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer fi.Close()
+	p := func(format string, args ...interface{}) {
+		fmt.Fprintf(fi, format, args...)
+	}
+
+	p("## Age-Partitioned Bloom Filter Parameter Metrics\n")
+	for k := uint8(1); k <= 50; k++ {
+		p("\n")
+		p("### k=%d\n\n", k)
+		p(" k  |  l  |  fprate  | query accesses (false result)\n")
+		p("----|-----|----------|------------------------------\n")
+		for l := uint8(1); l <= 100; l++ {
+			fp := calcFPRate(k, l)
+
+			// Ignore entries that essentially have a 100% fprate.
+			if 1-fp < 0.001 {
+				continue
+			}
+			accesses := calcAvgAccessFalse(k, l)
+
+			if fp > 10e-6 {
+				p(" %2d | %3d | %0.6f | %0.2f\n", k, l, fp, accesses)
+			} else {
+				p(" %2d | %3d | %0.3g | %0.2f\n", k, l, fp, accesses)
+			}
+		}
+	}
+}

--- a/container/apbf/go.mod
+++ b/container/apbf/go.mod
@@ -1,0 +1,5 @@
+module github.com/decred/dcrd/container/apbf
+
+go 1.11
+
+require github.com/dchest/siphash v1.2.2

--- a/container/apbf/go.sum
+++ b/container/apbf/go.sum
@@ -1,0 +1,2 @@
+github.com/dchest/siphash v1.2.2 h1:9DFz8tQwl9pTVt5iok/9zKyzA1Q6bRGiF3HPiEEVr9I=
+github.com/dchest/siphash v1.2.2/go.mod h1:q+IRvb2gOSrUnYoPqHiyHXS0FOBBOdl6tONBlVnOnt4=


### PR DESCRIPTION
This implements an Age-Partioned Bloom Filter (APBF) that is safe for concurrent access.

An APBF is a probabilistic data structure suitable for use in processing unbounded data streams where more recent items are more significant than older ones and some false positives are acceptable.  It has similar computational costs as traditional Bloom filters and provides space efficiency that is competitive with the current best-known, and more complex, Dictionary approaches.

Similar to classic Bloom filters, APBFs have a non-zero probability of false positives that can be tuned via parameters and are free from false negatives up to the capacity of the filter.  However, unlike classic Bloom filters, where the false positive rate climbs as items are added until all queries are a false positive, APBFs provide a configurable upper bound on the false positive rate for an unbounded number of additions.

The unbounded property is achieved by adding and retiring disjoint segments over time where each segment is a slice of a partitioned Bloom filter.  The slices are conceptually aged over time as new items are added by shifting them and discarding the oldest one.

While APBFs are useful in a variety of use cases, the primary motivation for adding them to Decred at the current time is for use in more efficiently deduplicating various continuous event streams, such as recently confirmed and rejected transactions and inventory (e.g. transactions, blocks, addresses) other peers are known to have.

Currently, a LRU cache is used for this purpose in several places which has a non-trivial amount of overhead.  For a concrete example of one particular instance, tracking the known addresses for the maximum default number of 125 peers can currently consume up to around 150 MiB [1].

On the other hand, using the APBF implementation this introduces will, once properly updated, allow that to be reduced to around 3.63 MiB [1] while still maintaining a false positive rate of 1 in a million and exhibiting similar computational performance.

The included `README.md` contains benchmark and the results of experimental validation of the implementation with respect to false positive rate.

[1] EDIT: Actual profiling conducted later shows this is closer to 211 MiB and 4.88 MiB including GC overhead, respectively, versus these original estimates.