### PR TITLE
peer: Start v3 module dev cycle.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/decred/dcrd/gcs/v3 v3.0.0-20210129195202-a4265d63b619
 	github.com/decred/dcrd/hdkeychain/v3 v3.0.1-0.20210129190127-4ebd135a82f1
 	github.com/decred/dcrd/lru v1.1.0
-	github.com/decred/dcrd/peer/v2 v2.2.1-0.20210129192908-660d0518b4cf
+	github.com/decred/dcrd/peer/v3 v3.0.0
 	github.com/decred/dcrd/rpc/jsonrpc/types/v3 v3.0.0-20210129200153-14fd1a785bf2
 	github.com/decred/dcrd/rpcclient/v7 v7.0.0-20210129214723-fc227a05904d
 	github.com/decred/dcrd/txscript/v4 v4.0.0-20210129190127-4ebd135a82f1
@@ -61,7 +61,7 @@ replace (
 	github.com/decred/dcrd/hdkeychain/v3 => ./hdkeychain
 	github.com/decred/dcrd/limits => ./limits
 	github.com/decred/dcrd/lru => ./lru
-	github.com/decred/dcrd/peer/v2 => ./peer
+	github.com/decred/dcrd/peer/v3 => ./peer
 	github.com/decred/dcrd/rpc/jsonrpc/types/v3 => ./rpc/jsonrpc/types
 	github.com/decred/dcrd/rpcclient/v7 => ./rpcclient
 	github.com/decred/dcrd/txscript/v4 => ./txscript

--- a/internal/netsync/manager.go
+++ b/internal/netsync/manager.go
@@ -24,7 +24,7 @@ import (
 	"github.com/decred/dcrd/internal/progresslog"
 	"github.com/decred/dcrd/internal/rpcserver"
 	"github.com/decred/dcrd/lru"
-	peerpkg "github.com/decred/dcrd/peer/v2"
+	peerpkg "github.com/decred/dcrd/peer/v3"
 	"github.com/decred/dcrd/wire"
 )
 

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -20,7 +20,7 @@ import (
 	"github.com/decred/dcrd/gcs/v3"
 	"github.com/decred/dcrd/internal/mempool"
 	"github.com/decred/dcrd/internal/mining"
-	"github.com/decred/dcrd/peer/v2"
+	"github.com/decred/dcrd/peer/v3"
 	"github.com/decred/dcrd/rpc/jsonrpc/types/v3"
 	"github.com/decred/dcrd/wire"
 )

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -41,7 +41,7 @@ import (
 	"github.com/decred/dcrd/internal/mempool"
 	"github.com/decred/dcrd/internal/mining"
 	"github.com/decred/dcrd/internal/version"
-	"github.com/decred/dcrd/peer/v2"
+	"github.com/decred/dcrd/peer/v3"
 	"github.com/decred/dcrd/rpc/jsonrpc/types/v3"
 	"github.com/decred/dcrd/txscript/v4"
 	"github.com/decred/dcrd/wire"

--- a/log.go
+++ b/log.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2017 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -22,7 +22,7 @@ import (
 	"github.com/decred/dcrd/internal/mining/cpuminer"
 	"github.com/decred/dcrd/internal/netsync"
 	"github.com/decred/dcrd/internal/rpcserver"
-	"github.com/decred/dcrd/peer/v2"
+	"github.com/decred/dcrd/peer/v3"
 	"github.com/decred/dcrd/txscript/v4"
 	"github.com/decred/slog"
 	"github.com/jrick/logrotate/rotator"

--- a/peer/example_test.go
+++ b/peer/example_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2015-2016 The btcsuite developers
-// Copyright (c) 2016-2020 The Decred developers
+// Copyright (c) 2016-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -10,7 +10,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/decred/dcrd/peer/v2"
+	"github.com/decred/dcrd/peer/v3"
 	"github.com/decred/dcrd/wire"
 )
 

--- a/peer/go.mod
+++ b/peer/go.mod
@@ -1,4 +1,4 @@
-module github.com/decred/dcrd/peer/v2
+module github.com/decred/dcrd/peer/v3
 
 go 1.11
 

--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -20,7 +20,7 @@ import (
 	"github.com/decred/dcrd/internal/mining/cpuminer"
 	"github.com/decred/dcrd/internal/netsync"
 	"github.com/decred/dcrd/internal/rpcserver"
-	"github.com/decred/dcrd/peer/v2"
+	"github.com/decred/dcrd/peer/v3"
 	"github.com/decred/dcrd/wire"
 )
 

--- a/server.go
+++ b/server.go
@@ -45,7 +45,7 @@ import (
 	"github.com/decred/dcrd/internal/rpcserver"
 	"github.com/decred/dcrd/internal/version"
 	"github.com/decred/dcrd/lru"
-	"github.com/decred/dcrd/peer/v2"
+	"github.com/decred/dcrd/peer/v3"
 	"github.com/decred/dcrd/txscript/v4"
 	"github.com/decred/dcrd/wire"
 )


### PR DESCRIPTION
Upcoming changes constitute breaking public API changes to the peer module, therefore, this follows the process for introducing major API breaks which consists of:

- Bump the major version in the go.mod of the affected module if not already done since the last release tag
- Add a replacement to the go.mod in the main module if not already done since the last release tag
- Update all imports in the repo to use the new major version as necessary
- Make necessary modifications to allow all other modules to use the new version in the same commit
- Repeat the process for any other modules the require a new major as a result of consuming the new major(s)