### PR TITLE
multi: Add UtxoCache.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ and [Decrediton (GUI)](https://github.com/decred/decrediton).
 ## Minimum Recommended Specifications (dcrd only)
 
 * 12 GB disk space (as of April 2020, increases over time)
-* 1GB memory (RAM)
+* 2GB memory (RAM)
 * ~150MB/day download, ~1.5GB/day upload
   * Plus one-time initial download of the entire block chain
 * Windows 10 (server preferred), macOS, Linux

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2015-2016 The btcsuite developers
-// Copyright (c) 2016-2020 The Decred developers
+// Copyright (c) 2016-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -993,16 +993,13 @@ func deserializeUtxoEntry(serialized []byte, txOutIndex uint32) (*UtxoEntry, err
 	offset += bytesRead
 
 	// Create a new utxo entry with the details deserialized above.
-	const spent = false
-	const modified = false
 	entry := &UtxoEntry{
 		amount:        amount,
 		pkScript:      script,
 		blockHeight:   uint32(blockHeight),
 		blockIndex:    uint32(blockIndex),
 		scriptVersion: scriptVersion,
-		packedFlags: encodeUtxoFlags(isCoinBase, spent, modified, hasExpiry,
-			txType),
+		packedFlags:   encodeUtxoFlags(isCoinBase, hasExpiry, txType),
 	}
 
 	// Copy the minimal outputs if this was a ticket submission output.

--- a/blockchain/chainio_test.go
+++ b/blockchain/chainio_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2015-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -828,9 +828,6 @@ func TestUtxoSerialization(t *testing.T) {
 		withCoinbase = true
 		noExpiry     = false
 		withExpiry   = true
-		unspent      = false
-		spent        = true
-		unmodified   = false
 	)
 
 	tests := []struct {
@@ -851,8 +848,6 @@ func TestUtxoSerialization(t *testing.T) {
 				scriptVersion: 0,
 				packedFlags: encodeUtxoFlags(
 					withCoinbase,
-					unspent,
-					unmodified,
 					noExpiry,
 					stake.TxTypeRegular,
 				),
@@ -872,8 +867,6 @@ func TestUtxoSerialization(t *testing.T) {
 				scriptVersion: 0,
 				packedFlags: encodeUtxoFlags(
 					withCoinbase,
-					unspent,
-					unmodified,
 					noExpiry,
 					stake.TxTypeRegular,
 				),
@@ -892,8 +885,6 @@ func TestUtxoSerialization(t *testing.T) {
 				scriptVersion: 0,
 				packedFlags: encodeUtxoFlags(
 					noCoinbase,
-					unspent,
-					unmodified,
 					noExpiry,
 					stake.TxTypeRegular,
 				),
@@ -912,8 +903,6 @@ func TestUtxoSerialization(t *testing.T) {
 				scriptVersion: 0,
 				packedFlags: encodeUtxoFlags(
 					noCoinbase,
-					unspent,
-					unmodified,
 					withExpiry,
 					stake.TxTypeSStx,
 				),
@@ -940,8 +929,6 @@ func TestUtxoSerialization(t *testing.T) {
 				scriptVersion: 0xffff,
 				packedFlags: encodeUtxoFlags(
 					withCoinbase,
-					unspent,
-					unmodified,
 					noExpiry,
 					stake.TxTypeRegular,
 				),
@@ -960,8 +947,6 @@ func TestUtxoSerialization(t *testing.T) {
 				scriptVersion: 0,
 				packedFlags: encodeUtxoFlags(
 					noCoinbase,
-					unspent,
-					unmodified,
 					withExpiry,
 					stake.TxTypeRegular,
 				),
@@ -979,10 +964,9 @@ func TestUtxoSerialization(t *testing.T) {
 				blockHeight:   33333,
 				blockIndex:    3,
 				scriptVersion: 0,
+				state:         utxoStateModified | utxoStateSpent,
 				packedFlags: encodeUtxoFlags(
 					withCoinbase,
-					spent,
-					unmodified,
 					withExpiry,
 					stake.TxTypeRegular,
 				),

--- a/blockchain/common_test.go
+++ b/blockchain/common_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -117,6 +117,10 @@ func chainSetup(dbName string, params *chaincfg.Params) (*BlockChain, func(), er
 			ChainParams: &paramsCopy,
 			TimeSource:  NewMedianTime(),
 			SigCache:    sigCache,
+			UtxoCache: NewUtxoCache(&UtxoCacheConfig{
+				DB:      db,
+				MaxSize: 100 * 1024 * 1024, // 100 MiB
+			}),
 		})
 
 	if err != nil {

--- a/blockchain/example_test.go
+++ b/blockchain/example_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -52,6 +52,10 @@ func ExampleBlockChain_ProcessBlock() {
 			DB:          db,
 			ChainParams: mainNetParams,
 			TimeSource:  blockchain.NewMedianTime(),
+			UtxoCache: blockchain.NewUtxoCache(&blockchain.UtxoCacheConfig{
+				DB:      db,
+				MaxSize: 100 * 1024 * 1024, // 100 MiB
+			}),
 		})
 	if err != nil {
 		fmt.Printf("Failed to create chain instance: %v\n", err)

--- a/blockchain/fullblocks_test.go
+++ b/blockchain/fullblocks_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2016 The btcsuite developers
-// Copyright (c) 2016-2020 The Decred developers
+// Copyright (c) 2016-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -111,6 +111,10 @@ func chainSetup(dbName string, params *chaincfg.Params) (*blockchain.BlockChain,
 			ChainParams: &paramsCopy,
 			TimeSource:  blockchain.NewMedianTime(),
 			SigCache:    sigCache,
+			UtxoCache: blockchain.NewUtxoCache(&blockchain.UtxoCacheConfig{
+				DB:      db,
+				MaxSize: 100 * 1024 * 1024, // 100 MiB
+			}),
 		})
 
 	if err != nil {

--- a/blockchain/go.mod
+++ b/blockchain/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrd/blockchain/v4
 
-go 1.13
+go 1.14
 
 require (
 	github.com/decred/dcrd/blockchain/stake/v4 v4.0.0-20210129192908-660d0518b4cf

--- a/blockchain/headercmt.go
+++ b/blockchain/headercmt.go
@@ -74,7 +74,7 @@ func (b *BlockChain) FetchUtxoViewParentTemplate(block *wire.MsgBlock) (*UtxoVie
 	// Since the block template is building on the parent of the current tip,
 	// undo the transactions and spend information for the tip block to reach
 	// the point of view of the block template.
-	view := NewUtxoViewpoint()
+	view := NewUtxoViewpoint(b.utxoCache)
 	view.SetBestHash(&tip.hash)
 	tipBlock, err := b.fetchMainChainBlockByNode(tip)
 	if err != nil {
@@ -103,7 +103,7 @@ func (b *BlockChain) FetchUtxoViewParentTemplate(block *wire.MsgBlock) (*UtxoVie
 	// Update the view to unspend all of the spent txos and remove the utxos
 	// created by the tip block.  Also, if the block votes against its parent,
 	// reconnect all of the regular transactions.
-	err = view.disconnectBlock(b.db, tipBlock, parent, stxos, isTreasuryEnabled)
+	err = view.disconnectBlock(tipBlock, parent, stxos, isTreasuryEnabled)
 	if err != nil {
 		return nil, err
 	}

--- a/blockchain/sequencelock_test.go
+++ b/blockchain/sequencelock_test.go
@@ -55,7 +55,7 @@ func TestCalcSequenceLock(t *testing.T) {
 			PkScript: nil,
 		}},
 	})
-	view := NewUtxoViewpoint()
+	view := NewUtxoViewpoint(nil)
 	view.AddTxOuts(targetTx, int64(numBlocks)-4, 0, noTreasury)
 	view.SetBestHash(&node.hash)
 

--- a/blockchain/stakeext.go
+++ b/blockchain/stakeext.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -112,7 +112,7 @@ func (b *BlockChain) TicketsWithAddress(address dcrutil.Address, isTreasuryEnabl
 	err := b.db.View(func(dbTx database.Tx) error {
 		for _, hash := range tickets {
 			outpoint := wire.OutPoint{Hash: hash, Index: 0, Tree: wire.TxTreeStake}
-			utxo, err := dbFetchUtxoEntry(dbTx, outpoint)
+			utxo, err := b.utxoCache.FetchEntry(dbTx, outpoint)
 			if err != nil {
 				return err
 			}
@@ -224,7 +224,7 @@ func (b *BlockChain) TicketPoolValue() (dcrutil.Amount, error) {
 	err := b.db.View(func(dbTx database.Tx) error {
 		for _, hash := range sn.LiveTickets() {
 			outpoint := wire.OutPoint{Hash: hash, Index: 0, Tree: wire.TxTreeStake}
-			utxo, err := dbFetchUtxoEntry(dbTx, outpoint)
+			utxo, err := b.utxoCache.FetchEntry(dbTx, outpoint)
 			if err != nil {
 				return err
 			}

--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -1,0 +1,910 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package blockchain
+
+import (
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/database/v2"
+	"github.com/decred/dcrd/dcrutil/v4"
+	"github.com/decred/dcrd/wire"
+)
+
+const (
+	// outpointSize is the size of an outpoint on a 64-bit platform.  It is
+	// equivalent to what unsafe.Sizeof(wire.OutPoint{}) returns on a 64-bit
+	// platform.
+	outpointSize = 56
+
+	// pointerSize is the size of a pointer on a 64-bit platform.
+	pointerSize = 8
+
+	// p2pkhScriptLen is the length of a standard pay-to-pubkey-hash script.  It
+	// is used in the calculation to approximate the average size of a utxo entry
+	// when setting the initial capacity of the cache.
+	p2pkhScriptLen = 25
+
+	// mapOverhead is the number of bytes per entry to use when approximating the
+	// memory overhead of the entries map itself (i.e. the memory usage due to
+	// internals of the map, such as the underlying buckets that are allocated).
+	// This number was determined by inspecting the true size of the map with
+	// various numbers of entries and comparing it with the total size of all
+	// entries in the map.  The average overhead came out to 57 bytes per entry.
+	mapOverhead = 57
+
+	// evictionPercentage is the targeted percentage of entries to evict from the
+	// cache when its maximum size has been reached.
+	//
+	// A lower percentage will result in a higher overall hit ratio for the cache,
+	// and thus better performance, but will require eviction again sooner.  This
+	// value was selected to keep the hit ratio of the cache as high as possible
+	// while still evicting a significant portion of the cache when it reaches its
+	// maximum allowed size.
+	evictionPercentage = 0.15
+
+	// periodicFlushInterval is the amount of time to wait before a periodic flush
+	// is required.
+	//
+	// The cache is flushed periodically during initial block download to avoid
+	// requiring a flush that would take a significant amount of time on shutdown
+	// (or, in the case of an unclean shutdown, a significant amount of time to
+	// initialize the cache when restarted).
+	periodicFlushInterval = time.Minute * 2
+)
+
+// UtxoCache is an unspent transaction output cache that sits on top of the
+// utxo set database and provides significant runtime performance benefits at
+// the cost of some additional memory usage.  It drastically reduces the amount
+// of reading and writing to disk, especially during initial block download when
+// a very large number of blocks are being processed in quick succession.
+//
+// The UtxoCache is a read-through cache.  All utxo reads go through the cache.
+// When there is a cache miss, the cache loads the missing data from the
+// database, caches it, and returns it to the caller.
+//
+// The UtxoCache is a write-back cache.  Writes to the cache are acknowledged
+// by the cache immediately but are only periodically flushed to the database.
+// This allows intermediate steps to effectively be skipped.  For example, a
+// utxo that is created and then spent in between flushes never needs to be
+// written to the utxo set in the database.
+//
+// Due to the write-back nature of the cache, at any given time the database
+// may not be in sync with the cache, and therefore all utxo reads and writes
+// MUST go through the cache, and never read or write to the database directly.
+type UtxoCache struct {
+	// db is the database that contains the utxo set.  It is set when the instance
+	// is created and is not changed afterward.
+	db database.DB
+
+	// maxSize is the maximum allowed size of the utxo cache, in bytes.  It is set
+	// when the instance is created and is not changed afterward.
+	maxSize uint64
+
+	// cacheLock protects access to the fields in the struct below this point.  A
+	// standard mutex is used rather than a read-write mutex since the cache will
+	// often write when reads result in a cache miss, so it is generally not worth
+	// the additional overhead of using a read-write mutex.
+	cacheLock sync.Mutex
+
+	// entries holds the cached utxo entries.
+	entries map[wire.OutPoint]*UtxoEntry
+
+	// lastFlushHash is the block hash of the last flush.  It is used to compare
+	// the state of the cache to the utxo set state in the database so that the
+	// utxo set can properly be initialized in the case that the latest utxo data
+	// had not been flushed to the database yet.
+	lastFlushHash chainhash.Hash
+
+	// lastFlushTime is the last time that the cache was flushed to the database.
+	// It is used to determine when to periodically flush the cache to the
+	// database during initial block download even if the cache isn't full to
+	// minimize the amount of progress lost if an unclean shutdown occurs.
+	lastFlushTime time.Time
+
+	// lastEvictionHeight is the block height of the last eviction.  When the
+	// cache reaches the maximum allowed size, entries are evicted based on the
+	// height of the block that they are contained in, and last eviction height is
+	// updated to the current height.
+	lastEvictionHeight uint32
+
+	// totalEntrySize is the total size of all utxo entries in the cache, in
+	// bytes.  It is updated whenever an entry is added or removed from the cache.
+	totalEntrySize uint64
+
+	// The following fields track the total number of cache hits and misses and
+	// are used to measure the overall cache hit ratio.
+	hits   uint64
+	misses uint64
+}
+
+// UtxoCacheConfig is a descriptor which specifies the utxo cache instance
+// configuration.
+type UtxoCacheConfig struct {
+	// DB defines the database which houses the utxo set.
+	//
+	// This field is required.
+	DB database.DB
+
+	// MaxSize defines the maximum allowed size of the utxo cache, in bytes.
+	//
+	// This field is required.
+	MaxSize uint64
+}
+
+// NewUtxoCache returns a UtxoCache instance using the provided configuration
+// details.
+func NewUtxoCache(config *UtxoCacheConfig) *UtxoCache {
+	// Approximate the maximum number of entries allowed in the cache in order
+	// to set the initial capacity of the entries map.
+	avgEntrySize := mapOverhead + outpointSize + pointerSize + baseEntrySize +
+		p2pkhScriptLen
+	maxEntries := math.Ceil(float64(config.MaxSize) / float64(avgEntrySize))
+
+	return &UtxoCache{
+		db:            config.DB,
+		maxSize:       config.MaxSize,
+		entries:       make(map[wire.OutPoint]*UtxoEntry, uint64(maxEntries)),
+		lastFlushTime: time.Now(),
+	}
+}
+
+// totalSize returns the total size of the cache on a 64-bit platform, in bytes.
+// Note that this only takes the entries map into account, which represents the
+// vast majoirty of the memory that the cache uses, and does not include the
+// memory usage of other fields in the utxo cache struct.
+//
+// This function MUST be called with the cache lock held.
+func (c *UtxoCache) totalSize() uint64 {
+	numEntries := uint64(len(c.entries))
+	return mapOverhead*numEntries + outpointSize*numEntries +
+		pointerSize*numEntries + c.totalEntrySize
+}
+
+// hitRatio returns the percentage of cache lookups that resulted in a cache
+// hit.
+//
+// This function MUST be called with the cache lock held.
+func (c *UtxoCache) hitRatio() float64 {
+	totalLookups := c.hits + c.misses
+	if totalLookups == 0 {
+		return 100
+	}
+
+	return float64(c.hits) / float64(totalLookups) * 100
+}
+
+// addEntry adds the specified output to the cache.  The entry being added MUST
+// NOT be mutated by the caller after being passed to this function.
+//
+// Note that this function does not check if the entry is unspendable and
+// therefore the caller should ensure that the entry is spendable before adding
+// it to the cache.
+//
+// This function MUST be called with the cache lock held.
+func (c *UtxoCache) addEntry(outpoint wire.OutPoint, entry *UtxoEntry) error {
+	// Attempt to get an existing entry from the cache.
+	cachedEntry := c.entries[outpoint]
+
+	// If an existing entry does not exist, the added entry should be marked as
+	// modified and fresh.
+	if cachedEntry == nil {
+		entry.state |= utxoStateModified | utxoStateFresh
+	}
+
+	// Add the entry to the cache.  In the case that an entry already exists, the
+	// existing entry is overwritten.  All fields are overwritten because it's
+	// possible (although extremely unlikely) that the existing entry is being
+	// replaced by a different transaction with the same hash.  This is allowed so
+	// long as the previous transaction is fully spent.
+	c.entries[outpoint] = entry
+
+	// Update the total entry size of the cache.
+	if cachedEntry != nil {
+		c.totalEntrySize -= cachedEntry.size()
+	}
+	c.totalEntrySize += entry.size()
+
+	return nil
+}
+
+// AddEntry adds the specified output to the cache.  The entry being added MUST
+// NOT be mutated by the caller after being passed to this function.
+//
+// Note that this function does not check if the entry is unspendable and
+// therefore the caller should ensure that the entry is spendable before adding
+// it to the cache.
+//
+// This function is safe for concurrent access.
+func (c *UtxoCache) AddEntry(outpoint wire.OutPoint, entry *UtxoEntry) error {
+	c.cacheLock.Lock()
+	err := c.addEntry(outpoint, entry)
+	c.cacheLock.Unlock()
+	return err
+}
+
+// spendEntry marks the specified output as spent.
+//
+// This function MUST be called with the cache lock held.
+func (c *UtxoCache) spendEntry(outpoint wire.OutPoint) {
+	// Attempt to get an existing entry from the cache.
+	cachedEntry := c.entries[outpoint]
+
+	// If the entry is nil or already spent, return immediately.
+	if cachedEntry == nil || cachedEntry.IsSpent() {
+		return
+	}
+
+	// If the entry is fresh, and is now being spent, it can safely be removed.
+	// This is an optimization to skip writing to the database for outputs that
+	// are added and spent in between flushes to the database.
+	if cachedEntry.isFresh() {
+		// The entry in the map is marked as nil rather than deleting it so that
+		// subsequent lookups for the outpoint will still result in a cache hit and
+		// avoid querying the database.
+		c.entries[outpoint] = nil
+		c.totalEntrySize -= cachedEntry.size()
+		return
+	}
+
+	// Mark the output as spent and modified.
+	cachedEntry.Spend()
+}
+
+// SpendEntry marks the specified output as spent.
+//
+// This function is safe for concurrent access.
+func (c *UtxoCache) SpendEntry(outpoint wire.OutPoint) {
+	c.cacheLock.Lock()
+	c.spendEntry(outpoint)
+	c.cacheLock.Unlock()
+}
+
+// fetchEntry returns the specified transaction output from the utxo set.  If
+// the output exists in the cache, it is returned immediately.  Otherwise, it
+// uses an existing database transaction to fetch the output from the database,
+// cache it, and return it to the caller.  A cloned copy of the entry is
+// returned so it can safely be mutated by the caller without invalidating the
+// cache.
+//
+// When there is no entry for the provided output, nil will be returned for both
+// the entry and the error.
+//
+// This function MUST be called with the cache lock held.
+func (c *UtxoCache) fetchEntry(dbTx database.Tx, outpoint wire.OutPoint) (*UtxoEntry, error) {
+	// If the cache already has the entry, return it immediately.  A cloned copy
+	// of the entry is returned so it can safely be mutated by the caller without
+	// invalidating the cache.
+	if entry, found := c.entries[outpoint]; found {
+		c.hits++
+		return entry.Clone(), nil
+	}
+
+	// Increment cache misses.
+	c.misses++
+
+	// Fetch the entry from the database.
+	//
+	// NOTE: Missing entries are not considered an error here and instead
+	// will result in nil entries in the view.  This is intentionally done
+	// so other code can use the presence of an entry in the view as a way
+	// to unnecessarily avoid attempting to reload it from the database.
+	entry, err := dbFetchUtxoEntry(dbTx, outpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	// Update the total entry size of the cache.
+	if entry != nil {
+		c.totalEntrySize += entry.size()
+	}
+
+	// Add the entry to the cache and return it.  A cloned copy of the entry is
+	// returned so it can safely be mutated by the caller without invalidating the
+	// cache.
+	c.entries[outpoint] = entry
+	return entry.Clone(), nil
+}
+
+// FetchEntry returns the specified transaction output from the utxo set.  If
+// the output exists in the cache, it is returned immediately.  Otherwise, it
+// uses an existing database transaction to fetch the output from the database,
+// cache it, and return it to the caller.  A cloned copy of the entry is
+// returned so it can safely be mutated by the caller without invalidating the
+// cache.
+//
+// When there is no entry for the provided output, nil will be returned for both
+// the entry and the error.
+//
+// This function is safe for concurrent access.
+func (c *UtxoCache) FetchEntry(dbTx database.Tx, outpoint wire.OutPoint) (*UtxoEntry, error) {
+	c.cacheLock.Lock()
+	entry, err := c.fetchEntry(dbTx, outpoint)
+	c.cacheLock.Unlock()
+	return entry, err
+}
+
+// FetchEntries adds the requested transaction outputs to the provided view.  It
+// first checks the cache for each output, and if an output does not exist in
+// the cache, it will fetch it from the database.
+//
+// Upon completion of this function, the view will contain an entry for each
+// requested outpoint.  Spent outputs, or those which otherwise don't exist,
+// will result in a nil entry in the view.
+//
+// This function is safe for concurrent access.
+func (c *UtxoCache) FetchEntries(filteredSet viewFilteredSet, view *UtxoViewpoint) error {
+	c.cacheLock.Lock()
+	err := c.db.View(func(dbTx database.Tx) error {
+		for outpoint := range filteredSet {
+			entry, err := c.fetchEntry(dbTx, outpoint)
+			if err != nil {
+				return err
+			}
+
+			// NOTE: Missing entries are not considered an error here and instead
+			// will result in nil entries in the view.  This is intentionally done
+			// so other code can use the presence of an entry in the view as a way
+			// to unnecessarily avoid attempting to reload it from the database.
+			view.entries[outpoint] = entry
+		}
+
+		return nil
+	})
+	c.cacheLock.Unlock()
+
+	return err
+}
+
+// Commit updates all entries in the cache based on the state of each entry in
+// the provided view.
+//
+// All entries in the provided view that are marked as modified and spent are
+// removed from the view.  Additionally, all entries that are added to the cache
+// are removed from the provided view.
+//
+// This function is safe for concurrent access.
+func (c *UtxoCache) Commit(view *UtxoViewpoint) error {
+	c.cacheLock.Lock()
+	for outpoint, entry := range view.entries {
+		// If the entry is nil, delete it from the view and continue.
+		if entry == nil {
+			delete(view.entries, outpoint)
+			continue
+		}
+
+		// If the entry is not modified and not fresh, continue as there is nothing
+		// to do.
+		if !entry.isModified() && !entry.isFresh() {
+			continue
+		}
+
+		// If the entry is modified and spent, mark it as spent in the cache and
+		// then delete it from the view.
+		if entry.isModified() && entry.IsSpent() {
+			// Mark the entry as spent in the cache.
+			c.spendEntry(outpoint)
+
+			// Delete the entry from the view.
+			delete(view.entries, outpoint)
+			continue
+		}
+
+		// If we passed all of the conditions above, the entry is modified or fresh,
+		// but not spent, and should be added to the cache.
+		err := c.addEntry(outpoint, entry)
+		if err != nil {
+			c.cacheLock.Unlock()
+			return err
+		}
+
+		// All entries that are added to the cache should be removed from the
+		// provided view.  This is an optimization to allow the cache to take
+		// ownership of the entry from the view and avoid an additional allocation.
+		// It is removed from the view to ensure that it is not mutated by the
+		// caller after being added to the cache.
+		//
+		// This does cause the view to refetch the entry if it is requested again
+		// after being removed.  However, this only really occurs during reorgs,
+		// whereas committing the view to the cache happens with every connected
+		// block, so this optimizes for the much more common case.
+		delete(view.entries, outpoint)
+	}
+	c.cacheLock.Unlock()
+
+	return nil
+}
+
+// calcEvictionHeight returns the eviction height based on the best height of
+// the main chain and the last eviction height.  All entries that are contained
+// in a block at a height less than the eviction height will be evicted from the
+// cache when the cache reaches its maximum allowed size.
+//
+// Eviction is based on height since the height of the block that an entry is
+// contained in is a proxy for how old the utxo is.  On average, recent utxos
+// are much more likely to be spent in upcoming blocks than older utxos, so the
+// strategy used is to evict the oldest utxos in order to maximize the hit ratio
+// of the cache.
+//
+// This function MUST be called with the cache lock held.
+func (c *UtxoCache) calcEvictionHeight(bestHeight uint32) uint32 {
+	if bestHeight < c.lastEvictionHeight {
+		return bestHeight
+	}
+
+	lastEvictionDepth := bestHeight - c.lastEvictionHeight
+	numBlocksToEvict := math.Ceil(float64(lastEvictionDepth) * evictionPercentage)
+	return c.lastEvictionHeight + uint32(numBlocksToEvict)
+}
+
+// shouldFlush returns whether or not a flush should be performed.
+//
+// If the maximum size of the cache has been reached, or if the periodic flush
+// interval has been reached, then a flush is required.
+//
+// This function MUST be called with the cache lock held.
+func (c *UtxoCache) shouldFlush(bestHash *chainhash.Hash) bool {
+	// No need to flush if the cache has already been flushed through the best
+	// hash.
+	if c.lastFlushHash == *bestHash {
+		return false
+	}
+
+	// Flush if the max size of the cache has been reached.
+	if c.totalSize() >= c.maxSize {
+		return true
+	}
+
+	// Flush if the periodic flush interval has been reached.
+	return time.Since(c.lastFlushTime) >= periodicFlushInterval
+}
+
+// flush commits all modified entries to the database and conditionally evicts
+// entries.
+//
+// Entries that are nil or spent are always evicted since they are
+// unlikely to be accessed again.  Additionally, if the cache has reached its
+// maximum size, entries are evicted based on the height of the block that they
+// are contained in.
+//
+// This function MUST be called with the cache lock held.
+func (c *UtxoCache) flush(bestHash *chainhash.Hash, bestHeight uint32, logFlush bool) error {
+	// If the maximum allowed size of the cache has been reached, determine the
+	// eviction height.
+	var evictionHeight uint32
+	memUsage := c.totalSize()
+	if memUsage >= c.maxSize {
+		evictionHeight = c.calcEvictionHeight(bestHeight)
+	}
+
+	// Log that a flush is starting and indicate the current memory usage, hit
+	// ratio, and eviction height.
+	var hitRatio float64
+	var evictionLog string
+	var preFlushNumEntries int
+	if logFlush {
+		preFlushNumEntries = len(c.entries)
+		memUsageMiB := float64(memUsage) / 1024 / 1024
+		memUsagePercent := float64(memUsage) / float64(c.maxSize) * 100
+		hitRatio = c.hitRatio()
+		if evictionHeight != 0 {
+			evictionLog = fmt.Sprintf(", eviction height: %d", evictionHeight)
+		}
+		log.Debugf("UTXO cache flush starting (%d entries, %.2f MiB (%.2f%%), "+
+			"%.2f%% hit ratio, height: %d%s)", preFlushNumEntries, memUsageMiB,
+			memUsagePercent, hitRatio, bestHeight, evictionLog)
+	}
+
+	// Flush the entries in the cache to the database and update the utxo set
+	// state in the database.
+	//
+	// It is important that the utxo set state is always updated in the same
+	// database transaction as the utxo set itself so that it is always in sync.
+	err := c.db.Update(func(dbTx database.Tx) error {
+		for outpoint, entry := range c.entries {
+			// Write the entry to the database.
+			err := dbPutUtxoEntry(dbTx, outpoint, entry)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Update the utxo set state in the database.
+		return dbPutUtxoSetState(dbTx, &utxoSetState{
+			lastFlushHeight: bestHeight,
+			lastFlushHash:   *bestHash,
+		})
+	})
+	if err != nil {
+		return err
+	}
+
+	// Update the entries in the cache after flushing to the database.  This is
+	// done after the updates to the database have been successfully committed to
+	// ensure that an unexpected database error would not leave the cache in an
+	// inconsistent state.
+	for outpoint, entry := range c.entries {
+		// Conditionally evict entries from the cache.  Entries that are nil or
+		// spent are always evicted since they are unlikely to be accessed again.
+		// Additionally, entries that are contained in a block with a height less
+		// than the eviction height are evicted.
+		if entry == nil || entry.IsSpent() ||
+			entry.BlockHeight() < int64(evictionHeight) {
+
+			// Remove the entry from the cache.
+			delete(c.entries, outpoint)
+
+			// Update the total entry size of the cache.
+			if entry != nil {
+				c.totalEntrySize -= entry.size()
+			}
+
+			continue
+		}
+
+		// If the entry wasn't removed from the cache, clear the modified and
+		// fresh flags since it has been updated in the database.
+		entry.state &^= utxoStateModified
+		entry.state &^= utxoStateFresh
+	}
+
+	// Update the last flush on the cache instance now that the flush has been
+	// completed.
+	c.lastFlushHash = *bestHash
+	c.lastFlushTime = time.Now()
+
+	// Update the last eviction height on the cache instance if we evicted just
+	// now.
+	if evictionHeight != 0 {
+		c.lastEvictionHeight = evictionHeight
+	}
+
+	// Log that the flush has been completed and indicate the updated memory usage
+	// as it will be reduced due to evicting entries above.
+	if logFlush {
+		remainingEntries := len(c.entries)
+		flushedEntries := preFlushNumEntries - remainingEntries
+		memUsage = c.totalSize()
+		memUsageMiB := float64(memUsage) / 1024 / 1024
+		memUsagePercent := float64(memUsage) / float64(c.maxSize) * 100
+		log.Debugf("UTXO cache flush completed (%d entries flushed, %d entries "+
+			"remaining, %.2f MiB (%.2f%%))", flushedEntries, remainingEntries,
+			memUsageMiB, memUsagePercent)
+	}
+
+	return nil
+}
+
+// MaybeFlush conditionally flushes the cache to the database.
+//
+// If the maximum size of the cache has been reached, or if the periodic flush
+// interval has been reached, then a flush is required.  Additionally, a flush
+// can be forced by setting the force flush parameter.
+//
+// This function is safe for concurrent access.
+func (c *UtxoCache) MaybeFlush(bestHash *chainhash.Hash, bestHeight uint32,
+	forceFlush bool, logFlush bool) error {
+
+	c.cacheLock.Lock()
+	if forceFlush || c.shouldFlush(bestHash) {
+		err := c.flush(bestHash, bestHeight, logFlush)
+		c.cacheLock.Unlock()
+		return err
+	}
+
+	c.cacheLock.Unlock()
+	return nil
+}
+
+// InitUtxoCache initializes the utxo cache by ensuring that the utxo set is
+// caught up to the tip of the best chain.
+//
+// Since the cache is only flushed to the database periodically, the utxo set
+// may not be caught up to the tip of the best chain.  This function catches the
+// utxo set up by replaying all blocks from the block after the block that was
+// last flushed to the tip block through the cache.
+//
+// This function should only be called during initialization.
+func (b *BlockChain) InitUtxoCache(tip *blockNode) error {
+	log.Infof("UTXO cache initializing (max size: %d MiB)...",
+		b.utxoCache.maxSize/1024/1024)
+
+	// Fetch the utxo set state from the database.
+	var state *utxoSetState
+	err := b.db.View(func(dbTx database.Tx) error {
+		var err error
+		state, err = dbFetchUtxoSetState(dbTx)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+
+	// If the state is nil, update the state to the tip.  This should only be the
+	// case when starting from a fresh database or a database that has not been
+	// run with the utxo cache yet.
+	if state == nil {
+		state = &utxoSetState{
+			lastFlushHeight: uint32(tip.height),
+			lastFlushHash:   tip.hash,
+		}
+		err := b.db.Update(func(dbTx database.Tx) error {
+			return dbPutUtxoSetState(dbTx, state)
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	// Set the last flush hash and the last eviction height from the saved state
+	// since that is where we are starting from.
+	b.utxoCache.lastFlushHash = state.lastFlushHash
+	b.utxoCache.lastEvictionHeight = state.lastFlushHeight
+
+	// If state is already caught up to the tip, return as there is nothing to do.
+	if state.lastFlushHash == tip.hash {
+		log.Info("UTXO cache initialization completed")
+		return nil
+	}
+
+	// Find the fork point between the current tip and the last flushed block.
+	lastFlushedNode := b.index.LookupNode(&state.lastFlushHash)
+	if lastFlushedNode == nil {
+		// panic if the last flushed block node does not exist.  This should never
+		// happen unless the database is corrupted.
+		panicf("last flushed block node hash %v (height %v) does not exist",
+			state.lastFlushHash, state.lastFlushHeight)
+	}
+	fork := b.bestChain.FindFork(lastFlushedNode)
+
+	// Disconnect all of the blocks back to the point of the fork.  This entails
+	// loading the blocks and their associated spent txos from the database and
+	// using that information to unspend all of the spent txos and remove the
+	// utxos created by the blocks.  In addition, if a block votes against its
+	// parent, the regular transactions are reconnected.
+	//
+	// Note that blocks will only need to be disconnected during initialization
+	// if an unclean shutdown occurred between a block being disconnected and the
+	// cache being flushed.  Since the cache is always flushed immediately after
+	// disconnecting a block, this will occur very infrequently.  In the typical
+	// catchup case, the fork node will be the last flushed node itself and this
+	// loop will be skipped.
+	view := NewUtxoViewpoint(b.utxoCache)
+	view.SetBestHash(&tip.hash)
+	var nextBlockToDetach *dcrutil.Block
+	n := lastFlushedNode
+	for n != nil && n != fork {
+		select {
+		case <-b.interrupt:
+			return errInterruptRequested
+		default:
+		}
+
+		// Grab the block to detach based on the node.  Use the fact that the
+		// blocks are being detached in reverse order, so the parent of the
+		// current block being detached is the next one being detached.
+		block := nextBlockToDetach
+		if block == nil {
+			var err error
+			block, err = b.fetchBlockByNode(n)
+			if err != nil {
+				return err
+			}
+		}
+		if n.hash != *block.Hash() {
+			panicf("detach block node hash %v (height %v) does not match "+
+				"previous parent block hash %v", &n.hash, n.height,
+				block.Hash())
+		}
+
+		// Grab the parent of the current block and also save a reference to it
+		// as the next block to detach so it doesn't need to be loaded again on
+		// the next iteration.
+		parent, err := b.fetchBlockByNode(n.parent)
+		if err != nil {
+			return err
+		}
+		nextBlockToDetach = parent
+
+		// Determine if treasury agenda is active.
+		isTreasuryEnabled, err := b.isTreasuryAgendaActive(n.parent)
+		if err != nil {
+			return err
+		}
+
+		// Load all of the spent txos for the block from the spend journal.
+		var stxos []spentTxOut
+		err = b.db.View(func(dbTx database.Tx) error {
+			stxos, err = dbFetchSpendJournalEntry(dbTx, block, isTreasuryEnabled)
+			return err
+		})
+		if err != nil {
+			return err
+		}
+
+		// Update the view to unspend all of the spent txos and remove the utxos
+		// created by the block.  Also, if the block votes against its parent,
+		// reconnect all of the regular transactions.
+		err = view.disconnectBlock(block, parent, stxos, isTreasuryEnabled)
+		if err != nil {
+			return err
+		}
+
+		// Commit all entries in the view to the utxo cache.  All entries in the
+		// view that are marked as modified and spent are removed from the view.
+		// Additionally, all entries that are added to the cache are removed from
+		// the view.
+		err = b.utxoCache.Commit(view)
+		if err != nil {
+			return err
+		}
+
+		// Conditionally flush the utxo cache to the database.  Don't force flush
+		// since many blocks may be disconnected and connected in quick succession
+		// when initializing.
+		err = b.utxoCache.MaybeFlush(&n.hash, uint32(n.height), false, true)
+		if err != nil {
+			return err
+		}
+
+		n = n.parent
+	}
+
+	// Determine the blocks to attach after the fork point.  Each block is added
+	// to the slice from back to front so they are attached in the appropriate
+	// order when iterating the slice below.
+	replayNodes := make([]*blockNode, tip.height-fork.height)
+	for n := tip; n != nil && n != fork; n = n.parent {
+		replayNodes[n.height-fork.height-1] = n
+	}
+
+	// Replay all of the blocks through the cache.
+	var prevBlockAttached *dcrutil.Block
+	for i, n := range replayNodes {
+		select {
+		case <-b.interrupt:
+			return errInterruptRequested
+		default:
+		}
+
+		// Grab the block to attach based on the node.  The parent of the block is
+		// the previous one that was attached except for the first node being
+		// attached, which needs to be fetched.
+		block, err := b.fetchBlockByNode(n)
+		if err != nil {
+			return err
+		}
+		parent := prevBlockAttached
+		if i == 0 {
+			parent, err = b.fetchBlockByNode(n.parent)
+			if err != nil {
+				return err
+			}
+		}
+		if n.parent.hash != *parent.Hash() {
+			panicf("attach block node hash %v (height %v) parent hash %v does "+
+				"not match previous parent block hash %v", &n.hash, n.height,
+				&n.parent.hash, parent.Hash())
+		}
+
+		// Store the loaded block as parent of the block in the next iteration.
+		prevBlockAttached = block
+
+		// Determine if treasury agenda is active.
+		isTreasuryEnabled, err := b.isTreasuryAgendaActive(n.parent)
+		if err != nil {
+			return err
+		}
+
+		// Update the view to mark all utxos referenced by the block as
+		// spent and add all transactions being created by this block to it.
+		// In the case the block votes against the parent, also disconnect
+		// all of the regular transactions in the parent block.
+		err = view.connectBlock(b.db, block, parent, nil, isTreasuryEnabled)
+		if err != nil {
+			return err
+		}
+
+		// Commit all entries in the view to the utxo cache.  All entries in the
+		// view that are marked as modified and spent are removed from the view.
+		// Additionally, all entries that are added to the cache are removed from
+		// the view.
+		err = b.utxoCache.Commit(view)
+		if err != nil {
+			return err
+		}
+
+		// Conditionally flush the utxo cache to the database.  Don't force flush
+		// since many blocks may be connected in quick succession when initializing.
+		err = b.utxoCache.MaybeFlush(&n.hash, uint32(n.height), false, true)
+		if err != nil {
+			return err
+		}
+	}
+
+	log.Info("UTXO cache initialization completed")
+	return nil
+}
+
+// ShutdownUtxoCache flushes the utxo cache to the database on shutdown.  Since
+// the cache is flushed periodically during initial block download and flushed
+// after every block is connected after initial block download is complete,
+// this flush that occurs during shutdown should finish relatively quickly.
+//
+// Note that if an unclean shutdown occurs, the cache will still be initialized
+// properly when restarted as during initialization it will replay blocks to
+// catch up to the tip block if it was not fully flushed before shutting down.
+// However, it is still preferred to flush when shutting down versus always
+// recovering on startup since it is faster.
+//
+// This function should only be called during shutdown.
+func (b *BlockChain) ShutdownUtxoCache() {
+	b.chainLock.RLock()
+	defer b.chainLock.RUnlock()
+
+	tip := b.bestChain.Tip()
+
+	// Force a cache flush and log the flush details.
+	b.utxoCache.MaybeFlush(&tip.hash, uint32(tip.height), true, true)
+}
+
+// FetchUtxoEntry loads and returns the requested unspent transaction output
+// from the point of view of the the main chain tip.
+//
+// NOTE: Requesting an output for which there is no data will NOT return an
+// error.  Instead both the entry and the error will be nil.  This is done to
+// allow pruning of spent transaction outputs.  In practice this means the
+// caller must check if the returned entry is nil before invoking methods on it.
+//
+// This function is safe for concurrent access however the returned entry (if
+// any) is NOT.
+func (b *BlockChain) FetchUtxoEntry(outpoint wire.OutPoint) (*UtxoEntry, error) {
+	b.chainLock.RLock()
+	defer b.chainLock.RUnlock()
+
+	var entry *UtxoEntry
+	err := b.db.View(func(dbTx database.Tx) error {
+		var err error
+		entry, err = b.utxoCache.FetchEntry(dbTx, outpoint)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return entry, nil
+}
+
+// UtxoStats represents unspent output statistics on the current utxo set.
+type UtxoStats struct {
+	Utxos          int64
+	Transactions   int64
+	Size           int64
+	Total          int64
+	SerializedHash chainhash.Hash
+}
+
+// FetchUtxoStats returns statistics on the current utxo set.
+//
+// NOTE: During initial block download the utxo stats will lag behind the best
+// block that is currently synced since the utxo cache is only flushed to the
+// database periodically.  After initial block download the utxo stats will
+// always be in sync with the best block.
+func (b *BlockChain) FetchUtxoStats() (*UtxoStats, error) {
+	var stats *UtxoStats
+	err := b.db.View(func(dbTx database.Tx) error {
+		var err error
+		stats, err = dbFetchUtxoStats(dbTx)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return stats, nil
+}

--- a/blockchain/utxocache_test.go
+++ b/blockchain/utxocache_test.go
@@ -1,0 +1,1061 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package blockchain
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/decred/dcrd/blockchain/stake/v4"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/database/v2"
+	"github.com/decred/dcrd/wire"
+)
+
+// Define constants for indicating flags throughout the tests.
+const (
+	noCoinbase   = false
+	withCoinbase = true
+	noExpiry     = false
+	withExpiry   = true
+)
+
+// outpoint299 returns a test outpoint from block height 299 that can be used
+// throughout the tests.
+func outpoint299() wire.OutPoint {
+	return wire.OutPoint{
+		Hash: *mustParseHash("e299d2cc5deb5b39d230ad2a6046ff9cc164064f431a2893eb6" +
+			"28b467d018452"),
+		Index: 0,
+		Tree:  wire.TxTreeRegular,
+	}
+}
+
+// entry299 returns a utxo entry from block height 299 that can be used
+// throughout the tests.
+func entry299() *UtxoEntry {
+	return &UtxoEntry{
+		amount: 58795424,
+		pkScript: hexToBytes("76a914454017705ab80470d089c7f644e39cc9e0fd308e" +
+			"88ac"),
+		blockHeight:   299,
+		blockIndex:    1,
+		scriptVersion: 0,
+		packedFlags: encodeUtxoFlags(
+			noCoinbase,
+			noExpiry,
+			stake.TxTypeRegular,
+		),
+	}
+}
+
+// outpoint1100 returns a test outpoint from block height 1100 that can be used
+// throughout the tests.
+func outpoint1100() wire.OutPoint {
+	return wire.OutPoint{
+		Hash: *mustParseHash("ce1d0f74440c391d15516015224755a8661e56e796ac25490f3" +
+			"0ad1081c5d638"),
+		Index: 1,
+		Tree:  wire.TxTreeRegular,
+	}
+}
+
+// entry1100 returns a utxo entry from block height 1100 that can be used
+// throughout the tests.
+func entry1100() *UtxoEntry {
+	return &UtxoEntry{
+		amount: 52454022,
+		pkScript: hexToBytes("76a9146b65f16ebca9b848158701d5a2eb5124547a2144" +
+			"88ac"),
+		blockHeight:   1100,
+		blockIndex:    1,
+		scriptVersion: 0,
+		packedFlags: encodeUtxoFlags(
+			noCoinbase,
+			noExpiry,
+			stake.TxTypeRegular,
+		),
+	}
+}
+
+// outpoint1200 returns a test outpoint from block height 1200 that can be used
+// throughout the tests.
+func outpoint1200() wire.OutPoint {
+	return wire.OutPoint{
+		Hash: *mustParseHash("72914cae2d4bc75f7777373b7c085c4b92d59f3e059fc7fd39d" +
+			"ef71c9fe188b5"),
+		Index: 2,
+		Tree:  wire.TxTreeRegular,
+	}
+}
+
+// entry1200 returns a utxo entry from block height 1200 that can be used
+// throughout the tests.
+func entry1200() *UtxoEntry {
+	return &UtxoEntry{
+		amount: 1871749598,
+		pkScript: hexToBytes("76a9142ec5027abadede723c47b6acdbace3be10b7e937" +
+			"88ac"),
+		blockHeight:   1200,
+		blockIndex:    0,
+		scriptVersion: 0,
+		packedFlags: encodeUtxoFlags(
+			withCoinbase,
+			noExpiry,
+			stake.TxTypeRegular,
+		),
+	}
+}
+
+// outpoint85314 returns a test outpoint from block height 85314 that can be
+// used throughout the tests.
+func outpoint85314() wire.OutPoint {
+	return wire.OutPoint{
+		Hash: *mustParseHash("d3bce77da2747baa85fb7ca4f6f8e123f31cd15ac691b2f8254" +
+			"3780158587d3a"),
+		Index: 0,
+		Tree:  wire.TxTreeStake,
+	}
+}
+
+// entry85314 returns a utxo entry from block height 85314 that can be used
+// throughout the tests.
+func entry85314() *UtxoEntry {
+	return &UtxoEntry{
+		amount: 4294959555,
+		pkScript: hexToBytes("ba76a914a13afb81d54c9f8bb0c5e082d56fd563ab9b359" +
+			"688ac"),
+		blockHeight:   85314,
+		blockIndex:    6,
+		scriptVersion: 0,
+		packedFlags: encodeUtxoFlags(
+			noCoinbase,
+			withExpiry,
+			stake.TxTypeSStx,
+		),
+		ticketMinOuts: &ticketMinimalOutputs{
+			data: hexToBytes("03808efefade57001aba76a914a13afb81d54c9f8bb0c5e08" +
+				"2d56fd563ab9b359688ac0000206a1e9ac39159847e259c9162405b5f6c8135d" +
+				"2c7eaf1a375040001000000005800001abd76a91400000000000000000000000" +
+				"0000000000000000088ac"),
+		},
+	}
+}
+
+// createTestUtxoDatabase creates a test database with the utxo set bucket.
+func createTestUtxoDatabase(t *testing.T) database.DB {
+	t.Helper()
+
+	// Create a test database.
+	dbPath := filepath.Join(os.TempDir(), t.Name())
+	_ = os.RemoveAll(dbPath)
+	db, err := database.Create("ffldb", dbPath, wire.MainNet)
+	if err != nil {
+		t.Fatalf("error creating test database: %v", err)
+	}
+	t.Cleanup(func() {
+		os.RemoveAll(dbPath)
+	})
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	// Create the utxo set bucket.
+	err = db.Update(func(dbTx database.Tx) error {
+		_, err := dbTx.Metadata().CreateBucketIfNotExists(utxoSetBucketName)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("error creating utxo bucket: %v", err)
+	}
+
+	return db
+}
+
+// createTestUtxoCache creates a test utxo cache with the specified entries.
+func createTestUtxoCache(t *testing.T, entries map[wire.OutPoint]*UtxoEntry) *UtxoCache {
+	t.Helper()
+
+	utxoCache := NewUtxoCache(&UtxoCacheConfig{})
+	for outpoint, entry := range entries {
+		// Add the entry to the cache.  The entry is cloned before being added so
+		// that any modifications that the cache makes to the entry are not
+		// reflected in the provided test entry.
+		err := utxoCache.AddEntry(outpoint, entry.Clone())
+		if err != nil {
+			t.Fatalf("unexpected error when adding entry: %v", err)
+		}
+
+		// Set the state of the cached entries based on the provided entries.  This
+		// is allowed for tests to easily simulate entries in the cache that are not
+		// fresh without having to fetch them from the database.
+		cachedEntry := utxoCache.entries[outpoint]
+		if cachedEntry != nil {
+			cachedEntry.state = entry.state
+		}
+	}
+	return utxoCache
+}
+
+// TestTotalSize validates that the correct number of bytes is returned for the
+// size of the utxo cache.
+func TestTotalSize(t *testing.T) {
+	t.Parallel()
+
+	// Create test entries to be used throughout the tests.
+	outpointRegular := outpoint1200()
+	entryRegular := entry1200()
+	outpointTicket := outpoint85314()
+	entryTicket := entry85314()
+
+	tests := []struct {
+		name    string
+		entries map[wire.OutPoint]*UtxoEntry
+		want    uint64
+	}{{
+		name:    "without any entries",
+		entries: map[wire.OutPoint]*UtxoEntry{},
+		want:    0,
+	}, {
+		name: "with entries",
+		entries: map[wire.OutPoint]*UtxoEntry{
+			outpointRegular: entryRegular,
+			outpointTicket:  entryTicket,
+		},
+		// mapOverhead*numEntries + outpointSize*numEntries +
+		// pointerSize*numEntries + (first entry: base entry size + len(pkScript)) +
+		// (second entry: base entry size + len(pkScript) + len(ticketMinOuts.data))
+		want: mapOverhead*2 + outpointSize*2 + pointerSize*2 +
+			(baseEntrySize + 25) + (baseEntrySize + 26 + 99),
+	}}
+
+	for _, test := range tests {
+		// Create a utxo cache with the entries specified by the test.
+		utxoCache := createTestUtxoCache(t, test.entries)
+
+		// Validate that total size returns the expected value.
+		got := utxoCache.totalSize()
+		if got != test.want {
+			t.Errorf("%q: unexpected result -- got %d, want %d", test.name, got,
+				test.want)
+		}
+	}
+}
+
+// TestHitRatio validates that the correct hit ratio is returned based on the
+// number of cache hits and misses.
+func TestHitRatio(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		hits   uint64
+		misses uint64
+		want   float64
+	}{{
+		name: "no hits or misses",
+		want: 100,
+	}, {
+		name: "all hits, no misses",
+		hits: 50,
+		want: 100,
+	}, {
+		name:   "98.5% hit ratio",
+		hits:   197,
+		misses: 3,
+		want:   98.5,
+	}}
+
+	for _, test := range tests {
+		// Create a utxo cache with hits and misses as specified by the test.
+		utxoCache := NewUtxoCache(&UtxoCacheConfig{})
+		utxoCache.hits = test.hits
+		utxoCache.misses = test.misses
+
+		// Validate that hit ratio returns the expected value.
+		got := utxoCache.hitRatio()
+		if got != test.want {
+			t.Errorf("%q: unexpected result -- got %f, want %f", test.name, got,
+				test.want)
+		}
+	}
+}
+
+// TestAddEntry validates that entries are added to the cache properly under a
+// variety of conditions.
+func TestAddEntry(t *testing.T) {
+	t.Parallel()
+
+	// Create test entries to be used throughout the tests.
+	outpoint := outpoint299()
+	entry := entry299()
+	entryModified := entry.Clone()
+	entryModified.amount++
+	entryModified.state |= utxoStateModified
+	entryFresh := entry.Clone()
+	entryFresh.state |= utxoStateModified | utxoStateFresh
+
+	tests := []struct {
+		name            string
+		existingEntries map[wire.OutPoint]*UtxoEntry
+		outpoint        wire.OutPoint
+		entry           *UtxoEntry
+		wantEntry       *UtxoEntry
+	}{{
+		name:      "add an entry that does not already exist in the cache",
+		outpoint:  outpoint,
+		entry:     entry,
+		wantEntry: entryFresh,
+	}, {
+		name: "add an entry that overwrites an existing entry",
+		existingEntries: map[wire.OutPoint]*UtxoEntry{
+			outpoint: entry,
+		},
+		outpoint:  outpoint,
+		entry:     entryModified,
+		wantEntry: entryModified,
+	}}
+
+	for _, test := range tests {
+		// Create a utxo cache with the existing entries specified by the test.
+		utxoCache := createTestUtxoCache(t, test.existingEntries)
+		wantTotalEntrySize := utxoCache.totalEntrySize
+
+		// Attempt to get an existing entry from the cache.  If it exists, subtract
+		// its size from the expected total entry size since it will be overwritten.
+		existingEntry := utxoCache.entries[test.outpoint]
+		if existingEntry != nil {
+			wantTotalEntrySize -= test.entry.size()
+		}
+
+		// Add the entry specified by the test.
+		err := utxoCache.AddEntry(test.outpoint, test.entry)
+		if err != nil {
+			t.Fatalf("%q: unexpected error when adding entry: %v", test.name, err)
+		}
+		wantTotalEntrySize += test.entry.size()
+
+		// Attempt to get the added entry from the cache.
+		cachedEntry := utxoCache.entries[test.outpoint]
+
+		// Validate that the added entry exists in the cache.
+		if cachedEntry == nil {
+			t.Fatalf("%q: expected entry for outpoint %v to exist in the cache",
+				test.name, test.outpoint)
+		}
+
+		// Validate that the entry is marked as modified.
+		if !cachedEntry.isModified() {
+			t.Fatalf("%q: unexpected modified flag -- got false, want true",
+				test.name)
+		}
+
+		// Validate that the cached entry matches the expected entry.
+		if !reflect.DeepEqual(cachedEntry, test.wantEntry) {
+			t.Fatalf("%q: mismatched cached entry:\nwant: %+v\n got: %+v\n",
+				test.name, test.wantEntry, cachedEntry)
+		}
+
+		// Validate that the total entry size was updated as expected.
+		if utxoCache.totalEntrySize != wantTotalEntrySize {
+			t.Fatalf("%q: unexpected total entry size -- got %v, want %v", test.name,
+				utxoCache.totalEntrySize, wantTotalEntrySize)
+		}
+	}
+}
+
+// TestSpendEntry validates that entries in the cache are properly updated when
+// being spent under a variety of conditions.
+func TestSpendEntry(t *testing.T) {
+	t.Parallel()
+
+	// Create test entries to be used throughout the tests.
+	outpoint := outpoint299()
+	entry := entry299()
+	entryFresh := entry.Clone()
+	entryFresh.state |= utxoStateModified | utxoStateFresh
+	entrySpent := entry.Clone()
+	entrySpent.Spend()
+
+	tests := []struct {
+		name            string
+		existingEntries map[wire.OutPoint]*UtxoEntry
+		outpoint        wire.OutPoint
+		entry           *UtxoEntry
+	}{{
+		name:     "spend an entry that does not exist in the cache",
+		outpoint: outpoint,
+		entry:    entry,
+	}, {
+		name: "spend an entry that exists in the cache but is already spent",
+		existingEntries: map[wire.OutPoint]*UtxoEntry{
+			outpoint: entrySpent,
+		},
+		outpoint: outpoint,
+		entry:    entrySpent,
+	}, {
+		name: "spend an entry that exists in the cache and is fresh",
+		existingEntries: map[wire.OutPoint]*UtxoEntry{
+			outpoint: entryFresh,
+		},
+		outpoint: outpoint,
+		entry:    entryFresh,
+	}, {
+		name: "spend an entry that exists in the cache and is not fresh",
+		existingEntries: map[wire.OutPoint]*UtxoEntry{
+			outpoint: entry,
+		},
+		outpoint: outpoint,
+		entry:    entry,
+	}}
+
+	for _, test := range tests {
+		// Create a utxo cache with the existing entries specified by the test.
+		utxoCache := createTestUtxoCache(t, test.existingEntries)
+		wantTotalEntrySize := utxoCache.totalEntrySize
+
+		// Attempt to get an existing entry from the cache.
+		entry := utxoCache.entries[test.outpoint]
+		var entryAlreadySpent bool
+		if entry != nil {
+			entryAlreadySpent = entry.IsSpent()
+		}
+
+		// Spend the entry specified by the test.
+		utxoCache.SpendEntry(test.outpoint)
+
+		// If the existing entry was nil or spent, continue as there is nothing
+		// else to validate.
+		if entry == nil || entryAlreadySpent {
+			continue
+		}
+
+		// If the entry is fresh, validate that it was removed from the cache when
+		// spent.
+		if entry.isFresh() {
+			wantTotalEntrySize -= test.entry.size()
+			if utxoCache.entries[test.outpoint] != nil {
+				t.Fatalf("%q: entry for outpoint %v was not removed from the cache",
+					test.name, test.outpoint)
+			}
+		}
+
+		// Validate that the total entry size was updated as expected.
+		if utxoCache.totalEntrySize != wantTotalEntrySize {
+			t.Fatalf("%q: unexpected total entry size -- got %v, want %v", test.name,
+				utxoCache.totalEntrySize, wantTotalEntrySize)
+		}
+
+		// If entry is not fresh, validate that it still exists in the cache and is
+		// now marked as spent.
+		if !entry.isFresh() {
+			cachedEntry := utxoCache.entries[test.outpoint]
+			if cachedEntry == nil || !cachedEntry.IsSpent() {
+				t.Fatalf("%q: expected entry for outpoint %v to exist in the cache "+
+					"and be marked spent", test.name, test.outpoint)
+			}
+		}
+	}
+}
+
+// TestFetchEntry validates that fetch entry returns the correct entry under a
+// variety of conditions.
+func TestFetchEntry(t *testing.T) {
+	t.Parallel()
+
+	// Create a test database.
+	db := createTestUtxoDatabase(t)
+
+	// Create test entries to be used throughout the tests.
+	outpoint := outpoint299()
+	entry := entry299()
+	entryModified := entry.Clone()
+	entryModified.state |= utxoStateModified
+
+	tests := []struct {
+		name          string
+		cachedEntries map[wire.OutPoint]*UtxoEntry
+		dbEntries     map[wire.OutPoint]*UtxoEntry
+		outpoint      wire.OutPoint
+		cacheHit      bool
+		wantEntry     *UtxoEntry
+	}{{
+		name:     "entry is not in the cache or the database",
+		outpoint: outpoint,
+	}, {
+		name: "entry is in the cache",
+		cachedEntries: map[wire.OutPoint]*UtxoEntry{
+			outpoint: entry,
+		},
+		outpoint:  outpoint,
+		cacheHit:  true,
+		wantEntry: entry,
+	}, {
+		name: "entry is not in the cache but is in the database",
+		dbEntries: map[wire.OutPoint]*UtxoEntry{
+			outpoint: entryModified,
+		},
+		outpoint:  outpoint,
+		wantEntry: entry,
+	}}
+
+	for _, test := range tests {
+		// Create a utxo cache with the cached entries specified by the test.
+		utxoCache := createTestUtxoCache(t, test.cachedEntries)
+		wantTotalEntrySize := utxoCache.totalEntrySize
+
+		// Add entries specified by the test to the test database.
+		err := db.Update(func(dbTx database.Tx) error {
+			for outpoint, entry := range test.dbEntries {
+				err := dbPutUtxoEntry(dbTx, outpoint, entry)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("%q: unexpected error adding entries to test db: %v", test.name,
+				err)
+		}
+
+		// Attempt to fetch the entry for the outpoint specified by the test.
+		var entry *UtxoEntry
+		err = db.View(func(dbTx database.Tx) error {
+			var err error
+			entry, err = utxoCache.FetchEntry(dbTx, test.outpoint)
+			return err
+		})
+		if err != nil {
+			t.Fatalf("%q: unexpected error fetching entry: %v", test.name, err)
+		}
+
+		// Ensure that the fetched entry matches the expected entry.
+		if !reflect.DeepEqual(entry, test.wantEntry) {
+			t.Fatalf("%q: mismatched entry:\nwant: %+v\n got: %+v\n", test.name,
+				test.wantEntry, entry)
+		}
+
+		// Ensure that the entry is now cached.
+		cachedEntry := utxoCache.entries[test.outpoint]
+		if !reflect.DeepEqual(cachedEntry, test.wantEntry) {
+			t.Fatalf("%q: mismatched cached entry:\nwant: %+v\n got: %+v\n",
+				test.name, test.wantEntry, cachedEntry)
+		}
+
+		// Validate the cache hits and misses counts.
+		if test.cacheHit && utxoCache.hits != 1 {
+			t.Fatalf("%q: unexpected cache hits -- got %v, want 1", test.name,
+				utxoCache.hits)
+		}
+		if !test.cacheHit && utxoCache.misses != 1 {
+			t.Fatalf("%q: unexpected cache misses -- got %v, want 1", test.name,
+				utxoCache.misses)
+		}
+
+		// Validate that the total entry size was updated as expected.
+		if !test.cacheHit && cachedEntry != nil {
+			wantTotalEntrySize += cachedEntry.size()
+		}
+		if utxoCache.totalEntrySize != wantTotalEntrySize {
+			t.Fatalf("%q: unexpected total entry size -- got %v, want %v", test.name,
+				utxoCache.totalEntrySize, wantTotalEntrySize)
+		}
+	}
+}
+
+// TestFetchEntries validates that the provided view is populated with the
+// requested entries as expecetd.
+func TestFetchEntries(t *testing.T) {
+	t.Parallel()
+
+	// Create a test database.
+	db := createTestUtxoDatabase(t)
+
+	// Create test entries to be used throughout the tests.
+	outpoint299 := outpoint299()
+	outpoint1100 := outpoint1100()
+	entry1100 := entry1100()
+	outpoint1200 := outpoint1200()
+	entry1200 := entry1200()
+	entry1200Modified := entry1200.Clone()
+	entry1200Modified.state |= utxoStateModified
+
+	tests := []struct {
+		name          string
+		cachedEntries map[wire.OutPoint]*UtxoEntry
+		dbEntries     map[wire.OutPoint]*UtxoEntry
+		filteredSet   viewFilteredSet
+		wantEntries   map[wire.OutPoint]*UtxoEntry
+	}{{
+		name: "entries are fetched from the cache and the database",
+		cachedEntries: map[wire.OutPoint]*UtxoEntry{
+			outpoint1100: entry1100,
+		},
+		dbEntries: map[wire.OutPoint]*UtxoEntry{
+			outpoint1200: entry1200Modified,
+		},
+		filteredSet: viewFilteredSet{
+			outpoint299:  struct{}{},
+			outpoint1100: struct{}{},
+			outpoint1200: struct{}{},
+		},
+		wantEntries: map[wire.OutPoint]*UtxoEntry{
+			outpoint299:  nil,
+			outpoint1100: entry1100,
+			outpoint1200: entry1200,
+		},
+	}}
+
+	for _, test := range tests {
+		// Create a utxo cache with the cached entries specified by the test.
+		utxoCache := createTestUtxoCache(t, test.cachedEntries)
+		utxoCache.db = db
+
+		// Add entries specified by the test to the test database.
+		err := db.Update(func(dbTx database.Tx) error {
+			for outpoint, entry := range test.dbEntries {
+				err := dbPutUtxoEntry(dbTx, outpoint, entry)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("%q: unexpected error adding entries to test db: %v", test.name,
+				err)
+		}
+
+		// Fetch the entries requested by the test and add them to a view.
+		view := NewUtxoViewpoint(utxoCache)
+		err = utxoCache.FetchEntries(test.filteredSet, view)
+		if err != nil {
+			t.Fatalf("%q: unexpected error fetching entries for view: %v", test.name,
+				err)
+		}
+
+		// Ensure that the fetched entries match the expected entries.
+		if !reflect.DeepEqual(view.entries, test.wantEntries) {
+			t.Fatalf("%q: mismatched entries:\nwant: %+v\n got: %+v\n", test.name,
+				test.wantEntries, view.entries)
+		}
+	}
+}
+
+// TestCommit validates that all entries in both the cache and the provided view
+// are updated appropriately when committing the provided view to the cache.
+func TestCommit(t *testing.T) {
+	t.Parallel()
+
+	// Create test entries to be used throughout the tests.
+	outpoint299 := outpoint299()
+	outpoint1100 := outpoint1100()
+	entry1100Unmodified := entry1100()
+	outpoint1200 := outpoint1200()
+	entry1200 := entry1200()
+	entry1200Spent := entry1200.Clone()
+	entry1200Spent.Spend()
+	outpoint85314 := outpoint85314()
+	entry85314Modified := entry85314()
+	entry85314Modified.state |= utxoStateModified
+
+	tests := []struct {
+		name              string
+		viewEntries       map[wire.OutPoint]*UtxoEntry
+		cachedEntries     map[wire.OutPoint]*UtxoEntry
+		wantViewEntries   map[wire.OutPoint]*UtxoEntry
+		wantCachedEntries map[wire.OutPoint]*UtxoEntry
+	}{{
+		name: "view contains nil, unmodified, spent, and modified entries",
+		viewEntries: map[wire.OutPoint]*UtxoEntry{
+			outpoint299:   nil,
+			outpoint1100:  entry1100Unmodified,
+			outpoint1200:  entry1200Spent,
+			outpoint85314: entry85314Modified,
+		},
+		cachedEntries: map[wire.OutPoint]*UtxoEntry{
+			outpoint1200: entry1200,
+		},
+		// outpoint299 is removed from the view since the entry is nil.
+		// entry1100Unmodified remains in the view since it is unmodified.
+		// entry1200Spent is removed from the view since the entry is spent.
+		// entry85314Modified is removed from the view since it is modified and
+		// added to the cache.
+		wantViewEntries: map[wire.OutPoint]*UtxoEntry{
+			outpoint1100: entry1100Unmodified,
+		},
+		// entry1200Spent remains in the cache but is now spent.
+		// entry85314Modified is added to the cache.
+		wantCachedEntries: map[wire.OutPoint]*UtxoEntry{
+			outpoint1200:  entry1200Spent,
+			outpoint85314: entry85314Modified,
+		},
+	}}
+
+	for _, test := range tests {
+		// Create a utxo cache with the cached entries specified by the test.
+		utxoCache := createTestUtxoCache(t, test.cachedEntries)
+
+		// Create a utxo cache with the view entries specified by the test.
+		view := &UtxoViewpoint{
+			cache:   utxoCache,
+			entries: test.viewEntries,
+		}
+
+		// Commit the view to the cache.
+		err := utxoCache.Commit(view)
+		if err != nil {
+			t.Fatalf("%q: unexpected error committing view to the cache: %v",
+				test.name, err)
+		}
+
+		// Validate the cached entries after committing.
+		if !reflect.DeepEqual(utxoCache.entries, test.wantCachedEntries) {
+			t.Fatalf("%q: mismatched cached entries:\nwant: %+v\n got: %+v\n",
+				test.name, test.wantCachedEntries, utxoCache.entries)
+		}
+
+		// Validate the view entries after committing.
+		if !reflect.DeepEqual(view.entries, test.wantViewEntries) {
+			t.Fatalf("%q: mismatched view entries:\nwant: %+v\n got: %+v\n",
+				test.name, test.wantViewEntries, view.entries)
+		}
+	}
+}
+
+// TestCalcEvictionHeight validates that the correct eviction height is returned
+// based on the provided best height and the last eviction height.
+func TestCalcEvictionHeight(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		lastEvictionHeight uint32
+		bestHeight         uint32
+		want               uint32
+	}{{
+		name:       "no last eviction",
+		bestHeight: 100,
+		want:       15,
+	}, {
+		name:               "best height less than last eviction height",
+		lastEvictionHeight: 101,
+		bestHeight:         100,
+		want:               100,
+	}, {
+		name:               "best height greater than last eviction height",
+		lastEvictionHeight: 99,
+		bestHeight:         200,
+		want:               115,
+	}}
+
+	for _, test := range tests {
+		// Create a utxo cache with the last eviction height as specified by the
+		// test.
+		utxoCache := NewUtxoCache(&UtxoCacheConfig{})
+		utxoCache.lastEvictionHeight = test.lastEvictionHeight
+
+		// Validate that calc eviction height returns the expected value.
+		got := utxoCache.calcEvictionHeight(test.bestHeight)
+		if got != test.want {
+			t.Errorf("%q: unexpected result -- got %d, want %d", test.name, got,
+				test.want)
+		}
+	}
+}
+
+// TestShouldFlush validates that it is correctly determined whether or not a
+// flush should be performed given various conditions.
+func TestShouldFlush(t *testing.T) {
+	t.Parallel()
+
+	// Create test hashes to be used throughout the tests.
+	block1000Hash := mustParseHash("0000000000004740ad140c86753f9295e09f9cc81b1" +
+		"bb75d7f5552aeeedb7012")
+	block2000Hash := mustParseHash("0000000000000c8a886e3f7c32b1bb08422066dcfd0" +
+		"08de596471f11a5aff475")
+
+	tests := []struct {
+		name           string
+		totalEntrySize uint64
+		maxSize        uint64
+		lastFlushTime  time.Time
+		lastFlushHash  *chainhash.Hash
+		bestHash       *chainhash.Hash
+		want           bool
+	}{{
+		name:           "already flushed through the best hash",
+		totalEntrySize: 100,
+		maxSize:        1000,
+		lastFlushTime:  time.Now(),
+		lastFlushHash:  block1000Hash,
+		bestHash:       block1000Hash,
+		want:           false,
+	}, {
+		name:           "less than max size and periodic duration not reached",
+		totalEntrySize: 100,
+		maxSize:        1000,
+		lastFlushTime:  time.Now(),
+		lastFlushHash:  block1000Hash,
+		bestHash:       block2000Hash,
+		want:           false,
+	}, {
+		name:           "equal to max size",
+		totalEntrySize: 1000,
+		maxSize:        1000,
+		lastFlushTime:  time.Now(),
+		lastFlushHash:  block1000Hash,
+		bestHash:       block2000Hash,
+		want:           true,
+	}, {
+		name:           "greater than max size",
+		totalEntrySize: 1001,
+		maxSize:        1000,
+		lastFlushTime:  time.Now(),
+		lastFlushHash:  block1000Hash,
+		bestHash:       block2000Hash,
+		want:           true,
+	}, {
+		name:           "less than max size but periodic duration reached",
+		totalEntrySize: 100,
+		maxSize:        1000,
+		lastFlushTime:  time.Now().Add(periodicFlushInterval * -1),
+		lastFlushHash:  block1000Hash,
+		bestHash:       block2000Hash,
+		want:           true,
+	}}
+
+	for _, test := range tests {
+		// Create a utxo cache and set the field values as specified by the test.
+		utxoCache := NewUtxoCache(&UtxoCacheConfig{
+			MaxSize: test.maxSize,
+		})
+		utxoCache.totalEntrySize = test.totalEntrySize
+		utxoCache.lastFlushTime = test.lastFlushTime
+		utxoCache.lastFlushHash = *test.lastFlushHash
+
+		// Validate that should flush returns the expected value.
+		got := utxoCache.shouldFlush(test.bestHash)
+		if got != test.want {
+			t.Errorf("%q: unexpected result -- got %v, want %v", test.name, got,
+				test.want)
+		}
+	}
+}
+
+// TestMaybeFlush validates that the cache is properly flushed to the database
+// under a variety of conditions.
+func TestMaybeFlush(t *testing.T) {
+	t.Parallel()
+
+	// Create a test database.
+	db := createTestUtxoDatabase(t)
+
+	// Create test hashes to be used throughout the tests.
+	block1000Hash := mustParseHash("0000000000004740ad140c86753f9295e09f9cc81b1" +
+		"bb75d7f5552aeeedb7012")
+	block2000Hash := mustParseHash("0000000000000c8a886e3f7c32b1bb08422066dcfd0" +
+		"08de596471f11a5aff475")
+
+	// entry299Fresh is from block height 299 and is modified and fresh.
+	outpoint299 := outpoint299()
+	entry299Fresh := entry299()
+	entry299Fresh.state |= utxoStateModified | utxoStateFresh
+
+	// entry299Unmodified is from block height 299 and is unmodified.
+	entry299Unmodified := entry299()
+
+	// entry1100Spent is from block height 1100 and is modified and spent.
+	outpoint1100 := outpoint1100()
+	entry1100Spent := entry1100()
+	entry1100Spent.Spend()
+
+	// entry1100Modified is from block height 1100 and is modified and unspent.
+	entry1100Modified := entry1100()
+	entry1100Modified.state |= utxoStateModified
+
+	// entry1100Unmodified is from block height 1100 and is unspent and
+	// unmodified.
+	entry1100Unmodified := entry1100()
+
+	// entry1200Fresh is from block height 1200 and is modified and fresh.
+	outpoint1200 := outpoint1200()
+	entry1200Fresh := entry1200()
+	entry1200Fresh.state |= utxoStateModified | utxoStateFresh
+
+	// entry1200Unmodified is from block height 1200 and is unmodified.
+	entry1200Unmodified := entry1200()
+
+	tests := []struct {
+		name                     string
+		maxSize                  uint64
+		lastEvictionHeight       uint32
+		lastFlushHash            *chainhash.Hash
+		bestHash                 *chainhash.Hash
+		bestHeight               uint32
+		forceFlush               bool
+		cachedEntries            map[wire.OutPoint]*UtxoEntry
+		dbEntries                map[wire.OutPoint]*UtxoEntry
+		wantCachedEntries        map[wire.OutPoint]*UtxoEntry
+		wantDbEntries            map[wire.OutPoint]*UtxoEntry
+		wantLastEvictionHeight   uint32
+		wantLastFlushHash        *chainhash.Hash
+		wantUpdatedLastFlushTime bool
+	}{{
+		name:               "flush not required",
+		maxSize:            1000,
+		lastEvictionHeight: 0,
+		lastFlushHash:      block1000Hash,
+		bestHash:           block2000Hash,
+		bestHeight:         2000,
+		cachedEntries: map[wire.OutPoint]*UtxoEntry{
+			outpoint299:  entry299Fresh,
+			outpoint1100: entry1100Spent,
+			outpoint1200: entry1200Fresh,
+		},
+		dbEntries: map[wire.OutPoint]*UtxoEntry{
+			outpoint1100: entry1100Modified,
+		},
+		// The cache should remain unchanged since a flush is not required.
+		wantCachedEntries: map[wire.OutPoint]*UtxoEntry{
+			outpoint299:  entry299Fresh,
+			outpoint1100: entry1100Spent,
+			outpoint1200: entry1200Fresh,
+		},
+		// The db should remain unchanged since a flush is not required.
+		wantDbEntries: map[wire.OutPoint]*UtxoEntry{
+			outpoint1100: entry1100Unmodified,
+		},
+		wantLastEvictionHeight:   0,
+		wantLastFlushHash:        block1000Hash,
+		wantUpdatedLastFlushTime: false,
+	}, {
+		name:               "all entries flushed, some entries evicted",
+		maxSize:            0,
+		lastEvictionHeight: 0,
+		lastFlushHash:      block1000Hash,
+		bestHash:           block2000Hash,
+		bestHeight:         2000,
+		cachedEntries: map[wire.OutPoint]*UtxoEntry{
+			outpoint299:  entry299Fresh,
+			outpoint1100: entry1100Spent,
+			outpoint1200: entry1200Fresh,
+		},
+		dbEntries: map[wire.OutPoint]*UtxoEntry{
+			outpoint1100: entry1100Modified,
+		},
+		// entry299Fresh should be evicted from the cache due to its height.
+		// entry1100Spent should be evicted since it is spent.
+		// entry1200Fresh should remain in the cache but should now be unmodified.
+		wantCachedEntries: map[wire.OutPoint]*UtxoEntry{
+			outpoint1200: entry1200Unmodified,
+		},
+		// entry299Unmodified should be added to the db during the flush.
+		// entry1100Unmodified should be removed from the db since it now spent.
+		// entry1200Unmodified should be added to the db during the flush.
+		wantDbEntries: map[wire.OutPoint]*UtxoEntry{
+			outpoint299:  entry299Unmodified,
+			outpoint1200: entry1200Unmodified,
+		},
+		wantLastEvictionHeight:   300,
+		wantLastFlushHash:        block2000Hash,
+		wantUpdatedLastFlushTime: true,
+	}}
+
+	for _, test := range tests {
+		// Create a utxo cache with the cached entries specified by the test.
+		utxoCache := createTestUtxoCache(t, test.cachedEntries)
+		utxoCache.db = db
+		utxoCache.maxSize = test.maxSize
+		utxoCache.lastEvictionHeight = test.lastEvictionHeight
+		utxoCache.lastFlushHash = *test.lastFlushHash
+		origLastFlushTime := utxoCache.lastFlushTime
+
+		// Add entries specified by the test to the test database.
+		err := db.Update(func(dbTx database.Tx) error {
+			for outpoint, entry := range test.dbEntries {
+				err := dbPutUtxoEntry(dbTx, outpoint, entry)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("%q: unexpected error adding entries to test db: %v", test.name,
+				err)
+		}
+
+		// Conditionally flush the cache based on the test parameters.
+		err = utxoCache.MaybeFlush(test.bestHash, test.bestHeight, test.forceFlush,
+			false)
+		if err != nil {
+			t.Fatalf("%q: unexpected error flushing cache: %v", test.name, err)
+		}
+
+		// Validate that the cached entries match the expected entries after
+		// eviction.
+		if !reflect.DeepEqual(utxoCache.entries, test.wantCachedEntries) {
+			t.Fatalf("%q: mismatched cached entries:\nwant: %+v\n got: %+v\n",
+				test.name, test.wantCachedEntries, utxoCache.entries)
+		}
+
+		// Validate that the db entries match the expected entries after flushing
+		// the cache.
+		dbEntries := make(map[wire.OutPoint]*UtxoEntry)
+		err = db.View(func(dbTx database.Tx) error {
+			for outpoint := range test.cachedEntries {
+				entry, err := dbFetchUtxoEntry(dbTx, outpoint)
+				if err != nil {
+					return err
+				}
+
+				if entry != nil {
+					dbEntries[outpoint] = entry
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("%q: unexpected error fetching entries from test db: %v",
+				test.name, err)
+		}
+		if !reflect.DeepEqual(dbEntries, test.wantDbEntries) {
+			t.Fatalf("%q: mismatched db entries:\nwant: %+v\n got: %+v\n", test.name,
+				test.wantDbEntries, dbEntries)
+		}
+
+		// Validate that the last flush hash and time have been updated as expexted.
+		if utxoCache.lastFlushHash != *test.wantLastFlushHash {
+			t.Fatalf("%q: unexpected last flush hash -- got %x, want %x", test.name,
+				utxoCache.lastFlushHash, *test.wantLastFlushHash)
+		}
+		updatedLastFlushTime := utxoCache.lastFlushTime != origLastFlushTime
+		if updatedLastFlushTime != test.wantUpdatedLastFlushTime {
+			t.Fatalf("%q: unexpected updated last flush time -- got %v, want %v",
+				test.name, updatedLastFlushTime, test.wantUpdatedLastFlushTime)
+		}
+
+		// Validate the updated last eviction height.
+		if utxoCache.lastEvictionHeight != test.wantLastEvictionHeight {
+			t.Fatalf("%q: unexpected last eviction height -- got %d, want %d",
+				test.name, utxoCache.lastEvictionHeight, test.wantLastEvictionHeight)
+		}
+
+		// Validate the updated total entry size of the cache.
+		wantTotalEntrySize := uint64(0)
+		for _, entry := range test.wantCachedEntries {
+			wantTotalEntrySize += entry.size()
+		}
+		if utxoCache.totalEntrySize != wantTotalEntrySize {
+			t.Fatalf("%q: unexpected total entry size -- got %v, want %v", test.name,
+				utxoCache.totalEntrySize, wantTotalEntrySize)
+		}
+	}
+}

--- a/blockchain/utxoentry.go
+++ b/blockchain/utxoentry.go
@@ -8,6 +8,13 @@ import (
 	"github.com/decred/dcrd/blockchain/stake/v4"
 )
 
+const (
+	// baseEntrySize is the base size of a utxo entry on a 64-bit platform,
+	// excluding the contents of the script and ticket minimal outputs.  It is
+	// equivalent to what unsafe.Sizeof(UtxoEntry{}) returns on a 64-bit platform.
+	baseEntrySize = 56
+)
+
 // utxoState defines the in-memory state of a utxo entry.
 //
 // The bit representation is:
@@ -117,6 +124,15 @@ type UtxoEntry struct {
 	// output as defined by utxoFlags.  This approach is used in order to reduce
 	// memory usage since there will be a lot of these in memory.
 	packedFlags utxoFlags
+}
+
+// size returns the number of bytes that the entry uses on a 64-bit platform.
+func (entry *UtxoEntry) size() uint64 {
+	size := baseEntrySize + len(entry.pkScript)
+	if entry.ticketMinOuts != nil {
+		size += len(entry.ticketMinOuts.data)
+	}
+	return uint64(size)
 }
 
 // isModified returns whether or not the output has been modified since it was

--- a/blockchain/utxoentry.go
+++ b/blockchain/utxoentry.go
@@ -4,14 +4,17 @@
 
 package blockchain
 
-import "github.com/decred/dcrd/blockchain/stake/v4"
+import (
+	"github.com/decred/dcrd/blockchain/stake/v4"
+)
 
 // utxoState defines the in-memory state of a utxo entry.
 //
 // The bit representation is:
 //   bit  0    - transaction output has been spent
 //   bit  1    - transaction output has been modified since it was loaded
-//   bits 2-7  - unused
+//   bit  2    - transaction output is fresh
+//   bits 3-7  - unused
 type utxoState uint8
 
 const (
@@ -21,6 +24,10 @@ const (
 	// utxoStateModified indicates that a txout has been modified since it was
 	// loaded.
 	utxoStateModified
+
+	// utxoStateFresh indicates that a txout is fresh, which means that it exists
+	// in the utxo cache but does not exist in the underlying database.
+	utxoStateFresh
 )
 
 // utxoFlags defines additional information for the containing transaction of a
@@ -116,6 +123,11 @@ type UtxoEntry struct {
 // loaded.
 func (entry *UtxoEntry) isModified() bool {
 	return entry.state&utxoStateModified == utxoStateModified
+}
+
+// isFresh returns whether or not the output is fresh.
+func (entry *UtxoEntry) isFresh() bool {
+	return entry.state&utxoStateFresh == utxoStateFresh
 }
 
 // IsCoinBase returns whether or not the output was contained in a coinbase

--- a/blockchain/utxoentry_test.go
+++ b/blockchain/utxoentry_test.go
@@ -181,107 +181,110 @@ func TestUtxoEntry(t *testing.T) {
 		// Validate the modified flag.
 		isModified := entry.isModified()
 		if isModified != test.modified {
-			t.Fatalf("unexpected modified flag -- got %v, want %v", isModified,
-				test.modified)
+			t.Fatalf("%q: unexpected modified flag -- got %v, want %v", test.name,
+				isModified, test.modified)
 		}
 
 		// Validate the coinbase flag.
 		isCoinBase := entry.IsCoinBase()
 		if isCoinBase != test.coinbase {
-			t.Fatalf("unexpected coinbase flag -- got %v, want %v", isCoinBase,
-				test.coinbase)
+			t.Fatalf("%q: unexpected coinbase flag -- got %v, want %v", test.name,
+				isCoinBase, test.coinbase)
 		}
 
 		// Validate the spent flag.
 		isSpent := entry.IsSpent()
 		if isSpent != test.spent {
-			t.Fatalf("unexpected spent flag -- got %v, want %v", isSpent, test.spent)
+			t.Fatalf("%q: unexpected spent flag -- got %v, want %v", test.name,
+				isSpent, test.spent)
 		}
 
 		// Validate the expiry flag.
 		hasExpiry := entry.HasExpiry()
 		if hasExpiry != test.expiry {
-			t.Fatalf("unexpected expiry flag -- got %v, want %v", hasExpiry,
-				test.expiry)
+			t.Fatalf("%q: unexpected expiry flag -- got %v, want %v", test.name,
+				hasExpiry, test.expiry)
 		}
 
 		// Validate the height of the block containing the output.
 		gotBlockHeight := entry.BlockHeight()
 		if gotBlockHeight != int64(test.blockHeight) {
-			t.Fatalf("unexpected block height -- got %v, want %v", gotBlockHeight,
-				int64(test.blockHeight))
+			t.Fatalf("%q: unexpected block height -- got %v, want %v", test.name,
+				gotBlockHeight, int64(test.blockHeight))
 		}
 
 		// Validate the index of the transaction that the output is contained in.
 		gotBlockIndex := entry.BlockIndex()
 		if gotBlockIndex != test.blockIndex {
-			t.Fatalf("unexpected block index -- got %v, want %v", gotBlockIndex,
-				test.blockIndex)
+			t.Fatalf("%q: unexpected block index -- got %v, want %v", test.name,
+				gotBlockIndex, test.blockIndex)
 		}
 
 		// Validate the type of the transaction that the output is contained in.
 		gotTxType := entry.TransactionType()
 		if gotTxType != test.txType {
-			t.Fatalf("unexpected transaction type -- got %v, want %v", gotTxType,
-				test.txType)
+			t.Fatalf("%q: unexpected transaction type -- got %v, want %v", test.name,
+				gotTxType, test.txType)
 		}
 
 		// Validate the amount of the output.
 		gotAmount := entry.Amount()
 		if gotAmount != test.amount {
-			t.Fatalf("unexpected amount -- got %v, want %v", gotAmount, test.amount)
+			t.Fatalf("%q: unexpected amount -- got %v, want %v", test.name, gotAmount,
+				test.amount)
 		}
 
 		// Validate the script of the output.
 		gotScript := entry.PkScript()
 		if !bytes.Equal(gotScript, test.pkScript) {
-			t.Fatalf("unexpected script -- got %v, want %v", gotScript, test.pkScript)
+			t.Fatalf("%q: unexpected script -- got %v, want %v", test.name, gotScript,
+				test.pkScript)
 		}
 
 		// Validate the script version of the output.
 		gotScriptVersion := entry.ScriptVersion()
 		if gotScriptVersion != test.scriptVersion {
-			t.Fatalf("unexpected script version -- got %v, want %v", gotScriptVersion,
-				test.scriptVersion)
+			t.Fatalf("%q: unexpected script version -- got %v, want %v", test.name,
+				gotScriptVersion, test.scriptVersion)
 		}
 
 		// Spend the entry.  Validate that it is marked as spent and modified.
 		entry.Spend()
 		if !entry.IsSpent() {
-			t.Fatal("expected entry to be spent")
+			t.Fatalf("%q: expected entry to be spent", test.name)
 		}
 		if !entry.isModified() {
-			t.Fatal("expected entry to be modified")
+			t.Fatalf("%q: expected entry to be modified", test.name)
 		}
 
 		// Validate that if spend is called again the entry is still marked as spent
 		// and modified.
 		entry.Spend()
 		if !entry.IsSpent() {
-			t.Fatal("expected entry to still be marked as spent")
+			t.Fatalf("%q: expected entry to still be marked as spent", test.name)
 		}
 		if !entry.isModified() {
-			t.Fatal("expected entry to still be marked as modified")
+			t.Fatalf("%q: expected entry to still be marked as modified", test.name)
 		}
 
 		// Validate the ticket minimal outputs.
 		ticketMinOutsResult := entry.TicketMinimalOutputs()
 		if !reflect.DeepEqual(ticketMinOutsResult, test.deserializedTicketMinOuts) {
-			t.Fatalf("unexpected ticket min outs -- got %v, want %v",
+			t.Fatalf("%q: unexpected ticket min outs -- got %v, want %v", test.name,
 				ticketMinOutsResult, test.deserializedTicketMinOuts)
 		}
 
 		// Clone the entry and validate that all values are deep equal.
 		clonedEntry := entry.Clone()
 		if !reflect.DeepEqual(clonedEntry, entry) {
-			t.Fatalf("expected entry to be equal to cloned entry -- got %v, want %v",
-				clonedEntry, entry)
+			t.Fatalf("%q: expected entry to be equal to cloned entry -- got %v, "+
+				"want %v", test.name, clonedEntry, entry)
 		}
 
 		// Validate that clone returns nil when called on a nil entry.
 		var nilEntry *UtxoEntry
 		if nilEntry.Clone() != nil {
-			t.Fatal("expected nil when calling clone on a nil entry")
+			t.Fatalf("%q: expected nil when calling clone on a nil entry", test.name)
 		}
 	}
 }

--- a/blockchain/utxoentry_test.go
+++ b/blockchain/utxoentry_test.go
@@ -108,6 +108,7 @@ func TestUtxoEntry(t *testing.T) {
 		scriptVersion             uint16
 		ticketMinOuts             *ticketMinimalOutputs
 		deserializedTicketMinOuts []*stake.MinimalOutput
+		size                      uint64
 	}{{
 		name:     "coinbase output",
 		coinbase: true,
@@ -118,6 +119,8 @@ func TestUtxoEntry(t *testing.T) {
 		blockHeight:   54321,
 		blockIndex:    0,
 		scriptVersion: 0,
+		// baseEntrySize + len(pkScript).
+		size: baseEntrySize + 25,
 	}, {
 		name:   "ticket submission output",
 		fresh:  true,
@@ -151,6 +154,8 @@ func TestUtxoEntry(t *testing.T) {
 			Value:   0,
 			Version: 0,
 		}},
+		// baseEntrySize + len(pkScript) + len(ticketMinOuts.data).
+		size: baseEntrySize + 26 + 99,
 	}}
 
 	for _, test := range tests {
@@ -178,6 +183,13 @@ func TestUtxoEntry(t *testing.T) {
 		}
 		if test.fresh {
 			entry.state |= utxoStateFresh
+		}
+
+		// Validate the size of the entry.
+		size := entry.size()
+		if size != test.size {
+			t.Fatalf("%q: unexpected size -- got %v, want %v", test.name, size,
+				test.size)
 		}
 
 		// Validate the spent flag.

--- a/blockchain/utxoentry_test.go
+++ b/blockchain/utxoentry_test.go
@@ -97,6 +97,7 @@ func TestUtxoEntry(t *testing.T) {
 		name                      string
 		spent                     bool
 		modified                  bool
+		fresh                     bool
 		coinbase                  bool
 		expiry                    bool
 		txType                    stake.TxType
@@ -119,6 +120,7 @@ func TestUtxoEntry(t *testing.T) {
 		scriptVersion: 0,
 	}, {
 		name:   "ticket submission output",
+		fresh:  true,
 		expiry: true,
 		txType: stake.TxTypeSStx,
 		amount: 4294959555,
@@ -174,6 +176,9 @@ func TestUtxoEntry(t *testing.T) {
 		if test.modified {
 			entry.state |= utxoStateModified
 		}
+		if test.fresh {
+			entry.state |= utxoStateFresh
+		}
 
 		// Validate the spent flag.
 		isSpent := entry.IsSpent()
@@ -187,6 +192,13 @@ func TestUtxoEntry(t *testing.T) {
 		if isModified != test.modified {
 			t.Fatalf("%q: unexpected modified flag -- got %v, want %v", test.name,
 				isModified, test.modified)
+		}
+
+		// Validate the fresh flag.
+		isFresh := entry.isFresh()
+		if isFresh != test.fresh {
+			t.Fatalf("%q: unexpected fresh flag -- got %v, want %v", test.name,
+				isFresh, test.fresh)
 		}
 
 		// Validate the coinbase flag.

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -290,6 +290,10 @@ func TestCheckBlockHeaderContext(t *testing.T) {
 			DB:          db,
 			ChainParams: params,
 			TimeSource:  NewMedianTime(),
+			UtxoCache: NewUtxoCache(&UtxoCacheConfig{
+				DB:      db,
+				MaxSize: 100 * 1024 * 1024, // 100 MiB
+			}),
 		})
 	if err != nil {
 		t.Fatalf("Failed to create chain instance: %v\n", err)

--- a/doc.go
+++ b/doc.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -45,6 +45,8 @@ Application Options:
                                Use show to list available subsystems (info)
       --sigcachemaxsize=       The maximum number of entries in the signature
                                verification cache (default: 100000)
+      --utxocachemaxsize=      The maximum size in MiB of the utxo cache
+                               (default: 150, minimum: 25, maximum: 32768)
       --norpc                  Disable built-in RPC server -- NOTE: The RPC
                                server is disabled by default if no
                                rpcuser/rpcpass or rpclimituser/rpclimitpass is

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -87,7 +87,7 @@ func (s *fakeChain) FetchUtxoView(tx *dcrutil.Tx, treeValid bool) (*blockchain.U
 
 	// Add entries for the outputs of the tx to the new view.
 	msgTx := tx.MsgTx()
-	viewpoint := blockchain.NewUtxoViewpoint()
+	viewpoint := blockchain.NewUtxoViewpoint(nil)
 	outpoint := wire.OutPoint{Hash: *tx.Hash(), Tree: tx.Tree()}
 	for txOutIdx := range msgTx.TxOut {
 		outpoint.Index = uint32(txOutIdx)
@@ -754,7 +754,7 @@ func newPoolHarness(chainParams *chaincfg.Params) (*poolHarness, []spendableOutp
 	// Create a new fake chain and harness bound to it.
 	subsidyCache := standalone.NewSubsidyCache(chainParams)
 	chain := &fakeChain{
-		utxos:       blockchain.NewUtxoViewpoint(),
+		utxos:       blockchain.NewUtxoViewpoint(nil),
 		utxoTimes:   make(map[wire.OutPoint]int64),
 		blocks:      make(map[chainhash.Hash]*dcrutil.Block),
 		scriptFlags: BaseStandardVerifyFlags,

--- a/internal/mining/mining_harness_test.go
+++ b/internal/mining/mining_harness_test.go
@@ -144,7 +144,7 @@ func (c *fakeChain) FetchUtxoView(tx *dcrutil.Tx, treeValid bool) (*blockchain.U
 
 	// Add entries for the outputs of the tx to the new view.
 	msgTx := tx.MsgTx()
-	viewpoint := blockchain.NewUtxoViewpoint()
+	viewpoint := blockchain.NewUtxoViewpoint(nil)
 	prevOut := wire.OutPoint{Hash: *tx.Hash(), Tree: tx.Tree()}
 	for txOutIdx := range msgTx.TxOut {
 		prevOut.Index = uint32(txOutIdx)
@@ -195,7 +195,7 @@ func (c *fakeChain) MaxTreasuryExpenditure(preTVIBlock *chainhash.Hash) (int64, 
 
 // NewUtxoViewpoint returns a new empty unspent transaction output view.
 func (c *fakeChain) NewUtxoViewpoint() *blockchain.UtxoViewpoint {
-	return blockchain.NewUtxoViewpoint()
+	return blockchain.NewUtxoViewpoint(nil)
 }
 
 // TipGeneration returns a mocked entire generation of blocks stemming from the
@@ -1296,8 +1296,8 @@ func newMiningHarness(chainParams *chaincfg.Params) (*miningHarness, []spendable
 		blocks:                          make(map[chainhash.Hash]*dcrutil.Block),
 		isHeaderCommitmentsAgendaActive: true,
 		isTreasuryAgendaActive:          true,
-		parentUtxos:                     blockchain.NewUtxoViewpoint(),
-		utxos:                           blockchain.NewUtxoViewpoint(),
+		parentUtxos:                     blockchain.NewUtxoViewpoint(nil),
+		utxos:                           blockchain.NewUtxoViewpoint(nil),
 	}
 
 	// Set the proof of work limit and next required difficulty very high by

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -281,6 +281,11 @@ type Chain interface {
 	FetchUtxoEntry(outpoint wire.OutPoint) (UtxoEntry, error)
 
 	// FetchUtxoStats returns statistics on the current utxo set.
+	//
+	// NOTE: During initial block download the utxo stats will lag behind the best
+	// block that is currently synced since the utxo cache is only flushed to the
+	// database periodically.  After initial block download the utxo stats will
+	// always be in sync with the best block.
 	FetchUtxoStats() (*blockchain.UtxoStats, error)
 
 	// GetStakeVersions returns a cooked array of StakeVersions.  We do this in

--- a/sampleconfig/sampleconfig.go
+++ b/sampleconfig/sampleconfig.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 The Decred developers
+// Copyright (c) 2017-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -292,6 +292,12 @@ const fileContents = `[Application Options]
 ; Limit the signature cache to a max of 50000 entries.
 ; sigcachemaxsize=50000
 
+; ------------------------------------------------------------------------------
+; Unspent Transaction Output (UTXO) Cache
+; ------------------------------------------------------------------------------
+
+; Limit the utxo cache to a max of 100 MiB.
+; utxocachemaxsize=150
 
 ; ------------------------------------------------------------------------------
 ; Coin Generation (Mining) Settings - The following options control the


### PR DESCRIPTION
**NOTE**: If you plan to test this, it is recommended to make a copy of your data directory first.  Though this does not have a database migration, this changes the way that the utxo set is synced to the database and in the case of an unclean shutdown on this branch, the old code will not be able to recover.

---

`UtxoCache` is an unspent transaction output cache that sits on top of the utxo set database and provides significant runtime performance benefits at the cost of some additional memory usage.  It drastically reduces the amount of reading and writing to disk, especially during initial block download when a very large number of blocks are being processed in quick succession.

Initial block download performance results are as follows.  This testing was done syncing from a local peer (to avoid peer speed/latency variance) on a 2.4 GHz 8-Core w/ SSD machine (I don't have a HDD to test with currently but the performance improvement may be even more significant in that case since the speedup is primarily due to reducing reads/writes to disk):
- Master
  - Average IBD Time: ~48 mins
  - Peak Real Memory Usage: ~850MB
- With `UtxoCache` (w/ default `utxocachemaxsize` of 150 MiB)
  - Average IBD Time: ~32 mins (~33% faster)
  - Peak Real Memory Usage: ~1250MB
  - Cache Hit Ratio: ~99%

The `UtxoCache` is a read-through cache.  All utxo reads go through the cache.  When there is a cache miss, the cache loads the missing data from the database, caches it, and returns it to the caller.

The `UtxoCache` is a write-back cache.  Writes to the cache are acknowledged by the cache immediately but are only periodically flushed to the database.  This allows intermediate steps to effectively be skipped.  For example, a utxo that is created and then spent in between flushes never needs to be written to the utxo set in the database.

Due to the write-back nature of the cache, at any given time the database may not be in sync with the cache, and therefore all utxo reads and writes now go through the cache, and never read or write to the database directly.

This has been broken down into separate commits where possible to make the review process a bit easier since it is a fairly large changeset.  An overview of the changes is as follows:

- Update `UtxoEntry` for the cache
  - Separate utxo state from tx flags
  - Add `utxoStateFresh` to `UtxoEntry`, which indicates that an entry exists in the utxo cache but does not exist in the
underlying database
  - Add size method to `UtxoEntry` to be used as part of tracking the total size of the utxo cache
- Add `utxocachemaxsize`
  -  Add a `utxocachemaxsize` configuration option which represents the maximum size in MiB of the utxo cache.  The default value is 150 MiB and the minimum value is 25 MiB
- Deep copy view entry script from tx
  - Update utxo viewpoints to deep copy the script when getting it from a msg tx.  This is required since the tx out script is a subslice of the overall contiguous buffer that the msg tx houses for all scripts within the tx.  It is deep copied here since this entry may be added to the utxo cache, and we don't want the utxo cache holding the entry to prevent all of the other tx scripts from getting garbage collected
- Add `utxoSetState` to the database
  -  Add a `utxoSetState` type that is tracked in the database. The utxo set state contains information regarding the current state of the utxo set.  In particular, it tracks the block height and block hash of the last completed flush
  - The utxo set state is tracked in the database since at any given time, the utxo cache may not be consistent with the utxo set in the database.  This is due to the fact that the utxo cache only flushes changes to the database periodically.  Therefore, during initialization, the utxo set state is used to identify the last flushed state of the utxo set and it can be caught up to the current best state of the main chain.
  - Add full test coverage for the new serialization and deserialization functions
- Add `UtxoCache` and `UtxoCacheConfig` struct types and `NewUtxoCache` method
  - Update server to create the utxo cache with the configured max size and pass to the block chain instance that is created
  - Update all test block chains to create a utxo cache 
- Add `FetchEntry` to `UtxoCache`
  - `FetchEntry` returns the specified transaction output from the utxo set
  - If the output exists in the cache, it is returned immediately.  Otherwise, it uses an existing database transaction to fetch the output from the database, caches it, and returns it to the caller.
- Add `AddEntry` to `UtxoCache`
  - `AddEntry` adds the specified output to the cache
- Add `SpendEntry` to `UtxoCache`
  - `SpendEntry` marks the specified output as spent
  - Remove entries that are marked as fresh and then subsequently spent.  This is an optimization to skip writing to the database for outputs that are added and spent in between flushes to the database.
- Update `UtxoViewpoint` to hold the `UtxoCache`
  - Update fetching entries from the database to fetch entries from the cache instead
- Add `Commit` to `UtxoCache`
  - `Commit` updates all entries in the cache based on the state of each entry in the provided view
  - All entries in the provided view that are marked as modified and spent are removed from the view
  - Additionally, all entries that are added to the cache are removed from the provided view
- Add `MaybeFlush` to `UtxoCache`
  - `MaybeFlush` conditionally flushes the cache to the database
  - If the maximum size of the cache has been reached, or if the periodic flush duration has been reached, then a flush is required
  - A flush can be forced by setting the force flush parameter
  - Flushing commits all modified entries to the database and conditionally evicts entries
  - Entries that are nil or spent are always evicted since they are unlikely to be accessed again.  Additionally, if the cache has reached its maximum size, entries are evicted based on the height of the block that they are contained in
- Update connect block and disconnect block to commit to the cache and conditionally flush to the database
  - Rather than writing to the utxo set in the database every time that a block is connected or disconnected, commit the updated view to the cache and call `MaybeFlush` on the cache to conditionally flush it to the database
- Add `InitUtxoCache` to `UtxoCache`
  - `InitUtxoCache` initializes the utxo cache by ensuring that the utxo set is caught up to the tip of the best chain
  - Since the cache is only flushed to the database periodically, the utxo set may not be caught up to the tip of the best chain
  - `InitUtxoCache` catches the utxo set up by replaying all blocks from the block after the block that was last flushed to the tip block through the cache
- Add `ShutdownUtxoCache` to `BlockChain`
  - `ShutdownUtxoCache` flushes the utxo cache to the database on shutdown.  Since the cache is flushed periodically during initial block download and flushed after every block is connected after initial block download is complete, this flush that occurs during shutdown should finish relatively quickly
  - Note that if an unclean shutdown occurs, the cache will still be initialized properly when restarted as during initialization it will replay blocks to catch up to the tip block if it was not fully flushed before shutting down.  However, it is still preferred to flush when shutting down versus always recovering on startup since it is faster
- Track the hit ratio of `UtxoCache`
  - Track the number of hits and misses when accessing the cache in order to calculate the overall hit ratio of the cache to gauge its performance
- Add `UtxoCache` test coverage
  - Full test coverage has been added to the `UtxoCache` type and its methods

---

- Other implementation notes:
  - There is definitely still plenty of room for further optimizations.
  - I did experiment a bit with chunked allocation/free lists/sync pool for the entries and scripts that the cache holds but they were ultimately resulting in worse performance.  There may still be an optimization there but what ended up working best was just the `UtxoCache` taking ownership of the entries from the view and avoiding additional allocations when adding the entries altogether.
  - One optimization that will be followed up on (suggested by @davecgh) is to separate out the utxo database, which should bring both performance and memory usage improvements.
    - One reason why the cache results in more than a 100 MiB increase in overall memory usage when setting the max to 100 MiB is due to the database caching layer copying entries and holding them before flushing them to the db.  If we separate out the utxo database we can likely just remove the db caching since we have an optimized higher-level cache in place now.

---

**Part of https://github.com/decred/dcrd/issues/1145.**