### PR TITLE
txscript: Accept raw public keys in MultiSigScript.

### DIFF
--- a/txscript/sign_test.go
+++ b/txscript/sign_test.go
@@ -2228,9 +2228,8 @@ func TestSignTxOutput(t *testing.T) {
 				break
 			}
 
-			pkScript, err := MultiSigScript(
-				[]*dcrutil.AddressSecpPubKey{address1, address2},
-				2)
+			pkScript, err := MultiSigScript(2, pk1.SerializeCompressed(),
+				pk2.SerializeCompressed())
 			if err != nil {
 				t.Errorf("failed to make pkscript "+
 					"for %s: %v", msg, err)
@@ -2336,9 +2335,8 @@ func TestSignTxOutput(t *testing.T) {
 				break
 			}
 
-			pkScript, err := MultiSigScript(
-				[]*dcrutil.AddressSecpPubKey{address1, address2},
-				2)
+			pkScript, err := MultiSigScript(2, pk1.SerializeCompressed(),
+				pk2.SerializeCompressed())
 			if err != nil {
 				t.Errorf("failed to make pkscript "+
 					"for %s: %v", msg, err)
@@ -2484,9 +2482,8 @@ func TestSignTxOutput(t *testing.T) {
 				break
 			}
 
-			pkScript, err := MultiSigScript(
-				[]*dcrutil.AddressSecpPubKey{address1, address2},
-				2)
+			pkScript, err := MultiSigScript(2, pk1.SerializeCompressed(),
+				pk2.SerializeCompressed())
 			if err != nil {
 				t.Errorf("failed to make pkscript "+
 					"for %s: %v", msg, err)


### PR DESCRIPTION
This modifies `MultiSigScript` to accept raw serialized variadic pubkeys instead of a fixed slice of addresses and updates the tests to be more consistent with the rest of the code.

It also now takes the required number of signatures (threshold) as the first parameter so it more closely matches the typical way threshold signatures are referred to.  Namely, `m-of-n` where `m` is the threshold and `n` is the number of pubkeys.

These style of multisig scripts involve public keys as opposed to addresses, and callers typically have the public key as opposed to an address already anyway, so the new API is more convenient, logical, and flexible.

Finally, in order to keep the semantics the same such that only compressed secp256k1 public keys are used, an additional check is added to reject the provided serialized public keys when they do not adhere to the strict compressed public key encoding requirements.