### PR TITLE
txscript: Break dcrutil dependency.

### DIFF
--- a/hdkeychain/go.sum
+++ b/hdkeychain/go.sum
@@ -17,7 +17,6 @@ github.com/decred/dcrd/dcrec v1.0.0 h1:W+z6Es+Rai3MXYVoPAxYr5U1DGis0Co33scJ6uH2J
 github.com/decred/dcrd/dcrec v1.0.0/go.mod h1:HIaqbEJQ+PDzQcORxnqen5/V1FR3B4VpIfmePklt8Q8=
 github.com/decred/dcrd/dcrec/edwards/v2 v2.0.1 h1:V6eqU1crZzuoFT4KG2LhaU5xDSdkHuvLQsj25wd7Wb4=
 github.com/decred/dcrd/dcrec/edwards/v2 v2.0.1/go.mod h1:d0H8xGMWbiIQP7gN3v2rByWUcuZPm9YsgmnfoxgbINc=
-github.com/decred/dcrd/dcrutil/v4 v4.0.0-20210129181600-6ae0142d3b28/go.mod h1:xe59jKcMx5G/dbRmsZ8+FzY+WQDE/7YBP3k3uzJTtmI=
 github.com/decred/dcrd/wire v1.4.0 h1:KmSo6eTQIvhXS0fLBQ/l7hG7QLcSJQKSwSyzSqJYDk0=
 github.com/decred/dcrd/wire v1.4.0/go.mod h1:WxC/0K+cCAnBh+SKsRjIX9YPgvrjhmE+6pZlel1G7Ro=
 github.com/decred/slog v1.1.0/go.mod h1:kVXlGnt6DHy2fV5OjSeuvCJ0OmlmTF6LFpEPMu/fOY0=

--- a/txscript/go.mod
+++ b/txscript/go.mod
@@ -12,12 +12,8 @@ require (
 	github.com/decred/dcrd/dcrec v1.0.0
 	github.com/decred/dcrd/dcrec/edwards/v2 v2.0.1
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210127014238-b33b46cf1a24
-	github.com/decred/dcrd/dcrutil/v4 v4.0.0-20210129181600-6ae0142d3b28
 	github.com/decred/dcrd/wire v1.4.0
 	github.com/decred/slog v1.1.0
 )
 
-replace (
-	github.com/decred/dcrd/dcrec/secp256k1/v4 => ../dcrec/secp256k1
-	github.com/decred/dcrd/dcrutil/v4 => ../dcrutil
-)
+replace github.com/decred/dcrd/dcrec/secp256k1/v4 => ../dcrec/secp256k1


### PR DESCRIPTION
**This requires #2625**.

Now that the addresses have all been converted over to use the `stdaddr` package, this removes only remaining dependencies on `dcrutil` which are in the tests in order to avoid cyclic dependencies when updating the `dcrutil` code to the use the `stdaddr` package.