### PR TITLE
cpuminer: Remove unused MiningAddrs from Config.

### DIFF
--- a/internal/mining/cpuminer/cpuminer.go
+++ b/internal/mining/cpuminer/cpuminer.go
@@ -89,10 +89,6 @@ type Config struct {
 	// generate block templates that the miner will attempt to solve.
 	BgBlkTmplGenerator *mining.BgBlkTmplGenerator
 
-	// MiningAddrs is a list of payment addresses to use for the generated
-	// blocks.  Each generated block will randomly choose one of them.
-	MiningAddrs []dcrutil.Address
-
 	// ProcessBlock defines the function to call with any solved blocks.
 	// It typically must run the provided block through the same set of
 	// rules and handling as any other block coming from the network.

--- a/server.go
+++ b/server.go
@@ -3585,7 +3585,6 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 			ChainParams:                s.chainParams,
 			PermitConnectionlessMining: cfg.SimNet || cfg.RegNet,
 			BgBlkTmplGenerator:         s.bg,
-			MiningAddrs:                cfg.miningAddrs,
 			ProcessBlock:               s.syncManager.ProcessBlock,
 			ConnectedCount:             s.ConnectedCount,
 			IsCurrent:                  s.syncManager.IsCurrent,


### PR DESCRIPTION
This removes the unused `MiningAddrs` field from the `cpuminer` `Config` struct as the `cpuminer` no longer requires direct access to them after it was converted to make use of the background template generator.