### PR TITLE
stdaddr: Introduce package for standard addrs.

### DIFF
--- a/dcrutil/address.go
+++ b/dcrutil/address.go
@@ -149,7 +149,7 @@ func NewAddressPubKey(decoded []byte, net AddressParams) (Address, error) {
 				append([]byte{toAppend}, decoded[1:]...),
 				net)
 		case dcrec.STEd25519:
-			return NewAddressEdwardsPubKey(decoded, net)
+			return NewAddressEdwardsPubKey(decoded[1:], net)
 		case dcrec.STSchnorrSecp256k1:
 			return NewAddressSecSchnorrPubKey(
 				append([]byte{toAppend}, decoded[1:]...),

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/decred/dcrd/chaincfg/v3 v3.0.0
 	github.com/decred/dcrd/connmgr/v3 v3.0.0
 	github.com/decred/dcrd/container/apbf v1.0.0
+	github.com/decred/dcrd/crypto/blake256 v1.0.0
 	github.com/decred/dcrd/crypto/ripemd160 v1.0.1
 	github.com/decred/dcrd/database/v2 v2.0.3-0.20210129190127-4ebd135a82f1
 	github.com/decred/dcrd/dcrec v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/decred/dcrd/crypto/ripemd160 v1.0.1
 	github.com/decred/dcrd/database/v2 v2.0.3-0.20210129190127-4ebd135a82f1
 	github.com/decred/dcrd/dcrec v1.0.0
+	github.com/decred/dcrd/dcrec/edwards/v2 v2.0.1
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210127014238-b33b46cf1a24
 	github.com/decred/dcrd/dcrjson/v3 v3.1.0
 	github.com/decred/dcrd/dcrutil/v4 v4.0.0-20210129181600-6ae0142d3b28

--- a/internal/staging/stdaddr/README.md
+++ b/internal/staging/stdaddr/README.md
@@ -1,0 +1,221 @@
+stdaddr
+=======
+
+[![Build Status](https://github.com/decred/dcrd/workflows/Build%20and%20Test/badge.svg)](https://github.com/decred/dcrd/actions)
+[![ISC License](https://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![Doc](https://img.shields.io/badge/doc-reference-blue.svg)](https://pkg.go.dev/github.com/decred/dcrd/internal/staging/stdaddr)
+
+## Decred Address Overview
+
+An address is a human-readable representation of a possible destination for a
+payment.  More specifically, it encodes information needed to create a smart
+contract via a
+[transaction script](https://devdocs.decred.org/developer-guides/transactions/txscript/overview/)
+that imposes constraints required to redeem funds.
+
+Under the hood, an address typically consists of 4 primary components:
+
+- The network for which the address is valid
+- The data necessary to create a payment script with the appropriate constraints
+- The scripting language version of the aforementioned script
+- A checksum to prevent errors due to improper entry
+
+It is also worth keeping in mind that the scripting language version may be
+implicit depending on the specific concrete encoding of the address.
+
+### Supported Version 0 Addresses
+
+The following table lists the `version 0` address types this package supports
+along with whether the type is supported by the staking system, whether it has
+an associated `hash160`, and some additional notes and recommendations:
+
+Version 0 Address Type    | Staking? | Hash160? | Notes / Recommendations
+--------------------------|----------|----------|----------------------------------
+p2pk-ecdsa-secp256k1      |    N     |    N     | Prefer p2pkh in on-chain txns [1]
+p2pk-ed25519              |    N     |    N     | Not recommended [2]
+p2pk-schnorr-secp256k1    |    N     |    N     | Prefer p2pkh, single party [1,3]
+**p2pkh-ecdsa-secp256k1** |  **Y**   |  **Y**   | **Preferred v0 address**
+p2pkh-ed25519             |    N     |    Y     | Not recommended [2]
+p2pkh-schnorr-secp256k1   |    N     |    Y     | Only use with single party [3]
+p2sh                      |    Y     |    Y     | -
+
+Abbreviations:
+
+* p2pk = Pay-to-public-key
+* p2pkh = Pay-to-public-key-hash
+* p2sh = Pay-to-script-hash
+
+Notes:
+
+- [1] Pay to public key addresses are only recommended for use in sharing public
+      keys via off-chain protocols such as multi-party signature creation.  Pay
+      to public key hash addresses should be used for on-chain transactions to
+      avoid revealing the public key until the funds are redeemed.
+- [2] Version 0 addresses involving Ed25519 are not recommended due to lack of
+      support for safe hierarchical derivation and the requirement for a legacy
+      implementation of the curve that has known issues.
+- [3] Version 0 addresses involving Schnorr signatures are only recommended for
+      use with single parties as extra care must be taken when used with
+      multiple parties to avoid potential theft of funds by malicious
+      counterparties.
+
+## Note about Standardness vs Consensus
+
+This package is named `stdaddr` to clearly convey that addresses are a
+**standardized** construction built on top of the underlying scripting system
+that is enforced by the consensus rules.  The specific scripts that the
+addresses represent are referred to as standard scripts since they are
+recognized forms that most software considers standard by policy.  However, the
+consensus rules for regular transactions must support so called non-standard
+scripts as well (any script that is not one of the recognized forms).
+
+This distinction between standardness and consensus is extremely important for
+developers working on the consensus rules, since consensus must **NOT** use
+addresses directly and instead must work with the actual underlying scripts.  An
+address is a human-readable representation of an underlying script along with
+additional metadata to help prevent misuse and typographical errors.  The
+underlying scripts are enforced by consensus, not the other way around!
+
+## Package Usage Primer
+
+The overall design of this package is based on a few key interfaces to provide a
+generalized capabilities-based approach to working with the various types of
+addresses along with unique types for each supported address type that implement
+said interfaces.
+
+Interacting with addresses typically falls into the following categories:
+
+- Instantiating addresses
+  - Decoding existing addresses
+  - Creating addresses of the types which correspond to desired encumbrances
+- Generating the payment script and associated version for use in regular
+  transaction outputs
+- Determining additional capabilities of an address by type asserting supported
+  interfaces
+
+### Address Versions
+
+All software that works with sending funds to addresses must be able to produce
+payment scripts that correspond to the same scripting language version the
+original creator of the address (aka the recipient) supports as they might
+otherwise not be able to actually redeem the funds.
+
+This requirement creates a one-to-one correspondence between a given address and
+the underlying scripting language version.  Since the original base58-based
+address format does not encode a scripting language version and are implicitly
+expected to create version 0 scripts, they are referred to as version 0
+addresses.
+
+It is expected that new version addresses will be introduced in the future that
+change the address format to improve some of the shortcomings of base58
+addresses as well as properly encode a scripting language version.
+
+### Instantiating Addresses
+
+In order to provide a more ergonomic API depending on the specific needs of
+callers, this package offers two approaches to instantiating addresses:
+
+1. Methods that accept and instantiate addresses for any supported version.  For
+   example, `DecodeAddress` and `NewAddressPubKeyHashEcdsaSecp256k1`.
+2. Methods that accept and instantiate addresses for a specific version.  For
+   example, `DecodeAddressV0` and `NewAddressPubKeyHashEcdsaSecp256k1V0`.
+
+The first approach is likely suitable for most callers as it is intended to
+support all historical address types as well as allow easily specifying a script
+version from a dynamic variable.  For example, applications involving historical
+data analytics, such as block explorers, should prefer this approach.
+
+However, callers might wish to only support decoding and creating specific
+address versions in which case the second approach is more suitable.  Further,
+when it comes to creating addresses, since not all adddress types will
+necessarily be supported by all scripting language versions, the second approach
+makes it clear from the API exactly which types of addresses are supported for a
+given version at compile time whereas the first approach requires the caller to
+check for errors at run time.
+
+### Generating Payment Scripts and Displaying a Human-Readable Address String
+
+In order to generalize support for the various standard address types, this
+package provides an `Address` interface which is the primary interface
+implemented by all supported address types.
+
+Use the `PaymentScript` method to obtain the scripting language version
+associated with the address along with a script to pay a transaction output to
+the address and the `Address` method to get the human-readable string encoding
+of the address.
+
+### Address Use in the Staking System
+
+A distinguishing aspect of the staking system in Decred is that it imposes
+additional constraints on the types of addresses that can be used versus those
+for regular transactions.  This is because scripts in the staking system are
+tightly controlled by consensus to only permit very specific scripts, unlike
+regular transactions which allow scripts composed of any sequence of
+[opcodes](https://devdocs.decred.org/developer-guides/transactions/txscript/opcodes/)
+that evaluate to true.
+
+In order to support this difference, this package provides the `StakeAddress`
+interface which is only implemented by the address types that are supported by
+the staking system.  This allows callers to determine if an address can be used
+in the staking system by type asserting the interface and then making use of the
+relevant methods provided by the interface to interact with the staking system.
+Refer to the code examples to see this in action as well as the API
+documentation of the interface methods for further details.
+
+### Converting Public Key to Public Key Hash Addresses
+
+It is often necessary to share public keys in interactive and manual off-chain
+protocols, such as multi-party signature creation.  Since raw public keys are
+valid for any network, it is generally less error prone and more convenient to
+use human-readable public key addresses in this case because they ensure the
+correct network is involved as well as help prevent entry errors.
+
+However, whenever dealing with on-chain transactions, public key hash addresses
+should typically be used instead to avoid revealing the public key until the
+funds are redeemed.
+
+With the aim of supporting easy conversion of a public key address to a public
+key hash address for the cases when the caller already has the former available,
+this package provides the `AddressPubKeyHasher` interface which is only
+implemented by the public key address types.  This allows callers to determine
+if an address can be converted to its public key hash variant by type asserting
+the interface and then convert it by making use of the `AddressPubKeyHash`
+method provided by the interface.
+
+### Hash160 Use in Addresses
+
+The term `Hash160` is used as shorthand to refer to a hash that is created via a
+combination of [RIPEMD-160](../../../crypto/ripemd160) and
+[BLAKE256](../../../crypto/blake256).  Specifically, it is the result of
+`RIPEMD-160(BLAKE256(data))`.
+
+For address types that involve Hash160 hashes, such as version 0 public key hash
+and script hash addresses, it can be convenient for callers to extract the
+associated hash.
+
+To enable the hash extraction, this package provides the `Hash160er` interface
+which is only implemented by the address types that involve Hash160.  This
+allows callers to determine if an address involves a Hash160 by type asserting
+the interface and then extract it by making use of the `Hash160` method provided
+by the interface.
+
+## Installation and Updating
+
+This package is internal and therefore is neither directly installed nor needs
+to be manually updated.
+
+## Examples
+
+* [DecodeAddress](https://pkg.go.dev/github.com/decred/dcrd/internal/staging/stdaddr#example-DecodeAddress)
+
+  Demonstrates decoding addresses, generating their payment scripts and
+  associated scripting language versions, determining supported capabilities by
+  checking if interfaces are implemented, obtaining the associated underlying
+  hash160 for addresses that support it, converting public key addresses to
+  their public key hash variant, and generating stake-related scripts for
+  addresses that can be used in the staking system.
+
+## License
+
+Package stdaddr is licensed under the [copyfree](http://copyfree.org) ISC
+License.

--- a/internal/staging/stdaddr/address.go
+++ b/internal/staging/stdaddr/address.go
@@ -123,9 +123,16 @@ type Secp256k1PublicKey interface {
 //
 // This function can be useful to callers who already need the serialized public
 // key for other purposes to avoid the need to serialize it multiple times.
+//
+// NOTE: Version 0 scripts are the only currently supported version.
 func NewAddressPubKeyEcdsaSecp256k1Raw(scriptVersion uint16,
 	serializedPubKey []byte,
 	params AddressParams) (Address, error) {
+
+	switch scriptVersion {
+	case 0:
+		return NewAddressPubKeyEcdsaSecp256k1V0Raw(serializedPubKey, params)
+	}
 
 	str := fmt.Sprintf("pubkey addresses for version %d are not supported",
 		scriptVersion)
@@ -140,9 +147,16 @@ func NewAddressPubKeyEcdsaSecp256k1Raw(scriptVersion uint16,
 // key already serialized in the _compressed_ format instead of a concrete type.
 // It can be useful to callers who already need the serialized public key for
 // other purposes to avoid the need to serialize it multiple times.
+//
+// NOTE: Version 0 scripts are the only currently supported version.
 func NewAddressPubKeyEcdsaSecp256k1(scriptVersion uint16,
 	pubKey Secp256k1PublicKey,
 	params AddressParams) (Address, error) {
+
+	switch scriptVersion {
+	case 0:
+		return NewAddressPubKeyEcdsaSecp256k1V0(pubKey, params)
+	}
 
 	str := fmt.Sprintf("pubkey addresses for version %d are not supported",
 		scriptVersion)

--- a/internal/staging/stdaddr/address.go
+++ b/internal/staging/stdaddr/address.go
@@ -169,8 +169,15 @@ func NewAddressPubKeyEcdsaSecp256k1(scriptVersion uint16,
 //
 // See NewAddressPubKeyEd25519 for a variant that accepts the public key as a
 // concrete type instance instead.
+//
+// NOTE: Version 0 scripts are the only currently supported version.
 func NewAddressPubKeyEd25519Raw(scriptVersion uint16, serializedPubKey []byte,
 	params AddressParams) (Address, error) {
+
+	switch scriptVersion {
+	case 0:
+		return NewAddressPubKeyEd25519V0Raw(serializedPubKey, params)
+	}
 
 	str := fmt.Sprintf("pubkey addresses for version %d are not supported",
 		scriptVersion)
@@ -193,8 +200,15 @@ type Ed25519PublicKey interface {
 // already serialized instead of a concrete type.  It can be useful to callers
 // who already need the serialized public key for other purposes to avoid the
 // need to serialize it multiple times.
+//
+// NOTE: Version 0 scripts are the only currently supported version.
 func NewAddressPubKeyEd25519(scriptVersion uint16, pubKey Ed25519PublicKey,
 	params AddressParams) (Address, error) {
+
+	switch scriptVersion {
+	case 0:
+		return NewAddressPubKeyEd25519V0(pubKey, params)
+	}
 
 	str := fmt.Sprintf("pubkey addresses for version %d are not supported",
 		scriptVersion)

--- a/internal/staging/stdaddr/address.go
+++ b/internal/staging/stdaddr/address.go
@@ -307,8 +307,15 @@ func NewAddressPubKeyHashEcdsaSecp256k1(scriptVersion uint16, pkHash []byte,
 // the Hash160 of the correct public key or it will not be redeemable with the
 // expected public key because it would hash to a different value than the
 // payment script generated for the provided incorrect public key hash expects.
+//
+// NOTE: Version 0 scripts are the only currently supported version.
 func NewAddressPubKeyHashEd25519(scriptVersion uint16, pkHash []byte,
 	params AddressParams) (Address, error) {
+
+	switch scriptVersion {
+	case 0:
+		return NewAddressPubKeyHashEd25519V0(pkHash, params)
+	}
 
 	str := fmt.Sprintf("pubkey hash addresses for version %d are not "+
 		"supported", scriptVersion)

--- a/internal/staging/stdaddr/address.go
+++ b/internal/staging/stdaddr/address.go
@@ -283,8 +283,15 @@ func NewAddressPubKeySchnorrSecp256k1(scriptVersion uint16,
 // compressed format since it occupies less space on the chain and is more
 // consistent with other address formats where uncompressed public keys are NOT
 // supported.
+//
+// NOTE: Version 0 scripts are the only currently supported version.
 func NewAddressPubKeyHashEcdsaSecp256k1(scriptVersion uint16, pkHash []byte,
 	params AddressParams) (Address, error) {
+
+	switch scriptVersion {
+	case 0:
+		return NewAddressPubKeyHashEcdsaSecp256k1V0(pkHash, params)
+	}
 
 	str := fmt.Sprintf("pubkey hash addresses for version %d are not "+
 		"supported", scriptVersion)

--- a/internal/staging/stdaddr/address.go
+++ b/internal/staging/stdaddr/address.go
@@ -1,0 +1,335 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+// Package stdaddr provides facilities for working with human-readable Decred
+// payment addresses.
+package stdaddr
+
+import (
+	"fmt"
+
+	"github.com/decred/dcrd/crypto/ripemd160"
+)
+
+// AddressParams defines an interface that is used to provide the parameters
+// required when encoding and decoding addresses.  These values are typically
+// well-defined and unique per network.
+type AddressParams interface {
+}
+
+// Address represents any type of destination a transaction output may spend to.
+// Some examples include pay-to-pubkey (P2PK), pay-to-pubkey-hash (P2PKH), and
+// pay-to-script-hash (P2SH).  Address is designed to be generic enough that
+// other kinds of addresses may be added in the future without changing the
+// decoding and encoding API.
+type Address interface {
+	// Address returns the string encoding of the payment address for the
+	// associated script version and payment script.
+	Address() string
+
+	// PaymentScript returns the script version associated with the address
+	// along with a script to pay a transaction output to the address.
+	PaymentScript() (uint16, []byte)
+}
+
+// StakeAddress is an interface for generating the specialized scripts that are
+// used in the staking system.  Only specific address types are supported by the
+// staking system and therefore only those address types will implement this
+// interface.
+//
+// Version 1 and 3 staking transactions only support version 0 scripts and
+// address types of AddressPubKeyHashEcdsaSecp256k1V0 and AddressScriptHashV0.
+//
+// Callers can programmatically assert a specific address implements this
+// interface to access the methods.
+type StakeAddress interface {
+	Address
+
+	// VotingRightsScript returns the script version associated with the address
+	// along with a script to give voting rights to the address.  It is only
+	// valid when used in stake ticket purchase transactions.
+	VotingRightsScript() (uint16, []byte)
+
+	// RewardCommitmentScript returns the script version associated with the
+	// address along with a script that commits the original funds locked to
+	// purchase a ticket plus the reward to the address along with limits to
+	// impose on any fees.
+	RewardCommitmentScript(amount int64, limits uint16) (uint16, []byte)
+
+	// StakeChangeScript returns the script version associated with the address
+	// along with a script to pay change to the address.  It is only valid when
+	// used in stake ticket purchase and treasury add transactions.
+	StakeChangeScript() (uint16, []byte)
+
+	// PayVoteCommitmentScript returns the script version associated with the
+	// address along with a script to pay the original funds locked to purchase
+	// a ticket plus the reward to the address.  The address must have
+	// previously been committed to by the ticket purchase.  The script is only
+	// valid when used in stake vote transactions whose associated tickets are
+	// eligible to vote.
+	PayVoteCommitmentScript() (uint16, []byte)
+
+	// PayRevokeCommitmentScript returns the script version associated with the
+	// address along with a script to revoke an expired or missed ticket which
+	// pays the original funds locked to purchase a ticket to the address.  The
+	// address must have previously been committed to by the ticket purchase.
+	// The script is only valid when used in stake revocation transactions whose
+	// associated tickets have been missed or have expired.
+	PayRevokeCommitmentScript() (uint16, []byte)
+
+	// PayFromTreasuryScript returns the script version associated with the
+	// address along with a script that pays funds from the treasury to the
+	// address.  The script is only valid when used in treasury spend
+	// transactions.
+	PayFromTreasuryScript() (uint16, []byte)
+}
+
+// AddressPubKeyHasher is an interface for public key addresses that can be
+// converted to an address that imposes an encumbrance that requires the public
+// key that hashes to a given public key hash along with a valid signature for
+// that public key.
+//
+// The specific public key and signature types are dependent on the original
+// address.
+type AddressPubKeyHasher interface {
+	AddressPubKeyHash() Address
+}
+
+// Hash160er is an interface that allows the RIPEMD-160 hash to be obtained from
+// addresses that involve them.
+type Hash160er interface {
+	Hash160() *[ripemd160.Size]byte
+}
+
+// Secp256k1PublicKey is an interface that represents a secp256k1 public key for
+// use in creating pay-to-pubkey addresses that involve them.
+type Secp256k1PublicKey interface {
+	// SerializeCompressed serializes a public key in the 33-byte compressed
+	// format.
+	SerializeCompressed() []byte
+}
+
+// NewAddressPubKeyEcdsaSecp256k1Raw returns an address that represents a
+// payment destination which imposes an encumbrance that requires a valid ECDSA
+// signature for a specific secp256k1 public key.
+//
+// The provided public key MUST be a valid secp256k1 public key serialized in
+// the _compressed_ format or an error will be returned.
+//
+// See NewAddressPubKeyEcdsaSecp256k1 for a variant that accepts the public
+// key as a concrete type instance instead.
+//
+// This function can be useful to callers who already need the serialized public
+// key for other purposes to avoid the need to serialize it multiple times.
+func NewAddressPubKeyEcdsaSecp256k1Raw(scriptVersion uint16,
+	serializedPubKey []byte,
+	params AddressParams) (Address, error) {
+
+	str := fmt.Sprintf("pubkey addresses for version %d are not supported",
+		scriptVersion)
+	return nil, makeError(ErrUnsupportedScriptVersion, str)
+}
+
+// NewAddressPubKeyEcdsaSecp256k1 returns an address that represents a
+// payment destination which imposes an encumbrance that requires a valid ECDSA
+// signature for a specific secp256k1 public key.
+//
+// See NewAddressPubKeyEcdsaSecp256k1Raw for a variant that accepts the public
+// key already serialized in the _compressed_ format instead of a concrete type.
+// It can be useful to callers who already need the serialized public key for
+// other purposes to avoid the need to serialize it multiple times.
+func NewAddressPubKeyEcdsaSecp256k1(scriptVersion uint16,
+	pubKey Secp256k1PublicKey,
+	params AddressParams) (Address, error) {
+
+	str := fmt.Sprintf("pubkey addresses for version %d are not supported",
+		scriptVersion)
+	return nil, makeError(ErrUnsupportedScriptVersion, str)
+}
+
+// NewAddressPubKeyEd25519Raw returns an address that represents a payment
+// destination which imposes an encumbrance that requires a valid Ed25519
+// signature for a specific Ed25519 public key.
+//
+// See NewAddressPubKeyEd25519 for a variant that accepts the public key as a
+// concrete type instance instead.
+func NewAddressPubKeyEd25519Raw(scriptVersion uint16, serializedPubKey []byte,
+	params AddressParams) (Address, error) {
+
+	str := fmt.Sprintf("pubkey addresses for version %d are not supported",
+		scriptVersion)
+	return nil, makeError(ErrUnsupportedScriptVersion, str)
+}
+
+// Ed25519PublicKey is an interface type that represents an Ed25519 public key
+// for use in creating pay-to-pubkey addresses that involve them.
+type Ed25519PublicKey interface {
+	// Serialize serializes the public key in a 32-byte compressed little endian
+	// format.
+	Serialize() []byte
+}
+
+// NewAddressPubKeyEd25519 returns an address that represents a payment
+// destination which imposes an encumbrance that requires a valid Ed25519
+// signature for a specific Ed25519 public key.
+//
+// See NewAddressPubKeyEd25519Raw for a variant that accepts the public key
+// already serialized instead of a concrete type.  It can be useful to callers
+// who already need the serialized public key for other purposes to avoid the
+// need to serialize it multiple times.
+func NewAddressPubKeyEd25519(scriptVersion uint16, pubKey Ed25519PublicKey,
+	params AddressParams) (Address, error) {
+
+	str := fmt.Sprintf("pubkey addresses for version %d are not supported",
+		scriptVersion)
+	return nil, makeError(ErrUnsupportedScriptVersion, str)
+}
+
+// NewAddressPubKeySchnorrSecp256k1Raw returns an address that represents a
+// payment destination which imposes an encumbrance that requires a valid
+// EC-Schnorr-DCR signature for a specific secp256k1 public key.
+//
+// The provided public key MUST be a valid secp256k1 public key serialized in
+// the _compressed_ format or an error will be returned.
+//
+// See NewAddressPubKeySchnorrSecp256k1 for a variant that accepts the public
+// key as a concrete type instance instead.
+//
+// This function can be useful to callers who already need the serialized public
+// key for other purposes to avoid the need to serialize it multiple times.
+func NewAddressPubKeySchnorrSecp256k1Raw(scriptVersion uint16,
+	serializedPubKey []byte,
+	params AddressParams) (Address, error) {
+
+	str := fmt.Sprintf("pubkey addresses for version %d are not supported",
+		scriptVersion)
+	return nil, makeError(ErrUnsupportedScriptVersion, str)
+}
+
+// NewAddressPubKeySchnorrSecp256k1 returns an address that represents a payment
+// destination which imposes an encumbrance that requires a valid EC-Schnorr-DCR
+// signature for a specific secp256k1 public key.
+//
+// See NewAddressPubKeySchnorrSecp256k1Raw for a variant that accepts the public
+// key already serialized in the _compressed_ format instead of a concrete type.
+// It can be useful to callers who already need the serialized public key for
+// other purposes to avoid the need to serialize it multiple times.
+func NewAddressPubKeySchnorrSecp256k1(scriptVersion uint16,
+	pubKey Secp256k1PublicKey,
+	params AddressParams) (Address, error) {
+
+	str := fmt.Sprintf("pubkey addresses for version %d are not supported",
+		scriptVersion)
+	return nil, makeError(ErrUnsupportedScriptVersion, str)
+}
+
+// NewAddressPubKeyHashEcdsaSecp256k1 returns an address that represents a
+// payment destination which imposes an encumbrance that requires a secp256k1
+// public key that hashes to the provided public key hash along with a valid
+// ECDSA signature for that public key.
+//
+// For version 0 scripts, the provided public key hash must be 20 bytes and is
+// expected to be the Hash160 of the associated secp256k1 public key serialized
+// in the _compressed_ format.
+//
+// It is important to note that while it is technically possible for legacy
+// reasons to create this specific type of address based on the hash of a public
+// key in the uncompressed format, so long as it is also redeemed with that same
+// public key in uncompressed format, it is *HIGHLY* recommended to use the
+// compressed format since it occupies less space on the chain and is more
+// consistent with other address formats where uncompressed public keys are NOT
+// supported.
+func NewAddressPubKeyHashEcdsaSecp256k1(scriptVersion uint16, pkHash []byte,
+	params AddressParams) (Address, error) {
+
+	str := fmt.Sprintf("pubkey hash addresses for version %d are not "+
+		"supported", scriptVersion)
+	return nil, makeError(ErrUnsupportedScriptVersion, str)
+}
+
+// NewAddressPubKeyHashEd25519 returns an address that represents a a payment
+// destination which imposes an encumbrance that requires an Ed25519 public key
+// that hashes to the provided public key hash along with a valid Ed25519
+// signature for that public key.
+//
+// For version 0 scripts, the provided public key hash must be 20 bytes and be
+// the Hash160 of the correct public key or it will not be redeemable with the
+// expected public key because it would hash to a different value than the
+// payment script generated for the provided incorrect public key hash expects.
+func NewAddressPubKeyHashEd25519(scriptVersion uint16, pkHash []byte,
+	params AddressParams) (Address, error) {
+
+	str := fmt.Sprintf("pubkey hash addresses for version %d are not "+
+		"supported", scriptVersion)
+	return nil, makeError(ErrUnsupportedScriptVersion, str)
+}
+
+// NewAddressPubKeyHashSchnorrSecp256k1 returns an address that represents a
+// payment destination which imposes an encumbrance that requires a secp256k1
+// public key in the _compressed_ format that hashes to the provided public key
+// hash along with a valid EC-Schnorr-DCR signature for that public key.
+//
+// For version 0 scripts, the provided public key hash must be 20 bytes and is
+// expected to be the Hash160 of the associated secp256k1 public key serialized
+// in the _compressed_ format.
+//
+// WARNING: It is important to note that, unlike in the case of the ECDSA
+// variant of this type of address, redemption via a public key in the
+// uncompressed format is NOT supported by the consensus rules for this type, so
+// it is *EXTREMELY* important to ensure the provided hash is of the serialized
+// public key in the compressed format or the associated coins will NOT be
+// redeemable.
+func NewAddressPubKeyHashSchnorrSecp256k1(scriptVersion uint16, pkHash []byte,
+	params AddressParams) (Address, error) {
+
+	str := fmt.Sprintf("pubkey hash addresses for version %d are not "+
+		"supported", scriptVersion)
+	return nil, makeError(ErrUnsupportedScriptVersion, str)
+}
+
+// NewAddressScriptHashFromHash returns an address that represents a payment
+// destination which imposes an encumbrance that requires a script that hashes
+// to the provided script hash along with all of the encumbrances that script
+// itself imposes.  The script is commonly referred to as a redeem script.
+//
+// For version 0 scripts, the provided script hash must be 20 bytes and is
+// expected to be the Hash160 of the associated redeem script.
+//
+// See NewAddressScriptHash for a variant that accepts the redeem script instead
+// of its hash.  It can be used as a convenience for callers that have the
+// redeem script available.
+func NewAddressScriptHashFromHash(scriptVersion uint16, scriptHash []byte,
+	params AddressParams) (Address, error) {
+
+	str := fmt.Sprintf("script hash addresses for version %d are not "+
+		"supported", scriptVersion)
+	return nil, makeError(ErrUnsupportedScriptVersion, str)
+}
+
+// NewAddressScriptHash returns an address that represents a payment destination
+// which imposes an encumbrance that requires a script that hashes to the same
+// value as the provided script along with all of the encumbrances that script
+// itself imposes.  The script is commonly referred to as a redeem script.
+//
+// See NewAddressScriptHashFromHash for a variant that accepts the hash of the
+// script directly instead of the script.  It can be useful to callers that
+// either already have the script hash available or do not know the associated
+// script.
+func NewAddressScriptHash(scriptVersion uint16, redeemScript []byte,
+	params AddressParams) (Address, error) {
+
+	str := fmt.Sprintf("script hash addresses for version %d are not "+
+		"supported", scriptVersion)
+	return nil, makeError(ErrUnsupportedScriptVersion, str)
+}
+
+// DecodeAddress decodes the string encoding of an address and returns the
+// relevant Address if it is a valid encoding for a known address type and is
+// for the provided network.
+func DecodeAddress(addr string, params AddressParams) (Address, error) {
+	// Parsing code for future address/script versions goes here.
+
+	str := fmt.Sprintf("address %q is not a supported type", addr)
+	return nil, makeError(ErrUnsupportedAddress, str)
+}

--- a/internal/staging/stdaddr/address.go
+++ b/internal/staging/stdaddr/address.go
@@ -363,8 +363,15 @@ func NewAddressPubKeyHashSchnorrSecp256k1(scriptVersion uint16, pkHash []byte,
 // See NewAddressScriptHash for a variant that accepts the redeem script instead
 // of its hash.  It can be used as a convenience for callers that have the
 // redeem script available.
+//
+// NOTE: Version 0 scripts are the only currently supported version.
 func NewAddressScriptHashFromHash(scriptVersion uint16, scriptHash []byte,
 	params AddressParams) (Address, error) {
+
+	switch scriptVersion {
+	case 0:
+		return NewAddressScriptHashV0FromHash(scriptHash, params)
+	}
 
 	str := fmt.Sprintf("script hash addresses for version %d are not "+
 		"supported", scriptVersion)
@@ -380,8 +387,15 @@ func NewAddressScriptHashFromHash(scriptVersion uint16, scriptHash []byte,
 // script directly instead of the script.  It can be useful to callers that
 // either already have the script hash available or do not know the associated
 // script.
+//
+// NOTE: Version 0 scripts are the only currently supported version.
 func NewAddressScriptHash(scriptVersion uint16, redeemScript []byte,
 	params AddressParams) (Address, error) {
+
+	switch scriptVersion {
+	case 0:
+		return NewAddressScriptHashV0(redeemScript, params)
+	}
 
 	str := fmt.Sprintf("script hash addresses for version %d are not "+
 		"supported", scriptVersion)

--- a/internal/staging/stdaddr/address.go
+++ b/internal/staging/stdaddr/address.go
@@ -337,8 +337,15 @@ func NewAddressPubKeyHashEd25519(scriptVersion uint16, pkHash []byte,
 // it is *EXTREMELY* important to ensure the provided hash is of the serialized
 // public key in the compressed format or the associated coins will NOT be
 // redeemable.
+//
+// NOTE: Version 0 scripts are the only currently supported version.
 func NewAddressPubKeyHashSchnorrSecp256k1(scriptVersion uint16, pkHash []byte,
 	params AddressParams) (Address, error) {
+
+	switch scriptVersion {
+	case 0:
+		return NewAddressPubKeyHashSchnorrSecp256k1V0(pkHash, params)
+	}
 
 	str := fmt.Sprintf("pubkey hash addresses for version %d are not "+
 		"supported", scriptVersion)

--- a/internal/staging/stdaddr/address.go
+++ b/internal/staging/stdaddr/address.go
@@ -227,9 +227,16 @@ func NewAddressPubKeyEd25519(scriptVersion uint16, pubKey Ed25519PublicKey,
 //
 // This function can be useful to callers who already need the serialized public
 // key for other purposes to avoid the need to serialize it multiple times.
+//
+// NOTE: Version 0 scripts are the only currently supported version.
 func NewAddressPubKeySchnorrSecp256k1Raw(scriptVersion uint16,
 	serializedPubKey []byte,
 	params AddressParams) (Address, error) {
+
+	switch scriptVersion {
+	case 0:
+		return NewAddressPubKeySchnorrSecp256k1V0Raw(serializedPubKey, params)
+	}
 
 	str := fmt.Sprintf("pubkey addresses for version %d are not supported",
 		scriptVersion)
@@ -244,9 +251,16 @@ func NewAddressPubKeySchnorrSecp256k1Raw(scriptVersion uint16,
 // key already serialized in the _compressed_ format instead of a concrete type.
 // It can be useful to callers who already need the serialized public key for
 // other purposes to avoid the need to serialize it multiple times.
+//
+// NOTE: Version 0 scripts are the only currently supported version.
 func NewAddressPubKeySchnorrSecp256k1(scriptVersion uint16,
 	pubKey Secp256k1PublicKey,
 	params AddressParams) (Address, error) {
+
+	switch scriptVersion {
+	case 0:
+		return NewAddressPubKeySchnorrSecp256k1V0(pubKey, params)
+	}
 
 	str := fmt.Sprintf("pubkey addresses for version %d are not supported",
 		scriptVersion)

--- a/internal/staging/stdaddr/address_test.go
+++ b/internal/staging/stdaddr/address_test.go
@@ -897,6 +897,116 @@ func TestAddresses(t *testing.T) {
 		decodeErr: nil,
 		version:   0,
 		payScript: "76a914f15da1cb8d1bcb162c6ab446c95757a6e791c9168852be",
+	}, {
+		// ---------------------------------------------------------------------
+		// Negative P2SH tests.
+		// ---------------------------------------------------------------------
+
+		name: "p2sh wrong hash length",
+		makeAddr: func() (Address, error) {
+			hash := hexToBytes("00f815b036d9bbbce5e9f2a00abd1bf3dc91e95510")
+			return NewAddressScriptHashFromHash(0, hash, mainNetParams)
+		},
+		makeErr: ErrInvalidHashLen,
+	}, {
+		name: "p2sh from script hash unsupported script version",
+		makeAddr: func() (Address, error) {
+			hash := hexToBytes("f815b036d9bbbce5e9f2a00abd1bf3dc91e95510")
+			return NewAddressScriptHashFromHash(9999, hash, mainNetParams)
+		},
+		makeErr: ErrUnsupportedScriptVersion,
+	}, {
+		name: "p2sh from redeem script unsupported script version",
+		makeAddr: func() (Address, error) {
+			script := hexToBytes("a914f0b4e85100aee1a996f22915eb3c3f764d53779a87")
+			return NewAddressScriptHash(9999, script, mainNetParams)
+		},
+		makeErr: ErrUnsupportedScriptVersion,
+	}, {
+		// ---------------------------------------------------------------------
+		// Positive P2SH tests.
+		// ---------------------------------------------------------------------
+
+		name: "mainnet p2sh",
+		makeAddr: func() (Address, error) {
+			script := hexToBytes("512103aa43f0a6c15730d886cc1f0342046d2017548" +
+				"3d90d7ccb657f90c489111d794c51ae")
+			return NewAddressScriptHash(0, script, mainNetParams)
+		},
+		makeErr:      nil,
+		addr:         "DcuQKx8BES9wU7C6Q5VmLBjw436r27hayjS",
+		net:          mainNetParams,
+		decodeErr:    nil,
+		version:      0,
+		payScript:    "a914f0b4e85100aee1a996f22915eb3c3f764d53779a87",
+		rewardAmount: 1e8,
+		feeLimits:    0x5800,
+		rewardScript: "6a1ef0b4e85100aee1a996f22915eb3c3f764d53779a00e1f505000000800058",
+		voteScript:   "baa914f0b4e85100aee1a996f22915eb3c3f764d53779a87",
+		changeScript: "bda914f0b4e85100aee1a996f22915eb3c3f764d53779a87",
+		commitScript: "bba914f0b4e85100aee1a996f22915eb3c3f764d53779a87",
+		revokeScript: "bca914f0b4e85100aee1a996f22915eb3c3f764d53779a87",
+		trsyScript:   "c3a914f0b4e85100aee1a996f22915eb3c3f764d53779a87",
+	}, {
+		name: "mainnet p2sh 2",
+		makeAddr: func() (Address, error) {
+			hash := hexToBytes("c7da5095683436f4435fc4e7163dcafda1a2d007")
+			return NewAddressScriptHashFromHash(0, hash, mainNetParams)
+		},
+		makeErr:      nil,
+		addr:         "DcqgK4N4Ccucu2Sq4VDAdu4wH4LASLhzLVp",
+		net:          mainNetParams,
+		decodeErr:    nil,
+		version:      0,
+		payScript:    "a914c7da5095683436f4435fc4e7163dcafda1a2d00787",
+		voteScript:   "baa914c7da5095683436f4435fc4e7163dcafda1a2d00787",
+		rewardAmount: 9556193632,
+		feeLimits:    0x5900,
+		rewardScript: "6a1ec7da5095683436f4435fc4e7163dcafda1a2d00760f19739020000800059",
+		changeScript: "bda914c7da5095683436f4435fc4e7163dcafda1a2d00787",
+		commitScript: "bba914c7da5095683436f4435fc4e7163dcafda1a2d00787",
+		revokeScript: "bca914c7da5095683436f4435fc4e7163dcafda1a2d00787",
+		trsyScript:   "c3a914c7da5095683436f4435fc4e7163dcafda1a2d00787",
+	}, {
+		name: "testnet p2sh",
+		makeAddr: func() (Address, error) {
+			hash := hexToBytes("36c1ca10a8a6a4b5d4204ac970853979903aa284")
+			return NewAddressScriptHashFromHash(0, hash, testNetParams)
+		},
+		makeErr:      nil,
+		addr:         "TccWLgcquqvwrfBocq5mcK5kBiyw8MvyvCi",
+		net:          testNetParams,
+		decodeErr:    nil,
+		version:      0,
+		payScript:    "a91436c1ca10a8a6a4b5d4204ac970853979903aa28487",
+		voteScript:   "baa91436c1ca10a8a6a4b5d4204ac970853979903aa28487",
+		rewardAmount: 2428220961,
+		feeLimits:    0x5800,
+		rewardScript: "6a1e36c1ca10a8a6a4b5d4204ac970853979903aa28421b6bb90000000800058",
+		changeScript: "bda91436c1ca10a8a6a4b5d4204ac970853979903aa28487",
+		commitScript: "bba91436c1ca10a8a6a4b5d4204ac970853979903aa28487",
+		revokeScript: "bca91436c1ca10a8a6a4b5d4204ac970853979903aa28487",
+		trsyScript:   "c3a91436c1ca10a8a6a4b5d4204ac970853979903aa28487",
+	}, {
+		name: "regnet p2sh",
+		makeAddr: func() (Address, error) {
+			hash := hexToBytes("36c1ca10a8a6a4b5d4204ac970853979903aa284")
+			return NewAddressScriptHashFromHash(0, hash, regNetParams)
+		},
+		makeErr:      nil,
+		addr:         "RcKq28Eheeo2eJvWakqWWAr5pqCUWykwDHe",
+		net:          regNetParams,
+		decodeErr:    nil,
+		version:      0,
+		payScript:    "a91436c1ca10a8a6a4b5d4204ac970853979903aa28487",
+		voteScript:   "baa91436c1ca10a8a6a4b5d4204ac970853979903aa28487",
+		rewardAmount: 2428220961,
+		feeLimits:    0x5800,
+		rewardScript: "6a1e36c1ca10a8a6a4b5d4204ac970853979903aa28421b6bb90000000800058",
+		changeScript: "bda91436c1ca10a8a6a4b5d4204ac970853979903aa28487",
+		commitScript: "bba91436c1ca10a8a6a4b5d4204ac970853979903aa28487",
+		revokeScript: "bca91436c1ca10a8a6a4b5d4204ac970853979903aa28487",
+		trsyScript:   "c3a91436c1ca10a8a6a4b5d4204ac970853979903aa28487",
 	}}
 
 	for _, test := range tests {

--- a/internal/staging/stdaddr/address_test.go
+++ b/internal/staging/stdaddr/address_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/decred/base58"
 	"github.com/decred/dcrd/crypto/ripemd160"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 )
 
 // mockAddrParams implements the AddressParams interface and is used throughout
@@ -97,6 +98,32 @@ func mockTestNetParams() *mockAddrParams {
 	}
 }
 
+// mockRegNetParams returns mock regression test address parameters to use
+// throughout the tests.  They match the Decred regnet params as of the time
+// this comment was written.
+func mockRegNetParams() *mockAddrParams {
+	return &mockAddrParams{
+		pubKeyID:     [2]byte{0x25, 0xe5}, // starts with Rk
+		pkhEcdsaID:   [2]byte{0x0e, 0x00}, // starts with Rs
+		pkhEd25519ID: [2]byte{0x0d, 0xe0}, // starts with Re
+		pkhSchnorrID: [2]byte{0x0d, 0xc2}, // starts with RS
+		scriptHashID: [2]byte{0x0d, 0xdb}, // starts with Rc
+		privKeyID:    [2]byte{0x22, 0xfe}, // starts with Pr
+	}
+}
+
+// hexToBytes converts the passed hex string into bytes and will panic if there
+// is an error.  This is only provided for the hard-coded constants so errors in
+// the source code can be detected. It will only (and must only) be called with
+// hard-coded values.
+func hexToBytes(s string) []byte {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		panic("invalid hex in source file: " + s)
+	}
+	return b
+}
+
 // TestAddresses ensures that address-related APIs work as intended including
 // that they are properly encoded and decoded, that they produce the expected
 // payment-related scripts, and that error paths fail as expected.  For
@@ -105,6 +132,7 @@ func mockTestNetParams() *mockAddrParams {
 func TestAddresses(t *testing.T) {
 	mainNetParams := mockMainNetParams()
 	testNetParams := mockTestNetParams()
+	regNetParams := mockRegNetParams()
 
 	type newAddrFn func() (Address, error)
 	tests := []struct {
@@ -148,6 +176,215 @@ func TestAddresses(t *testing.T) {
 		addr:      "DsUZxxoHlSty8DCfwfartwTYbuhmVct7tJu",
 		net:       mainNetParams,
 		decodeErr: ErrUnsupportedAddress,
+	}, {
+		// ---------------------------------------------------------------------
+		// Negative P2PK ECDSA secp256k1 tests.
+		// ---------------------------------------------------------------------
+
+		name: "mainnet p2pk-ecdsa-secp256k1 uncompressed (0x04) rejected via constructor",
+		makeAddr: func() (Address, error) {
+			pkHex := "0464c44653d6567eff5753c5d24a682ddc2b2cadfe1b0c6433b163" +
+				"74dace6778f0b87ca4279b565d2130ce59f75bfbb2b88da794143d7cfd3" +
+				"e80808a1fa3203904"
+			pk := hexToBytes(pkHex)
+			return NewAddressPubKeyEcdsaSecp256k1Raw(0, pk, mainNetParams)
+		},
+		makeErr: ErrInvalidPubKeyFormat,
+	}, {
+		name:      "mainnet p2pk-ecdsa-secp256k1 uncompressed (0x04) rejected via decode",
+		addr:      "HiQeNVx8PNYP8ysyunUoicyNdfRUrEu1kzPE6v5gECBHBYgDzXCg8BsDGjmaHCpV97ytaQGHz5XDMJgJVHjv9YeSXWkHfwmBJj",
+		net:       mainNetParams,
+		decodeErr: ErrUnsupportedAddress,
+	}, {
+		name: "mainnet p2pk-ecdsa-secp256k1 hybrid (0x06) rejected via constructor",
+		makeAddr: func() (Address, error) {
+			pkHex := "0664c44653d6567eff5753c5d24a682ddc2b2cadfe1b0c6433b163" +
+				"74dace6778f0b87ca4279b565d2130ce59f75bfbb2b88da794143d7cfd3" +
+				"e80808a1fa3203904"
+			pk := hexToBytes(pkHex)
+			return NewAddressPubKeyEcdsaSecp256k1Raw(0, pk, mainNetParams)
+		},
+		makeErr: ErrInvalidPubKeyFormat,
+	}, {
+		name: "mainnet p2pk-ecdsa-secp256k1 hybrid (0x07) rejected via constructor",
+		makeAddr: func() (Address, error) {
+			pkHex := "07348d8aeb4253ca52456fe5da94ab1263bfee16bb8192497f6663" +
+				"89ca964f84798375129d7958843b14258b905dc94faed324dd8a9d67ffa" +
+				"c8cc0a85be84bac5d"
+			pk := hexToBytes(pkHex)
+			return NewAddressPubKeyEcdsaSecp256k1Raw(0, pk, mainNetParams)
+		},
+		makeErr: ErrInvalidPubKeyFormat,
+	}, {
+		name: "p2pk-ecdsa-secp256k1 unsupported script version",
+		makeAddr: func() (Address, error) {
+			pkHex := "028f53838b7639563f27c94845549a41e5146bcd52e7fef0ea6da143a02b0fe2ed"
+			pk := hexToBytes(pkHex)
+			return NewAddressPubKeyEcdsaSecp256k1Raw(9999, pk, mainNetParams)
+		},
+		makeErr: ErrUnsupportedScriptVersion,
+	}, {
+		name: "p2pk-ecdsa-secp256k1 unsupported script version via concrete constructor",
+		makeAddr: func() (Address, error) {
+			pkHex := "028f53838b7639563f27c94845549a41e5146bcd52e7fef0ea6da143a02b0fe2ed"
+			pk, err := secp256k1.ParsePubKey(hexToBytes(pkHex))
+			if err != nil {
+				return nil, err
+			}
+			return NewAddressPubKeyEcdsaSecp256k1(9999, pk, mainNetParams)
+		},
+		makeErr: ErrUnsupportedScriptVersion,
+	}, {
+		name: "p2pk-ecdsa-secp256k1 malformed pubkey",
+		makeAddr: func() (Address, error) {
+			pkHex := "028f53838b7639563f27c94845549a41e5146bcd52e7fef0ea6da143a02b0fe2"
+			pk := hexToBytes(pkHex)
+			return NewAddressPubKeyEcdsaSecp256k1Raw(0, pk, mainNetParams)
+		},
+		makeErr: ErrInvalidPubKey,
+	}, {
+		name:      "p2pk-ecdsa-secp256k1 malformed pubkey via decode",
+		addr:      "3tWTcxjUnAKTzHh8pHPYpSsUKVbTvziNGHtbBFQkY12khQWuW83p",
+		net:       mainNetParams,
+		decodeErr: ErrUnsupportedAddress,
+	}, {
+		// ---------------------------------------------------------------------
+		// Positive P2PK ECDSA secp256k1 tests.
+		// ---------------------------------------------------------------------
+
+		name: "mainnet p2pk-ecdsa-secp256k1 compressed (0x02)",
+		makeAddr: func() (Address, error) {
+			pkHex := "028f53838b7639563f27c94845549a41e5146bcd52e7fef0ea6da143a02b0fe2ed"
+			pk := hexToBytes(pkHex)
+			return NewAddressPubKeyEcdsaSecp256k1Raw(0, pk, mainNetParams)
+		},
+		makeErr:   nil,
+		addr:      "DkM3ZigNyiwHrsXRjkDQ8t8tW6uKGW9g61qEkG3bMqQPQWYEf5X3J",
+		net:       mainNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "21028f53838b7639563f27c94845549a41e5146bcd52e7fef0ea6da143a02b0fe2edac",
+	}, {
+		name: "mainnet p2pk-ecdsa-secp256k1 compressed (0x03)",
+		makeAddr: func() (Address, error) {
+			pkHex := "03e925aafc1edd44e7c7f1ea4fb7d265dc672f204c3d0c81930389c10b81fb75de"
+			pk := hexToBytes(pkHex)
+			return NewAddressPubKeyEcdsaSecp256k1Raw(0, pk, mainNetParams)
+		},
+		makeErr:   nil,
+		addr:      "DkRM4ZcdejbYRu4AbcEdfDLzU9w1ZTqPXatXvL1g8Q77ibDjz7gwF",
+		net:       mainNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "2103e925aafc1edd44e7c7f1ea4fb7d265dc672f204c3d0c81930389c10b81fb75deac",
+	}, {
+		name: "mainnet p2pk-ecdsa-secp256k1 compressed via concrete constructor",
+		makeAddr: func() (Address, error) {
+			pkHex := "028f53838b7639563f27c94845549a41e5146bcd52e7fef0ea6da143a02b0fe2ed"
+			pk, err := secp256k1.ParsePubKey(hexToBytes(pkHex))
+			if err != nil {
+				return nil, err
+			}
+			return NewAddressPubKeyEcdsaSecp256k1(0, pk, mainNetParams)
+		},
+		makeErr:   nil,
+		addr:      "DkM3ZigNyiwHrsXRjkDQ8t8tW6uKGW9g61qEkG3bMqQPQWYEf5X3J",
+		net:       mainNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "21028f53838b7639563f27c94845549a41e5146bcd52e7fef0ea6da143a02b0fe2edac",
+	}, {
+		name: "mainnet p2pk-ecdsa-secp256k1 compressed from uncompressed via concrete constructor",
+		makeAddr: func() (Address, error) {
+			pkHex := "0464c44653d6567eff5753c5d24a682ddc2b2cadfe1b0c6433b163" +
+				"74dace6778f0b87ca4279b565d2130ce59f75bfbb2b88da794143d7cfd3" +
+				"e80808a1fa3203904"
+			pk, err := secp256k1.ParsePubKey(hexToBytes(pkHex))
+			if err != nil {
+				return nil, err
+			}
+			return NewAddressPubKeyEcdsaSecp256k1(0, pk, mainNetParams)
+		},
+		makeErr:   nil,
+		addr:      "DkM3EyZ546GghVSkvzb6J47PvGDyntqiDtFgipQhNj78Xm2mUYRpf",
+		net:       mainNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "210264c44653d6567eff5753c5d24a682ddc2b2cadfe1b0c6433b16374dace6778f0ac",
+	}, {
+		name: "testnet p2pk-ecdsa-secp256k1 compressed (0x02)",
+		makeAddr: func() (Address, error) {
+			pkHex := "026a40c403e74670c4de7656a09caa2353d4b383a9ce66eef51e1220eacf4be06e"
+			pk := hexToBytes(pkHex)
+			return NewAddressPubKeyEcdsaSecp256k1Raw(0, pk, testNetParams)
+		},
+		makeErr:   nil,
+		addr:      "TkKmMiY5iDh4U3KkSopYgkU1AzhAcQZiSoVhYhFymZHGMi9LM9Fdt",
+		net:       testNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "21026a40c403e74670c4de7656a09caa2353d4b383a9ce66eef51e1220eacf4be06eac",
+	}, {
+		name: "testnet p2pk-ecdsa-secp256k1 compressed (0x03)",
+		makeAddr: func() (Address, error) {
+			pkHex := "030844ee70d8384d5250e9bb3a6a73d4b5bec770e8b31d6a0ae9fb739009d91af5"
+			pk := hexToBytes(pkHex)
+			return NewAddressPubKeyEcdsaSecp256k1Raw(0, pk, testNetParams)
+		},
+		makeErr:   nil,
+		addr:      "TkQ3RrFierkUUbgipYwgeVfV8ch3fktfrDamGyDYESPBXMaVNNmWG",
+		net:       testNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "21030844ee70d8384d5250e9bb3a6a73d4b5bec770e8b31d6a0ae9fb739009d91af5ac",
+	}, {
+		name: "testnet p2pk-ecdsa-secp256k1 compressed via concrete constructor",
+		makeAddr: func() (Address, error) {
+			pkHex := "026a40c403e74670c4de7656a09caa2353d4b383a9ce66eef51e1220eacf4be06e"
+			pk, err := secp256k1.ParsePubKey(hexToBytes(pkHex))
+			if err != nil {
+				return nil, err
+			}
+			return NewAddressPubKeyEcdsaSecp256k1(0, pk, testNetParams)
+		},
+		makeErr:   nil,
+		addr:      "TkKmMiY5iDh4U3KkSopYgkU1AzhAcQZiSoVhYhFymZHGMi9LM9Fdt",
+		net:       testNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "21026a40c403e74670c4de7656a09caa2353d4b383a9ce66eef51e1220eacf4be06eac",
+	}, {
+		name: "testnet p2pk-ecdsa-secp256k1 compressed from uncompressed via concrete constructor",
+		makeAddr: func() (Address, error) {
+			pkHex := "046a40c403e74670c4de7656a09caa2353d4b383a9ce66eef51e12" +
+				"20eacf4be06ed548c8c16fb5eb9007cb94220b3bb89491d5a1fd2d77867" +
+				"fca64217acecf2244"
+			pk, err := secp256k1.ParsePubKey(hexToBytes(pkHex))
+			if err != nil {
+				return nil, err
+			}
+			return NewAddressPubKeyEcdsaSecp256k1(0, pk, testNetParams)
+		},
+		makeErr:   nil,
+		addr:      "TkKmMiY5iDh4U3KkSopYgkU1AzhAcQZiSoVhYhFymZHGMi9LM9Fdt",
+		net:       testNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "21026a40c403e74670c4de7656a09caa2353d4b383a9ce66eef51e1220eacf4be06eac",
+	}, {
+		name:      "regnet p2pk-ecdsa-secp256k1 compressed (0x02)",
+		addr:      "Rk41kKgrecrxQ8bLg8GJm1feMPBFtFeb4rG56tDfMdAtvPy4HneyR",
+		net:       regNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "21026a40c403e74670c4de7656a09caa2353d4b383a9ce66eef51e1220eacf4be06eac",
+	}, {
+		name:      "regnet p2pk-ecdsa-secp256k1 compressed (0x03)",
+		addr:      "Rk8HpTQVbFvNQgxK3sPSiks8K1B8wbyYUGM8qABDpWGp63Q5mnG52",
+		net:       regNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "21030844ee70d8384d5250e9bb3a6a73d4b5bec770e8b31d6a0ae9fb739009d91af5ac",
 	}}
 
 	for _, test := range tests {
@@ -380,6 +617,20 @@ func TestDecodeAddressV0Corners(t *testing.T) {
 		addr:      "DsUZxxoHlSty8DCfwfartwTYbuhmVct7tJu",
 		net:       mainNetParams,
 		decodeErr: ErrMalformedAddress,
+	}, {
+		// ---------------------------------------------------------------------
+		// Negative P2PK ECDSA secp256k1 tests.
+		// ---------------------------------------------------------------------
+
+		name:      "mainnet p2pk-ecdsa-secp256k1 uncompressed (0x04) rejected via decode",
+		addr:      "HiQeNVx8PNYP8ysyunUoicyNdfRUrEu1kzPE6v5gECBHBYgDzXCg8BsDGjmaHCpV97ytaQGHz5XDMJgJVHjv9YeSXWkHfwmBJj",
+		net:       mainNetParams,
+		decodeErr: ErrMalformedAddressData,
+	}, {
+		name:      "p2pk-ecdsa-secp256k1 malformed pubkey via decode",
+		addr:      "3tWTcxjUnAKTzHh8pHPYpSsUKVbTvziNGHtbBFQkY12khQWuW83p",
+		net:       mainNetParams,
+		decodeErr: ErrMalformedAddressData,
 	}}
 
 	for _, test := range tests {

--- a/internal/staging/stdaddr/address_test.go
+++ b/internal/staging/stdaddr/address_test.go
@@ -500,6 +500,157 @@ func TestAddresses(t *testing.T) {
 		decodeErr: nil,
 		version:   0,
 		payScript: "20cecc1507dc1ddd7295951c290888f095adb9044d1b73d696e6df065d683bd4fc51be",
+	}, {
+		// ---------------------------------------------------------------------
+		// Negative P2PK Schnorr secp256k1 tests.
+		// ---------------------------------------------------------------------
+
+		name: "mainnet p2pk-schnorr-secp256k1 uncompressed (0x04) rejected via constructor",
+		makeAddr: func() (Address, error) {
+			pkHex := "0464c44653d6567eff5753c5d24a682ddc2b2cadfe1b0c6433b163" +
+				"74dace6778f0b87ca4279b565d2130ce59f75bfbb2b88da794143d7cfd3" +
+				"e80808a1fa3203904"
+			pk := hexToBytes(pkHex)
+			return NewAddressPubKeySchnorrSecp256k1Raw(0, pk, mainNetParams)
+		},
+		makeErr: ErrInvalidPubKeyFormat,
+	}, {
+		name:      "mainnet p2pk-schnorr-secp256k1 uncompressed (0x04) rejected via decode",
+		addr:      "HiQjU9uCJtiQD7osQuYHWJRFiBCTuqtaTw8QFMtMgAW2ny4nUENeXDiV5VxfVZrK6PZynKPDpL7bwc6XLFNpV8k7ePDJmkkVCh",
+		net:       mainNetParams,
+		decodeErr: ErrUnsupportedAddress,
+	}, {
+		name: "mainnet p2pk-schnorr-secp256k1 hybrid (0x06) rejected via constructor",
+		makeAddr: func() (Address, error) {
+			pkHex := "0664c44653d6567eff5753c5d24a682ddc2b2cadfe1b0c6433b163" +
+				"74dace6778f0b87ca4279b565d2130ce59f75bfbb2b88da794143d7cfd3" +
+				"e80808a1fa3203904"
+			pk := hexToBytes(pkHex)
+			return NewAddressPubKeySchnorrSecp256k1Raw(0, pk, mainNetParams)
+		},
+		makeErr: ErrInvalidPubKeyFormat,
+	}, {
+		name: "mainnet p2pk-schnorr-secp256k1 hybrid (0x07) rejected via constructor",
+		makeAddr: func() (Address, error) {
+			pkHex := "07348d8aeb4253ca52456fe5da94ab1263bfee16bb8192497f6663" +
+				"89ca964f84798375129d7958843b14258b905dc94faed324dd8a9d67ffa" +
+				"c8cc0a85be84bac5d"
+			pk := hexToBytes(pkHex)
+			return NewAddressPubKeySchnorrSecp256k1Raw(0, pk, mainNetParams)
+		},
+		makeErr: ErrInvalidPubKeyFormat,
+	}, {
+		name: "p2pk-schnorr-secp256k1 unsupported script version",
+		makeAddr: func() (Address, error) {
+			pkHex := "028f53838b7639563f27c94845549a41e5146bcd52e7fef0ea6da143a02b0fe2ed"
+			pk := hexToBytes(pkHex)
+			return NewAddressPubKeySchnorrSecp256k1Raw(9999, pk, mainNetParams)
+		},
+		makeErr: ErrUnsupportedScriptVersion,
+	}, {
+		name: "p2pk-schnorr-secp256k1 unsupported script version via concrete constructor",
+		makeAddr: func() (Address, error) {
+			pkHex := "028f53838b7639563f27c94845549a41e5146bcd52e7fef0ea6da143a02b0fe2ed"
+			pk, err := secp256k1.ParsePubKey(hexToBytes(pkHex))
+			if err != nil {
+				return nil, err
+			}
+			return NewAddressPubKeySchnorrSecp256k1(9999, pk, mainNetParams)
+		},
+		makeErr: ErrUnsupportedScriptVersion,
+	}, {
+		name: "p2pk-schnorr-secp256k1 malformed pubkey",
+		makeAddr: func() (Address, error) {
+			pkHex := "028f53838b7639563f27c94845549a41e5146bcd52e7fef0ea6da143a02b0fe2"
+			pk := hexToBytes(pkHex)
+			return NewAddressPubKeySchnorrSecp256k1Raw(0, pk, mainNetParams)
+		},
+		makeErr: ErrInvalidPubKey,
+	}, {
+		name:      "p2pk-schnorr-secp256k1 malformed pubkey via decode",
+		addr:      "3tWUW3oD87XtmFVGnLX4Z3Hdesm2qRvvN8H5kq3yXxJumCxbvCpo",
+		net:       mainNetParams,
+		decodeErr: ErrUnsupportedAddress,
+	}, {
+		// ---------------------------------------------------------------------
+		// Positive P2PK Schnorr secp256k1 tests.
+		// ---------------------------------------------------------------------
+
+		name:      "mainnet p2pk-schnorr-secp256k1 compressed (0x02)",
+		addr:      "DkM7TD2qsne9DKo4uA2ZNt3XhejYVwT5mmQWtUXtjdPhRHXTSKxN4",
+		net:       mainNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "21028f53838b7639563f27c94845549a41e5146bcd52e7fef0ea6da143a02b0fe2ed52be",
+	}, {
+		name:      "mainnet p2pk-schnorr-secp256k1 compressed (0x03)",
+		addr:      "DkRQx3y6YoJPnMKom23nuDFdfhmEnu8oDLTp4YVyWC6RjND19UxHk",
+		net:       mainNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "2103e925aafc1edd44e7c7f1ea4fb7d265dc672f204c3d0c81930389c10b81fb75de52be",
+	}, {
+		name: "mainnet p2pk-schnorr-secp256k1 compressed via concrete constructor",
+		makeAddr: func() (Address, error) {
+			pkHex := "028f53838b7639563f27c94845549a41e5146bcd52e7fef0ea6da143a02b0fe2ed"
+			pk, err := secp256k1.ParsePubKey(hexToBytes(pkHex))
+			if err != nil {
+				return nil, err
+			}
+			return NewAddressPubKeySchnorrSecp256k1(0, pk, mainNetParams)
+		},
+		makeErr:   nil,
+		addr:      "DkM7TD2qsne9DKo4uA2ZNt3XhejYVwT5mmQWtUXtjdPhRHXTSKxN4",
+		net:       mainNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "21028f53838b7639563f27c94845549a41e5146bcd52e7fef0ea6da143a02b0fe2ed52be",
+	}, {
+		name: "mainnet p2pk-schnorr-secp256k1 compressed from uncompressed via concrete constructor",
+		makeAddr: func() (Address, error) {
+			pkHex := "048f53838b7639563f27c94845549a41e5146bcd52e7fef0ea6da1" +
+				"43a02b0fe2ed91badd9f6403cc485dc3d5ca83ee8917dca57414866b083" +
+				"087c1c83b7a8e3304"
+			pk, err := secp256k1.ParsePubKey(hexToBytes(pkHex))
+			if err != nil {
+				return nil, err
+			}
+			return NewAddressPubKeySchnorrSecp256k1(0, pk, mainNetParams)
+		},
+		makeErr:   nil,
+		addr:      "DkM7TD2qsne9DKo4uA2ZNt3XhejYVwT5mmQWtUXtjdPhRHXTSKxN4",
+		net:       mainNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "21028f53838b7639563f27c94845549a41e5146bcd52e7fef0ea6da143a02b0fe2ed52be",
+	}, {
+		name:      "testnet p2pk-schnorr-secp256k1 compressed (0x02)",
+		addr:      "TkKqFCtYcHPupVbPcDdhvkNeNYXPqqs88Z4ygukH9MGaNV8e1WWhX",
+		net:       testNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "21026a40c403e74670c4de7656a09caa2353d4b383a9ce66eef51e1220eacf4be06e52be",
+	}, {
+		name:      "testnet p2pk-schnorr-secp256k1 compressed (0x03)",
+		addr:      "TkQ7KLcBYvTKq3xMyxkqtVa8LAXGuCC5XyA3RBhqcENVY8ZiDjuAB",
+		net:       testNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "21030844ee70d8384d5250e9bb3a6a73d4b5bec770e8b31d6a0ae9fb739009d91af552be",
+	}, {
+		name:      "regnet p2pk-schnorr-secp256k1 compressed (0x02)",
+		addr:      "Rk45dp3KYgZokaryqY5U11aHYw1V7gwzkbqMF6hxjRACwAxDivM6N",
+		net:       regNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "21026a40c403e74670c4de7656a09caa2353d4b383a9ce66eef51e1220eacf4be06e52be",
+	}, {
+		name:      "regnet p2pk-schnorr-secp256k1 compressed (0x03)",
+		addr:      "Rk8MhwkxVKdDm9DxDHCbxkmmWZ1NB3GxA1vQyNfXCJG86pPPnnn9M",
+		net:       regNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "21030844ee70d8384d5250e9bb3a6a73d4b5bec770e8b31d6a0ae9fb739009d91af552be",
 	}}
 
 	for _, test := range tests {
@@ -753,6 +904,20 @@ func TestDecodeAddressV0Corners(t *testing.T) {
 
 		name:      "p2pk-ed25519 malformed pubkey (only 31 bytes) via decode",
 		addr:      "3tWUQtEa3P4SDQwjER81wkTxe4kiYLgNAso3pt2X5k3NFHRVQeNv",
+		net:       mainNetParams,
+		decodeErr: ErrMalformedAddressData,
+	}, {
+		// ---------------------------------------------------------------------
+		// Negative P2PK Schnorr secp256k1 tests.
+		// ---------------------------------------------------------------------
+
+		name:      "mainnet p2pk-schnorr-secp256k1 uncompressed (0x04) rejected via decode",
+		addr:      "HiQjU9uCJtiQD7osQuYHWJRFiBCTuqtaTw8QFMtMgAW2ny4nUENeXDiV5VxfVZrK6PZynKPDpL7bwc6XLFNpV8k7ePDJmkkVCh",
+		net:       mainNetParams,
+		decodeErr: ErrMalformedAddressData,
+	}, {
+		name:      "p2pk-schnorr-secp256k1 malformed pubkey via decode",
+		addr:      "3tWUW3oD87XtmFVGnLX4Z3Hdesm2qRvvN8H5kq3yXxJumCxbvCpo",
 		net:       mainNetParams,
 		decodeErr: ErrMalformedAddressData,
 	}}

--- a/internal/staging/stdaddr/address_test.go
+++ b/internal/staging/stdaddr/address_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/decred/base58"
 	"github.com/decred/dcrd/crypto/ripemd160"
+	"github.com/decred/dcrd/dcrec/edwards/v2"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 )
 
@@ -385,6 +386,120 @@ func TestAddresses(t *testing.T) {
 		decodeErr: nil,
 		version:   0,
 		payScript: "21030844ee70d8384d5250e9bb3a6a73d4b5bec770e8b31d6a0ae9fb739009d91af5ac",
+	}, {
+		// ---------------------------------------------------------------------
+		// Negative P2PK Ed25519 tests.
+		// ---------------------------------------------------------------------
+
+		name: "p2pk-ed25519 unsupported script version",
+		makeAddr: func() (Address, error) {
+			pkHex := "cecc1507dc1ddd7295951c290888f095adb9044d1b73d696e6df065d683bd4fc"
+			pk := hexToBytes(pkHex)
+			return NewAddressPubKeyEd25519Raw(9999, pk, mainNetParams)
+		},
+		makeErr: ErrUnsupportedScriptVersion,
+	}, {
+		name: "p2pk-ed25519 unsupported script version via concrete constructor",
+		makeAddr: func() (Address, error) {
+			pkHex := "cecc1507dc1ddd7295951c290888f095adb9044d1b73d696e6df065d683bd4fc"
+			pk, err := edwards.ParsePubKey(hexToBytes(pkHex))
+			if err != nil {
+				return nil, err
+			}
+			return NewAddressPubKeyEd25519(9999, pk, mainNetParams)
+		},
+		makeErr: ErrUnsupportedScriptVersion,
+	}, {
+		name: "p2pk-ed25519 malformed pubkey",
+		makeAddr: func() (Address, error) {
+			return NewAddressPubKeyEd25519Raw(0, nil, mainNetParams)
+		},
+		makeErr: ErrInvalidPubKey,
+	}, {
+		name:      "p2pk-ed25519 malformed pubkey (only 31 bytes) via decode",
+		addr:      "3tWUQtEa3P4SDQwjER81wkTxe4kiYLgNAso3pt2X5k3NFHRVQeNv",
+		net:       mainNetParams,
+		decodeErr: ErrUnsupportedAddress,
+	}, {
+		// ---------------------------------------------------------------------
+		// Positive P2PK Ed25519 tests.
+		// ---------------------------------------------------------------------
+
+		name: "mainnet p2pk-ed25519",
+		makeAddr: func() (Address, error) {
+			// From pubkey for privkey 0x00...01.
+			pkHex := "cecc1507dc1ddd7295951c290888f095adb9044d1b73d696e6df065d683bd4fc"
+			pk := hexToBytes(pkHex)
+			return NewAddressPubKeyEd25519Raw(0, pk, mainNetParams)
+		},
+		makeErr:   nil,
+		addr:      "DkM5zR8tqWNAHngZQDTyAeqzabZxMKrkSbCFULDhmvySn3uHmm221",
+		net:       mainNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "20cecc1507dc1ddd7295951c290888f095adb9044d1b73d696e6df065d683bd4fc51be",
+	}, {
+		name: "mainnet p2pk-ed25519 via concrete constructor",
+		makeAddr: func() (Address, error) {
+			// From pubkey for privkey 0x00...01.
+			pkHex := "cecc1507dc1ddd7295951c290888f095adb9044d1b73d696e6df065d683bd4fc"
+			pk, err := edwards.ParsePubKey(hexToBytes(pkHex))
+			if err != nil {
+				return nil, err
+			}
+			return NewAddressPubKeyEd25519(0, pk, mainNetParams)
+		},
+		makeErr:   nil,
+		addr:      "DkM5zR8tqWNAHngZQDTyAeqzabZxMKrkSbCFULDhmvySn3uHmm221",
+		net:       mainNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "20cecc1507dc1ddd7295951c290888f095adb9044d1b73d696e6df065d683bd4fc51be",
+	}, {
+		name: "testnet p2pk-ed25519",
+		makeAddr: func() (Address, error) {
+			// From pubkey for privkey 0x00...01.
+			pkHex := "cecc1507dc1ddd7295951c290888f095adb9044d1b73d696e6df065d683bd4fc"
+			pk := hexToBytes(pkHex)
+			return NewAddressPubKeyEd25519Raw(0, pk, testNetParams)
+		},
+		makeErr:   nil,
+		addr:      "TkKp4jynaSAyyV5FooNX3UBGzeXhxYq7e96YtjbRS5XEaar5zFom4",
+		net:       testNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "20cecc1507dc1ddd7295951c290888f095adb9044d1b73d696e6df065d683bd4fc51be",
+	}, {
+		name: "testnet p2pk-ed25519 via concrete constructor",
+		makeAddr: func() (Address, error) {
+			// From pubkey for privkey 0x00...01.
+			pkHex := "cecc1507dc1ddd7295951c290888f095adb9044d1b73d696e6df065d683bd4fc"
+			pk, err := edwards.ParsePubKey(hexToBytes(pkHex))
+			if err != nil {
+				return nil, err
+			}
+			return NewAddressPubKeyEd25519(0, pk, testNetParams)
+		},
+		makeErr:   nil,
+		addr:      "TkKp4jynaSAyyV5FooNX3UBGzeXhxYq7e96YtjbRS5XEaar5zFom4",
+		net:       testNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "20cecc1507dc1ddd7295951c290888f095adb9044d1b73d696e6df065d683bd4fc51be",
+	}, {
+		name: "regnet p2pk-ed25519",
+		makeAddr: func() (Address, error) {
+			// From pubkey for privkey 0x00...01.
+			pkHex := "cecc1507dc1ddd7295951c290888f095adb9044d1b73d696e6df065d683bd4fc"
+			pk := hexToBytes(pkHex)
+			return NewAddressPubKeyEd25519Raw(0, pk, regNetParams)
+		},
+		makeErr:   nil,
+		addr:      "Rk44TM8ZWqLsuaLr37pH7jNvB31oEPuzGBrvSvZ729Qs9GfoiBryE",
+		net:       regNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "20cecc1507dc1ddd7295951c290888f095adb9044d1b73d696e6df065d683bd4fc51be",
 	}}
 
 	for _, test := range tests {
@@ -629,6 +744,15 @@ func TestDecodeAddressV0Corners(t *testing.T) {
 	}, {
 		name:      "p2pk-ecdsa-secp256k1 malformed pubkey via decode",
 		addr:      "3tWTcxjUnAKTzHh8pHPYpSsUKVbTvziNGHtbBFQkY12khQWuW83p",
+		net:       mainNetParams,
+		decodeErr: ErrMalformedAddressData,
+	}, {
+		// ---------------------------------------------------------------------
+		// Negative P2PK Ed25519 tests.
+		// ---------------------------------------------------------------------
+
+		name:      "p2pk-ed25519 malformed pubkey (only 31 bytes) via decode",
+		addr:      "3tWUQtEa3P4SDQwjER81wkTxe4kiYLgNAso3pt2X5k3NFHRVQeNv",
 		net:       mainNetParams,
 		decodeErr: ErrMalformedAddressData,
 	}}

--- a/internal/staging/stdaddr/address_test.go
+++ b/internal/staging/stdaddr/address_test.go
@@ -753,6 +753,80 @@ func TestAddresses(t *testing.T) {
 		commitScript: "bb76a914f15da1cb8d1bcb162c6ab446c95757a6e791c91688ac",
 		revokeScript: "bc76a914f15da1cb8d1bcb162c6ab446c95757a6e791c91688ac",
 		trsyScript:   "c376a914f15da1cb8d1bcb162c6ab446c95757a6e791c91688ac",
+	}, {
+		// ---------------------------------------------------------------------
+		// Negative P2PKH ed25519 tests.
+		// ---------------------------------------------------------------------
+
+		name: "p2pkh-ed25519 wrong hash length",
+		makeAddr: func() (Address, error) {
+			hash := hexToBytes("000ef030107fd26e0b6bf40512bca2ceb1dd80adaa")
+			return NewAddressPubKeyHashEd25519(0, hash, mainNetParams)
+		},
+		makeErr: ErrInvalidHashLen,
+	}, {
+		name: "p2pkh-ed25519 unsupported script version",
+		makeAddr: func() (Address, error) {
+			hash := hexToBytes("0ef030107fd26e0b6bf40512bca2ceb1dd80adaa")
+			return NewAddressPubKeyHashEd25519(9999, hash, mainNetParams)
+		},
+		makeErr: ErrUnsupportedScriptVersion,
+	}, {
+		// ---------------------------------------------------------------------
+		// Positive P2PKH Ed25519 tests.
+		// ---------------------------------------------------------------------
+
+		name: "mainnet p2pkh-ed25519",
+		makeAddr: func() (Address, error) {
+			// From pubkey for privkey 0x00...01.
+			hash := hexToBytes("456d8ee57a4b9121987b4ecab8c3bcb5797e8a53")
+			return NewAddressPubKeyHashEd25519(0, hash, mainNetParams)
+		},
+		makeErr:   nil,
+		addr:      "DeeUhrRoTp4DftsqddVW96yMGMW4sgQFYUE",
+		net:       mainNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "76a914456d8ee57a4b9121987b4ecab8c3bcb5797e8a538851be",
+	}, {
+		name: "mainnet p2pkh-ed25519 2",
+		makeAddr: func() (Address, error) {
+			// From pubkey for privkey 0x00...02.
+			hash := hexToBytes("09788a8dcb216efa354e487d57d76255b1af4320")
+			return NewAddressPubKeyHashEd25519(0, hash, mainNetParams)
+		},
+		makeErr:   nil,
+		addr:      "DeZ1gU2ta8auk5et79R74GYR3pnF31KXbFo",
+		net:       mainNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "76a91409788a8dcb216efa354e487d57d76255b1af43208851be",
+	}, {
+		name: "testnet p2pkh-ed25519",
+		makeAddr: func() (Address, error) {
+			// From pubkey for privkey 0x00...01.
+			hash := hexToBytes("456d8ee57a4b9121987b4ecab8c3bcb5797e8a53")
+			return NewAddressPubKeyHashEd25519(0, hash, testNetParams)
+		},
+		makeErr:   nil,
+		addr:      "TeeXvqZJrc7KnFZCT27fHfzcrTTzSF1aSRG",
+		net:       testNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "76a914456d8ee57a4b9121987b4ecab8c3bcb5797e8a538851be",
+	}, {
+		name: "regnet p2pkh-ed25519",
+		makeAddr: func() (Address, error) {
+			// From pubkey for privkey 0x00...01.
+			hash := hexToBytes("456d8ee57a4b9121987b4ecab8c3bcb5797e8a53")
+			return NewAddressPubKeyHashEd25519(0, hash, regNetParams)
+		},
+		makeErr:   nil,
+		addr:      "ReMrcHBAbQyQZuHuQwsQBXkxVZgXpnbqX72",
+		net:       regNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "76a914456d8ee57a4b9121987b4ecab8c3bcb5797e8a538851be",
 	}}
 
 	for _, test := range tests {
@@ -949,6 +1023,11 @@ func TestAddresses(t *testing.T) {
 		switch a := decodedAddr.(type) {
 		case *AddressPubKeyEcdsaSecp256k1V0:
 			id := test.net.AddrIDPubKeyHashECDSAV0()
+			wantPkhAddr = base58.CheckEncode(Hash160(a.serializedPubKey), id)
+			pkhAddr = a.AddressPubKeyHash()
+
+		case *AddressPubKeyEd25519V0:
+			id := test.net.AddrIDPubKeyHashEd25519V0()
 			wantPkhAddr = base58.CheckEncode(Hash160(a.serializedPubKey), id)
 			pkhAddr = a.AddressPubKeyHash()
 		}

--- a/internal/staging/stdaddr/address_test.go
+++ b/internal/staging/stdaddr/address_test.go
@@ -827,6 +827,76 @@ func TestAddresses(t *testing.T) {
 		decodeErr: nil,
 		version:   0,
 		payScript: "76a914456d8ee57a4b9121987b4ecab8c3bcb5797e8a538851be",
+	}, {
+		// ---------------------------------------------------------------------
+		// Negative P2PKH Schnorr secp256k1 tests.
+		// ---------------------------------------------------------------------
+
+		name: "p2pkh-schnorr-secp256k1 wrong hash length",
+		makeAddr: func() (Address, error) {
+			hash := hexToBytes("000ef030107fd26e0b6bf40512bca2ceb1dd80adaa")
+			return NewAddressPubKeyHashSchnorrSecp256k1(0, hash, mainNetParams)
+		},
+		makeErr: ErrInvalidHashLen,
+	}, {
+		name: "p2pkh-schnorr-secp256k1 unsupported script version",
+		makeAddr: func() (Address, error) {
+			hash := hexToBytes("0ef030107fd26e0b6bf40512bca2ceb1dd80adaa")
+			return NewAddressPubKeyHashSchnorrSecp256k1(9999, hash, mainNetParams)
+		},
+		makeErr: ErrUnsupportedScriptVersion,
+	}, {
+		// ---------------------------------------------------------------------
+		// Positive P2PKH Schnorr secp256k1 tests.
+		// ---------------------------------------------------------------------
+
+		name: "mainnet p2pkh-schnorr-secp256k1",
+		makeAddr: func() (Address, error) {
+			hash := hexToBytes("2789d58cfa0957d206f025c2af056fc8a77cebb0")
+			return NewAddressPubKeyHashSchnorrSecp256k1(0, hash, mainNetParams)
+		},
+		makeErr:   nil,
+		addr:      "DSXcZv4oSRiEoWL2a9aD8sgfptRo1YEXNKj",
+		net:       mainNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "76a9142789d58cfa0957d206f025c2af056fc8a77cebb08852be",
+	}, {
+		name: "mainnet p2pkh-schnorr-secp256k1 2",
+		makeAddr: func() (Address, error) {
+			hash := hexToBytes("229ebac30efd6a69eec9c1a48e048b7c975c25f2")
+			return NewAddressPubKeyHashSchnorrSecp256k1(0, hash, mainNetParams)
+		},
+		makeErr:   nil,
+		addr:      "DSXAZZwbBmmqzdTxnxRgDN1kxEqA4xJfufA",
+		net:       mainNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "76a914229ebac30efd6a69eec9c1a48e048b7c975c25f28852be",
+	}, {
+		name: "testnet p2pkh-schnorr-secp256k1",
+		makeAddr: func() (Address, error) {
+			hash := hexToBytes("f15da1cb8d1bcb162c6ab446c95757a6e791c916")
+			return NewAddressPubKeyHashSchnorrSecp256k1(0, hash, testNetParams)
+		},
+		makeErr:   nil,
+		addr:      "TSr4xSiznUfzxkJcH7F3xuaFCUBdEb5Jfzg",
+		net:       testNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "76a914f15da1cb8d1bcb162c6ab446c95757a6e791c9168852be",
+	}, {
+		name: "regnet p2pkh-sep256k1-schnorr",
+		makeAddr: func() (Address, error) {
+			hash := hexToBytes("f15da1cb8d1bcb162c6ab446c95757a6e791c916")
+			return NewAddressPubKeyHashSchnorrSecp256k1(0, hash, regNetParams)
+		},
+		makeErr:   nil,
+		addr:      "RSZPdtLrXHY5kQ3KF2znrmLaqaQAdB3CRu7",
+		net:       regNetParams,
+		decodeErr: nil,
+		version:   0,
+		payScript: "76a914f15da1cb8d1bcb162c6ab446c95757a6e791c9168852be",
 	}}
 
 	for _, test := range tests {
@@ -1028,6 +1098,11 @@ func TestAddresses(t *testing.T) {
 
 		case *AddressPubKeyEd25519V0:
 			id := test.net.AddrIDPubKeyHashEd25519V0()
+			wantPkhAddr = base58.CheckEncode(Hash160(a.serializedPubKey), id)
+			pkhAddr = a.AddressPubKeyHash()
+
+		case *AddressPubKeySchnorrSecp256k1V0:
+			id := test.net.AddrIDPubKeyHashSchnorrV0()
 			wantPkhAddr = base58.CheckEncode(Hash160(a.serializedPubKey), id)
 			pkhAddr = a.AddressPubKeyHash()
 		}

--- a/internal/staging/stdaddr/address_test.go
+++ b/internal/staging/stdaddr/address_test.go
@@ -651,6 +651,108 @@ func TestAddresses(t *testing.T) {
 		decodeErr: nil,
 		version:   0,
 		payScript: "21030844ee70d8384d5250e9bb3a6a73d4b5bec770e8b31d6a0ae9fb739009d91af552be",
+	}, {
+		// ---------------------------------------------------------------------
+		// Negative P2PKH ECDSA secp256k1 tests.
+		// ---------------------------------------------------------------------
+
+		name: "p2pkh-ecdsa-secp256k1 wrong hash length",
+		makeAddr: func() (Address, error) {
+			hash := hexToBytes("000ef030107fd26e0b6bf40512bca2ceb1dd80adaa")
+			return NewAddressPubKeyHashEcdsaSecp256k1(0, hash, mainNetParams)
+		},
+		makeErr: ErrInvalidHashLen,
+	}, {
+		name: "p2pkh-ecdsa-secp256k1 unsupported script version",
+		makeAddr: func() (Address, error) {
+			hash := hexToBytes("2789d58cfa0957d206f025c2af056fc8a77cebb0")
+			return NewAddressPubKeyHashEcdsaSecp256k1(9999, hash, mainNetParams)
+		},
+		makeErr: ErrUnsupportedScriptVersion,
+	}, {
+		// ---------------------------------------------------------------------
+		// Positive P2PKH ECDSA secp256k1 tests.
+		// ---------------------------------------------------------------------
+
+		name: "mainnet p2pkh-ecdsa-secp256k1",
+		makeAddr: func() (Address, error) {
+			hash := hexToBytes("2789d58cfa0957d206f025c2af056fc8a77cebb0")
+			return NewAddressPubKeyHashEcdsaSecp256k1(0, hash, mainNetParams)
+		},
+		makeErr:      nil,
+		addr:         "DsUZxxoHJSty8DCfwfartwTYbuhmVct7tJu",
+		net:          mainNetParams,
+		decodeErr:    nil,
+		version:      0,
+		payScript:    "76a9142789d58cfa0957d206f025c2af056fc8a77cebb088ac",
+		voteScript:   "ba76a9142789d58cfa0957d206f025c2af056fc8a77cebb088ac",
+		rewardAmount: 1e8,
+		feeLimits:    0x5800,
+		rewardScript: "6a1e2789d58cfa0957d206f025c2af056fc8a77cebb000e1f505000000000058",
+		changeScript: "bd76a9142789d58cfa0957d206f025c2af056fc8a77cebb088ac",
+		commitScript: "bb76a9142789d58cfa0957d206f025c2af056fc8a77cebb088ac",
+		revokeScript: "bc76a9142789d58cfa0957d206f025c2af056fc8a77cebb088ac",
+		trsyScript:   "c376a9142789d58cfa0957d206f025c2af056fc8a77cebb088ac",
+	}, {
+		name: "mainnet p2pkh-ecdsa-secp256k1 2",
+		makeAddr: func() (Address, error) {
+			hash := hexToBytes("229ebac30efd6a69eec9c1a48e048b7c975c25f2")
+			return NewAddressPubKeyHashEcdsaSecp256k1(0, hash, mainNetParams)
+		},
+		makeErr:      nil,
+		addr:         "DsU7xcg53nxaKLLcAUSKyRndjG78Z2VZnX9",
+		net:          mainNetParams,
+		decodeErr:    nil,
+		version:      0,
+		payScript:    "76a914229ebac30efd6a69eec9c1a48e048b7c975c25f288ac",
+		voteScript:   "ba76a914229ebac30efd6a69eec9c1a48e048b7c975c25f288ac",
+		rewardAmount: 9556193632,
+		feeLimits:    0x5900,
+		rewardScript: "6a1e229ebac30efd6a69eec9c1a48e048b7c975c25f260f19739020000000059",
+		changeScript: "bd76a914229ebac30efd6a69eec9c1a48e048b7c975c25f288ac",
+		commitScript: "bb76a914229ebac30efd6a69eec9c1a48e048b7c975c25f288ac",
+		revokeScript: "bc76a914229ebac30efd6a69eec9c1a48e048b7c975c25f288ac",
+		trsyScript:   "c376a914229ebac30efd6a69eec9c1a48e048b7c975c25f288ac",
+	}, {
+		name: "testnet p2pkh-ecdsa-secp256k1",
+		makeAddr: func() (Address, error) {
+			hash := hexToBytes("f15da1cb8d1bcb162c6ab446c95757a6e791c916")
+			return NewAddressPubKeyHashEcdsaSecp256k1(0, hash, testNetParams)
+		},
+		makeErr:      nil,
+		addr:         "Tso2MVTUeVrjHTBFedFhiyM7yVTbieqp91h",
+		net:          testNetParams,
+		decodeErr:    nil,
+		version:      0,
+		payScript:    "76a914f15da1cb8d1bcb162c6ab446c95757a6e791c91688ac",
+		voteScript:   "ba76a914f15da1cb8d1bcb162c6ab446c95757a6e791c91688ac",
+		rewardAmount: 2428220961,
+		feeLimits:    0x5800,
+		rewardScript: "6a1ef15da1cb8d1bcb162c6ab446c95757a6e791c91621b6bb90000000000058",
+		changeScript: "bd76a914f15da1cb8d1bcb162c6ab446c95757a6e791c91688ac",
+		commitScript: "bb76a914f15da1cb8d1bcb162c6ab446c95757a6e791c91688ac",
+		revokeScript: "bc76a914f15da1cb8d1bcb162c6ab446c95757a6e791c91688ac",
+		trsyScript:   "c376a914f15da1cb8d1bcb162c6ab446c95757a6e791c91688ac",
+	}, {
+		name: "regnet p2pkh-sep256k1-ecdsa",
+		makeAddr: func() (Address, error) {
+			hash := hexToBytes("f15da1cb8d1bcb162c6ab446c95757a6e791c916")
+			return NewAddressPubKeyHashEcdsaSecp256k1(0, hash, regNetParams)
+		},
+		makeErr:      nil,
+		addr:         "RsWM2w5LPJip56uxcZ1Scq7Tcbg97EfiwPA",
+		net:          regNetParams,
+		decodeErr:    nil,
+		version:      0,
+		payScript:    "76a914f15da1cb8d1bcb162c6ab446c95757a6e791c91688ac",
+		voteScript:   "ba76a914f15da1cb8d1bcb162c6ab446c95757a6e791c91688ac",
+		rewardAmount: 2428220961,
+		feeLimits:    0x5800,
+		rewardScript: "6a1ef15da1cb8d1bcb162c6ab446c95757a6e791c91621b6bb90000000000058",
+		changeScript: "bd76a914f15da1cb8d1bcb162c6ab446c95757a6e791c91688ac",
+		commitScript: "bb76a914f15da1cb8d1bcb162c6ab446c95757a6e791c91688ac",
+		revokeScript: "bc76a914f15da1cb8d1bcb162c6ab446c95757a6e791c91688ac",
+		trsyScript:   "c376a914f15da1cb8d1bcb162c6ab446c95757a6e791c91688ac",
 	}}
 
 	for _, test := range tests {
@@ -838,6 +940,24 @@ func TestAddresses(t *testing.T) {
 			t.Errorf("%s: mismatched decoded stringer -- got %v, want %v",
 				test.name, ds.String(), test.addr)
 			continue
+		}
+
+		// Ensure the AddressPubKeyHash method for the address types that
+		// support it returns the expected address.
+		var pkhAddr Address
+		var wantPkhAddr string
+		switch a := decodedAddr.(type) {
+		case *AddressPubKeyEcdsaSecp256k1V0:
+			id := test.net.AddrIDPubKeyHashECDSAV0()
+			wantPkhAddr = base58.CheckEncode(Hash160(a.serializedPubKey), id)
+			pkhAddr = a.AddressPubKeyHash()
+		}
+		if pkhAddr != nil {
+			gotAddr := pkhAddr.Address()
+			if gotAddr != wantPkhAddr {
+				t.Errorf("%s: mismatched pkh address -- got %s, want %s",
+					test.name, gotAddr, wantPkhAddr)
+			}
 		}
 
 		// Ensure the Hash160 method for the addresses that support it returns

--- a/internal/staging/stdaddr/address_test.go
+++ b/internal/staging/stdaddr/address_test.go
@@ -1,0 +1,457 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package stdaddr
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/decred/base58"
+	"github.com/decred/dcrd/crypto/ripemd160"
+)
+
+// mockAddrParams implements the AddressParams interface and is used throughout
+// the tests to mock multiple networks.
+type mockAddrParams struct {
+	pubKeyID     [2]byte
+	pkhEcdsaID   [2]byte
+	pkhEd25519ID [2]byte
+	pkhSchnorrID [2]byte
+	scriptHashID [2]byte
+	privKeyID    [2]byte
+}
+
+// AddrIDPubKeyV0 returns the magic prefix bytes associated with the mock params
+// for version 0 pay-to-pubkey addresses.
+//
+// This is part of the AddressParams interface.
+func (p *mockAddrParams) AddrIDPubKeyV0() [2]byte {
+	return p.pubKeyID
+}
+
+// AddrIDPubKeyHashECDSAV0 returns the magic prefix bytes associated with the
+// mock params for version 0 pay-to-pubkey-hash addresses where the underlying
+// pubkey is secp256k1 and the signature algorithm is ECDSA.
+//
+// This is part of the AddressParams interface.
+func (p *mockAddrParams) AddrIDPubKeyHashECDSAV0() [2]byte {
+	return p.pkhEcdsaID
+}
+
+// AddrIDPubKeyHashEd25519V0 returns the magic prefix bytes associated with the
+// mock params for version 0 pay-to-pubkey-hash addresses where the underlying
+// pubkey and signature algorithm are Ed25519.
+//
+// This is part of the AddressParams interface.
+func (p *mockAddrParams) AddrIDPubKeyHashEd25519V0() [2]byte {
+	return p.pkhEd25519ID
+}
+
+// AddrIDPubKeyHashSchnorrV0 returns the magic prefix bytes associated with the
+// mock params for version 0 pay-to-pubkey-hash addresses where the underlying
+// pubkey is secp256k1 and the signature algorithm is Schnorr.
+//
+// This is part of the AddressParams interface.
+func (p *mockAddrParams) AddrIDPubKeyHashSchnorrV0() [2]byte {
+	return p.pkhSchnorrID
+}
+
+// AddrIDScriptHashV0 returns the magic prefix bytes associated with the mock
+// params for version 0 pay-to-script-hash addresses.
+//
+// This is part of the AddressParams interface.
+func (p *mockAddrParams) AddrIDScriptHashV0() [2]byte {
+	return p.scriptHashID
+}
+
+// mockMainNetParams returns mock mainnet address parameters to use throughout
+// the tests.  They match the Decred mainnet params as of the time this comment
+// was written.
+func mockMainNetParams() *mockAddrParams {
+	return &mockAddrParams{
+		pubKeyID:     [2]byte{0x13, 0x86}, // starts with Dk
+		pkhEcdsaID:   [2]byte{0x07, 0x3f}, // starts with Ds
+		pkhEd25519ID: [2]byte{0x07, 0x1f}, // starts with De
+		pkhSchnorrID: [2]byte{0x07, 0x01}, // starts with DS
+		scriptHashID: [2]byte{0x07, 0x1a}, // starts with Dc
+		privKeyID:    [2]byte{0x22, 0xde}, // starts with Pm
+	}
+}
+
+// mockTestNetParams returns mock testnet address parameters to use throughout
+// the tests.  They match the Decred testnet params as of the time this comment
+// was written.
+func mockTestNetParams() *mockAddrParams {
+	return &mockAddrParams{
+		pubKeyID:     [2]byte{0x28, 0xf7}, // starts with Tk
+		pkhEcdsaID:   [2]byte{0x0f, 0x21}, // starts with Ts
+		pkhEd25519ID: [2]byte{0x0f, 0x01}, // starts with Te
+		pkhSchnorrID: [2]byte{0x0e, 0xe3}, // starts with TS
+		scriptHashID: [2]byte{0x0e, 0xfc}, // starts with Tc
+		privKeyID:    [2]byte{0x23, 0x0e}, // starts with Pt
+	}
+}
+
+// TestAddresses ensures that address-related APIs work as intended including
+// that they are properly encoded and decoded, that they produce the expected
+// payment-related scripts, and that error paths fail as expected.  For
+// addresses that implement the stake address interface, the stake-related
+// scripts are also tested.
+func TestAddresses(t *testing.T) {
+	mainNetParams := mockMainNetParams()
+	testNetParams := mockTestNetParams()
+
+	type newAddrFn func() (Address, error)
+	tests := []struct {
+		name         string        // test description
+		makeAddr     newAddrFn     // function to construct new address via API
+		makeErr      error         // expected error from new address function
+		addr         string        // expected address and address to decode
+		net          AddressParams // params for network
+		decodeErr    error         // expected error from decode
+		version      uint16        // expected scripts version
+		payScript    string        // hex-encoded expected payment script
+		voteScript   string        // hex-encoded expected voting rights script
+		rewardAmount int64         // reward commitment amount
+		feeLimits    uint16        // reward fee limits commitment
+		rewardScript string        // hex-encoded expected reward commitment script
+		changeScript string        // hex-encoded expected stake change script
+		commitScript string        // hex-encoded expected vote commitment script
+		revokeScript string        // hex-encoded expected revoke commitment script
+		trsyScript   string        // hex-encoded expected pay from treasury script
+	}{{
+		// ---------------------------------------------------------------------
+		// Misc decoding error tests.
+		// ---------------------------------------------------------------------
+
+		name:      "bad checksum",
+		addr:      "TsmWaPM77WSyA3aiQ2Q1KnwGDVWvEkhip23",
+		net:       testNetParams,
+		decodeErr: ErrBadAddressChecksum,
+	}, {
+		name:      "parse valid mainnet address with testnet rejected",
+		addr:      "DsUZxxoHJSty8DCfwfartwTYbuhmVct7tJu",
+		net:       testNetParams,
+		decodeErr: ErrUnsupportedAddress,
+	}, {
+		name:      "mainnet p2pk with no data for pubkey",
+		addr:      "Aiz5jz1s",
+		net:       mainNetParams,
+		decodeErr: ErrUnsupportedAddress,
+	}, {
+		name:      "invalid base58 (l not in base58 alphabet)",
+		addr:      "DsUZxxoHlSty8DCfwfartwTYbuhmVct7tJu",
+		net:       mainNetParams,
+		decodeErr: ErrUnsupportedAddress,
+	}}
+
+	for _, test := range tests {
+		// Create address from test constructor and ensure it produces the
+		// expected encoded address when the constructor is specified.
+		if test.makeAddr != nil {
+			addr, err := test.makeAddr()
+			if !errors.Is(err, test.makeErr) {
+				t.Errorf("%s: mismatched err -- got %v, want %v", test.name, err,
+					test.makeErr)
+				continue
+			}
+			if err != nil {
+				continue
+			}
+
+			// Ensure encoding the address is the same as the original.
+			encoded := addr.Address()
+			if encoded != test.addr {
+				t.Errorf("%s: unexpected address -- got %v, want %v", test.name,
+					encoded, test.addr)
+				continue
+			}
+		}
+
+		// Decode address and ensure the expected error is received.
+		decodedAddr, err := DecodeAddress(test.addr, test.net)
+		if !errors.Is(err, test.decodeErr) {
+			t.Errorf("%s: mismatched err -- got %v, want %v", test.name, err,
+				test.decodeErr)
+			continue
+		}
+		if err != nil {
+			continue
+		}
+
+		// Ensure the payment script version and contents are the expected
+		// values.
+		wantPayScript, err := hex.DecodeString(test.payScript)
+		if err != nil {
+			t.Errorf("%s: unexpected hex decode err: %v", test.name, err)
+			continue
+		}
+		gotPayScriptVersion, gotPayScript := decodedAddr.PaymentScript()
+		if gotPayScriptVersion != test.version {
+			t.Errorf("%s: mismatched payment script version -- got %d, want %d",
+				test.name, gotPayScriptVersion, test.version)
+			continue
+		}
+		if !bytes.Equal(gotPayScript, wantPayScript) {
+			t.Errorf("%s: mismatched payment script -- got %x, want %x",
+				test.name, gotPayScript, wantPayScript)
+			continue
+		}
+
+		// Ensure stake-specific interface results produce the expected values.
+		if stakeAddr, ok := decodedAddr.(StakeAddress); ok {
+			// Ensure the voting rights script version and contents are the
+			// expected values.
+			wantScript, err := hex.DecodeString(test.voteScript)
+			if err != nil {
+				t.Errorf("%s: unexpected hex decode err: %v", test.name, err)
+				continue
+			}
+			gotScriptVer, gotScript := stakeAddr.VotingRightsScript()
+			if gotScriptVer != test.version {
+				t.Errorf("%s: mismatched voting rights script version -- got "+
+					"%d, want %d", test.name, gotScriptVer,
+					test.version)
+				continue
+			}
+			if !bytes.Equal(gotScript, wantScript) {
+				t.Errorf("%s: mismatched voting rights script -- got %x, want %x",
+					test.name, gotScript, wantScript)
+				continue
+			}
+
+			// Ensure the reward commitment script version and contents are the
+			// expected values.
+			wantScript, err = hex.DecodeString(test.rewardScript)
+			if err != nil {
+				t.Errorf("%s: unexpected hex decode err: %v", test.name, err)
+				continue
+			}
+			gotScriptVer, gotScript = stakeAddr.RewardCommitmentScript(
+				test.rewardAmount, test.feeLimits)
+			if gotScriptVer != test.version {
+				t.Errorf("%s: mismatched reward cmt script version -- got %d, "+
+					"want %d", test.name, gotScriptVer, test.version)
+				continue
+			}
+			if !bytes.Equal(gotScript, wantScript) {
+				t.Errorf("%s: mismatched reward cmt script -- got %x, want %x",
+					test.name, gotScript, wantScript)
+				continue
+			}
+
+			// Ensure the stake change script version and contents are the
+			// expected values.
+			wantScript, err = hex.DecodeString(test.changeScript)
+			if err != nil {
+				t.Errorf("%s: unexpected hex decode err: %v", test.name, err)
+				continue
+			}
+			gotScriptVer, gotScript = stakeAddr.StakeChangeScript()
+			if gotScriptVer != test.version {
+				t.Errorf("%s: mismatched change script version -- got %d, "+
+					"want %d", test.name, gotScriptVer, test.version)
+				continue
+			}
+			if !bytes.Equal(gotScript, wantScript) {
+				t.Errorf("%s: mismatched change script -- got %x, want %x",
+					test.name, gotScript, wantScript)
+				continue
+			}
+
+			// Ensure the vote commitment script version and contents are the
+			// expected values.
+			wantScript, err = hex.DecodeString(test.commitScript)
+			if err != nil {
+				t.Errorf("%s: unexpected hex decode err: %v", test.name, err)
+				continue
+			}
+			gotScriptVer, gotScript = stakeAddr.PayVoteCommitmentScript()
+			if gotScriptVer != test.version {
+				t.Errorf("%s: mismatched vote commit script version -- got %d, "+
+					"want %d", test.name, gotScriptVer, test.version)
+				continue
+			}
+			if !bytes.Equal(gotScript, wantScript) {
+				t.Errorf("%s: mismatched vote commit script -- got %x, want %x",
+					test.name, gotScript, wantScript)
+				continue
+			}
+
+			// Ensure the revoke commitment script version and contents are the
+			// expected values.
+			wantScript, err = hex.DecodeString(test.revokeScript)
+			if err != nil {
+				t.Errorf("%s: unexpected hex decode err: %v", test.name, err)
+				continue
+			}
+			gotScriptVer, gotScript = stakeAddr.PayRevokeCommitmentScript()
+			if gotScriptVer != test.version {
+				t.Errorf("%s: mismatched revoke cmt script version -- got %d, "+
+					"want %d", test.name, gotScriptVer, test.version)
+				continue
+			}
+			if !bytes.Equal(gotScript, wantScript) {
+				t.Errorf("%s: mismatched revoke cmt script -- got %x, want %x",
+					test.name, gotScript, wantScript)
+				continue
+			}
+
+			// Ensure the pay from treasury script version and contents are the
+			// expected values.
+			wantScript, err = hex.DecodeString(test.trsyScript)
+			if err != nil {
+				t.Errorf("%s: unexpected hex decode err: %v", test.name, err)
+				continue
+			}
+			gotScriptVer, gotScript = stakeAddr.PayFromTreasuryScript()
+			if gotScriptVer != test.version {
+				t.Errorf("%s: mismatched treasury change script version -- "+
+					"got %d, want %d", test.name, gotScriptVer, test.version)
+				continue
+			}
+			if !bytes.Equal(gotScript, wantScript) {
+				t.Errorf("%s: mismatched treasury change script -- got %x, "+
+					"want %x", test.name, gotScript, wantScript)
+				continue
+			}
+		}
+
+		// Ensure encoding the address is the same as the original.
+		encoded := decodedAddr.Address()
+		if encoded != test.addr {
+			t.Errorf("%s: decoding and encoding produced different addresses "+
+				"-- got %v, want %v", test.name, encoded, test.addr)
+			continue
+		}
+
+		// Ensure the stringer returns the same address as the original.
+		if ds, ok := decodedAddr.(fmt.Stringer); ok && ds.String() != test.addr {
+			t.Errorf("%s: mismatched decoded stringer -- got %v, want %v",
+				test.name, ds.String(), test.addr)
+			continue
+		}
+
+		// Ensure the Hash160 method for the addresses that support it returns
+		// the expected value.
+		if h160er, ok := decodedAddr.(Hash160er); ok {
+			decodedBytes := base58.Decode(test.addr)
+			wantH160 := decodedBytes[2 : 2+ripemd160.Size]
+			if gotH160 := h160er.Hash160()[:]; !bytes.Equal(gotH160, wantH160) {
+				t.Errorf("%s: mismatched hash160 -- got %x, want %x", test.name,
+					gotH160, wantH160)
+				return
+			}
+		}
+	}
+}
+
+// TestDecodeAddressV0Corners ensures that some additional errors that are
+// specific to decoding version 0 addresses directly, as opposed to via the
+// generic API, work as intended.  This is necessary because the generic address
+// decoding function contains additional logic to avoid even attempting to
+// decode addresses which can't possibly be one of the supported version 0
+// address types, while the version 0 decoding logic specifically attempts to
+// decode the address in order to provide more detailed errors.
+func TestDecodeAddressV0Corners(t *testing.T) {
+	mainNetParams := mockMainNetParams()
+
+	tests := []struct {
+		name      string        // test description
+		addr      string        // expected address and address to decode
+		net       AddressParams // params for network
+		decodeErr error         // expected error from decode
+	}{{
+		// ---------------------------------------------------------------------
+		// Misc decoding error tests.
+		// ---------------------------------------------------------------------
+
+		name:      "mainnet p2pk with no data for pubkey",
+		addr:      "Aiz5jz1s",
+		net:       mainNetParams,
+		decodeErr: ErrMalformedAddressData,
+	}, {
+		name:      "invalid base58 (l not in base58 alphabet)",
+		addr:      "DsUZxxoHlSty8DCfwfartwTYbuhmVct7tJu",
+		net:       mainNetParams,
+		decodeErr: ErrMalformedAddress,
+	}}
+
+	for _, test := range tests {
+		_, err := DecodeAddressV0(test.addr, test.net)
+		if !errors.Is(err, test.decodeErr) {
+			t.Errorf("%s: mismatched err -- got %v, want %v", test.name, err,
+				test.decodeErr)
+			continue
+		}
+	}
+}
+
+// TestProbablyV0Base58Addr ensures the function that determines if an address
+// is probably a base58 address works as intended by checking off by ones and
+// ensuring all allowed characters in the modified base58 alphabet are accepted.
+func TestProbablyV0Base58Addr(t *testing.T) {
+	tests := []struct {
+		name string // test description
+		str  string // string to test
+		want bool   // expected result
+	}{{
+		name: "all allowed base58 chars part 1",
+		str:  "123456789ABCDEFGHJKLMNPQRSTUVWXYZab",
+		want: true,
+	}, {
+		name: "all allowed base58 chars part 2",
+		str:  "QRSTUVWXYZabcdefghijkmnopqrstuvwxyz",
+		want: true,
+	}, {
+		name: "invalid base58 (0 not in base58 alphabet, one less than '1')",
+		str:  "DsUZxxoH0Sty8DCfwfartwTYbuhmVct7tJu",
+		want: false,
+	}, {
+		name: "invalid base58 ({ not in base58 alphabet, one more than 'z')",
+		str:  "DsUZxxoH{Sty8DCfwfartwTYbuhmVct7tJu",
+		want: false,
+	}, {
+		name: "invalid base58 (I not in base58 alphabet)",
+		str:  "DsUZxxoHISty8DCfwfartwTYbuhmVct7tJu",
+		want: false,
+	}, {
+		name: "invalid base58 (O not in base58 alphabet)",
+		str:  "DsUZxxoHOSty8DCfwfartwTYbuhmVct7tJu",
+		want: false,
+	}, {
+		name: "invalid base58 (l not in base58 alphabet)",
+		str:  "DsUZxxoHlSty8DCfwfartwTYbuhmVct7tJu",
+		want: false,
+	}, {
+		name: "invalid base58 (: not in base58 alphabet, one more than '9')",
+		str:  "DsUZxxoH:Sty8DCfwfartwTYbuhmVct7tJu",
+		want: false,
+	}, {
+		name: "invalid base58 (@ not in base58 alphabet, one less than 'A')",
+		str:  "DsUZxxoH@Sty8DCfwfartwTYbuhmVct7tJu",
+		want: false,
+	}, {
+		name: "invalid base58 ([ not in base58 alphabet, one more than 'Z')",
+		str:  "DsUZxxoH[Sty8DCfwfartwTYbuhmVct7tJu",
+		want: false,
+	}, {
+		name: "invalid base58 (` not in base58 alphabet, one less than 'a')",
+		str:  "DsUZxxoH`Sty8DCfwfartwTYbuhmVct7tJu",
+		want: false,
+	}}
+
+	for _, test := range tests {
+		got := probablyV0Base58Addr(test.str)
+		if got != test.want {
+			t.Errorf("%q: unexpected result -- got %v, want %v", test.name, got,
+				test.want)
+			continue
+		}
+	}
+}

--- a/internal/staging/stdaddr/addressv0.go
+++ b/internal/staging/stdaddr/addressv0.go
@@ -13,6 +13,16 @@ import (
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 )
 
+// These are redefinitions of version 0 opcodes in the txscript package that are
+// used in this package to generate payment scripts.  Ultimately, this should be
+// using the constant definitions from txscript instead, but it would currently
+// create a cyclic dependency since txscript will need to depend on this package
+// for signing.
+const (
+	opData33   = 0x21
+	opCheckSig = 0xac
+)
+
 const (
 	// sigTypeSecp256k1PubKeyCompOddFlag specifies the bitmask to apply to the
 	// pubkey address signature type byte for those that deal with compressed
@@ -46,6 +56,146 @@ type AddressParamsV0 interface {
 	// AddrIDScriptHashV0 returns the magic prefix bytes for version 0
 	// pay-to-script-hash addresses.
 	AddrIDScriptHashV0() [2]byte
+}
+
+// encodeAddressV0 returns a human-readable payment address for the data and
+// netID which encodes the network and address type using the format for version
+// 0 scripts.
+func encodeAddressV0(data []byte, netID [2]byte) string {
+	// The overall format for an address for version 0 scripts is the base58
+	// check encoding of data which varies by address type.  In other words, it
+	// is:
+	//
+	//   2-byte network and address type || data || 4-byte checksum
+	return base58.CheckEncode(data, netID)
+}
+
+// AddressPubKeyEcdsaSecp256k1V0 specifies an address that represents a payment
+// destination which imposes an encumbrance that requires a valid ECDSA
+// signature for a specific secp256k1 public key.
+//
+// This is commonly referred to as pay-to-pubkey (P2PK) for legacy reasons,
+// however, since it is possible to support multiple algorithm and signature
+// scheme combinations, it is technically more accurate to refer to it as
+// pay-to-pubkey-ecdsa-secp256k1.
+type AddressPubKeyEcdsaSecp256k1V0 struct {
+	pubKeyID         [2]byte
+	pubKeyHashID     [2]byte
+	serializedPubKey []byte
+}
+
+// Ensure AddressPubKeyEcdsaSecp256k1V0 implements the Address interface.
+var _ Address = (*AddressPubKeyEcdsaSecp256k1V0)(nil)
+
+// NewAddressPubKeyEcdsaSecp256k1V0Raw returns an address that represents a
+// payment destination which imposes an encumbrance that requires a valid ECDSA
+// signature for a specific secp256k1 public key using version 0 scripts.
+//
+// The provided public key MUST be a valid secp256k1 public key serialized in
+// the _compressed_ format or an error will be returned.
+//
+// See NewAddressPubKeyEcdsaSecp256k1V0 for a variant that accepts the public
+// key as a concrete type instance instead.
+//
+// This function can be useful to callers who already need the serialized public
+// key for other purposes to avoid the need to serialize it multiple times.
+func NewAddressPubKeyEcdsaSecp256k1V0Raw(serializedPubKey []byte,
+	params AddressParamsV0) (*AddressPubKeyEcdsaSecp256k1V0, error) {
+
+	// Attempt to parse the provided public key to ensure it is both a valid
+	// serialization and that it is a valid point on the secp256k1 curve.
+	_, err := secp256k1.ParsePubKey(serializedPubKey)
+	if err != nil {
+		str := fmt.Sprintf("failed to parse public key: %v", err)
+		return nil, makeError(ErrInvalidPubKey, str)
+	}
+
+	// Ensure the provided serialized public key is in the compressed format.
+	// This probably should be returned from secp256k1, but do it here to avoid
+	// API churn.  The pubkey is known to be valid since it parsed above, so
+	// it's safe to simply examine the leading byte to get the format.
+	//
+	// Notice that both the uncompressed and hybrid forms are intentionally not
+	// supported.
+	switch serializedPubKey[0] {
+	case secp256k1.PubKeyFormatCompressedEven:
+	case secp256k1.PubKeyFormatCompressedOdd:
+	default:
+		str := fmt.Sprintf("serialized public key %x is not a valid format",
+			serializedPubKey)
+		return nil, makeError(ErrInvalidPubKeyFormat, str)
+	}
+
+	return &AddressPubKeyEcdsaSecp256k1V0{
+		pubKeyID:         params.AddrIDPubKeyV0(),
+		pubKeyHashID:     params.AddrIDPubKeyHashECDSAV0(),
+		serializedPubKey: serializedPubKey,
+	}, nil
+}
+
+// NewAddressPubKeyEcdsaSecp256k1V0 returns an address that represents a
+// payment destination which imposes an encumbrance that requires a valid ECDSA
+// signature for a specific secp256k1 public key using version 0 scripts.
+//
+// See NewAddressPubKeyEcdsaSecp256k1V0Raw for a variant that accepts the public
+// key already serialized in the _compressed_ format instead of a concrete type.
+// It can be useful to callers who already need the serialized public key for
+// other purposes to avoid the need to serialize it multiple times.
+func NewAddressPubKeyEcdsaSecp256k1V0(pubKey Secp256k1PublicKey,
+	params AddressParamsV0) (*AddressPubKeyEcdsaSecp256k1V0, error) {
+
+	return &AddressPubKeyEcdsaSecp256k1V0{
+		pubKeyID:         params.AddrIDPubKeyV0(),
+		pubKeyHashID:     params.AddrIDPubKeyHashECDSAV0(),
+		serializedPubKey: pubKey.SerializeCompressed(),
+	}, nil
+}
+
+// Address returns the string encoding of the payment address for the associated
+// script version and payment script.
+//
+// This is part of the Address interface implementation.
+func (addr *AddressPubKeyEcdsaSecp256k1V0) Address() string {
+	// The format for the data portion of a public key address used with
+	// elliptic curves is:
+	//   identifier byte || 32-byte X coordinate
+	//
+	// The identifier byte specifies the curve and signature scheme combination
+	// as well as encoding the oddness of the Y coordinate for secp256k1 public
+	// keys in the high bit.
+	var data [33]byte
+	data[0] = byte(dcrec.STEcdsaSecp256k1)
+	if addr.serializedPubKey[0] == secp256k1.PubKeyFormatCompressedOdd {
+		data[0] |= sigTypeSecp256k1PubKeyCompOddFlag
+	}
+	copy(data[1:], addr.serializedPubKey[1:])
+	return encodeAddressV0(data[:], addr.pubKeyID)
+}
+
+// PaymentScript returns the script version associated with the address along
+// with a script to pay a transaction output to the address.
+//
+// This is part of the Address interface implementation.
+func (addr *AddressPubKeyEcdsaSecp256k1V0) PaymentScript() (uint16, []byte) {
+	// A pay-to-pubkey-ecdsa-secp256k1 script is one of the following forms:
+	//  <33-byte compressed pubkey> CHECKSIG
+	//  <65-byte uncompressed pubkey> CHECKSIG
+	//
+	// However, this address type intentionally only supports the compressed
+	// form.
+	var script [35]byte
+	script[0] = opData33
+	copy(script[1:34], addr.serializedPubKey)
+	script[34] = opCheckSig
+	return 0, script[:]
+}
+
+// String returns a human-readable string for the address.
+//
+// This is equivalent to calling Address, but is provided so the type can be
+// used as a fmt.Stringer.
+func (addr *AddressPubKeyEcdsaSecp256k1V0) String() string {
+	return addr.Address()
 }
 
 // DecodeAddressV0 decodes the string encoding of an address and returns the

--- a/internal/staging/stdaddr/addressv0.go
+++ b/internal/staging/stdaddr/addressv0.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package stdaddr
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/decred/base58"
+	"github.com/decred/dcrd/dcrec"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+)
+
+const (
+	// sigTypeSecp256k1PubKeyCompOddFlag specifies the bitmask to apply to the
+	// pubkey address signature type byte for those that deal with compressed
+	// secp256k1 pubkeys to specify the omitted y coordinate is odd.
+	sigTypeSecp256k1PubKeyCompOddFlag = uint8(1 << 7)
+)
+
+// AddressParamsV0 defines an interface that is used to provide the parameters
+// required when encoding and decoding addresses for version 0 scripts.  These
+// values are typically well-defined and unique per network.
+type AddressParamsV0 interface {
+	// AddrIDPubKeyV0 returns the magic prefix bytes for version 0 pay-to-pubkey
+	// addresses.
+	AddrIDPubKeyV0() [2]byte
+
+	// AddrIDPubKeyHashECDSAV0 returns the magic prefix bytes for version 0
+	// pay-to-pubkey-hash addresses where the underlying pubkey is secp256k1 and
+	// the signature algorithm is ECDSA.
+	AddrIDPubKeyHashECDSAV0() [2]byte
+
+	// AddrIDPubKeyHashEd25519V0 returns the magic prefix bytes for version 0
+	// pay-to-pubkey-hash addresses where the underlying pubkey and signature
+	// algorithm are Ed25519.
+	AddrIDPubKeyHashEd25519V0() [2]byte
+
+	// AddrIDPubKeyHashSchnorrV0 returns the magic prefix bytes for version 0
+	// pay-to-pubkey-hash addresses where the underlying pubkey is secp256k1 and
+	// the signature algorithm is Schnorr.
+	AddrIDPubKeyHashSchnorrV0() [2]byte
+
+	// AddrIDScriptHashV0 returns the magic prefix bytes for version 0
+	// pay-to-script-hash addresses.
+	AddrIDScriptHashV0() [2]byte
+}
+
+// DecodeAddressV0 decodes the string encoding of an address and returns the
+// relevant Address if it is a valid encoding for a known version 0 address type
+// and is for the network identified by the provided parameters.
+func DecodeAddressV0(addr string, params AddressParamsV0) (Address, error) {
+	// Attempt to decode the address and address type.
+	decoded, addrID, err := base58.CheckDecode(addr)
+	if err != nil {
+		kind := ErrMalformedAddress
+		if errors.Is(err, base58.ErrChecksum) {
+			kind = ErrBadAddressChecksum
+		}
+		str := fmt.Sprintf("failed to decoded address %q: %v", addr, err)
+		return nil, makeError(kind, str)
+	}
+
+	// Decode the address according to the address type.
+	switch addrID {
+	case params.AddrIDScriptHashV0():
+		return NewAddressScriptHashFromHash(0, decoded, params)
+
+	case params.AddrIDPubKeyHashECDSAV0():
+		return NewAddressPubKeyHashEcdsaSecp256k1(0, decoded, params)
+
+	case params.AddrIDPubKeyHashSchnorrV0():
+		return NewAddressPubKeyHashSchnorrSecp256k1(0, decoded, params)
+
+	case params.AddrIDPubKeyHashEd25519V0():
+		return NewAddressPubKeyHashEd25519(0, decoded, params)
+
+	case params.AddrIDPubKeyV0():
+		// Ensure the decoded data has the expected signature type identifier
+		// byte.
+		if len(decoded) < 1 {
+			str := fmt.Sprintf("address %q decoded data is empty", addr)
+			return nil, makeError(ErrMalformedAddressData, str)
+		}
+
+		// Decode according to the crypto algorithm and signature scheme.
+		sigType := decoded[0] & ^sigTypeSecp256k1PubKeyCompOddFlag
+		switch dcrec.SignatureType(sigType) {
+		case dcrec.STEcdsaSecp256k1:
+			// The encoded data for this case is the 32-byte X coordinate for a
+			// secp256k1 public key along with the oddness of the Y coordinate
+			// encoded via the high bit of the first byte.
+			//
+			// Reconstruct the standard compressed serialized public key format
+			// by choosing the correct prefix byte depending on the encoded
+			// Y-coordinate oddness pass it along to the constructor of the
+			// appropriate type to validate and return the relevant address
+			// instance.
+			const reqPubKeyLen = 33
+			if len(decoded) != reqPubKeyLen {
+				str := fmt.Sprintf("public key is %d bytes vs required %d bytes",
+					len(decoded), reqPubKeyLen)
+				return nil, makeError(ErrMalformedAddressData, str)
+			}
+			isOddY := decoded[0]&sigTypeSecp256k1PubKeyCompOddFlag != 0
+			prefix := secp256k1.PubKeyFormatCompressedEven
+			if isOddY {
+				prefix = secp256k1.PubKeyFormatCompressedOdd
+			}
+			decoded[0] = prefix
+			return NewAddressPubKeyEcdsaSecp256k1Raw(0, decoded, params)
+
+		case dcrec.STEd25519:
+			const reqPubKeyLen = 32
+			pubKey := decoded[1:]
+			if len(pubKey) != reqPubKeyLen {
+				str := fmt.Sprintf("public key is %d bytes vs required %d bytes",
+					len(pubKey), reqPubKeyLen)
+				return nil, makeError(ErrMalformedAddressData, str)
+			}
+
+			// The encoded data for this case is the actual Ed25519 public key,
+			// so just pass it along unaltered to the constructor of the
+			// appropriate type to validate and return the relevant address
+			// instance.
+			return NewAddressPubKeyEd25519Raw(0, pubKey, params)
+
+		case dcrec.STSchnorrSecp256k1:
+			// The encoded data for this case is the 32-byte X coordinate for a
+			// secp256k1 public key along with the oddness of the Y coordinate
+			// encoded via the high bit of the first byte.
+			//
+			// Reconstruct the standard compressed serialized public key format
+			// by choosing the correct prefix byte depending on the encoded
+			// Y-coordinate oddness pass it along to the constructor of the
+			// appropriate type to validate and return the relevant address
+			// instance.
+			const reqPubKeyLen = 33
+			if len(decoded) != reqPubKeyLen {
+				str := fmt.Sprintf("public key is %d bytes vs required %d bytes",
+					len(decoded), reqPubKeyLen)
+				return nil, makeError(ErrMalformedAddressData, str)
+			}
+			isOddY := decoded[0]&sigTypeSecp256k1PubKeyCompOddFlag != 0
+			prefix := secp256k1.PubKeyFormatCompressedEven
+			if isOddY {
+				prefix = secp256k1.PubKeyFormatCompressedOdd
+			}
+			decoded[0] = prefix
+			return NewAddressPubKeySchnorrSecp256k1Raw(0, decoded, params)
+		}
+	}
+
+	str := fmt.Sprintf("address %q is not a supported type", addr)
+	return nil, makeError(ErrUnsupportedAddress, str)
+}

--- a/internal/staging/stdaddr/bench_test.go
+++ b/internal/staging/stdaddr/bench_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package stdaddr
+
+import (
+	"testing"
+
+	"github.com/decred/dcrd/chaincfg/v3"
+)
+
+// BenchmarkDecode benchmarks the performance of decoding various types of
+// addresses.
+func BenchmarkDecode(b *testing.B) {
+	mainNetParams := chaincfg.MainNetParams()
+
+	benches := []struct {
+		name   string // benchmark name
+		addr   string // address to decode
+		params AddressParams
+	}{{
+		name:   "v0 p2sh",
+		addr:   "DcuQKx8BES9wU7C6Q5VmLBjw436r27hayjS",
+		params: mainNetParams,
+	}, {
+		name:   "v0 p2pkh-ecdsa-secp256k1",
+		addr:   "DsUZxxoHJSty8DCfwfartwTYbuhmVct7tJu",
+		params: mainNetParams,
+	}, {
+		name:   "v0 p2pkh-ed25519",
+		addr:   "DeeUhrRoTp4DftsqddVW96yMGMW4sgQFYUE",
+		params: mainNetParams,
+	}, {
+		name:   "v0 p2pkh-schnorr-secp256k1",
+		addr:   "DSXcZv4oSRiEoWL2a9aD8sgfptRo1YEXNKj",
+		params: mainNetParams,
+	}, {
+		name:   "v0 p2pk-ecdsa-secp256k1",
+		addr:   "DkM3ZigNyiwHrsXRjkDQ8t8tW6uKGW9g61qEkG3bMqQPQWYEf5X3J",
+		params: mainNetParams,
+	}, {
+		name:   "v0 p2pk-ed25519",
+		addr:   "DkM5zR8tqWNAHngZQDTyAeqzabZxMKrkSbCFULDhmvySn3uHmm221",
+		params: mainNetParams,
+	}, {
+		name:   "v0 p2pk-schnorr-secp256k1",
+		addr:   "DkM7TD2qsne9DKo4uA2ZNt3XhejYVwT5mmQWtUXtjdPhRHXTSKxN4",
+		params: mainNetParams,
+	}}
+
+	for _, bench := range benches {
+		b.Run(bench.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := DecodeAddress(bench.addr, bench.params)
+				if err != nil {
+					b.Fatalf("%q: unexpected error: %v", bench.name, err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkPaymentScript benchmarks the performance of generating payment
+// scripts for various types of addresses.
+func BenchmarkPaymentScript(b *testing.B) {
+	mainNetParams := chaincfg.MainNetParams()
+
+	benches := []struct {
+		name   string // benchmark name
+		addr   string // address to decode
+		params AddressParams
+	}{{
+		name:   "v0 p2sh",
+		addr:   "DcuQKx8BES9wU7C6Q5VmLBjw436r27hayjS",
+		params: mainNetParams,
+	}, {
+		name:   "v0 p2pkh-ecdsa-secp256k1",
+		addr:   "DsUZxxoHJSty8DCfwfartwTYbuhmVct7tJu",
+		params: mainNetParams,
+	}, {
+		name:   "v0 p2pkh-ed25519",
+		addr:   "DeeUhrRoTp4DftsqddVW96yMGMW4sgQFYUE",
+		params: mainNetParams,
+	}, {
+		name:   "v0 p2pkh-schnorr-secp256k1",
+		addr:   "DSXcZv4oSRiEoWL2a9aD8sgfptRo1YEXNKj",
+		params: mainNetParams,
+	}, {
+		name:   "v0 p2pk-ecdsa-secp256k1",
+		addr:   "DkM3ZigNyiwHrsXRjkDQ8t8tW6uKGW9g61qEkG3bMqQPQWYEf5X3J",
+		params: mainNetParams,
+	}, {
+		name:   "v0 p2pk-ed25519",
+		addr:   "DkM5zR8tqWNAHngZQDTyAeqzabZxMKrkSbCFULDhmvySn3uHmm221",
+		params: mainNetParams,
+	}, {
+		name:   "v0 p2pk-schnorr-secp256k1",
+		addr:   "DkM7TD2qsne9DKo4uA2ZNt3XhejYVwT5mmQWtUXtjdPhRHXTSKxN4",
+		params: mainNetParams,
+	}}
+
+	for _, bench := range benches {
+		addr, err := DecodeAddress(bench.addr, bench.params)
+		if err != nil {
+			b.Fatalf("%q: unexpected error: %v", bench.name, err)
+		}
+		b.Run(bench.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _ = addr.PaymentScript()
+			}
+		})
+	}
+}

--- a/internal/staging/stdaddr/error.go
+++ b/internal/staging/stdaddr/error.go
@@ -16,6 +16,17 @@ const (
 	// ErrUnsupportedScriptVersion indicates that an address type does not
 	// support a given script version.
 	ErrUnsupportedScriptVersion = ErrorKind("ErrUnsupportedScriptVersion")
+
+	// ErrMalformedAddress indicates an address failed to decode.
+	ErrMalformedAddress = ErrorKind("ErrMalformedAddress")
+
+	// ErrMalformedAddressData indicates an address successfully decoded and is
+	// a recognized type, but the encoded data is not the expected length.
+	ErrMalformedAddressData = ErrorKind("ErrMalformedAddressData")
+
+	// ErrBadAddressChecksum indicates an address failed to decode due to an
+	// invalid checksum.
+	ErrBadAddressChecksum = ErrorKind("ErrBadAddressChecksum")
 )
 
 // Error satisfies the error interface and prints human-readable errors.

--- a/internal/staging/stdaddr/error.go
+++ b/internal/staging/stdaddr/error.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package stdaddr
+
+// ErrorKind identifies a kind of error.
+type ErrorKind string
+
+// These constants are used to identify a specific ErrorKind.
+const (
+	// ErrUnsupportedAddress indicates that an address successfully decoded, but
+	// is not a supported/recognized type.
+	ErrUnsupportedAddress = ErrorKind("ErrUnsupportedAddress")
+
+	// ErrUnsupportedScriptVersion indicates that an address type does not
+	// support a given script version.
+	ErrUnsupportedScriptVersion = ErrorKind("ErrUnsupportedScriptVersion")
+)
+
+// Error satisfies the error interface and prints human-readable errors.
+func (e ErrorKind) Error() string {
+	return string(e)
+}
+
+// Error identifies an address-related error.
+//
+// It has full support for errors.Is and errors.As, so the caller can ascertain
+// the specific reason for the error by checking the underlying error.
+type Error struct {
+	Err         error
+	Description string
+}
+
+// Error satisfies the error interface and prints human-readable errors.
+func (e Error) Error() string {
+	return e.Description
+}
+
+// Unwrap returns the underlying wrapped error.
+func (e Error) Unwrap() error {
+	return e.Err
+}
+
+// makeError creates an Error given a set of arguments.
+func makeError(kind ErrorKind, desc string) Error {
+	return Error{Err: kind, Description: desc}
+}

--- a/internal/staging/stdaddr/error.go
+++ b/internal/staging/stdaddr/error.go
@@ -35,6 +35,10 @@ const (
 	// ErrInvalidPubKeyFormat indicates that a serialized public key parsed
 	// successfully, but is not one of the allowed formats.
 	ErrInvalidPubKeyFormat = ErrorKind("ErrInvalidPubKeyFormat")
+
+	// ErrInvalidHashLen indicates that either a public key hash or a script
+	// hash is not an allowed length.
+	ErrInvalidHashLen = ErrorKind("ErrInvalidHashLen")
 )
 
 // Error satisfies the error interface and prints human-readable errors.

--- a/internal/staging/stdaddr/error.go
+++ b/internal/staging/stdaddr/error.go
@@ -27,6 +27,14 @@ const (
 	// ErrBadAddressChecksum indicates an address failed to decode due to an
 	// invalid checksum.
 	ErrBadAddressChecksum = ErrorKind("ErrBadAddressChecksum")
+
+	// ErrInvalidPubKey indicates that a serialized public key failed to
+	// parse.
+	ErrInvalidPubKey = ErrorKind("ErrInvalidPubKey")
+
+	// ErrInvalidPubKeyFormat indicates that a serialized public key parsed
+	// successfully, but is not one of the allowed formats.
+	ErrInvalidPubKeyFormat = ErrorKind("ErrInvalidPubKeyFormat")
 )
 
 // Error satisfies the error interface and prints human-readable errors.

--- a/internal/staging/stdaddr/error_test.go
+++ b/internal/staging/stdaddr/error_test.go
@@ -23,6 +23,7 @@ func TestErrorKindStringer(t *testing.T) {
 		{ErrBadAddressChecksum, "ErrBadAddressChecksum"},
 		{ErrInvalidPubKey, "ErrInvalidPubKey"},
 		{ErrInvalidPubKeyFormat, "ErrInvalidPubKeyFormat"},
+		{ErrInvalidHashLen, "ErrInvalidHashLen"},
 	}
 
 	for i, test := range tests {

--- a/internal/staging/stdaddr/error_test.go
+++ b/internal/staging/stdaddr/error_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package stdaddr
+
+import (
+	"errors"
+	"io"
+	"testing"
+)
+
+// TestErrorKindStringer tests the stringized output for the ErrorKind type.
+func TestErrorKindStringer(t *testing.T) {
+	tests := []struct {
+		in   ErrorKind
+		want string
+	}{
+		{ErrUnsupportedAddress, "ErrUnsupportedAddress"},
+		{ErrUnsupportedScriptVersion, "ErrUnsupportedScriptVersion"},
+	}
+
+	for i, test := range tests {
+		result := test.in.Error()
+		if result != test.want {
+			t.Errorf("#%d: got: %s want: %s", i, result, test.want)
+			continue
+		}
+	}
+}
+
+// TestError tests the error output for the Error type.
+func TestError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   Error
+		want string
+	}{{
+		Error{Description: "some error"},
+		"some error",
+	}, {
+		Error{Description: "human-readable error"},
+		"human-readable error",
+	}}
+
+	for i, test := range tests {
+		result := test.in.Error()
+		if result != test.want {
+			t.Errorf("#%d: got: %s want: %s", i, result, test.want)
+			continue
+		}
+	}
+}
+
+// TestErrorKindIsAs ensures both ErrorKind and Error can be identified as being
+// a specific error kind via errors.Is and unwrapped via errors.As.
+func TestErrorKindIsAs(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		target    error
+		wantMatch bool
+		wantAs    ErrorKind
+	}{{
+		name:      "ErrUnsupportedAddress == ErrUnsupportedAddress",
+		err:       ErrUnsupportedAddress,
+		target:    ErrUnsupportedAddress,
+		wantMatch: true,
+		wantAs:    ErrUnsupportedAddress,
+	}, {
+		name:      "Error.ErrUnsupportedAddress == ErrUnsupportedAddress",
+		err:       makeError(ErrUnsupportedAddress, ""),
+		target:    ErrUnsupportedAddress,
+		wantMatch: true,
+		wantAs:    ErrUnsupportedAddress,
+	}, {
+		name:      "ErrUnsupportedAddress != ErrUnsupportedScriptVersion",
+		err:       ErrUnsupportedAddress,
+		target:    ErrUnsupportedScriptVersion,
+		wantMatch: false,
+		wantAs:    ErrUnsupportedAddress,
+	}, {
+		name:      "Error.ErrUnsupportedAddress != ErrUnsupportedScriptVersion",
+		err:       makeError(ErrUnsupportedAddress, ""),
+		target:    ErrUnsupportedScriptVersion,
+		wantMatch: false,
+		wantAs:    ErrUnsupportedAddress,
+	}, {
+		name:      "ErrUnsupportedAddress != Error.ErrUnsupportedScriptVersion",
+		err:       ErrUnsupportedAddress,
+		target:    makeError(ErrUnsupportedScriptVersion, ""),
+		wantMatch: false,
+		wantAs:    ErrUnsupportedAddress,
+	}, {
+		name:      "Error.ErrUnsupportedAddress != Error.ErrUnsupportedScriptVersion",
+		err:       makeError(ErrUnsupportedAddress, ""),
+		target:    makeError(ErrUnsupportedScriptVersion, ""),
+		wantMatch: false,
+		wantAs:    ErrUnsupportedAddress,
+	}, {
+		name:      "Error.ErrUnsupportedAddress != io.EOF",
+		err:       makeError(ErrUnsupportedAddress, ""),
+		target:    io.EOF,
+		wantMatch: false,
+		wantAs:    ErrUnsupportedAddress,
+	}}
+
+	for _, test := range tests {
+		// Ensure the error matches or not depending on the expected result.
+		result := errors.Is(test.err, test.target)
+		if result != test.wantMatch {
+			t.Errorf("%s: incorrect error identification -- got %v, want %v",
+				test.name, result, test.wantMatch)
+			continue
+		}
+
+		// Ensure the underlying error kind can be unwrapped is and is the
+		// expected kind.
+		var kind ErrorKind
+		if !errors.As(test.err, &kind) {
+			t.Errorf("%s: unable to unwrap to error kind", test.name)
+			continue
+		}
+		if kind != test.wantAs {
+			t.Errorf("%s: unexpected unwrapped error kind -- got %v, want %v",
+				test.name, kind, test.wantAs)
+			continue
+		}
+	}
+}

--- a/internal/staging/stdaddr/error_test.go
+++ b/internal/staging/stdaddr/error_test.go
@@ -18,6 +18,9 @@ func TestErrorKindStringer(t *testing.T) {
 	}{
 		{ErrUnsupportedAddress, "ErrUnsupportedAddress"},
 		{ErrUnsupportedScriptVersion, "ErrUnsupportedScriptVersion"},
+		{ErrMalformedAddress, "ErrMalformedAddress"},
+		{ErrMalformedAddressData, "ErrMalformedAddressData"},
+		{ErrBadAddressChecksum, "ErrBadAddressChecksum"},
 	}
 
 	for i, test := range tests {

--- a/internal/staging/stdaddr/error_test.go
+++ b/internal/staging/stdaddr/error_test.go
@@ -21,6 +21,8 @@ func TestErrorKindStringer(t *testing.T) {
 		{ErrMalformedAddress, "ErrMalformedAddress"},
 		{ErrMalformedAddressData, "ErrMalformedAddressData"},
 		{ErrBadAddressChecksum, "ErrBadAddressChecksum"},
+		{ErrInvalidPubKey, "ErrInvalidPubKey"},
+		{ErrInvalidPubKeyFormat, "ErrInvalidPubKeyFormat"},
 	}
 
 	for i, test := range tests {

--- a/internal/staging/stdaddr/example_test.go
+++ b/internal/staging/stdaddr/example_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package stdaddr_test
+
+import (
+	"fmt"
+
+	"github.com/decred/dcrd/chaincfg/v3"
+	"github.com/decred/dcrd/internal/staging/stdaddr"
+)
+
+// This example demonstrates decoding addresses, generating their payment
+// scripts and associated script versions, determining supported capabilities by
+// checking if interfaces are implemented, obtaining the associated underlying
+// hash160 for addresses that support it, converting public key addresses to
+// their public key hash variant, and generating stake-related scripts for
+// addresses that can be used in the staking system.
+func ExampleDecodeAddress() {
+	// Ordinarily addresses would be read from the user or the result of a
+	// derivation, but they are hard coded here for the purposes of this
+	// example.
+	simNetParams := chaincfg.SimNetParams()
+	addrsToDecode := []string{
+		// v0 pay-to-pubkey ecdsa
+		"SkLUJQxtYoVrewN6fwqsU6JQjxLs5a6xfcTsGfUYiLr2AUY6HuLMN",
+
+		// v0 pay-to-pubkey-hash ecdsa
+		"Sspzuh5xuvqxccYLWJDJjCtqp166NRxcaPB",
+
+		// v0 pay-to-pubkey schnorr
+		"SkLYBuKMSsCi1PdjqMf2i6D3wWB6K1QNMN39Qsxr68qLBFXMTwcpG",
+
+		// v0 pay-to-pubkey-hash schnorr
+		"SSt3WeMV3ufEHufh8nCey97y2yp7tNdPyES",
+
+		// v0 pay-to-script-hash
+		"ScrkZMau4jj7JUHUvU4YMMRRi4w1o3Wp1vY",
+	}
+	for idx, encodedAddr := range addrsToDecode {
+		addr, err := stdaddr.DecodeAddress(encodedAddr, simNetParams)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		// Obtain the payment script and associated script version that would
+		// ordinarily by used in a transaction output to send funds to the
+		// address.
+		scriptVer, script := addr.PaymentScript()
+		fmt.Printf("addr%d: %s\n", idx, addr)
+		fmt.Printf("  payment script version: %d\n", scriptVer)
+		fmt.Printf("  payment script: %x\n", script)
+
+		// Access the RIPEMD-160 hash from addresses that involve it.
+		if h160er, ok := addr.(stdaddr.Hash160er); ok {
+			fmt.Printf("  hash160: %x\n", *h160er.Hash160())
+		}
+
+		// Demonstrate converting public key addresses to the public key hash
+		// variant when supported.  This is primarily provided for convenience
+		// when the caller already happens to have the public key address handy
+		// such as in cases where public keys are shared through some protocol.
+		if pkHasher, ok := addr.(stdaddr.AddressPubKeyHasher); ok {
+			fmt.Printf("  p2pkh addr: %s\n", pkHasher.AddressPubKeyHash())
+		}
+
+		// Obtain stake-related scripts and associated script versions that
+		// would ordinarily be used in stake transactions such as ticket
+		// purchases and votes for supported addresses.
+		//
+		// Note that only very specific addresses can be used as destinations in
+		// the staking system and this approach provides a capabilities based
+		// mechanism to determine support.
+		if stakeAddr, ok := addr.(stdaddr.StakeAddress); ok {
+			// Obtain the voting rights script and associated script version
+			// that would ordinarily by used in a ticket purchase transaction to
+			// give voting rights to the address.
+			voteScriptVer, voteScript := stakeAddr.VotingRightsScript()
+			fmt.Printf("  voting rights script version: %d\n", voteScriptVer)
+			fmt.Printf("  voting rights script: %x\n", voteScript)
+
+			// Obtain the rewards commitment script and associated script
+			// version that would ordinarily by used in a ticket purchase
+			// transaction to commit the original funds locked plus the reward
+			// to the address.
+			//
+			// Ordinarily the reward amount and fee limits would need to be
+			// calculated correctly, but they are hard coded here for the
+			// purposes of this example.
+			const rewardAmount = 1e8
+			const feeLimit = 0x5800
+			rewardScriptVer, rewardScript := stakeAddr.RewardCommitmentScript(
+				rewardAmount, feeLimit)
+			fmt.Printf("  reward script version: %d\n", rewardScriptVer)
+			fmt.Printf("  reward script: %x\n", rewardScript)
+		}
+	}
+
+	// Output:
+	// addr0: SkLUJQxtYoVrewN6fwqsU6JQjxLs5a6xfcTsGfUYiLr2AUY6HuLMN
+	//   payment script version: 0
+	//   payment script: 210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac
+	//   p2pkh addr: Sspzuh5xuvqxccYLWJDJjCtqp166NRxcaPB
+	// addr1: Sspzuh5xuvqxccYLWJDJjCtqp166NRxcaPB
+	//   payment script version: 0
+	//   payment script: 76a914e280cb6e66b96679aec288b1fbdbd4db08077a1b88ac
+	//   hash160: e280cb6e66b96679aec288b1fbdbd4db08077a1b
+	//   voting rights script version: 0
+	//   voting rights script: ba76a914e280cb6e66b96679aec288b1fbdbd4db08077a1b88ac
+	//   reward script version: 0
+	//   reward script: 6a1ee280cb6e66b96679aec288b1fbdbd4db08077a1b00e1f505000000000058
+	// addr2: SkLYBuKMSsCi1PdjqMf2i6D3wWB6K1QNMN39Qsxr68qLBFXMTwcpG
+	//   payment script version: 0
+	//   payment script: 210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179852be
+	//   p2pkh addr: SSt3WeMV3ufEHufh8nCey97y2yp7tNdPyES
+	// addr3: SSt3WeMV3ufEHufh8nCey97y2yp7tNdPyES
+	//   payment script version: 0
+	//   payment script: 76a914e280cb6e66b96679aec288b1fbdbd4db08077a1b8852be
+	//   hash160: e280cb6e66b96679aec288b1fbdbd4db08077a1b
+	// addr4: ScrkZMau4jj7JUHUvU4YMMRRi4w1o3Wp1vY
+	//   payment script version: 0
+	//   payment script: a914ae7cd0a69b915796aa9318e1ad74f3579bfcb36587
+	//   hash160: ae7cd0a69b915796aa9318e1ad74f3579bfcb365
+	//   voting rights script version: 0
+	//   voting rights script: baa914ae7cd0a69b915796aa9318e1ad74f3579bfcb36587
+	//   reward script version: 0
+	//   reward script: 6a1eae7cd0a69b915796aa9318e1ad74f3579bfcb36500e1f505000000800058
+}


### PR DESCRIPTION
The current code for handling standard addresses implemented in `dcrutil` was written many years ago prior a wide variety of changes and several new features added by Decred.  As a result, it entirely lacks support for some features and supports others in a roundabout and non-intuitive way.

Specifically, it does not support or provide a clean path to enable support for different script versions and the way they are handled in stake transactions is entirely non-intuitive.

Further, back when the original address code was implemented, it was necessary to implement script creation in the `txscript` package which led to the current design of providing methods such as `txscript.PayTo{AddrScript,SStx,SStxChange}`, and others, which need to type assert the specific concrete types of addresses in order to produce the necessary scripts.  This, unfortunately, effectively negates the use of an interface to support generic addresses because it means callers, such as `dcrwallet`, are not able to implement their own types without somewhat invisibly breaking the script creation.

Finally, the aforementioned blending of the address code into `txscript` has led to confusion regarding what is considered standard and what is considered consensus which has tripped up several contributors over the years.

This aims to resolve all of the aforementioned issues by introducing a new package named `stdaddr` which entirely reworks the way addresses are handled.

It is split up into a series of commits to help ease the review process such that the initial generic infrastructure is introduced first, followed by the overall version 0 address decoding logic, then each supported version 0 address, followed by an example, and finally what I hope is a fairly complete `README.md` that describes the architecture.  Comprehensive tests are included.

For the time being, the package is introduced into the internal staging area for initial review.

The following provides an overview of some of the key features of the new design:

- Supports versioned addresses
- Produces scripts directly via methods implemented on underlying types
- Provides direct support for creation of the scripts necessary for the staking system
- Uses a capabilities-based approach via interfaces so callers can cleanly and generically determine under what circumstances addresses can be used
- Allows callers to create their own concrete address types without worrying about breaking the existing ones
- Clearly denotes that addresses are a standardized construction that must not be used directly in consensus code

Finally, although the primary goal here is not optimization, this also significantly reduces the execution time and number of allocations needed to produce the payment scripts as can be seen in the following benchmarks:

Name                       | old time/op | new time/op | delta
---------------------------|-------------|-------------|------
p2sh                       | 207ns ± 1%  | 39ns ± 1%   | -81.24%  (p=0.008 n=5+5)
p2pkh-ecdsa-secp256k1      | 219ns ± 2%  | 45ns ± 8%   | -79.44%  (p=0.008 n=5+5)
p2pkh-ed25519              | 235ns ± 2%  | 42ns ± 4%   | -82.30%  (p=0.008 n=5+5)
p2pkh-schnorr-secp256k1    | 232ns ± 1%  | 42ns ± 3%   | -81.99%  (p=0.008 n=5+5)
p2pk-ecdsa-secp256k1       | 276ns ± 1%  | 47ns ± 2%   | -83.10%  (p=0.008 n=5+5)
p2pk-ed25519               | 665ns ± 6%  | 47ns ± 1%   | -92.98%  (p=0.008 n=5+5)
p2pk-schnorr-secp256k1     | 283ns ± 1%  | 47ns ± 4%   | -83.47%  (p=0.008 n=5+5)

Name                    | old alloc/op | new alloc/op | delta
------------------------|--------------|--------------|------
p2sh                    | 512B ± 0%    | 24B ± 0%     | -95.31%  (p=0.008 n=5+5)
p2pkh-ecdsa-secp256k1   | 512B ± 0%    | 32B ± 0%     | -93.75%  (p=0.008 n=5+5)
p2pkh-ed25519           | 512B ± 0%    | 32B ± 0%     | -93.75%  (p=0.008 n=5+5)
p2pkh-schnorr-secp256k1 | 512B ± 0%    | 32B ± 0%     | -93.75%  (p=0.008 n=5+5)
p2pk-ecdsa-secp256k1    | 560B ± 0%    | 48B ± 0%     | -91.43%  (p=0.008 n=5+5)
p2pk-ed25519            | 640B ± 0%    | 48B ± 0%     | -92.50%  (p=0.008 n=5+5)
p2pk-schnorr-secp256k1  | 560B ± 0%    | 48B ± 0%     | -91.43%  (p=0.008 n=5+5)
