### PR TITLE
blockchain: Add UtxoCache Initialize tests.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -143,7 +143,7 @@ type BlockChain struct {
 	sigCache            *txscript.SigCache
 	indexManager        indexers.IndexManager
 	interrupt           <-chan struct{}
-	utxoCache           *UtxoCache
+	utxoCache           UtxoCacher
 
 	// subsidyCache is the cache that provides quick lookup of subsidy
 	// values.
@@ -2152,7 +2152,7 @@ type Config struct {
 	// the database directly.
 	//
 	// This field is required.
-	UtxoCache *UtxoCache
+	UtxoCache UtxoCacher
 }
 
 // New returns a BlockChain instance using the provided configuration details.

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1931,7 +1931,7 @@ func (b *BlockChain) initChainState(ctx context.Context) error {
 
 	// Initialize the utxo cache to ensure that the state of the utxo set is
 	// caught up to the tip of the best chain.
-	return b.InitUtxoCache(tip)
+	return b.utxoCache.Initialize(b, tip)
 }
 
 // dbFetchBlockByNode uses an existing database transaction to retrieve the raw

--- a/blockchain/utxoviewpoint.go
+++ b/blockchain/utxoviewpoint.go
@@ -25,7 +25,7 @@ import (
 // The unspent outputs are needed by other transactions for things such as
 // script validation and double spend prevention.
 type UtxoViewpoint struct {
-	cache    *UtxoCache
+	cache    UtxoCacher
 	entries  map[wire.OutPoint]*UtxoEntry
 	bestHash chainhash.Hash
 }
@@ -757,7 +757,7 @@ func (view *UtxoViewpoint) clone() *UtxoViewpoint {
 }
 
 // NewUtxoViewpoint returns a new empty unspent transaction output view.
-func NewUtxoViewpoint(cache *UtxoCache) *UtxoViewpoint {
+func NewUtxoViewpoint(cache UtxoCacher) *UtxoViewpoint {
 	return &UtxoViewpoint{
 		cache:   cache,
 		entries: make(map[wire.OutPoint]*UtxoEntry),


### PR DESCRIPTION
**This is rebased on https://github.com/decred/dcrd/pull/2591.**

This adds additional tests around utxo cache initialization to ensure that it recovers in various scenarios that are hard to simulate or hit with manual testing.  The changes are as follows:

- blockchain: Make InitUtxoCache a UtxoCache method.
  - This changes the InitUtxoCache method on the BlockChain type to a Initialize method on the UtxoCache type instead.  This simplifies providing alternative implementations for testing since the Initialize method deals with internal fields of the UtxoCache type.
- blockchain: Add UtxoCacher interface. 
  - This adds a UtxoCacher interface so that alternative utxo cache implementations can be provided.  In particular, this will be used to provide a mock implementation for testing in order to more easily simulate various scenarios.
  - In addition to introducing the UtxoCacher interface, this updates BlockChain and UtxoViewpoint to use the interface rather than the concrete type.
- blockchain: Add UtxoCache Initialize tests.
  -  This adds tests for the UtxoCache Initialize method.  These tests include recovery scenarios that are particularly hard to simulate to ensure that those code paths are not broken in the future.
  - In order to test recovery scenarios, this introduces a test utxo cache that allows for toggling flushing on and off.
  - Additionally, this adds an ExpectUtxoSetState method to chaingenHarness that allows for easily validating the last flushed block for the utxo set.
- blockchain: Add TestShutdownUtxoCache tests.