### PR TITLE
txscript: Add script bldr unchecked op add.

### DIFF
--- a/txscript/bench_test.go
+++ b/txscript/bench_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019 The Decred developers
+// Copyright (c) 2018-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -244,7 +244,7 @@ func BenchmarkGetPreciseSigOpCount(b *testing.B) {
 	// as the final data push so the benchmark will cover the p2sh path.
 	scriptHash := "0x0000000000000000000000000000000000000001"
 	pkScript := mustParseShortForm("HASH160 DATA_20 " + scriptHash + " EQUAL")
-	sigScript, err := NewScriptBuilder().AddFullData(redeemScript).Script()
+	sigScript, err := NewScriptBuilder().AddData(redeemScript).Script()
 	if err != nil {
 		b.Fatalf("failed to create signature script: %v", err)
 	}
@@ -269,7 +269,7 @@ func BenchmarkGetPreciseSigOpCountTreasury(b *testing.B) {
 	// as the final data push so the benchmark will cover the p2sh path.
 	scriptHash := "0x0000000000000000000000000000000000000001"
 	pkScript := mustParseShortForm("HASH160 DATA_20 " + scriptHash + " EQUAL")
-	sigScript, err := NewScriptBuilder().AddFullData(redeemScript).Script()
+	sigScript, err := NewScriptBuilder().AddDataUnchecked(redeemScript).Script()
 	if err != nil {
 		b.Fatalf("failed to create signature script: %v", err)
 	}

--- a/txscript/reference_test.go
+++ b/txscript/reference_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2017 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -185,7 +185,7 @@ func parseShortForm(script string) ([]byte, error) {
 
 		// Quoted data.
 		if len(tok) >= 2 && tok[0] == '\'' && tok[len(tok)-1] == '\'' {
-			builder.AddFullData([]byte(tok[1 : len(tok)-1]))
+			builder.AddDataUnchecked([]byte(tok[1 : len(tok)-1]))
 			return nil
 		}
 
@@ -196,7 +196,7 @@ func parseShortForm(script string) ([]byte, error) {
 				return fmt.Errorf("bad token %q", tok)
 			}
 			data := strings.Repeat(m[1], int(count))
-			builder.AddFullData([]byte(data))
+			builder.AddDataUnchecked([]byte(data))
 			return nil
 		}
 

--- a/txscript/reference_test.go
+++ b/txscript/reference_test.go
@@ -153,12 +153,10 @@ func parseShortForm(script string) ([]byte, error) {
 
 		// Raw data.
 		if bts, err := parseHex(tok); err == nil {
-			// Concatenate the bytes manually since the test code
+			// Use the unchecked variant since the test code
 			// intentionally creates scripts that are too large and
 			// would cause the builder to error otherwise.
-			if builder.err == nil {
-				builder.script = append(builder.script, bts...)
-			}
+			builder.AddOpsUnchecked(bts)
 			return nil
 		}
 
@@ -173,13 +171,11 @@ func parseShortForm(script string) ([]byte, error) {
 				return fmt.Errorf("bad token %q", tok)
 			}
 
-			// Concatenate the bytes manually since the test code
+			// Use the unchecked variant since the test code
 			// intentionally creates scripts that are too large and
 			// would cause the builder to error otherwise.
 			bts = bytes.Repeat(bts, int(count))
-			if builder.err == nil {
-				builder.script = append(builder.script, bts...)
-			}
+			builder.AddOpsUnchecked(bts)
 			return nil
 		}
 

--- a/txscript/scriptbuilder.go
+++ b/txscript/scriptbuilder.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -171,14 +171,14 @@ func (b *ScriptBuilder) addData(data []byte) *ScriptBuilder {
 	return b
 }
 
-// AddFullData should not typically be used by ordinary users as it does not
-// include the checks which prevent data pushes larger than the maximum allowed
-// sizes which leads to scripts that can't be executed.  This is provided for
-// testing purposes such as regression tests where sizes are intentionally made
-// larger than allowed.
+// AddDataUnchecked should not typically be used by ordinary users as it does
+// not include the checks which prevent data pushes larger than the maximum
+// allowed sizes which leads to scripts that can't be executed.  This is
+// provided for testing purposes such as regression tests where sizes are
+// intentionally made larger than allowed.
 //
 // Use AddData instead.
-func (b *ScriptBuilder) AddFullData(data []byte) *ScriptBuilder {
+func (b *ScriptBuilder) AddDataUnchecked(data []byte) *ScriptBuilder {
 	if b.err != nil {
 		return b
 	}

--- a/txscript/scriptbuilder.go
+++ b/txscript/scriptbuilder.go
@@ -53,6 +53,22 @@ type ScriptBuilder struct {
 	err    error
 }
 
+// AddOpsUnchecked should not typically be used by ordinary users as it does not
+// include the checks which prevent scripts from exceeding the largest allowed
+// script size which leads to scripts that can't be executed.  This is provided
+// for testing purposes such as regression tests where sizes are intentionally
+// made larger than allowed.
+//
+// Use AddOps instead.
+func (b *ScriptBuilder) AddOpsUnchecked(opcodes []byte) *ScriptBuilder {
+	if b.err != nil {
+		return b
+	}
+
+	b.script = append(b.script, opcodes...)
+	return b
+}
+
 // AddOp pushes the passed opcode to the end of the script.  The script will not
 // be modified if pushing the opcode would cause the script to exceed the
 // maximum allowed script engine size.

--- a/txscript/scriptnum_test.go
+++ b/txscript/scriptnum_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2015-2017 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 


### PR DESCRIPTION
This renames the `AddFullData` method of the `ScriptBuilder` to `AddDataUnchecked` to make its semantics more obvious and then adds a new method named `AddOpsUnchecked` that is similar to `AddDataUnchecked` in that it allows the limits that are ordinarily impose to be bypassed for regression testing purposes where sizes are intentionally made larger than allowed.

The motivation is to allow the script builder to be used in regression tests which exercise negative paths outside of the `txscript` package.

It also updates the test code to make use of the method instead of reaching into the internals to manually concatenate the opcodes.