### PR TITLE
addrmgr: Start v2 module dev cycle.

### DIFF
--- a/addrmgr/go.mod
+++ b/addrmgr/go.mod
@@ -1,4 +1,4 @@
-module github.com/decred/dcrd/addrmgr
+module github.com/decred/dcrd/addrmgr/v2
 
 go 1.11
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/base58 v1.0.3
-	github.com/decred/dcrd/addrmgr v1.2.0
+	github.com/decred/dcrd/addrmgr/v2 v2.0.0
 	github.com/decred/dcrd/bech32 v1.1.1
 	github.com/decred/dcrd/blockchain/stake/v4 v4.0.0-20210129192908-660d0518b4cf
 	github.com/decred/dcrd/blockchain/standalone/v2 v2.0.0
@@ -42,7 +42,7 @@ require (
 )
 
 replace (
-	github.com/decred/dcrd/addrmgr => ./addrmgr
+	github.com/decred/dcrd/addrmgr/v2 => ./addrmgr
 	github.com/decred/dcrd/bech32 => ./bech32
 	github.com/decred/dcrd/blockchain/stake/v4 => ./blockchain/stake
 	github.com/decred/dcrd/blockchain/standalone/v2 => ./blockchain/standalone

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -10,7 +10,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/decred/dcrd/addrmgr"
+	"github.com/decred/dcrd/addrmgr/v2"
 	"github.com/decred/dcrd/blockchain/stake/v4"
 	"github.com/decred/dcrd/blockchain/v4"
 	"github.com/decred/dcrd/blockchain/v4/indexers"

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/decred/dcrd/addrmgr"
+	"github.com/decred/dcrd/addrmgr/v2"
 	"github.com/decred/dcrd/blockchain/stake/v4"
 	"github.com/decred/dcrd/blockchain/standalone/v2"
 	"github.com/decred/dcrd/blockchain/v4"

--- a/log.go
+++ b/log.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/decred/dcrd/addrmgr"
+	"github.com/decred/dcrd/addrmgr/v2"
 	"github.com/decred/dcrd/blockchain/stake/v4"
 	"github.com/decred/dcrd/blockchain/v4"
 	"github.com/decred/dcrd/blockchain/v4/indexers"

--- a/server.go
+++ b/server.go
@@ -26,7 +26,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/decred/dcrd/addrmgr"
+	"github.com/decred/dcrd/addrmgr/v2"
 	"github.com/decred/dcrd/blockchain/stake/v4"
 	"github.com/decred/dcrd/blockchain/standalone/v2"
 	"github.com/decred/dcrd/blockchain/v4"


### PR DESCRIPTION
Upcoming changes constitute breaking public API changes to the `addrmgr` module. This PR follows the process for introducing major API breaks which consists of:

- Bump the major version in the go.mod of the affected module if not already done since the last release tag
- Add a replacement to the go.mod in the main module if not already done since the last release tag
- Update all imports in the repo to use the new major version as necessary
- Make necessary modifications to allow all other modules to use the new version in the same commit
- Repeat the process for any other modules that require a new major as a result of consuming the new major(s)
