### PR TITLE
multi: Use an APBF for recently confirmed txns.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/chaincfg/v3 v3.0.0
 	github.com/decred/dcrd/connmgr/v3 v3.0.0
+	github.com/decred/dcrd/container/apbf v1.0.0
 	github.com/decred/dcrd/crypto/ripemd160 v1.0.1
 	github.com/decred/dcrd/database/v2 v2.0.3-0.20210129190127-4ebd135a82f1
 	github.com/decred/dcrd/dcrec v1.0.0
@@ -50,6 +51,7 @@ replace (
 	github.com/decred/dcrd/chaincfg/chainhash => ./chaincfg/chainhash
 	github.com/decred/dcrd/chaincfg/v3 => ./chaincfg
 	github.com/decred/dcrd/connmgr/v3 => ./connmgr
+	github.com/decred/dcrd/container/apbf => ./container/apbf
 	github.com/decred/dcrd/crypto/blake256 => ./crypto/blake256
 	github.com/decred/dcrd/crypto/ripemd160 => ./crypto/ripemd160
 	github.com/decred/dcrd/database/v2 => ./database

--- a/internal/netsync/manager.go
+++ b/internal/netsync/manager.go
@@ -18,12 +18,12 @@ import (
 	"github.com/decred/dcrd/blockchain/v4"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v3"
+	"github.com/decred/dcrd/container/apbf"
 	"github.com/decred/dcrd/database/v2"
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/internal/mempool"
 	"github.com/decred/dcrd/internal/progresslog"
 	"github.com/decred/dcrd/internal/rpcserver"
-	"github.com/decred/dcrd/lru"
 	peerpkg "github.com/decred/dcrd/peer/v3"
 	"github.com/decred/dcrd/wire"
 )
@@ -1241,7 +1241,7 @@ func (m *SyncManager) needTx(hash *chainhash.Hash) bool {
 	}
 
 	// No need for transactions that were recently confirmed.
-	if m.cfg.RecentlyConfirmedTxns.Contains(*hash) {
+	if m.cfg.RecentlyConfirmedTxns.Contains(hash[:]) {
 		return false
 	}
 
@@ -1816,7 +1816,7 @@ type Config struct {
 	// RecentlyConfirmedTxns specifies a size limited set to use for tracking
 	// and querying the most recently confirmed transactions.  It is useful for
 	// preventing duplicate requests.
-	RecentlyConfirmedTxns *lru.Cache
+	RecentlyConfirmedTxns *apbf.Filter
 }
 
 // New returns a new network chain synchronization manager.  Use Run to begin


### PR DESCRIPTION
**This requires #2579**.

This modifies the server to track the recently confirmed transactions using a much more efficient APBF instead of an LRU cache which has significant overhead in addition to having to store the entirety of all items added to it.

This is acceptable because false positives are acceptable as the goal is to deduplicate transaction requests which is an ideal case for APBFs.

More concretely, the current LRU cache that stores the recently confirmed transactions takes around 2.67 MiB per profiling while the new APBF only takes around 180 KiB, a reduction of around 93%, while exhibiting roughly the same computational performance.
