### PR TITLE
multi: Deprecate reject wire protocol message.

### DIFF
--- a/peer/doc.go
+++ b/peer/doc.go
@@ -104,10 +104,10 @@ of a most-recently used algorithm.
 Message Sending Helper Functions
 
 In addition to the bare QueueMessage function previously described, the
-PushAddrMsg, PushGetBlocksMsg, PushGetHeadersMsg, and PushRejectMsg functions
-are provided as a convenience.  While it is of course possible to create and
-send these message manually via QueueMessage, these helper functions provided
-additional useful functionality that is typically desired.
+PushAddrMsg, PushGetBlocksMsg, and PushGetHeadersMsg functions are provided as a
+convenience.  While it is of course possible to create and send these messages
+manually via QueueMessage, these helper functions provided additional useful
+functionality that is typically desired.
 
 For example, the PushAddrMsg function automatically limits the addresses to the
 maximum number allowed by the message and randomizes the chosen addresses when
@@ -115,13 +115,9 @@ there are too many.  This allows the caller to simply provide a slice of known
 addresses, such as that returned by the addrmgr package, without having to worry
 about the details.
 
-Next, the PushGetBlocksMsg and PushGetHeadersMsg functions will construct proper
-messages using a block locator and ignore back to back duplicate requests.
-
-Finally, the PushRejectMsg function can be used to easily create and send an
-appropriate reject message based on the provided parameters as well as
-optionally provides a flag to cause it to block until the message is actually
-sent.
+Finally, the PushGetBlocksMsg and PushGetHeadersMsg functions will construct
+proper messages using a block locator and ignore back to back duplicate
+requests.
 
 Peer Statistics
 

