### PR TITLE
addrmgr: Decouple address manager from wire.NetAddress

### DIFF
--- a/addrmgr/addrmanager.go
+++ b/addrmgr/addrmanager.go
@@ -688,28 +688,6 @@ func (a *AddrManager) AddAddress(addr, srcAddr *wire.NetAddress) {
 	a.updateAddress(addr, srcAddr)
 }
 
-// addAddressByIP adds an address where we are given an ip:port and not a
-// wire.NetAddress.
-func (a *AddrManager) addAddressByIP(addrIP string) error {
-	// Split IP and port
-	addr, portStr, err := net.SplitHostPort(addrIP)
-	if err != nil {
-		return err
-	}
-	// Put it in wire.Netaddress
-	ip := net.ParseIP(addr)
-	if ip == nil {
-		return fmt.Errorf("invalid ip address %s", addr)
-	}
-	port, err := strconv.ParseUint(portStr, 10, 0)
-	if err != nil {
-		return fmt.Errorf("invalid port %s: %v", portStr, err)
-	}
-	na := wire.NewNetAddressIPPort(ip, uint16(port), 0)
-	a.AddAddress(na, na) // XXX use correct src address
-	return nil
-}
-
 // numAddresses returns the number of addresses known to the address manager.
 //
 // This function MUST be called with the address manager lock held (for reads).

--- a/addrmgr/addrmanager_test.go
+++ b/addrmgr/addrmanager_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -91,6 +91,9 @@ func addNaTests() {
 	addNaTest("fed1::2:2", 8334, "[fed1::2:2]:8334")
 	addNaTest("fee2::3:3", 8335, "[fee2::3:3]:8335")
 	addNaTest("fef3::4:4", 8336, "[fef3::4:4]:8336")
+
+	// Tor
+	addNaTest("fd87:d87e:eb43::", 8333, "aaaaaaaaaaaaaaaa.onion:8333")
 }
 
 func addNaTest(ip string, port uint16, want string) {
@@ -118,24 +121,19 @@ func TestAddAddressByIP(t *testing.T) {
 	var tests = []struct {
 		addrIP string
 		err    error
-	}{
-		{
-			someIP + ":8333",
-			nil,
-		},
-		{
-			someIP,
-			addrErr,
-		},
-		{
-			someIP[:12] + ":8333",
-			fmtErr,
-		},
-		{
-			someIP + ":abcd",
-			fmtErr,
-		},
-	}
+	}{{
+		someIP + ":8333",
+		nil,
+	}, {
+		someIP,
+		addrErr,
+	}, {
+		someIP[:12] + ":8333",
+		fmtErr,
+	}, {
+		someIP + ":abcd",
+		fmtErr,
+	}}
 
 	dir, err := os.MkdirTemp("", "testaddressbyip")
 	if err != nil {
@@ -161,23 +159,23 @@ func TestAddAddressByIP(t *testing.T) {
 		}
 	}
 	if err := amgr.Stop(); err != nil {
-		t.Fatalf("Address Manager failed to stop: %v", err)
+		t.Fatalf("address manager failed to stop: %v", err)
 	}
 
-	// make sure the peers file has been written
-	peersFile := filepath.Join(dir, PeersFilename)
+	// Make sure the peers file has been written to.
+	peersFile := filepath.Join(dir, peersFilename)
 	if _, err := os.Stat(peersFile); err != nil {
-		t.Fatalf("Peers file does not exist: %s", peersFile)
+		t.Fatalf("peers file does not exist: %s", peersFile)
 	}
 
-	// start address manager again to read peers file
+	// Start the address manager again to read peers file.
 	amgr = New(dir, nil)
 	amgr.Start()
 	if ka := amgr.GetAddress(); ka == nil {
-		t.Errorf("Address Manager should contain known address")
+		t.Fatal("address manager should contain known address")
 	}
 	if err := amgr.Stop(); err != nil {
-		t.Fatalf("Address Manager failed to stop: %v", err)
+		t.Fatalf("address manager failed to stop: %v", err)
 	}
 }
 
