### PR TITLE
multi: Convert to use new stdaddr package.

### DIFF
--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -21,6 +21,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/dcrutil/v4"
+	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -125,7 +126,7 @@ func TestBlockchainFunctions(t *testing.T) {
 			"want %v, got %v", expectedVal, val)
 	}
 
-	a, _ := dcrutil.DecodeAddress("SsbKpMkPnadDcZFFZqRPY8nvdFagrktKuzB", params)
+	a, _ := stdaddr.DecodeAddress("SsbKpMkPnadDcZFFZqRPY8nvdFagrktKuzB", params)
 	hs, err := chain.TicketsWithAddress(a, noTreasury)
 	if err != nil {
 		t.Errorf("Failed to do TicketsWithAddress: %v", err)

--- a/blockchain/chaingen/generator.go
+++ b/blockchain/chaingen/generator.go
@@ -468,15 +468,6 @@ func (g *Generator) CreateCoinbaseTx(blockHeight uint32, numVotes uint16) *wire.
 	return tx
 }
 
-// PurchaseCommitmentScript returns a standard provably-pruneable OP_RETURN
-// commitment script suitable for use in a ticket purchase tx (sstx) using the
-// provided target address, amount, and fee limits.
-func PurchaseCommitmentScript(addr stdaddr.StakeAddress, amount, voteFeeLimit, revocationFeeLimit dcrutil.Amount) []byte {
-	_, script := addr.RewardCommitmentScript(int64(amount), int64(voteFeeLimit),
-		int64(revocationFeeLimit))
-	return script
-}
-
 // CreateTicketPurchaseTx creates a new transaction that spends the provided
 // output to purchase a stake submission ticket (sstx) at the given ticket
 // price.  Both the ticket and the change will go to a p2sh script that is

--- a/blockchain/chaingen/generator.go
+++ b/blockchain/chaingen/generator.go
@@ -492,8 +492,8 @@ func (g *Generator) CreateTicketPurchaseTx(spend *SpendableOut, ticketPrice, fee
 	voteScriptVer, voteScript := g.p2shOpTrueAddr.VotingRightsScript()
 
 	// Generate the commitment script.
-	commitScript := PurchaseCommitmentScript(g.p2shOpTrueAddr, ticketPrice+fee,
-		0, ticketPrice)
+	commitScriptVer, commitScript := g.p2shOpTrueAddr.RewardCommitmentScript(
+		int64(ticketPrice+fee), 0, int64(ticketPrice))
 
 	// Calculate change and generate script to deliver it.
 	change := spend.amount - ticketPrice - fee
@@ -511,7 +511,7 @@ func (g *Generator) CreateTicketPurchaseTx(spend *SpendableOut, ticketPrice, fee
 		SignatureScript:  opTrueRedeemScript,
 	})
 	tx.AddTxOut(newTxOut(int64(ticketPrice), voteScriptVer, voteScript))
-	tx.AddTxOut(wire.NewTxOut(0, commitScript))
+	tx.AddTxOut(newTxOut(0, commitScriptVer, commitScript))
 	tx.AddTxOut(newTxOut(int64(change), changeScriptVer, changeScript))
 	return tx
 }

--- a/blockchain/go.mod
+++ b/blockchain/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/decred/dcrd/dcrutil/v4 v4.0.0-20210129181600-6ae0142d3b28
 	github.com/decred/dcrd/gcs/v3 v3.0.0-20210129195202-a4265d63b619
 	github.com/decred/dcrd/lru v1.1.0
-	github.com/decred/dcrd/txscript/v4 v4.0.0-20210129190127-4ebd135a82f1
+	github.com/decred/dcrd/txscript/v4 v4.0.0-20210330065944-a2366e6e0b3b
 	github.com/decred/dcrd/wire v1.4.0
 	github.com/decred/slog v1.1.0
 )

--- a/blockchain/indexers/existsaddrindex.go
+++ b/blockchain/indexers/existsaddrindex.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 The Decred developers
+// Copyright (c) 2016-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -282,8 +282,12 @@ func (idx *ExistsAddrIndex) ConnectBlock(dbTx database.Tx, block, parent *dcruti
 					// Ignore unsupported address types.
 					continue
 				}
+				utilAddr, err := stdAddrToUtilAddr(addr, idx.chainParams)
+				if err != nil {
+					continue
+				}
 
