### PR TITLE
blockchain: Allow alternate tips for current check.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1493,7 +1493,8 @@ func (b *BlockChain) maybeUpdateIsCurrent(curBest *blockNode) {
 		b.index.RLock()
 		bestHeader := b.index.bestHeader
 		b.index.RUnlock()
-		syncedToBestHeader := curBest.Ancestor(bestHeader.height) == bestHeader
+		syncedToBestHeader := curBest.height == bestHeader.height ||
+			curBest.Ancestor(bestHeader.height) == bestHeader
 		if !syncedToBestHeader {
 			return
 		}


### PR DESCRIPTION
This updates the check which determines whether the chain believes it is current to also detect when the current best chain tip is an alternative tip at the same height as the best header.

This is being done because the best header is determined based on when the block data was received during steady state operation to prevent miners being able to gain an unfair advantage, however, that order is intentionally not stored to the database since it only applies to steady state.  The result is that restarting the software when there are multiple chain tips might result in one of the other variants becoming the best header as compared to when it was shutdown and thus it will not match the current best block.