--- a/peer/example_test.go
+++ b/peer/example_test.go
@@ -71,9 +71,8 @@ func Example_newOutboundPeer() {
 		Net:              wire.SimNet,
 		Services:         0,
 		Listeners: peer.MessageListeners{
-			OnVersion: func(p *peer.Peer, msg *wire.MsgVersion) *wire.MsgReject {
+			OnVersion: func(p *peer.Peer, msg *wire.MsgVersion) {
 				fmt.Println("outbound: received version")
-				return nil
 			},
 			OnVerAck: func(p *peer.Peer, msg *wire.MsgVerAck) {
 				verack <- struct{}{}

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -711,9 +711,6 @@ func TestOutboundPeer(t *testing.T) {
 		return
 	}
 
-	p2.PushRejectMsg("block", wire.RejectMalformed, "malformed", nil, false)
-	p2.PushRejectMsg("block", wire.RejectInvalid, "invalid", nil, false)
-
 	// Test Queue Messages
 	p2.QueueMessage(wire.NewMsgGetAddr(), nil)
 	p2.QueueMessage(wire.NewMsgPing(1), nil)

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -386,9 +386,8 @@ func TestPeerListeners(t *testing.T) {
 			OnFeeFilter: func(p *Peer, msg *wire.MsgFeeFilter) {
 				ok <- msg
 			},
-			OnVersion: func(p *Peer, msg *wire.MsgVersion) *wire.MsgReject {
+			OnVersion: func(p *Peer, msg *wire.MsgVersion) {
 				ok <- msg
-				return nil
 			},
 			OnVerAck: func(p *Peer, msg *wire.MsgVerAck) {
 				verack <- struct{}{}

--- a/server.go
+++ b/server.go
@@ -671,7 +671,7 @@ func hasServices(advertised, desired wire.ServiceFlag) bool {
 // OnVersion is invoked when a peer receives a version wire message and is used
 // to negotiate the protocol version details as well as kick start the
 // communications.
-func (sp *serverPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) *wire.MsgReject {
+func (sp *serverPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) {
 	// Update the address manager with the advertised services for outbound
 	// connections in case they have changed.  This is not done for inbound
 	// connections to help prevent malicious behavior and is skipped when
@@ -695,7 +695,7 @@ func (sp *serverPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) *wire.MsgRej
 			"the required version %d", sp.Peer, msg.ProtocolVersion,
 			wire.SendHeadersVersion)
 		sp.Disconnect()
-		return nil
+		return
 	}
 
 	// Reject outbound peers that are not full nodes.
@@ -706,7 +706,7 @@ func (sp *serverPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) *wire.MsgRej
 			"providing desired services %v", sp.Peer, msg.Services,
 			missingServices)
 		sp.Disconnect()
-		return nil
+		return
 	}
 
 	// Update the address manager and request known addresses from the
@@ -751,7 +751,6 @@ func (sp *serverPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) *wire.MsgRej
 
 	// Add valid peer to the server.
 	sp.server.AddPeer(sp)
-	return nil
 }
 
 // OnVerAck is invoked when a peer receives a verack wire message.  It creates

--- a/wire/message_test.go
+++ b/wire/message_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -88,30 +88,30 @@ func TestMessage(t *testing.T) {
 		dcrnet CurrencyNet // Network to use for wire encoding
 		bytes  int         // Expected num bytes read/written
 	}{
-		{msgVersion, msgVersion, pver, MainNet, 125},          // [0]
-		{msgVerack, msgVerack, pver, MainNet, 24},             // [1]
-		{msgGetAddr, msgGetAddr, pver, MainNet, 24},           // [2]
-		{msgAddr, msgAddr, pver, MainNet, 25},                 // [3]
-		{msgGetBlocks, msgGetBlocks, pver, MainNet, 61},       // [4]
-		{msgBlock, msgBlock, pver, MainNet, 522},              // [5]
-		{msgInv, msgInv, pver, MainNet, 25},                   // [6]
-		{msgGetData, msgGetData, pver, MainNet, 25},           // [7]
-		{msgNotFound, msgNotFound, pver, MainNet, 25},         // [8]
-		{msgTx, msgTx, pver, MainNet, 39},                     // [9]
-		{msgPing, msgPing, pver, MainNet, 32},                 // [10]
-		{msgPong, msgPong, pver, MainNet, 32},                 // [11]
-		{msgGetHeaders, msgGetHeaders, pver, MainNet, 61},     // [12]
-		{msgHeaders, msgHeaders, pver, MainNet, 25},           // [13]
-		{msgMemPool, msgMemPool, pver, MainNet, 24},           // [15]
-		{msgReject, msgReject, pver, MainNet, 79},             // [20]
-		{msgGetCFilter, msgGetCFilter, pver, MainNet, 57},     // [21]
-		{msgGetCFHeaders, msgGetCFHeaders, pver, MainNet, 58}, // [22]
-		{msgGetCFTypes, msgGetCFTypes, pver, MainNet, 24},     // [23]
-		{msgCFilter, msgCFilter, pver, MainNet, 65},           // [24]
-		{msgCFHeaders, msgCFHeaders, pver, MainNet, 58},       // [25]
-		{msgCFTypes, msgCFTypes, pver, MainNet, 26},           // [26]
-		{msgGetInitState, msgGetInitState, pver, MainNet, 25}, // [27]
-		{msgInitState, msgInitState, pver, MainNet, 27},       // [28]
+		{msgVersion, msgVersion, pver, MainNet, 125},
+		{msgVerack, msgVerack, pver, MainNet, 24},
+		{msgGetAddr, msgGetAddr, pver, MainNet, 24},
+		{msgAddr, msgAddr, pver, MainNet, 25},
+		{msgGetBlocks, msgGetBlocks, pver, MainNet, 61},
+		{msgBlock, msgBlock, pver, MainNet, 522},
+		{msgInv, msgInv, pver, MainNet, 25},
+		{msgGetData, msgGetData, pver, MainNet, 25},
+		{msgNotFound, msgNotFound, pver, MainNet, 25},
+		{msgTx, msgTx, pver, MainNet, 39},
+		{msgPing, msgPing, pver, MainNet, 32},
+		{msgPong, msgPong, pver, MainNet, 32},
+		{msgGetHeaders, msgGetHeaders, pver, MainNet, 61},
+		{msgHeaders, msgHeaders, pver, MainNet, 25},
+		{msgMemPool, msgMemPool, pver, MainNet, 24},
+		{msgReject, msgReject, RemoveRejectVersion - 1, MainNet, 79},
+		{msgGetCFilter, msgGetCFilter, pver, MainNet, 57},
+		{msgGetCFHeaders, msgGetCFHeaders, pver, MainNet, 58},
+		{msgGetCFTypes, msgGetCFTypes, pver, MainNet, 24},
+		{msgCFilter, msgCFilter, pver, MainNet, 65},
+		{msgCFHeaders, msgCFHeaders, pver, MainNet, 58},
+		{msgCFTypes, msgCFTypes, pver, MainNet, 26},
+		{msgGetInitState, msgGetInitState, pver, MainNet, 25},
+		{msgInitState, msgInitState, pver, MainNet, 27},
 	}
 
 	t.Logf("Running %d tests", len(tests))

--- a/wire/msgversion.go
+++ b/wire/msgversion.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -19,7 +19,7 @@ import (
 const MaxUserAgentLen = 256
 
 // DefaultUserAgent for wire in the stack
-const DefaultUserAgent = "/dcrwire:0.4.0/"
+const DefaultUserAgent = "/dcrwire:1.0.0/"
 
 // MsgVersion implements the Message interface and represents a Decred version
 // message.  It is used for a peer to advertise itself as soon as an outbound

--- a/wire/protocol.go
+++ b/wire/protocol.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2018 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -17,7 +17,7 @@ const (
 	InitialProcotolVersion uint32 = 1
 
 	// ProtocolVersion is the latest protocol version this package supports.
-	ProtocolVersion uint32 = 8
+	ProtocolVersion uint32 = 9
 
 	// NodeBloomVersion is the protocol version which added the SFNodeBloom
 	// service flag (unused).
@@ -47,6 +47,10 @@ const (
 	// InitStateVersion is the protocol version which adds the initstate
 	// and getinitstate messages.
 	InitStateVersion uint32 = 8
+
+	// RemoveRejectVersion is the protocol version which removes support for the
+	// reject message.
+	RemoveRejectVersion uint32 = 9
 )
 
 // ServiceFlag identifies services supported by a Decred peer.


### PR DESCRIPTION
**This requires #2585**.

This deprecates the `reject` wire protocol message towards its eventual removal in a future version of the software.

Per previous discussions, this handles the first part of the deprecation roadmap as follows:

* Stop sending `reject` messages and ignore any received `reject` message
* Bump the wire protocol version to version 9 and make it an error with associated protocol violation handling to send the message for all peers that have negotiated to the new protocol version
* However, any peers negotiated to an older version are not punished for sending them, newer versions simply won't send them and will ignore them from the older version peer

This additionally bumps the default user agent of the `wire` package to `dcrwire:1.0.0`.

The changes are split into multiple commits structured such that first each subsystem that responds with `reject` messages is modified to stop sending them, then all related APIs that are no longer necessary removed, and finally the `wire` protocol is updated to bump the protocol version and make it illegal under that new version.

This is the first part of #2546.