-				addrs = append(addrs, addr)
+				addrs = append(addrs, utilAddr)
 			}
 
 			for _, addr := range addrs {
@@ -404,8 +408,12 @@ func (idx *ExistsAddrIndex) addUnconfirmedTx(tx *wire.MsgTx, isTreasuryEnabled b
 				// Ignore unsupported address types.
 				continue
 			}
+			utilAddr, err := stdAddrToUtilAddr(addr, idx.chainParams)
+			if err != nil {
+				continue
+			}
 
-			addrs = append(addrs, addr)
+			addrs = append(addrs, utilAddr)
 		}
 
 		for _, addr := range addrs {

--- a/blockchain/indexers/existsaddrindex.go
+++ b/blockchain/indexers/existsaddrindex.go
@@ -244,8 +244,8 @@ func (idx *ExistsAddrIndex) ConnectBlock(dbTx database.Tx, block, parent *dcruti
 			if txscript.IsMultisigSigScript(txIn.SignatureScript) {
 				rs := txscript.MultisigRedeemScriptFromScriptSig(
 					txIn.SignatureScript)
-				class, addrs, err := extractPkScriptAddrs(scriptVersion, rs,
-					idx.chainParams, isTreasuryEnabled)
+				class, addrs, _, err := txscript.ExtractPkScriptAddrs(
+					scriptVersion, rs, idx.chainParams, isTreasuryEnabled)
 				if err != nil {
 					// Non-standard outputs are skipped.
 					continue
@@ -267,7 +267,7 @@ func (idx *ExistsAddrIndex) ConnectBlock(dbTx database.Tx, block, parent *dcruti
 		}
 
 		for _, txOut := range tx.MsgTx().TxOut {
-			class, addrs, err := extractPkScriptAddrs(txOut.Version,
+			class, addrs, _, err := txscript.ExtractPkScriptAddrs(txOut.Version,
 				txOut.PkScript, idx.chainParams, isTreasuryEnabled)
 			if err != nil {
 				// Non-standard outputs are skipped.
@@ -363,8 +363,8 @@ func (idx *ExistsAddrIndex) addUnconfirmedTx(tx *wire.MsgTx, isTreasuryEnabled b
 			const scriptVersion = 0
 			rs := txscript.MultisigRedeemScriptFromScriptSig(
 				txIn.SignatureScript)
-			class, addrs, err := extractPkScriptAddrs(scriptVersion, rs,
-				idx.chainParams, isTreasuryEnabled)
+			class, addrs, _, err := txscript.ExtractPkScriptAddrs(scriptVersion,
+				rs, idx.chainParams, isTreasuryEnabled)
 			if err != nil {
 				// Non-standard outputs are skipped.
 				continue
@@ -388,8 +388,8 @@ func (idx *ExistsAddrIndex) addUnconfirmedTx(tx *wire.MsgTx, isTreasuryEnabled b
 	}
 
 	for _, txOut := range tx.TxOut {
-		class, addrs, err := extractPkScriptAddrs(txOut.Version, txOut.PkScript,
-			idx.chainParams, isTreasuryEnabled)
+		class, addrs, _, err := txscript.ExtractPkScriptAddrs(txOut.Version,
+			txOut.PkScript, idx.chainParams, isTreasuryEnabled)
 		if err != nil {
 			// Non-standard outputs are skipped.
 			continue

--- a/blockchain/stake/go.mod
+++ b/blockchain/stake/go.mod
@@ -6,10 +6,9 @@ require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/chaincfg/v3 v3.0.0
 	github.com/decred/dcrd/database/v2 v2.0.3-0.20210129190127-4ebd135a82f1
-	github.com/decred/dcrd/dcrec v1.0.0
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210127014238-b33b46cf1a24
 	github.com/decred/dcrd/dcrutil/v4 v4.0.0-20210129181600-6ae0142d3b28
-	github.com/decred/dcrd/txscript/v4 v4.0.0-20210129190127-4ebd135a82f1
+	github.com/decred/dcrd/txscript/v4 v4.0.0-20210330065944-a2366e6e0b3b
 	github.com/decred/dcrd/wire v1.4.0
 	github.com/decred/slog v1.1.0
 )

--- a/blockchain/stake/scripttype_test.go
+++ b/blockchain/stake/scripttype_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Decred developers
+// Copyright (c) 2020-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -7,12 +7,12 @@ package stake
 import (
 	"testing"
 
-	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/txscript/v4"
+	"github.com/decred/dcrd/txscript/v4/stdaddr"
 )
 
 var (
-	hash160 = dcrutil.Hash160([]byte("test"))
+	hash160 = stdaddr.Hash160([]byte("test"))
 )
 
 func TestIsRevocationScript(t *testing.T) {

--- a/blockchain/stake/staketx.go
+++ b/blockchain/stake/staketx.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 //
@@ -15,9 +15,9 @@ import (
 	"math/big"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
-	"github.com/decred/dcrd/dcrec"
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/txscript/v4"
+	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -395,7 +395,7 @@ func TxSStxStakeOutputInfo(tx *wire.MsgTx) ([]bool, [][]byte, []int64, []int64,
 
 // AddrFromSStxPkScrCommitment extracts a P2SH or P2PKH address from a ticket
 // commitment pkScript.
-func AddrFromSStxPkScrCommitment(pkScript []byte, params dcrutil.AddressParams) (dcrutil.Address, error) {
+func AddrFromSStxPkScrCommitment(pkScript []byte, params stdaddr.AddressParams) (stdaddr.Address, error) {
 	if len(pkScript) < SStxPKHMinOutSize {
 		str := "short read of sstx commit pkscript"
 		return nil, stakeRuleError(ErrSStxBadCommitAmount, str)
@@ -417,10 +417,9 @@ func AddrFromSStxPkScrCommitment(pkScript []byte, params dcrutil.AddressParams) 
 
 	// Return the correct address type.
 	if isP2SH {
-		return dcrutil.NewAddressScriptHashFromHash(hashBytes, params)
+		return stdaddr.NewAddressScriptHashV0FromHash(hashBytes, params)
 	}
-	return dcrutil.NewAddressPubKeyHash(hashBytes, params,
-		dcrec.STEcdsaSecp256k1)
+	return stdaddr.NewAddressPubKeyHashEcdsaSecp256k1V0(hashBytes, params)
 }
 
 // AmountFromSStxPkScrCommitment extracts a commitment amount from a

--- a/blockchain/stake/staketx_test.go
+++ b/blockchain/stake/staketx_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -14,6 +14,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/txscript/v4"
+	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -1260,7 +1261,7 @@ func TestGetStakeRewards(t *testing.T) {
 }
 
 func TestIsNullDataScript(t *testing.T) {
-	var hash160 = dcrutil.Hash160([]byte("test"))
+	var hash160 = stdaddr.Hash160([]byte("test"))
 	var overMaxDataCarrierSize = make([]byte, txscript.MaxDataCarrierSize+1)
 	var underMaxDataCarrierSize = make([]byte, txscript.MaxDataCarrierSize/2)
 	rand.Read(overMaxDataCarrierSize)

--- a/blockchain/stakeext.go
+++ b/blockchain/stakeext.go
@@ -10,6 +10,7 @@ import (
 	"github.com/decred/dcrd/database/v2"
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/txscript/v4"
+	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -101,13 +102,14 @@ func (b *BlockChain) MissedTickets() ([]chainhash.Hash, error) {
 // corresponding to the given address.
 //
 // This function is safe for concurrent access.
-func (b *BlockChain) TicketsWithAddress(address dcrutil.Address, isTreasuryEnabled bool) ([]chainhash.Hash, error) {
+func (b *BlockChain) TicketsWithAddress(address stdaddr.Address, isTreasuryEnabled bool) ([]chainhash.Hash, error) {
 	b.chainLock.RLock()
 	sn := b.bestChain.Tip().stakeNode
 	b.chainLock.RUnlock()
 
 	tickets := sn.LiveTickets()
 
+	encodedAddr := address.Address()
 	var ticketsWithAddr []chainhash.Hash
 	err := b.db.View(func(dbTx database.Tx) error {
 		for _, hash := range tickets {
@@ -122,7 +124,7 @@ func (b *BlockChain) TicketsWithAddress(address dcrutil.Address, isTreasuryEnabl
 			if err != nil {
 				return err
 			}
-			if addrs[0].Address() == address.Address() {
+			if addrs[0].Address() == encodedAddr {
 				ticketsWithAddr = append(ticketsWithAddr, hash)
 			}
 		}

--- a/blockchain/treasury_test.go
+++ b/blockchain/treasury_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Decred developers
+// Copyright (c) 2020-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -27,6 +27,7 @@ import (
 	"github.com/decred/dcrd/gcs/v3/blockcf2"
 	"github.com/decred/dcrd/lru"
 	"github.com/decred/dcrd/txscript/v4"
+	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -1874,13 +1875,13 @@ func TestSpendableTreasuryTxs(t *testing.T) {
 	spendPrivKey := secp256k1.NewPrivateKey(new(secp256k1.ModNScalar).SetInt(1))
 	pubKey := spendPrivKey.PubKey().SerializeCompressed()
 	pubKeyHash := dcrutil.Hash160(pubKey)
-	spendP2pkhAddr, err := dcrutil.NewAddressPubKeyHash(pubKeyHash, params,
-		dcrec.STEcdsaSecp256k1)
+	spendP2pkhAddr, err := stdaddr.NewAddressPubKeyHashEcdsaSecp256k1V0(
+		pubKeyHash, params)
 	if err != nil {
 		t.Fatal(err)
 	}
 	spendP2shScript := []byte{txscript.OP_NOP, txscript.OP_TRUE}
-	spendP2shAddr, err := dcrutil.NewAddressScriptHash(spendP2shScript,
+	spendP2shAddr, err := stdaddr.NewAddressScriptHashV0(spendP2shScript,
 		params)
 	if err != nil {
 		t.Fatal(err)
@@ -1889,13 +1890,13 @@ func TestSpendableTreasuryTxs(t *testing.T) {
 	addPrivKey := secp256k1.NewPrivateKey(new(secp256k1.ModNScalar).SetInt(2))
 	pubKey = addPrivKey.PubKey().SerializeCompressed()
 	pubKeyHash = dcrutil.Hash160(pubKey)
-	addP2pkhAddr, err := dcrutil.NewAddressPubKeyHash(pubKeyHash, params,
-		dcrec.STEcdsaSecp256k1)
+	addP2pkhAddr, err := stdaddr.NewAddressPubKeyHashEcdsaSecp256k1V0(
+		pubKeyHash, params)
 	if err != nil {
 		t.Fatal(err)
 	}
 	addP2shScript := []byte{txscript.OP_NOP, txscript.OP_NOP, txscript.OP_TRUE}
-	addP2shAddr, err := dcrutil.NewAddressScriptHash(addP2shScript, params)
+	addP2shAddr, err := stdaddr.NewAddressScriptHashV0(addP2shScript, params)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/config.go
+++ b/config.go
@@ -31,6 +31,7 @@ import (
 	"github.com/decred/dcrd/internal/version"
 	"github.com/decred/dcrd/rpc/jsonrpc/types/v3"
 	"github.com/decred/dcrd/sampleconfig"
+	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/go-socks/socks"
 	"github.com/decred/slog"
 	flags "github.com/jessevdk/go-flags"
@@ -232,7 +233,7 @@ type config struct {
 	lookup        func(string) ([]net.IP, error)
 	oniondial     func(context.Context, string, string) (net.Conn, error)
 	dial          func(context.Context, string, string) (net.Conn, error)
-	miningAddrs   []dcrutil.Address
+	miningAddrs   []stdaddr.Address
 	minRelayTxFee dcrutil.Amount
 	whitelists    []*net.IPNet
 	ipv4NetInfo   types.NetworksResult
@@ -1084,9 +1085,9 @@ func loadConfig(appName string) (*config, []string, error) {
 	}
 
 	// Check mining addresses are valid and saved parsed versions.
-	cfg.miningAddrs = make([]dcrutil.Address, 0, len(cfg.MiningAddrs))
+	cfg.miningAddrs = make([]stdaddr.Address, 0, len(cfg.MiningAddrs))
 	for _, strAddr := range cfg.MiningAddrs {
-		addr, err := dcrutil.DecodeAddress(strAddr, cfg.params.Params)
+		addr, err := stdaddr.DecodeAddress(strAddr, cfg.params.Params)
 		if err != nil {
 			str := "%s: mining address '%s' failed to decode: %w"
 			err := fmt.Errorf(str, funcName, strAddr, err)

--- a/gcs/go.mod
+++ b/gcs/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/decred/dcrd/blockchain/stake/v4 v4.0.0-20210129192908-660d0518b4cf
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/crypto/blake256 v1.0.0
-	github.com/decred/dcrd/txscript/v4 v4.0.0-20210129190127-4ebd135a82f1
+	github.com/decred/dcrd/txscript/v4 v4.0.0-20210330065944-a2366e6e0b3b
 	github.com/decred/dcrd/wire v1.4.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/decred/dcrd/peer/v3 v3.0.0
 	github.com/decred/dcrd/rpc/jsonrpc/types/v3 v3.0.0-20210129200153-14fd1a785bf2
 	github.com/decred/dcrd/rpcclient/v7 v7.0.0-20210129214723-fc227a05904d
-	github.com/decred/dcrd/txscript/v4 v4.0.0-20210129190127-4ebd135a82f1
+	github.com/decred/dcrd/txscript/v4 v4.0.0-20210330065944-a2366e6e0b3b
 	github.com/decred/dcrd/wire v1.4.0
 	github.com/decred/go-socks v1.1.0
 	github.com/decred/slog v1.2.0

--- a/hdkeychain/example_test.go
+++ b/hdkeychain/example_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -9,9 +9,8 @@ import (
 	"fmt"
 
 	"github.com/decred/dcrd/chaincfg/v3"
-	"github.com/decred/dcrd/dcrec"
-	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/hdkeychain/v3"
+	"github.com/decred/dcrd/txscript/v4/stdaddr"
 )
 
 // This example demonstrates how to generate a cryptographically random seed
@@ -127,9 +126,8 @@ func Example_defaultWalletLayout() {
 	// pubKeyHashAddr is a convenience function to convert an extended
 	// pubkey to a standard pay-to-pubkey-hash address.
 	pubKeyHashAddr := func(extKey *hdkeychain.ExtendedKey) (string, error) {
-		pkHash := dcrutil.Hash160(extKey.SerializedPubKey())
-		addr, err := dcrutil.NewAddressPubKeyHash(pkHash, net,
-			dcrec.STEcdsaSecp256k1)
+		pkHash := stdaddr.Hash160(extKey.SerializedPubKey())
+		addr, err := stdaddr.NewAddressPubKeyHashEcdsaSecp256k1V0(pkHash, net)
 		if err != nil {
 			fmt.Println(err)
 			return "", err

--- a/hdkeychain/go.mod
+++ b/hdkeychain/go.mod
@@ -7,12 +7,11 @@ require (
 	github.com/decred/dcrd/chaincfg/v3 v3.0.0
 	github.com/decred/dcrd/crypto/blake256 v1.0.0
 	github.com/decred/dcrd/crypto/ripemd160 v1.0.1
-	github.com/decred/dcrd/dcrec v1.0.0
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210127014238-b33b46cf1a24
-	github.com/decred/dcrd/dcrutil/v4 v4.0.0-20210129181600-6ae0142d3b28
+	github.com/decred/dcrd/txscript/v4 v4.0.0-20210330065944-a2366e6e0b3b
 )
 
 replace (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 => ../dcrec/secp256k1
-	github.com/decred/dcrd/dcrutil/v4 => ../dcrutil
+	github.com/decred/dcrd/txscript/v4 => ../txscript
 )

--- a/hdkeychain/go.sum
+++ b/hdkeychain/go.sum
@@ -2,6 +2,7 @@ github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7I
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dchest/siphash v1.2.2/go.mod h1:q+IRvb2gOSrUnYoPqHiyHXS0FOBBOdl6tONBlVnOnt4=
 github.com/decred/base58 v1.0.3 h1:KGZuh8d1WEMIrK0leQRM47W85KqCAdl2N+uagbctdDI=
 github.com/decred/base58 v1.0.3/go.mod h1:pXP9cXCfM2sFLb2viz2FNIdeMWmZDBKG3ZBYbiSM78E=
 github.com/decred/dcrd/chaincfg/chainhash v1.0.2 h1:rt5Vlq/jM3ZawwiacWjPa+smINyLRN07EO0cNBV6DGU=
@@ -16,5 +17,7 @@ github.com/decred/dcrd/dcrec v1.0.0 h1:W+z6Es+Rai3MXYVoPAxYr5U1DGis0Co33scJ6uH2J
 github.com/decred/dcrd/dcrec v1.0.0/go.mod h1:HIaqbEJQ+PDzQcORxnqen5/V1FR3B4VpIfmePklt8Q8=
 github.com/decred/dcrd/dcrec/edwards/v2 v2.0.1 h1:V6eqU1crZzuoFT4KG2LhaU5xDSdkHuvLQsj25wd7Wb4=
 github.com/decred/dcrd/dcrec/edwards/v2 v2.0.1/go.mod h1:d0H8xGMWbiIQP7gN3v2rByWUcuZPm9YsgmnfoxgbINc=
+github.com/decred/dcrd/dcrutil/v4 v4.0.0-20210129181600-6ae0142d3b28/go.mod h1:xe59jKcMx5G/dbRmsZ8+FzY+WQDE/7YBP3k3uzJTtmI=
 github.com/decred/dcrd/wire v1.4.0 h1:KmSo6eTQIvhXS0fLBQ/l7hG7QLcSJQKSwSyzSqJYDk0=
 github.com/decred/dcrd/wire v1.4.0/go.mod h1:WxC/0K+cCAnBh+SKsRjIX9YPgvrjhmE+6pZlel1G7Ro=
+github.com/decred/slog v1.1.0/go.mod h1:kVXlGnt6DHy2fV5OjSeuvCJ0OmlmTF6LFpEPMu/fOY0=

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -359,13 +359,13 @@ type poolHarness struct {
 // GetScript is the pool harness' implementation of the ScriptDB interface.
 // It returns the pool harness' payment redeem script for any address
 // passed in.
-func (p *poolHarness) GetScript(addr dcrutil.Address) ([]byte, error) {
+func (p *poolHarness) GetScript(addr stdaddr.Address) ([]byte, error) {
 	return p.payScript, nil
 }
 
 // GetKey is the pool harness' implementation of the KeyDB interface.
 // It returns the pool harness' signature key for any address passed in.
-func (p *poolHarness) GetKey(addr dcrutil.Address) ([]byte, dcrec.SignatureType, bool, error) {
+func (p *poolHarness) GetKey(addr stdaddr.Address) ([]byte, dcrec.SignatureType, bool, error) {
 	return p.signKey, p.sigType, true, nil
 }
 

--- a/internal/mempool/policy_test.go
+++ b/internal/mempool/policy_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2016-2020 The Decred developers
+// Copyright (c) 2016-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -14,10 +14,10 @@ import (
 	"github.com/decred/dcrd/blockchain/stake/v4"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v3"
-	"github.com/decred/dcrd/dcrec"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/txscript/v4"
+	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -326,18 +326,15 @@ func TestCheckTransactionStandard(t *testing.T) {
 		SignatureScript:  dummySigScript,
 	}
 	addrHash := [20]byte{0x01}
-	addr, err := dcrutil.NewAddressPubKeyHash(addrHash[:],
-		chaincfg.RegNetParams(), dcrec.STEcdsaSecp256k1)
+	addr, err := stdaddr.NewAddressPubKeyHashEcdsaSecp256k1V0(addrHash[:],
+		chaincfg.RegNetParams())
 	if err != nil {
 		t.Fatalf("NewAddressPubKeyHash: unexpected error: %v", err)
 	}
-	dummyPkScript, err := txscript.PayToAddrScript(addr)
-	if err != nil {
-		t.Fatalf("PayToAddrScript: unexpected error: %v", err)
-	}
+	dummyPkScriptVer, dummyPkScript := addr.PaymentScript()
 	dummyTxOut := wire.TxOut{
 		Value:    100000000, // 1 BTC
-		Version:  0,
+		Version:  dummyPkScriptVer,
 		PkScript: dummyPkScript,
 	}
 

--- a/internal/mining/bgblktmplgenerator.go
+++ b/internal/mining/bgblktmplgenerator.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 The Decred developers
+// Copyright (c) 2019-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -17,6 +17,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/lru"
+	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -323,7 +324,7 @@ type BgBlkTmplConfig struct {
 
 	// MiningAddrs specifies the addresses to choose from when paying mining
 	// rewards in generated templates.
-	MiningAddrs []dcrutil.Address
+	MiningAddrs []stdaddr.Address
 
 	// AllowUnsyncedMining indicates block templates should be created even when
 	// the chain is not fully synced.

--- a/internal/mining/mining_harness_test.go
+++ b/internal/mining/mining_harness_test.go
@@ -933,13 +933,13 @@ type miningHarness struct {
 // GetScript is the mining harness' implementation of the ScriptDB interface.
 // It returns the mining harness' payment redeem script for any address passed
 // in.
-func (m *miningHarness) GetScript(addr dcrutil.Address) ([]byte, error) {
+func (m *miningHarness) GetScript(addr stdaddr.Address) ([]byte, error) {
 	return m.payScript, nil
 }
 
 // GetKey is the mining harness' implementation of the KeyDB interface. It
 // returns the mining harness' signature key for any address passed in.
-func (m *miningHarness) GetKey(addr dcrutil.Address) ([]byte, dcrec.SignatureType, bool, error) {
+func (m *miningHarness) GetKey(addr stdaddr.Address) ([]byte, dcrec.SignatureType, bool, error) {
 	return m.signKey, m.sigType, true, nil
 }
 

--- a/internal/mining/mining_test.go
+++ b/internal/mining/mining_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Decred developers
+// Copyright (c) 2020-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -13,6 +13,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/txscript/v4"
+	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -28,7 +29,7 @@ func TestNewBlockTemplateBasicErrorScenarios(t *testing.T) {
 	}
 
 	// Create a test address for use in template generation.
-	address, err := dcrutil.DecodeAddress("Dsi8CRt85xYyempXs7ZPL1rBxvDdAGZmgsg",
+	address, err := stdaddr.DecodeAddress("Dsi8CRt85xYyempXs7ZPL1rBxvDdAGZmgsg",
 		harness.chainParams)
 	if err != nil {
 		t.Fatalf("error decoding address: %v", err)
@@ -70,7 +71,7 @@ func TestNewBlockTemplate(t *testing.T) {
 	}
 
 	// Create a test address for use in template generation.
-	address, err := dcrutil.DecodeAddress("Dsi8CRt85xYyempXs7ZPL1rBxvDdAGZmgsg",
+	address, err := stdaddr.DecodeAddress("Dsi8CRt85xYyempXs7ZPL1rBxvDdAGZmgsg",
 		harness.chainParams)
 	if err != nil {
 		t.Fatalf("error decoding address: %v", err)

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -373,7 +373,7 @@ type Chain interface {
 
 	// TicketsWithAddress returns a slice of ticket hashes that are currently
 	// live corresponding to the given address.
-	TicketsWithAddress(address dcrutil.Address, isTreasuryEnabled bool) ([]chainhash.Hash, error)
+	TicketsWithAddress(address stdaddr.Address, isTreasuryEnabled bool) ([]chainhash.Hash, error)
 
 	// TipGeneration returns the entire generation of blocks stemming from the
 	// parent of the current tip.

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -22,6 +22,7 @@ import (
 	"github.com/decred/dcrd/internal/mining"
 	"github.com/decred/dcrd/peer/v3"
 	"github.com/decred/dcrd/rpc/jsonrpc/types/v3"
+	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -552,11 +553,11 @@ type FiltererV2 interface {
 // ExistsAddresser before calling methods associated with it.
 type ExistsAddresser interface {
 	// ExistsAddress returns whether or not an address has been seen before.
-	ExistsAddress(addr dcrutil.Address) (bool, error)
+	ExistsAddress(addr stdaddr.Address) (bool, error)
 
 	// ExistsAddresses returns whether or not each address in a slice of
 	// addresses has been seen before.
-	ExistsAddresses(addrs []dcrutil.Address) ([]bool, error)
+	ExistsAddresses(addrs []stdaddr.Address) ([]bool, error)
 }
 
 // TxMempooler represents a source of mempool transaction data for the RPC
@@ -607,13 +608,13 @@ type AddrIndexer interface {
 	// NOTE: These results only include transactions confirmed in blocks.  See the
 	// UnconfirmedTxnsForAddress method for obtaining unconfirmed transactions
 	// that involve a given address.
-	EntriesForAddress(dbTx database.Tx, addr dcrutil.Address, numToSkip,
+	EntriesForAddress(dbTx database.Tx, addr stdaddr.Address, numToSkip,
 		numRequested uint32, reverse bool) ([]indexers.TxIndexEntry, uint32, error)
 
 	// UnconfirmedTxnsForAddress returns all transactions currently in the
 	// unconfirmed (memory-only) address index that involve the passed address.
 	// Unsupported address types are ignored and will result in no results.
-	UnconfirmedTxnsForAddress(addr dcrutil.Address) []*dcrutil.Tx
+	UnconfirmedTxnsForAddress(addr stdaddr.Address) []*dcrutil.Tx
 }
 
 // TxIndexer provides an interface for retrieving details for a given

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -1519,7 +1519,7 @@ func handleExistsAddress(_ context.Context, s *Server, cmd interface{}) (interfa
 
 	// Decode the provided address.  This also ensures the network encoded with
 	// the address matches the network the server is currently on.
-	addr, err := dcrutil.DecodeAddress(c.Address, s.cfg.ChainParams)
+	addr, err := stdaddr.DecodeAddress(c.Address, s.cfg.ChainParams)
 	if err != nil {
 		return nil, rpcAddressKeyError("Could not decode address: %v",
 			err)
@@ -1544,11 +1544,11 @@ func handleExistsAddresses(_ context.Context, s *Server, cmd interface{}) (inter
 	}
 
 	c := cmd.(*types.ExistsAddressesCmd)
-	addresses := make([]dcrutil.Address, len(c.Addresses))
+	addresses := make([]stdaddr.Address, len(c.Addresses))
 	for i := range c.Addresses {
 		// Decode the provided address.  This also ensures the network encoded
 		// with the address matches the network the server is currently on.
-		addr, err := dcrutil.DecodeAddress(c.Addresses[i], s.cfg.ChainParams)
+		addr, err := stdaddr.DecodeAddress(c.Addresses[i], s.cfg.ChainParams)
 		if err != nil {
 			return nil, rpcAddressKeyError("Could not decode address: %v", err)
 		}
@@ -4314,7 +4314,7 @@ func createVinListPrevOut(s *Server, mtx *wire.MsgTx,
 // fetchMempoolTxnsForAddress queries the address index for all unconfirmed
 // transactions that involve the provided address.  The results will be limited
 // by the number to skip and the number requested.
-func fetchMempoolTxnsForAddress(s *Server, addr dcrutil.Address, numToSkip, numRequested uint32) ([]*dcrutil.Tx, uint32) {
+func fetchMempoolTxnsForAddress(s *Server, addr stdaddr.Address, numToSkip, numRequested uint32) ([]*dcrutil.Tx, uint32) {
 	// There are no entries to return when there are less available than
 	// the number being skipped.
 	mpTxns := s.cfg.AddrIndexer.UnconfirmedTxnsForAddress(addr)
@@ -4359,7 +4359,7 @@ func handleSearchRawTransactions(_ context.Context, s *Server, cmd interface{}) 
 
 	// Attempt to decode the supplied address.  This also ensures the network
 	// encoded with the address matches the network the server is currently on.
-	addr, err := dcrutil.DecodeAddress(c.Address, s.cfg.ChainParams)
+	addr, err := stdaddr.DecodeAddress(c.Address, s.cfg.ChainParams)
 	if err != nil {
 		return nil, rpcAddressKeyError("Could not decode address: %v",
 			err)

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -50,6 +50,7 @@ import (
 	"github.com/decred/dcrd/internal/version"
 	"github.com/decred/dcrd/rpc/jsonrpc/types/v3"
 	"github.com/decred/dcrd/txscript/v4"
+	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 	"github.com/jrick/bitset"
 )
@@ -1165,6 +1166,12 @@ func createVinList(mtx *wire.MsgTx, isTreasuryEnabled bool) []types.Vin {
 	return vinList
 }
 
+// stdAddrToUtilAddr converts stdaddr addresses to dcrutil addresses until all
+// code is converted over to use the new pacakage.
+func stdAddrToUtilAddr(addr stdaddr.Address, params stdaddr.AddressParams) (dcrutil.Address, error) {
+	return dcrutil.DecodeAddress(addr.Address(), params)
+}
+
 // createVoutList returns a slice of JSON objects for the outputs of the passed
 // transaction.
 func createVoutList(mtx *wire.MsgTx, chainParams *chaincfg.Params, filterAddrMap map[string]struct{}, isTreasuryEnabled bool) []types.Vout {
@@ -1192,7 +1199,8 @@ func createVoutList(mtx *wire.MsgTx, chainParams *chaincfg.Params, filterAddrMap
 					"commitment addr output for tx hash "+
 					"%v, output idx %v", mtx.TxHash(), i)
 			} else {
-				addrs = []dcrutil.Address{addr}
+				utilAddr, _ := stdAddrToUtilAddr(addr, chainParams)
+				addrs = []dcrutil.Address{utilAddr}
 			}
 			amt, err := stake.AmountFromSStxPkScrCommitment(v.PkScript)
 			if err != nil {

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -5083,7 +5083,7 @@ func handleTicketsForAddress(_ context.Context, s *Server, cmd interface{}) (int
 
 	// Decode the provided address.  This also ensures the network encoded
 	// with the address matches the network the server is currently on.
-	addr, err := dcrutil.DecodeAddress(c.Address, s.cfg.ChainParams)
+	addr, err := stdaddr.DecodeAddress(c.Address, s.cfg.ChainParams)
 	if err != nil {
 		return nil, rpcInvalidError("Invalid address: %v", err)
 	}

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -4855,8 +4855,8 @@ func TestHandleGetTxOut(t *testing.T) {
 	script := txOut.PkScript
 	scriptVersion := txOut.Version
 	disbuf, _ := txscript.DisasmString(script)
-	scriptClass, addrs, reqSigs, _ := extractPkScriptAddrs(scriptVersion,
-		script, defaultChainParams, false)
+	scriptClass, addrs, reqSigs, _ := txscript.ExtractPkScriptAddrs(
+		scriptVersion, script, defaultChainParams, false)
 	addresses := make([]string, len(addrs))
 	for i, addr := range addrs {
 		addresses[i] = addr.Address()

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -941,7 +941,7 @@ func (f *testFiltererV2) FilterByBlockHash(hash *chainhash.Hash) (*gcs.FilterV2,
 // testMiningState provides a mock mining state.
 type testMiningState struct {
 	allowUnsyncedMining bool
-	miningAddrs         []dcrutil.Address
+	miningAddrs         []stdaddr.Address
 	workState           *workState
 }
 
@@ -1318,7 +1318,7 @@ type rpcTest struct {
 	mockLogManager        *testLogManager
 	mockFiltererV2        *testFiltererV2
 	mockTxMempooler       *testTxMempooler
-	mockMiningAddrs       []dcrutil.Address
+	mockMiningAddrs       []stdaddr.Address
 	mockHelpCacher        *testHelpCacher
 	result                interface{}
 	wantErr               bool
@@ -1969,7 +1969,7 @@ func TestHandleCreateRawSStx(t *testing.T) {
 			COuts:  defaultCmdCOuts,
 		},
 		wantErr: true,
-		errCode: dcrjson.ErrRPCInternal.Code,
+		errCode: dcrjson.ErrRPCInvalidAddressOrKey,
 	}, {
 		name:    "handleCreateRawSStx: change amount greater than input amount",
 		handler: handleCreateRawSStx,
@@ -2029,7 +2029,7 @@ func TestHandleCreateRawSStx(t *testing.T) {
 			}},
 		},
 		wantErr: true,
-		errCode: dcrjson.ErrRPCInternal.Code,
+		errCode: dcrjson.ErrRPCInvalidAddressOrKey,
 	}, {
 		name:    "handleCreateRawSStx: invalid change amount > dcrutil.MaxAmount",
 		handler: handleCreateRawSStx,
@@ -2109,7 +2109,7 @@ func TestHandleCreateRawSStx(t *testing.T) {
 			}},
 		},
 		wantErr: true,
-		errCode: dcrjson.ErrRPCInternal.Code,
+		errCode: dcrjson.ErrRPCInvalidAddressOrKey,
 	}})
 }
 
@@ -3313,11 +3313,11 @@ func TestHandleGenerate(t *testing.T) {
 	hashStrTwo := "00000000000000001a1ec2becd0dd90bfbd0c65f42fdaf608dd9ceac2a3aee1d"
 	generatedBlocks := []*chainhash.Hash{mustParseHash(hashStrOne), mustParseHash(hashStrTwo)}
 	res := []string{hashStrOne, hashStrTwo}
-	miningAddr, err := dcrutil.DecodeAddress("DcurAwesomeAddressmqDctW5wJCW1Cn2MF", defaultChainParams)
+	miningAddr, err := stdaddr.DecodeAddress("DcurAwesomeAddressmqDctW5wJCW1Cn2MF", defaultChainParams)
 	if err != nil {
 		t.Fatalf("[DecodeAddress] unexpected error: %v", err)
 	}
-	miningAddrs := []dcrutil.Address{miningAddr}
+	miningAddrs := []stdaddr.Address{miningAddr}
 	chainParams := cloneParams(defaultChainParams)
 	chainParams.GenerateSupported = true
 	cpu := defaultMockCPUMiner()
@@ -4855,8 +4855,8 @@ func TestHandleGetTxOut(t *testing.T) {
 	script := txOut.PkScript
 	scriptVersion := txOut.Version
 	disbuf, _ := txscript.DisasmString(script)
-	scriptClass, addrs, reqSigs, _ := txscript.ExtractPkScriptAddrs(
-		scriptVersion, script, defaultChainParams, false)
+	scriptClass, addrs, reqSigs, _ := extractPkScriptAddrs(scriptVersion,
+		script, defaultChainParams, false)
 	addresses := make([]string, len(addrs))
 	for i, addr := range addrs {
 		addresses[i] = addr.Address()
@@ -5995,14 +5995,14 @@ func TestHandleGetWork(t *testing.T) {
 	buf.Write(submissionB[240:])
 	invalidPOWSub := buf.String()
 
-	miningaddr, err := dcrutil.DecodeAddress("DsRM6qwzT3r85evKvDBJBviTgYcaLKL4ipD", defaultChainParams)
+	miningaddr, err := stdaddr.DecodeAddress("DsRM6qwzT3r85evKvDBJBviTgYcaLKL4ipD", defaultChainParams)
 	if err != nil {
 		t.Fatalf("[DecodeAddress] unexpected error: %v", err)
 	}
 
 	mine := func() *testMiningState {
 		ms := defaultMockMiningState()
-		ms.miningAddrs = []dcrutil.Address{miningaddr}
+		ms.miningAddrs = []stdaddr.Address{miningaddr}
 		return ms
 	}
 
@@ -6128,7 +6128,7 @@ func TestHandleGetWork(t *testing.T) {
 		},
 		mockMiningState: func() *testMiningState {
 			ms := defaultMockMiningState()
-			ms.miningAddrs = []dcrutil.Address{miningaddr}
+			ms.miningAddrs = []stdaddr.Address{miningaddr}
 			ms.workState = newWorkState()
 			return ms
 		}(),
@@ -6210,7 +6210,7 @@ func TestHandleSetGenerate(t *testing.T) {
 
 	procLimit := 2
 	zeroProcLimit := 0
-	miningaddr, err := dcrutil.DecodeAddress("DsRM6qwzT3r85evKvDBJBviTgYcaLKL4ipD", defaultChainParams)
+	miningaddr, err := stdaddr.DecodeAddress("DsRM6qwzT3r85evKvDBJBviTgYcaLKL4ipD", defaultChainParams)
 	if err != nil {
 		t.Fatalf("[DecodeAddress] unexpected error: %v", err)
 	}
@@ -6233,7 +6233,7 @@ func TestHandleSetGenerate(t *testing.T) {
 		},
 		mockMiningState: func() *testMiningState {
 			ms := defaultMockMiningState()
-			ms.miningAddrs = []dcrutil.Address{miningaddr}
+			ms.miningAddrs = []stdaddr.Address{miningaddr}
 			return ms
 		}(),
 	}, {

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/decred/dcrd/peer/v3"
 	"github.com/decred/dcrd/rpc/jsonrpc/types/v3"
 	"github.com/decred/dcrd/txscript/v4"
+	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -547,13 +548,13 @@ type testExistsAddresser struct {
 
 // ExistsAddress returns a mocked bool representing whether or not an address
 // has been seen before.
-func (e *testExistsAddresser) ExistsAddress(addr dcrutil.Address) (bool, error) {
+func (e *testExistsAddresser) ExistsAddress(addr stdaddr.Address) (bool, error) {
 	return e.existsAddress, e.existsAddressErr
 }
 
 // ExistsAddresses returns a mocked bool slice representing whether or not each
 // address in a slice of addresses has been seen before.
-func (e *testExistsAddresser) ExistsAddresses(addrs []dcrutil.Address) ([]bool, error) {
+func (e *testExistsAddresser) ExistsAddresses(addrs []stdaddr.Address) ([]bool, error) {
 	return e.existsAddresses, e.existsAddressesErr
 }
 
@@ -569,14 +570,14 @@ type testAddrIndexer struct {
 // EntriesForAddress returns a mocked slice of indexers.TxIndexEntry that
 // involve the given address.
 func (a *testAddrIndexer) EntriesForAddress(dbTx database.Tx,
-	addr dcrutil.Address, numToSkip, numRequested uint32, reverse bool) (
+	addr stdaddr.Address, numToSkip, numRequested uint32, reverse bool) (
 	[]indexers.TxIndexEntry, uint32, error) {
 	return a.entriesForAddress, a.entriesForAddressSkipped, a.entriesForAddressErr
 }
 
 // UnconfirmedTxnsForAddress returns a mocked slice of transactions that are
 // currently in the unconfirmed (memory-only) address index.
-func (a *testAddrIndexer) UnconfirmedTxnsForAddress(addr dcrutil.Address) []*dcrutil.Tx {
+func (a *testAddrIndexer) UnconfirmedTxnsForAddress(addr stdaddr.Address) []*dcrutil.Tx {
 	return a.unconfirmedTxnsForAddress
 }
 

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -393,7 +393,7 @@ func (c *testRPCChain) TicketPoolValue() (dcrutil.Amount, error) {
 
 // TicketsWithAddress returns a mocked slice of ticket hashes that are currently
 // live corresponding to the given address.
-func (c *testRPCChain) TicketsWithAddress(address dcrutil.Address, isTreasuryEnabled bool) ([]chainhash.Hash, error) {
+func (c *testRPCChain) TicketsWithAddress(address stdaddr.Address, isTreasuryEnabled bool) ([]chainhash.Hash, error) {
 	return c.ticketsWithAddress, c.ticketsWithAddressErr
 }
 

--- a/internal/rpcserver/rpcwebsocket.go
+++ b/internal/rpcserver/rpcwebsocket.go
@@ -687,7 +687,7 @@ func (m *wsNotificationManager) subscribedClients(tx *dcrutil.Tx, clients map[ch
 
 		for i, output := range msgTx.TxOut {
 			watchOutput := true
-			sc, addrs, _, err := extractPkScriptAddrs(output.Version,
+			sc, addrs, _, err := txscript.ExtractPkScriptAddrs(output.Version,
 				output.PkScript, params, isTreasuryEnabled)
 			if err != nil {
 				// Clients are not able to subscribe to
@@ -1196,7 +1196,7 @@ func (m *wsNotificationManager) notifyRelevantTxAccepted(tx *dcrutil.Tx,
 		}
 
 		for i, output := range msgTx.TxOut {
-			_, addrs, _, err := extractPkScriptAddrs(output.Version,
+			_, addrs, _, err := txscript.ExtractPkScriptAddrs(output.Version,
 				output.PkScript, m.server.cfg.ChainParams, isTreasuryEnabled)
 			if err != nil {
 				continue
@@ -2317,7 +2317,7 @@ func rescanBlock(filter *wsClientFilter, block *dcrutil.Block, params *chaincfg.
 
 	LoopOutputs:
 		for i, output := range tx.TxOut {
-			_, addrs, _, err := extractPkScriptAddrs(output.Version,
+			_, addrs, _, err := txscript.ExtractPkScriptAddrs(output.Version,
 				output.PkScript, params, isTreasuryEnabled)
 			if err != nil {
 				continue

--- a/rpcclient/chain.go
+++ b/rpcclient/chain.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -17,6 +17,7 @@ import (
 	"github.com/decred/dcrd/gcs/v3"
 	"github.com/decred/dcrd/gcs/v3/blockcf2"
 	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v3"
+	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -628,14 +629,14 @@ func (r *FutureValidateAddressResult) Receive() (*chainjson.ValidateAddressChain
 // the returned instance.
 //
 // See ValidateAddress for the blocking version and more details.
-func (c *Client) ValidateAddressAsync(ctx context.Context, address dcrutil.Address) *FutureValidateAddressResult {
+func (c *Client) ValidateAddressAsync(ctx context.Context, address stdaddr.Address) *FutureValidateAddressResult {
 	addr := address.Address()
 	cmd := chainjson.NewValidateAddressCmd(addr)
 	return (*FutureValidateAddressResult)(c.sendCmd(ctx, cmd))
 }
 
 // ValidateAddress returns information about the given Decred address.
-func (c *Client) ValidateAddress(ctx context.Context, address dcrutil.Address) (*chainjson.ValidateAddressChainResult, error) {
+func (c *Client) ValidateAddress(ctx context.Context, address stdaddr.Address) (*chainjson.ValidateAddressChainResult, error) {
 	return c.ValidateAddressAsync(ctx, address).Receive()
 }
 
@@ -666,7 +667,7 @@ func (r *FutureVerifyMessageResult) Receive() (bool, error) {
 // returned instance.
 //
 // See VerifyMessage for the blocking version and more details.
-func (c *Client) VerifyMessageAsync(ctx context.Context, address dcrutil.Address, signature, message string) *FutureVerifyMessageResult {
+func (c *Client) VerifyMessageAsync(ctx context.Context, address stdaddr.Address, signature, message string) *FutureVerifyMessageResult {
 	addr := address.Address()
 	cmd := chainjson.NewVerifyMessageCmd(addr, signature, message)
 	return (*FutureVerifyMessageResult)(c.sendCmd(ctx, cmd))
@@ -676,7 +677,7 @@ func (c *Client) VerifyMessageAsync(ctx context.Context, address dcrutil.Address
 //
 // NOTE: This function requires to the wallet to be unlocked.  See the
 // WalletPassphrase function for more details.
-func (c *Client) VerifyMessage(ctx context.Context, address dcrutil.Address, signature, message string) (bool, error) {
+func (c *Client) VerifyMessage(ctx context.Context, address stdaddr.Address, signature, message string) (bool, error) {
 	return c.VerifyMessageAsync(ctx, address, signature, message).Receive()
 }
 

--- a/rpcclient/extensions.go
+++ b/rpcclient/extensions.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2015 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -12,6 +12,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil/v4"
 	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v3"
+	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -134,7 +135,7 @@ func (r *FutureExistsAddressResult) Receive() (bool, error) {
 // ExistsAddressAsync returns an instance of a type that can be used to get the
 // result of the RPC at some future time by invoking the Receive function on the
 // returned instance.
-func (c *Client) ExistsAddressAsync(ctx context.Context, address dcrutil.Address) *FutureExistsAddressResult {
+func (c *Client) ExistsAddressAsync(ctx context.Context, address stdaddr.Address) *FutureExistsAddressResult {
 	cmd := chainjson.NewExistsAddressCmd(address.Address())
 	return (*FutureExistsAddressResult)(c.sendCmd(ctx, cmd))
 }
@@ -143,7 +144,7 @@ func (c *Client) ExistsAddressAsync(ctx context.Context, address dcrutil.Address
 // used on the main chain or in mempool.
 //
 // NOTE: This is a dcrd extension.
-func (c *Client) ExistsAddress(ctx context.Context, address dcrutil.Address) (bool, error) {
+func (c *Client) ExistsAddress(ctx context.Context, address stdaddr.Address) (bool, error) {
 	return c.ExistsAddressAsync(ctx, address).Receive()
 }
 
@@ -172,7 +173,7 @@ func (r *FutureExistsAddressesResult) Receive() (string, error) {
 // ExistsAddressesAsync returns an instance of a type that can be used to get the
 // result of the RPC at some future time by invoking the Receive function on the
 // returned instance.
-func (c *Client) ExistsAddressesAsync(ctx context.Context, addresses []dcrutil.Address) *FutureExistsAddressesResult {
+func (c *Client) ExistsAddressesAsync(ctx context.Context, addresses []stdaddr.Address) *FutureExistsAddressesResult {
 	addrsStr := make([]string, len(addresses))
 	for i := range addresses {
 		addrsStr[i] = addresses[i].Address()
@@ -186,7 +187,7 @@ func (c *Client) ExistsAddressesAsync(ctx context.Context, addresses []dcrutil.A
 // in the blockchain or memory pool.
 //
 // NOTE: This is a dcrd extension.
-func (c *Client) ExistsAddresses(ctx context.Context, addresses []dcrutil.Address) (string, error) {
+func (c *Client) ExistsAddresses(ctx context.Context, addresses []stdaddr.Address) (string, error) {
 	return c.ExistsAddressesAsync(ctx, addresses).Receive()
 }
 

--- a/rpcclient/go.mod
+++ b/rpcclient/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/decred/dcrd/dcrutil/v4 v4.0.0-20210129181600-6ae0142d3b28
 	github.com/decred/dcrd/gcs/v3 v3.0.0-20210129195202-a4265d63b619
 	github.com/decred/dcrd/rpc/jsonrpc/types/v3 v3.0.0-20210129200153-14fd1a785bf2
+	github.com/decred/dcrd/txscript/v4 v4.0.0-20210330065944-a2366e6e0b3b
 	github.com/decred/dcrd/wire v1.4.0
 	github.com/decred/go-socks v1.1.0
 	github.com/decred/slog v1.1.0

--- a/rpcclient/notify.go
+++ b/rpcclient/notify.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -16,6 +16,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil/v4"
 	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v3"
+	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -1139,7 +1140,7 @@ func (r *FutureLoadTxFilterResult) Receive() error {
 // See LoadTxFilter for the blocking version and more details.
 //
 // NOTE: This is a dcrd extension and requires a websocket connection.
-func (c *Client) LoadTxFilterAsync(ctx context.Context, reload bool, addresses []dcrutil.Address,
+func (c *Client) LoadTxFilterAsync(ctx context.Context, reload bool, addresses []stdaddr.Address,
 	outPoints []wire.OutPoint) *FutureLoadTxFilterResult {
 
 	addrStrs := make([]string, len(addresses))
@@ -1164,6 +1165,6 @@ func (c *Client) LoadTxFilterAsync(ctx context.Context, reload bool, addresses [
 // during mempool acceptance, block acceptance, and for all rescanned blocks.
 //
 // NOTE: This is a dcrd extension and requires a websocket connection.
-func (c *Client) LoadTxFilter(ctx context.Context, reload bool, addresses []dcrutil.Address, outPoints []wire.OutPoint) error {
+func (c *Client) LoadTxFilter(ctx context.Context, reload bool, addresses []stdaddr.Address, outPoints []wire.OutPoint) error {
 	return c.LoadTxFilterAsync(ctx, reload, addresses, outPoints).Receive()
 }

--- a/rpctest/rpc_harness.go
+++ b/rpctest/rpc_harness.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2016 The btcsuite developers
-// Copyright (c) 2017-2020 The Decred developers
+// Copyright (c) 2017-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -21,6 +21,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/rpcclient/v7"
+	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -259,7 +260,7 @@ func (h *Harness) SetUp(createTestChain bool, numMatureOutputs uint32) error {
 
 	// Filter transactions that pay to the coinbase associated with the
 	// wallet.
-	filterAddrs := []dcrutil.Address{h.wallet.coinbaseAddr}
+	filterAddrs := []stdaddr.Address{h.wallet.coinbaseAddr}
 	if err := h.Node.LoadTxFilter(ctx, true, filterAddrs, nil); err != nil {
 		return err
 	}
@@ -367,7 +368,7 @@ func (h *Harness) connectRPCClient() error {
 // wallet.
 //
 // This function is safe for concurrent access.
-func (h *Harness) NewAddress() (dcrutil.Address, error) {
+func (h *Harness) NewAddress() (stdaddr.Address, error) {
 	return h.wallet.NewAddress()
 }
 

--- a/rpctest/rpc_harness_test.go
+++ b/rpctest/rpc_harness_test.go
@@ -26,15 +26,6 @@ const (
 	numMatureOutputs = 25
 )
 
-// newTxOut returns a new transaction output with the given parameters.
-func newTxOut(amount int64, pkScriptVer uint16, pkScript []byte) *wire.TxOut {
-	return &wire.TxOut{
-		Value:    amount,
-		Version:  pkScriptVer,
-		PkScript: pkScript,
-	}
-}
-
 func testSendOutputs(ctx context.Context, r *Harness, t *testing.T) {
 	tracef(t, "testSendOutputs start")
 	defer tracef(t, "testSendOutputs end")

--- a/server.go
+++ b/server.go
@@ -3687,6 +3687,17 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 			return nil, errors.New("no usable rpc listen addresses")
 		}
 
+		// Convert stdaddr addresses to dcrutil addresses until all code is
+		// converted.
+		utilAddrs := make([]dcrutil.Address, 0, len(cfg.miningAddrs))
+		for _, addr := range cfg.miningAddrs {
+			utilAddr, err := dcrutil.DecodeAddress(addr.Address(), chainParams)
+			if err != nil {
+				return nil, err
+			}
+			utilAddrs = append(utilAddrs, utilAddr)
+		}
+
 		rpcsConfig := rpcserver.Config{
 			Listeners:    rpcListeners,
 			ConnMgr:      &rpcConnManager{&s},
@@ -3718,7 +3729,7 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 			RPCMaxConcurrentReqs: cfg.RPCMaxConcurrentReqs,
 			RPCMaxWebsockets:     cfg.RPCMaxWebsockets,
 			TestNet:              cfg.TestNet,
-			MiningAddrs:          cfg.miningAddrs,
+			MiningAddrs:          utilAddrs,
 			AllowUnsyncedMining:  cfg.AllowUnsyncedMining,
 			MaxProtocolVersion:   maxProtocolVersion,
 			UserAgentVersion:     userAgentVersion,

--- a/server.go
+++ b/server.go
@@ -3687,17 +3687,6 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 			return nil, errors.New("no usable rpc listen addresses")
 		}
 
-		// Convert stdaddr addresses to dcrutil addresses until all code is
-		// converted.
-		utilAddrs := make([]dcrutil.Address, 0, len(cfg.miningAddrs))
-		for _, addr := range cfg.miningAddrs {
-			utilAddr, err := dcrutil.DecodeAddress(addr.Address(), chainParams)
-			if err != nil {
-				return nil, err
-			}
-			utilAddrs = append(utilAddrs, utilAddr)
-		}
-
 		rpcsConfig := rpcserver.Config{
 			Listeners:    rpcListeners,
 			ConnMgr:      &rpcConnManager{&s},
@@ -3729,7 +3718,7 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 			RPCMaxConcurrentReqs: cfg.RPCMaxConcurrentReqs,
 			RPCMaxWebsockets:     cfg.RPCMaxWebsockets,
 			TestNet:              cfg.TestNet,
-			MiningAddrs:          utilAddrs,
+			MiningAddrs:          cfg.miningAddrs,
 			AllowUnsyncedMining:  cfg.AllowUnsyncedMining,
 			MaxProtocolVersion:   maxProtocolVersion,
 			UserAgentVersion:     userAgentVersion,

--- a/txscript/error.go
+++ b/txscript/error.go
@@ -27,10 +27,6 @@ const (
 	// index that is greater than or equal to the number of outputs.
 	ErrInvalidSigHashSingleIndex = ErrorKind("ErrInvalidSigHashSingleIndex")
 
-	// ErrUnsupportedAddress is returned when a concrete type that
-	// implements a dcrutil.Address is not a supported type.
-	ErrUnsupportedAddress = ErrorKind("ErrUnsupportedAddress")
-
 	// ErrNotMultisigScript is returned from CalcMultiSigStats when the
 	// provided script is not a multisig script.
 	ErrNotMultisigScript = ErrorKind("ErrNotMultisigScript")

--- a/txscript/error_test.go
+++ b/txscript/error_test.go
@@ -19,7 +19,6 @@ func TestErrorKindStringer(t *testing.T) {
 	}{
 		{ErrInvalidIndex, "ErrInvalidIndex"},
 		{ErrInvalidSigHashSingleIndex, "ErrInvalidSigHashSingleIndex"},
-		{ErrUnsupportedAddress, "ErrUnsupportedAddress"},
 		{ErrTooManyRequiredSigs, "ErrTooManyRequiredSigs"},
 		{ErrTooMuchNullData, "ErrTooMuchNullData"},
 		{ErrUnsupportedScriptVersion, "ErrUnsupportedScriptVersion"},

--- a/txscript/example_test.go
+++ b/txscript/example_test.go
@@ -25,39 +25,6 @@ const (
 	noTreasury = false
 )
 
-// This example demonstrates creating a script which pays to a Decred address.
-// It also prints the created script hex and uses the DisasmString function to
-// display the disassembled script.
-func ExamplePayToAddrScript() {
-	// Parse the address to send the coins to into an address which is useful to
-	// ensure the accuracy of the address and determine the address type.  It is
-	// also required to determine the payment script.
-	mainNetParams := chaincfg.MainNetParams()
-	addressStr := "DsSej1qR3Fyc8kV176DCh9n9cY9nqf9Quxk"
-	address, err := stdaddr.DecodeAddress(addressStr, mainNetParams)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-
-	// Create a public key script that pays to the address.
-	scriptVersion, script := address.PaymentScript()
-	fmt.Printf("Script Version: %d\n", scriptVersion)
-	fmt.Printf("Script Hex: %x\n", script)
-
-	disasm, err := txscript.DisasmString(script)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-	fmt.Println("Script Disassembly:", disasm)
-
-	// Output:
-	// Script Version: 0
-	// Script Hex: 76a914128004ff2fcaf13b2b91eb654b1dc2b674f7ec6188ac
-	// Script Disassembly: OP_DUP OP_HASH160 128004ff2fcaf13b2b91eb654b1dc2b674f7ec61 OP_EQUALVERIFY OP_CHECKSIG
-}
-
 // This example demonstrates extracting information from a standard public key
 // script.
 func ExampleExtractPkScriptAddrs() {

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -810,16 +810,6 @@ func payToSchnorrPubKeyScript(serializedPubKey []byte) ([]byte, error) {
 		AddOp(OP_CHECKSIGALT).Script()
 }
 
-// PayToSSGenPKHDirect creates a new script to pay a transaction output to a
-// public key hash, but tags the output with OP_SSGEN. For use in constructing
-// valid SSGen txs. Unlike PayToSSGen, this function directly uses the HASH160
-// pubkeyhash (instead of an address).
-func PayToSSGenPKHDirect(pkh []byte) ([]byte, error) {
-	return NewScriptBuilder().AddOp(OP_SSGEN).AddOp(OP_DUP).
-		AddOp(OP_HASH160).AddData(pkh).AddOp(OP_EQUALVERIFY).
-		AddOp(OP_CHECKSIG).Script()
-}
-
 // PayToSSRtx creates a new script to pay a transaction output to a
 // public key hash, but tags the output with OP_SSRTX. For use in constructing
 // valid SSRtx.

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -820,15 +820,6 @@ func PayToSSGenPKHDirect(pkh []byte) ([]byte, error) {
 		AddOp(OP_CHECKSIG).Script()
 }
 
-// PayToSSGenSHDirect creates a new script to pay a transaction output to a
-// script hash, but tags the output with OP_SSGEN. For use in constructing
-// valid SSGen txs. Unlike PayToSSGen, this function directly uses the HASH160
-// script hash (instead of an address).
-func PayToSSGenSHDirect(sh []byte) ([]byte, error) {
-	return NewScriptBuilder().AddOp(OP_SSGEN).AddOp(OP_HASH160).
-		AddData(sh).AddOp(OP_EQUAL).Script()
-}
-
 // PayToSSRtx creates a new script to pay a transaction output to a
 // public key hash, but tags the output with OP_SSRTX. For use in constructing
 // valid SSRtx.

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -781,13 +781,6 @@ func payToScriptHashScript(scriptHash []byte) ([]byte, error) {
 		AddOp(OP_EQUAL).Script()
 }
 
-// payToPubkeyScript creates a new script to pay a transaction output to a
-// public key. It is expected that the input is a valid pubkey.
-func payToPubKeyScript(serializedPubKey []byte) ([]byte, error) {
-	return NewScriptBuilder().AddData(serializedPubKey).
-		AddOp(OP_CHECKSIG).Script()
-}
-
 // GenerateSStxAddrPush generates an OP_RETURN push for SSGen payment addresses in
 // an SStx.
 func GenerateSStxAddrPush(addr dcrutil.Address, amount dcrutil.Amount, limits uint16) ([]byte, error) {

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -810,49 +810,6 @@ func payToSchnorrPubKeyScript(serializedPubKey []byte) ([]byte, error) {
 		AddOp(OP_CHECKSIGALT).Script()
 }
 
-// PayToSSGen creates a new script to pay a transaction output to a public key
-// hash or script hash, but tags the output with OP_SSGEN. For use in constructing
-// valid SSGen txs.
-func PayToSSGen(addr dcrutil.Address) ([]byte, error) {
-	// Only pay to pubkey hash and pay to script hash are
-	// supported.
-	scriptType := PubKeyHashTy
-	switch addr := addr.(type) {
-	case *dcrutil.AddressPubKeyHash:
-		if addr == nil {
-			return nil, scriptError(ErrUnsupportedAddress,
-				nilAddrErrStr)
-		}
-		if addr.DSA() != dcrec.STEcdsaSecp256k1 {
-			str := "unable to generate payment script for " +
-				"unsupported digital signature algorithm"
-			return nil, scriptError(ErrUnsupportedAddress, str)
-		}
-
-	case *dcrutil.AddressScriptHash:
-		if addr == nil {
-			return nil, scriptError(ErrUnsupportedAddress,
-				nilAddrErrStr)
-		}
-		scriptType = ScriptHashTy
-
-	default:
-		str := fmt.Sprintf("unable to generate payment script for "+
-			"unsupported address type %T", addr)
-		return nil, scriptError(ErrUnsupportedAddress, str)
-	}
-
-	hash := addr.ScriptAddress()
-
-	if scriptType == PubKeyHashTy {
-		return NewScriptBuilder().AddOp(OP_SSGEN).AddOp(OP_DUP).
-			AddOp(OP_HASH160).AddData(hash).AddOp(OP_EQUALVERIFY).
-			AddOp(OP_CHECKSIG).Script()
-	}
-	return NewScriptBuilder().AddOp(OP_SSGEN).AddOp(OP_HASH160).
-		AddData(hash).AddOp(OP_EQUAL).Script()
-}
-
 // PayToSSGenPKHDirect creates a new script to pay a transaction output to a
 // public key hash, but tags the output with OP_SSGEN. For use in constructing
 // valid SSGen txs. Unlike PayToSSGen, this function directly uses the HASH160

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -774,13 +774,6 @@ func payToPubKeyHashSchnorrScript(pubKeyHash []byte) ([]byte, error) {
 		AddOp(OP_CHECKSIGALT).Script()
 }
 
-// payToScriptHashScript creates a new script to pay a transaction output to a
-// script hash. It is expected that the input is a valid hash.
-func payToScriptHashScript(scriptHash []byte) ([]byte, error) {
-	return NewScriptBuilder().AddOp(OP_HASH160).AddData(scriptHash).
-		AddOp(OP_EQUAL).Script()
-}
-
 // GenerateSStxAddrPush generates an OP_RETURN push for SSGen payment addresses in
 // an SStx.
 func GenerateSStxAddrPush(addr dcrutil.Address, amount dcrutil.Amount, limits uint16) ([]byte, error) {

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -763,17 +763,6 @@ func payToPubKeyHashEdwardsScript(pubKeyHash []byte) ([]byte, error) {
 		AddOp(OP_CHECKSIGALT).Script()
 }
 
-// payToPubKeyHashSchnorrScript creates a new script to pay a transaction
-// output to a 20-byte pubkey hash of a secp256k1 public key, but expecting
-// a schnorr signature instead of a classic secp256k1 signature. It is
-// expected that the input is a valid hash.
-func payToPubKeyHashSchnorrScript(pubKeyHash []byte) ([]byte, error) {
-	schnorrData := []byte{byte(dcrec.STSchnorrSecp256k1)}
-	return NewScriptBuilder().AddOp(OP_DUP).AddOp(OP_HASH160).
-		AddData(pubKeyHash).AddOp(OP_EQUALVERIFY).AddData(schnorrData).
-		AddOp(OP_CHECKSIGALT).Script()
-}
-
 // GenerateSStxAddrPush generates an OP_RETURN push for SSGen payment addresses in
 // an SStx.
 func GenerateSStxAddrPush(addr dcrutil.Address, amount dcrutil.Amount, limits uint16) ([]byte, error) {

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -810,16 +810,6 @@ func payToSchnorrPubKeyScript(serializedPubKey []byte) ([]byte, error) {
 		AddOp(OP_CHECKSIGALT).Script()
 }
 
-// PayToSSRtxPKHDirect creates a new script to pay a transaction output to a
-// public key hash, but tags the output with OP_SSRTX. For use in constructing
-// valid SSRtx. Unlike PayToSSRtx, this function directly uses the HASH160
-// pubkeyhash (instead of an address).
-func PayToSSRtxPKHDirect(pkh []byte) ([]byte, error) {
-	return NewScriptBuilder().AddOp(OP_SSRTX).AddOp(OP_DUP).
-		AddOp(OP_HASH160).AddData(pkh).AddOp(OP_EQUALVERIFY).
-		AddOp(OP_CHECKSIG).Script()
-}
-
 // PayToSSRtxSHDirect creates a new script to pay a transaction output to a
 // script hash, but tags the output with OP_SSRTX. For use in constructing
 // valid SSRtx. Unlike PayToSSRtx, this function directly uses the HASH160

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -810,15 +810,6 @@ func payToSchnorrPubKeyScript(serializedPubKey []byte) ([]byte, error) {
 		AddOp(OP_CHECKSIGALT).Script()
 }
 
-// PayToSSRtxSHDirect creates a new script to pay a transaction output to a
-// script hash, but tags the output with OP_SSRTX. For use in constructing
-// valid SSRtx. Unlike PayToSSRtx, this function directly uses the HASH160
-// script hash (instead of an address).
-func PayToSSRtxSHDirect(sh []byte) ([]byte, error) {
-	return NewScriptBuilder().AddOp(OP_SSRTX).AddOp(OP_HASH160).
-		AddData(sh).AddOp(OP_EQUAL).Script()
-}
-
 // GenerateSStxAddrPush generates an OP_RETURN push for SSGen payment addresses in
 // an SStx.
 func GenerateSStxAddrPush(addr dcrutil.Address, amount dcrutil.Amount, limits uint16) ([]byte, error) {

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -781,11 +781,6 @@ func payToScriptHashScript(scriptHash []byte) ([]byte, error) {
 		AddOp(OP_EQUAL).Script()
 }
 
-// PayToScriptHashScript is the exported version of payToScriptHashScript.
-func PayToScriptHashScript(scriptHash []byte) ([]byte, error) {
-	return payToScriptHashScript(scriptHash)
-}
-
 // payToPubkeyScript creates a new script to pay a transaction output to a
 // public key. It is expected that the input is a valid pubkey.
 func payToPubKeyScript(serializedPubKey []byte) ([]byte, error) {

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -810,49 +810,6 @@ func payToSchnorrPubKeyScript(serializedPubKey []byte) ([]byte, error) {
 		AddOp(OP_CHECKSIGALT).Script()
 }
 
-// PayToSStxChange creates a new script to pay a transaction output to a
-// public key hash, but tags the output with OP_SSTXCHANGE. For use in constructing
-// valid SStxs.
-func PayToSStxChange(addr dcrutil.Address) ([]byte, error) {
-	// Only pay to pubkey hash and pay to script hash are
-	// supported.
-	scriptType := PubKeyHashTy
-	switch addr := addr.(type) {
-	case *dcrutil.AddressPubKeyHash:
-		if addr == nil {
-			return nil, scriptError(ErrUnsupportedAddress,
-				nilAddrErrStr)
-		}
-		if addr.DSA() != dcrec.STEcdsaSecp256k1 {
-			str := "unable to generate payment script for " +
-				"unsupported digital signature algorithm"
-			return nil, scriptError(ErrUnsupportedAddress, str)
-		}
-
-	case *dcrutil.AddressScriptHash:
-		if addr == nil {
-			return nil, scriptError(ErrUnsupportedAddress,
-				nilAddrErrStr)
-		}
-		scriptType = ScriptHashTy
-
-	default:
-		str := fmt.Sprintf("unable to generate payment script for "+
-			"unsupported address type %T", addr)
-		return nil, scriptError(ErrUnsupportedAddress, str)
-	}
-
-	hash := addr.ScriptAddress()
-
-	if scriptType == PubKeyHashTy {
-		return NewScriptBuilder().AddOp(OP_SSTXCHANGE).AddOp(OP_DUP).
-			AddOp(OP_HASH160).AddData(hash).AddOp(OP_EQUALVERIFY).
-			AddOp(OP_CHECKSIG).Script()
-	}
-	return NewScriptBuilder().AddOp(OP_SSTXCHANGE).AddOp(OP_HASH160).
-		AddData(hash).AddOp(OP_EQUAL).Script()
-}
-
 // PayToSSGen creates a new script to pay a transaction output to a public key
 // hash or script hash, but tags the output with OP_SSGEN. For use in constructing
 // valid SSGen txs.

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -744,15 +744,6 @@ func MultisigRedeemScriptFromScriptSig(script []byte) []byte {
 	return finalOpcodeData(scriptVersion, script)
 }
 
-// payToPubKeyHashScript creates a new script to pay a transaction
-// output to a 20-byte pubkey hash. It is expected that the input is a valid
-// hash.
-func payToPubKeyHashScript(pubKeyHash []byte) ([]byte, error) {
-	return NewScriptBuilder().AddOp(OP_DUP).AddOp(OP_HASH160).
-		AddData(pubKeyHash).AddOp(OP_EQUALVERIFY).AddOp(OP_CHECKSIG).
-		Script()
-}
-
 // GenerateSStxAddrPush generates an OP_RETURN push for SSGen payment addresses in
 // an SStx.
 func GenerateSStxAddrPush(addr dcrutil.Address, amount dcrutil.Amount, limits uint16) ([]byte, error) {

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -810,49 +810,6 @@ func payToSchnorrPubKeyScript(serializedPubKey []byte) ([]byte, error) {
 		AddOp(OP_CHECKSIGALT).Script()
 }
 
-// PayToSStx creates a new script to pay a transaction output to a script hash or
-// public key hash, but tags the output with OP_SSTX. For use in constructing
-// valid SStxs.
-func PayToSStx(addr dcrutil.Address) ([]byte, error) {
-	// Only pay to pubkey hash and pay to script hash are
-	// supported.
-	scriptType := PubKeyHashTy
-	switch addr := addr.(type) {
-	case *dcrutil.AddressPubKeyHash:
-		if addr == nil {
-			return nil, scriptError(ErrUnsupportedAddress,
-				nilAddrErrStr)
-		}
-		if addr.DSA() != dcrec.STEcdsaSecp256k1 {
-			str := "unable to generate payment script for " +
-				"unsupported digital signature algorithm"
-			return nil, scriptError(ErrUnsupportedAddress, str)
-		}
-
-	case *dcrutil.AddressScriptHash:
-		if addr == nil {
-			return nil, scriptError(ErrUnsupportedAddress,
-				nilAddrErrStr)
-		}
-		scriptType = ScriptHashTy
-
-	default:
-		str := fmt.Sprintf("unable to generate payment script for "+
-			"unsupported address type %T", addr)
-		return nil, scriptError(ErrUnsupportedAddress, str)
-	}
-
-	hash := addr.ScriptAddress()
-
-	if scriptType == PubKeyHashTy {
-		return NewScriptBuilder().AddOp(OP_SSTX).AddOp(OP_DUP).
-			AddOp(OP_HASH160).AddData(hash).AddOp(OP_EQUALVERIFY).
-			AddOp(OP_CHECKSIG).Script()
-	}
-	return NewScriptBuilder().AddOp(OP_SSTX).AddOp(OP_HASH160).
-		AddData(hash).AddOp(OP_EQUAL).Script()
-}
-
 // PayToSStxChange creates a new script to pay a transaction output to a
 // public key hash, but tags the output with OP_SSTXCHANGE. For use in constructing
 // valid SStxs.

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -810,49 +810,6 @@ func payToSchnorrPubKeyScript(serializedPubKey []byte) ([]byte, error) {
 		AddOp(OP_CHECKSIGALT).Script()
 }
 
-// PayToSSRtx creates a new script to pay a transaction output to a
-// public key hash, but tags the output with OP_SSRTX. For use in constructing
-// valid SSRtx.
-func PayToSSRtx(addr dcrutil.Address) ([]byte, error) {
-	// Only pay to pubkey hash and pay to script hash are
-	// supported.
-	scriptType := PubKeyHashTy
-	switch addr := addr.(type) {
-	case *dcrutil.AddressPubKeyHash:
-		if addr == nil {
-			return nil, scriptError(ErrUnsupportedAddress,
-				nilAddrErrStr)
-		}
-		if addr.DSA() != dcrec.STEcdsaSecp256k1 {
-			str := "unable to generate payment script for " +
-				"unsupported digital signature algorithm"
-			return nil, scriptError(ErrUnsupportedAddress, str)
-		}
-
-	case *dcrutil.AddressScriptHash:
-		if addr == nil {
-			return nil, scriptError(ErrUnsupportedAddress,
-				nilAddrErrStr)
-		}
-		scriptType = ScriptHashTy
-
-	default:
-		str := fmt.Sprintf("unable to generate payment script for "+
-			"unsupported address type %T", addr)
-		return nil, scriptError(ErrUnsupportedAddress, str)
-	}
-
-	hash := addr.ScriptAddress()
-
-	if scriptType == PubKeyHashTy {
-		return NewScriptBuilder().AddOp(OP_SSRTX).AddOp(OP_DUP).
-			AddOp(OP_HASH160).AddData(hash).AddOp(OP_EQUALVERIFY).
-			AddOp(OP_CHECKSIG).Script()
-	}
-	return NewScriptBuilder().AddOp(OP_SSRTX).AddOp(OP_HASH160).
-		AddData(hash).AddOp(OP_EQUAL).Script()
-}
-
 // PayToSSRtxPKHDirect creates a new script to pay a transaction output to a
 // public key hash, but tags the output with OP_SSRTX. For use in constructing
 // valid SSRtx. Unlike PayToSSRtx, this function directly uses the HASH160

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -888,58 +888,6 @@ func GenerateProvablyPruneableOut(data []byte) ([]byte, error) {
 	return NewScriptBuilder().AddOp(OP_RETURN).AddData(data).Script()
 }
 
-// PayToAddrScript creates a new script to pay a transaction output to a the
-// specified address.
-func PayToAddrScript(addr dcrutil.Address) ([]byte, error) {
-	switch addr := addr.(type) {
-	case *dcrutil.AddressPubKeyHash:
-		if addr == nil {
-			return nil, scriptError(ErrUnsupportedAddress,
-				nilAddrErrStr)
-		}
-		switch addr.DSA() {
-		case dcrec.STEcdsaSecp256k1:
-			return payToPubKeyHashScript(addr.ScriptAddress())
-		case dcrec.STEd25519:
-			return payToPubKeyHashEdwardsScript(addr.ScriptAddress())
-		case dcrec.STSchnorrSecp256k1:
-			return payToPubKeyHashSchnorrScript(addr.ScriptAddress())
-		}
-
-	case *dcrutil.AddressScriptHash:
-		if addr == nil {
-			return nil, scriptError(ErrUnsupportedAddress,
-				nilAddrErrStr)
-		}
-		return payToScriptHashScript(addr.ScriptAddress())
-
-	case *dcrutil.AddressSecpPubKey:
-		if addr == nil {
-			return nil, scriptError(ErrUnsupportedAddress,
-				nilAddrErrStr)
-		}
-		return payToPubKeyScript(addr.ScriptAddress())
-
-	case *dcrutil.AddressEdwardsPubKey:
-		if addr == nil {
-			return nil, scriptError(ErrUnsupportedAddress,
-				nilAddrErrStr)
-		}
-		return payToEdwardsPubKeyScript(addr.ScriptAddress())
-
-	case *dcrutil.AddressSecSchnorrPubKey:
-		if addr == nil {
-			return nil, scriptError(ErrUnsupportedAddress,
-				nilAddrErrStr)
-		}
-		return payToSchnorrPubKeyScript(addr.ScriptAddress())
-	}
-
-	str := fmt.Sprintf("unable to generate payment script for unsupported "+
-		"address type %T", addr)
-	return nil, scriptError(ErrUnsupportedAddress, str)
-}
-
 // MultiSigScript returns a valid script for a multisignature redemption where
 // the specified threshold number of the keys in the given public keys are
 // required to have signed the transaction for success.

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -788,14 +788,6 @@ func payToPubKeyScript(serializedPubKey []byte) ([]byte, error) {
 		AddOp(OP_CHECKSIG).Script()
 }
 
-// payToEdwardsPubKeyScript creates a new script to pay a transaction output
-// to an Ed25519 public key. It is expected that the input is a valid pubkey.
-func payToEdwardsPubKeyScript(serializedPubKey []byte) ([]byte, error) {
-	edwardsData := []byte{byte(dcrec.STEd25519)}
-	return NewScriptBuilder().AddData(serializedPubKey).AddData(edwardsData).
-		AddOp(OP_CHECKSIGALT).Script()
-}
-
 // GenerateSStxAddrPush generates an OP_RETURN push for SSGen payment addresses in
 // an SStx.
 func GenerateSStxAddrPush(addr dcrutil.Address, amount dcrutil.Amount, limits uint16) ([]byte, error) {

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -753,16 +753,6 @@ func payToPubKeyHashScript(pubKeyHash []byte) ([]byte, error) {
 		Script()
 }
 
-// payToPubKeyHashEdwardsScript creates a new script to pay a transaction
-// output to a 20-byte pubkey hash of an Edwards public key. It is expected
-// that the input is a valid hash.
-func payToPubKeyHashEdwardsScript(pubKeyHash []byte) ([]byte, error) {
-	edwardsData := []byte{byte(dcrec.STEd25519)}
-	return NewScriptBuilder().AddOp(OP_DUP).AddOp(OP_HASH160).
-		AddData(pubKeyHash).AddOp(OP_EQUALVERIFY).AddData(edwardsData).
-		AddOp(OP_CHECKSIGALT).Script()
-}
-
 // GenerateSStxAddrPush generates an OP_RETURN push for SSGen payment addresses in
 // an SStx.
 func GenerateSStxAddrPush(addr dcrutil.Address, amount dcrutil.Amount, limits uint16) ([]byte, error) {

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -796,15 +796,6 @@ func payToEdwardsPubKeyScript(serializedPubKey []byte) ([]byte, error) {
 		AddOp(OP_CHECKSIGALT).Script()
 }
 
-// payToSchnorrPubKeyScript creates a new script to pay a transaction output
-// to a secp256k1 public key, but to be signed by Schnorr type signature. It
-// is expected that the input is a valid pubkey.
-func payToSchnorrPubKeyScript(serializedPubKey []byte) ([]byte, error) {
-	schnorrData := []byte{byte(dcrec.STSchnorrSecp256k1)}
-	return NewScriptBuilder().AddData(serializedPubKey).AddData(schnorrData).
-		AddOp(OP_CHECKSIGALT).Script()
-}
-
 // GenerateSStxAddrPush generates an OP_RETURN push for SSGen payment addresses in
 // an SStx.
 func GenerateSStxAddrPush(addr dcrutil.Address, amount dcrutil.Amount, limits uint16) ([]byte, error) {

--- a/txscript/standard_test.go
+++ b/txscript/standard_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2017 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -14,9 +14,9 @@ import (
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v3"
-	"github.com/decred/dcrd/dcrec"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/dcrutil/v4"
+	"github.com/decred/dcrd/txscript/v4/stdaddr"
 )
 
 // mainNetParams is an instance of the main network parameters and is shared
@@ -37,16 +37,16 @@ func mustParseShortForm(script string) []byte {
 	return s
 }
 
-// newAddressPubKey returns a new dcrutil.AddressPubKey from the provided
-// serialized public key.  It panics if an error occurs.  This is only used in
-// the tests as a helper since the only way it can fail is if there is an error
-// in the test source code.
-func newAddressPubKey(serializedPubKey []byte) dcrutil.Address {
+// newAddressPubKey returns a new pubkey address from the provided serialized
+// public key.  It panics if an error occurs.  This is only used in the tests as
+// a helper since the only way it can fail is if there is an error in the test
+// source code.
+func newAddressPubKey(serializedPubKey []byte) stdaddr.Address {
 	pubkey, err := secp256k1.ParsePubKey(serializedPubKey)
 	if err != nil {
 		panic("invalid public key in test source")
 	}
-	addr, err := dcrutil.NewAddressSecpPubKeyCompressed(pubkey, mainNetParams)
+	addr, err := stdaddr.NewAddressPubKeyEcdsaSecp256k1V0(pubkey, mainNetParams)
 	if err != nil {
 		panic("invalid public key in test source")
 	}
@@ -54,13 +54,12 @@ func newAddressPubKey(serializedPubKey []byte) dcrutil.Address {
 	return addr
 }
 
-// newAddressPubKeyHash returns a new dcrutil.AddressPubKeyHash from the
-// provided hash.  It panics if an error occurs.  This is only used in the tests
-// as a helper since the only way it can fail is if there is an error in the
-// test source code.
-func newAddressPubKeyHash(pkHash []byte) dcrutil.Address {
-	addr, err := dcrutil.NewAddressPubKeyHash(pkHash, mainNetParams,
-		dcrec.STEcdsaSecp256k1)
+// newAddressPubKeyHash returns a new pubkey hash from the provided hash.  It
+// panics if an error occurs.  This is only used in the tests as a helper since
+// the only way it can fail is if there is an error in the test source code.
+func newAddressPubKeyHash(pkHash []byte) stdaddr.Address {
+	addr, err := stdaddr.NewAddressPubKeyHashEcdsaSecp256k1V0(pkHash,
+		mainNetParams)
 	if err != nil {
 		panic("invalid public key hash in test source")
 	}
@@ -68,12 +67,13 @@ func newAddressPubKeyHash(pkHash []byte) dcrutil.Address {
 	return addr
 }
 
-// newAddressScriptHash returns a new dcrutil.AddressScriptHash from the
-// provided hash.  It panics if an error occurs.  This is only used in the tests
-// as a helper since the only way it can fail is if there is an error in the
-// test source code.
-func newAddressScriptHash(scriptHash []byte) dcrutil.Address {
-	addr, err := dcrutil.NewAddressScriptHashFromHash(scriptHash, mainNetParams)
+// newAddressScriptHash returns a new script hash address from the provided
+// hash.  It panics if an error occurs.  This is only used in the tests as a
+// helper since the only way it can fail is if there is an error in the test
+// source code.
+func newAddressScriptHash(scriptHash []byte) stdaddr.Address {
+	addr, err := stdaddr.NewAddressScriptHashV0FromHash(scriptHash,
+		mainNetParams)
 	if err != nil {
 		panic("invalid script hash in test source")
 	}
@@ -90,7 +90,7 @@ func TestExtractPkScriptAddrs(t *testing.T) {
 	tests := []struct {
 		name    string
 		script  []byte
-		addrs   []dcrutil.Address
+		addrs   []stdaddr.Address
 		reqSigs int
 		class   ScriptClass
 		noparse bool
@@ -99,7 +99,7 @@ func TestExtractPkScriptAddrs(t *testing.T) {
 			name: "standard p2pk with compressed pubkey (0x02)",
 			script: hexToBytes("2102192d74d0cb94344c9569c2e779015" +
 				"73d8d7903c3ebec3a957724895dca52c6b4ac"),
-			addrs: []dcrutil.Address{
+			addrs: []stdaddr.Address{
 				newAddressPubKey(hexToBytes("02192d74d0cb9434" +
 					"4c9569c2e77901573d8d7903c3ebec3a9577" +
 					"24895dca52c6b4")),
@@ -113,7 +113,7 @@ func TestExtractPkScriptAddrs(t *testing.T) {
 				"c1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddf" +
 				"b84ccf9744464f82e160bfa9b8b64f9d4c03f999b864" +
 				"3f656b412a3ac"),
-			addrs: []dcrutil.Address{
+			addrs: []stdaddr.Address{
 				newAddressPubKey(hexToBytes("0411db93e1dcdb8a" +
 					"016b49840f8c53bc1eb68a382e97b1482eca" +
 					"d7b148a6909a5cb2e0eaddfb84ccf9744464" +
@@ -127,7 +127,7 @@ func TestExtractPkScriptAddrs(t *testing.T) {
 			name: "standard p2pk with compressed pubkey (0x03)",
 			script: hexToBytes("2103b0bd634234abbb1ba1e986e884185" +
 				"c61cf43e001f9137f23c2c409273eb16e65ac"),
-			addrs: []dcrutil.Address{
+			addrs: []stdaddr.Address{
 				newAddressPubKey(hexToBytes("03b0bd634234abbb" +
 					"1ba1e986e884185c61cf43e001f9137f23c2" +
 					"c409273eb16e65")),
@@ -141,7 +141,7 @@ func TestExtractPkScriptAddrs(t *testing.T) {
 				"c61cf43e001f9137f23c2c409273eb16e6537a576782" +
 				"eba668a7ef8bd3b3cfb1edb7117ab65129b8a2e681f3" +
 				"c1e0908ef7bac"),
-			addrs: []dcrutil.Address{
+			addrs: []stdaddr.Address{
 				newAddressPubKey(hexToBytes("04b0bd634234abbb" +
 					"1ba1e986e884185c61cf43e001f9137f23c2" +
 					"c409273eb16e6537a576782eba668a7ef8bd" +
@@ -155,7 +155,7 @@ func TestExtractPkScriptAddrs(t *testing.T) {
 			name: "standard p2pkh",
 			script: hexToBytes("76a914ad06dd6ddee55cbca9a9e3713bd" +
 				"7587509a3056488ac"),
-			addrs: []dcrutil.Address{
+			addrs: []stdaddr.Address{
 				newAddressPubKeyHash(hexToBytes("ad06dd6ddee5" +
 					"5cbca9a9e3713bd7587509a30564")),
 			},
@@ -166,7 +166,7 @@ func TestExtractPkScriptAddrs(t *testing.T) {
 			name: "standard p2sh",
 			script: hexToBytes("a91463bcc565f9e68ee0189dd5cc67f1b" +
 				"0e5f02f45cb87"),
-			addrs: []dcrutil.Address{
+			addrs: []stdaddr.Address{
 				newAddressScriptHash(hexToBytes("63bcc565f9e6" +
 					"8ee0189dd5cc67f1b0e5f02f45cb")),
 			},
@@ -183,7 +183,7 @@ func TestExtractPkScriptAddrs(t *testing.T) {
 				"1354d80e550078cb532a34bfa2fcfdeb7d76519aecc6" +
 				"2770f5b0e4ef8551946d8a540911abe3e7854a26f39f" +
 				"58b25c15342af52ae"),
-			addrs: []dcrutil.Address{
+			addrs: []stdaddr.Address{
 				newAddressPubKey(hexToBytes("04cc71eb30d653c0" +
 					"c3163990c47b976f3fb3f37cccdcbedb169a" +
 					"1dfef58bbfbfaff7d8a473e7e2e6d317b87b" +
@@ -211,7 +211,7 @@ func TestExtractPkScriptAddrs(t *testing.T) {
 				"2bbf781c5410d3f22a7a3a56ffefb2238af8627363bd" +
 				"f2ed97c1f89784a1aecdb43384f11d2acc64443c7fc2" +
 				"99cef0400421a53ae"),
-			addrs: []dcrutil.Address{
+			addrs: []stdaddr.Address{
 				newAddressPubKey(hexToBytes("04cb9c3c222c5f7a" +
 					"7d3b9bd152f363a0b6d54c9eb312c4d4f9af" +
 					"1e8551b6c421a6a4ab0e29105f24de20ff46" +
@@ -288,7 +288,7 @@ func TestExtractPkScriptAddrs(t *testing.T) {
 				"16e20626520666f756e6420696e207472616e7361637" +
 				"4696f6e2036633533636439383731313965663739376" +
 				"435616463636453ae"),
-			addrs:   []dcrutil.Address{},
+			addrs:   []stdaddr.Address{},
 			reqSigs: 1,
 			class:   MultiSigTy,
 		},
@@ -305,7 +305,7 @@ func TestExtractPkScriptAddrs(t *testing.T) {
 				"13963663463303363363039633539336333653931666" +
 				"56465373032392102323364643432643235363339643" +
 				"338613663663530616234636434340a00000053ae"),
-			addrs:   []dcrutil.Address{},
+			addrs:   []stdaddr.Address{},
 			reqSigs: 1,
 			class:   MultiSigTy,
 		},
@@ -386,146 +386,6 @@ func TestExtractPkScriptAddrs(t *testing.T) {
 			t.Errorf("ExtractPkScriptAddrs #%d (%s) unexpected "+
 				"script type - got %s, want %s", i, test.name,
 				class, test.class)
-			continue
-		}
-	}
-}
-
-// bogusAddress implements the dcrutil.Address interface so the tests can ensure
-// unsupported address types are handled properly.
-type bogusAddress struct{}
-
-// Address simply returns an empty string.  It exists to satisfy the
-// dcrutil.Address interface.
-func (b *bogusAddress) Address() string {
-	return ""
-}
-
-// ScriptAddress simply returns an empty byte slice.  It exists to satisfy the
-// dcrutil.Address interface.
-func (b *bogusAddress) ScriptAddress() []byte {
-	return nil
-}
-
-// Hash160 simply returns an empty byte slice.  It exists to satisfy the
-// dcrutil.Address interface.
-func (b *bogusAddress) Hash160() *[20]byte {
-	return nil
-}
-
-// String simply returns an empty string.  It exists to satisfy the
-// dcrutil.Address interface.
-func (b *bogusAddress) String() string {
-	return ""
-}
-
-// TestPayToAddrScript ensures the PayToAddrScript function generates the
-// correct scripts for the various types of addresses.
-func TestPayToAddrScript(t *testing.T) {
-	t.Parallel()
-
-	// 1MirQ9bwyQcGVJPwKUgapu5ouK2E2Ey4gX
-	p2pkhMain, err := dcrutil.NewAddressPubKeyHash(hexToBytes("e34cce70c86"+
-		"373273efcc54ce7d2a491bb4a0e84"), mainNetParams, dcrec.STEcdsaSecp256k1)
-	if err != nil {
-		t.Fatalf("Unable to create public key hash address: %v", err)
-	}
-
-	// Taken from transaction:
-	// b0539a45de13b3e0403909b8bd1a555b8cbe45fd4e3f3fda76f3a5f52835c29d
-	p2shMain, _ := dcrutil.NewAddressScriptHashFromHash(hexToBytes("e8c30"+
-		"0c87986efa84c37c0519929019ef86eb5b4"), mainNetParams)
-	if err != nil {
-		t.Fatalf("Unable to create script hash address: %v", err)
-	}
-
-	//  mainnet p2pk 13CG6SJ3yHUXo4Cr2RY4THLLJrNFuG3gUg
-	p2pkCompressedMain, err := dcrutil.NewAddressSecpPubKey(hexToBytes("02192d7"+
-		"4d0cb94344c9569c2e77901573d8d7903c3ebec3a957724895dca52c6b4"),
-		mainNetParams)
-	if err != nil {
-		t.Fatalf("Unable to create pubkey address (compressed): %v",
-			err)
-	}
-	p2pkCompressed2Main, err := dcrutil.NewAddressSecpPubKey(hexToBytes("03b0b"+
-		"d634234abbb1ba1e986e884185c61cf43e001f9137f23c2c409273eb16e65"),
-		mainNetParams)
-	if err != nil {
-		t.Fatalf("Unable to create pubkey address (compressed 2): %v",
-			err)
-	}
-
-	p2pkUncompressedMain := newAddressPubKey(hexToBytes("0411db" +
-		"93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2" +
-		"e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3"))
-
-	tests := []struct {
-		in       dcrutil.Address
-		expected string
-		err      error
-	}{
-		// pay-to-pubkey-hash address on mainnet 0
-		{
-			p2pkhMain,
-			"DUP HASH160 DATA_20 0xe34cce70c86373273efcc54ce7d2a4" +
-				"91bb4a0e8488 CHECKSIG",
-			nil,
-		},
-		// pay-to-script-hash address on mainnet 1
-		{
-			p2shMain,
-			"HASH160 DATA_20 0xe8c300c87986efa84c37c0519929019ef8" +
-				"6eb5b4 EQUAL",
-			nil,
-		},
-		// pay-to-pubkey address on mainnet. compressed key. 2
-		{
-			p2pkCompressedMain,
-			"DATA_33 0x02192d74d0cb94344c9569c2e77901573d8d7903c3" +
-				"ebec3a957724895dca52c6b4 CHECKSIG",
-			nil,
-		},
-		// pay-to-pubkey address on mainnet. compressed key (other way). 3
-		{
-			p2pkCompressed2Main,
-			"DATA_33 0x03b0bd634234abbb1ba1e986e884185c61cf43e001" +
-				"f9137f23c2c409273eb16e65 CHECKSIG",
-			nil,
-		},
-		// pay-to-pubkey address on mainnet. for Decred this would
-		// be uncompressed, but standard for Decred is 33 byte
-		// compressed public keys.
-		{
-			p2pkUncompressedMain,
-			"DATA_33 0x0311db93e1dcdb8a016b49840f8c53bc1eb68a382e97b" +
-				"1482ecad7b148a6909a5cac",
-			nil,
-		},
-
-		// Supported address types with nil pointers.
-		{(*dcrutil.AddressPubKeyHash)(nil), "", ErrUnsupportedAddress},
-		{(*dcrutil.AddressScriptHash)(nil), "", ErrUnsupportedAddress},
-		{(*dcrutil.AddressSecpPubKey)(nil), "", ErrUnsupportedAddress},
-		{(*dcrutil.AddressEdwardsPubKey)(nil), "", ErrUnsupportedAddress},
-		{(*dcrutil.AddressSecSchnorrPubKey)(nil), "", ErrUnsupportedAddress},
-
-		// Unsupported address type.
-		{&bogusAddress{}, "", ErrUnsupportedAddress},
-	}
-
-	t.Logf("Running %d tests", len(tests))
-	for i, test := range tests {
-		pkScript, err := PayToAddrScript(test.in)
-		if !errors.Is(err, test.err) {
-			t.Errorf("PayToAddrScript #%d unexpected error - got %v, want %v",
-				i, err, test.err)
-			continue
-		}
-
-		expected := mustParseShortForm(test.expected)
-		if !bytes.Equal(pkScript, expected) {
-			t.Errorf("PayToAddrScript #%d got: %x\nwant: %x",
-				i, pkScript, expected)
 			continue
 		}
 	}
@@ -1060,7 +920,7 @@ func TestGenerateSStxAddrPush(t *testing.T) {
 	testNetParams := chaincfg.TestNet3Params()
 	var tests = []struct {
 		addrStr  string
-		net      dcrutil.AddressParams
+		net      stdaddr.AddressParams
 		amount   dcrutil.Amount
 		limits   uint16
 		expected []byte

--- a/txscript/standard_test.go
+++ b/txscript/standard_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
-	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/txscript/v4/stdaddr"
 )
 
@@ -911,51 +910,6 @@ func TestGenerateProvablyPruneableOut(t *testing.T) {
 				"got: %v, want: %v", i, test.name, scriptType,
 				test.class)
 			continue
-		}
-	}
-}
-
-// TestGenerateSStxAddrPush ensures an expected OP_RETURN push is generated.
-func TestGenerateSStxAddrPush(t *testing.T) {
-	testNetParams := chaincfg.TestNet3Params()
-	var tests = []struct {
-		addrStr  string
-		net      stdaddr.AddressParams
-		amount   dcrutil.Amount
-		limits   uint16
-		expected []byte
-	}{
-		{
-			"Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx",
-			mainNetParams,
-			1000,
-			10,
-			hexToBytes("6a1ef5916158e3e2c4551c1796708db8367207ed1" +
-				"3bbe8030000000000800a00"),
-		},
-		{
-			"TscB7V5RuR1oXpA364DFEsNDuAs8Rk6BHJE",
-			testNetParams,
-			543543,
-			256,
-			hexToBytes("6a1e7a5c4cca76f2e0b36db4763daacbd6cbb6ee6" +
-				"e7b374b0800000000000001"),
-		},
-	}
-	for _, test := range tests {
-		addr, err := dcrutil.DecodeAddress(test.addrStr, test.net)
-		if err != nil {
-			t.Errorf("DecodeAddress failed: %v", err)
-			continue
-		}
-		s, err := GenerateSStxAddrPush(addr, test.amount, test.limits)
-		if err != nil {
-			t.Errorf("GenerateSStxAddrPush failed: %v", err)
-			continue
-		}
-		if !bytes.Equal(s, test.expected) {
-			t.Errorf("GenerateSStxAddrPush: unexpected script:\n "+
-				"got %x\nwant %x", s, test.expected)
 		}
 	}
 }


### PR DESCRIPTION
**This requires #2619, #2624, and #2620**.

~**NOTE: I've left this marked as a draft for now because the various `go.mod` files in the affected modules will need to be updated to use the latest `txscript` module once the aforementioned prerequisite PRs have landed to avoid issues for external consumers, however, this is otherwise ready for review.**~

---

This converts all packages in the repository to make use of the new `stdaddr` package for addresses instead of `dcrutil.Address`+`txscript.PayToX` methods as well as to support and make use of the script version returned by the new addresses accordingly.  It also removes the aforementioned `txscript.PayToX` methods once they are no longer used.

Since this involves modifications to a large number of packages in the repository, this PR is split into a series of individual commits such that everything builds and passes all tests each step of the way.  In order to achieve that goal, each commit updates a single package to use the new addresses while simultaneously updating all consumers of that package in the repository to deal with any fallout of API changes.  Typically, this means some temporary address conversion code is introduced and then removed in a later commit once it's no longer needed.  Finally, all of the unused methods and any associated tests are then removed one by one.

See each individual commit for more details about each individual change, but the following is a high level overview:

- Converts the following packages to use the new `stdaddr` package:
  - `internal/mining`
  - `internal/mempool`
  - `blockchain/stake`
  - `blockchain/indexers`
  - `blockchain`
  - `blockchain/fullblocktests`
  - `blockchain/chaingen`
  - `rpcclient`
  - `rpctest`
  - `internal/rpcserver`
  - `hdkeychain`
  - `txscript`
- Updates all call sites that deal with addresses to properly use the script version returned by the address script generation methods
- Makes minor modifications for consistency and other cleanup while converting
- Removes the following methods:
  - `chaingen.PurchaseCommitmentScript`
  - `txscript.PayToSStx`
  - `txscript.PayToSStxChange`
  - `txscript.PayToSSGen`
  - `txscript.PayToSSGenSHDirect`
  - `txscript.PayToSSGenPKHDirect`
  - `txscript.PayToSSRtx`
  - `txscript.PayToSSRtxPKHDirect`
  - `txscript.PayToSSRtxSHDirect`
  - `txscript.PayToAddrScript`
  - `txscript.PayToScriptHashScript`
  - `txscript.payToSchnorrPubKeyScript`
  - `txscript.payToEdwardsPubKeyScript`
  - `txscript.payToPubKeyScript`
  - `txscript.payToScriptHashScript`
  - `txscript.payToPubKeyHashSchnorrScript`
  - `txscript.payToPubKeyHashEdwardsScript`
  - `txscript.payToPubKeyHashScript`
  - `txscript.GenerateSStxAddrPush`