@@ -185,90 +183,135 @@ func TestAddAddressUpdate(t *testing.T) {
 	amgr := New("testaddaddressupdate", nil)
 	amgr.Start()
 	if ka := amgr.GetAddress(); ka != nil {
-		t.Fatalf("Address Manager should contain no address")
+		t.Fatal("address manager should contain no addresses")
 	}
 	ip := net.ParseIP(someIP)
 	if ip == nil {
-		t.Fatalf("Invalid IP address %s", someIP)
+		t.Fatalf("invalid IP address %s", someIP)
 	}
 	na := wire.NewNetAddressIPPort(ip, 8333, 0)
 	amgr.AddAddress(na, na)
 	ka := amgr.GetAddress()
+	newlyAddedAddr := ka.NetAddress()
 	if ka == nil {
-		t.Errorf("Address Manager should contain known address")
+		t.Fatal("address manager should contain newly added known address")
 	}
-	if !reflect.DeepEqual(ka.NetAddress(), na) {
-		t.Errorf("Address Manager should contain address that was added")
+	if newlyAddedAddr == na {
+		t.Fatal("newly added known address should have a new network address " +
+			"reference, but a previously held reference was found")
 	}
-	// add address again, but with different time stamp (to trigger update)
+	if !reflect.DeepEqual(newlyAddedAddr, na) {
+		t.Fatalf("address manager should contain address that was added - "+
+			"got %v, want %v", newlyAddedAddr, na)
+	}
+	// Add the same address again, but with different timestamp to trigger
+	// an update rather than an insert.
 	ts := na.Timestamp.Add(time.Second)
 	na.Timestamp = ts
 	amgr.AddAddress(na, na)
-	// address should be in there
-	ka = amgr.GetAddress()
-	if ka == nil {
-		t.Errorf("Address Manager should contain known address")
+
+	// The address should be in the address manager with a new timestamp.
+	// The network address reference held by the known address should also
+	// differ.
+	updatedKnownAddress := amgr.GetAddress()
+	netAddrFromUpdate := updatedKnownAddress.NetAddress()
+	if updatedKnownAddress == nil {
+		t.Fatal("address manager should contain updated known address")
 	}
-	if !reflect.DeepEqual(ka.NetAddress(), na) {
-		t.Errorf("Address Manager should contain address that was added")
+	if ka != updatedKnownAddress {
+		t.Fatalf("updated known address returned by the address manager " +
+			"should not be a new known address reference")
 	}
-	if !ka.NetAddress().Timestamp.Equal(ts) {
-		t.Errorf("Address Manager did not update timestamp")
+	if netAddrFromUpdate == newlyAddedAddr || netAddrFromUpdate == na {
+		t.Fatal("updated known address should have a new network address " +
+			"reference, but a previously held reference was found")
+	}
+	if !reflect.DeepEqual(netAddrFromUpdate, na) {
+		t.Fatalf("address manager should contain address that was updated - "+
+			"got %v, want %v", netAddrFromUpdate, na)
+	}
+	if !netAddrFromUpdate.Timestamp.Equal(ts) {
+		t.Fatal("address manager did not update timestamp")
 	}
 	if err := amgr.Stop(); err != nil {
-		t.Fatalf("Address Manager failed to stop: %v", err)
+		t.Fatalf("address manager failed to stop - %v", err)
 	}
 }
 
 func TestAddLocalAddress(t *testing.T) {
 	var tests = []struct {
+		name     string
 		address  wire.NetAddress
 		priority AddressPriority
 		valid    bool
-	}{
-		{
-			wire.NetAddress{IP: net.ParseIP("192.168.0.100")},
-			InterfacePrio,
-			false,
-		},
-		{
-			wire.NetAddress{IP: net.ParseIP("204.124.1.1")},
-			InterfacePrio,
-			true,
-		},
-		{
-			wire.NetAddress{IP: net.ParseIP("204.124.1.1")},
-			BoundPrio,
-			true,
-		},
-		{
-			wire.NetAddress{IP: net.ParseIP("::1")},
-			InterfacePrio,
-			false,
-		},
-		{
-			wire.NetAddress{IP: net.ParseIP("fe80::1")},
-			InterfacePrio,
-			false,
-		},
-		{
-			wire.NetAddress{IP: net.ParseIP("2620:100::1")},
-			InterfacePrio,
-			true,
-		},
-	}
+	}{{
+		name:     "unroutable local IPv4 address",
+		address:  wire.NetAddress{IP: net.ParseIP("192.168.0.100")},
+		priority: InterfacePrio,
+		valid:    false,
+	}, {
+		name:     "routable IPv4 address",
+		address:  wire.NetAddress{IP: net.ParseIP("204.124.1.1")},
+		priority: InterfacePrio,
+		valid:    true,
+	}, {
+		name:     "routable IPv4 address with bound priority",
+		address:  wire.NetAddress{IP: net.ParseIP("204.124.1.1")},
+		priority: BoundPrio,
+		valid:    true,
+	}, {
+		name:     "unroutable local IPv6 address",
+		address:  wire.NetAddress{IP: net.ParseIP("::1")},
+		priority: InterfacePrio,
+		valid:    false,
+	}, {
+		name:     "unroutable local IPv6 address 2",
+		address:  wire.NetAddress{IP: net.ParseIP("fe80::1")},
+		priority: InterfacePrio,
+		valid:    false,
+	}, {
+		name:     "routable IPv6 address",
+		address:  wire.NetAddress{IP: net.ParseIP("2620:100::1")},
+		priority: InterfacePrio,
+		valid:    true,
+	}}
+
 	amgr := New("testaddlocaladdress", nil)
-	for x, test := range tests {
-		result := amgr.AddLocalAddress(&test.address, test.priority)
+	validLocalAddresses := make(map[string]struct{})
+	for _, test := range tests {
+		netAddr := &test.address
+		result := amgr.AddLocalAddress(netAddr, test.priority)
 		if result == nil && !test.valid {
-			t.Errorf("TestAddLocalAddress test #%d failed: %s should have "+
-				"been accepted", x, test.address.IP)
+			t.Errorf("%q: address should have been accepted", test.name)
 			continue
 		}
 		if result != nil && test.valid {
-			t.Errorf("TestAddLocalAddress test #%d failed: %s should not have "+
-				"been accepted", x, test.address.IP)
+			t.Errorf("%q: address should not have been accepted", test.name)
 			continue
+		}
+		if test.valid && !amgr.HasLocalAddress(netAddr) {
+			t.Errorf("%q: expected to have local address", test.name)
+			continue
+		}
+		if !test.valid && amgr.HasLocalAddress(netAddr) {
+			t.Errorf("%q: expected to not have local address", test.name)
+			continue
+		}
+		if test.valid {
+			// Set up data to test behavior of a call to LocalAddresses() for
+			// addresses that were added to the local address manager.
+			validLocalAddresses[NetAddressKey(netAddr)] = struct{}{}
+		}
+	}
+
+	// Ensure that all of the addresses that were expected to be added to the
+	// address manager are also returned from a call to LocalAddresses.
+	for _, localAddr := range amgr.LocalAddresses() {
+		localAddrIP := net.ParseIP(localAddr.Address)
+		netAddr := &wire.NetAddress{IP: localAddrIP}
+		netAddrKey := NetAddressKey(netAddr)
+		if _, ok := validLocalAddresses[netAddrKey]; !ok {
+			t.Errorf("expected to find local address with key %v", netAddrKey)
 		}
 	}
 }
@@ -276,22 +319,34 @@ func TestAddLocalAddress(t *testing.T) {
 func TestAttempt(t *testing.T) {
 	n := New("testattempt", lookupFunc)
 
-	// Add a new address and get it
+	// Add a new address and get it.
 	err := n.addAddressByIP(someIP + ":8333")
 	if err != nil {
-		t.Fatalf("Adding address failed: %v", err)
+		t.Fatalf("adding address failed - %v", err)
 	}
 	ka := n.GetAddress()
 
 	if !ka.LastAttempt().IsZero() {
-		t.Errorf("Address should not have attempts, but does")
+		t.Fatal("address should not have been attempted")
 	}
 
 	na := ka.NetAddress()
-	n.Attempt(na)
+	err = n.Attempt(na)
+	if err != nil {
+		t.Fatalf("marking address as attempted failed - %v", err)
+	}
 
 	if ka.LastAttempt().IsZero() {
-		t.Errorf("Address should have an attempt, but does not")
+		t.Fatal("address should have an attempt, but does not")
+	}
+
+	// Attempt an ip not known to the address manager.
+	unknownIP := net.ParseIP("1.2.3.4")
+	unknownNetAddress := wire.NewNetAddressIPPort(unknownIP, 1234,
+		wire.SFNodeNetwork)
+	err = n.Attempt(unknownNetAddress)
+	if err == nil {
+		t.Fatal("attempting unknown address should have returned an error")
 	}
 }
 
@@ -301,26 +356,40 @@ func TestConnected(t *testing.T) {
 	// Add a new address and get it
 	err := n.addAddressByIP(someIP + ":8333")
 	if err != nil {
-		t.Fatalf("Adding address failed: %v", err)
+		t.Fatalf("failed to add address - %v", err)
 	}
 	ka := n.GetAddress()
 	na := ka.NetAddress()
 	// make it an hour ago
 	na.Timestamp = time.Unix(time.Now().Add(time.Hour*-1).Unix(), 0)
 
-	n.Connected(na)
+	err = n.Connected(na)
+	if err != nil {
+		t.Fatalf("marking address as connected failed - %v", err)
+	}
 
 	if !ka.NetAddress().Timestamp.After(na.Timestamp) {
-		t.Errorf("Address should have a new timestamp, but does not")
+		t.Fatal("address should have a new timestamp, but does not")
+	}
+
+	// Attempt to flag an ip address not known to the address manager as
+	// connected.
+	unknownIP := net.ParseIP("1.2.3.4")
+	unknownNetAddress := wire.NewNetAddressIPPort(unknownIP, 1234,
+		wire.SFNodeNetwork)
+	err = n.Connected(unknownNetAddress)
+	if err == nil {
+		t.Fatal("attempting to mark unknown address as connected should have " +
+			"returned an error")
 	}
 }
 
 func TestNeedMoreAddresses(t *testing.T) {
 	n := New("testneedmoreaddresses", lookupFunc)
-	addrsToAdd := 1500
+	addrsToAdd := needAddressThreshold
 	b := n.NeedMoreAddresses()
 	if !b {
-		t.Errorf("Expected that we need more addresses")
+		t.Fatal("expected the address manager to need more addresses")
 	}
 	addrs := make([]*wire.NetAddress, addrsToAdd)
 
@@ -338,12 +407,13 @@ func TestNeedMoreAddresses(t *testing.T) {
 	n.AddAddresses(addrs, srcAddr)
 	numAddrs := n.numAddresses()
 	if numAddrs > addrsToAdd {
-		t.Errorf("Number of addresses is too many %d vs %d", numAddrs, addrsToAdd)
+		t.Fatalf("number of addresses is too many %d vs %d", numAddrs,
+			addrsToAdd)
 	}
 
 	b = n.NeedMoreAddresses()
 	if b {
-		t.Errorf("Expected that we don't need more addresses")
+		t.Fatal("expected address manager to not need more addresses")
 	}
 }
 
@@ -370,12 +440,103 @@ func TestGood(t *testing.T) {
 
 	numAddrs := n.numAddresses()
 	if numAddrs >= addrsToAdd {
-		t.Errorf("Number of addresses is too many: %d vs %d", numAddrs, addrsToAdd)
+		t.Fatalf("Number of addresses is too many: %d vs %d", numAddrs,
+			addrsToAdd)
 	}
 
 	numCache := len(n.AddressCache())
 	if numCache >= numAddrs/4 {
-		t.Errorf("Number of addresses in cache: got %d, want %d", numCache, numAddrs/4)
+		t.Fatalf("Number of addresses in cache: got %d, want %d", numCache,
+			numAddrs/4)
+	}
+
+	// Test internal behavior of how addresses are managed between the new and
+	// tried address buckets. When an address is initially added it should enter
+	// the new bucket, and when marked good it should move to the tried bucket.
+	// If the tried bucket is full then it should make room for the newly tried
+	// address by moving the old one back to the new bucket.
+	n = New("testgood_tried_overflow", lookupFunc)
+	n.triedBucketSize = 1
+	n.getNewBucket = func(netAddr, srcAddr *wire.NetAddress) int {
+		return 0
+	}
+	n.getTriedBucket = func(netAddr *wire.NetAddress) int {
+		return 0
+	}
+
+	addrA := wire.NewNetAddressIPPort(net.ParseIP("173.144.173.1"), 8333, 0)
+	addrB := wire.NewNetAddressIPPort(net.ParseIP("173.144.173.2"), 8333, 0)
+	addrAKey := NetAddressKey(addrA)
+	addrBKey := NetAddressKey(addrB)
+
+	// Neither address should exist in the address index prior to being
+	// added to the address manager. The new and tried buckets should also be
+	// empty.
+	if len(n.addrIndex) > 0 {
+		t.Fatal("expected address index to be empty prior to adding addresses" +
+			" to the address manager")
+	}
+	if len(n.addrNew[0]) > 0 {
+		t.Fatal("expected new bucket to be empty prior to adding addresses" +
+			" to the address manager")
+	}
+	if len(n.addrTried[0]) > 0 {
+		t.Fatal("expected tried bucket to be empty prior to adding addresses" +
+			" to the address manager")
+	}
+
+	n.AddAddress(addrA, srcAddr)
+	n.AddAddress(addrB, srcAddr)
+
+	// Both addresses should exist in the address index and new bucket after
+	// being added to the address manager.  The tried bucket should be empty.
+	if _, exists := n.addrIndex[addrAKey]; !exists {
+		t.Fatalf("expected address %s to exist in address index", addrAKey)
+	}
+	if _, exists := n.addrIndex[addrBKey]; !exists {
+		t.Fatalf("expected address %s to exist in address index", addrBKey)
+	}
+	if _, exists := n.addrNew[0][addrAKey]; !exists {
+		t.Fatalf("expected address %s to exist in new bucket", addrAKey)
+	}
+	if _, exists := n.addrNew[0][addrBKey]; !exists {
+		t.Fatalf("expected address %s to exist in new bucket", addrBKey)
+	}
+	if len(n.addrTried[0]) > 0 {
+		t.Fatal("expected tried bucket to contain no elements")
+	}
+
+	// Flagging the first address as good should move it to the tried bucket and
+	// remove it from the new bucket.
+	n.Good(addrA)
+	if _, exists := n.addrNew[0][addrAKey]; exists {
+		t.Fatalf("expected address %s to not exist in new bucket", addrAKey)
+	}
+	if len(n.addrTried[0]) != 1 {
+		t.Fatal("expected tried bucket to contain exactly one element")
+	}
+	if NetAddressKey(n.addrTried[0][0].na) != addrAKey {
+		t.Fatalf("expected address %s to exist in tried bucket", addrAKey)
+	}
+
+	// Flagging the second address as good should cause it to move from the new
+	// bucket to the tried bucket. It should also cause the first address to be
+	// evicted from the tried bucket and move back to the new bucket since the
+	// tried bucket has been limited in capacity to one element.
+	n.Good(addrB)
+	if _, exists := n.addrNew[0][addrBKey]; exists {
+		t.Fatalf("expected address %s to not exist in the new bucket", addrBKey)
+	}
+	if len(n.addrTried[0]) != 1 {
+		t.Fatalf("expected tried bucket to contain exactly one element - "+
+			"got %d", len(n.addrTried[0]))
+	}
+	if NetAddressKey(n.addrTried[0][0].na) != addrBKey {
+		t.Fatalf("expected address %s to exist in tried bucket", addrBKey)
+	}
+	if _, exists := n.addrNew[0][addrAKey]; !exists {
+		t.Fatalf("expected address %s to exist in the new bucket after being "+
+			"evicted from the tried bucket", addrAKey)
 	}
 }
 
@@ -384,35 +545,53 @@ func TestGetAddress(t *testing.T) {
 
 	// Get an address from an empty set (should error)
 	if rv := n.GetAddress(); rv != nil {
-		t.Errorf("GetAddress failed: got: %v want: %v\n", rv, nil)
+		t.Fatalf("GetAddress failed - got: %v want: %v\n", rv, nil)
 	}
 
 	// Add a new address and get it
 	err := n.addAddressByIP(someIP + ":8333")
 	if err != nil {
-		t.Fatalf("Adding address failed: %v", err)
+		t.Fatalf("adding address failed - %v", err)
 	}
 	ka := n.GetAddress()
 	if ka == nil {
-		t.Fatalf("Did not get an address where there is one in the pool")
+		t.Fatal("did not get an address where there is one in the pool")
 	}
-	if ka.NetAddress().IP.String() != someIP {
-		t.Errorf("Wrong IP: got %v, want %v", ka.NetAddress().IP.String(), someIP)
+
+	ipStringA := ka.NetAddress().IP.String()
+	if ipStringA != someIP {
+		t.Fatalf("unexpected ip - got %v, want %v", ipStringA, someIP)
 	}
 
 	// Mark this as a good address and get it
-	n.Good(ka.NetAddress())
+	err = n.Good(ka.NetAddress())
+	if err != nil {
+		t.Fatalf("marking address as good failed: %v", err)
+	}
+
 	ka = n.GetAddress()
 	if ka == nil {
-		t.Fatalf("Did not get an address where there is one in the pool")
+		t.Fatal("did not get an address when one was expected")
 	}
-	if ka.NetAddress().IP.String() != someIP {
-		t.Errorf("Wrong IP: got %v, want %v", ka.NetAddress().IP.String(), someIP)
+
+	ipStringB := ka.NetAddress().IP.String()
+	if ipStringB != someIP {
+		t.Fatalf("unexpected ip - got %v, want %v", ipStringB, someIP)
 	}
 
 	numAddrs := n.numAddresses()
 	if numAddrs != 1 {
-		t.Errorf("Wrong number of addresses: got %d, want %d", numAddrs, 1)
+		t.Fatalf("unexpected number of addresses - got %d, want 1", numAddrs)
+	}
+
+	// Attempting to mark an unknown address as good should return an error.
+	unknownIP := net.ParseIP("1.2.3.4")
+	unknownNetAddress := wire.NewNetAddressIPPort(unknownIP, 1234,
+		wire.SFNodeNetwork)
+	err = n.Good(unknownNetAddress)
+	if err == nil {
+		t.Fatal("attempting to mark unknown address as good should have " +
+			"returned an error")
 	}
 }
 
@@ -430,41 +609,28 @@ func TestGetBestLocalAddress(t *testing.T) {
 		want1      wire.NetAddress
 		want2      wire.NetAddress
 		want3      wire.NetAddress
-	}{
-		{
-			// Remote connection from public IPv4
-			wire.NetAddress{IP: net.ParseIP("204.124.8.1")},
-			wire.NetAddress{IP: net.IPv4zero},
-			wire.NetAddress{IP: net.IPv4zero},
-			wire.NetAddress{IP: net.ParseIP("204.124.8.100")},
-			wire.NetAddress{IP: net.ParseIP("fd87:d87e:eb43:25::1")},
-		},
-		{
-			// Remote connection from private IPv4
-			wire.NetAddress{IP: net.ParseIP("172.16.0.254")},
-			wire.NetAddress{IP: net.IPv4zero},
-			wire.NetAddress{IP: net.IPv4zero},
-			wire.NetAddress{IP: net.IPv4zero},
-			wire.NetAddress{IP: net.IPv4zero},
-		},
-		{
-			// Remote connection from public IPv6
-			wire.NetAddress{IP: net.ParseIP("2602:100:abcd::102")},
-			wire.NetAddress{IP: net.IPv6zero},
-			wire.NetAddress{IP: net.ParseIP("2001:470::1")},
-			wire.NetAddress{IP: net.ParseIP("2001:470::1")},
-			wire.NetAddress{IP: net.ParseIP("2001:470::1")},
-		},
-		/* XXX
-		{
-			// Remote connection from Tor
-			wire.NetAddress{IP: net.ParseIP("fd87:d87e:eb43::100")},
-			wire.NetAddress{IP: net.IPv4zero},
-			wire.NetAddress{IP: net.ParseIP("204.124.8.100")},
-			wire.NetAddress{IP: net.ParseIP("fd87:d87e:eb43:25::1")},
-		},
-		*/
-	}
+	}{{
+		// Remote connection from public IPv4
+		wire.NetAddress{IP: net.ParseIP("204.124.8.1")},
+		wire.NetAddress{IP: net.IPv4zero},
+		wire.NetAddress{IP: net.IPv4zero},
+		wire.NetAddress{IP: net.ParseIP("204.124.8.100")},
+		wire.NetAddress{IP: net.ParseIP("fd87:d87e:eb43:25::1")},
+	}, {
+		// Remote connection from private IPv4
+		wire.NetAddress{IP: net.ParseIP("172.16.0.254")},
+		wire.NetAddress{IP: net.IPv4zero},
+		wire.NetAddress{IP: net.IPv4zero},
+		wire.NetAddress{IP: net.IPv4zero},
+		wire.NetAddress{IP: net.IPv4zero},
+	}, {
+		// Remote connection from public IPv6
+		wire.NetAddress{IP: net.ParseIP("2602:100:abcd::102")},
+		wire.NetAddress{IP: net.IPv6zero},
+		wire.NetAddress{IP: net.ParseIP("2001:470::1")},
+		wire.NetAddress{IP: net.ParseIP("2001:470::1")},
+		wire.NetAddress{IP: net.ParseIP("2001:470::1")},
+	}}
 
 	amgr := New("testgetbestlocaladdress", nil)
 
@@ -541,7 +707,7 @@ func TestCorruptPeersFile(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(dir)
-	peersFile := filepath.Join(dir, PeersFilename)
+	peersFile := filepath.Join(dir, peersFilename)
 	// create corrupt (empty) peers file
 	fp, err := os.Create(peersFile)
 	if err != nil {
@@ -555,5 +721,299 @@ func TestCorruptPeersFile(t *testing.T) {
 	amgr.Stop()
 	if _, err := os.Stat(peersFile); err != nil {
 		t.Fatalf("Corrupt peers file has not been removed: %s", peersFile)
+	}
+}
+
+// TestValidatePeerNa tests whether a remote address is considered reachable
+// from a local address.
+func TestValidatePeerNa(t *testing.T) {
+	const unroutableIpv4Address = "0.0.0.0"
+	const unroutableIpv6Address = "::1"
+	const routableIpv4Address = "12.1.2.3"
+	const routableIpv6Address = "2003::"
+	onionCatTorV2Address := onionCatNet.IP.String()
+	rfc4380IPAddress := rfc4380Net.IP.String()
+	rfc3964IPAddress := rfc3964Net.IP.String()
+	rfc6052IPAddress := rfc6052Net.IP.String()
+	rfc6145IPAddress := rfc6145Net.IP.String()
+
+	tests := []struct {
+		name          string
+		localAddress  string
+		remoteAddress string
+		valid         bool
+		reach         int
+	}{{
+		name:          "torv2 to torv2",
+		localAddress:  onionCatTorV2Address,
+		remoteAddress: onionCatTorV2Address,
+		valid:         false,
+		reach:         Private,
+	}, {
+		name:          "routable ipv4 to torv2",
+		localAddress:  routableIpv4Address,
+		remoteAddress: onionCatTorV2Address,
+		valid:         true,
+		reach:         Ipv4,
+	}, {
+		name:          "unroutable ipv4 to torv2",
+		localAddress:  unroutableIpv4Address,
+		remoteAddress: onionCatTorV2Address,
+		valid:         false,
+		reach:         Default,
+	}, {
+		name:          "routable ipv6 to torv2",
+		localAddress:  routableIpv6Address,
+		remoteAddress: onionCatTorV2Address,
+		valid:         false,
+		reach:         Default,
+	}, {
+		name:          "unroutable ipv6 to torv2",
+		localAddress:  unroutableIpv6Address,
+		remoteAddress: onionCatTorV2Address,
+		valid:         false,
+		reach:         Default,
+	}, {
+		name:          "rfc4380 to rfc4380",
+		localAddress:  rfc4380IPAddress,
+		remoteAddress: rfc4380IPAddress,
+		valid:         true,
+		reach:         Teredo,
+	}, {
+		name:          "unroutable ipv4 to rfc4380",
+		localAddress:  unroutableIpv4Address,
+		remoteAddress: rfc4380IPAddress,
+		valid:         false,
+		reach:         Default,
+	}, {
+		name:          "routable ipv4 to rfc4380",
+		localAddress:  routableIpv4Address,
+		remoteAddress: rfc4380IPAddress,
+		valid:         true,
+		reach:         Ipv4,
+	}, {
+		name:          "routable ipv6 to rfc4380",
+		localAddress:  routableIpv6Address,
+		remoteAddress: rfc4380IPAddress,
+		valid:         true,
+		reach:         Ipv6Weak,
+	}, {
+		name:          "routable ipv4 to routable ipv4",
+		localAddress:  routableIpv4Address,
+		remoteAddress: routableIpv4Address,
+		valid:         true,
+		reach:         Ipv4,
+	}, {
+		name:          "routable ipv6 to routable ipv4",
+		localAddress:  routableIpv6Address,
+		remoteAddress: routableIpv4Address,
+		valid:         false,
+		reach:         Unreachable,
+	}, {
+		name:          "unroutable ipv4 to routable ipv6",
+		localAddress:  unroutableIpv4Address,
+		remoteAddress: routableIpv6Address,
+		valid:         false,
+		reach:         Default,
+	}, {
+		name:          "unroutable ipv6 to routable ipv6",
+		localAddress:  unroutableIpv6Address,
+		remoteAddress: routableIpv6Address,
+		valid:         false,
+		reach:         Default,
+	}, {
+		name:          "unroutable ipv4 to routable ipv6",
+		localAddress:  unroutableIpv4Address,
+		remoteAddress: routableIpv6Address,
+		valid:         false,
+		reach:         Default,
+	}, {
+		name:          "routable ipv4 to unroutable ipv6",
+		localAddress:  routableIpv4Address,
+		remoteAddress: unroutableIpv6Address,
+		valid:         false,
+		reach:         Unreachable,
+	}, {
+		name:          "routable ivp6 rfc4380 to routable ipv6",
+		localAddress:  rfc4380IPAddress,
+		remoteAddress: routableIpv6Address,
+		valid:         true,
+		reach:         Teredo,
+	}, {
+		name:          "routable ipv4 to routable ipv6",
+		localAddress:  routableIpv4Address,
+		remoteAddress: routableIpv6Address,
+		valid:         true,
+		reach:         Ipv4,
+	}, {
+		name:          "tunnelled ipv6 rfc3964 to routable ipv6",
+		localAddress:  rfc3964IPAddress,
+		remoteAddress: routableIpv6Address,
+		valid:         true,
+		reach:         Ipv6Weak,
+	}, {
+		name:          "tunnelled ipv6 rfc6052 to routable ipv6",
+		localAddress:  rfc6052IPAddress,
+		remoteAddress: routableIpv6Address,
+		valid:         true,
+		reach:         Ipv6Weak,
+	}, {
+		name:          "tunnelled ipv6 rfc6145 to routable ipv6",
+		localAddress:  rfc6145IPAddress,
+		remoteAddress: routableIpv6Address,
+		valid:         true,
+		reach:         Ipv6Weak,
+	}}
+
+	addressManager := New("testValidatePeerNa", nil)
+	for _, test := range tests {
+		localIP := net.ParseIP(test.localAddress)
+		remoteIP := net.ParseIP(test.remoteAddress)
+		localNa := wire.NewNetAddressIPPort(localIP, 8333, wire.SFNodeNetwork)
+		remoteNa := wire.NewNetAddressIPPort(remoteIP, 8333, wire.SFNodeNetwork)
+
+		valid, reach := addressManager.ValidatePeerNa(localNa, remoteNa)
+		if valid != test.valid {
+			t.Errorf("%q: unexpected return value for valid - want '%v', "+
+				"got '%v'", test.name, test.valid, valid)
+			continue
+		}
+		if reach != test.reach {
+			t.Errorf("%q: unexpected return value for reach - want '%v', "+
+				"got '%v'", test.name, test.reach, reach)
+		}
+	}
+}
+
+// TestHostToNetAddress ensures that HostToNetAddress behaves as expected
+// given valid and invalid host name arguments.
+func TestHostToNetAddress(t *testing.T) {
+	// Define a hostname that will cause a lookup to be performed using the
+	// lookupFunc provided to the address manager instance for each test.
+	const hostnameForLookup = "hostname.test"
+	const services = wire.SFNodeNetwork
+
+	tests := []struct {
+		name       string
+		host       string
+		port       uint16
+		lookupFunc func(host string) ([]net.IP, error)
+		wantErr    bool
+		want       *wire.NetAddress
+	}{{
+		name:       "valid onion address",
+		host:       "a5ccbdkubbr2jlcp.onion",
+		port:       8333,
+		lookupFunc: nil,
+		wantErr:    false,
+		want: wire.NewNetAddressIPPort(
+			net.ParseIP("fd87:d87e:eb43:744:208d:5408:63a4:ac4f"), 8333,
+			services),
+	}, {
+		name:       "invalid onion address",
+		host:       "0000000000000000.onion",
+		port:       8333,
+		lookupFunc: nil,
+		wantErr:    true,
+		want:       nil,
+	}, {
+		name: "unresolvable host name",
+		host: hostnameForLookup,
+		port: 8333,
+		lookupFunc: func(host string) ([]net.IP, error) {
+			return nil, fmt.Errorf("unresolvable host %v", host)
+		},
+		wantErr: true,
+		want:    nil,
+	}, {
+		name: "not resolved host name",
+		host: hostnameForLookup,
+		port: 8333,
+		lookupFunc: func(host string) ([]net.IP, error) {
+			return nil, nil
+		},
+		wantErr: true,
+		want:    nil,
+	}, {
+		name: "resolved host name",
+		host: hostnameForLookup,
+		port: 8333,
+		lookupFunc: func(host string) ([]net.IP, error) {
+			return []net.IP{net.ParseIP("127.0.0.1")}, nil
+		},
+		wantErr: false,
+		want: wire.NewNetAddressIPPort(net.ParseIP("127.0.0.1"), 8333,
+			services),
+	}, {
+		name:       "valid ip address",
+		host:       "12.1.2.3",
+		port:       8333,
+		lookupFunc: nil,
+		wantErr:    false,
+		want: wire.NewNetAddressIPPort(net.ParseIP("12.1.2.3"), 8333,
+			services),
+	}}
+
+	for _, test := range tests {
+		addrManager := New("testHostToNetAddress", test.lookupFunc)
+		result, err := addrManager.HostToNetAddress(test.host, test.port,
+			services)
+		if test.wantErr == true && err == nil {
+			t.Errorf("%q: expected error but one was not returned", test.name)
+		}
+		if !reflect.DeepEqual(result, test.want) {
+			t.Errorf("%q: unexpected result - got %v, want %v", test.name,
+				result, test.want)
+		}
+	}
+}
+
+// TestSetServices ensures that a known address' services are updated as
+// expected and that the services field is not mutated when new services are
+// added.
+func TestSetServices(t *testing.T) {
+	addressManager := New("testSetServices", nil)
+	const services = wire.SFNodeNetwork
+
+	// Attempt to set services for an address not known to the address manager.
+	// This should have no effect and exercises paths that avoid a panic.
+	notKnownAddr := wire.NewNetAddressIPPort(net.ParseIP("0.0.0.0"), 8333,
+		services)
+	err := addressManager.SetServices(notKnownAddr, services)
+	if err == nil {
+		t.Fatal("setting services for unknown address should return error")
+	}
+
+	// Add a new address to the address manager.
+	netAddr := wire.NewNetAddressIPPort(net.ParseIP("1.2.3.4"), 8333, services)
+	srcAddr := wire.NewNetAddressIPPort(net.ParseIP("5.6.7.8"), 8333, services)
+	addressManager.AddAddress(netAddr, srcAddr)
+
+	// Ensure that the services field for a network address returned from the
+	// address manager is not mutated by a call to SetServices.
+	knownAddress := addressManager.GetAddress()
+	if knownAddress == nil {
+		t.Fatal("expected known address, got nil")
+	}
+	netAddrA := knownAddress.na
+	if netAddrA.Services != services {
+		t.Fatalf("unexpected network address services - got %x, want %x",
+			netAddrA.Services, services)
+	}
+
+	// Set the new services for the network address and verify that the
+	// previously seen network address netAddrA's services are not modified.
+	const newServiceFlags = services << 1
+	addressManager.SetServices(netAddr, newServiceFlags)
+	netAddrB := knownAddress.na
+	if netAddrA == netAddrB {
+		t.Fatal("expected known address to have new network address reference")
+	}
+	if netAddrA.Services != services {
+		t.Fatal("netAddrA services flag was mutated")
+	}
+	if netAddrB.Services != newServiceFlags {
+		t.Fatalf("netAddrB has invalid services - got %x, want %x",
+			netAddrB.Services, newServiceFlags)
 	}
 }

--- a/addrmgr/addrmanager_test.go
+++ b/addrmgr/addrmanager_test.go
@@ -107,73 +107,66 @@ func lookupFunc(host string) ([]net.IP, error) {
 	return nil, errors.New("not implemented")
 }
 
-func TestStartStop(t *testing.T) {
-	n := New("teststartstop", lookupFunc)
-	n.Start()
-	if err := n.Stop(); err != nil {
-		t.Fatalf("Address Manager failed to stop: %v", err)
-	}
+// addAddressByIP is a convenience function that adds an address to the
+// address manager given a valid string representation of an ip address and
+// a port.
+func (a *AddrManager) addAddressByIP(addr string, port uint16) {
+	ip := net.ParseIP(addr)
+	na := wire.NewNetAddressIPPort(ip, port, 0)
+	a.AddAddress(na, na)
 }
 
-func TestAddAddressByIP(t *testing.T) {
-	fmtErr := fmt.Errorf("")
-	addrErr := &net.AddrError{}
-	var tests = []struct {
-		addrIP string
-		err    error
-	}{{
-		someIP + ":8333",
-		nil,
-	}, {
-		someIP,
-		addrErr,
-	}, {
-		someIP[:12] + ":8333",
-		fmtErr,
-	}, {
-		someIP + ":abcd",
-		fmtErr,
-	}}
-
-	dir, err := os.MkdirTemp("", "testaddressbyip")
+// TestStartStop tests the behavior of the address manager when it is started
+// and stopped.
+func TestStartStop(t *testing.T) {
+	dir, err := os.MkdirTemp("", "teststartstop")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(dir)
+
+	// Ensure the peers file does not exist before starting the address manager.
+	peersFile := filepath.Join(dir, peersFilename)
+	if _, err := os.Stat(peersFile); !os.IsNotExist(err) {
+		t.Fatalf("peers file exists though it should not: %s", peersFile)
+	}
+
 	amgr := New(dir, nil)
 	amgr.Start()
-	for i, test := range tests {
-		err := amgr.addAddressByIP(test.addrIP)
-		if test.err != nil && err == nil {
-			t.Errorf("TestGood test %d failed expected an error and got none", i)
-			continue
-		}
-		if test.err == nil && err != nil {
-			t.Errorf("TestGood test %d failed expected no error and got one", i)
-			continue
-		}
-		if reflect.TypeOf(err) != reflect.TypeOf(test.err) {
-			t.Errorf("TestGood test %d failed got %v, want %v", i,
-				reflect.TypeOf(err), reflect.TypeOf(test.err))
-			continue
-		}
-	}
+
+	// Add single network address to the address manager.
+	amgr.addAddressByIP(someIP, 8333)
+
+	// Stop the address manager to force the known addresses to be flushed
+	// to the peers file.
 	if err := amgr.Stop(); err != nil {
 		t.Fatalf("address manager failed to stop: %v", err)
 	}
 
-	// Make sure the peers file has been written to.
-	peersFile := filepath.Join(dir, peersFilename)
+	// Verify that the the peers file has been written to.
 	if _, err := os.Stat(peersFile); err != nil {
 		t.Fatalf("peers file does not exist: %s", peersFile)
 	}
 
-	// Start the address manager again to read peers file.
+	// Start a new address manager, which initializes it from the peers file.
 	amgr = New(dir, nil)
 	amgr.Start()
-	if ka := amgr.GetAddress(); ka == nil {
+
+	knownAddress := amgr.GetAddress()
+	if knownAddress == nil {
 		t.Fatal("address manager should contain known address")
 	}
+
+	// Verify that the known address matches what was added to the address
+	// manager previously.
+
+	wantNetAddrKey := net.JoinHostPort(someIP, "8333")
+	gotNetAddrKey := NetAddressKey(knownAddress.na)
+	if gotNetAddrKey != wantNetAddrKey {
+		t.Fatal("address manager does not contain expected address - "+
+			"got %v, want %v", gotNetAddrKey, wantNetAddrKey)
+	}
+
 	if err := amgr.Stop(); err != nil {
 		t.Fatalf("address manager failed to stop: %v", err)
 	}
@@ -320,10 +313,7 @@ func TestAttempt(t *testing.T) {
 	n := New("testattempt", lookupFunc)
 
 	// Add a new address and get it.
-	err := n.addAddressByIP(someIP + ":8333")
-	if err != nil {
-		t.Fatalf("adding address failed - %v", err)
-	}
+	n.addAddressByIP(someIP, 8333)
 	ka := n.GetAddress()
 
 	if !ka.LastAttempt().IsZero() {
@@ -331,7 +321,7 @@ func TestAttempt(t *testing.T) {
 	}
 
 	na := ka.NetAddress()
-	err = n.Attempt(na)
+	err := n.Attempt(na)
 	if err != nil {
 		t.Fatalf("marking address as attempted failed - %v", err)
 	}
@@ -354,16 +344,13 @@ func TestConnected(t *testing.T) {
 	n := New("testconnected", lookupFunc)
 
 	// Add a new address and get it
-	err := n.addAddressByIP(someIP + ":8333")
-	if err != nil {
-		t.Fatalf("failed to add address - %v", err)
-	}
+	n.addAddressByIP(someIP, 8333)
 	ka := n.GetAddress()
 	na := ka.NetAddress()
 	// make it an hour ago
 	na.Timestamp = time.Unix(time.Now().Add(time.Hour*-1).Unix(), 0)
 
-	err = n.Connected(na)
+	err := n.Connected(na)
 	if err != nil {
 		t.Fatalf("marking address as connected failed - %v", err)
 	}
@@ -549,10 +536,7 @@ func TestGetAddress(t *testing.T) {
 	}
 
 	// Add a new address and get it
-	err := n.addAddressByIP(someIP + ":8333")
-	if err != nil {
-		t.Fatalf("adding address failed - %v", err)
-	}
+	n.addAddressByIP(someIP, 8333)
 	ka := n.GetAddress()
 	if ka == nil {
 		t.Fatal("did not get an address where there is one in the pool")
@@ -564,7 +548,7 @@ func TestGetAddress(t *testing.T) {
 	}
 
 	// Mark this as a good address and get it
-	err = n.Good(ka.NetAddress())
+	err := n.Good(ka.NetAddress())
 	if err != nil {
 		t.Fatalf("marking address as good failed: %v", err)
 	}

--- a/addrmgr/addrmanager_test.go
+++ b/addrmgr/addrmanager_test.go
@@ -726,7 +726,7 @@ func TestValidatePeerNa(t *testing.T) {
 		localAddress  string
 		remoteAddress string
 		valid         bool
-		reach         int
+		reach         NetAddressReach
 	}{{
 		name:          "torv2 to torv2",
 		localAddress:  onionCatTorV2Address,

--- a/addrmgr/error.go
+++ b/addrmgr/error.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package addrmgr
+
+// ErrorKind identifies a kind of error.  It has full support for errors.Is
+// and errors.As, so the caller can directly check against an error kind
+// when determining the reason for an error.
+type ErrorKind string
+
+// These constants are used to identify a specific RuleError.
+const (
+	// ErrAddressNotFound indicates that an operation in the address manager
+	// failed due to an address lookup failure.
+	ErrAddressNotFound = ErrorKind("ErrAddressNotFound")
+)
+
+// Error satisfies the error interface and prints human-readable errors.
+func (e ErrorKind) Error() string {
+	return string(e)
+}
+
+// Error identifies an address manager error. It has full support for
+// errors.Is and errors.As, so the caller can ascertain the specific reason
+// for the error by checking the underlying error.
+type Error struct {
+	Err         error
+	Description string
+}
+
+// Error satisfies the error interface and prints human-readable errors.
+func (e Error) Error() string {
+	return e.Description
+}
+
+// Unwrap returns the underlying wrapped error.
+func (e Error) Unwrap() error {
+	return e.Err
+}
+
+// makeError creates an Error given a set of arguments.
+func makeError(kind ErrorKind, desc string) Error {
+	return Error{Err: kind, Description: desc}
+}

--- a/addrmgr/knownaddress.go
+++ b/addrmgr/knownaddress.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -8,8 +8,6 @@ package addrmgr
 import (
 	"sync"
 	"time"
-
-	"github.com/decred/dcrd/wire"
 )
 
 // KnownAddress tracks information about a known network address that is used
@@ -20,11 +18,11 @@ type KnownAddress struct {
 	mtx sync.Mutex
 
 	// na is the primary network address that the known address represents.
-	na *wire.NetAddress
+	na *NetAddress
 
 	// srcAddr is the network address of the peer that suggested the primary
 	// network address.
-	srcAddr *wire.NetAddress
+	srcAddr *NetAddress
 
 	// The following fields track the attempts made to connect to the primary
 	// network address.  Initially connecting to a peer counts as an attempt,
@@ -45,7 +43,7 @@ type KnownAddress struct {
 
 // NetAddress returns the underlying wire.NetAddress associated with the
 // known address.
-func (ka *KnownAddress) NetAddress() *wire.NetAddress {
+func (ka *KnownAddress) NetAddress() *NetAddress {
 	ka.mtx.Lock()
 	defer ka.mtx.Unlock()
 	return ka.na

--- a/addrmgr/knownaddress.go
+++ b/addrmgr/knownaddress.go
@@ -15,14 +15,32 @@ import (
 // KnownAddress tracks information about a known network address that is used
 // to determine how viable an address is.
 type KnownAddress struct {
-	mtx         sync.Mutex
-	na          *wire.NetAddress
-	srcAddr     *wire.NetAddress
+	// mtx is used to ensure safe concurrent access to methods on a known
+	// address instance.
+	mtx sync.Mutex
+
+	// na is the primary network address that the known address represents.
+	na *wire.NetAddress
+
+	// srcAddr is the network address of the peer that suggested the primary
+	// network address.
+	srcAddr *wire.NetAddress
+
+	// The following fields track the attempts made to connect to the primary
+	// network address.  Initially connecting to a peer counts as an attempt,
+	// and a successful version message exchange resets the number of attempts
+	// to zero.
 	attempts    int
 	lastattempt time.Time
 	lastsuccess time.Time
-	tried       bool
-	refs        int // reference count of new buckets
+
+	// tried indicates whether the address currently exists in a tried bucket.
+	tried bool
+
+	// refs represents the total number of new buckets that the known address
+	// exists in.  This is updated as the address moves between new and tried
+	// buckets.
+	refs int
 }
 
 // NetAddress returns the underlying wire.NetAddress associated with the

--- a/addrmgr/knownaddress_test.go
+++ b/addrmgr/knownaddress_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -9,13 +9,18 @@ import (
 	"math"
 	"testing"
 	"time"
-
-	"github.com/decred/dcrd/wire"
 )
 
-func newKnownAddress(na *wire.NetAddress, attempts int, lastattempt, lastsuccess time.Time, tried bool, refs int) *KnownAddress {
-	return &KnownAddress{na: na, attempts: attempts, lastattempt: lastattempt,
-		lastsuccess: lastsuccess, tried: tried, refs: refs}
+func newKnownAddress(ts time.Time, attempts int, lastattempt, lastsuccess time.Time, tried bool, refs int) *KnownAddress {
+	na := &NetAddress{Timestamp: ts}
+	return &KnownAddress{
+		na:          na,
+		attempts:    attempts,
+		lastattempt: lastattempt,
+		lastsuccess: lastsuccess,
+		tried:       tried,
+		refs:        refs,
+	}
 }
 
 func TestChance(t *testing.T) {
@@ -23,34 +28,32 @@ func TestChance(t *testing.T) {
 	var tests = []struct {
 		addr     *KnownAddress
 		expected float64
-	}{
-		{
-			// Test normal case
-			newKnownAddress(&wire.NetAddress{Timestamp: now.Add(-35 * time.Second)},
-				0, now.Add(-30*time.Minute), now, false, 0),
-			1.0,
-		}, {
-			// Test case in which lastseen < 0
-			newKnownAddress(&wire.NetAddress{Timestamp: now.Add(20 * time.Second)},
-				0, now.Add(-30*time.Minute), now, false, 0),
-			1.0,
-		}, {
-			// Test case in which lastattempt < 0
-			newKnownAddress(&wire.NetAddress{Timestamp: now.Add(-35 * time.Second)},
-				0, now.Add(30*time.Minute), now, false, 0),
-			1.0 * .01,
-		}, {
-			// Test case in which lastattempt < ten minutes
-			newKnownAddress(&wire.NetAddress{Timestamp: now.Add(-35 * time.Second)},
-				0, now.Add(-5*time.Minute), now, false, 0),
-			1.0 * .01,
-		}, {
-			// Test case with several failed attempts.
-			newKnownAddress(&wire.NetAddress{Timestamp: now.Add(-35 * time.Second)},
-				2, now.Add(-30*time.Minute), now, false, 0),
-			1 / 1.5 / 1.5,
-		},
-	}
+	}{{
+		// Test normal case
+		newKnownAddress(now.Add(-35*time.Second),
+			0, now.Add(-30*time.Minute), now, false, 0),
+		1.0,
+	}, {
+		// Test case in which lastseen < 0
+		newKnownAddress(now.Add(20*time.Second),
+			0, now.Add(-30*time.Minute), now, false, 0),
+		1.0,
+	}, {
+		// Test case in which lastattempt < 0
+		newKnownAddress(now.Add(-35*time.Second),
+			0, now.Add(30*time.Minute), now, false, 0),
+		1.0 * .01,
+	}, {
+		// Test case in which lastattempt < ten minutes
+		newKnownAddress(now.Add(-35*time.Second),
+			0, now.Add(-5*time.Minute), now, false, 0),
+		1.0 * .01,
+	}, {
+		// Test case with several failed attempts.
+		newKnownAddress(now.Add(-35*time.Second),
+			2, now.Add(-30*time.Minute), now, false, 0),
+		1 / 1.5 / 1.5,
+	}}
 
 	err := .0001
 	for i, test := range tests {
@@ -70,50 +73,45 @@ func TestIsBad(t *testing.T) {
 	hoursOld := now.Add(-5 * time.Hour)
 	zeroTime := time.Time{}
 
-	futureNa := &wire.NetAddress{Timestamp: future}
-	minutesOldNa := &wire.NetAddress{Timestamp: minutesOld}
-	monthOldNa := &wire.NetAddress{Timestamp: monthOld}
-	currentNa := &wire.NetAddress{Timestamp: secondsOld}
-
 	// Test addresses that have been tried in the last minute.
-	if newKnownAddress(futureNa, 3, secondsOld, zeroTime, false, 0).isBad() {
+	if newKnownAddress(future, 3, secondsOld, zeroTime, false, 0).isBad() {
 		t.Errorf("test case 1: addresses that have been tried in the last minute are not bad.")
 	}
-	if newKnownAddress(monthOldNa, 3, secondsOld, zeroTime, false, 0).isBad() {
+	if newKnownAddress(monthOld, 3, secondsOld, zeroTime, false, 0).isBad() {
 		t.Errorf("test case 2: addresses that have been tried in the last minute are not bad.")
 	}
-	if newKnownAddress(currentNa, 3, secondsOld, zeroTime, false, 0).isBad() {
+	if newKnownAddress(secondsOld, 3, secondsOld, zeroTime, false, 0).isBad() {
 		t.Errorf("test case 3: addresses that have been tried in the last minute are not bad.")
 	}
-	if newKnownAddress(currentNa, 3, secondsOld, monthOld, true, 0).isBad() {
+	if newKnownAddress(secondsOld, 3, secondsOld, monthOld, true, 0).isBad() {
 		t.Errorf("test case 4: addresses that have been tried in the last minute are not bad.")
 	}
-	if newKnownAddress(currentNa, 2, secondsOld, secondsOld, true, 0).isBad() {
+	if newKnownAddress(secondsOld, 2, secondsOld, secondsOld, true, 0).isBad() {
 		t.Errorf("test case 5: addresses that have been tried in the last minute are not bad.")
 	}
 
 	// Test address that claims to be from the future.
-	if !newKnownAddress(futureNa, 0, minutesOld, hoursOld, true, 0).isBad() {
+	if !newKnownAddress(future, 0, minutesOld, hoursOld, true, 0).isBad() {
 		t.Errorf("test case 6: addresses that claim to be from the future are bad.")
 	}
 
 	// Test address that has not been seen in over a month.
-	if !newKnownAddress(monthOldNa, 0, minutesOld, hoursOld, true, 0).isBad() {
+	if !newKnownAddress(monthOld, 0, minutesOld, hoursOld, true, 0).isBad() {
 		t.Errorf("test case 7: addresses more than a month old are bad.")
 	}
 
 	// It has failed at least three times and never succeeded.
-	if !newKnownAddress(minutesOldNa, 3, minutesOld, zeroTime, true, 0).isBad() {
+	if !newKnownAddress(minutesOld, 3, minutesOld, zeroTime, true, 0).isBad() {
 		t.Errorf("test case 8: addresses that have never succeeded are bad.")
 	}
 
 	// It has failed ten times in the last week
-	if !newKnownAddress(minutesOldNa, 10, minutesOld, monthOld, true, 0).isBad() {
+	if !newKnownAddress(minutesOld, 10, minutesOld, monthOld, true, 0).isBad() {
 		t.Errorf("test case 9: addresses that have not succeeded in too long are bad.")
 	}
 
 	// Test an address that should work.
-	if newKnownAddress(minutesOldNa, 2, minutesOld, hoursOld, true, 0).isBad() {
+	if newKnownAddress(minutesOld, 2, minutesOld, hoursOld, true, 0).isBad() {
 		t.Errorf("test case 10: This should be a valid address.")
 	}
 }

--- a/addrmgr/netaddress.go
+++ b/addrmgr/netaddress.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package addrmgr
+
+import (
+	"encoding/base32"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/decred/dcrd/wire"
+)
+
+// NetAddress defines information about a peer on the network.
+type NetAddress struct {
+	// IP address of the peer. It is defined as a byte array to support various
+	// address types that are not standard to the net module and therefore not
+	// entirely appropriate to store as a net.IP.
+	IP []byte
+
+	// Port is the port of the remote peer.
+	Port uint16
+
+	// Timestamp is the last time the address was seen.
+	Timestamp time.Time
+
+	// Services represents the service flags supported by this network address.
+	Services wire.ServiceFlag
+}
+
+// IsRoutable returns a boolean indicating whether the network address is
+// routable.
+func (netAddr *NetAddress) IsRoutable() bool {
+	return IsRoutable(netAddr.IP)
+}
+
+// ipString returns a string representation of the network address' IP field.
+// If the ip is in the range used for TORv2 addresses then it will be
+// transformed into the respective .onion address.  It does not include the
+// port.
+func (netAddr *NetAddress) ipString() string {
+	netIP := netAddr.IP
+	if isOnionCatTor(netIP) {
+		// We know now that na.IP is long enough.
+		base32 := base32.StdEncoding.EncodeToString(netIP[6:])
+		return strings.ToLower(base32) + ".onion"
+	}
+	return net.IP(netIP).String()
+}
+
+// Key returns a string that can be used to uniquely represent the network
+// address and includes the port.
+func (netAddr *NetAddress) Key() string {
+	portString := strconv.FormatUint(uint64(netAddr.Port), 10)
+	return net.JoinHostPort(netAddr.ipString(), portString)
+}
+
+// String returns a human-readable string for the network address.  This is
+// equivalent to calling Key, but is provided so the type can be used as a
+// fmt.Stringer.
+func (netAddr *NetAddress) String() string {
+	return netAddr.Key()
+}
+
+// Clone creates a shallow copy of the NetAddress instance. The IP reference
+// is shared since it is not mutated.
+func (netAddr *NetAddress) Clone() *NetAddress {
+	netAddrCopy := *netAddr
+	return &netAddrCopy
+}
+
+// AddService adds the provided service to the set of services that the
+// network address supports.
+func (netAddr *NetAddress) AddService(service wire.ServiceFlag) {
+	netAddr.Services |= service
+}
+
+// newAddressFromString creates a new address manager network address from the
+// provided string.  The address is expected to be provided in the format
+// host:port.
+func (a *AddrManager) newAddressFromString(addr string) (*NetAddress, error) {
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+	port, err := strconv.ParseUint(portStr, 10, 16)
+	if err != nil {
+		return nil, err
+	}
+
+	return a.HostToNetAddress(host, uint16(port), wire.SFNodeNetwork)
+}
+
+// NewNetAddressIPPort creates a new address manager network address given an ip,
+// port, and the supported service flags for the address.
+func NewNetAddressIPPort(ip net.IP, port uint16, services wire.ServiceFlag) *NetAddress {
+	timestamp := time.Unix(time.Now().Unix(), 0)
+	return &NetAddress{
+		IP:        ip,
+		Port:      port,
+		Services:  services,
+		Timestamp: timestamp,
+	}
+}

--- a/addrmgr/netaddress_test.go
+++ b/addrmgr/netaddress_test.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package addrmgr
+
+import (
+	"net"
+	"reflect"
+	"testing"
+
+	"github.com/decred/dcrd/wire"
+)
+
+// TestKey verifies that Key converts a network address to an expected string
+// value.
+func TestKey(t *testing.T) {
+	tests := []struct {
+		ip   string
+		port uint16
+		want string
+	}{
+		// IPv4
+		// Localhost
+		{ip: "127.0.0.1", port: 8333, want: "127.0.0.1:8333"},
+		{ip: "127.0.0.1", port: 8334, want: "127.0.0.1:8334"},
+
+		// Class A
+		{ip: "1.0.0.1", port: 8333, want: "1.0.0.1:8333"},
+		{ip: "2.2.2.2", port: 8334, want: "2.2.2.2:8334"},
+		{ip: "27.253.252.251", port: 8335, want: "27.253.252.251:8335"},
+		{ip: "123.3.2.1", port: 8336, want: "123.3.2.1:8336"},
+
+		// Private Class A
+		{ip: "10.0.0.1", port: 8333, want: "10.0.0.1:8333"},
+		{ip: "10.1.1.1", port: 8334, want: "10.1.1.1:8334"},
+		{ip: "10.2.2.2", port: 8335, want: "10.2.2.2:8335"},
+		{ip: "10.10.10.10", port: 8336, want: "10.10.10.10:8336"},
+
+		// Class B
+		{ip: "128.0.0.1", port: 8333, want: "128.0.0.1:8333"},
+		{ip: "129.1.1.1", port: 8334, want: "129.1.1.1:8334"},
+		{ip: "180.2.2.2", port: 8335, want: "180.2.2.2:8335"},
+		{ip: "191.10.10.10", port: 8336, want: "191.10.10.10:8336"},
+
+		// Private Class B
+		{ip: "172.16.0.1", port: 8333, want: "172.16.0.1:8333"},
+		{ip: "172.16.1.1", port: 8334, want: "172.16.1.1:8334"},
+		{ip: "172.16.2.2", port: 8335, want: "172.16.2.2:8335"},
+		{ip: "172.16.172.172", port: 8336, want: "172.16.172.172:8336"},
+
+		// Class C
+		{ip: "193.0.0.1", port: 8333, want: "193.0.0.1:8333"},
+		{ip: "200.1.1.1", port: 8334, want: "200.1.1.1:8334"},
+		{ip: "205.2.2.2", port: 8335, want: "205.2.2.2:8335"},
+		{ip: "223.10.10.10", port: 8336, want: "223.10.10.10:8336"},
+
+		// Private Class C
+		{ip: "192.168.0.1", port: 8333, want: "192.168.0.1:8333"},
+		{ip: "192.168.1.1", port: 8334, want: "192.168.1.1:8334"},
+		{ip: "192.168.2.2", port: 8335, want: "192.168.2.2:8335"},
+		{ip: "192.168.192.192", port: 8336, want: "192.168.192.192:8336"},
+
+		// IPv6
+		// Localhost
+		{ip: "::1", port: 8333, want: "[::1]:8333"},
+		{ip: "fe80::1", port: 8334, want: "[fe80::1]:8334"},
+
+		// Link-local
+		{ip: "fe80::1:1", port: 8333, want: "[fe80::1:1]:8333"},
+		{ip: "fe91::2:2", port: 8334, want: "[fe91::2:2]:8334"},
+		{ip: "fea2::3:3", port: 8335, want: "[fea2::3:3]:8335"},
+		{ip: "feb3::4:4", port: 8336, want: "[feb3::4:4]:8336"},
+
+		// Site-local
+		{ip: "fec0::1:1", port: 8333, want: "[fec0::1:1]:8333"},
+		{ip: "fed1::2:2", port: 8334, want: "[fed1::2:2]:8334"},
+		{ip: "fee2::3:3", port: 8335, want: "[fee2::3:3]:8335"},
+		{ip: "fef3::4:4", port: 8336, want: "[fef3::4:4]:8336"},
+
+		// TORv2
+		{ip: "fd87:d87e:eb43::", port: 8333, want: "aaaaaaaaaaaaaaaa.onion:8333"},
+	}
+
+	for _, test := range tests {
+		netAddr := NewNetAddressIPPort(net.ParseIP(test.ip), test.port, wire.SFNodeNetwork)
+		key := netAddr.Key()
+		if key != test.want {
+			t.Errorf("unexpected network address key -- got %s, want %s",
+				key, test.want)
+			continue
+		}
+	}
+}
+
+// TestClone verifies that a new instance of the network address struct is
+// created when cloned.
+func TestClone(t *testing.T) {
+	const port = 0
+	netAddr := NewNetAddressIPPort(net.ParseIP("1.2.3.4"), port, wire.SFNodeNetwork)
+	netAddrClone := netAddr.Clone()
+
+	if netAddr == netAddrClone {
+		t.Fatal("expected new network address reference")
+	}
+	if !reflect.DeepEqual(netAddr, netAddrClone) {
+		t.Fatalf("unxpected clone result -- got %v, want %v",
+			netAddrClone, netAddr)
+	}
+}
+
+// TestAddService verifies that the service flag is set as expected on a
+// network address instance.
+func TestAddService(t *testing.T) {
+	const port = 0
+	netAddr := NewNetAddressIPPort(net.ParseIP("1.2.3.4"), port, wire.SFNodeNetwork)
+	netAddr.AddService(wire.SFNodeNetwork)
+
+	if netAddr.Services != wire.SFNodeNetwork {
+		t.Fatalf("expected service flag to be set -- got %x, want %x",
+			netAddr.Services, wire.SFNodeNetwork)
+	}
+}

--- a/addrmgr/network.go
+++ b/addrmgr/network.go
@@ -118,18 +118,19 @@ func isOnionCatTor(netIP net.IP) bool {
 	return onionCatNet.Contains(netIP)
 }
 
-// NetworkAddress type is used to classify a network address.
-type NetworkAddress int
+// NetAddressType is used to indicate which network a network address belongs
+// to.
+type NetAddressType uint8
 
 const (
-	LocalAddress NetworkAddress = iota
+	LocalAddress NetAddressType = iota
 	IPv4Address
 	IPv6Address
-	OnionAddress
+	TORv2Address
 )
 
-// getNetwork returns the network address type of the provided network address.
-func getNetwork(netIP net.IP) NetworkAddress {
+// addressType returns the network address type of the provided network address.
+func addressType(netIP net.IP) NetAddressType {
 	switch {
 	case isLocal(netIP):
 		return LocalAddress
@@ -138,7 +139,7 @@ func getNetwork(netIP net.IP) NetworkAddress {
 		return IPv4Address
 
 	case isOnionCatTor(netIP):
-		return OnionAddress
+		return TORv2Address
 
 	default:
 		return IPv6Address

--- a/addrmgr/network.go
+++ b/addrmgr/network.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -101,21 +101,21 @@ func ipNet(ip string, ones, bits int) net.IPNet {
 }
 
 // isIPv4 returns whether or not the given address is an IPv4 address.
-func isIPv4(na *wire.NetAddress) bool {
-	return na.IP.To4() != nil
+func isIPv4(netIP net.IP) bool {
+	return netIP.To4() != nil
 }
 
 // isLocal returns whether or not the given address is a local address.
-func isLocal(na *wire.NetAddress) bool {
-	return na.IP.IsLoopback() || zero4Net.Contains(na.IP)
+func isLocal(netIP net.IP) bool {
+	return netIP.IsLoopback() || zero4Net.Contains(netIP)
 }
 
 // isOnionCatTor returns whether or not the passed address is in the IPv6 range
 // used by bitcoin to support Tor (fd87:d87e:eb43::/48).  Note that this range
 // is the same range used by OnionCat, which is part of the RFC4193 unique local
 // IPv6 range.
-func isOnionCatTor(na *wire.NetAddress) bool {
-	return onionCatNet.Contains(na.IP)
+func isOnionCatTor(netIP net.IP) bool {
+	return onionCatNet.Contains(netIP)
 }
 
 // NetworkAddress type is used to classify a network address.
@@ -129,15 +129,15 @@ const (
 )
 
 // getNetwork returns the network address type of the provided network address.
-func getNetwork(na *wire.NetAddress) NetworkAddress {
+func getNetwork(netIP net.IP) NetworkAddress {
 	switch {
-	case isLocal(na):
+	case isLocal(netIP):
 		return LocalAddress
 
-	case isIPv4(na):
+	case isIPv4(netIP):
 		return IPv4Address
 
-	case isOnionCatTor(na):
+	case isOnionCatTor(netIP):
 		return OnionAddress
 
 	default:
@@ -148,9 +148,9 @@ func getNetwork(na *wire.NetAddress) NetworkAddress {
 // isRFC1918 returns whether or not the passed address is part of the IPv4
 // private network address space as defined by RFC1918 (10.0.0.0/8,
 // 172.16.0.0/12, or 192.168.0.0/16).
-func isRFC1918(na *wire.NetAddress) bool {
+func isRFC1918(netIP net.IP) bool {
 	for _, rfc := range rfc1918Nets {
-		if rfc.Contains(na.IP) {
+		if rfc.Contains(netIP) {
 			return true
 		}
 	}
@@ -159,58 +159,58 @@ func isRFC1918(na *wire.NetAddress) bool {
 
 // isRFC2544 returns whether or not the passed address is part of the IPv4
 // address space as defined by RFC2544 (198.18.0.0/15)
-func isRFC2544(na *wire.NetAddress) bool {
-	return rfc2544Net.Contains(na.IP)
+func isRFC2544(netIP net.IP) bool {
+	return rfc2544Net.Contains(netIP)
 }
 
 // isRFC3849 returns whether or not the passed address is part of the IPv6
 // documentation range as defined by RFC3849 (2001:DB8::/32).
-func isRFC3849(na *wire.NetAddress) bool {
-	return rfc3849Net.Contains(na.IP)
+func isRFC3849(netIP net.IP) bool {
+	return rfc3849Net.Contains(netIP)
 }
 
 // isRFC3927 returns whether or not the passed address is part of the IPv4
 // autoconfiguration range as defined by RFC3927 (169.254.0.0/16).
-func isRFC3927(na *wire.NetAddress) bool {
-	return rfc3927Net.Contains(na.IP)
+func isRFC3927(netIP net.IP) bool {
+	return rfc3927Net.Contains(netIP)
 }
 
 // isRFC3964 returns whether or not the passed address is part of the IPv6 to
 // IPv4 encapsulation range as defined by RFC3964 (2002::/16).
-func isRFC3964(na *wire.NetAddress) bool {
-	return rfc3964Net.Contains(na.IP)
+func isRFC3964(netIP net.IP) bool {
+	return rfc3964Net.Contains(netIP)
 }
 
 // isRFC4193 returns whether or not the passed address is part of the IPv6
 // unique local range as defined by RFC4193 (FC00::/7).
-func isRFC4193(na *wire.NetAddress) bool {
-	return rfc4193Net.Contains(na.IP)
+func isRFC4193(netIP net.IP) bool {
+	return rfc4193Net.Contains(netIP)
 }
 
 // isRFC4380 returns whether or not the passed address is part of the IPv6
 // teredo tunneling over UDP range as defined by RFC4380 (2001::/32).
-func isRFC4380(na *wire.NetAddress) bool {
-	return rfc4380Net.Contains(na.IP)
+func isRFC4380(netIP net.IP) bool {
+	return rfc4380Net.Contains(netIP)
 }
 
 // isRFC4843 returns whether or not the passed address is part of the IPv6
 // ORCHID range as defined by RFC4843 (2001:10::/28).
-func isRFC4843(na *wire.NetAddress) bool {
-	return rfc4843Net.Contains(na.IP)
+func isRFC4843(netIP net.IP) bool {
+	return rfc4843Net.Contains(netIP)
 }
 
 // isRFC4862 returns whether or not the passed address is part of the IPv6
 // stateless address autoconfiguration range as defined by RFC4862 (FE80::/64).
-func isRFC4862(na *wire.NetAddress) bool {
-	return rfc4862Net.Contains(na.IP)
+func isRFC4862(netIP net.IP) bool {
+	return rfc4862Net.Contains(netIP)
 }
 
 // isRFC5737 returns whether or not the passed address is part of the IPv4
 // documentation address space as defined by RFC5737 (192.0.2.0/24,
 // 198.51.100.0/24, 203.0.113.0/24)
-func isRFC5737(na *wire.NetAddress) bool {
+func isRFC5737(netIP net.IP) bool {
 	for _, rfc := range rfc5737Net {
-		if rfc.Contains(na.IP) {
+		if rfc.Contains(netIP) {
 			return true
 		}
 	}
@@ -220,41 +220,41 @@ func isRFC5737(na *wire.NetAddress) bool {
 
 // isRFC6052 returns whether or not the passed address is part of the IPv6
 // well-known prefix range as defined by RFC6052 (64:FF9B::/96).
-func isRFC6052(na *wire.NetAddress) bool {
-	return rfc6052Net.Contains(na.IP)
+func isRFC6052(netIP net.IP) bool {
+	return rfc6052Net.Contains(netIP)
 }
 
 // isRFC6145 returns whether or not the passed address is part of the IPv6 to
 // IPv4 translated address range as defined by RFC6145 (::FFFF:0:0:0/96).
-func isRFC6145(na *wire.NetAddress) bool {
-	return rfc6145Net.Contains(na.IP)
+func isRFC6145(netIP net.IP) bool {
+	return rfc6145Net.Contains(netIP)
 }
 
 // isRFC6598 returns whether or not the passed address is part of the IPv4
 // shared address space specified by RFC6598 (100.64.0.0/10)
-func isRFC6598(na *wire.NetAddress) bool {
-	return rfc6598Net.Contains(na.IP)
+func isRFC6598(netIP net.IP) bool {
+	return rfc6598Net.Contains(netIP)
 }
 
 // isValid returns whether or not the passed address is valid.  The address is
 // considered invalid under the following circumstances:
 // IPv4: It is either a zero or all bits set address.
 // IPv6: It is either a zero or RFC3849 documentation address.
-func isValid(na *wire.NetAddress) bool {
+func isValid(netIP net.IP) bool {
 	// IsUnspecified returns if address is 0, so only all bits set, and
 	// RFC3849 need to be explicitly checked.
-	return na.IP != nil && !(na.IP.IsUnspecified() ||
-		na.IP.Equal(net.IPv4bcast))
+	return netIP != nil && !(netIP.IsUnspecified() ||
+		netIP.Equal(net.IPv4bcast))
 }
 
 // IsRoutable returns whether or not the passed address is routable over
 // the public internet.  This is true as long as the address is valid and is not
 // in any reserved ranges.
-func IsRoutable(na *wire.NetAddress) bool {
-	return isValid(na) && !(isRFC1918(na) || isRFC2544(na) ||
-		isRFC3927(na) || isRFC4862(na) || isRFC3849(na) ||
-		isRFC4843(na) || isRFC5737(na) || isRFC6598(na) ||
-		isLocal(na) || (isRFC4193(na) && !isOnionCatTor(na)))
+func IsRoutable(netIP net.IP) bool {
+	return isValid(netIP) && !(isRFC1918(netIP) || isRFC2544(netIP) ||
+		isRFC3927(netIP) || isRFC4862(netIP) || isRFC3849(netIP) ||
+		isRFC4843(netIP) || isRFC5737(netIP) || isRFC6598(netIP) ||
+		isLocal(netIP) || (isRFC4193(netIP) && !isOnionCatTor(netIP)))
 }
 
 // GroupKey returns a string representing the network group an address is part
@@ -263,46 +263,47 @@ func IsRoutable(na *wire.NetAddress) bool {
 // onion address for Tor address, and the string "unroutable" for an unroutable
 // address.
 func GroupKey(na *wire.NetAddress) string {
-	if isLocal(na) {
+	netIP := na.IP
+	if isLocal(netIP) {
 		return "local"
 	}
-	if !IsRoutable(na) {
+	if !IsRoutable(netIP) {
 		return "unroutable"
 	}
-	if isIPv4(na) {
-		return na.IP.Mask(net.CIDRMask(16, 32)).String()
+	if isIPv4(netIP) {
+		return netIP.Mask(net.CIDRMask(16, 32)).String()
 	}
-	if isRFC6145(na) || isRFC6052(na) {
+	if isRFC6145(netIP) || isRFC6052(netIP) {
 		// last four bytes are the ip address
-		ip := na.IP[12:16]
-		return ip.Mask(net.CIDRMask(16, 32)).String()
+		newIP := netIP[12:16]
+		return newIP.Mask(net.CIDRMask(16, 32)).String()
 	}
 
-	if isRFC3964(na) {
-		ip := na.IP[2:6]
-		return ip.Mask(net.CIDRMask(16, 32)).String()
+	if isRFC3964(netIP) {
+		newIP := netIP[2:6]
+		return newIP.Mask(net.CIDRMask(16, 32)).String()
 	}
-	if isRFC4380(na) {
+	if isRFC4380(netIP) {
 		// teredo tunnels have the last 4 bytes as the v4 address XOR
 		// 0xff.
-		ip := net.IP(make([]byte, 4))
-		for i, byte := range na.IP[12:16] {
-			ip[i] = byte ^ 0xff
+		newIP := net.IP(make([]byte, 4))
+		for i, byte := range netIP[12:16] {
+			newIP[i] = byte ^ 0xff
 		}
-		return ip.Mask(net.CIDRMask(16, 32)).String()
+		return newIP.Mask(net.CIDRMask(16, 32)).String()
 	}
-	if isOnionCatTor(na) {
+	if isOnionCatTor(netIP) {
 		// group is keyed off the first 4 bits of the actual onion key.
-		return fmt.Sprintf("tor:%d", na.IP[6]&((1<<4)-1))
+		return fmt.Sprintf("tor:%d", netIP[6]&((1<<4)-1))
 	}
 
 	// OK, so now we know ourselves to be a IPv6 address.
 	// bitcoind uses /32 for everything, except for Hurricane Electric's
 	// (he.net) IP range, which it uses /36 for.
 	bits := 32
-	if heNet.Contains(na.IP) {
+	if heNet.Contains(netIP) {
 		bits = 36
 	}
 
-	return na.IP.Mask(net.CIDRMask(bits, 128)).String()
+	return netIP.Mask(net.CIDRMask(bits, 128)).String()
 }

--- a/addrmgr/network.go
+++ b/addrmgr/network.go
@@ -8,8 +8,6 @@ package addrmgr
 import (
 	"fmt"
 	"net"
-
-	"github.com/decred/dcrd/wire"
 )
 
 var (
@@ -263,8 +261,8 @@ func IsRoutable(netIP net.IP) bool {
 // "local" for a local address, the string "tor:key" where key is the /4 of the
 // onion address for Tor address, and the string "unroutable" for an unroutable
 // address.
-func GroupKey(na *wire.NetAddress) string {
-	netIP := na.IP
+func (na *NetAddress) GroupKey() string {
+	netIP := net.IP(na.IP)
 	if isLocal(netIP) {
 		return "local"
 	}

--- a/addrmgr/network_test.go
+++ b/addrmgr/network_test.go
@@ -191,11 +191,10 @@ func TestGroupKey(t *testing.T) {
 
 	for i, test := range tests {
 		nip := net.ParseIP(test.ip)
-		na := wire.NewNetAddressIPPort(nip, 8333, wire.SFNodeNetwork)
-		if key := GroupKey(na); key != test.expected {
+		na := NewNetAddressIPPort(nip, 8333, wire.SFNodeNetwork)
+		if key := na.GroupKey(); key != test.expected {
 			t.Errorf("TestGroupKey #%d (%s): unexpected group key "+
-				"- got '%s', want '%s'", i, test.name,
-				key, test.expected)
+				"- got '%s', want '%s'", i, test.name, key, test.expected)
 		}
 	}
 }

--- a/addrmgr/network_test.go
+++ b/addrmgr/network_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -16,7 +16,7 @@ import (
 // address based on RFCs work as intended.
 func TestIPTypes(t *testing.T) {
 	type ipTest struct {
-		in       wire.NetAddress
+		ip       net.IP
 		rfc1918  bool
 		rfc2544  bool
 		rfc3849  bool
@@ -39,8 +39,7 @@ func TestIPTypes(t *testing.T) {
 		rfc4193, rfc4380, rfc4843, rfc4862, rfc5737, rfc6052, rfc6145, rfc6598,
 		local, valid, routable bool) ipTest {
 		nip := net.ParseIP(ip)
-		na := *wire.NewNetAddressIPPort(nip, 8333, wire.SFNodeNetwork)
-		test := ipTest{na, rfc1918, rfc2544, rfc3849, rfc3927, rfc3964, rfc4193, rfc4380,
+		test := ipTest{nip, rfc1918, rfc2544, rfc3849, rfc3927, rfc3964, rfc4193, rfc4380,
 			rfc4843, rfc4862, rfc5737, rfc6052, rfc6145, rfc6598, local, valid, routable}
 		return test
 	}
@@ -88,56 +87,56 @@ func TestIPTypes(t *testing.T) {
 
 	t.Logf("Running %d tests", len(tests))
 	for _, test := range tests {
-		if rv := isRFC1918(&test.in); rv != test.rfc1918 {
-			t.Errorf("isRFC1918 %s\n got: %v want: %v", test.in.IP, rv, test.rfc1918)
+		if rv := isRFC1918(test.ip); rv != test.rfc1918 {
+			t.Errorf("isRFC1918 %s\n got: %v want: %v", test.ip, rv, test.rfc1918)
 		}
 
-		if rv := isRFC3849(&test.in); rv != test.rfc3849 {
-			t.Errorf("isRFC3849 %s\n got: %v want: %v", test.in.IP, rv, test.rfc3849)
+		if rv := isRFC3849(test.ip); rv != test.rfc3849 {
+			t.Errorf("isRFC3849 %s\n got: %v want: %v", test.ip, rv, test.rfc3849)
 		}
 
-		if rv := isRFC3927(&test.in); rv != test.rfc3927 {
-			t.Errorf("isRFC3927 %s\n got: %v want: %v", test.in.IP, rv, test.rfc3927)
+		if rv := isRFC3927(test.ip); rv != test.rfc3927 {
+			t.Errorf("isRFC3927 %s\n got: %v want: %v", test.ip, rv, test.rfc3927)
 		}
 
-		if rv := isRFC3964(&test.in); rv != test.rfc3964 {
-			t.Errorf("isRFC3964 %s\n got: %v want: %v", test.in.IP, rv, test.rfc3964)
+		if rv := isRFC3964(test.ip); rv != test.rfc3964 {
+			t.Errorf("isRFC3964 %s\n got: %v want: %v", test.ip, rv, test.rfc3964)
 		}
 
-		if rv := isRFC4193(&test.in); rv != test.rfc4193 {
-			t.Errorf("isRFC4193 %s\n got: %v want: %v", test.in.IP, rv, test.rfc4193)
+		if rv := isRFC4193(test.ip); rv != test.rfc4193 {
+			t.Errorf("isRFC4193 %s\n got: %v want: %v", test.ip, rv, test.rfc4193)
 		}
 
-		if rv := isRFC4380(&test.in); rv != test.rfc4380 {
-			t.Errorf("isRFC4380 %s\n got: %v want: %v", test.in.IP, rv, test.rfc4380)
+		if rv := isRFC4380(test.ip); rv != test.rfc4380 {
+			t.Errorf("isRFC4380 %s\n got: %v want: %v", test.ip, rv, test.rfc4380)
 		}
 
-		if rv := isRFC4843(&test.in); rv != test.rfc4843 {
-			t.Errorf("isRFC4843 %s\n got: %v want: %v", test.in.IP, rv, test.rfc4843)
+		if rv := isRFC4843(test.ip); rv != test.rfc4843 {
+			t.Errorf("isRFC4843 %s\n got: %v want: %v", test.ip, rv, test.rfc4843)
 		}
 
-		if rv := isRFC4862(&test.in); rv != test.rfc4862 {
-			t.Errorf("isRFC4862 %s\n got: %v want: %v", test.in.IP, rv, test.rfc4862)
+		if rv := isRFC4862(test.ip); rv != test.rfc4862 {
+			t.Errorf("isRFC4862 %s\n got: %v want: %v", test.ip, rv, test.rfc4862)
 		}
 
-		if rv := isRFC6052(&test.in); rv != test.rfc6052 {
-			t.Errorf("isRFC6052 %s\n got: %v want: %v", test.in.IP, rv, test.rfc6052)
+		if rv := isRFC6052(test.ip); rv != test.rfc6052 {
+			t.Errorf("isRFC6052 %s\n got: %v want: %v", test.ip, rv, test.rfc6052)
 		}
 
-		if rv := isRFC6145(&test.in); rv != test.rfc6145 {
-			t.Errorf("isRFC1918 %s\n got: %v want: %v", test.in.IP, rv, test.rfc6145)
+		if rv := isRFC6145(test.ip); rv != test.rfc6145 {
+			t.Errorf("isRFC1918 %s\n got: %v want: %v", test.ip, rv, test.rfc6145)
 		}
 
-		if rv := isLocal(&test.in); rv != test.local {
-			t.Errorf("isLocal %s\n got: %v want: %v", test.in.IP, rv, test.local)
+		if rv := isLocal(test.ip); rv != test.local {
+			t.Errorf("isLocal %s\n got: %v want: %v", test.ip, rv, test.local)
 		}
 
-		if rv := isValid(&test.in); rv != test.valid {
-			t.Errorf("IsValid %s\n got: %v want: %v", test.in.IP, rv, test.valid)
+		if rv := isValid(test.ip); rv != test.valid {
+			t.Errorf("IsValid %s\n got: %v want: %v", test.ip, rv, test.valid)
 		}
 
-		if rv := IsRoutable(&test.in); rv != test.routable {
-			t.Errorf("IsRoutable %s\n got: %v want: %v", test.in.IP, rv, test.routable)
+		if rv := IsRoutable(test.ip); rv != test.routable {
+			t.Errorf("IsRoutable %s\n got: %v want: %v", test.ip, rv, test.routable)
 		}
 	}
 }
@@ -192,8 +191,8 @@ func TestGroupKey(t *testing.T) {
 
 	for i, test := range tests {
 		nip := net.ParseIP(test.ip)
-		na := *wire.NewNetAddressIPPort(nip, 8333, wire.SFNodeNetwork)
-		if key := GroupKey(&na); key != test.expected {
+		na := wire.NewNetAddressIPPort(nip, 8333, wire.SFNodeNetwork)
+		if key := GroupKey(na); key != test.expected {
 			t.Errorf("TestGroupKey #%d (%s): unexpected group key "+
 				"- got '%s', want '%s'", i, test.name,
 				key, test.expected)

--- a/server.go
+++ b/server.go
@@ -191,8 +191,8 @@ type relayMsg struct {
 // naSubmission represents a network address submission from an outbound peer.
 type naSubmission struct {
 	na           *wire.NetAddress
-	netType      addrmgr.NetworkAddress
-	reach        int
+	netType      addrmgr.NetAddressType
+	reach        addrmgr.NetAddressReach
 	score        uint32
 	lastAccessed int64
 }
@@ -278,7 +278,7 @@ func (sc *naSubmissionCache) incrementScore(key string) error {
 
 // bestSubmission fetches the best scoring submission of the provided
 // network interface.
-func (sc *naSubmissionCache) bestSubmission(net addrmgr.NetworkAddress) *naSubmission {
+func (sc *naSubmissionCache) bestSubmission(net addrmgr.NetAddressType) *naSubmission {
 	sc.mtx.Lock()
 	defer sc.mtx.Unlock()
 
@@ -362,7 +362,7 @@ func (ps *peerState) forAllPeers(closure func(sp *serverPeer)) {
 // ResolveLocalAddress picks the best suggested network address from available
 // options, per the network interface key provided. The best suggestion, if
 // found, is added as a local address.
-func (ps *peerState) ResolveLocalAddress(netType addrmgr.NetworkAddress, addrMgr *addrmgr.AddrManager, services wire.ServiceFlag) {
+func (ps *peerState) ResolveLocalAddress(netType addrmgr.NetAddressType, addrMgr *addrmgr.AddrManager, services wire.ServiceFlag) {
 	best := ps.subCache.bestSubmission(netType)
 	if best == nil {
 		return

--- a/server.go
+++ b/server.go
@@ -725,7 +725,7 @@ func (sp *serverPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) {
 		if !cfg.DisableListen && sp.server.syncManager.IsCurrent() {
 			// Get address that best matches.
 			lna := addrManager.GetBestLocalAddress(remoteAddr)
-			if addrmgr.IsRoutable(lna) {
+			if addrmgr.IsRoutable(lna.IP) {
 				// Filter addresses the peer already knows about.
 				addresses := []*wire.NetAddress{lna}
 				sp.pushAddrMsg(addresses)

--- a/server.go
+++ b/server.go
@@ -571,17 +571,23 @@ func (sp *serverPeer) newestBlock() (*chainhash.Hash, int64, error) {
 	return &best.Hash, best.Height, nil
 }
 
+// addKnownAddress adds the given address to the set of known addresses to
+// the peer to prevent sending duplicate addresses.
+func (sp *serverPeer) addKnownAddress(na *addrmgr.NetAddress) {
+	sp.knownAddresses.Add([]byte(na.Key()))
+}
+
 // addKnownAddresses adds the given addresses to the set of known addresses to
 // the peer to prevent sending duplicate addresses.
-func (sp *serverPeer) addKnownAddresses(addresses []*wire.NetAddress) {
+func (sp *serverPeer) addKnownAddresses(addresses []*addrmgr.NetAddress) {
 	for _, na := range addresses {
-		sp.knownAddresses.Add([]byte(addrmgr.NetAddressKey(na)))
+		sp.addKnownAddress(na)
 	}
 }
 
 // addressKnown true if the given address is already known to the peer.
-func (sp *serverPeer) addressKnown(na *wire.NetAddress) bool {
-	return sp.knownAddresses.Contains([]byte(addrmgr.NetAddressKey(na)))
+func (sp *serverPeer) addressKnown(na *addrmgr.NetAddress) bool {
+	return sp.knownAddresses.Contains([]byte(na.Key()))
 }
 
 // setDisableRelayTx toggles relaying of transactions for the given peer.
@@ -603,14 +609,40 @@ func (sp *serverPeer) relayTxDisabled() bool {
 	return isDisabled
 }
 
+// wireToAddrmgrNetAddress converts a wire NetAddress to an address manager
+// NetAddress.
+func wireToAddrmgrNetAddress(netAddr *wire.NetAddress) *addrmgr.NetAddress {
+	newNetAddr := addrmgr.NewNetAddressIPPort(netAddr.IP, netAddr.Port, netAddr.Services)
+	newNetAddr.Timestamp = netAddr.Timestamp
+	return newNetAddr
+}
+
+// wireToAddrmgrNetAddresses converts a collection of wire net addresses to a
+// collection of address manager net addresses.
+func wireToAddrmgrNetAddresses(netAddr []*wire.NetAddress) []*addrmgr.NetAddress {
+	addrs := make([]*addrmgr.NetAddress, len(netAddr))
+	for i, wireAddr := range netAddr {
+		addrs[i] = wireToAddrmgrNetAddress(wireAddr)
+	}
+	return addrs
+}
+
+// addrmgrToWireNetAddress converts an address manager net address to a wire net
+// address.
+func addrmgrToWireNetAddress(netAddr *addrmgr.NetAddress) *wire.NetAddress {
+	return wire.NewNetAddressTimestamp(netAddr.Timestamp, netAddr.Services,
+		netAddr.IP, netAddr.Port)
+}
+
 // pushAddrMsg sends an addr message to the connected peer using the provided
 // addresses.
-func (sp *serverPeer) pushAddrMsg(addresses []*wire.NetAddress) {
+func (sp *serverPeer) pushAddrMsg(addresses []*addrmgr.NetAddress) {
 	// Filter addresses already known to the peer.
 	addrs := make([]*wire.NetAddress, 0, len(addresses))
 	for _, addr := range addresses {
 		if !sp.addressKnown(addr) {
-			addrs = append(addrs, addr)
+			wireNetAddr := addrmgrToWireNetAddress(addr)
+			addrs = append(addrs, wireNetAddr)
 		}
 	}
 	known, err := sp.PushAddrMsg(addrs)
@@ -619,7 +651,9 @@ func (sp *serverPeer) pushAddrMsg(addresses []*wire.NetAddress) {
 		sp.Disconnect()
 		return
 	}
-	sp.addKnownAddresses(known)
+
+	knownNetAddrs := wireToAddrmgrNetAddresses(known)
+	sp.addKnownAddresses(knownNetAddrs)
 }
 
 // addBanScore increases the persistent and decaying ban score fields by the
@@ -684,7 +718,7 @@ func (sp *serverPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) {
 	// it is updated regardless in the case a new minimum protocol version is
 	// enforced and the remote node has not upgraded yet.
 	isInbound := sp.Inbound()
-	remoteAddr := sp.NA()
+	remoteAddr := wireToAddrmgrNetAddress(sp.NA())
 	addrManager := sp.server.addrManager
 	if !cfg.SimNet && !cfg.RegNet && !isInbound {
 		err := addrManager.SetServices(remoteAddr, msg.Services)
@@ -725,9 +759,9 @@ func (sp *serverPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) {
 		if !cfg.DisableListen && sp.server.syncManager.IsCurrent() {
 			// Get address that best matches.
 			lna := addrManager.GetBestLocalAddress(remoteAddr)
-			if addrmgr.IsRoutable(lna.IP) {
+			if lna.IsRoutable() {
 				// Filter addresses the peer already knows about.
-				addresses := []*wire.NetAddress{lna}
+				addresses := []*addrmgr.NetAddress{lna}
 				sp.pushAddrMsg(addresses)
 			}
 		}
@@ -1379,7 +1413,8 @@ func (sp *serverPeer) OnAddr(p *peer.Peer, msg *wire.MsgAddr) {
 	}
 
 	now := time.Now()
-	for _, na := range msg.AddrList {
+	addrList := wireToAddrmgrNetAddresses(msg.AddrList)
+	for _, na := range addrList {
 		// Don't add more address if we're disconnecting.
 		if !p.Connected() {
 			return
@@ -1393,15 +1428,14 @@ func (sp *serverPeer) OnAddr(p *peer.Peer, msg *wire.MsgAddr) {
 		}
 
 		// Add address to known addresses for this peer.
-		sp.addKnownAddresses([]*wire.NetAddress{na})
+		sp.addKnownAddress(na)
 	}
 
 	// Add addresses to server address manager.  The address manager handles
 	// the details of things such as preventing duplicate addresses, max
 	// addresses, and last seen updates.
-	// XXX bitcoind gives a 2 hour time penalty here, do we want to do the
-	// same?
-	sp.server.addrManager.AddAddresses(msg.AddrList, p.NA())
+	remoteAddr := wireToAddrmgrNetAddress(p.NA())
+	sp.server.addrManager.AddAddresses(addrList, remoteAddr)
 }
 
 // OnRead is invoked when a peer receives a message and it is used to update
@@ -1701,7 +1735,8 @@ func (s *server) handleAddPeerMsg(state *peerState, sp *serverPeer) bool {
 			}
 		}
 	} else {
-		state.outboundGroups[addrmgr.GroupKey(sp.NA())]++
+		remoteAddr := wireToAddrmgrNetAddress(sp.NA())
+		state.outboundGroups[remoteAddr.GroupKey()]++
 		if sp.persistent {
 			state.persistentPeers[sp.ID()] = sp
 		} else {
@@ -1736,7 +1771,8 @@ func (s *server) handleAddPeerMsg(state *peerState, sp *serverPeer) bool {
 				net = addrmgr.IPv6Address
 			}
 
-			valid, reach := s.addrManager.ValidatePeerNa(na, sp.NA())
+			localAddr := wireToAddrmgrNetAddress(na)
+			valid, reach := s.addrManager.ValidatePeerNa(localAddr, remoteAddr)
 			if !valid {
 				return true
 			}
@@ -1786,7 +1822,8 @@ func (s *server) handleDonePeerMsg(state *peerState, sp *serverPeer) {
 	}
 	if _, ok := list[sp.ID()]; ok {
 		if !sp.Inbound() && sp.VersionKnown() {
-			state.outboundGroups[addrmgr.GroupKey(sp.NA())]--
+			remoteAddr := wireToAddrmgrNetAddress(sp.NA())
+			state.outboundGroups[remoteAddr.GroupKey()]--
 		}
 		if !sp.Inbound() && sp.connReq != nil {
 			s.connManager.Disconnect(sp.connReq.ID())
@@ -1803,7 +1840,8 @@ func (s *server) handleDonePeerMsg(state *peerState, sp *serverPeer) {
 	// Update the address' last seen time if the peer has acknowledged
 	// our version and has sent us its version as well.
 	if sp.VerAckReceived() && sp.VersionKnown() && sp.NA() != nil {
-		err := s.addrManager.Connected(sp.NA())
+		remoteAddr := wireToAddrmgrNetAddress(sp.NA())
+		err := s.addrManager.Connected(remoteAddr)
 		if err != nil {
 			srvrLog.Debugf("Marking address as connected failed: %v", err)
 		}
@@ -2016,10 +2054,11 @@ func (s *server) handleQuery(state *peerState, querymsg interface{}) {
 		found := disconnectPeer(state.persistentPeers, msg.cmp, func(sp *serverPeer) {
 			// Keep group counts ok since we remove from
 			// the list now.
-			state.outboundGroups[addrmgr.GroupKey(sp.NA())]--
+			remoteAddr := wireToAddrmgrNetAddress(sp.NA())
+			state.outboundGroups[remoteAddr.GroupKey()]--
 
-			peerLog.Debugf("Removing persistent peer %s:%d (reqid %d)",
-				sp.NA().IP, sp.NA().Port, sp.connReq.ID())
+			peerLog.Debugf("Removing persistent peer %s (reqid %d)", remoteAddr,
+				sp.connReq.ID())
 			connReq := sp.connReq
 
 			// Mark the peer's connReq as nil to prevent it from scheduling a
@@ -2071,7 +2110,8 @@ func (s *server) handleQuery(state *peerState, querymsg interface{}) {
 		found = disconnectPeer(state.outboundPeers, msg.cmp, func(sp *serverPeer) {
 			// Keep group counts ok since we remove from
 			// the list now.
-			state.outboundGroups[addrmgr.GroupKey(sp.NA())]--
+			remoteAddr := wireToAddrmgrNetAddress(sp.NA())
+			state.outboundGroups[remoteAddr.GroupKey()]--
 		})
 		if found {
 			// If there are multiple outbound connections to the same
@@ -2079,7 +2119,8 @@ func (s *server) handleQuery(state *peerState, querymsg interface{}) {
 			// peers are found.
 			for found {
 				found = disconnectPeer(state.outboundPeers, msg.cmp, func(sp *serverPeer) {
-					state.outboundGroups[addrmgr.GroupKey(sp.NA())]--
+					remoteAddr := wireToAddrmgrNetAddress(sp.NA())
+					state.outboundGroups[remoteAddr.GroupKey()]--
 				})
 			}
 			msg.reply <- nil
@@ -2147,8 +2188,14 @@ func newPeerConfig(sp *serverPeer) *peer.Config {
 			OnWrite:          sp.OnWrite,
 			OnNotFound:       sp.OnNotFound,
 		},
-		NewestBlock:       sp.newestBlock,
-		HostToNetAddress:  sp.server.addrManager.HostToNetAddress,
+		NewestBlock: sp.newestBlock,
+		HostToNetAddress: func(host string, port uint16, services wire.ServiceFlag) (*wire.NetAddress, error) {
+			address, err := sp.server.addrManager.HostToNetAddress(host, port, services)
+			if err != nil {
+				return nil, err
+			}
+			return addrmgrToWireNetAddress(address), nil
+		},
 		Proxy:             cfg.Proxy,
 		UserAgentName:     userAgentName,
 		UserAgentVersion:  userAgentVersion,
@@ -2191,7 +2238,9 @@ func (s *server) outboundPeerConnected(c *connmgr.ConnReq, conn net.Conn) {
 	sp.isWhitelisted = isWhitelisted(conn.RemoteAddr())
 	sp.AssociateConnection(conn)
 	go s.peerDoneHandler(sp)
-	err = s.addrManager.Attempt(sp.NA())
+
+	remoteAddr := wireToAddrmgrNetAddress(sp.NA())
+	err = s.addrManager.Attempt(remoteAddr)
 	if err != nil {
 		srvrLog.Debugf("Marking address as attempted failed: %v", err)
 	}
@@ -3004,13 +3053,14 @@ func (s *server) querySeeders(ctx context.Context) {
 			// seeded addresses.  In the incredibly rare event that the lookup
 			// fails after it just succeeded, fall back to using the first
 			// returned address as the source.
-			srcAddr := addrs[0]
+			srcAddr := wireToAddrmgrNetAddress(addrs[0])
 			srcIPs, err := dcrdLookup(seeder)
 			if err == nil && len(srcIPs) > 0 {
 				const httpsPort = 443
-				srcAddr = wire.NewNetAddressIPPort(srcIPs[0], httpsPort, 0)
+				srcAddr = addrmgr.NewNetAddressIPPort(srcIPs[0], httpsPort, 0)
 			}
-			s.addrManager.AddAddresses(addrs, srcAddr)
+			addresses := wireToAddrmgrNetAddresses(addrs)
+			s.addrManager.AddAddresses(addresses, srcAddr)
 		}(seeder)
 	}
 }
@@ -3166,15 +3216,15 @@ out:
 					srvrLog.Warnf("UPnP can't get external address: %v", err)
 					continue out
 				}
-				na := wire.NewNetAddressIPPort(externalip, uint16(listenPort),
-					s.services)
-				err = s.addrManager.AddLocalAddress(na, addrmgr.UpnpPrio)
+				localAddr := addrmgr.NewNetAddressIPPort(externalip,
+					uint16(listenPort), s.services)
+				err = s.addrManager.AddLocalAddress(localAddr, addrmgr.UpnpPrio)
 				if err != nil {
 					srvrLog.Warnf("Failed to add UPnP local address %s: %v",
-						na.IP.String(), err)
+						localAddr, err)
 				} else {
 					srvrLog.Warnf("Successfully bound via UPnP to %s",
-						addrmgr.NetAddressKey(na))
+						localAddr)
 					first = false
 				}
 			}
@@ -3664,8 +3714,8 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB,
 				// in the same group so that we are not connecting
 				// to the same network segment at the expense of
 				// others.
-				key := addrmgr.GroupKey(addr.NetAddress())
-				if s.OutboundGroupCount(key) != 0 {
+				netAddr := addr.NetAddress()
+				if s.OutboundGroupCount(netAddr.GroupKey()) != 0 {
 					continue
 				}
 
@@ -3676,13 +3726,12 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB,
 				}
 
 				// allow nondefault ports after 50 failed tries.
-				if fmt.Sprintf("%d", addr.NetAddress().Port) !=
+				if fmt.Sprintf("%d", netAddr.Port) !=
 					s.chainParams.DefaultPort && tries < 50 {
 					continue
 				}
 
-				addrString := addrmgr.NetAddressKey(addr.NetAddress())
-				return addrStringToNetAddr(addrString)
+				return addrStringToNetAddr(netAddr.Key())
 			}
 
 			return nil, errors.New("no valid connect address")
@@ -3850,6 +3899,7 @@ func initListeners(ctx context.Context, params *chaincfg.Params, amgr *addrmgr.A
 				}
 				eport = uint16(port)
 			}
+
 			na, err := amgr.HostToNetAddress(host, eport, services)
 			if err != nil {
 				srvrLog.Warnf("Not adding %s as externalip: %v", sip, err)
@@ -3946,7 +3996,8 @@ func addLocalAddress(addrMgr *addrmgr.AddrManager, addr string, services wire.Se
 				continue
 			}
 
-			netAddr := wire.NewNetAddressIPPort(ifaceIP, uint16(port), services)
+			netAddr := addrmgr.NewNetAddressIPPort(ifaceIP, uint16(port),
+				services)
 			addrMgr.AddLocalAddress(netAddr, addrmgr.BoundPrio)
 		}
 	} else {


### PR DESCRIPTION
This change decouples the address manager's internal handling of network addresses to use a type owned by the address manager.