### PR TITLE
[multi] Add getaddrv2 and addrv2.

### DIFF
--- a/addrmgr/addrmanager.go
+++ b/addrmgr/addrmanager.go
@@ -16,14 +16,12 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
-	"github.com/decred/dcrd/wire"
 )
 
 // peersFilename is the default filename to store serialized peers.
@@ -102,11 +100,11 @@ type AddrManager struct {
 
 	// getTriedBucket returns an index in the tried bucket for the network
 	// address.
-	getTriedBucket func(netAddr *wire.NetAddress) int
+	getTriedBucket func(netAddr *NetAddress) int
 
 	// getNewBucket returns an index in the addrNew bucket for the network
 	// address.
-	getNewBucket func(netAddr, srcAddr *wire.NetAddress) int
+	getNewBucket func(netAddr, srcAddr *NetAddress) int
 
 	// triedBucketSize is the maximum number of addresses in each tried bucket.
 	triedBucketSize int
@@ -130,12 +128,12 @@ type serializedAddrManager struct {
 	Version      int
 	Key          [32]byte
 	Addresses    []*serializedKnownAddress
-	NewBuckets   [newBucketCount][]string // string is NetAddressKey
+	NewBuckets   [newBucketCount][]string // string is NetAddress.Key()
 	TriedBuckets [triedBucketCount][]string
 }
 
 type localAddress struct {
-	na    *wire.NetAddress
+	na    *NetAddress
 	score AddressPriority
 }
 
@@ -233,16 +231,16 @@ const (
 	serialisationVersion = 1
 )
 
-// updateAddress is a helper function to either update an address already known
+// addOrUpdateAddress is a helper function to either update an address already known
 // to the address manager, or to add the address if not already known.
-func (a *AddrManager) updateAddress(netAddr, srcAddr *wire.NetAddress) {
+func (a *AddrManager) addOrUpdateAddress(netAddr, srcAddr *NetAddress) {
 	// Filter out non-routable addresses. Note that non-routable
 	// also includes invalid and local addresses.
-	if !IsRoutable(netAddr.IP) {
+	if !netAddr.IsRoutable() {
 		return
 	}
 
-	addr := NetAddressKey(netAddr)
+	addrKey := netAddr.Key()
 	ka := a.find(netAddr)
 	if ka != nil {
 		// TODO(oga) only update addresses periodically.
@@ -255,11 +253,11 @@ func (a *AddrManager) updateAddress(netAddr, srcAddr *wire.NetAddress) {
 			(ka.na.Services&netAddr.Services) !=
 				netAddr.Services {
 
-			naCopy := *ka.na
+			naCopy := ka.na.Clone()
 			naCopy.Timestamp = netAddr.Timestamp
 			naCopy.AddService(netAddr.Services)
 			ka.mtx.Lock()
-			ka.na = &naCopy
+			ka.na = naCopy
 			ka.mtx.Unlock()
 		}
 
@@ -283,9 +281,9 @@ func (a *AddrManager) updateAddress(netAddr, srcAddr *wire.NetAddress) {
 		// Make a copy of the net address to avoid races since it is
 		// updated elsewhere in the addrmanager code and would otherwise
 		// change the actual netaddress on the peer.
-		netAddrCopy := *netAddr
-		ka = &KnownAddress{na: &netAddrCopy, srcAddr: srcAddr}
-		a.addrIndex[addr] = ka
+		netAddrCopy := netAddr.Clone()
+		ka = &KnownAddress{na: netAddrCopy, srcAddr: srcAddr}
+		a.addrIndex[addrKey] = ka
 		a.nNew++
 		a.addrChanged = true
 	}
@@ -293,7 +291,7 @@ func (a *AddrManager) updateAddress(netAddr, srcAddr *wire.NetAddress) {
 	bucket := a.getNewBucket(netAddr, srcAddr)
 
 	// If the address already exists in the new bucket, do not replace it.
-	if _, ok := a.addrNew[bucket][addr]; ok {
+	if _, ok := a.addrNew[bucket][addrKey]; ok {
 		return
 	}
 
@@ -305,10 +303,10 @@ func (a *AddrManager) updateAddress(netAddr, srcAddr *wire.NetAddress) {
 
 	// Add to new bucket.
 	ka.refs++
-	a.addrNew[bucket][addr] = ka
+	a.addrNew[bucket][addrKey] = ka
 	a.addrChanged = true
 
-	log.Tracef("Added new address %s for a total of %d addresses", addr,
+	log.Tracef("Added new address %s for a total of %d addresses", addrKey,
 		a.nTried+a.nNew)
 }
 
@@ -341,7 +339,7 @@ func (a *AddrManager) expireNew(bucket int) {
 	}
 
 	if oldest != nil {
-		key := NetAddressKey(oldest.na)
+		key := oldest.na.Key()
 		log.Tracef("expiring oldest address %v", key)
 
 		delete(a.addrNew[bucket], key)
@@ -395,10 +393,10 @@ func getNewBucket(key [32]byte, netAddrIP, srcAddrIP net.IP) int {
 
 // getTriedBucket returns a psuedorandom tried bucket index for the provided
 // network address using key as a seed.
-func getTriedBucket(key [32]byte, netAddr *wire.NetAddress) int {
+func getTriedBucket(key [32]byte, netAddr *NetAddress) int {
 	data1 := []byte{}
 	data1 = append(data1, key[:]...)
-	data1 = append(data1, []byte(NetAddressKey(netAddr))...)
+	data1 = append(data1, []byte(netAddr.Key())...)
 	hash1 := chainhash.HashB(data1)
 	hash64 := binary.LittleEndian.Uint64(hash1)
 	hash64 %= triedBucketsPerGroup
@@ -455,7 +453,7 @@ func (a *AddrManager) savePeers() {
 		ska := new(serializedKnownAddress)
 		ska.Addr = k
 		ska.TimeStamp = v.na.Timestamp.Unix()
-		ska.Src = NetAddressKey(v.srcAddr)
+		ska.Src = v.srcAddr.Key()
 		ska.Attempts = v.attempts
 		ska.LastAttempt = v.lastattempt.Unix()
 		ska.LastSuccess = v.lastsuccess.Unix()
@@ -476,7 +474,7 @@ func (a *AddrManager) savePeers() {
 		sam.TriedBuckets[i] = make([]string, len(a.addrTried[i]))
 		j := 0
 		for _, ka := range a.addrTried[i] {
-			sam.TriedBuckets[i][j] = NetAddressKey(ka.na)
+			sam.TriedBuckets[i][j] = ka.na.Key()
 			j++
 		}
 	}
@@ -550,21 +548,25 @@ func (a *AddrManager) deserializePeers(filePath string) error {
 	copy(a.key[:], sam.Key[:])
 
 	for _, v := range sam.Addresses {
-		ka := new(KnownAddress)
-		ka.na, err = a.DeserializeNetAddress(v.Addr)
+		netAddr, err := a.newAddressFromString(v.Addr)
 		if err != nil {
 			return fmt.Errorf("failed to deserialize netaddress "+
 				"%s: %v", v.Addr, err)
 		}
-		ka.srcAddr, err = a.DeserializeNetAddress(v.Src)
+		srcAddr, err := a.newAddressFromString(v.Src)
 		if err != nil {
 			return fmt.Errorf("failed to deserialize netaddress "+
 				"%s: %v", v.Src, err)
 		}
-		ka.attempts = v.Attempts
-		ka.lastattempt = time.Unix(v.LastAttempt, 0)
-		ka.lastsuccess = time.Unix(v.LastSuccess, 0)
-		a.addrIndex[NetAddressKey(ka.na)] = ka
+
+		ka := &KnownAddress{
+			na:          netAddr,
+			srcAddr:     srcAddr,
+			attempts:    v.Attempts,
+			lastattempt: time.Unix(v.LastAttempt, 0),
+			lastsuccess: time.Unix(v.LastSuccess, 0),
+		}
+		a.addrIndex[ka.na.Key()] = ka
 	}
 
 	for i := range sam.NewBuckets {
@@ -612,20 +614,6 @@ func (a *AddrManager) deserializePeers(filePath string) error {
 	return nil
 }
 
-// DeserializeNetAddress converts a given address string to a *wire.NetAddress
-func (a *AddrManager) DeserializeNetAddress(addr string) (*wire.NetAddress, error) {
-	host, portStr, err := net.SplitHostPort(addr)
-	if err != nil {
-		return nil, err
-	}
-	port, err := strconv.ParseUint(portStr, 10, 16)
-	if err != nil {
-		return nil, err
-	}
-
-	return a.HostToNetAddress(host, uint16(port), wire.SFNodeNetwork)
-}
-
 // Start begins the core address handler which manages a pool of known
 // addresses, timeouts, and interval based writes.  If the address manager is
 // starting or has already been started, invoking this method has no
@@ -666,24 +654,13 @@ func (a *AddrManager) Stop() error {
 // number of addresses and silently ignores duplicate addresses.
 //
 // This function is safe for concurrent access.
-func (a *AddrManager) AddAddresses(addrs []*wire.NetAddress, srcAddr *wire.NetAddress) {
+func (a *AddrManager) AddAddresses(addrs []*NetAddress, srcAddr *NetAddress) {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
 
 	for _, na := range addrs {
-		a.updateAddress(na, srcAddr)
+		a.addOrUpdateAddress(na, srcAddr)
 	}
-}
-
-// AddAddress adds a new address to the address manager.  It enforces a max
-// number of addresses and silently ignores duplicate addresses.
-//
-// This function is safe for concurrent access.
-func (a *AddrManager) AddAddress(addr, srcAddr *wire.NetAddress) {
-	a.mtx.Lock()
-	defer a.mtx.Unlock()
-
-	a.updateAddress(addr, srcAddr)
 }
 
 // numAddresses returns the number of addresses known to the address manager.
@@ -708,7 +685,7 @@ func (a *AddrManager) NeedMoreAddresses() bool {
 // address manager.
 //
 // This function is safe for concurrent access.
-func (a *AddrManager) AddressCache() []*wire.NetAddress {
+func (a *AddrManager) AddressCache() []*NetAddress {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
 
@@ -718,7 +695,7 @@ func (a *AddrManager) AddressCache() []*wire.NetAddress {
 		return nil
 	}
 
-	allAddr := make([]*wire.NetAddress, 0, addrLen)
+	allAddr := make([]*NetAddress, 0, addrLen)
 	// Iteration order is undefined here, but we randomize it anyway.
 	for _, v := range a.addrIndex {
 		// Skip low quality addresses.
@@ -766,10 +743,10 @@ func (a *AddrManager) reset() {
 		a.addrTried[i] = nil
 	}
 	a.addrChanged = true
-	a.getNewBucket = func(netAddr, srcAddr *wire.NetAddress) int {
+	a.getNewBucket = func(netAddr, srcAddr *NetAddress) int {
 		return getNewBucket(a.key, netAddr.IP, srcAddr.IP)
 	}
-	a.getTriedBucket = func(netAddr *wire.NetAddress) int {
+	a.getTriedBucket = func(netAddr *NetAddress) int {
 		return getTriedBucket(a.key, netAddr)
 	}
 }
@@ -781,7 +758,7 @@ func (a *AddrManager) reset() {
 // cannot be resolved, an error is returned.
 //
 // This function is safe for concurrent access.
-func (a *AddrManager) HostToNetAddress(host string, port uint16, services wire.ServiceFlag) (*wire.NetAddress, error) {
+func (a *AddrManager) HostToNetAddress(host string, port uint16, services ServiceFlag) (*NetAddress, error) {
 	// Tor address is 16 char base32 + ".onion"
 	var ip net.IP
 	if len(host) == 22 && host[16:] == ".onion" {
@@ -806,28 +783,7 @@ func (a *AddrManager) HostToNetAddress(host string, port uint16, services wire.S
 		ip = ips[0]
 	}
 
-	return wire.NewNetAddressIPPort(ip, port, services), nil
-}
-
-// ipString returns a string for the ip from the provided NetAddress. If the
-// ip is in the range used for TORv2 addresses then it will be transformed into
-// the respective .onion address.
-func ipString(na *wire.NetAddress) string {
-	if isOnionCatTor(na.IP) {
-		// We know now that na.IP is long enough.
-		base32 := base32.StdEncoding.EncodeToString(na.IP[6:])
-		return strings.ToLower(base32) + ".onion"
-	}
-
-	return na.IP.String()
-}
-
-// NetAddressKey returns a string key in the form of ip:port for IPv4 addresses
-// or [ip]:port for IPv6 addresses.
-func NetAddressKey(na *wire.NetAddress) string {
-	port := strconv.FormatUint(uint64(na.Port), 10)
-
-	return net.JoinHostPort(ipString(na), port)
+	return NewNetAddress(ip, port, services), nil
 }
 
 // GetAddress returns a single address that should be routable.  It picks a
@@ -862,8 +818,7 @@ func (a *AddrManager) GetAddress() *KnownAddress {
 
 			randval := a.rand.Intn(large)
 			if float64(randval) < (factor * ka.chance() * float64(large)) {
-				log.Tracef("Selected %v from tried bucket",
-					NetAddressKey(ka.na))
+				log.Tracef("Selected %v from tried bucket", ka.na.Key())
 				return ka
 			}
 			factor *= 1.2
@@ -888,8 +843,7 @@ func (a *AddrManager) GetAddress() *KnownAddress {
 			}
 			randval := a.rand.Intn(large)
 			if float64(randval) < (factor * ka.chance() * float64(large)) {
-				log.Tracef("Selected %v from new bucket",
-					NetAddressKey(ka.na))
+				log.Tracef("Selected %v from new bucket", ka.na.Key())
 				return ka
 			}
 			factor *= 1.2
@@ -897,8 +851,8 @@ func (a *AddrManager) GetAddress() *KnownAddress {
 	}
 }
 
-func (a *AddrManager) find(addr *wire.NetAddress) *KnownAddress {
-	return a.addrIndex[NetAddressKey(addr)]
+func (a *AddrManager) find(addr *NetAddress) *KnownAddress {
+	return a.addrIndex[addr.Key()]
 }
 
 // Attempt increases the given address' attempt counter and updates
@@ -906,7 +860,7 @@ func (a *AddrManager) find(addr *wire.NetAddress) *KnownAddress {
 // is not known to the address manager an error is returned.
 //
 // This function is safe for concurrent access.
-func (a *AddrManager) Attempt(addr *wire.NetAddress) error {
+func (a *AddrManager) Attempt(addr *NetAddress) error {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
 
@@ -914,7 +868,7 @@ func (a *AddrManager) Attempt(addr *wire.NetAddress) error {
 	// Surely address will be in tried by now?
 	ka := a.find(addr)
 	if ka == nil {
-		str := fmt.Sprintf("address %s not found", ipString(addr))
+		str := fmt.Sprintf("address %s not found", addr.ipString())
 		return makeError(ErrAddressNotFound, str)
 	}
 
@@ -931,13 +885,13 @@ func (a *AddrManager) Attempt(addr *wire.NetAddress) error {
 // is returned.
 //
 // This function is safe for concurrent access.
-func (a *AddrManager) Connected(addr *wire.NetAddress) error {
+func (a *AddrManager) Connected(addr *NetAddress) error {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
 
 	ka := a.find(addr)
 	if ka == nil {
-		str := fmt.Sprintf("address %s not found", ipString(addr))
+		str := fmt.Sprintf("address %s not found", addr.ipString())
 		return makeError(ErrAddressNotFound, str)
 	}
 
@@ -947,9 +901,9 @@ func (a *AddrManager) Connected(addr *wire.NetAddress) error {
 	if now.After(ka.na.Timestamp.Add(time.Minute * 20)) {
 		// ka.na is immutable, so replace it.
 		ka.mtx.Lock()
-		naCopy := *ka.na
+		naCopy := ka.na.Clone()
 		naCopy.Timestamp = time.Now()
-		ka.na = &naCopy
+		ka.na = naCopy
 		ka.mtx.Unlock()
 	}
 	return nil
@@ -960,13 +914,13 @@ func (a *AddrManager) Connected(addr *wire.NetAddress) error {
 // address is not known to the address manager an error is returned.
 //
 // This function is safe for concurrent access.
-func (a *AddrManager) Good(addr *wire.NetAddress) error {
+func (a *AddrManager) Good(addr *NetAddress) error {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
 
 	ka := a.find(addr)
 	if ka == nil {
-		str := fmt.Sprintf("address %s not found", ipString(addr))
+		str := fmt.Sprintf("address %s not found", addr.ipString())
 		return makeError(ErrAddressNotFound, str)
 	}
 
@@ -988,7 +942,7 @@ func (a *AddrManager) Good(addr *wire.NetAddress) error {
 
 	// remove from all new buckets.
 	// record one of the buckets in question and call it the `first'
-	addrKey := NetAddressKey(addr)
+	addrKey := ka.na.Key()
 	addrNewAvailableIndex := -1
 	for i := range a.addrNew {
 		// we check for existence so we can record the first one
@@ -1004,7 +958,7 @@ func (a *AddrManager) Good(addr *wire.NetAddress) error {
 	a.nNew--
 
 	if addrNewAvailableIndex == -1 {
-		str := fmt.Sprintf("%s is not marked as a new address", ipString(addr))
+		str := fmt.Sprintf("%s is not marked as a new address", addr.ipString())
 		return makeError(ErrAddressNotFound, str)
 	}
 
@@ -1047,7 +1001,7 @@ func (a *AddrManager) Good(addr *wire.NetAddress) error {
 	// since an address is being evicted from a tried bucket to a new bucket.
 	a.nNew++
 
-	rmkey := NetAddressKey(rmka.na)
+	rmkey := rmka.na.Key()
 	log.Tracef("Replacing %s with %s in tried", rmkey, addrKey)
 
 	// We made sure there is space here just above.
@@ -1057,13 +1011,13 @@ func (a *AddrManager) Good(addr *wire.NetAddress) error {
 
 // SetServices sets the services for the given address to the provided value.
 // If the address is not known to the address manager an error is returned.
-func (a *AddrManager) SetServices(addr *wire.NetAddress, services wire.ServiceFlag) error {
+func (a *AddrManager) SetServices(addr *NetAddress, services ServiceFlag) error {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
 
 	ka := a.find(addr)
 	if ka == nil {
-		str := fmt.Sprintf("address %s not found", ipString(addr))
+		str := fmt.Sprintf("address %s not found", addr.ipString())
 		return makeError(ErrAddressNotFound, str)
 	}
 
@@ -1071,9 +1025,9 @@ func (a *AddrManager) SetServices(addr *wire.NetAddress, services wire.ServiceFl
 	if ka.na.Services != services {
 		// ka.na is immutable, so replace it.
 		ka.mtx.Lock()
-		naCopy := *ka.na
+		naCopy := ka.na.Clone()
 		naCopy.Services = services
-		ka.na = &naCopy
+		ka.na = naCopy
 		ka.mtx.Unlock()
 	}
 	return nil
@@ -1083,15 +1037,15 @@ func (a *AddrManager) SetServices(addr *wire.NetAddress, services wire.ServiceFl
 // with the given priority.
 //
 // This function is safe for concurrent access.
-func (a *AddrManager) AddLocalAddress(na *wire.NetAddress, priority AddressPriority) error {
-	if !IsRoutable(na.IP) {
-		return fmt.Errorf("address %s is not routable", ipString(na))
+func (a *AddrManager) AddLocalAddress(na *NetAddress, priority AddressPriority) error {
+	if !na.IsRoutable() {
+		return fmt.Errorf("address %s is not routable", na.ipString())
 	}
 
 	a.lamtx.Lock()
 	defer a.lamtx.Unlock()
 
-	key := NetAddressKey(na)
+	key := na.Key()
 	la, ok := a.localAddresses[key]
 	if !ok || la.score < priority {
 		if ok {
@@ -1109,10 +1063,9 @@ func (a *AddrManager) AddLocalAddress(na *wire.NetAddress, priority AddressPrior
 // HasLocalAddress asserts if the manager has the provided local address.
 //
 // This function is safe for concurrent access.
-func (a *AddrManager) HasLocalAddress(na *wire.NetAddress) bool {
-	key := NetAddressKey(na)
+func (a *AddrManager) HasLocalAddress(na *NetAddress) bool {
 	a.lamtx.Lock()
-	_, ok := a.localAddresses[key]
+	_, ok := a.localAddresses[na.Key()]
 	a.lamtx.Unlock()
 	return ok
 }
@@ -1128,7 +1081,7 @@ func (a *AddrManager) LocalAddresses() []LocalAddr {
 	addrs := make([]LocalAddr, 0, len(a.localAddresses))
 	for _, addr := range a.localAddresses {
 		la := LocalAddr{
-			Address: addr.na.IP.String(),
+			Address: addr.na.ipString(),
 			Port:    addr.na.Port,
 		}
 
@@ -1171,8 +1124,8 @@ const (
 // address to the provided remote address.
 //
 // This function is safe for concurrent access.
-func getReachabilityFrom(localAddr, remoteAddr *wire.NetAddress) NetAddressReach {
-	if !IsRoutable(remoteAddr.IP) {
+func getReachabilityFrom(localAddr, remoteAddr *NetAddress) NetAddressReach {
+	if !remoteAddr.IsRoutable() {
 		return Unreachable
 	}
 
@@ -1181,7 +1134,7 @@ func getReachabilityFrom(localAddr, remoteAddr *wire.NetAddress) NetAddressReach
 			return Private
 		}
 
-		if IsRoutable(localAddr.IP) && isIPv4(localAddr.IP) {
+		if localAddr.IsRoutable() && isIPv4(localAddr.IP) {
 			return Ipv4
 		}
 
@@ -1189,7 +1142,7 @@ func getReachabilityFrom(localAddr, remoteAddr *wire.NetAddress) NetAddressReach
 	}
 
 	if isRFC4380(remoteAddr.IP) {
-		if !IsRoutable(localAddr.IP) {
+		if !localAddr.IsRoutable() {
 			return Default
 		}
 
@@ -1205,7 +1158,7 @@ func getReachabilityFrom(localAddr, remoteAddr *wire.NetAddress) NetAddressReach
 	}
 
 	if isIPv4(remoteAddr.IP) {
-		if IsRoutable(localAddr.IP) && isIPv4(localAddr.IP) {
+		if localAddr.IsRoutable() && isIPv4(localAddr.IP) {
 			return Ipv4
 		}
 		return Unreachable
@@ -1218,7 +1171,7 @@ func getReachabilityFrom(localAddr, remoteAddr *wire.NetAddress) NetAddressReach
 		tunnelled = true
 	}
 
-	if !IsRoutable(localAddr.IP) {
+	if !localAddr.IsRoutable() {
 		return Default
 	}
 
@@ -1242,13 +1195,13 @@ func getReachabilityFrom(localAddr, remoteAddr *wire.NetAddress) NetAddressReach
 // for the given remote address.
 //
 // This function is safe for concurrent access.
-func (a *AddrManager) GetBestLocalAddress(remoteAddr *wire.NetAddress) *wire.NetAddress {
+func (a *AddrManager) GetBestLocalAddress(remoteAddr *NetAddress) *NetAddress {
 	a.lamtx.Lock()
 	defer a.lamtx.Unlock()
 
-	bestreach := Default
+	bestreach := Unreachable
 	var bestscore AddressPriority
-	var bestAddress *wire.NetAddress
+	var bestAddress *NetAddress
 	for _, la := range a.localAddresses {
 		reach := getReachabilityFrom(la.na, remoteAddr)
 		if reach > bestreach ||
@@ -1272,7 +1225,7 @@ func (a *AddrManager) GetBestLocalAddress(remoteAddr *wire.NetAddress) *wire.Net
 		} else {
 			ip = net.IPv4zero
 		}
-		bestAddress = wire.NewNetAddressIPPort(ip, 0, wire.SFNodeNetwork)
+		bestAddress = NewNetAddress(ip, 0, sfNodeNetwork)
 	}
 
 	return bestAddress
@@ -1283,7 +1236,7 @@ func (a *AddrManager) GetBestLocalAddress(remoteAddr *wire.NetAddress) *wire.Net
 // from the peer that suggested it.
 //
 // This function is safe for concurrent access.
-func (a *AddrManager) ValidatePeerNa(localAddr, remoteAddr *wire.NetAddress) (bool, NetAddressReach) {
+func (a *AddrManager) ValidatePeerNa(localAddr, remoteAddr *NetAddress) (bool, NetAddressReach) {
 	net := getNetwork(localAddr.IP)
 	reach := getReachabilityFrom(localAddr, remoteAddr)
 	valid := (net == IPv4Address && reach == Ipv4) || (net == IPv6Address &&

--- a/addrmgr/addrmanager.go
+++ b/addrmgr/addrmanager.go
@@ -686,28 +686,6 @@ func (a *AddrManager) AddAddress(addr, srcAddr *wire.NetAddress) {
 	a.updateAddress(addr, srcAddr)
 }
 
-// addAddressByIP adds an address where we are given an ip:port and not a
-// wire.NetAddress.
-func (a *AddrManager) addAddressByIP(addrIP string) error {
-	// Split IP and port
-	addr, portStr, err := net.SplitHostPort(addrIP)
-	if err != nil {
-		return err
-	}
-	// Put it in wire.Netaddress
-	ip := net.ParseIP(addr)
-	if ip == nil {
-		return fmt.Errorf("invalid ip address %s", addr)
-	}
-	port, err := strconv.ParseUint(portStr, 10, 0)
-	if err != nil {
-		return fmt.Errorf("invalid port %s: %v", portStr, err)
-	}
-	na := wire.NewNetAddressIPPort(ip, uint16(port), 0)
-	a.AddAddress(na, na) // XXX use correct src address
-	return nil
-}
-
 // numAddresses returns the number of addresses known to the address manager.
 //
 // This function MUST be called with the address manager lock held (for reads).

--- a/addrmgr/addrmanager.go
+++ b/addrmgr/addrmanager.go
@@ -238,7 +238,7 @@ const (
 func (a *AddrManager) updateAddress(netAddr, srcAddr *wire.NetAddress) {
 	// Filter out non-routable addresses. Note that non-routable
 	// also includes invalid and local addresses.
-	if !IsRoutable(netAddr) {
+	if !IsRoutable(netAddr.IP) {
 		return
 	}
 
@@ -374,11 +374,11 @@ func (a *AddrManager) getOldestAddressIndex(bucket int) int {
 // IPs using key as a seed.
 // This is used to as a mitigation against eclipse attacks described in
 // "Eclipse Attacks on Bitcoin’s Peer-to-Peer Network" by Heilman et al.
-func getNewBucket(key [32]byte, netAddr, srcAddr *wire.NetAddress) int {
+func getNewBucket(key [32]byte, netAddrIP, srcAddrIP net.IP) int {
 	data1 := []byte{}
 	data1 = append(data1, key[:]...)
-	data1 = append(data1, []byte(GroupKey(netAddr))...)
-	data1 = append(data1, []byte(GroupKey(srcAddr))...)
+	data1 = append(data1, []byte(GroupKey(netAddrIP))...)
+	data1 = append(data1, []byte(GroupKey(srcAddrIP))...)
 	hash1 := chainhash.HashB(data1)
 	hash64 := binary.LittleEndian.Uint64(hash1)
 	hash64 %= newBucketsPerGroup
@@ -386,7 +386,7 @@ func getNewBucket(key [32]byte, netAddr, srcAddr *wire.NetAddress) int {
 	binary.LittleEndian.PutUint64(hashbuf[:], hash64)
 	data2 := []byte{}
 	data2 = append(data2, key[:]...)
-	data2 = append(data2, GroupKey(srcAddr)...)
+	data2 = append(data2, GroupKey(srcAddrIP)...)
 	data2 = append(data2, hashbuf[:]...)
 
 	hash2 := chainhash.HashB(data2)
@@ -406,7 +406,7 @@ func getTriedBucket(key [32]byte, netAddr *wire.NetAddress) int {
 	binary.LittleEndian.PutUint64(hashbuf[:], hash64)
 	data2 := []byte{}
 	data2 = append(data2, key[:]...)
-	data2 = append(data2, GroupKey(netAddr)...)
+	data2 = append(data2, GroupKey(netAddr.IP)...)
 	data2 = append(data2, hashbuf[:]...)
 
 	hash2 := chainhash.HashB(data2)
@@ -767,7 +767,7 @@ func (a *AddrManager) reset() {
 	}
 	a.addrChanged = true
 	a.getNewBucket = func(netAddr, srcAddr *wire.NetAddress) int {
-		return getNewBucket(a.key, netAddr, srcAddr)
+		return getNewBucket(a.key, netAddr.IP, srcAddr.IP)
 	}
 	a.getTriedBucket = func(netAddr *wire.NetAddress) int {
 		return getTriedBucket(a.key, netAddr)
@@ -813,7 +813,7 @@ func (a *AddrManager) HostToNetAddress(host string, port uint16, services wire.S
 // ip is in the range used for TORv2 addresses then it will be transformed into
 // the respective .onion address.
 func ipString(na *wire.NetAddress) string {
-	if isOnionCatTor(na) {
+	if isOnionCatTor(na.IP) {
 		// We know now that na.IP is long enough.
 		base32 := base32.StdEncoding.EncodeToString(na.IP[6:])
 		return strings.ToLower(base32) + ".onion"
@@ -1084,7 +1084,7 @@ func (a *AddrManager) SetServices(addr *wire.NetAddress, services wire.ServiceFl
 //
 // This function is safe for concurrent access.
 func (a *AddrManager) AddLocalAddress(na *wire.NetAddress, priority AddressPriority) error {
-	if !IsRoutable(na) {
+	if !IsRoutable(na.IP) {
 		return fmt.Errorf("address %s is not routable", ipString(na))
 	}
 
@@ -1169,40 +1169,40 @@ const (
 //
 // This function is safe for concurrent access.
 func getReachabilityFrom(localAddr, remoteAddr *wire.NetAddress) int {
-	if !IsRoutable(remoteAddr) {
+	if !IsRoutable(remoteAddr.IP) {
 		return Unreachable
 	}
 
-	if isOnionCatTor(remoteAddr) {
-		if isOnionCatTor(localAddr) {
+	if isOnionCatTor(remoteAddr.IP) {
+		if isOnionCatTor(localAddr.IP) {
 			return Private
 		}
 
-		if IsRoutable(localAddr) && isIPv4(localAddr) {
+		if IsRoutable(localAddr.IP) && isIPv4(localAddr.IP) {
 			return Ipv4
 		}
 
 		return Default
 	}
 
-	if isRFC4380(remoteAddr) {
-		if !IsRoutable(localAddr) {
+	if isRFC4380(remoteAddr.IP) {
+		if !IsRoutable(localAddr.IP) {
 			return Default
 		}
 
-		if isRFC4380(localAddr) {
+		if isRFC4380(localAddr.IP) {
 			return Teredo
 		}
 
-		if isIPv4(localAddr) {
+		if isIPv4(localAddr.IP) {
 			return Ipv4
 		}
 
 		return Ipv6Weak
 	}
 
-	if isIPv4(remoteAddr) {
-		if IsRoutable(localAddr) && isIPv4(localAddr) {
+	if isIPv4(remoteAddr.IP) {
+		if IsRoutable(localAddr.IP) && isIPv4(localAddr.IP) {
 			return Ipv4
 		}
 		return Unreachable
@@ -1211,19 +1211,19 @@ func getReachabilityFrom(localAddr, remoteAddr *wire.NetAddress) int {
 	/* ipv6 */
 	var tunnelled bool
 	// Is our v6 tunnelled?
-	if isRFC3964(localAddr) || isRFC6052(localAddr) || isRFC6145(localAddr) {
+	if isRFC3964(localAddr.IP) || isRFC6052(localAddr.IP) || isRFC6145(localAddr.IP) {
 		tunnelled = true
 	}
 
-	if !IsRoutable(localAddr) {
+	if !IsRoutable(localAddr.IP) {
 		return Default
 	}
 
-	if isRFC4380(localAddr) {
+	if isRFC4380(localAddr.IP) {
 		return Teredo
 	}
 
-	if isIPv4(localAddr) {
+	if isIPv4(localAddr.IP) {
 		return Ipv4
 	}
 
@@ -1264,7 +1264,7 @@ func (a *AddrManager) GetBestLocalAddress(remoteAddr *wire.NetAddress) *wire.Net
 
 		// Send something unroutable if nothing suitable.
 		var ip net.IP
-		if !isIPv4(remoteAddr) && !isOnionCatTor(remoteAddr) {
+		if !isIPv4(remoteAddr.IP) && !isOnionCatTor(remoteAddr.IP) {
 			ip = net.IPv6zero
 		} else {
 			ip = net.IPv4zero
@@ -1281,7 +1281,7 @@ func (a *AddrManager) GetBestLocalAddress(remoteAddr *wire.NetAddress) *wire.Net
 //
 // This function is safe for concurrent access.
 func (a *AddrManager) ValidatePeerNa(localAddr, remoteAddr *wire.NetAddress) (bool, int) {
-	net := getNetwork(localAddr)
+	net := getNetwork(localAddr.IP)
 	reach := getReachabilityFrom(localAddr, remoteAddr)
 	valid := (net == IPv4Address && reach == Ipv4) || (net == IPv6Address &&
 		(reach == Ipv6Weak || reach == Ipv6Strong || reach == Teredo))

--- a/addrmgr/addrmanager.go
+++ b/addrmgr/addrmanager.go
@@ -1138,14 +1138,17 @@ func (a *AddrManager) LocalAddresses() []LocalAddr {
 	return addrs
 }
 
+// NetAddressReach represents the connection state between two addresses.
+type NetAddressReach int
+
 const (
 	// Unreachable represents a publicly unreachable connection state
 	// between two addresses.
-	Unreachable = 0
+	Unreachable NetAddressReach = 0
 
 	// Default represents the default connection state between
 	// two addresses.
-	Default = iota
+	Default NetAddressReach = iota
 
 	// Teredo represents a connection state between two RFC4380 addresses.
 	Teredo
@@ -1168,7 +1171,7 @@ const (
 // address to the provided remote address.
 //
 // This function is safe for concurrent access.
-func getReachabilityFrom(localAddr, remoteAddr *wire.NetAddress) int {
+func getReachabilityFrom(localAddr, remoteAddr *wire.NetAddress) NetAddressReach {
 	if !IsRoutable(remoteAddr.IP) {
 		return Unreachable
 	}
@@ -1243,7 +1246,7 @@ func (a *AddrManager) GetBestLocalAddress(remoteAddr *wire.NetAddress) *wire.Net
 	a.lamtx.Lock()
 	defer a.lamtx.Unlock()
 
-	bestreach := 0
+	bestreach := Default
 	var bestscore AddressPriority
 	var bestAddress *wire.NetAddress
 	for _, la := range a.localAddresses {
@@ -1280,7 +1283,7 @@ func (a *AddrManager) GetBestLocalAddress(remoteAddr *wire.NetAddress) *wire.Net
 // from the peer that suggested it.
 //
 // This function is safe for concurrent access.
-func (a *AddrManager) ValidatePeerNa(localAddr, remoteAddr *wire.NetAddress) (bool, int) {
+func (a *AddrManager) ValidatePeerNa(localAddr, remoteAddr *wire.NetAddress) (bool, NetAddressReach) {
 	net := getNetwork(localAddr.IP)
 	reach := getReachabilityFrom(localAddr, remoteAddr)
 	valid := (net == IPv4Address && reach == Ipv4) || (net == IPv6Address &&

--- a/addrmgr/addrmanager.go
+++ b/addrmgr/addrmanager.go
@@ -26,31 +26,95 @@ import (
 	"github.com/decred/dcrd/wire"
 )
 
-// PeersFilename is the default filename to store serialized peers.
-const PeersFilename = "peers.json"
+// peersFilename is the default filename to store serialized peers.
+const peersFilename = "peers.json"
 
 // AddrManager provides a concurrency safe address manager for caching potential
 // peers on the Decred network.
 type AddrManager struct {
-	mtx            sync.Mutex                               // main mutex used to sync methods
-	peersFile      string                                   // path of file to store peers in
-	lookupFunc     func(string) ([]net.IP, error)           // for DNS lookups
-	rand           *rand.Rand                               // internal PRNG
-	key            [32]byte                                 // cryptographically secure random bytes
-	addrIndex      map[string]*KnownAddress                 // address key to ka for all addresses
-	addrNew        [newBucketCount]map[string]*KnownAddress // storage for new addresses
-	addrTried      [triedBucketCount][]*KnownAddress        // storage for tried addresses
-	addrChanged    bool                                     // true if address state needs saving
-	started        int32                                    // is 1 if started
-	shutdown       int32                                    // is 1 if shutdown is done or in progress
-	wg             sync.WaitGroup                           // wait group used by main handler
-	quit           chan struct{}                            // channel to notify main handler of shutdown
-	nTried         int                                      // number of tried addresses
-	nNew           int                                      // number of new addresses (i.e., not tried)
-	lamtx          sync.Mutex                               // local address mutex
-	localAddresses map[string]*localAddress                 // address key to la for all local addresses
+	// mtx is used to ensure safe concurrent access to fields on an instance
+	// of the address manager.
+	mtx sync.Mutex
+
+	// peersFile is the path of file that the address manager's serialized state
+	// is saved to and loaded from.
+	peersFile string
+
+	// lookupFunc is a function provided to the address manager that is used to
+	// perform DNS lookups for a given hostname.
+	// The provided function MUST be safe for concurrent access.
+	lookupFunc func(string) ([]net.IP, error)
+
+	// rand is the address manager's internal PRNG.  It is used to both randomly
+	// retrieve addresses from the address manager's internal new and tried
+	// buckets in addition to deciding whether a not-known address is accepted
+	// to the address manager.
+	rand *rand.Rand
+
+	// key is a random seed used to map addresses to a new and tried buckets.
+	key [32]byte
+
+	// addrIndex maintains an index of all addresses known to the address
+	// manager, including both new and tried addresses. The key is a
+	// unique string representation of the underlying network address.
+	addrIndex map[string]*KnownAddress
+
+	// addrNew stores addresses considered newly added to the address manager
+	// and have not been tried.  It also serves as storage for addresses that
+	// were considered tried but were randomly evicted due to the address
+	// manager exceeding tried address capacity.
+	addrNew [newBucketCount]map[string]*KnownAddress
+
+	// addrTried is a collection of tried buckets that store tried addresses.
+	// Tried address are address that have been tested
+	addrTried [triedBucketCount][]*KnownAddress
+
+	// addrChanged signals whether the address manager needs to have its state
+	// serialized and saved to the file system.
+	addrChanged bool
+
+	// started signals whether the address manager has been started.  It's value
+	// is 1 or more if started.
+	started int32
+
+	// shutdown signals whether a shutdown of the address manager has been
+	// initiated.  It's value is 1 or more if a shutdown is done or in progress.
+	shutdown int32
+
+	// The following fields are used for lifecycle management of the
+	// address manager.
+	wg   sync.WaitGroup
+	quit chan struct{}
+
+	// nTried represents the total number of tried addresses across all tried
+	// buckets.
+	nTried int
+
+	// nNew represents the total number of new addresses across all new buckets.
+	nNew int
+
+	// lamtx is used to protect access to the local address map.
+	lamtx sync.Mutex
+
+	// localAddresses stores all known local addresses, keyed by the respective
+	// network address' unique string representation.
+	localAddresses map[string]*localAddress
+
+	// getTriedBucket returns an index in the tried bucket for the network
+	// address.
+	getTriedBucket func(netAddr *wire.NetAddress) int
+
+	// getNewBucket returns an index in the addrNew bucket for the network
+	// address.
+	getNewBucket func(netAddr, srcAddr *wire.NetAddress) int
+
+	// triedBucketSize is the maximum number of addresses in each tried bucket.
+	triedBucketSize int
 }
 
+// serializedKnownAddress is used to represent the serializable state of a
+// KnownAddress instance. It excludes convenience fields such as ref count and
+// tried since those values can be derived from the address manager's state.
 type serializedKnownAddress struct {
 	Addr        string
 	Src         string
@@ -58,9 +122,10 @@ type serializedKnownAddress struct {
 	TimeStamp   int64
 	LastAttempt int64
 	LastSuccess int64
-	// no refcount or tried, that is available from context.
 }
 
+// serializedAddrManager is used to represent the serializable state of a
+// AddrManager instance.
 type serializedAddrManager struct {
 	Version      int
 	Key          [32]byte
@@ -111,9 +176,9 @@ const (
 	// cache to disk for future use.
 	dumpAddressInterval = time.Minute * 10
 
-	// triedBucketSize is the maximum number of addresses in each
-	// tried address bucket.
-	triedBucketSize = 256
+	// defaultTriedBucketSize is the default value for the maximum number of
+	// addresses in each tried address bucket.
+	defaultTriedBucketSize = 256
 
 	// triedBucketCount is the number of buckets we split tried
 	// addresses over.
@@ -156,8 +221,8 @@ const (
 	minBadDays = 7
 
 	// getAddrMax is the most addresses that we will send in response
-	// to a getAddr (in practice the most addresses we will return from a
-	// call to AddressCache()).
+	// to a getAddr message. Effectively, this defines the most addresses
+	// returned from a call to AddressCache().
 	getAddrMax = 2500
 
 	// getAddrPercent is the percentage of total addresses known that we
@@ -223,12 +288,11 @@ func (a *AddrManager) updateAddress(netAddr, srcAddr *wire.NetAddress) {
 		a.addrIndex[addr] = ka
 		a.nNew++
 		a.addrChanged = true
-		// XXX time penalty?
 	}
 
 	bucket := a.getNewBucket(netAddr, srcAddr)
 
-	// Already exists?
+	// If the address already exists in the new bucket, do not replace it.
 	if _, ok := a.addrNew[bucket][addr]; ok {
 		return
 	}
@@ -290,10 +354,10 @@ func (a *AddrManager) expireNew(bucket int) {
 	}
 }
 
-// pickTried selects an address from the tried bucket to be evicted.
-// We just choose the eldest. Bitcoind selects 4 random entries and throws away
-// the older of them.
-func (a *AddrManager) pickTried(bucket int) int {
+// getOldestAddressIndex returns the index of the oldest address in the tried
+// bucket.  It is used when there is a need to evict an element from a tried
+// bucket to make room for a newly tried address.
+func (a *AddrManager) getOldestAddressIndex(bucket int) int {
 	var oldest *KnownAddress
 	var idx int
 
@@ -306,13 +370,13 @@ func (a *AddrManager) pickTried(bucket int) int {
 	return idx
 }
 
-func (a *AddrManager) getNewBucket(netAddr, srcAddr *wire.NetAddress) int {
-	// bitcoind:
-	// doublesha256(key + sourcegroup + int64(doublesha256(key + group
-	// + sourcegroup))%bucket_per_source_group) % num_new_buckets
-
+// getNewBucket returns a psuedorandom new bucket index for the provided
+// IPs using key as a seed.
+// This is used to as a mitigation against eclipse attacks described in
+// "Eclipse Attacks on Bitcoin’s Peer-to-Peer Network" by Heilman et al.
+func getNewBucket(key [32]byte, netAddr, srcAddr *wire.NetAddress) int {
 	data1 := []byte{}
-	data1 = append(data1, a.key[:]...)
+	data1 = append(data1, key[:]...)
 	data1 = append(data1, []byte(GroupKey(netAddr))...)
 	data1 = append(data1, []byte(GroupKey(srcAddr))...)
 	hash1 := chainhash.HashB(data1)
@@ -321,7 +385,7 @@ func (a *AddrManager) getNewBucket(netAddr, srcAddr *wire.NetAddress) int {
 	var hashbuf [8]byte
 	binary.LittleEndian.PutUint64(hashbuf[:], hash64)
 	data2 := []byte{}
-	data2 = append(data2, a.key[:]...)
+	data2 = append(data2, key[:]...)
 	data2 = append(data2, GroupKey(srcAddr)...)
 	data2 = append(data2, hashbuf[:]...)
 
@@ -329,12 +393,11 @@ func (a *AddrManager) getNewBucket(netAddr, srcAddr *wire.NetAddress) int {
 	return int(binary.LittleEndian.Uint64(hash2) % newBucketCount)
 }
 
-func (a *AddrManager) getTriedBucket(netAddr *wire.NetAddress) int {
-	// bitcoind hashes this as:
-	// doublesha256(key + group + truncate_to_64bits(doublesha256(key))
-	// % buckets_per_group) % num_buckets
+// getTriedBucket returns a psuedorandom tried bucket index for the provided
+// network address using key as a seed.
+func getTriedBucket(key [32]byte, netAddr *wire.NetAddress) int {
 	data1 := []byte{}
-	data1 = append(data1, a.key[:]...)
+	data1 = append(data1, key[:]...)
 	data1 = append(data1, []byte(NetAddressKey(netAddr))...)
 	hash1 := chainhash.HashB(data1)
 	hash64 := binary.LittleEndian.Uint64(hash1)
@@ -342,7 +405,7 @@ func (a *AddrManager) getTriedBucket(netAddr *wire.NetAddress) int {
 	var hashbuf [8]byte
 	binary.LittleEndian.PutUint64(hashbuf[:], hash64)
 	data2 := []byte{}
-	data2 = append(data2, a.key[:]...)
+	data2 = append(data2, key[:]...)
 	data2 = append(data2, GroupKey(netAddr)...)
 	data2 = append(data2, hashbuf[:]...)
 
@@ -442,7 +505,7 @@ func (a *AddrManager) savePeers() {
 }
 
 // loadPeers loads the known address from the saved file.  If empty, missing, or
-// malformed file, just don't load anything and start fresh
+// malformed file, just don't load anything and start fresh.
 func (a *AddrManager) loadPeers() {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
@@ -564,9 +627,13 @@ func (a *AddrManager) DeserializeNetAddress(addr string) (*wire.NetAddress, erro
 }
 
 // Start begins the core address handler which manages a pool of known
-// addresses, timeouts, and interval based writes.
+// addresses, timeouts, and interval based writes.  If the address manager is
+// starting or has already been started, invoking this method has no
+// effect.
+//
+// This function is safe for concurrent access.
 func (a *AddrManager) Start() {
-	// Already started?
+	// Return early if the address manager has already been started.
 	if atomic.AddInt32(&a.started, 1) != 1 {
 		return
 	}
@@ -583,9 +650,9 @@ func (a *AddrManager) Start() {
 
 // Stop gracefully shuts down the address manager by stopping the main handler.
 func (a *AddrManager) Stop() error {
+	// Return early if the address manager has already been stopped.
 	if atomic.AddInt32(&a.shutdown, 1) != 1 {
-		log.Warnf("Address manager is already in the process of " +
-			"shutting down")
+		log.Warnf("Address manager is already in the process of shutting down")
 		return nil
 	}
 
@@ -596,8 +663,9 @@ func (a *AddrManager) Stop() error {
 }
 
 // AddAddresses adds new addresses to the address manager.  It enforces a max
-// number of addresses and silently ignores duplicate addresses.  It is
-// safe for concurrent access.
+// number of addresses and silently ignores duplicate addresses.
+//
+// This function is safe for concurrent access.
 func (a *AddrManager) AddAddresses(addrs []*wire.NetAddress, srcAddr *wire.NetAddress) {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
@@ -608,8 +676,9 @@ func (a *AddrManager) AddAddresses(addrs []*wire.NetAddress, srcAddr *wire.NetAd
 }
 
 // AddAddress adds a new address to the address manager.  It enforces a max
-// number of addresses and silently ignores duplicate addresses.  It is
-// safe for concurrent access.
+// number of addresses and silently ignores duplicate addresses.
+//
+// This function is safe for concurrent access.
 func (a *AddrManager) AddAddress(addr, srcAddr *wire.NetAddress) {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
@@ -640,12 +709,16 @@ func (a *AddrManager) addAddressByIP(addrIP string) error {
 }
 
 // numAddresses returns the number of addresses known to the address manager.
+//
+// This function MUST be called with the address manager lock held (for reads).
 func (a *AddrManager) numAddresses() int {
 	return a.nTried + a.nNew
 }
 
 // NeedMoreAddresses returns whether or not the address manager needs more
 // addresses.
+//
+// This function is safe for concurrent access.
 func (a *AddrManager) NeedMoreAddresses() bool {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
@@ -653,8 +726,10 @@ func (a *AddrManager) NeedMoreAddresses() bool {
 	return a.numAddresses() < needAddressThreshold
 }
 
-// AddressCache returns the current address cache.  It must be treated as
-// read-only (but since it is a copy now, this is not as dangerous).
+// AddressCache returns a randomized subset of all addresses known to the
+// address manager.
+//
+// This function is safe for concurrent access.
 func (a *AddrManager) AddressCache() []*wire.NetAddress {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
@@ -666,7 +741,7 @@ func (a *AddrManager) AddressCache() []*wire.NetAddress {
 	}
 
 	allAddr := make([]*wire.NetAddress, 0, addrLen)
-	// Iteration order is undefined here, but we randomise it anyway.
+	// Iteration order is undefined here, but we randomize it anyway.
 	for _, v := range a.addrIndex {
 		// Skip low quality addresses.
 		if v.isBad() {
@@ -713,11 +788,21 @@ func (a *AddrManager) reset() {
 		a.addrTried[i] = nil
 	}
 	a.addrChanged = true
+	a.getNewBucket = func(netAddr, srcAddr *wire.NetAddress) int {
+		return getNewBucket(a.key, netAddr, srcAddr)
+	}
+	a.getTriedBucket = func(netAddr *wire.NetAddress) int {
+		return getTriedBucket(a.key, netAddr)
+	}
 }
 
-// HostToNetAddress returns a netaddress given a host address. If the address is
-// a Tor .onion address this will be taken care of. Else if the host is not an
-// IP address it will be resolved (via Tor if required).
+// HostToNetAddress parses and returns an address manager network address given
+// a hostname in a supported format (IPv4, IPv6, TORv2).  If the hostname
+// cannot be immediately converted from a known address format, it will be
+// resolved using the lookup function provided to the address manager. If it
+// cannot be resolved, an error is returned.
+//
+// This function is safe for concurrent access.
 func (a *AddrManager) HostToNetAddress(host string, port uint16, services wire.ServiceFlag) (*wire.NetAddress, error) {
 	// Tor address is 16 char base32 + ".onion"
 	var ip net.IP
@@ -747,8 +832,8 @@ func (a *AddrManager) HostToNetAddress(host string, port uint16, services wire.S
 }
 
 // ipString returns a string for the ip from the provided NetAddress. If the
-// ip is in the range used for Tor addresses then it will be transformed into
-// the relevant .onion address.
+// ip is in the range used for TORv2 addresses then it will be transformed into
+// the respective .onion address.
 func ipString(na *wire.NetAddress) string {
 	if isOnionCatTor(na) {
 		// We know now that na.IP is long enough.
@@ -771,6 +856,8 @@ func NetAddressKey(na *wire.NetAddress) string {
 // random one from the possible addresses with preference given to ones that
 // have not been used recently and should not pick 'close' addresses
 // consecutively.
+//
+// This function is safe for concurrent access.
 func (a *AddrManager) GetAddress() *KnownAddress {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
@@ -837,8 +924,11 @@ func (a *AddrManager) find(addr *wire.NetAddress) *KnownAddress {
 }
 
 // Attempt increases the given address' attempt counter and updates
-// the last attempt time.
-func (a *AddrManager) Attempt(addr *wire.NetAddress) {
+// the last attempt time, if it is known to the address manager. If the address
+// is not known to the address manager an error is returned.
+//
+// This function is safe for concurrent access.
+func (a *AddrManager) Attempt(addr *wire.NetAddress) error {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
 
@@ -846,7 +936,8 @@ func (a *AddrManager) Attempt(addr *wire.NetAddress) {
 	// Surely address will be in tried by now?
 	ka := a.find(addr)
 	if ka == nil {
-		return
+		str := fmt.Sprintf("address %s not found", ipString(addr))
+		return makeError(ErrAddressNotFound, str)
 	}
 
 	// set last tried time to now
@@ -854,18 +945,22 @@ func (a *AddrManager) Attempt(addr *wire.NetAddress) {
 	ka.attempts++
 	ka.lastattempt = time.Now()
 	ka.mtx.Unlock()
+	return nil
 }
 
 // Connected Marks the given address as currently connected and working at the
-// current time.  The address must already be known to AddrManager else it will
-// be ignored.
-func (a *AddrManager) Connected(addr *wire.NetAddress) {
+// current time.  If the address is not known to the address manager an error
+// is returned.
+//
+// This function is safe for concurrent access.
+func (a *AddrManager) Connected(addr *wire.NetAddress) error {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
 
 	ka := a.find(addr)
 	if ka == nil {
-		return
+		str := fmt.Sprintf("address %s not found", ipString(addr))
+		return makeError(ErrAddressNotFound, str)
 	}
 
 	// Update the time as long as it has been 20 minutes since last we did
@@ -879,18 +974,22 @@ func (a *AddrManager) Connected(addr *wire.NetAddress) {
 		ka.na = &naCopy
 		ka.mtx.Unlock()
 	}
+	return nil
 }
 
-// Good marks the given address as good.  To be called after a successful
-// connection and version exchange.  If the address is unknown to the address
-// manager it will be ignored.
-func (a *AddrManager) Good(addr *wire.NetAddress) {
+// Good marks the given address as good.  This should be called after a
+// successful outbound connection to and version exchange with a peer.  If the
+// address is not known to the address manager an error is returned.
+//
+// This function is safe for concurrent access.
+func (a *AddrManager) Good(addr *wire.NetAddress) error {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
 
 	ka := a.find(addr)
 	if ka == nil {
-		return
+		str := fmt.Sprintf("address %s not found", ipString(addr))
+		return makeError(ErrAddressNotFound, str)
 	}
 
 	// ka.Timestamp is not updated here to avoid leaking information
@@ -900,69 +999,74 @@ func (a *AddrManager) Good(addr *wire.NetAddress) {
 	ka.lastattempt = now
 	ka.attempts = 0
 
-	// move to tried set, optionally evicting other addresses if needed.
+	// If the address is already tried then return since it's already good.
+	// Otherwise, move it to a tried bucket. If the target tried bucket is full,
+	// then room will be made by evicting the oldest address in that bucket and
+	// moving it to a new bucket. If the psuedorandomly selected new bucket is
+	// full, then swap the addresses' positions between tried and new.
 	if ka.tried {
-		return
+		return nil
 	}
-
-	// ok, need to move it to tried.
 
 	// remove from all new buckets.
 	// record one of the buckets in question and call it the `first'
 	addrKey := NetAddressKey(addr)
-	oldBucket := -1
+	addrNewAvailableIndex := -1
 	for i := range a.addrNew {
 		// we check for existence so we can record the first one
 		if _, ok := a.addrNew[i][addrKey]; ok {
 			delete(a.addrNew[i], addrKey)
 			a.addrChanged = true
 			ka.refs--
-			if oldBucket == -1 {
-				oldBucket = i
+			if addrNewAvailableIndex == -1 {
+				addrNewAvailableIndex = i
 			}
 		}
 	}
 	a.nNew--
 
-	if oldBucket == -1 {
-		// What? wasn't in a bucket after all.... Panic?
-		return
+	if addrNewAvailableIndex == -1 {
+		str := fmt.Sprintf("%s is not marked as a new address", ipString(addr))
+		return makeError(ErrAddressNotFound, str)
 	}
 
 	bucket := a.getTriedBucket(ka.na)
 
-	// Room in this tried bucket?
-	if len(a.addrTried[bucket]) < triedBucketSize {
+	// If this tried bucket has enough capacity for another address,
+	// add the address to the bucket and flag it as tried.
+	if len(a.addrTried[bucket]) < a.triedBucketSize {
 		ka.tried = true
 		a.addrTried[bucket] = append(a.addrTried[bucket], ka)
 		a.addrChanged = true
 		a.nTried++
-		return
+		return nil
 	}
 
-	// No room, we have to evict something else.
-	triedIdx := a.pickTried(bucket)
-	rmka := a.addrTried[bucket][triedIdx]
+	// Since the tried bucket is at capacity, evict the oldest address
+	// in the tried bucket and move it to a new bucket.
+	oldestTriedIndex := a.getOldestAddressIndex(bucket)
+	rmka := a.addrTried[bucket][oldestTriedIndex]
 
 	// First bucket it would have been put in.
 	newBucket := a.getNewBucket(rmka.na, rmka.srcAddr)
 
-	// If no room in the original bucket, we put it in a bucket we just
-	// freed up a space in.
+	// If there is no room in the psuedorandomly selected new bucket,
+	// then reuse the new bucket that the newly tried address was removed from.
 	if len(a.addrNew[newBucket]) >= newBucketSize {
-		newBucket = oldBucket
+		newBucket = addrNewAvailableIndex
 	}
 
-	// replace with ka in list.
+	// Replace oldest tried address in bucket with ka.
 	ka.tried = true
-	a.addrTried[bucket][triedIdx] = ka
+	a.addrTried[bucket][oldestTriedIndex] = ka
 
 	rmka.tried = false
 	rmka.refs++
 
-	// We don't touch a.nTried here since the number of tried stays the same
-	// but we decremented a.nNew above, raise it again since we're putting
-	// something back.
+	// The total number of tried addresses a.nTried is not modified here since
+	// the number of tried addresses stays the same.  However, since the total
+	// number of new addresses a.nNew was decremented above, increment it now
+	// since an address is being evicted from a tried bucket to a new bucket.
 	a.nNew++
 
 	rmkey := NetAddressKey(rmka.na)
@@ -970,16 +1074,19 @@ func (a *AddrManager) Good(addr *wire.NetAddress) {
 
 	// We made sure there is space here just above.
 	a.addrNew[newBucket][rmkey] = rmka
+	return nil
 }
 
 // SetServices sets the services for the given address to the provided value.
-func (a *AddrManager) SetServices(addr *wire.NetAddress, services wire.ServiceFlag) {
+// If the address is not known to the address manager an error is returned.
+func (a *AddrManager) SetServices(addr *wire.NetAddress, services wire.ServiceFlag) error {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
 
 	ka := a.find(addr)
 	if ka == nil {
-		return
+		str := fmt.Sprintf("address %s not found", ipString(addr))
+		return makeError(ErrAddressNotFound, str)
 	}
 
 	// Update the services if needed.
@@ -991,13 +1098,16 @@ func (a *AddrManager) SetServices(addr *wire.NetAddress, services wire.ServiceFl
 		ka.na = &naCopy
 		ka.mtx.Unlock()
 	}
+	return nil
 }
 
 // AddLocalAddress adds na to the list of known local addresses to advertise
 // with the given priority.
+//
+// This function is safe for concurrent access.
 func (a *AddrManager) AddLocalAddress(na *wire.NetAddress, priority AddressPriority) error {
 	if !IsRoutable(na) {
-		return fmt.Errorf("address %s is not routable", na.IP)
+		return fmt.Errorf("address %s is not routable", ipString(na))
 	}
 
 	a.lamtx.Lock()
@@ -1019,6 +1129,8 @@ func (a *AddrManager) AddLocalAddress(na *wire.NetAddress, priority AddressPrior
 }
 
 // HasLocalAddress asserts if the manager has the provided local address.
+//
+// This function is safe for concurrent access.
 func (a *AddrManager) HasLocalAddress(na *wire.NetAddress) bool {
 	key := NetAddressKey(na)
 	a.lamtx.Lock()
@@ -1076,6 +1188,8 @@ const (
 
 // getReachabilityFrom returns the relative reachability of the provided local
 // address to the provided remote address.
+//
+// This function is safe for concurrent access.
 func getReachabilityFrom(localAddr, remoteAddr *wire.NetAddress) int {
 	if !IsRoutable(remoteAddr) {
 		return Unreachable
@@ -1145,6 +1259,8 @@ func getReachabilityFrom(localAddr, remoteAddr *wire.NetAddress) int {
 
 // GetBestLocalAddress returns the most appropriate local address to use
 // for the given remote address.
+//
+// This function is safe for concurrent access.
 func (a *AddrManager) GetBestLocalAddress(remoteAddr *wire.NetAddress) *wire.NetAddress {
 	a.lamtx.Lock()
 	defer a.lamtx.Unlock()
@@ -1184,6 +1300,8 @@ func (a *AddrManager) GetBestLocalAddress(remoteAddr *wire.NetAddress) *wire.Net
 // ValidatePeerNa returns the validity and reachability of the
 // provided local address based on its routablility and reachability
 // from the peer that suggested it.
+//
+// This function is safe for concurrent access.
 func (a *AddrManager) ValidatePeerNa(localAddr, remoteAddr *wire.NetAddress) (bool, int) {
 	net := getNetwork(localAddr)
 	reach := getReachabilityFrom(localAddr, remoteAddr)
@@ -1192,16 +1310,17 @@ func (a *AddrManager) ValidatePeerNa(localAddr, remoteAddr *wire.NetAddress) (bo
 	return valid, reach
 }
 
-// New returns a new Decred address manager.
+// New constructs a new address manager instance.
 // Use Start to begin processing asynchronous address updates.
 // The address manager uses lookupFunc for necessary DNS lookups.
 func New(dataDir string, lookupFunc func(string) ([]net.IP, error)) *AddrManager {
 	am := AddrManager{
-		peersFile:      filepath.Join(dataDir, PeersFilename),
-		lookupFunc:     lookupFunc,
-		rand:           rand.New(rand.NewSource(time.Now().UnixNano())),
-		quit:           make(chan struct{}),
-		localAddresses: make(map[string]*localAddress),
+		peersFile:       filepath.Join(dataDir, peersFilename),
+		lookupFunc:      lookupFunc,
+		rand:            rand.New(rand.NewSource(time.Now().UnixNano())),
+		quit:            make(chan struct{}),
+		localAddresses:  make(map[string]*localAddress),
+		triedBucketSize: defaultTriedBucketSize,
 	}
 	am.reset()
 	return &am

--- a/addrmgr/addrmanager.go
+++ b/addrmgr/addrmanager.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -1048,15 +1048,6 @@ func (a *AddrManager) LocalAddresses() []LocalAddr {
 	return addrs
 }
 
-// FetchLocalAddresses fetches a summary of local addresses information for
-// the getnetworkinfo rpc.
-//
-// Deprecated: This will be removed in the next major version bump.
-// Use LocalAddresses instead.
-func (a *AddrManager) FetchLocalAddresses() []LocalAddr {
-	return a.LocalAddresses()
-}
-
 const (
 	// Unreachable represents a publicly unreachable connection state
 	// between two addresses.
@@ -1199,16 +1190,6 @@ func (a *AddrManager) ValidatePeerNa(localAddr, remoteAddr *wire.NetAddress) (bo
 	valid := (net == IPv4Address && reach == Ipv4) || (net == IPv6Address &&
 		(reach == Ipv6Weak || reach == Ipv6Strong || reach == Teredo))
 	return valid, reach
-}
-
-// IsPeerNaValid asserts if the provided local address is routable
-// and reachabile from the peer that suggested it.
-//
-// Deprecated: This will be removed in the next major version bump.
-// Use ValidatePeerNa instead.
-func (a *AddrManager) IsPeerNaValid(localAddr, remoteAddr *wire.NetAddress) bool {
-	valid, _ := a.ValidatePeerNa(localAddr, remoteAddr)
-	return valid
 }
 
 // New returns a new Decred address manager.

--- a/addrmgr/addrmanager_test.go
+++ b/addrmgr/addrmanager_test.go
@@ -15,94 +15,10 @@ import (
 	"reflect"
 	"testing"
 	"time"
-
-	"github.com/decred/dcrd/wire"
 )
-
-// naTest is used to describe a test to be performed against the NetAddressKey
-// method.
-type naTest struct {
-	in   wire.NetAddress
-	want string
-}
-
-// naTests houses all of the tests to be performed against the NetAddressKey
-// method.
-var naTests = make([]naTest, 0)
 
 // Put some IP in here for convenience. Points to google.
 var someIP = "173.194.115.66"
-
-// addNaTests
-func addNaTests() {
-	// IPv4
-	// Localhost
-	addNaTest("127.0.0.1", 8333, "127.0.0.1:8333")
-	addNaTest("127.0.0.1", 8334, "127.0.0.1:8334")
-
-	// Class A
-	addNaTest("1.0.0.1", 8333, "1.0.0.1:8333")
-	addNaTest("2.2.2.2", 8334, "2.2.2.2:8334")
-	addNaTest("27.253.252.251", 8335, "27.253.252.251:8335")
-	addNaTest("123.3.2.1", 8336, "123.3.2.1:8336")
-
-	// Private Class A
-	addNaTest("10.0.0.1", 8333, "10.0.0.1:8333")
-	addNaTest("10.1.1.1", 8334, "10.1.1.1:8334")
-	addNaTest("10.2.2.2", 8335, "10.2.2.2:8335")
-	addNaTest("10.10.10.10", 8336, "10.10.10.10:8336")
-
-	// Class B
-	addNaTest("128.0.0.1", 8333, "128.0.0.1:8333")
-	addNaTest("129.1.1.1", 8334, "129.1.1.1:8334")
-	addNaTest("180.2.2.2", 8335, "180.2.2.2:8335")
-	addNaTest("191.10.10.10", 8336, "191.10.10.10:8336")
-
-	// Private Class B
-	addNaTest("172.16.0.1", 8333, "172.16.0.1:8333")
-	addNaTest("172.16.1.1", 8334, "172.16.1.1:8334")
-	addNaTest("172.16.2.2", 8335, "172.16.2.2:8335")
-	addNaTest("172.16.172.172", 8336, "172.16.172.172:8336")
-
-	// Class C
-	addNaTest("193.0.0.1", 8333, "193.0.0.1:8333")
-	addNaTest("200.1.1.1", 8334, "200.1.1.1:8334")
-	addNaTest("205.2.2.2", 8335, "205.2.2.2:8335")
-	addNaTest("223.10.10.10", 8336, "223.10.10.10:8336")
-
-	// Private Class C
-	addNaTest("192.168.0.1", 8333, "192.168.0.1:8333")
-	addNaTest("192.168.1.1", 8334, "192.168.1.1:8334")
-	addNaTest("192.168.2.2", 8335, "192.168.2.2:8335")
-	addNaTest("192.168.192.192", 8336, "192.168.192.192:8336")
-
-	// IPv6
-	// Localhost
-	addNaTest("::1", 8333, "[::1]:8333")
-	addNaTest("fe80::1", 8334, "[fe80::1]:8334")
-
-	// Link-local
-	addNaTest("fe80::1:1", 8333, "[fe80::1:1]:8333")
-	addNaTest("fe91::2:2", 8334, "[fe91::2:2]:8334")
-	addNaTest("fea2::3:3", 8335, "[fea2::3:3]:8335")
-	addNaTest("feb3::4:4", 8336, "[feb3::4:4]:8336")
-
-	// Site-local
-	addNaTest("fec0::1:1", 8333, "[fec0::1:1]:8333")
-	addNaTest("fed1::2:2", 8334, "[fed1::2:2]:8334")
-	addNaTest("fee2::3:3", 8335, "[fee2::3:3]:8335")
-	addNaTest("fef3::4:4", 8336, "[fef3::4:4]:8336")
-
-	// Tor
-	addNaTest("fd87:d87e:eb43::", 8333, "aaaaaaaaaaaaaaaa.onion:8333")
-}
-
-func addNaTest(ip string, port uint16, want string) {
-	nip := net.ParseIP(ip)
-	na := *wire.NewNetAddressIPPort(nip, port, wire.SFNodeNetwork)
-	test := naTest{na, want}
-	naTests = append(naTests, test)
-}
 
 func lookupFunc(host string) ([]net.IP, error) {
 	return nil, errors.New("not implemented")
@@ -112,8 +28,8 @@ func lookupFunc(host string) ([]net.IP, error) {
 // address string and port, rather than a wire.NetAddress.
 func (a *AddrManager) addAddressByIP(addr string, port uint16) {
 	ip := net.ParseIP(addr)
-	na := wire.NewNetAddressIPPort(ip, port, 0)
-	a.AddAddress(na, na)
+	na := NewNetAddress(ip, port, 0)
+	a.addOrUpdateAddress(na, na)
 }
 
 // TestStartStop tests the behavior of the address manager when it is started
@@ -160,7 +76,7 @@ func TestStartStop(t *testing.T) {
 	// Verify that the known address matches what was added to the address
 	// manager previously.
 	wantNetAddrKey := someIP + ":8333"
-	gotNetAddrKey := NetAddressKey(knownAddress.na)
+	gotNetAddrKey := knownAddress.na.Key()
 	if gotNetAddrKey != wantNetAddrKey {
 		t.Fatal("address manager does not contain expected address -- "+
 			"got %v, want %v", gotNetAddrKey, wantNetAddrKey)
@@ -171,7 +87,7 @@ func TestStartStop(t *testing.T) {
 	}
 }
 
-func TestAddAddressUpdate(t *testing.T) {
+func TestAddOrUpdateAddress(t *testing.T) {
 	amgr := New("testaddaddressupdate", nil)
 	amgr.Start()
 	if ka := amgr.GetAddress(); ka != nil {
@@ -181,8 +97,8 @@ func TestAddAddressUpdate(t *testing.T) {
 	if ip == nil {
 		t.Fatalf("Invalid IP address %s", someIP)
 	}
-	na := wire.NewNetAddressIPPort(ip, 8333, 0)
-	amgr.AddAddress(na, na)
+	na := NewNetAddress(net.ParseIP(someIP), 8333, 0)
+	amgr.addOrUpdateAddress(na, na)
 	ka := amgr.GetAddress()
 	if ka == nil {
 		t.Fatal("Address Manager should contain known address")
@@ -193,7 +109,7 @@ func TestAddAddressUpdate(t *testing.T) {
 	// add address again, but with different time stamp (to trigger update)
 	ts := na.Timestamp.Add(time.Second)
 	na.Timestamp = ts
-	amgr.AddAddress(na, na)
+	amgr.addOrUpdateAddress(na, na)
 	// address should be in there
 	ka = amgr.GetAddress()
 	if ka == nil {
@@ -213,51 +129,55 @@ func TestAddAddressUpdate(t *testing.T) {
 func TestAddLocalAddress(t *testing.T) {
 	var tests = []struct {
 		name     string
-		address  wire.NetAddress
+		ip       net.IP
 		priority AddressPriority
 		valid    bool
 	}{
 		{
 			name:     "unroutable local IPv4 address",
-			address:  wire.NetAddress{IP: net.ParseIP("192.168.0.100")},
+			ip:       net.ParseIP("192.168.0.100"),
 			priority: InterfacePrio,
 			valid:    false,
 		},
 		{
 			name:     "routable IPv4 address",
-			address:  wire.NetAddress{IP: net.ParseIP("204.124.1.1")},
+			ip:       net.ParseIP("204.124.1.1"),
 			priority: InterfacePrio,
 			valid:    true,
 		},
 		{
 			name:     "routable IPv4 address with bound priority",
-			address:  wire.NetAddress{IP: net.ParseIP("204.124.1.1")},
+			ip:       net.ParseIP("204.124.1.1"),
 			priority: BoundPrio,
 			valid:    true,
 		},
 		{
 			name:     "unroutable local IPv6 address",
-			address:  wire.NetAddress{IP: net.ParseIP("::1")},
+			ip:       net.ParseIP("::1"),
 			priority: InterfacePrio,
 			valid:    false,
 		},
 		{
 			name:     "unroutable local IPv6 address 2",
-			address:  wire.NetAddress{IP: net.ParseIP("fe80::1")},
+			ip:       net.ParseIP("fe80::1"),
 			priority: InterfacePrio,
 			valid:    false,
 		},
 		{
 			name:     "routable IPv6 address",
-			address:  wire.NetAddress{IP: net.ParseIP("2620:100::1")},
+			ip:       net.ParseIP("2620:100::1"),
 			priority: InterfacePrio,
 			valid:    true,
 		},
 	}
+
+	const testPort = 8333
+	const testServices = sfNodeNetwork
+
 	amgr := New("testaddlocaladdress", nil)
 	validLocalAddresses := make(map[string]struct{})
 	for _, test := range tests {
-		netAddr := &test.address
+		netAddr := NewNetAddress(test.ip, testPort, testServices)
 		result := amgr.AddLocalAddress(netAddr, test.priority)
 		if result == nil && !test.valid {
 			t.Errorf("%q: address should have been accepted", test.name)
@@ -278,7 +198,7 @@ func TestAddLocalAddress(t *testing.T) {
 		if test.valid {
 			// Set up data to test behavior of a call to LocalAddresses() for
 			// addresses that were added to the local address manager.
-			validLocalAddresses[NetAddressKey(netAddr)] = struct{}{}
+			validLocalAddresses[netAddr.Key()] = struct{}{}
 		}
 	}
 
@@ -286,8 +206,8 @@ func TestAddLocalAddress(t *testing.T) {
 	// address manager are also returned from a call to LocalAddresses.
 	for _, localAddr := range amgr.LocalAddresses() {
 		localAddrIP := net.ParseIP(localAddr.Address)
-		netAddr := &wire.NetAddress{IP: localAddrIP}
-		netAddrKey := NetAddressKey(netAddr)
+		netAddr := NewNetAddress(localAddrIP, testPort, testServices)
+		netAddrKey := netAddr.Key()
 		if _, ok := validLocalAddresses[netAddrKey]; !ok {
 			t.Errorf("expected to find local address with key %v", netAddrKey)
 		}
@@ -317,8 +237,7 @@ func TestAttempt(t *testing.T) {
 
 	// Attempt an ip not known to the address manager.
 	unknownIP := net.ParseIP("1.2.3.4")
-	unknownNetAddress := wire.NewNetAddressIPPort(unknownIP, 1234,
-		wire.SFNodeNetwork)
+	unknownNetAddress := NewNetAddress(unknownIP, 1234, sfNodeNetwork)
 	err = n.Attempt(unknownNetAddress)
 	if err == nil {
 		t.Fatal("Attempting unknown address should have returned an error")
@@ -347,8 +266,7 @@ func TestConnected(t *testing.T) {
 	// Attempt to flag an ip address not known to the address manager as
 	// connected.
 	unknownIP := net.ParseIP("1.2.3.4")
-	unknownNetAddress := wire.NewNetAddressIPPort(unknownIP, 1234,
-		wire.SFNodeNetwork)
+	unknownNetAddress := NewNetAddress(unknownIP, 1234, sfNodeNetwork)
 	err = n.Connected(unknownNetAddress)
 	if err == nil {
 		t.Fatal("Marking unknown address as connected should have errored")
@@ -362,18 +280,14 @@ func TestNeedMoreAddresses(t *testing.T) {
 	if !b {
 		t.Error("Expected that we need more addresses")
 	}
-	addrs := make([]*wire.NetAddress, addrsToAdd)
+	addrs := make([]*NetAddress, addrsToAdd)
 
-	var err error
 	for i := 0; i < addrsToAdd; i++ {
-		s := fmt.Sprintf("%d.%d.173.147:8333", i/128+60, i%128+60)
-		addrs[i], err = n.DeserializeNetAddress(s)
-		if err != nil {
-			t.Errorf("Failed to turn %s into an address: %v", s, err)
-		}
+		s := fmt.Sprintf("%d.%d.173.147", i/128+60, i%128+60)
+		addrs[i] = NewNetAddress(net.ParseIP(s), 8333, sfNodeNetwork)
 	}
 
-	srcAddr := wire.NewNetAddressIPPort(net.IPv4(173, 144, 173, 111), 8333, 0)
+	srcAddr := NewNetAddress(net.ParseIP("173.144.173.111"), 8333, 0)
 
 	n.AddAddresses(addrs, srcAddr)
 	numAddrs := n.numAddresses()
@@ -390,18 +304,14 @@ func TestNeedMoreAddresses(t *testing.T) {
 func TestGood(t *testing.T) {
 	n := New("testgood", lookupFunc)
 	addrsToAdd := 64 * 64
-	addrs := make([]*wire.NetAddress, addrsToAdd)
+	addrs := make([]*NetAddress, addrsToAdd)
 
-	var err error
 	for i := 0; i < addrsToAdd; i++ {
-		s := fmt.Sprintf("%d.173.147.%d:8333", i/64+60, i%64+60)
-		addrs[i], err = n.DeserializeNetAddress(s)
-		if err != nil {
-			t.Errorf("Failed to turn %s into an address: %v", s, err)
-		}
+		s := fmt.Sprintf("%d.173.147.%d", i/64+60, i%64+60)
+		addrs[i] = NewNetAddress(net.ParseIP(s), 8333, sfNodeNetwork)
 	}
 
-	srcAddr := wire.NewNetAddressIPPort(net.IPv4(173, 144, 173, 111), 8333, 0)
+	srcAddr := NewNetAddress(net.ParseIP("173.144.173.111"), 8333, sfNodeNetwork)
 
 	n.AddAddresses(addrs, srcAddr)
 	for _, addr := range addrs {
@@ -425,17 +335,17 @@ func TestGood(t *testing.T) {
 	// address by moving the old one back to the new bucket.
 	n = New("testgood_tried_overflow", lookupFunc)
 	n.triedBucketSize = 1
-	n.getNewBucket = func(netAddr, srcAddr *wire.NetAddress) int {
+	n.getNewBucket = func(netAddr, srcAddr *NetAddress) int {
 		return 0
 	}
-	n.getTriedBucket = func(netAddr *wire.NetAddress) int {
+	n.getTriedBucket = func(netAddr *NetAddress) int {
 		return 0
 	}
 
-	addrA := wire.NewNetAddressIPPort(net.ParseIP("173.144.173.1"), 8333, 0)
-	addrB := wire.NewNetAddressIPPort(net.ParseIP("173.144.173.2"), 8333, 0)
-	addrAKey := NetAddressKey(addrA)
-	addrBKey := NetAddressKey(addrB)
+	addrA := NewNetAddress(net.ParseIP("173.144.173.1"), 8333, 0)
+	addrB := NewNetAddress(net.ParseIP("173.144.173.2"), 8333, 0)
+	addrAKey := addrA.Key()
+	addrBKey := addrB.Key()
 
 	// Neither address should exist in the addrIndex bucket prior to being
 	// added to the address manager. The new and tried buckets should also be
@@ -453,8 +363,7 @@ func TestGood(t *testing.T) {
 			" to the address manager")
 	}
 
-	n.AddAddress(addrA, srcAddr)
-	n.AddAddress(addrB, srcAddr)
+	n.AddAddresses([]*NetAddress{addrA, addrB}, srcAddr)
 
 	// Both addresses should exist in the address index and new bucket after
 	// being added to the address manager.  The tried bucket should be empty.
@@ -483,7 +392,7 @@ func TestGood(t *testing.T) {
 	if len(n.addrTried[0]) != 1 {
 		t.Fatal("Expected tried bucket to contain exactly one element.")
 	}
-	if NetAddressKey(n.addrTried[0][0].na) != addrAKey {
+	if n.addrTried[0][0].na.Key() != addrAKey {
 		t.Fatal("Expected addrA to exist in tried bucket")
 	}
 
@@ -499,7 +408,7 @@ func TestGood(t *testing.T) {
 		t.Fatalf("Expected tried bucket to contain exactly one element, got %d",
 			len(n.addrTried[0]))
 	}
-	if NetAddressKey(n.addrTried[0][0].na) != addrBKey {
+	if n.addrTried[0][0].na.Key() != addrBKey {
 		t.Error("Expected addrB to exist in tried bucket")
 	}
 	if _, exists := n.addrNew[0][addrAKey]; !exists {
@@ -523,7 +432,7 @@ func TestGetAddress(t *testing.T) {
 		t.Fatal("Did not get an address where there is one in the pool")
 	}
 
-	ipStringA := ka.NetAddress().IP.String()
+	ipStringA := ka.NetAddress().ipString()
 	if ipStringA != someIP {
 		t.Fatalf("Wrong IP -- got %v, want %v", ipStringA, someIP)
 	}
@@ -539,21 +448,20 @@ func TestGetAddress(t *testing.T) {
 		t.Fatal("Did not get an address where there is one in the pool")
 	}
 
-	ipStringB := ka.NetAddress().IP.String()
+	ipStringB := ka.NetAddress().ipString()
 	if ipStringB != someIP {
-		t.Errorf("Wrong IP -- got %v, want %v", ipStringB, someIP)
+		t.Fatalf("Wrong IP -- got %v, want %v", ipStringB, someIP)
 	}
 
 	numAddrs := n.numAddresses()
 	if numAddrs != 1 {
-		t.Errorf("Wrong number of addresses -- got %d, want %d", numAddrs, 1)
+		t.Fatalf("wrong number of addresses -- got %d, want %d", numAddrs, 1)
 	}
 
 	// Marking an address not known to the address manager as good should return
 	// an error.
 	unknownIP := net.ParseIP("1.2.3.4")
-	unknownNetAddress := wire.NewNetAddressIPPort(unknownIP, 1234,
-		wire.SFNodeNetwork)
+	unknownNetAddress := NewNetAddress(unknownIP, 1234, sfNodeNetwork)
 	err = n.Good(unknownNetAddress)
 	if err == nil {
 		t.Fatal("Attempting unknown address should have returned an error")
@@ -561,43 +469,48 @@ func TestGetAddress(t *testing.T) {
 }
 
 func TestGetBestLocalAddress(t *testing.T) {
-	localAddrs := []wire.NetAddress{
-		{IP: net.ParseIP("192.168.0.100")},
-		{IP: net.ParseIP("::1")},
-		{IP: net.ParseIP("fe80::1")},
-		{IP: net.ParseIP("2001:470::1")},
+	newAddressFromIP := func(ip net.IP) *NetAddress {
+		const port = 0
+		return NewNetAddress(ip, port, sfNodeNetwork)
+	}
+
+	localAddrs := []*NetAddress{
+		newAddressFromIP(net.ParseIP("192.168.0.100")),
+		newAddressFromIP(net.ParseIP("::1")),
+		newAddressFromIP(net.ParseIP("fe80::1")),
+		newAddressFromIP(net.ParseIP("2001:470::1")),
 	}
 
 	var tests = []struct {
-		remoteAddr wire.NetAddress
-		want0      wire.NetAddress
-		want1      wire.NetAddress
-		want2      wire.NetAddress
-		want3      wire.NetAddress
+		remoteAddr *NetAddress
+		want0      *NetAddress
+		want1      *NetAddress
+		want2      *NetAddress
+		want3      *NetAddress
 	}{
 		{
 			// Remote connection from public IPv4
-			wire.NetAddress{IP: net.ParseIP("204.124.8.1")},
-			wire.NetAddress{IP: net.IPv4zero},
-			wire.NetAddress{IP: net.IPv4zero},
-			wire.NetAddress{IP: net.ParseIP("204.124.8.100")},
-			wire.NetAddress{IP: net.ParseIP("fd87:d87e:eb43:25::1")},
+			newAddressFromIP(net.ParseIP("204.124.8.1")),
+			newAddressFromIP(net.IPv4zero),
+			newAddressFromIP(net.IPv4zero),
+			newAddressFromIP(net.ParseIP("204.124.8.100")),
+			newAddressFromIP(net.ParseIP("fd87:d87e:eb43:25::1")),
 		},
 		{
 			// Remote connection from private IPv4
-			wire.NetAddress{IP: net.ParseIP("172.16.0.254")},
-			wire.NetAddress{IP: net.IPv4zero},
-			wire.NetAddress{IP: net.IPv4zero},
-			wire.NetAddress{IP: net.IPv4zero},
-			wire.NetAddress{IP: net.IPv4zero},
+			newAddressFromIP(net.ParseIP("172.16.0.254")),
+			newAddressFromIP(net.IPv4zero),
+			newAddressFromIP(net.IPv4zero),
+			newAddressFromIP(net.IPv4zero),
+			newAddressFromIP(net.IPv4zero),
 		},
 		{
 			// Remote connection from public IPv6
-			wire.NetAddress{IP: net.ParseIP("2602:100:abcd::102")},
-			wire.NetAddress{IP: net.IPv6zero},
-			wire.NetAddress{IP: net.ParseIP("2001:470::1")},
-			wire.NetAddress{IP: net.ParseIP("2001:470::1")},
-			wire.NetAddress{IP: net.ParseIP("2001:470::1")},
+			newAddressFromIP(net.ParseIP("2602:100:abcd::102")),
+			newAddressFromIP(net.IPv6zero),
+			newAddressFromIP(net.ParseIP("2001:470::1")),
+			newAddressFromIP(net.ParseIP("2001:470::1")),
+			newAddressFromIP(net.ParseIP("2001:470::1")),
 		},
 		/* XXX
 		{
@@ -614,8 +527,8 @@ func TestGetBestLocalAddress(t *testing.T) {
 
 	// Test against default when there's no address
 	for x, test := range tests {
-		got := amgr.GetBestLocalAddress(&test.remoteAddr)
-		if !test.want0.IP.Equal(got.IP) {
+		got := amgr.GetBestLocalAddress(test.remoteAddr)
+		if !reflect.DeepEqual(test.want0.IP, got.IP) {
 			t.Errorf("TestGetBestLocalAddress test1 #%d failed for remote address %s: want %s got %s",
 				x, test.remoteAddr.IP, test.want1.IP, got.IP)
 			continue
@@ -623,13 +536,13 @@ func TestGetBestLocalAddress(t *testing.T) {
 	}
 
 	for _, localAddr := range localAddrs {
-		amgr.AddLocalAddress(&localAddr, InterfacePrio)
+		amgr.AddLocalAddress(localAddr, InterfacePrio)
 	}
 
 	// Test against want1
 	for x, test := range tests {
-		got := amgr.GetBestLocalAddress(&test.remoteAddr)
-		if !test.want1.IP.Equal(got.IP) {
+		got := amgr.GetBestLocalAddress(test.remoteAddr)
+		if !reflect.DeepEqual(test.want1.IP, got.IP) {
 			t.Errorf("TestGetBestLocalAddress test1 #%d failed for remote address %s: want %s got %s",
 				x, test.remoteAddr.IP, test.want1.IP, got.IP)
 			continue
@@ -637,13 +550,13 @@ func TestGetBestLocalAddress(t *testing.T) {
 	}
 
 	// Add a public IP to the list of local addresses.
-	localAddr := wire.NetAddress{IP: net.ParseIP("204.124.8.100")}
-	amgr.AddLocalAddress(&localAddr, InterfacePrio)
+	localAddr := newAddressFromIP(net.ParseIP("204.124.8.100"))
+	amgr.AddLocalAddress(localAddr, InterfacePrio)
 
 	// Test against want2
 	for x, test := range tests {
-		got := amgr.GetBestLocalAddress(&test.remoteAddr)
-		if !test.want2.IP.Equal(got.IP) {
+		got := amgr.GetBestLocalAddress(test.remoteAddr)
+		if !reflect.DeepEqual(test.want2.IP, got.IP) {
 			t.Errorf("TestGetBestLocalAddress test2 #%d failed for remote address %s: want %s got %s",
 				x, test.remoteAddr.IP, test.want2.IP, got.IP)
 			continue
@@ -664,19 +577,6 @@ func TestGetBestLocalAddress(t *testing.T) {
 			}
 		}
 	*/
-}
-
-func TestNetAddressKey(t *testing.T) {
-	addNaTests()
-
-	t.Logf("Running %d tests", len(naTests))
-	for i, test := range naTests {
-		key := NetAddressKey(&test.in)
-		if key != test.want {
-			t.Errorf("NetAddressKey #%d\n got: %s want: %s", i, key, test.want)
-			continue
-		}
-	}
 }
 
 func TestCorruptPeersFile(t *testing.T) {
@@ -868,8 +768,8 @@ func TestValidatePeerNa(t *testing.T) {
 	for _, test := range tests {
 		localIP := net.ParseIP(test.localAddress)
 		remoteIP := net.ParseIP(test.remoteAddress)
-		localNa := wire.NewNetAddressIPPort(localIP, 8333, wire.SFNodeNetwork)
-		remoteNa := wire.NewNetAddressIPPort(remoteIP, 8333, wire.SFNodeNetwork)
+		localNa := NewNetAddress(localIP, 8333, sfNodeNetwork)
+		remoteNa := NewNetAddress(remoteIP, 8333, sfNodeNetwork)
 
 		valid, reach := addressManager.ValidatePeerNa(localNa, remoteNa)
 		if valid != test.valid {
@@ -890,7 +790,7 @@ func TestHostToNetAddress(t *testing.T) {
 	// Define a hostname that will cause a lookup to be performed using the
 	// lookupFunc provided to the address manager instance for each test.
 	const hostnameForLookup = "hostname.test"
-	const services = wire.SFNodeNetwork
+	const services = sfNodeNetwork
 
 	tests := []struct {
 		name       string
@@ -898,7 +798,7 @@ func TestHostToNetAddress(t *testing.T) {
 		port       uint16
 		lookupFunc func(host string) ([]net.IP, error)
 		wantErr    bool
-		want       *wire.NetAddress
+		want       *NetAddress
 	}{
 		{
 			name:       "valid onion address",
@@ -906,7 +806,7 @@ func TestHostToNetAddress(t *testing.T) {
 			port:       8333,
 			lookupFunc: nil,
 			wantErr:    false,
-			want: wire.NewNetAddressIPPort(
+			want: NewNetAddress(
 				net.ParseIP("fd87:d87e:eb43:744:208d:5408:63a4:ac4f"), 8333,
 				services),
 		},
@@ -946,8 +846,7 @@ func TestHostToNetAddress(t *testing.T) {
 				return []net.IP{net.ParseIP("127.0.0.1")}, nil
 			},
 			wantErr: false,
-			want: wire.NewNetAddressIPPort(net.ParseIP("127.0.0.1"), 8333,
-				services),
+			want:    NewNetAddress(net.ParseIP("127.0.0.1"), 8333, services),
 		},
 		{
 			name:       "valid ip address",
@@ -955,8 +854,7 @@ func TestHostToNetAddress(t *testing.T) {
 			port:       8333,
 			lookupFunc: nil,
 			wantErr:    false,
-			want: wire.NewNetAddressIPPort(net.ParseIP("12.1.2.3"), 8333,
-				services),
+			want:       NewNetAddress(net.ParseIP("12.1.2.3"), 8333, services),
 		},
 	}
 
@@ -979,21 +877,19 @@ func TestHostToNetAddress(t *testing.T) {
 // added.
 func TestSetServices(t *testing.T) {
 	addressManager := New("testSetServices", nil)
-	const services = wire.SFNodeNetwork
+	const services = sfNodeNetwork
 
 	// Attempt to set services for an address not known to the address manager.
-	// This should have no effect and exercises paths that avoid a panic.
-	notKnownAddr := wire.NewNetAddressIPPort(net.ParseIP("0.0.0.0"), 8333,
-		services)
+	notKnownAddr := NewNetAddress(net.ParseIP("1.2.3.4"), 8333, services)
 	err := addressManager.SetServices(notKnownAddr, services)
 	if err == nil {
 		t.Fatal("setting services for unknown address should return error")
 	}
 
 	// Add a new address to the address manager.
-	netAddr := wire.NewNetAddressIPPort(net.ParseIP("1.2.3.4"), 8333, services)
-	srcAddr := wire.NewNetAddressIPPort(net.ParseIP("5.6.7.8"), 8333, services)
-	addressManager.AddAddress(netAddr, srcAddr)
+	netAddr := NewNetAddress(net.ParseIP("1.2.3.4"), 8333, services)
+	srcAddr := NewNetAddress(net.ParseIP("5.6.7.8"), 8333, services)
+	addressManager.addOrUpdateAddress(netAddr, srcAddr)
 
 	// Ensure that the services field for a network address returned from the
 	// address manager is not mutated by a call to SetServices.

--- a/addrmgr/addrmanager_test.go
+++ b/addrmgr/addrmanager_test.go
@@ -720,7 +720,7 @@ func TestValidatePeerNa(t *testing.T) {
 		localAddress  string
 		remoteAddress string
 		valid         bool
-		reach         int
+		reach         NetAddressReach
 	}{
 		{
 			name:          "torv2 to torv2",

--- a/addrmgr/addrmanager_test.go
+++ b/addrmgr/addrmanager_test.go
@@ -318,7 +318,7 @@ func TestGood(t *testing.T) {
 		t.Errorf("Number of addresses is too many: %d vs %d", numAddrs, addrsToAdd)
 	}
 
-	numCache := len(n.AddressCache())
+	numCache := len(n.AddressCache(TORv2Address))
 	if numCache >= numAddrs/4 {
 		t.Errorf("Number of addresses in cache: got %d, want %d", numCache, numAddrs/4)
 	}
@@ -522,7 +522,7 @@ func TestGetBestLocalAddress(t *testing.T) {
 
 	// Test against default when there's no address
 	for x, test := range tests {
-		got := amgr.GetBestLocalAddress(test.remoteAddr)
+		got := amgr.GetBestLocalAddress(test.remoteAddr, IPv6Address)
 		if !reflect.DeepEqual(test.want0.IP, got.IP) {
 			t.Errorf("TestGetBestLocalAddress test1 #%d failed for remote address %s: want %s got %s",
 				x, test.remoteAddr.IP, test.want1.IP, got.IP)
@@ -536,7 +536,7 @@ func TestGetBestLocalAddress(t *testing.T) {
 
 	// Test against want1
 	for x, test := range tests {
-		got := amgr.GetBestLocalAddress(test.remoteAddr)
+		got := amgr.GetBestLocalAddress(test.remoteAddr, IPv6Address)
 		if !reflect.DeepEqual(test.want1.IP, got.IP) {
 			t.Errorf("TestGetBestLocalAddress test1 #%d failed for remote address %s: want %s got %s",
 				x, test.remoteAddr.IP, test.want1.IP, got.IP)
@@ -550,7 +550,7 @@ func TestGetBestLocalAddress(t *testing.T) {
 
 	// Test against want2
 	for x, test := range tests {
-		got := amgr.GetBestLocalAddress(test.remoteAddr)
+		got := amgr.GetBestLocalAddress(test.remoteAddr, IPv6Address)
 		if !reflect.DeepEqual(test.want2.IP, got.IP) {
 			t.Errorf("TestGetBestLocalAddress test2 #%d failed for remote address %s: want %s got %s",
 				x, test.remoteAddr.IP, test.want2.IP, got.IP)

--- a/addrmgr/addrmanager_test.go
+++ b/addrmgr/addrmanager_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -92,6 +92,9 @@ func addNaTests() {
 	addNaTest("fed1::2:2", 8334, "[fed1::2:2]:8334")
 	addNaTest("fee2::3:3", 8335, "[fee2::3:3]:8335")
 	addNaTest("fef3::4:4", 8336, "[fef3::4:4]:8336")
+
+	// Tor
+	addNaTest("fd87:d87e:eb43::", 8333, "aaaaaaaaaaaaaaaa.onion:8333")
 }
 
 func addNaTest(ip string, port uint16, want string) {
@@ -165,8 +168,8 @@ func TestAddAddressByIP(t *testing.T) {
 		t.Fatalf("Address Manager failed to stop: %v", err)
 	}
 
-	// make sure the peers file has been written
-	peersFile := filepath.Join(dir, PeersFilename)
+	// make sure the peers file has been written to.
+	peersFile := filepath.Join(dir, peersFilename)
 	if _, err := os.Stat(peersFile); err != nil {
 		t.Fatalf("Peers file does not exist: %s", peersFile)
 	}
@@ -175,7 +178,7 @@ func TestAddAddressByIP(t *testing.T) {
 	amgr = New(dir, nil)
 	amgr.Start()
 	if ka := amgr.GetAddress(); ka == nil {
-		t.Errorf("Address Manager should contain known address")
+		t.Fatal("Address Manager should contain known address")
 	}
 	if err := amgr.Stop(); err != nil {
 		t.Fatalf("Address Manager failed to stop: %v", err)
@@ -186,7 +189,7 @@ func TestAddAddressUpdate(t *testing.T) {
 	amgr := New("testaddaddressupdate", nil)
 	amgr.Start()
 	if ka := amgr.GetAddress(); ka != nil {
-		t.Fatalf("Address Manager should contain no address")
+		t.Fatal("Address Manager should contain no addresses")
 	}
 	ip := net.ParseIP(someIP)
 	if ip == nil {
@@ -196,10 +199,10 @@ func TestAddAddressUpdate(t *testing.T) {
 	amgr.AddAddress(na, na)
 	ka := amgr.GetAddress()
 	if ka == nil {
-		t.Errorf("Address Manager should contain known address")
+		t.Fatal("Address Manager should contain known address")
 	}
 	if !reflect.DeepEqual(ka.NetAddress(), na) {
-		t.Errorf("Address Manager should contain address that was added")
+		t.Fatal("Address Manager should contain address that was added")
 	}
 	// add address again, but with different time stamp (to trigger update)
 	ts := na.Timestamp.Add(time.Second)
@@ -208,13 +211,13 @@ func TestAddAddressUpdate(t *testing.T) {
 	// address should be in there
 	ka = amgr.GetAddress()
 	if ka == nil {
-		t.Errorf("Address Manager should contain known address")
+		t.Fatal("Address Manager should contain known address")
 	}
 	if !reflect.DeepEqual(ka.NetAddress(), na) {
-		t.Errorf("Address Manager should contain address that was added")
+		t.Fatal("Address Manager should contain address that was added")
 	}
 	if !ka.NetAddress().Timestamp.Equal(ts) {
-		t.Errorf("Address Manager did not update timestamp")
+		t.Fatal("Address Manager did not update timestamp")
 	}
 	if err := amgr.Stop(); err != nil {
 		t.Fatalf("Address Manager failed to stop: %v", err)
@@ -223,53 +226,84 @@ func TestAddAddressUpdate(t *testing.T) {
 
 func TestAddLocalAddress(t *testing.T) {
 	var tests = []struct {
+		name     string
 		address  wire.NetAddress
 		priority AddressPriority
 		valid    bool
 	}{
 		{
-			wire.NetAddress{IP: net.ParseIP("192.168.0.100")},
-			InterfacePrio,
-			false,
+			name:     "unroutable local IPv4 address",
+			address:  wire.NetAddress{IP: net.ParseIP("192.168.0.100")},
+			priority: InterfacePrio,
+			valid:    false,
 		},
 		{
-			wire.NetAddress{IP: net.ParseIP("204.124.1.1")},
-			InterfacePrio,
-			true,
+			name:     "routable IPv4 address",
+			address:  wire.NetAddress{IP: net.ParseIP("204.124.1.1")},
+			priority: InterfacePrio,
+			valid:    true,
 		},
 		{
-			wire.NetAddress{IP: net.ParseIP("204.124.1.1")},
-			BoundPrio,
-			true,
+			name:     "routable IPv4 address with bound priority",
+			address:  wire.NetAddress{IP: net.ParseIP("204.124.1.1")},
+			priority: BoundPrio,
+			valid:    true,
 		},
 		{
-			wire.NetAddress{IP: net.ParseIP("::1")},
-			InterfacePrio,
-			false,
+			name:     "unroutable local IPv6 address",
+			address:  wire.NetAddress{IP: net.ParseIP("::1")},
+			priority: InterfacePrio,
+			valid:    false,
 		},
 		{
-			wire.NetAddress{IP: net.ParseIP("fe80::1")},
-			InterfacePrio,
-			false,
+			name:     "unroutable local IPv6 address 2",
+			address:  wire.NetAddress{IP: net.ParseIP("fe80::1")},
+			priority: InterfacePrio,
+			valid:    false,
 		},
 		{
-			wire.NetAddress{IP: net.ParseIP("2620:100::1")},
-			InterfacePrio,
-			true,
+			name:     "routable IPv6 address",
+			address:  wire.NetAddress{IP: net.ParseIP("2620:100::1")},
+			priority: InterfacePrio,
+			valid:    true,
 		},
 	}
 	amgr := New("testaddlocaladdress", nil)
-	for x, test := range tests {
-		result := amgr.AddLocalAddress(&test.address, test.priority)
+	validLocalAddresses := make(map[string]struct{})
+	for _, test := range tests {
+		netAddr := &test.address
+		result := amgr.AddLocalAddress(netAddr, test.priority)
 		if result == nil && !test.valid {
-			t.Errorf("TestAddLocalAddress test #%d failed: %s should have "+
-				"been accepted", x, test.address.IP)
+			t.Errorf("%q: address should have been accepted", test.name)
 			continue
 		}
 		if result != nil && test.valid {
-			t.Errorf("TestAddLocalAddress test #%d failed: %s should not have "+
-				"been accepted", x, test.address.IP)
+			t.Errorf("%q: address should not have been accepted", test.name)
 			continue
+		}
+		if test.valid && !amgr.HasLocalAddress(netAddr) {
+			t.Errorf("%q: expected to have local address", test.name)
+			continue
+		}
+		if !test.valid && amgr.HasLocalAddress(netAddr) {
+			t.Errorf("%q: expected to not have local address", test.name)
+			continue
+		}
+		if test.valid {
+			// Set up data to test behavior of a call to LocalAddresses() for
+			// addresses that were added to the local address manager.
+			validLocalAddresses[NetAddressKey(netAddr)] = struct{}{}
+		}
+	}
+
+	// Ensure that all of the addresses that were expected to be added to the
+	// address manager are also returned from a call to LocalAddresses.
+	for _, localAddr := range amgr.LocalAddresses() {
+		localAddrIP := net.ParseIP(localAddr.Address)
+		netAddr := &wire.NetAddress{IP: localAddrIP}
+		netAddrKey := NetAddressKey(netAddr)
+		if _, ok := validLocalAddresses[netAddrKey]; !ok {
+			t.Errorf("expected to find local address with key %v", netAddrKey)
 		}
 	}
 }
@@ -285,14 +319,26 @@ func TestAttempt(t *testing.T) {
 	ka := n.GetAddress()
 
 	if !ka.LastAttempt().IsZero() {
-		t.Errorf("Address should not have attempts, but does")
+		t.Fatal("Address should not have attempts, but does")
 	}
 
 	na := ka.NetAddress()
-	n.Attempt(na)
+	err = n.Attempt(na)
+	if err != nil {
+		t.Fatalf("Marking address as attempted failed -- %v", err)
+	}
 
 	if ka.LastAttempt().IsZero() {
-		t.Errorf("Address should have an attempt, but does not")
+		t.Fatal("Address should have an attempt, but does not")
+	}
+
+	// Attempt an ip not known to the address manager.
+	unknownIP := net.ParseIP("1.2.3.4")
+	unknownNetAddress := wire.NewNetAddressIPPort(unknownIP, 1234,
+		wire.SFNodeNetwork)
+	err = n.Attempt(unknownNetAddress)
+	if err == nil {
+		t.Fatal("Attempting unknown address should have returned an error")
 	}
 }
 
@@ -309,10 +355,23 @@ func TestConnected(t *testing.T) {
 	// make it an hour ago
 	na.Timestamp = time.Unix(time.Now().Add(time.Hour*-1).Unix(), 0)
 
-	n.Connected(na)
+	err = n.Connected(na)
+	if err != nil {
+		t.Fatalf("Marking address as connected failed - %v", err)
+	}
 
 	if !ka.NetAddress().Timestamp.After(na.Timestamp) {
-		t.Errorf("Address should have a new timestamp, but does not")
+		t.Error("Address should have a new timestamp, but does not")
+	}
+
+	// Attempt to flag an ip address not known to the address manager as
+	// connected.
+	unknownIP := net.ParseIP("1.2.3.4")
+	unknownNetAddress := wire.NewNetAddressIPPort(unknownIP, 1234,
+		wire.SFNodeNetwork)
+	err = n.Connected(unknownNetAddress)
+	if err == nil {
+		t.Fatal("Marking unknown address as connected should have errored")
 	}
 }
 
@@ -321,7 +380,7 @@ func TestNeedMoreAddresses(t *testing.T) {
 	addrsToAdd := 1500
 	b := n.NeedMoreAddresses()
 	if !b {
-		t.Errorf("Expected that we need more addresses")
+		t.Error("Expected that we need more addresses")
 	}
 	addrs := make([]*wire.NetAddress, addrsToAdd)
 
@@ -344,7 +403,7 @@ func TestNeedMoreAddresses(t *testing.T) {
 
 	b = n.NeedMoreAddresses()
 	if b {
-		t.Errorf("Expected that we don't need more addresses")
+		t.Error("Expected that we don't need more addresses")
 	}
 }
 
@@ -378,6 +437,95 @@ func TestGood(t *testing.T) {
 	if numCache >= numAddrs/4 {
 		t.Errorf("Number of addresses in cache: got %d, want %d", numCache, numAddrs/4)
 	}
+
+	// Test internal behavior of how addresses are managed between the new and
+	// tried address buckets. When an address is initially added it should enter
+	// the new bucket, and when marked good it should move to the tried bucket.
+	// If the tried bucket is full then it should make room for the newly tried
+	// address by moving the old one back to the new bucket.
+	n = New("testgood_tried_overflow", lookupFunc)
+	n.triedBucketSize = 1
+	n.getNewBucket = func(netAddr, srcAddr *wire.NetAddress) int {
+		return 0
+	}
+	n.getTriedBucket = func(netAddr *wire.NetAddress) int {
+		return 0
+	}
+
+	addrA := wire.NewNetAddressIPPort(net.ParseIP("173.144.173.1"), 8333, 0)
+	addrB := wire.NewNetAddressIPPort(net.ParseIP("173.144.173.2"), 8333, 0)
+	addrAKey := NetAddressKey(addrA)
+	addrBKey := NetAddressKey(addrB)
+
+	// Neither address should exist in the addrIndex bucket prior to being
+	// added to the address manager. The new and tried buckets should also be
+	// empty.
+	if len(n.addrIndex) > 0 {
+		t.Fatal("Expected address index to be empty prior to adding addresses" +
+			" to the address manager")
+	}
+	if len(n.addrNew[0]) > 0 {
+		t.Fatal("Expected new bucket to be empty prior to adding addresses" +
+			" to the address manager")
+	}
+	if len(n.addrTried[0]) > 0 {
+		t.Fatal("Expected tried bucket to be empty prior to adding addresses" +
+			" to the address manager")
+	}
+
+	n.AddAddress(addrA, srcAddr)
+	n.AddAddress(addrB, srcAddr)
+
+	// Both addresses should exist in the address index and new bucket after
+	// being added to the address manager.  The tried bucket should be empty.
+	if _, exists := n.addrIndex[addrAKey]; !exists {
+		t.Fatal("Expected addrA to exist in address index")
+	}
+	if _, exists := n.addrIndex[addrBKey]; !exists {
+		t.Fatal("Expected addrB to exist in address index")
+	}
+	if _, exists := n.addrNew[0][addrAKey]; !exists {
+		t.Fatal("Expected addrA to exist in new bucket")
+	}
+	if _, exists := n.addrNew[0][addrBKey]; !exists {
+		t.Fatal("Expected addrB to exist in new bucket")
+	}
+	if len(n.addrTried[0]) > 0 {
+		t.Fatal("Expected tried bucket to contain no elements")
+	}
+
+	// Flagging addrA as good should move it to the tried bucket and remove
+	// it from the new bucket.
+	n.Good(addrA)
+	if _, exists := n.addrNew[0][addrAKey]; exists {
+		t.Fatal("Expected addrA to not exist in new bucket")
+	}
+	if len(n.addrTried[0]) != 1 {
+		t.Fatal("Expected tried bucket to contain exactly one element.")
+	}
+	if NetAddressKey(n.addrTried[0][0].na) != addrAKey {
+		t.Fatal("Expected addrA to exist in tried bucket")
+	}
+
+	// Flagging addrB as good should cause addrB to move from the new bucket to
+	// the tried bucket. It should also cause addrA to be evicted from the tried
+	// bucket and move back to the new bucket since the tried bucket has been
+	// limited in capacity to one element.
+	n.Good(addrB)
+	if _, exists := n.addrNew[0][addrBKey]; exists {
+		t.Fatal("Expected addrB to not exist in the new bucket")
+	}
+	if len(n.addrTried[0]) != 1 {
+		t.Fatalf("Expected tried bucket to contain exactly one element, got %d",
+			len(n.addrTried[0]))
+	}
+	if NetAddressKey(n.addrTried[0][0].na) != addrBKey {
+		t.Error("Expected addrB to exist in tried bucket")
+	}
+	if _, exists := n.addrNew[0][addrAKey]; !exists {
+		t.Error("Expected addrA to exist in the new bucket after being " +
+			"evicted from the tried bucket")
+	}
 }
 
 func TestGetAddress(t *testing.T) {
@@ -395,25 +543,43 @@ func TestGetAddress(t *testing.T) {
 	}
 	ka := n.GetAddress()
 	if ka == nil {
-		t.Fatalf("Did not get an address where there is one in the pool")
+		t.Fatal("Did not get an address where there is one in the pool")
 	}
-	if ka.NetAddress().IP.String() != someIP {
-		t.Errorf("Wrong IP: got %v, want %v", ka.NetAddress().IP.String(), someIP)
+
+	ipStringA := ka.NetAddress().IP.String()
+	if ipStringA != someIP {
+		t.Fatalf("Wrong IP -- got %v, want %v", ipStringA, someIP)
 	}
 
 	// Mark this as a good address and get it
-	n.Good(ka.NetAddress())
+	err = n.Good(ka.NetAddress())
+	if err != nil {
+		t.Fatalf("Marking address as good failed: %v", err)
+	}
+
 	ka = n.GetAddress()
 	if ka == nil {
-		t.Fatalf("Did not get an address where there is one in the pool")
+		t.Fatal("Did not get an address where there is one in the pool")
 	}
-	if ka.NetAddress().IP.String() != someIP {
-		t.Errorf("Wrong IP: got %v, want %v", ka.NetAddress().IP.String(), someIP)
+
+	ipStringB := ka.NetAddress().IP.String()
+	if ipStringB != someIP {
+		t.Errorf("Wrong IP -- got %v, want %v", ipStringB, someIP)
 	}
 
 	numAddrs := n.numAddresses()
 	if numAddrs != 1 {
-		t.Errorf("Wrong number of addresses: got %d, want %d", numAddrs, 1)
+		t.Errorf("Wrong number of addresses -- got %d, want %d", numAddrs, 1)
+	}
+
+	// Marking an address not known to the address manager as good should return
+	// an error.
+	unknownIP := net.ParseIP("1.2.3.4")
+	unknownNetAddress := wire.NewNetAddressIPPort(unknownIP, 1234,
+		wire.SFNodeNetwork)
+	err = n.Good(unknownNetAddress)
+	if err == nil {
+		t.Fatal("Attempting unknown address should have returned an error")
 	}
 }
 
@@ -542,7 +708,7 @@ func TestCorruptPeersFile(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(dir)
-	peersFile := filepath.Join(dir, PeersFilename)
+	peersFile := filepath.Join(dir, peersFilename)
 	// create corrupt (empty) peers file
 	fp, err := os.Create(peersFile)
 	if err != nil {
@@ -556,5 +722,327 @@ func TestCorruptPeersFile(t *testing.T) {
 	amgr.Stop()
 	if _, err := os.Stat(peersFile); err != nil {
 		t.Fatalf("Corrupt peers file has not been removed: %s", peersFile)
+	}
+}
+
+// TestValidatePeerNa tests whether a remote address is considered reachable
+// from a local address.
+func TestValidatePeerNa(t *testing.T) {
+	const unroutableIpv4Address = "0.0.0.0"
+	const unroutableIpv6Address = "::1"
+	const routableIpv4Address = "12.1.2.3"
+	const routableIpv6Address = "2003::"
+	onionCatTorV2Address := onionCatNet.IP.String()
+	rfc4380IPAddress := rfc4380Net.IP.String()
+	rfc3964IPAddress := rfc3964Net.IP.String()
+	rfc6052IPAddress := rfc6052Net.IP.String()
+	rfc6145IPAddress := rfc6145Net.IP.String()
+
+	tests := []struct {
+		name          string
+		localAddress  string
+		remoteAddress string
+		valid         bool
+		reach         int
+	}{
+		{
+			name:          "torv2 to torv2",
+			localAddress:  onionCatTorV2Address,
+			remoteAddress: onionCatTorV2Address,
+			valid:         false,
+			reach:         Private,
+		},
+		{
+			name:          "routable ipv4 to torv2",
+			localAddress:  routableIpv4Address,
+			remoteAddress: onionCatTorV2Address,
+			valid:         true,
+			reach:         Ipv4,
+		},
+		{
+			name:          "unroutable ipv4 to torv2",
+			localAddress:  unroutableIpv4Address,
+			remoteAddress: onionCatTorV2Address,
+			valid:         false,
+			reach:         Default,
+		},
+		{
+			name:          "routable ipv6 to torv2",
+			localAddress:  routableIpv6Address,
+			remoteAddress: onionCatTorV2Address,
+			valid:         false,
+			reach:         Default,
+		},
+		{
+			name:          "unroutable ipv6 to torv2",
+			localAddress:  unroutableIpv6Address,
+			remoteAddress: onionCatTorV2Address,
+			valid:         false,
+			reach:         Default,
+		},
+		{
+			name:          "rfc4380 to rfc4380",
+			localAddress:  rfc4380IPAddress,
+			remoteAddress: rfc4380IPAddress,
+			valid:         true,
+			reach:         Teredo,
+		},
+		{
+			name:          "unroutable ipv4 to rfc4380",
+			localAddress:  unroutableIpv4Address,
+			remoteAddress: rfc4380IPAddress,
+			valid:         false,
+			reach:         Default,
+		},
+		{
+			name:          "routable ipv4 to rfc4380",
+			localAddress:  routableIpv4Address,
+			remoteAddress: rfc4380IPAddress,
+			valid:         true,
+			reach:         Ipv4,
+		},
+		{
+			name:          "routable ipv6 to rfc4380",
+			localAddress:  routableIpv6Address,
+			remoteAddress: rfc4380IPAddress,
+			valid:         true,
+			reach:         Ipv6Weak,
+		},
+		{
+			name:          "routable ipv4 to routable ipv4",
+			localAddress:  routableIpv4Address,
+			remoteAddress: routableIpv4Address,
+			valid:         true,
+			reach:         Ipv4,
+		},
+		{
+			name:          "routable ipv6 to routable ipv4",
+			localAddress:  routableIpv6Address,
+			remoteAddress: routableIpv4Address,
+			valid:         false,
+			reach:         Unreachable,
+		},
+		{
+			name:          "unroutable ipv4 to routable ipv6",
+			localAddress:  unroutableIpv4Address,
+			remoteAddress: routableIpv6Address,
+			valid:         false,
+			reach:         Default,
+		},
+		{
+			name:          "unroutable ipv6 to routable ipv6",
+			localAddress:  unroutableIpv6Address,
+			remoteAddress: routableIpv6Address,
+			valid:         false,
+			reach:         Default,
+		},
+		{
+			name:          "unroutable ipv4 to routable ipv6",
+			localAddress:  unroutableIpv4Address,
+			remoteAddress: routableIpv6Address,
+			valid:         false,
+			reach:         Default,
+		},
+		{
+			name:          "routable ipv4 to unroutable ipv6",
+			localAddress:  routableIpv4Address,
+			remoteAddress: unroutableIpv6Address,
+			valid:         false,
+			reach:         Unreachable,
+		},
+		{
+			name:          "routable ivp6 rfc4380 to routable ipv6",
+			localAddress:  rfc4380IPAddress,
+			remoteAddress: routableIpv6Address,
+			valid:         true,
+			reach:         Teredo,
+		},
+		{
+			name:          "routable ipv4 to routable ipv6",
+			localAddress:  routableIpv4Address,
+			remoteAddress: routableIpv6Address,
+			valid:         true,
+			reach:         Ipv4,
+		},
+		{
+			name:          "tunnelled ipv6 rfc3964 to routable ipv6",
+			localAddress:  rfc3964IPAddress,
+			remoteAddress: routableIpv6Address,
+			valid:         true,
+			reach:         Ipv6Weak,
+		},
+		{
+			name:          "tunnelled ipv6 rfc6052 to routable ipv6",
+			localAddress:  rfc6052IPAddress,
+			remoteAddress: routableIpv6Address,
+			valid:         true,
+			reach:         Ipv6Weak,
+		},
+		{
+			name:          "tunnelled ipv6 rfc6145 to routable ipv6",
+			localAddress:  rfc6145IPAddress,
+			remoteAddress: routableIpv6Address,
+			valid:         true,
+			reach:         Ipv6Weak,
+		},
+	}
+
+	addressManager := New("testValidatePeerNa", nil)
+	for _, test := range tests {
+		localIP := net.ParseIP(test.localAddress)
+		remoteIP := net.ParseIP(test.remoteAddress)
+		localNa := wire.NewNetAddressIPPort(localIP, 8333, wire.SFNodeNetwork)
+		remoteNa := wire.NewNetAddressIPPort(remoteIP, 8333, wire.SFNodeNetwork)
+
+		valid, reach := addressManager.ValidatePeerNa(localNa, remoteNa)
+		if valid != test.valid {
+			t.Errorf("%q: unexpected return value for valid - want '%v', "+
+				"got '%v'", test.name, test.valid, valid)
+			continue
+		}
+		if reach != test.reach {
+			t.Errorf("%q: unexpected return value for reach - want '%v', "+
+				"got '%v'", test.name, test.reach, reach)
+		}
+	}
+}
+
+// TestHostToNetAddress ensures that HostToNetAddress behaves as expected
+// given valid and invalid host name arguments.
+func TestHostToNetAddress(t *testing.T) {
+	// Define a hostname that will cause a lookup to be performed using the
+	// lookupFunc provided to the address manager instance for each test.
+	const hostnameForLookup = "hostname.test"
+	const services = wire.SFNodeNetwork
+
+	tests := []struct {
+		name       string
+		host       string
+		port       uint16
+		lookupFunc func(host string) ([]net.IP, error)
+		wantErr    bool
+		want       *wire.NetAddress
+	}{
+		{
+			name:       "valid onion address",
+			host:       "a5ccbdkubbr2jlcp.onion",
+			port:       8333,
+			lookupFunc: nil,
+			wantErr:    false,
+			want: wire.NewNetAddressIPPort(
+				net.ParseIP("fd87:d87e:eb43:744:208d:5408:63a4:ac4f"), 8333,
+				services),
+		},
+		{
+			name:       "invalid onion address",
+			host:       "0000000000000000.onion",
+			port:       8333,
+			lookupFunc: nil,
+			wantErr:    true,
+			want:       nil,
+		},
+		{
+			name: "unresolvable host name",
+			host: hostnameForLookup,
+			port: 8333,
+			lookupFunc: func(host string) ([]net.IP, error) {
+				return nil, fmt.Errorf("unresolvable host %v", host)
+			},
+			wantErr: true,
+			want:    nil,
+		},
+		{
+			name: "not resolved host name",
+			host: hostnameForLookup,
+			port: 8333,
+			lookupFunc: func(host string) ([]net.IP, error) {
+				return nil, nil
+			},
+			wantErr: true,
+			want:    nil,
+		},
+		{
+			name: "resolved host name",
+			host: hostnameForLookup,
+			port: 8333,
+			lookupFunc: func(host string) ([]net.IP, error) {
+				return []net.IP{net.ParseIP("127.0.0.1")}, nil
+			},
+			wantErr: false,
+			want: wire.NewNetAddressIPPort(net.ParseIP("127.0.0.1"), 8333,
+				services),
+		},
+		{
+			name:       "valid ip address",
+			host:       "12.1.2.3",
+			port:       8333,
+			lookupFunc: nil,
+			wantErr:    false,
+			want: wire.NewNetAddressIPPort(net.ParseIP("12.1.2.3"), 8333,
+				services),
+		},
+	}
+
+	for _, test := range tests {
+		addrManager := New("testHostToNetAddress", test.lookupFunc)
+		result, err := addrManager.HostToNetAddress(test.host, test.port,
+			services)
+		if test.wantErr == true && err == nil {
+			t.Errorf("%q: expected error but one was not returned", test.name)
+		}
+		if !reflect.DeepEqual(result, test.want) {
+			t.Errorf("%q: unexpected result -- got %v, want %v", test.name,
+				result, test.want)
+		}
+	}
+}
+
+// TestSetServices ensures that a known address' services are updated as
+// expected and that the services field is not mutated when new services are
+// added.
+func TestSetServices(t *testing.T) {
+	addressManager := New("testSetServices", nil)
+	const services = wire.SFNodeNetwork
+
+	// Attempt to set services for an address not known to the address manager.
+	// This should have no effect and exercises paths that avoid a panic.
+	notKnownAddr := wire.NewNetAddressIPPort(net.ParseIP("0.0.0.0"), 8333,
+		services)
+	err := addressManager.SetServices(notKnownAddr, services)
+	if err == nil {
+		t.Fatal("setting services for unknown address should return error")
+	}
+
+	// Add a new address to the address manager.
+	netAddr := wire.NewNetAddressIPPort(net.ParseIP("1.2.3.4"), 8333, services)
+	srcAddr := wire.NewNetAddressIPPort(net.ParseIP("5.6.7.8"), 8333, services)
+	addressManager.AddAddress(netAddr, srcAddr)
+
+	// Ensure that the services field for a network address returned from the
+	// address manager is not mutated by a call to SetServices.
+	knownAddress := addressManager.GetAddress()
+	if knownAddress == nil {
+		t.Fatal("expected known address, got nil")
+	}
+	netAddrA := knownAddress.na
+	if netAddrA.Services != services {
+		t.Fatalf("unexpected network address services -- got %x, want %x",
+			netAddrA.Services, services)
+	}
+
+	// Set the new services for the network address and verify that the
+	// previously seen network address netAddrA's services are not modified.
+	const newServiceFlags = services << 1
+	addressManager.SetServices(netAddr, newServiceFlags)
+	netAddrB := knownAddress.na
+	if netAddrA == netAddrB {
+		t.Fatal("expected known address to have new network address reference")
+	}
+	if netAddrA.Services != services {
+		t.Fatal("netAddrA services flag was mutated")
+	}
+	if netAddrB.Services != newServiceFlags {
+		t.Fatalf("netAddrB has invalid services -- got %x, want %x",
+			netAddrB.Services, newServiceFlags)
 	}
 }

--- a/addrmgr/error.go
+++ b/addrmgr/error.go
@@ -14,6 +14,14 @@ const (
 	// ErrAddressNotFound indicates that an attempt to perform an action on
 	// was performed for an address not known to the address manager.
 	ErrAddressNotFound = ErrorKind("ErrAddressNotFound")
+
+	// ErrUnknownAddressType indicates that the network type could not be
+	// determined from a network address' bytes.
+	ErrUnknownAddressType = ErrorKind("ErrUnknownAddressType")
+
+	// ErrMismatchedAddressType indicates that the network type could not be
+	// determined from a network address' bytes.
+	ErrMismatchedAddressType = ErrorKind("ErrMismatchedAddressType")
 )
 
 // Error satisfies the error interface and prints human-readable errors.

--- a/addrmgr/error.go
+++ b/addrmgr/error.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package addrmgr
+
+// ErrorKind identifies a kind of error.  It has full support for errors.Is
+// and errors.As, so the caller can directly check against an error kind
+// when determining the reason for an error.
+type ErrorKind string
+
+// These constants are used to identify a specific RuleError.
+const (
+	// ErrAddressNotFound indicates that an attempt to perform an action on
+	// was performed for an address not known to the address manager.
+	ErrAddressNotFound = ErrorKind("ErrAddressNotFound")
+)
+
+// Error satisfies the error interface and prints human-readable errors.
+func (e ErrorKind) Error() string {
+	return string(e)
+}
+
+// Error identifies a mining rule rule violation. It has full support for
+// errors.Is and errors.As, so the caller can ascertain the specific reason
+// for the error by checking the underlying error. It is used to indicate
+// that processing of a block or transaction failed due to one of the many
+// validation rules.
+type Error struct {
+	Err         error
+	Description string
+}
+
+// Error satisfies the error interface and prints human-readable errors.
+func (e Error) Error() string {
+	return e.Description
+}
+
+// Unwrap returns the underlying wrapped error.
+func (e Error) Unwrap() error {
+	return e.Err
+}
+
+// makeError creates an Error given a set of arguments.
+func makeError(kind ErrorKind, desc string) Error {
+	return Error{Err: kind, Description: desc}
+}

--- a/addrmgr/go.mod
+++ b/addrmgr/go.mod
@@ -4,6 +4,5 @@ go 1.11
 
 require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
-	github.com/decred/dcrd/wire v1.4.0
 	github.com/decred/slog v1.1.0
 )

--- a/addrmgr/go.sum
+++ b/addrmgr/go.sum
@@ -1,10 +1,6 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decred/dcrd/chaincfg/chainhash v1.0.2 h1:rt5Vlq/jM3ZawwiacWjPa+smINyLRN07EO0cNBV6DGU=
 github.com/decred/dcrd/chaincfg/chainhash v1.0.2/go.mod h1:BpbrGgrPTr3YJYRN3Bm+D9NuaFd+zGyNeIKgrhCXK60=
 github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
-github.com/decred/dcrd/wire v1.4.0 h1:KmSo6eTQIvhXS0fLBQ/l7hG7QLcSJQKSwSyzSqJYDk0=
-github.com/decred/dcrd/wire v1.4.0/go.mod h1:WxC/0K+cCAnBh+SKsRjIX9YPgvrjhmE+6pZlel1G7Ro=
 github.com/decred/slog v1.1.0 h1:uz5ZFfmaexj1rEDgZvzQ7wjGkoSPjw2LCh8K+K1VrW4=
 github.com/decred/slog v1.1.0/go.mod h1:kVXlGnt6DHy2fV5OjSeuvCJ0OmlmTF6LFpEPMu/fOY0=

--- a/addrmgr/knownaddress.go
+++ b/addrmgr/knownaddress.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -8,26 +8,42 @@ package addrmgr
 import (
 	"sync"
 	"time"
-
-	"github.com/decred/dcrd/wire"
 )
 
 // KnownAddress tracks information about a known network address that is used
 // to determine how viable an address is.
 type KnownAddress struct {
-	mtx         sync.Mutex
-	na          *wire.NetAddress
-	srcAddr     *wire.NetAddress
+	// mtx is used to ensure safe concurrent access to methods on a known
+	// address instance.
+	mtx sync.Mutex
+
+	// na is the primary network address that the known address represents.
+	na *NetAddress
+
+	// srcAddr is the network address of the peer that suggested the primary
+	// network address.
+	srcAddr *NetAddress
+
+	// The following fields track the attempts made to connect to the primary
+	// network address.  Initially connecting to a peer counts as an attempt,
+	// and a successful version message exchange resets the number of attempts
+	// to zero.
 	attempts    int
 	lastattempt time.Time
 	lastsuccess time.Time
-	tried       bool
-	refs        int // reference count of new buckets
+
+	// tried indicates whether the address currently exists in a tried bucket.
+	tried bool
+
+	// refs represents the total number of new buckets that the known address
+	// exists in. This is updated as the address moves between new and tried
+	// buckets.
+	refs int
 }
 
 // NetAddress returns the underlying wire.NetAddress associated with the
 // known address.
-func (ka *KnownAddress) NetAddress() *wire.NetAddress {
+func (ka *KnownAddress) NetAddress() *NetAddress {
 	ka.mtx.Lock()
 	defer ka.mtx.Unlock()
 	return ka.na

--- a/addrmgr/knownaddress_test.go
+++ b/addrmgr/knownaddress_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -9,13 +9,18 @@ import (
 	"math"
 	"testing"
 	"time"
-
-	"github.com/decred/dcrd/wire"
 )
 
-func newKnownAddress(na *wire.NetAddress, attempts int, lastattempt, lastsuccess time.Time, tried bool, refs int) *KnownAddress {
-	return &KnownAddress{na: na, attempts: attempts, lastattempt: lastattempt,
-		lastsuccess: lastsuccess, tried: tried, refs: refs}
+func newKnownAddress(ts time.Time, attempts int, lastattempt, lastsuccess time.Time, tried bool, refs int) *KnownAddress {
+	na := &NetAddress{Timestamp: ts}
+	return &KnownAddress{
+		na:          na,
+		attempts:    attempts,
+		lastattempt: lastattempt,
+		lastsuccess: lastsuccess,
+		tried:       tried,
+		refs:        refs,
+	}
 }
 
 func TestChance(t *testing.T) {
@@ -26,27 +31,27 @@ func TestChance(t *testing.T) {
 	}{
 		{
 			// Test normal case
-			newKnownAddress(&wire.NetAddress{Timestamp: now.Add(-35 * time.Second)},
+			newKnownAddress(now.Add(-35*time.Second),
 				0, now.Add(-30*time.Minute), now, false, 0),
 			1.0,
 		}, {
 			// Test case in which lastseen < 0
-			newKnownAddress(&wire.NetAddress{Timestamp: now.Add(20 * time.Second)},
+			newKnownAddress(now.Add(20*time.Second),
 				0, now.Add(-30*time.Minute), now, false, 0),
 			1.0,
 		}, {
 			// Test case in which lastattempt < 0
-			newKnownAddress(&wire.NetAddress{Timestamp: now.Add(-35 * time.Second)},
+			newKnownAddress(now.Add(-35*time.Second),
 				0, now.Add(30*time.Minute), now, false, 0),
 			1.0 * .01,
 		}, {
 			// Test case in which lastattempt < ten minutes
-			newKnownAddress(&wire.NetAddress{Timestamp: now.Add(-35 * time.Second)},
+			newKnownAddress(now.Add(-35*time.Second),
 				0, now.Add(-5*time.Minute), now, false, 0),
 			1.0 * .01,
 		}, {
 			// Test case with several failed attempts.
-			newKnownAddress(&wire.NetAddress{Timestamp: now.Add(-35 * time.Second)},
+			newKnownAddress(now.Add(-35*time.Second),
 				2, now.Add(-30*time.Minute), now, false, 0),
 			1 / 1.5 / 1.5,
 		},
@@ -70,50 +75,45 @@ func TestIsBad(t *testing.T) {
 	hoursOld := now.Add(-5 * time.Hour)
 	zeroTime := time.Time{}
 
-	futureNa := &wire.NetAddress{Timestamp: future}
-	minutesOldNa := &wire.NetAddress{Timestamp: minutesOld}
-	monthOldNa := &wire.NetAddress{Timestamp: monthOld}
-	currentNa := &wire.NetAddress{Timestamp: secondsOld}
-
 	// Test addresses that have been tried in the last minute.
-	if newKnownAddress(futureNa, 3, secondsOld, zeroTime, false, 0).isBad() {
+	if newKnownAddress(future, 3, secondsOld, zeroTime, false, 0).isBad() {
 		t.Errorf("test case 1: addresses that have been tried in the last minute are not bad.")
 	}
-	if newKnownAddress(monthOldNa, 3, secondsOld, zeroTime, false, 0).isBad() {
+	if newKnownAddress(monthOld, 3, secondsOld, zeroTime, false, 0).isBad() {
 		t.Errorf("test case 2: addresses that have been tried in the last minute are not bad.")
 	}
-	if newKnownAddress(currentNa, 3, secondsOld, zeroTime, false, 0).isBad() {
+	if newKnownAddress(secondsOld, 3, secondsOld, zeroTime, false, 0).isBad() {
 		t.Errorf("test case 3: addresses that have been tried in the last minute are not bad.")
 	}
-	if newKnownAddress(currentNa, 3, secondsOld, monthOld, true, 0).isBad() {
+	if newKnownAddress(secondsOld, 3, secondsOld, monthOld, true, 0).isBad() {
 		t.Errorf("test case 4: addresses that have been tried in the last minute are not bad.")
 	}
-	if newKnownAddress(currentNa, 2, secondsOld, secondsOld, true, 0).isBad() {
+	if newKnownAddress(secondsOld, 2, secondsOld, secondsOld, true, 0).isBad() {
 		t.Errorf("test case 5: addresses that have been tried in the last minute are not bad.")
 	}
 
 	// Test address that claims to be from the future.
-	if !newKnownAddress(futureNa, 0, minutesOld, hoursOld, true, 0).isBad() {
+	if !newKnownAddress(future, 0, minutesOld, hoursOld, true, 0).isBad() {
 		t.Errorf("test case 6: addresses that claim to be from the future are bad.")
 	}
 
 	// Test address that has not been seen in over a month.
-	if !newKnownAddress(monthOldNa, 0, minutesOld, hoursOld, true, 0).isBad() {
+	if !newKnownAddress(monthOld, 0, minutesOld, hoursOld, true, 0).isBad() {
 		t.Errorf("test case 7: addresses more than a month old are bad.")
 	}
 
 	// It has failed at least three times and never succeeded.
-	if !newKnownAddress(minutesOldNa, 3, minutesOld, zeroTime, true, 0).isBad() {
+	if !newKnownAddress(minutesOld, 3, minutesOld, zeroTime, true, 0).isBad() {
 		t.Errorf("test case 8: addresses that have never succeeded are bad.")
 	}
 
 	// It has failed ten times in the last week
-	if !newKnownAddress(minutesOldNa, 10, minutesOld, monthOld, true, 0).isBad() {
+	if !newKnownAddress(minutesOld, 10, minutesOld, monthOld, true, 0).isBad() {
 		t.Errorf("test case 9: addresses that have not succeeded in too long are bad.")
 	}
 
 	// Test an address that should work.
-	if newKnownAddress(minutesOldNa, 2, minutesOld, hoursOld, true, 0).isBad() {
+	if newKnownAddress(minutesOld, 2, minutesOld, hoursOld, true, 0).isBad() {
 		t.Errorf("test case 10: This should be a valid address.")
 	}
 }

--- a/addrmgr/netaddress.go
+++ b/addrmgr/netaddress.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package addrmgr
+
+import (
+	"encoding/base32"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ServiceFlag identifies services supported by a Decred peer.
+type ServiceFlag uint64
+
+const (
+	// sfNodeNetwork is a flag used to indicate a peer is a full node.
+	sfNodeNetwork ServiceFlag = 1 << iota
+)
+
+// NetAddress defines information about a peer on the network.
+type NetAddress struct {
+	// IP address of the peer. It is defined as a byte array to support various
+	// address types that are not standard to the net module and therefore not
+	// entirely appropriate to store as a net.IP.
+	IP []byte
+
+	// Port is the port of the remote peer.
+	Port uint16
+
+	// Timestamp is the last time the address was seen.
+	Timestamp time.Time
+
+	// Services represents the service flags supported by this network address.
+	Services ServiceFlag
+}
+
+// IsRoutable returns a boolean indicating whether the network address is
+// routable.
+func (netAddr *NetAddress) IsRoutable() bool {
+	return isRoutable(netAddr.IP)
+}
+
+// ipString returns a string for the ip from the provided NetAddress. If the
+// ip is in the range used for TORv2 addresses then it will be transformed into
+// the respective .onion address.
+func (netAddr *NetAddress) ipString() string {
+	netIP := netAddr.IP
+	if isOnionCatTor(netIP) {
+		// We know now that na.IP is long enough.
+		base32 := base32.StdEncoding.EncodeToString(netIP[6:])
+		return strings.ToLower(base32) + ".onion"
+	}
+	return net.IP(netIP).String()
+}
+
+// Key returns a string that can be used to uniquely represent the network
+// address and includes the port.
+func (netAddr *NetAddress) Key() string {
+	portString := strconv.FormatUint(uint64(netAddr.Port), 10)
+	return net.JoinHostPort(netAddr.ipString(), portString)
+}
+
+// Clone creates a shallow copy of the NetAddress instance. The IP reference
+// is shared since it is not mutated.
+func (netAddr *NetAddress) Clone() *NetAddress {
+	netAddrCopy := *netAddr
+	return &netAddrCopy
+}
+
+// AddService adds the provided service to the set of services that the
+// network address supports.
+func (netAddr *NetAddress) AddService(service ServiceFlag) {
+	netAddr.Services |= service
+}
+
+// newAddressFromString creates a new address manager network address from the
+// provided string.  The address is expected to be provided in the format
+// host:port.
+func (a *AddrManager) newAddressFromString(addr string) (*NetAddress, error) {
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+	port, err := strconv.ParseUint(portStr, 10, 16)
+	if err != nil {
+		return nil, err
+	}
+
+	return a.HostToNetAddress(host, uint16(port), sfNodeNetwork)
+}
+
+// NewNetAddress creates a new address manager network address given an ip,
+// port, and the supported service flags for the address.
+func NewNetAddress(ip net.IP, port uint16, services ServiceFlag) *NetAddress {
+	timestamp := time.Unix(time.Now().Unix(), 0)
+	return &NetAddress{
+		IP:        ip,
+		Port:      port,
+		Services:  services,
+		Timestamp: timestamp,
+	}
+}

--- a/addrmgr/netaddress.go
+++ b/addrmgr/netaddress.go
@@ -6,6 +6,7 @@ package addrmgr
 
 import (
 	"encoding/base32"
+	"fmt"
 	"net"
 	"strconv"
 	"strings"
@@ -22,6 +23,9 @@ const (
 
 // NetAddress defines information about a peer on the network.
 type NetAddress struct {
+	// Type represents the type of network that the network address belongs to.
+	Type NetAddressType
+
 	// IP address of the peer. It is defined as a byte array to support various
 	// address types that are not standard to the net module and therefore not
 	// entirely appropriate to store as a net.IP.
@@ -48,8 +52,8 @@ func (netAddr *NetAddress) IsRoutable() bool {
 // the respective .onion address.
 func (netAddr *NetAddress) ipString() string {
 	netIP := netAddr.IP
-	if isOnionCatTor(netIP) {
-		// We know now that na.IP is long enough.
+	switch netAddr.Type {
+	case TORv2Address:
 		base32 := base32.StdEncoding.EncodeToString(netIP[6:])
 		return strings.ToLower(base32) + ".onion"
 	}
@@ -76,8 +80,110 @@ func (netAddr *NetAddress) AddService(service ServiceFlag) {
 	netAddr.Services |= service
 }
 
-// newAddressFromString creates a new address manager network address from the
-// provided string.  The address is expected to be provided in the format
+// HostToBytes deconstructs a given host to its respective []byte representation
+// and also returns the network address type.  If an error occurs while decoding
+// an onion address, the error is returned.  If the host cannot be converted
+// then an unknown address type is returned without error.
+func HostToBytes(host string) (NetAddressType, []byte, error) {
+	if strings.HasSuffix(host, ".onion") {
+		// Check if this is a TorV2 address.
+		if len(host) == 22 {
+			data, err := base32.StdEncoding.DecodeString(
+				strings.ToUpper(host[:16]))
+			if err != nil {
+				return UnknownAddressType, nil, err
+			}
+			prefix := []byte{0xfd, 0x87, 0xd8, 0x7e, 0xeb, 0x43}
+			addrBytes := append(prefix, data...)
+			return TORv2Address, addrBytes, nil
+		}
+	}
+
+	if ip := net.ParseIP(host); ip != nil {
+		if isIPv4(ip) {
+			return IPv4Address, ip.To4(), nil
+		}
+		if isOnionCatTor(ip) {
+			return TORv2Address, ip, nil
+		}
+		return IPv6Address, ip, nil
+	}
+
+	return UnknownAddressType, nil, nil
+}
+
+// canonicalizeIP converts the provided address' bytes into a standard structure
+// based on the type of the network address, if applicable.
+func canonicalizeIP(addrType NetAddressType, addrBytes []byte) []byte {
+	len := len(addrBytes)
+	switch {
+	case len == 16 && addrType == IPv4Address:
+		return net.IP(addrBytes).To4()
+	case len == 10 && addrType == TORv2Address:
+		prefix := []byte{0xfd, 0x87, 0xd8, 0x7e, 0xeb, 0x43}
+		return append(prefix, addrBytes...)
+	case addrType == IPv6Address:
+		return net.IP(addrBytes).To16()
+	}
+	return addrBytes
+}
+
+// deriveNetAddressType attempts to determine the network address type from
+// the address' raw bytes.  If the type cannot be determined, an error is
+// returned.
+func deriveNetAddressType(addrBytes []byte) (NetAddressType, error) {
+	len := len(addrBytes)
+	switch {
+	case isIPv4(addrBytes):
+		return IPv4Address, nil
+	case len == 10:
+		return TORv2Address, nil
+	case len == 16 && isOnionCatTor(addrBytes):
+		return TORv2Address, nil
+	case len == 16:
+		return IPv6Address, nil
+	}
+	return UnknownAddressType, makeError(ErrUnknownAddressType,
+		"unable to determine address type from raw network address bytes")
+}
+
+// assertNetAddressTypeValid returns an error if the suggested address type does
+// not appear to match the provided address.
+func assertNetAddressTypeValid(netAddressType NetAddressType, addrBytes []byte) error {
+	derivedAddressType, err := deriveNetAddressType(addrBytes)
+	if err != nil {
+		return err
+	}
+
+	if netAddressType != derivedAddressType {
+		str := fmt.Sprintf("derived address type does not match expected value"+
+			" (got %v, expected %v)", derivedAddressType, netAddressType)
+		return makeError(ErrMismatchedAddressType, str)
+	}
+
+	return nil
+}
+
+// NewNetAddressByType creates a new network address using the provided
+// parameters.  If the provided network id does not appear to match the address,
+// an error is returned.
+func NewNetAddressByType(netAddressType NetAddressType, addrBytes []byte, port uint16, timestamp time.Time, services ServiceFlag) (*NetAddress, error) {
+	canonicalizedIP := canonicalizeIP(netAddressType, addrBytes)
+	err := assertNetAddressTypeValid(netAddressType, canonicalizedIP)
+	if err != nil {
+		return nil, err
+	}
+	return &NetAddress{
+		Type:      netAddressType,
+		IP:        canonicalizedIP,
+		Port:      port,
+		Services:  services,
+		Timestamp: timestamp,
+	}, nil
+}
+
+// newAddressFromString creates a new address manager network address from
+// the provided string.  The address is expected to be provided in the format
 // host:port.
 func (a *AddrManager) newAddressFromString(addr string) (*NetAddress, error) {
 	host, portStr, err := net.SplitHostPort(addr)
@@ -89,15 +195,30 @@ func (a *AddrManager) newAddressFromString(addr string) (*NetAddress, error) {
 		return nil, err
 	}
 
-	return a.HostToNetAddress(host, uint16(port), sfNodeNetwork)
+	networkID, addrBytes, err := HostToBytes(host)
+	if err != nil {
+		return nil, err
+	}
+	if networkID == UnknownAddressType {
+		str := fmt.Sprintf("failed to deserialize address %s", addr)
+		return nil, makeError(ErrUnknownAddressType, str)
+	}
+	// Return error here if the network id is not known.
+	timestamp := time.Unix(time.Now().Unix(), 0)
+	return NewNetAddressByType(networkID, addrBytes, uint16(port), timestamp,
+		sfNodeNetwork)
 }
 
 // NewNetAddress creates a new address manager network address given an ip,
-// port, and the supported service flags for the address.
+// port, and the supported service flags for the address.  IP must be an IPv4 or
+// IPv6 address or a 10-byte TORv2 public key.
 func NewNetAddress(ip net.IP, port uint16, services ServiceFlag) *NetAddress {
+	netAddressType, _ := deriveNetAddressType(ip)
 	timestamp := time.Unix(time.Now().Unix(), 0)
+	canonicalizedIP := canonicalizeIP(netAddressType, ip)
 	return &NetAddress{
-		IP:        ip,
+		Type:      netAddressType,
+		IP:        canonicalizedIP,
 		Port:      port,
 		Services:  services,
 		Timestamp: timestamp,

--- a/addrmgr/netaddress_test.go
+++ b/addrmgr/netaddress_test.go
@@ -6,81 +6,194 @@ package addrmgr
 
 import (
 	"net"
+	"reflect"
 	"testing"
+	"time"
 )
+
+// TestNewNetAddressByType verifies that the TestNewNetAddressByType constructor
+// converts a network address with expected field values.
+func TestNewNetAddressByType(t *testing.T) {
+	const port = 8345
+	const services = sfNodeNetwork
+	timestamp := time.Unix(time.Now().Unix(), 0)
+
+	ipv4IP := net.ParseIP("127.0.0.1")
+	ipv6IP := net.ParseIP("::1")
+	torv2PublicKey := []byte{
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00,
+	}
+
+	tests := []struct {
+		name     string
+		addrType NetAddressType
+		ip       []byte
+		want     *NetAddress
+	}{
+		{
+			name:     "4 byte ipv4 address stored as 4 byte ip",
+			addrType: IPv4Address,
+			ip:       ipv4IP.To4(),
+			want: &NetAddress{
+				IP: []byte{
+					0x7f, 0x00, 0x00, 0x01,
+				},
+				Port:      port,
+				Services:  services,
+				Timestamp: timestamp,
+				Type:      IPv4Address,
+			},
+		},
+		{
+			name:     "16 byte ipv4 address stored as 4 byte ip",
+			addrType: IPv4Address,
+			ip:       ipv4IP.To16(),
+			want: &NetAddress{
+				IP:        []byte{0x7f, 0x00, 0x00, 0x01},
+				Port:      port,
+				Services:  services,
+				Timestamp: timestamp,
+				Type:      IPv4Address,
+			},
+		},
+		{
+			name:     "16 byte ipv6 address stored in 16 bytes",
+			addrType: IPv6Address,
+			ip:       ipv6IP,
+			want: &NetAddress{
+				IP: []byte{
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+				Port:      port,
+				Services:  services,
+				Timestamp: timestamp,
+				Type:      IPv6Address,
+			},
+		},
+		{
+			name:     "10 byte torv2 public key stored in 16 bytes with prefix",
+			addrType: TORv2Address,
+			ip:       torv2PublicKey,
+			want: &NetAddress{
+				IP: []byte{
+					0xfd, 0x87, 0xd8, 0x7e, 0xeb, 0x43, 0x00, 0x00,
+					0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00,
+				},
+				Port:      port,
+				Services:  services,
+				Timestamp: timestamp,
+				Type:      TORv2Address,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		addr, err := NewNetAddressByType(test.addrType, test.ip, port,
+			timestamp, services)
+		if err != nil {
+			t.Fatalf("%q: unexpected error - %v", test.name, err)
+		}
+		if !reflect.DeepEqual(addr, test.want) {
+			t.Errorf("%q: mismatched entries\ngot  %+v\nwant %+v", test.name,
+				addr, test.want)
+		}
+	}
+}
 
 // TestKey verifies that Key converts a network address to an expected string
 // value.
 func TestKey(t *testing.T) {
 	tests := []struct {
-		ip   string
+		host string
 		port uint16
 		want string
 	}{
 		// IPv4
 		// Localhost
-		{ip: "127.0.0.1", port: 8333, want: "127.0.0.1:8333"},
-		{ip: "127.0.0.1", port: 8334, want: "127.0.0.1:8334"},
+		{host: "127.0.0.1", port: 8333, want: "127.0.0.1:8333"},
+		{host: "127.0.0.1", port: 8334, want: "127.0.0.1:8334"},
 
 		// Class A
-		{ip: "1.0.0.1", port: 8333, want: "1.0.0.1:8333"},
-		{ip: "2.2.2.2", port: 8334, want: "2.2.2.2:8334"},
-		{ip: "27.253.252.251", port: 8335, want: "27.253.252.251:8335"},
-		{ip: "123.3.2.1", port: 8336, want: "123.3.2.1:8336"},
+		{host: "1.0.0.1", port: 8333, want: "1.0.0.1:8333"},
+		{host: "2.2.2.2", port: 8334, want: "2.2.2.2:8334"},
+		{host: "27.253.252.251", port: 8335, want: "27.253.252.251:8335"},
+		{host: "123.3.2.1", port: 8336, want: "123.3.2.1:8336"},
 
 		// Private Class A
-		{ip: "10.0.0.1", port: 8333, want: "10.0.0.1:8333"},
-		{ip: "10.1.1.1", port: 8334, want: "10.1.1.1:8334"},
-		{ip: "10.2.2.2", port: 8335, want: "10.2.2.2:8335"},
-		{ip: "10.10.10.10", port: 8336, want: "10.10.10.10:8336"},
+		{host: "10.0.0.1", port: 8333, want: "10.0.0.1:8333"},
+		{host: "10.1.1.1", port: 8334, want: "10.1.1.1:8334"},
+		{host: "10.2.2.2", port: 8335, want: "10.2.2.2:8335"},
+		{host: "10.10.10.10", port: 8336, want: "10.10.10.10:8336"},
 
 		// Class B
-		{ip: "128.0.0.1", port: 8333, want: "128.0.0.1:8333"},
-		{ip: "129.1.1.1", port: 8334, want: "129.1.1.1:8334"},
-		{ip: "180.2.2.2", port: 8335, want: "180.2.2.2:8335"},
-		{ip: "191.10.10.10", port: 8336, want: "191.10.10.10:8336"},
+		{host: "128.0.0.1", port: 8333, want: "128.0.0.1:8333"},
+		{host: "129.1.1.1", port: 8334, want: "129.1.1.1:8334"},
+		{host: "180.2.2.2", port: 8335, want: "180.2.2.2:8335"},
+		{host: "191.10.10.10", port: 8336, want: "191.10.10.10:8336"},
 
 		// Private Class B
-		{ip: "172.16.0.1", port: 8333, want: "172.16.0.1:8333"},
-		{ip: "172.16.1.1", port: 8334, want: "172.16.1.1:8334"},
-		{ip: "172.16.2.2", port: 8335, want: "172.16.2.2:8335"},
-		{ip: "172.16.172.172", port: 8336, want: "172.16.172.172:8336"},
+		{host: "172.16.0.1", port: 8333, want: "172.16.0.1:8333"},
+		{host: "172.16.1.1", port: 8334, want: "172.16.1.1:8334"},
+		{host: "172.16.2.2", port: 8335, want: "172.16.2.2:8335"},
+		{host: "172.16.172.172", port: 8336, want: "172.16.172.172:8336"},
 
 		// Class C
-		{ip: "193.0.0.1", port: 8333, want: "193.0.0.1:8333"},
-		{ip: "200.1.1.1", port: 8334, want: "200.1.1.1:8334"},
-		{ip: "205.2.2.2", port: 8335, want: "205.2.2.2:8335"},
-		{ip: "223.10.10.10", port: 8336, want: "223.10.10.10:8336"},
+		{host: "193.0.0.1", port: 8333, want: "193.0.0.1:8333"},
+		{host: "200.1.1.1", port: 8334, want: "200.1.1.1:8334"},
+		{host: "205.2.2.2", port: 8335, want: "205.2.2.2:8335"},
+		{host: "223.10.10.10", port: 8336, want: "223.10.10.10:8336"},
 
 		// Private Class C
-		{ip: "192.168.0.1", port: 8333, want: "192.168.0.1:8333"},
-		{ip: "192.168.1.1", port: 8334, want: "192.168.1.1:8334"},
-		{ip: "192.168.2.2", port: 8335, want: "192.168.2.2:8335"},
-		{ip: "192.168.192.192", port: 8336, want: "192.168.192.192:8336"},
+		{host: "192.168.0.1", port: 8333, want: "192.168.0.1:8333"},
+		{host: "192.168.1.1", port: 8334, want: "192.168.1.1:8334"},
+		{host: "192.168.2.2", port: 8335, want: "192.168.2.2:8335"},
+		{host: "192.168.192.192", port: 8336, want: "192.168.192.192:8336"},
 
 		// IPv6
 		// Localhost
-		{ip: "::1", port: 8333, want: "[::1]:8333"},
-		{ip: "fe80::1", port: 8334, want: "[fe80::1]:8334"},
+		{host: "::1", port: 8333, want: "[::1]:8333"},
+		{host: "fe80::1", port: 8334, want: "[fe80::1]:8334"},
 
 		// Link-local
-		{ip: "fe80::1:1", port: 8333, want: "[fe80::1:1]:8333"},
-		{ip: "fe91::2:2", port: 8334, want: "[fe91::2:2]:8334"},
-		{ip: "fea2::3:3", port: 8335, want: "[fea2::3:3]:8335"},
-		{ip: "feb3::4:4", port: 8336, want: "[feb3::4:4]:8336"},
+		{host: "fe80::1:1", port: 8333, want: "[fe80::1:1]:8333"},
+		{host: "fe91::2:2", port: 8334, want: "[fe91::2:2]:8334"},
+		{host: "fea2::3:3", port: 8335, want: "[fea2::3:3]:8335"},
+		{host: "feb3::4:4", port: 8336, want: "[feb3::4:4]:8336"},
 
 		// Site-local
-		{ip: "fec0::1:1", port: 8333, want: "[fec0::1:1]:8333"},
-		{ip: "fed1::2:2", port: 8334, want: "[fed1::2:2]:8334"},
-		{ip: "fee2::3:3", port: 8335, want: "[fee2::3:3]:8335"},
-		{ip: "fef3::4:4", port: 8336, want: "[fef3::4:4]:8336"},
+		{host: "fec0::1:1", port: 8333, want: "[fec0::1:1]:8333"},
+		{host: "fed1::2:2", port: 8334, want: "[fed1::2:2]:8334"},
+		{host: "fee2::3:3", port: 8335, want: "[fee2::3:3]:8335"},
+		{host: "fef3::4:4", port: 8336, want: "[fef3::4:4]:8336"},
 
 		// TORv2
-		{ip: "fd87:d87e:eb43::", port: 8333, want: "aaaaaaaaaaaaaaaa.onion:8333"},
+		{
+			host: "fd87:d87e:eb43::",
+			port: 8333,
+			want: "aaaaaaaaaaaaaaaa.onion:8333",
+		},
+		{
+			host: "aaaaaaaaaaaaaaaa.onion",
+			port: 8334,
+			want: "aaaaaaaaaaaaaaaa.onion:8334",
+		},
 	}
 
+	timeNow := time.Now()
 	for _, test := range tests {
-		netAddr := NewNetAddress(net.ParseIP(test.ip), test.port, sfNodeNetwork)
+		host := test.host
+		addrType, addrBytes, err := HostToBytes(host)
+		if err != nil {
+			t.Fatalf("failed to decode host %s: %v", host, err)
+		}
+
+		netAddr, err := NewNetAddressByType(addrType, addrBytes, test.port,
+			timeNow, sfNodeNetwork)
+		if err != nil {
+			t.Fatalf("failed to construct network address from host %q: %v",
+				host, err)
+		}
+
 		key := netAddr.Key()
 		if key != test.want {
 			t.Errorf("unexpected network address key -- got %s, want %s",

--- a/addrmgr/netaddress_test.go
+++ b/addrmgr/netaddress_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package addrmgr
+
+import (
+	"net"
+	"testing"
+)
+
+// TestKey verifies that Key converts a network address to an expected string
+// value.
+func TestKey(t *testing.T) {
+	tests := []struct {
+		ip   string
+		port uint16
+		want string
+	}{
+		// IPv4
+		// Localhost
+		{ip: "127.0.0.1", port: 8333, want: "127.0.0.1:8333"},
+		{ip: "127.0.0.1", port: 8334, want: "127.0.0.1:8334"},
+
+		// Class A
+		{ip: "1.0.0.1", port: 8333, want: "1.0.0.1:8333"},
+		{ip: "2.2.2.2", port: 8334, want: "2.2.2.2:8334"},
+		{ip: "27.253.252.251", port: 8335, want: "27.253.252.251:8335"},
+		{ip: "123.3.2.1", port: 8336, want: "123.3.2.1:8336"},
+
+		// Private Class A
+		{ip: "10.0.0.1", port: 8333, want: "10.0.0.1:8333"},
+		{ip: "10.1.1.1", port: 8334, want: "10.1.1.1:8334"},
+		{ip: "10.2.2.2", port: 8335, want: "10.2.2.2:8335"},
+		{ip: "10.10.10.10", port: 8336, want: "10.10.10.10:8336"},
+
+		// Class B
+		{ip: "128.0.0.1", port: 8333, want: "128.0.0.1:8333"},
+		{ip: "129.1.1.1", port: 8334, want: "129.1.1.1:8334"},
+		{ip: "180.2.2.2", port: 8335, want: "180.2.2.2:8335"},
+		{ip: "191.10.10.10", port: 8336, want: "191.10.10.10:8336"},
+
+		// Private Class B
+		{ip: "172.16.0.1", port: 8333, want: "172.16.0.1:8333"},
+		{ip: "172.16.1.1", port: 8334, want: "172.16.1.1:8334"},
+		{ip: "172.16.2.2", port: 8335, want: "172.16.2.2:8335"},
+		{ip: "172.16.172.172", port: 8336, want: "172.16.172.172:8336"},
+
+		// Class C
+		{ip: "193.0.0.1", port: 8333, want: "193.0.0.1:8333"},
+		{ip: "200.1.1.1", port: 8334, want: "200.1.1.1:8334"},
+		{ip: "205.2.2.2", port: 8335, want: "205.2.2.2:8335"},
+		{ip: "223.10.10.10", port: 8336, want: "223.10.10.10:8336"},
+
+		// Private Class C
+		{ip: "192.168.0.1", port: 8333, want: "192.168.0.1:8333"},
+		{ip: "192.168.1.1", port: 8334, want: "192.168.1.1:8334"},
+		{ip: "192.168.2.2", port: 8335, want: "192.168.2.2:8335"},
+		{ip: "192.168.192.192", port: 8336, want: "192.168.192.192:8336"},
+
+		// IPv6
+		// Localhost
+		{ip: "::1", port: 8333, want: "[::1]:8333"},
+		{ip: "fe80::1", port: 8334, want: "[fe80::1]:8334"},
+
+		// Link-local
+		{ip: "fe80::1:1", port: 8333, want: "[fe80::1:1]:8333"},
+		{ip: "fe91::2:2", port: 8334, want: "[fe91::2:2]:8334"},
+		{ip: "fea2::3:3", port: 8335, want: "[fea2::3:3]:8335"},
+		{ip: "feb3::4:4", port: 8336, want: "[feb3::4:4]:8336"},
+
+		// Site-local
+		{ip: "fec0::1:1", port: 8333, want: "[fec0::1:1]:8333"},
+		{ip: "fed1::2:2", port: 8334, want: "[fed1::2:2]:8334"},
+		{ip: "fee2::3:3", port: 8335, want: "[fee2::3:3]:8335"},
+		{ip: "fef3::4:4", port: 8336, want: "[fef3::4:4]:8336"},
+
+		// TORv2
+		{ip: "fd87:d87e:eb43::", port: 8333, want: "aaaaaaaaaaaaaaaa.onion:8333"},
+	}
+
+	for _, test := range tests {
+		netAddr := NewNetAddress(net.ParseIP(test.ip), test.port, sfNodeNetwork)
+		key := netAddr.Key()
+		if key != test.want {
+			t.Errorf("unexpected network address key -- got %s, want %s",
+				key, test.want)
+			continue
+		}
+	}
+}
+
+// TestClone verifies that a copy of the network address is made.
+func TestClone(t *testing.T) {
+	const port = 0
+	netAddr := NewNetAddress(net.ParseIP("1.2.3.4"), port, sfNodeNetwork)
+	netAddrClone := netAddr.Clone()
+
+	if netAddr == netAddrClone {
+		t.Error("expected new network address reference")
+	}
+}
+
+// TestAddService verifies that the service flag is set as expected on a
+// network address instance.
+func TestAddService(t *testing.T) {
+	const port = 0
+	netAddr := NewNetAddress(net.ParseIP("1.2.3.4"), port, ServiceFlag(0))
+	netAddr.AddService(sfNodeNetwork)
+
+	if netAddr.Services != sfNodeNetwork {
+		t.Errorf("expected service flag to be set -- got %x, want %x",
+			netAddr.Services, sfNodeNetwork)
+	}
+}

--- a/addrmgr/network.go
+++ b/addrmgr/network.go
@@ -116,18 +116,19 @@ func isOnionCatTor(netIP net.IP) bool {
 	return onionCatNet.Contains(netIP)
 }
 
-// NetworkAddress type is used to classify a network address.
-type NetworkAddress int
+// NetAddressType is used to indicate which network a network address belongs
+// to.
+type NetAddressType int
 
 const (
-	LocalAddress NetworkAddress = iota
+	LocalAddress NetAddressType = iota
 	IPv4Address
 	IPv6Address
-	OnionAddress
+	TORv2Address
 )
 
 // getNetwork returns the network address type of the provided network address.
-func getNetwork(netIP net.IP) NetworkAddress {
+func getNetwork(netIP net.IP) NetAddressType {
 	switch {
 	case isLocal(netIP):
 		return LocalAddress
@@ -136,7 +137,7 @@ func getNetwork(netIP net.IP) NetworkAddress {
 		return IPv4Address
 
 	case isOnionCatTor(netIP):
-		return OnionAddress
+		return TORv2Address
 
 	default:
 		return IPv6Address

--- a/addrmgr/network.go
+++ b/addrmgr/network.go
@@ -8,8 +8,6 @@ package addrmgr
 import (
 	"fmt"
 	"net"
-
-	"github.com/decred/dcrd/wire"
 )
 
 var (
@@ -101,21 +99,21 @@ func ipNet(ip string, ones, bits int) net.IPNet {
 }
 
 // isIPv4 returns whether or not the given address is an IPv4 address.
-func isIPv4(na *wire.NetAddress) bool {
-	return na.IP.To4() != nil
+func isIPv4(netIP net.IP) bool {
+	return netIP.To4() != nil
 }
 
 // isLocal returns whether or not the given address is a local address.
-func isLocal(na *wire.NetAddress) bool {
-	return na.IP.IsLoopback() || zero4Net.Contains(na.IP)
+func isLocal(netIP net.IP) bool {
+	return netIP.IsLoopback() || zero4Net.Contains(netIP)
 }
 
 // isOnionCatTor returns whether or not the passed address is in the IPv6 range
 // used by bitcoin to support Tor (fd87:d87e:eb43::/48).  Note that this range
 // is the same range used by OnionCat, which is part of the RFC4193 unique local
 // IPv6 range.
-func isOnionCatTor(na *wire.NetAddress) bool {
-	return onionCatNet.Contains(na.IP)
+func isOnionCatTor(netIP net.IP) bool {
+	return onionCatNet.Contains(netIP)
 }
 
 // NetworkAddress type is used to classify a network address.
@@ -129,15 +127,15 @@ const (
 )
 
 // getNetwork returns the network address type of the provided network address.
-func getNetwork(na *wire.NetAddress) NetworkAddress {
+func getNetwork(netIP net.IP) NetworkAddress {
 	switch {
-	case isLocal(na):
+	case isLocal(netIP):
 		return LocalAddress
 
-	case isIPv4(na):
+	case isIPv4(netIP):
 		return IPv4Address
 
-	case isOnionCatTor(na):
+	case isOnionCatTor(netIP):
 		return OnionAddress
 
 	default:
@@ -148,9 +146,9 @@ func getNetwork(na *wire.NetAddress) NetworkAddress {
 // isRFC1918 returns whether or not the passed address is part of the IPv4
 // private network address space as defined by RFC1918 (10.0.0.0/8,
 // 172.16.0.0/12, or 192.168.0.0/16).
-func isRFC1918(na *wire.NetAddress) bool {
+func isRFC1918(netIP net.IP) bool {
 	for _, rfc := range rfc1918Nets {
-		if rfc.Contains(na.IP) {
+		if rfc.Contains(netIP) {
 			return true
 		}
 	}
@@ -159,58 +157,58 @@ func isRFC1918(na *wire.NetAddress) bool {
 
 // isRFC2544 returns whether or not the passed address is part of the IPv4
 // address space as defined by RFC2544 (198.18.0.0/15)
-func isRFC2544(na *wire.NetAddress) bool {
-	return rfc2544Net.Contains(na.IP)
+func isRFC2544(netIP net.IP) bool {
+	return rfc2544Net.Contains(netIP)
 }
 
 // isRFC3849 returns whether or not the passed address is part of the IPv6
 // documentation range as defined by RFC3849 (2001:DB8::/32).
-func isRFC3849(na *wire.NetAddress) bool {
-	return rfc3849Net.Contains(na.IP)
+func isRFC3849(netIP net.IP) bool {
+	return rfc3849Net.Contains(netIP)
 }
 
 // isRFC3927 returns whether or not the passed address is part of the IPv4
 // autoconfiguration range as defined by RFC3927 (169.254.0.0/16).
-func isRFC3927(na *wire.NetAddress) bool {
-	return rfc3927Net.Contains(na.IP)
+func isRFC3927(netIP net.IP) bool {
+	return rfc3927Net.Contains(netIP)
 }
 
 // isRFC3964 returns whether or not the passed address is part of the IPv6 to
 // IPv4 encapsulation range as defined by RFC3964 (2002::/16).
-func isRFC3964(na *wire.NetAddress) bool {
-	return rfc3964Net.Contains(na.IP)
+func isRFC3964(netIP net.IP) bool {
+	return rfc3964Net.Contains(netIP)
 }
 
 // isRFC4193 returns whether or not the passed address is part of the IPv6
 // unique local range as defined by RFC4193 (FC00::/7).
-func isRFC4193(na *wire.NetAddress) bool {
-	return rfc4193Net.Contains(na.IP)
+func isRFC4193(netIP net.IP) bool {
+	return rfc4193Net.Contains(netIP)
 }
 
 // isRFC4380 returns whether or not the passed address is part of the IPv6
 // teredo tunneling over UDP range as defined by RFC4380 (2001::/32).
-func isRFC4380(na *wire.NetAddress) bool {
-	return rfc4380Net.Contains(na.IP)
+func isRFC4380(netIP net.IP) bool {
+	return rfc4380Net.Contains(netIP)
 }
 
 // isRFC4843 returns whether or not the passed address is part of the IPv6
 // ORCHID range as defined by RFC4843 (2001:10::/28).
-func isRFC4843(na *wire.NetAddress) bool {
-	return rfc4843Net.Contains(na.IP)
+func isRFC4843(netIP net.IP) bool {
+	return rfc4843Net.Contains(netIP)
 }
 
 // isRFC4862 returns whether or not the passed address is part of the IPv6
 // stateless address autoconfiguration range as defined by RFC4862 (FE80::/64).
-func isRFC4862(na *wire.NetAddress) bool {
-	return rfc4862Net.Contains(na.IP)
+func isRFC4862(netIP net.IP) bool {
+	return rfc4862Net.Contains(netIP)
 }
 
 // isRFC5737 returns whether or not the passed address is part of the IPv4
 // documentation address space as defined by RFC5737 (192.0.2.0/24,
 // 198.51.100.0/24, 203.0.113.0/24)
-func isRFC5737(na *wire.NetAddress) bool {
+func isRFC5737(netIP net.IP) bool {
 	for _, rfc := range rfc5737Net {
-		if rfc.Contains(na.IP) {
+		if rfc.Contains(netIP) {
 			return true
 		}
 	}
@@ -220,41 +218,41 @@ func isRFC5737(na *wire.NetAddress) bool {
 
 // isRFC6052 returns whether or not the passed address is part of the IPv6
 // well-known prefix range as defined by RFC6052 (64:FF9B::/96).
-func isRFC6052(na *wire.NetAddress) bool {
-	return rfc6052Net.Contains(na.IP)
+func isRFC6052(netIP net.IP) bool {
+	return rfc6052Net.Contains(netIP)
 }
 
 // isRFC6145 returns whether or not the passed address is part of the IPv6 to
 // IPv4 translated address range as defined by RFC6145 (::FFFF:0:0:0/96).
-func isRFC6145(na *wire.NetAddress) bool {
-	return rfc6145Net.Contains(na.IP)
+func isRFC6145(netIP net.IP) bool {
+	return rfc6145Net.Contains(netIP)
 }
 
 // isRFC6598 returns whether or not the passed address is part of the IPv4
 // shared address space specified by RFC6598 (100.64.0.0/10)
-func isRFC6598(na *wire.NetAddress) bool {
-	return rfc6598Net.Contains(na.IP)
+func isRFC6598(netIP net.IP) bool {
+	return rfc6598Net.Contains(netIP)
 }
 
 // isValid returns whether or not the passed address is valid.  The address is
 // considered invalid under the following circumstances:
 // IPv4: It is either a zero or all bits set address.
 // IPv6: It is either a zero or RFC3849 documentation address.
-func isValid(na *wire.NetAddress) bool {
+func isValid(netIP net.IP) bool {
 	// IsUnspecified returns if address is 0, so only all bits set, and
 	// RFC3849 need to be explicitly checked.
-	return na.IP != nil && !(na.IP.IsUnspecified() ||
-		na.IP.Equal(net.IPv4bcast))
+	return netIP != nil && !(netIP.IsUnspecified() ||
+		netIP.Equal(net.IPv4bcast))
 }
 
 // IsRoutable returns whether or not the passed address is routable over
 // the public internet.  This is true as long as the address is valid and is not
 // in any reserved ranges.
-func IsRoutable(na *wire.NetAddress) bool {
-	return isValid(na) && !(isRFC1918(na) || isRFC2544(na) ||
-		isRFC3927(na) || isRFC4862(na) || isRFC3849(na) ||
-		isRFC4843(na) || isRFC5737(na) || isRFC6598(na) ||
-		isLocal(na) || (isRFC4193(na) && !isOnionCatTor(na)))
+func IsRoutable(netIP net.IP) bool {
+	return isValid(netIP) && !(isRFC1918(netIP) || isRFC2544(netIP) ||
+		isRFC3927(netIP) || isRFC4862(netIP) || isRFC3849(netIP) ||
+		isRFC4843(netIP) || isRFC5737(netIP) || isRFC6598(netIP) ||
+		isLocal(netIP) || (isRFC4193(netIP) && !isOnionCatTor(netIP)))
 }
 
 // GroupKey returns a string representing the network group an address is part
@@ -262,47 +260,47 @@ func IsRoutable(na *wire.NetAddress) bool {
 // "local" for a local address, the string "tor:key" where key is the /4 of the
 // onion address for Tor address, and the string "unroutable" for an unroutable
 // address.
-func GroupKey(na *wire.NetAddress) string {
-	if isLocal(na) {
+func GroupKey(netIP net.IP) string {
+	if isLocal(netIP) {
 		return "local"
 	}
-	if !IsRoutable(na) {
+	if !IsRoutable(netIP) {
 		return "unroutable"
 	}
-	if isIPv4(na) {
-		return na.IP.Mask(net.CIDRMask(16, 32)).String()
+	if isIPv4(netIP) {
+		return netIP.Mask(net.CIDRMask(16, 32)).String()
 	}
-	if isRFC6145(na) || isRFC6052(na) {
+	if isRFC6145(netIP) || isRFC6052(netIP) {
 		// last four bytes are the ip address
-		ip := na.IP[12:16]
-		return ip.Mask(net.CIDRMask(16, 32)).String()
+		newIP := netIP[12:16]
+		return newIP.Mask(net.CIDRMask(16, 32)).String()
 	}
 
-	if isRFC3964(na) {
-		ip := na.IP[2:6]
-		return ip.Mask(net.CIDRMask(16, 32)).String()
+	if isRFC3964(netIP) {
+		newIP := netIP[2:6]
+		return newIP.Mask(net.CIDRMask(16, 32)).String()
 	}
-	if isRFC4380(na) {
+	if isRFC4380(netIP) {
 		// teredo tunnels have the last 4 bytes as the v4 address XOR
 		// 0xff.
-		ip := net.IP(make([]byte, 4))
-		for i, byte := range na.IP[12:16] {
-			ip[i] = byte ^ 0xff
+		newIP := net.IP(make([]byte, 4))
+		for i, byte := range netIP[12:16] {
+			newIP[i] = byte ^ 0xff
 		}
-		return ip.Mask(net.CIDRMask(16, 32)).String()
+		return newIP.Mask(net.CIDRMask(16, 32)).String()
 	}
-	if isOnionCatTor(na) {
+	if isOnionCatTor(netIP) {
 		// group is keyed off the first 4 bits of the actual onion key.
-		return fmt.Sprintf("tor:%d", na.IP[6]&((1<<4)-1))
+		return fmt.Sprintf("tor:%d", netIP[6]&((1<<4)-1))
 	}
 
 	// OK, so now we know ourselves to be a IPv6 address.
 	// bitcoind uses /32 for everything, except for Hurricane Electric's
 	// (he.net) IP range, which it uses /36 for.
 	bits := 32
-	if heNet.Contains(na.IP) {
+	if heNet.Contains(netIP) {
 		bits = 36
 	}
 
-	return na.IP.Mask(net.CIDRMask(bits, 128)).String()
+	return netIP.Mask(net.CIDRMask(bits, 128)).String()
 }

--- a/addrmgr/network.go
+++ b/addrmgr/network.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -249,7 +249,7 @@ func isValid(netIP net.IP) bool {
 // IsRoutable returns whether or not the passed address is routable over
 // the public internet.  This is true as long as the address is valid and is not
 // in any reserved ranges.
-func IsRoutable(netIP net.IP) bool {
+func isRoutable(netIP net.IP) bool {
 	return isValid(netIP) && !(isRFC1918(netIP) || isRFC2544(netIP) ||
 		isRFC3927(netIP) || isRFC4862(netIP) || isRFC3849(netIP) ||
 		isRFC4843(netIP) || isRFC5737(netIP) || isRFC6598(netIP) ||
@@ -265,7 +265,7 @@ func GroupKey(netIP net.IP) string {
 	if isLocal(netIP) {
 		return "local"
 	}
-	if !IsRoutable(netIP) {
+	if !isRoutable(netIP) {
 		return "unroutable"
 	}
 	if isIPv4(netIP) {

--- a/addrmgr/network.go
+++ b/addrmgr/network.go
@@ -121,28 +121,11 @@ func isOnionCatTor(netIP net.IP) bool {
 type NetAddressType int
 
 const (
-	LocalAddress NetAddressType = iota
+	UnknownAddressType NetAddressType = iota
 	IPv4Address
 	IPv6Address
 	TORv2Address
 )
-
-// getNetwork returns the network address type of the provided network address.
-func getNetwork(netIP net.IP) NetAddressType {
-	switch {
-	case isLocal(netIP):
-		return LocalAddress
-
-	case isIPv4(netIP):
-		return IPv4Address
-
-	case isOnionCatTor(netIP):
-		return TORv2Address
-
-	default:
-		return IPv6Address
-	}
-}
 
 // isRFC1918 returns whether or not the passed address is part of the IPv4
 // private network address space as defined by RFC1918 (10.0.0.0/8,

--- a/addrmgr/network.go
+++ b/addrmgr/network.go
@@ -118,7 +118,7 @@ func isOnionCatTor(netIP net.IP) bool {
 
 // NetAddressType is used to indicate which network a network address belongs
 // to.
-type NetAddressType int
+type NetAddressType uint8
 
 const (
 	UnknownAddressType NetAddressType = iota

--- a/addrmgr/network_test.go
+++ b/addrmgr/network_test.go
@@ -133,7 +133,7 @@ func TestIPTypes(t *testing.T) {
 			t.Errorf("IsValid %s\n got: %v want: %v", test.ip, rv, test.valid)
 		}
 
-		if rv := IsRoutable(test.ip); rv != test.routable {
+		if rv := isRoutable(test.ip); rv != test.routable {
 			t.Errorf("IsRoutable %s\n got: %v want: %v", test.ip, rv, test.routable)
 		}
 	}

--- a/addrmgr/network_test.go
+++ b/addrmgr/network_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -8,15 +8,13 @@ package addrmgr
 import (
 	"net"
 	"testing"
-
-	"github.com/decred/dcrd/wire"
 )
 
 // TestIPTypes ensures the various functions which determine the type of an IP
 // address based on RFCs work as intended.
 func TestIPTypes(t *testing.T) {
 	type ipTest struct {
-		in       wire.NetAddress
+		ip       net.IP
 		rfc1918  bool
 		rfc2544  bool
 		rfc3849  bool
@@ -39,8 +37,7 @@ func TestIPTypes(t *testing.T) {
 		rfc4193, rfc4380, rfc4843, rfc4862, rfc5737, rfc6052, rfc6145, rfc6598,
 		local, valid, routable bool) ipTest {
 		nip := net.ParseIP(ip)
-		na := *wire.NewNetAddressIPPort(nip, 8333, wire.SFNodeNetwork)
-		test := ipTest{na, rfc1918, rfc2544, rfc3849, rfc3927, rfc3964, rfc4193, rfc4380,
+		test := ipTest{nip, rfc1918, rfc2544, rfc3849, rfc3927, rfc3964, rfc4193, rfc4380,
 			rfc4843, rfc4862, rfc5737, rfc6052, rfc6145, rfc6598, local, valid, routable}
 		return test
 	}
@@ -88,56 +85,56 @@ func TestIPTypes(t *testing.T) {
 
 	t.Logf("Running %d tests", len(tests))
 	for _, test := range tests {
-		if rv := isRFC1918(&test.in); rv != test.rfc1918 {
-			t.Errorf("isRFC1918 %s\n got: %v want: %v", test.in.IP, rv, test.rfc1918)
+		if rv := isRFC1918(test.ip); rv != test.rfc1918 {
+			t.Errorf("isRFC1918 %s\n got: %v want: %v", test.ip, rv, test.rfc1918)
 		}
 
-		if rv := isRFC3849(&test.in); rv != test.rfc3849 {
-			t.Errorf("isRFC3849 %s\n got: %v want: %v", test.in.IP, rv, test.rfc3849)
+		if rv := isRFC3849(test.ip); rv != test.rfc3849 {
+			t.Errorf("isRFC3849 %s\n got: %v want: %v", test.ip, rv, test.rfc3849)
 		}
 
-		if rv := isRFC3927(&test.in); rv != test.rfc3927 {
-			t.Errorf("isRFC3927 %s\n got: %v want: %v", test.in.IP, rv, test.rfc3927)
+		if rv := isRFC3927(test.ip); rv != test.rfc3927 {
+			t.Errorf("isRFC3927 %s\n got: %v want: %v", test.ip, rv, test.rfc3927)
 		}
 
-		if rv := isRFC3964(&test.in); rv != test.rfc3964 {
-			t.Errorf("isRFC3964 %s\n got: %v want: %v", test.in.IP, rv, test.rfc3964)
+		if rv := isRFC3964(test.ip); rv != test.rfc3964 {
+			t.Errorf("isRFC3964 %s\n got: %v want: %v", test.ip, rv, test.rfc3964)
 		}
 
-		if rv := isRFC4193(&test.in); rv != test.rfc4193 {
-			t.Errorf("isRFC4193 %s\n got: %v want: %v", test.in.IP, rv, test.rfc4193)
+		if rv := isRFC4193(test.ip); rv != test.rfc4193 {
+			t.Errorf("isRFC4193 %s\n got: %v want: %v", test.ip, rv, test.rfc4193)
 		}
 
-		if rv := isRFC4380(&test.in); rv != test.rfc4380 {
-			t.Errorf("isRFC4380 %s\n got: %v want: %v", test.in.IP, rv, test.rfc4380)
+		if rv := isRFC4380(test.ip); rv != test.rfc4380 {
+			t.Errorf("isRFC4380 %s\n got: %v want: %v", test.ip, rv, test.rfc4380)
 		}
 
-		if rv := isRFC4843(&test.in); rv != test.rfc4843 {
-			t.Errorf("isRFC4843 %s\n got: %v want: %v", test.in.IP, rv, test.rfc4843)
+		if rv := isRFC4843(test.ip); rv != test.rfc4843 {
+			t.Errorf("isRFC4843 %s\n got: %v want: %v", test.ip, rv, test.rfc4843)
 		}
 
-		if rv := isRFC4862(&test.in); rv != test.rfc4862 {
-			t.Errorf("isRFC4862 %s\n got: %v want: %v", test.in.IP, rv, test.rfc4862)
+		if rv := isRFC4862(test.ip); rv != test.rfc4862 {
+			t.Errorf("isRFC4862 %s\n got: %v want: %v", test.ip, rv, test.rfc4862)
 		}
 
-		if rv := isRFC6052(&test.in); rv != test.rfc6052 {
-			t.Errorf("isRFC6052 %s\n got: %v want: %v", test.in.IP, rv, test.rfc6052)
+		if rv := isRFC6052(test.ip); rv != test.rfc6052 {
+			t.Errorf("isRFC6052 %s\n got: %v want: %v", test.ip, rv, test.rfc6052)
 		}
 
-		if rv := isRFC6145(&test.in); rv != test.rfc6145 {
-			t.Errorf("isRFC1918 %s\n got: %v want: %v", test.in.IP, rv, test.rfc6145)
+		if rv := isRFC6145(test.ip); rv != test.rfc6145 {
+			t.Errorf("isRFC1918 %s\n got: %v want: %v", test.ip, rv, test.rfc6145)
 		}
 
-		if rv := isLocal(&test.in); rv != test.local {
-			t.Errorf("isLocal %s\n got: %v want: %v", test.in.IP, rv, test.local)
+		if rv := isLocal(test.ip); rv != test.local {
+			t.Errorf("isLocal %s\n got: %v want: %v", test.ip, rv, test.local)
 		}
 
-		if rv := isValid(&test.in); rv != test.valid {
-			t.Errorf("IsValid %s\n got: %v want: %v", test.in.IP, rv, test.valid)
+		if rv := isValid(test.ip); rv != test.valid {
+			t.Errorf("IsValid %s\n got: %v want: %v", test.ip, rv, test.valid)
 		}
 
-		if rv := IsRoutable(&test.in); rv != test.routable {
-			t.Errorf("IsRoutable %s\n got: %v want: %v", test.in.IP, rv, test.routable)
+		if rv := IsRoutable(test.ip); rv != test.routable {
+			t.Errorf("IsRoutable %s\n got: %v want: %v", test.ip, rv, test.routable)
 		}
 	}
 }
@@ -192,8 +189,7 @@ func TestGroupKey(t *testing.T) {
 
 	for i, test := range tests {
 		nip := net.ParseIP(test.ip)
-		na := *wire.NewNetAddressIPPort(nip, 8333, wire.SFNodeNetwork)
-		if key := GroupKey(&na); key != test.expected {
+		if key := GroupKey(nip); key != test.expected {
 			t.Errorf("TestGroupKey #%d (%s): unexpected group key "+
 				"- got '%s', want '%s'", i, test.name,
 				key, test.expected)

--- a/config.go
+++ b/config.go
@@ -1312,14 +1312,14 @@ func dcrdDial(ctx context.Context, network, addr string) (net.Conn, error) {
 	return cfg.dial(ctx, network, addr)
 }
 
-// dcrdLookup returns the correct DNS lookup function to use depending on the
+// dcrdLookup invokes the correct DNS lookup function to use depending on the
 // passed host and configuration options.  For example, .onion addresses will be
 // resolved using the onion specific proxy if one was specified, but will
 // otherwise treat the normal proxy as tor unless --noonion was specified in
 // which case the lookup will fail.  Meanwhile, normal IP addresses will be
 // resolved using tor if a proxy was specified unless --noonion was also
 // specified in which case the normal system DNS resolver will be used.
-func dcrdLookup(host string) ([]net.IP, error) {
+func (cfg *config) dcrdLookup(host string) ([]net.IP, error) {
 	if strings.HasSuffix(host, ".onion") {
 		return cfg.onionlookup(host)
 	}

--- a/internal/mining/error.go
+++ b/internal/mining/error.go
@@ -1,10 +1,10 @@
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package mining
 
-// ErrorKind identifies a mining of error.  It has full support for errors.Is
+// ErrorKind identifies a kind of error.  It has full support for errors.Is
 // and errors.As, so the caller can directly check against an error kind
 // when determining the reason for an error.
 type ErrorKind string

--- a/peer/doc.go
+++ b/peer/doc.go
@@ -104,16 +104,16 @@ of a most-recently used algorithm.
 Message Sending Helper Functions
 
 In addition to the bare QueueMessage function previously described, the
-PushAddrMsg, PushGetBlocksMsg, and PushGetHeadersMsg functions are provided as a
-convenience.  While it is of course possible to create and send these messages
-manually via QueueMessage, these helper functions provided additional useful
-functionality that is typically desired.
+PushAddrMsg, PushAddrMsgV2, PushGetBlocksMsg, and PushGetHeadersMsg functions
+are provided as a convenience.  While it is of course possible to create and
+send these messages manually via QueueMessage, these helper functions provide
+additional useful functionality that is typically desired.
 
-For example, the PushAddrMsg function automatically limits the addresses to the
-maximum number allowed by the message and randomizes the chosen addresses when
-there are too many.  This allows the caller to simply provide a slice of known
-addresses, such as that returned by the addrmgr package, without having to worry
-about the details.
+For example, the PushAddrMsg and PushAddrMsgV2 functions automatically limit the
+addresses to the maximum number allowed by the message and randomizes the chosen
+addresses when there are too many.  This allows the caller to simply provide a
+slice of known addresses, such as that returned by the addrmgr package, without
+having to worry about the details.
 
 Finally, the PushGetBlocksMsg and PushGetHeadersMsg functions will construct
 proper messages using a block locator and ignore back to back duplicate

--- a/peer/go.mod
+++ b/peer/go.mod
@@ -4,6 +4,7 @@ go 1.11
 
 require (
 	github.com/davecgh/go-spew v1.1.1
+	github.com/decred/dcrd/addrmgr/v2 v2.0.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/lru v1.1.0
 	github.com/decred/dcrd/txscript/v4 v4.0.0-20210129190127-4ebd135a82f1
@@ -13,7 +14,9 @@ require (
 )
 
 replace (
+	github.com/decred/dcrd/addrmgr/v2 => ../addrmgr
 	github.com/decred/dcrd/dcrec/secp256k1/v4 => ../dcrec/secp256k1
 	github.com/decred/dcrd/dcrutil/v4 => ../dcrutil
 	github.com/decred/dcrd/txscript/v4 => ../txscript
+	github.com/decred/dcrd/wire => ../wire
 )

--- a/peer/go.sum
+++ b/peer/go.sum
@@ -20,8 +20,6 @@ github.com/decred/dcrd/dcrec/edwards/v2 v2.0.1 h1:V6eqU1crZzuoFT4KG2LhaU5xDSdkHu
 github.com/decred/dcrd/dcrec/edwards/v2 v2.0.1/go.mod h1:d0H8xGMWbiIQP7gN3v2rByWUcuZPm9YsgmnfoxgbINc=
 github.com/decred/dcrd/lru v1.1.0 h1:QwT6v8LFKOL3xQ3qtucgRk4pdiawrxIfCbUXWpm+JL4=
 github.com/decred/dcrd/lru v1.1.0/go.mod h1:mxKOwFd7lFjN2GZYsiz/ecgqR6kkYAl+0pz0tEMk218=
-github.com/decred/dcrd/wire v1.4.0 h1:KmSo6eTQIvhXS0fLBQ/l7hG7QLcSJQKSwSyzSqJYDk0=
-github.com/decred/dcrd/wire v1.4.0/go.mod h1:WxC/0K+cCAnBh+SKsRjIX9YPgvrjhmE+6pZlel1G7Ro=
 github.com/decred/go-socks v1.1.0 h1:dnENcc0KIqQo3HSXdgboXAHgqsCIutkqq6ntQjYtm2U=
 github.com/decred/go-socks v1.1.0/go.mod h1:sDhHqkZH0X4JjSa02oYOGhcGHYp12FsY1jQ/meV8md0=
 github.com/decred/slog v1.1.0 h1:uz5ZFfmaexj1rEDgZvzQ7wjGkoSPjw2LCh8K+K1VrW4=

--- a/peer/log.go
+++ b/peer/log.go
@@ -119,8 +119,14 @@ func messageSummary(msg wire.Message) string {
 	case *wire.MsgGetAddr:
 		// No summary.
 
+	case *wire.MsgGetAddrV2:
+		// No summary.
+
 	case *wire.MsgAddr:
-		return fmt.Sprintf("%d addr", len(msg.AddrList))
+		return fmt.Sprintf("%d addrs", len(msg.AddrList))
+
+	case *wire.MsgAddrV2:
+		return fmt.Sprintf("%d addrs", len(msg.AddrList))
 
 	case *wire.MsgPing:
 		// No summary - perhaps add nonce.

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/decred/dcrd/addrmgr/v2"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/lru"
 	"github.com/decred/dcrd/wire"
@@ -27,7 +28,7 @@ import (
 
 const (
 	// MaxProtocolVersion is the max protocol version the peer supports.
-	MaxProtocolVersion = wire.InitStateVersion
+	MaxProtocolVersion = wire.AddrV2Version
 
 	// outputBufferSize is the number of elements the output channels use.
 	outputBufferSize = 5000
@@ -96,8 +97,14 @@ type MessageListeners struct {
 	// OnGetAddr is invoked when a peer receives a getaddr wire message.
 	OnGetAddr func(p *Peer, msg *wire.MsgGetAddr)
 
+	// OnGetAddrV2 is invoked when a peer receives a getaddrV2 wire message.
+	OnGetAddrV2 func(p *Peer, msg *wire.MsgGetAddrV2)
+
 	// OnAddr is invoked when a peer receives an addr wire message.
 	OnAddr func(p *Peer, msg *wire.MsgAddr)
+
+	// OnAddrV2 is invoked when a peer receives an addrV2 wire message.
+	OnAddrV2 func(p *Peer, msg *wire.MsgAddrV2)
 
 	// OnPing is invoked when a peer receives a ping wire message.
 	OnPing func(p *Peer, msg *wire.MsgPing)
@@ -835,6 +842,41 @@ func (p *Peer) PushAddrMsg(addresses []*wire.NetAddress) ([]*wire.NetAddress, er
 	return msg.AddrList, nil
 }
 
+// PushAddrV2Msg sends an addrv2 message to the connected peer using the
+// provided addresses.  This function is useful over manually sending the
+// message via QueueMessage since it automatically limits the addresses to the
+// maximum number allowed by the message and randomizes the chosen addresses
+// when there are too many.  It returns the addresses that were actually sent
+// and no message will be sent if there are no entries in the provided addresses
+// slice.
+//
+// This function is safe for concurrent access.
+func (p *Peer) PushAddrV2Msg(addresses []*addrmgr.NetAddress) ([]*addrmgr.NetAddress, error) {
+	// Nothing to send.
+	if len(addresses) == 0 {
+		return nil, nil
+	}
+
+	msg := wire.NewMsgAddrV2()
+	msg.AddrList = make([]*addrmgr.NetAddress, len(addresses))
+	copy(msg.AddrList, addresses)
+
+	// Randomize the addresses sent if there are more than the maximum allowed.
+	if len(msg.AddrList) > wire.MaxAddrPerMsg {
+		// Shuffle the address list.
+		for i := range msg.AddrList {
+			j := rand.Intn(i + 1)
+			msg.AddrList[i], msg.AddrList[j] = msg.AddrList[j], msg.AddrList[i]
+		}
+
+		// Truncate it to the maximum size.
+		msg.AddrList = msg.AddrList[:wire.MaxAddrPerMsg]
+	}
+
+	p.QueueMessage(msg, nil)
+	return msg.AddrList, nil
+}
+
 // PushGetBlocksMsg sends a getblocks message for the provided block locator
 // and stop hash.  It will ignore back-to-back duplicate requests.
 //
@@ -1300,6 +1342,16 @@ out:
 			p.flagsMtx.Unlock()
 			if p.cfg.Listeners.OnVerAck != nil {
 				p.cfg.Listeners.OnVerAck(p, msg)
+			}
+
+		case *wire.MsgGetAddrV2:
+			if p.cfg.Listeners.OnGetAddrV2 != nil {
+				p.cfg.Listeners.OnGetAddrV2(p, msg)
+			}
+
+		case *wire.MsgAddrV2:
+			if p.cfg.Listeners.OnAddrV2 != nil {
+				p.cfg.Listeners.OnAddrV2(p, msg)
 			}
 
 		case *wire.MsgGetAddr:

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/decred/dcrd/addrmgr/v2"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/go-socks/socks"
@@ -326,6 +327,12 @@ func TestPeerListeners(t *testing.T) {
 	ok := make(chan wire.Message, 20)
 	peerCfg := &Config{
 		Listeners: MessageListeners{
+			OnGetAddrV2: func(p *Peer, msg *wire.MsgGetAddrV2) {
+				ok <- msg
+			},
+			OnAddrV2: func(p *Peer, msg *wire.MsgAddrV2) {
+				ok <- msg
+			},
 			OnGetAddr: func(p *Peer, msg *wire.MsgGetAddr) {
 				ok <- msg
 			},
@@ -451,127 +458,173 @@ func TestPeerListeners(t *testing.T) {
 		return
 	}
 
+	const pver = wire.ProtocolVersion
 	tests := []struct {
 		listener string
 		msg      wire.Message
+		pver     uint32
 	}{
 		{
-			"OnGetAddr",
-			wire.NewMsgGetAddr(),
+			listener: "OnGetAddrV2",
+			msg:      wire.NewMsgGetAddrV2(),
+			pver:     pver,
 		},
 		{
-			"OnAddr",
-			wire.NewMsgAddr(),
+			listener: "OnAddrV2",
+			msg: func() *wire.MsgAddrV2 {
+				// MsgAddrV2 must have at least one address to be valid.
+				msgAddrV2 := wire.NewMsgAddrV2()
+				addr := addrmgr.NewNetAddress(net.ParseIP("127.0.0.1"), 8333,
+					addrmgr.ServiceFlag(wire.SFNodeNetwork))
+				msgAddrV2.AddAddress(addr)
+				return msgAddrV2
+			}(),
+			pver: pver,
 		},
 		{
-			"OnPing",
-			wire.NewMsgPing(42),
+			listener: "OnGetAddr",
+			msg:      wire.NewMsgGetAddr(),
+			pver:     wire.AddrV2Version - 1,
 		},
 		{
-			"OnPong",
-			wire.NewMsgPong(42),
+			listener: "OnAddr",
+			msg:      wire.NewMsgAddr(),
+			pver:     wire.AddrV2Version - 1,
 		},
 		{
-			"OnMemPool",
-			wire.NewMsgMemPool(),
+			listener: "OnPing",
+			msg:      wire.NewMsgPing(42),
+			pver:     pver,
 		},
 		{
-			"OnTx",
-			wire.NewMsgTx(),
+			listener: "OnPong",
+			msg:      wire.NewMsgPong(42),
+			pver:     pver,
 		},
 		{
-			"OnBlock",
-			wire.NewMsgBlock(wire.NewBlockHeader(0, &chainhash.Hash{},
+			listener: "OnMemPool",
+			msg:      wire.NewMsgMemPool(),
+			pver:     pver,
+		},
+		{
+			listener: "OnTx",
+			msg:      wire.NewMsgTx(),
+			pver:     pver,
+		},
+		{
+			listener: "OnBlock",
+			msg: wire.NewMsgBlock(wire.NewBlockHeader(0, &chainhash.Hash{},
 				&chainhash.Hash{}, &chainhash.Hash{}, 1, [6]byte{},
 				1, 1, 1, 1, 1, 1, 1, 1, 1, [32]byte{},
 				binary.LittleEndian.Uint32([]byte{0xb0, 0x1d, 0xfa, 0xce}))),
+			pver: pver,
 		},
 		{
-			"OnInv",
-			wire.NewMsgInv(),
+			listener: "OnInv",
+			msg:      wire.NewMsgInv(),
+			pver:     pver,
 		},
 		{
-			"OnHeaders",
-			wire.NewMsgHeaders(),
+			listener: "OnHeaders",
+			msg:      wire.NewMsgHeaders(),
+			pver:     pver,
 		},
 		{
-			"OnNotFound",
-			wire.NewMsgNotFound(),
+			listener: "OnNotFound",
+			msg:      wire.NewMsgNotFound(),
+			pver:     pver,
 		},
 		{
-			"OnGetData",
-			wire.NewMsgGetData(),
+			listener: "OnGetData",
+			msg:      wire.NewMsgGetData(),
+			pver:     pver,
 		},
 		{
-			"OnGetBlocks",
-			wire.NewMsgGetBlocks(&chainhash.Hash{}),
+			listener: "OnGetBlocks",
+			msg:      wire.NewMsgGetBlocks(&chainhash.Hash{}),
+			pver:     pver,
 		},
 		{
-			"OnGetHeaders",
-			wire.NewMsgGetHeaders(),
+			listener: "OnGetHeaders",
+			msg:      wire.NewMsgGetHeaders(),
+			pver:     pver,
 		},
 		{
-			"OnGetCFilter",
-			wire.NewMsgGetCFilter(&chainhash.Hash{},
+			listener: "OnGetCFilter",
+			msg: wire.NewMsgGetCFilter(&chainhash.Hash{},
 				wire.GCSFilterRegular),
+			pver: pver,
 		},
 		{
-			"OnGetCFHeaders",
-			wire.NewMsgGetCFHeaders(),
+			listener: "OnGetCFHeaders",
+			msg:      wire.NewMsgGetCFHeaders(),
+			pver:     pver,
 		},
 		{
-			"OnGetCFTypes",
-			wire.NewMsgGetCFTypes(),
+			listener: "OnGetCFTypes",
+			msg:      wire.NewMsgGetCFTypes(),
+			pver:     pver,
 		},
 		{
-			"OnCFilter",
-			wire.NewMsgCFilter(&chainhash.Hash{},
+			listener: "OnCFilter",
+			msg: wire.NewMsgCFilter(&chainhash.Hash{},
 				wire.GCSFilterRegular, []byte("payload")),
+			pver: pver,
 		},
 		{
-			"OnCFHeaders",
-			wire.NewMsgCFHeaders(),
+			listener: "OnCFHeaders",
+			msg:      wire.NewMsgCFHeaders(),
+			pver:     pver,
 		},
 		{
-			"OnCFTypes",
-			wire.NewMsgCFTypes([]wire.FilterType{
+			listener: "OnCFTypes",
+			msg: wire.NewMsgCFTypes([]wire.FilterType{
 				wire.GCSFilterRegular, wire.GCSFilterExtended,
 			}),
+			pver: pver,
 		},
 		{
-			"OnFeeFilter",
-			wire.NewMsgFeeFilter(15000),
+			listener: "OnFeeFilter",
+			msg:      wire.NewMsgFeeFilter(15000),
+			pver:     pver,
 		},
 		{
-			"OnGetCFilterV2",
-			wire.NewMsgGetCFilterV2(&chainhash.Hash{}),
+			listener: "OnGetCFilterV2",
+			msg:      wire.NewMsgGetCFilterV2(&chainhash.Hash{}),
+			pver:     pver,
 		},
 		{
-			"OnCFilterV2",
-			wire.NewMsgCFilterV2(&chainhash.Hash{}, nil, 0, nil),
+			listener: "OnCFilterV2",
+			msg:      wire.NewMsgCFilterV2(&chainhash.Hash{}, nil, 0, nil),
+			pver:     pver,
 		},
 		// only one version message is allowed
 		// only one verack message is allowed
 		{
-			"OnReject",
-			wire.NewMsgReject("block", wire.RejectDuplicate, "dupe block"),
+			listener: "OnReject",
+			msg:      wire.NewMsgReject("block", wire.RejectDuplicate, "dupe block"),
+			pver:     wire.RemoveRejectVersion - 1,
 		},
 		{
-			"OnSendHeaders",
-			wire.NewMsgSendHeaders(),
+			listener: "OnSendHeaders",
+			msg:      wire.NewMsgSendHeaders(),
+			pver:     pver,
 		},
 		{
-			"OnGetInitState",
-			wire.NewMsgGetInitState(),
+			listener: "OnGetInitState",
+			msg:      wire.NewMsgGetInitState(),
+			pver:     pver,
 		},
 		{
-			"OnInitState",
-			wire.NewMsgInitState(),
+			listener: "OnInitState",
+			msg:      wire.NewMsgInitState(),
+			pver:     pver,
 		},
 	}
 	t.Logf("Running %d tests", len(tests))
 	for _, test := range tests {
-		// Queue the test message
+		inPeer.protocolVersion = test.pver
+		outPeer.protocolVersion = test.pver
 		outPeer.QueueMessage(test.msg, nil)
 		select {
 		case <-ok:
@@ -702,6 +755,17 @@ func TestOutboundPeer(t *testing.T) {
 		t.Errorf("PushAddrMsg: unexpected err %v\n", err)
 		return
 	}
+
+	var addrmgrAddrs []*addrmgr.NetAddress
+	for i := 0; i < 5; i++ {
+		na := &addrmgr.NetAddress{}
+		addrmgrAddrs = append(addrmgrAddrs, na)
+	}
+	if _, err := p2.PushAddrV2Msg(addrmgrAddrs); err != nil {
+		t.Errorf("PushAddrV2Msg: unexpected err %v\n", err)
+		return
+	}
+
 	if err := p2.PushGetBlocksMsg(nil, &chainhash.Hash{}); err != nil {
 		t.Errorf("PushGetBlocksMsg: unexpected err %v\n", err)
 		return
@@ -713,6 +777,7 @@ func TestOutboundPeer(t *testing.T) {
 
 	// Test Queue Messages
 	p2.QueueMessage(wire.NewMsgGetAddr(), nil)
+	p2.QueueMessage(wire.NewMsgGetAddrV2(), nil)
 	p2.QueueMessage(wire.NewMsgPing(1), nil)
 	p2.QueueMessage(wire.NewMsgMemPool(), nil)
 	p2.QueueMessage(wire.NewMsgGetData(), nil)

--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -303,7 +303,7 @@ func (cm *rpcConnManager) AddedNodeInfo() []rpcserver.Peer {
 // This function is safe for concurrent access and is part of the
 // rpcserver.ConnManager interface implementation.
 func (*rpcConnManager) Lookup(host string) ([]net.IP, error) {
-	return dcrdLookup(host)
+	return cfg.dcrdLookup(host)
 }
 
 // rpcSyncMgr provides an adaptor for use with the RPC server and implements the

--- a/server.go
+++ b/server.go
@@ -73,7 +73,7 @@ const (
 	connectionRetryInterval = time.Second * 5
 
 	// maxProtocolVersion is the max protocol version the server supports.
-	maxProtocolVersion = wire.InitStateVersion
+	maxProtocolVersion = wire.AddrV2Version
 
 	// These fields are used to track known addresses on a per-peer basis.
 	//
@@ -664,6 +664,11 @@ func (sp *serverPeer) pushAddrMsg(addresses []*addrmgr.NetAddress) {
 	// Filter addresses already known to the peer.
 	addrs := make([]*wire.NetAddress, 0, len(addresses))
 	for _, addr := range addresses {
+		if addr.Type != addrmgr.IPv4Address &&
+			addr.Type != addrmgr.IPv6Address &&
+			addr.Type != addrmgr.TORv2Address {
+			continue
+		}
 		if !sp.addressKnown(addr) {
 			wireNetAddr := addrmgrToWireNetAddress(addr)
 			addrs = append(addrs, wireNetAddr)
@@ -678,6 +683,25 @@ func (sp *serverPeer) pushAddrMsg(addresses []*addrmgr.NetAddress) {
 
 	knownNetAddrs := wireToAddrmgrNetAddresses(known)
 	sp.addKnownAddresses(knownNetAddrs)
+}
+
+// pushAddrV2Msg sends an addrv2 message to the connected peer using the
+// provided addresses.
+func (sp *serverPeer) pushAddrV2Msg(addresses []*addrmgr.NetAddress) {
+	// Filter addresses already known to the peer.
+	addrs := make([]*addrmgr.NetAddress, 0, len(addresses))
+	for _, addr := range addresses {
+		if !sp.addressKnown(addr) {
+			addrs = append(addrs, addr)
+		}
+	}
+	known, err := sp.PushAddrV2Msg(addrs)
+	if err != nil {
+		peerLog.Errorf("Can't push address v2 message to %s: %v", sp.Peer, err)
+		sp.Disconnect()
+		return
+	}
+	sp.addKnownAddresses(known)
 }
 
 // addBanScore increases the persistent and decaying ban score fields by the
@@ -727,6 +751,12 @@ func hasServices(advertised, desired wire.ServiceFlag) bool {
 	return advertised&desired == desired
 }
 
+// latestSupportedNetAddressType returns the highest supported network address
+// type at the given protocol version.
+func latestSupportedNetAddressType(pver uint32) addrmgr.NetAddressType {
+	return addrmgr.TORv2Address
+}
+
 // OnVersion is invoked when a peer receives a version wire message and is used
 // to negotiate the protocol version details as well as kick start the
 // communications.
@@ -742,6 +772,7 @@ func (sp *serverPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) {
 	// it is updated regardless in the case a new minimum protocol version is
 	// enforced and the remote node has not upgraded yet.
 	isInbound := sp.Inbound()
+	msgProtocolVersion := uint32(msg.ProtocolVersion)
 	remoteAddr := wireToAddrmgrNetAddress(sp.NA())
 	addrManager := sp.server.addrManager
 	if !cfg.SimNet && !cfg.RegNet && !isInbound {
@@ -752,7 +783,7 @@ func (sp *serverPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) {
 	}
 
 	// Reject peers that have a protocol version that is too old.
-	if msg.ProtocolVersion < int32(wire.SendHeadersVersion) {
+	if msgProtocolVersion < wire.SendHeadersVersion {
 		srvrLog.Debugf("Rejecting peer %s with protocol version %d prior to "+
 			"the required version %d", sp.Peer, msg.ProtocolVersion,
 			wire.SendHeadersVersion)
@@ -782,18 +813,29 @@ func (sp *serverPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) {
 		// known tip.
 		if !cfg.DisableListen && sp.server.syncManager.IsCurrent() {
 			// Get address that best matches.
-			lna := addrManager.GetBestLocalAddress(remoteAddr)
+			newestAddrType := latestSupportedNetAddressType(msgProtocolVersion)
+			lna := addrManager.GetBestLocalAddress(remoteAddr, newestAddrType)
 			if lna.IsRoutable() {
-				// Filter addresses the peer already knows about.
 				addresses := []*addrmgr.NetAddress{lna}
-				sp.pushAddrMsg(addresses)
+				if msgProtocolVersion >= wire.AddrV2Version {
+					sp.pushAddrV2Msg(addresses)
+				} else {
+					sp.pushAddrMsg(addresses)
+				}
+			} else {
+				srvrLog.Debugf("Local address %s is not routable and will not "+
+					"be broadcast to outbound peer %v", lna.Key(), sp.Addr())
 			}
 		}
 
 		// Request known addresses if the server address manager needs
 		// more.
 		if addrManager.NeedMoreAddresses() {
-			sp.QueueMessage(wire.NewMsgGetAddr(), nil)
+			if msgProtocolVersion >= wire.AddrV2Version {
+				sp.QueueMessage(wire.NewMsgGetAddrV2(), nil)
+			} else {
+				sp.QueueMessage(wire.NewMsgGetAddr(), nil)
+			}
 		}
 
 		// Mark the address as a known good address.
@@ -1044,7 +1086,7 @@ func (sp *serverPeer) OnGetInitState(p *peer.Peer, msg *wire.MsgGetInitState) {
 	sp.QueueMessage(initMsg, nil)
 }
 
-// OnInitState is invoked when a peer receives a initstate wire message.  It
+// OnInitState is invoked when a peer receives an initstate wire message.  It
 // requests the data advertised in the message from the peer.
 func (sp *serverPeer) OnInitState(p *peer.Peer, msg *wire.MsgInitState) {
 	blockHashes := make([]*chainhash.Hash, 0, len(msg.BlockHashes))
@@ -1409,10 +1451,48 @@ func (sp *serverPeer) OnGetAddr(p *peer.Peer, msg *wire.MsgGetAddr) {
 	sp.addrsSent = true
 
 	// Get the current known addresses from the address manager.
-	addrCache := sp.server.addrManager.AddressCache()
+	addrCache := sp.server.addrManager.AddressCache(addrmgr.TORv2Address)
 
 	// Push the addresses.
 	sp.pushAddrMsg(addrCache)
+}
+
+// OnGetAddrV2 is invoked when a peer receives a getaddrv2 wire message and is
+// used to provide the peer with known addresses from the address manager.
+func (sp *serverPeer) OnGetAddrV2(p *peer.Peer, msg *wire.MsgGetAddrV2) {
+	// Don't return any addresses when running on the simulation and regression
+	// test networks.  This helps prevent the networks from becoming another
+	// public test network since they will not be able to learn about other
+	// peers that have not specifically been provided.
+	if cfg.SimNet || cfg.RegNet {
+		return
+	}
+
+	// Do not accept getaddrv2 requests from outbound peers.  This reduces
+	// fingerprinting attacks.
+	if !p.Inbound() {
+		peerLog.Errorf("Received getaddrv2 request from outbound peer %s",
+			sp.Peer)
+		sp.server.BanPeer(sp)
+		return
+	}
+
+	// Only respond with addresses once per connection.  This helps reduce
+	// traffic and further reduces fingerprinting attacks.
+	if sp.addrsSent {
+		peerLog.Errorf("Received more than one getaddrv2 request from %s",
+			sp.Peer)
+		sp.server.BanPeer(sp)
+		return
+	}
+	sp.addrsSent = true
+
+	// Get the current known addresses from the address manager.
+	newestAddrType := latestSupportedNetAddressType(sp.ProtocolVersion())
+	addrCache := sp.server.addrManager.AddressCache(newestAddrType)
+
+	// Push the addresses.
+	sp.pushAddrV2Msg(addrCache)
 }
 
 // OnAddr is invoked when a peer receives an addr wire message and is used to
@@ -1438,7 +1518,7 @@ func (sp *serverPeer) OnAddr(p *peer.Peer, msg *wire.MsgAddr) {
 
 	now := time.Now()
 	for _, na := range msg.AddrList {
-		// Don't add more address if we're disconnecting.
+		// Don't add more addresses if we're disconnecting.
 		if !p.Connected() {
 			return
 		}
@@ -1458,12 +1538,46 @@ func (sp *serverPeer) OnAddr(p *peer.Peer, msg *wire.MsgAddr) {
 	// Add addresses to server address manager.  The address manager handles
 	// the details of things such as preventing duplicate addresses, max
 	// addresses, and last seen updates.
-	// XXX bitcoind gives a 2 hour time penalty here, do we want to do the
-	// same?
-
 	addresses := wireToAddrmgrNetAddresses(msg.AddrList)
 	srcAddr := wireToAddrmgrNetAddress(p.NA())
 	sp.server.addrManager.AddAddresses(addresses, srcAddr)
+}
+
+// OnAddrV2 is invoked when a peer receives an addrv2 wire message and is used
+// to notify the server about advertised addresses.
+func (sp *serverPeer) OnAddrV2(p *peer.Peer, msg *wire.MsgAddrV2) {
+	// Ignore addresses when running on the simulation and regression test
+	// networks.  This helps prevent the networks from becoming another public
+	// test network since they will not be able to learn about other peers that
+	// have not specifically been provided.
+	if cfg.SimNet || cfg.RegNet {
+		return
+	}
+
+	now := time.Now()
+	for _, netAddr := range msg.AddrList {
+		// Don't add more addresses if we're disconnecting.
+		if !p.Connected() {
+			peerLog.Debugf("Not adding addresses from disconnected peer %v", sp)
+			return
+		}
+
+		// Set the timestamp to 5 days ago if it's more than 24 hours
+		// in the future so this address is one of the first to be
+		// removed when space is needed.
+		if netAddr.Timestamp.After(now.Add(time.Minute * 10)) {
+			netAddr.Timestamp = now.Add(-1 * time.Hour * 24 * 5)
+		}
+
+		// Add address to known addresses for this peer.
+		sp.addKnownAddresses([]*addrmgr.NetAddress{netAddr})
+	}
+
+	// Add addresses to server address manager.  The address manager handles
+	// the details of things such as preventing duplicate addresses, max
+	// addresses, and last seen updates.
+	srcAddr := wireToAddrmgrNetAddress(p.NA())
+	sp.server.addrManager.AddAddresses(msg.AddrList, srcAddr)
 }
 
 // OnRead is invoked when a peer receives a message and it is used to update
@@ -1699,13 +1813,14 @@ func (s *server) handleAddPeerMsg(state *peerState, sp *serverPeer) bool {
 		return false
 	}
 
-	// Disconnect banned peers.
 	host, _, err := net.SplitHostPort(sp.Addr())
 	if err != nil {
 		srvrLog.Debugf("can't split hostport %v", err)
 		sp.Disconnect()
 		return false
 	}
+
+	// Disconnect banned peers.
 	if banEnd, ok := state.banned[host]; ok {
 		if time.Now().Before(banEnd) {
 			srvrLog.Debugf("Peer %s is banned for another %v - disconnecting",
@@ -2191,6 +2306,8 @@ func newPeerConfig(sp *serverPeer) *peer.Config {
 			OnGetCFilterV2:   sp.OnGetCFilterV2,
 			OnGetCFHeaders:   sp.OnGetCFHeaders,
 			OnGetCFTypes:     sp.OnGetCFTypes,
+			OnGetAddrV2:      sp.OnGetAddrV2,
+			OnAddrV2:         sp.OnAddrV2,
 			OnGetAddr:        sp.OnGetAddr,
 			OnAddr:           sp.OnAddr,
 			OnRead:           sp.OnRead,

--- a/server.go
+++ b/server.go
@@ -380,7 +380,8 @@ func (ps *peerState) ResolveLocalAddress(netType addrmgr.NetAddressType, addrMgr
 	}
 
 	addLocalAddress := func(bestSuggestion string, port uint16, services wire.ServiceFlag) {
-		na, err := addrMgr.HostToNetAddress(bestSuggestion, port, services)
+		na, err := addrMgr.HostToNetAddress(bestSuggestion, port,
+			addrmgr.ServiceFlag(services))
 		if err != nil {
 			amgrLog.Errorf("unable to generate network address using host %v: "+
 				"%v", bestSuggestion, err)
@@ -572,15 +573,15 @@ func (sp *serverPeer) newestBlock() (*chainhash.Hash, int64, error) {
 
 // addKnownAddresses adds the given addresses to the set of known addresses to
 // the peer to prevent sending duplicate addresses.
-func (sp *serverPeer) addKnownAddresses(addresses []*wire.NetAddress) {
+func (sp *serverPeer) addKnownAddresses(addresses []*addrmgr.NetAddress) {
 	for _, na := range addresses {
-		sp.knownAddresses.Add([]byte(addrmgr.NetAddressKey(na)))
+		sp.knownAddresses.Add([]byte(na.Key()))
 	}
 }
 
 // addressKnown true if the given address is already known to the peer.
-func (sp *serverPeer) addressKnown(na *wire.NetAddress) bool {
-	return sp.knownAddresses.Contains([]byte(addrmgr.NetAddressKey(na)))
+func (sp *serverPeer) addressKnown(na *addrmgr.NetAddress) bool {
+	return sp.knownAddresses.Contains([]byte(na.Key()))
 }
 
 // setDisableRelayTx toggles relaying of transactions for the given peer.
@@ -602,14 +603,41 @@ func (sp *serverPeer) relayTxDisabled() bool {
 	return isDisabled
 }
 
+// wireToAddrmgrNetAddress converts a wire NetAddress to an address manager
+// NetAddress.
+func wireToAddrmgrNetAddress(netAddr *wire.NetAddress) *addrmgr.NetAddress {
+	newNetAddr := addrmgr.NewNetAddress(netAddr.IP, netAddr.Port,
+		addrmgr.ServiceFlag(netAddr.Services))
+	newNetAddr.Timestamp = netAddr.Timestamp
+	return newNetAddr
+}
+
+// wireToAddrmgrNetAddresses converts a collection of wire net addresses to a
+// collection of address manager net addresses.
+func wireToAddrmgrNetAddresses(netAddr []*wire.NetAddress) []*addrmgr.NetAddress {
+	addrs := make([]*addrmgr.NetAddress, len(netAddr))
+	for i, wireAddr := range netAddr {
+		addrs[i] = wireToAddrmgrNetAddress(wireAddr)
+	}
+	return addrs
+}
+
+// addrmgrToWireNetAddress converts an address manager net address to a wire net
+// address.
+func addrmgrToWireNetAddress(netAddr *addrmgr.NetAddress) *wire.NetAddress {
+	return wire.NewNetAddressTimestamp(netAddr.Timestamp,
+		wire.ServiceFlag(netAddr.Services), netAddr.IP, netAddr.Port)
+}
+
 // pushAddrMsg sends an addr message to the connected peer using the provided
 // addresses.
-func (sp *serverPeer) pushAddrMsg(addresses []*wire.NetAddress) {
+func (sp *serverPeer) pushAddrMsg(addresses []*addrmgr.NetAddress) {
 	// Filter addresses already known to the peer.
 	addrs := make([]*wire.NetAddress, 0, len(addresses))
 	for _, addr := range addresses {
 		if !sp.addressKnown(addr) {
-			addrs = append(addrs, addr)
+			wireNetAddr := addrmgrToWireNetAddress(addr)
+			addrs = append(addrs, wireNetAddr)
 		}
 	}
 	known, err := sp.PushAddrMsg(addrs)
@@ -618,7 +646,9 @@ func (sp *serverPeer) pushAddrMsg(addresses []*wire.NetAddress) {
 		sp.Disconnect()
 		return
 	}
-	sp.addKnownAddresses(known)
+
+	knownNetAddrs := wireToAddrmgrNetAddresses(known)
+	sp.addKnownAddresses(knownNetAddrs)
 }
 
 // addBanScore increases the persistent and decaying ban score fields by the
@@ -683,10 +713,10 @@ func (sp *serverPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) {
 	// it is updated regardless in the case a new minimum protocol version is
 	// enforced and the remote node has not upgraded yet.
 	isInbound := sp.Inbound()
-	remoteAddr := sp.NA()
+	remoteAddr := wireToAddrmgrNetAddress(sp.NA())
 	addrManager := sp.server.addrManager
 	if !cfg.SimNet && !cfg.RegNet && !isInbound {
-		err := addrManager.SetServices(remoteAddr, msg.Services)
+		err := addrManager.SetServices(remoteAddr, addrmgr.ServiceFlag(msg.Services))
 		if err != nil {
 			srvrLog.Errorf("Setting services for address failed: %v", err)
 		}
@@ -724,9 +754,9 @@ func (sp *serverPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) {
 		if !cfg.DisableListen && sp.server.syncManager.IsCurrent() {
 			// Get address that best matches.
 			lna := addrManager.GetBestLocalAddress(remoteAddr)
-			if addrmgr.IsRoutable(lna.IP) {
+			if lna.IsRoutable() {
 				// Filter addresses the peer already knows about.
-				addresses := []*wire.NetAddress{lna}
+				addresses := []*addrmgr.NetAddress{lna}
 				sp.pushAddrMsg(addresses)
 			}
 		}
@@ -1392,7 +1422,8 @@ func (sp *serverPeer) OnAddr(p *peer.Peer, msg *wire.MsgAddr) {
 		}
 
 		// Add address to known addresses for this peer.
-		sp.addKnownAddresses([]*wire.NetAddress{na})
+		netAddr := wireToAddrmgrNetAddress(na)
+		sp.addKnownAddresses([]*addrmgr.NetAddress{netAddr})
 	}
 
 	// Add addresses to server address manager.  The address manager handles
@@ -1400,7 +1431,10 @@ func (sp *serverPeer) OnAddr(p *peer.Peer, msg *wire.MsgAddr) {
 	// addresses, and last seen updates.
 	// XXX bitcoind gives a 2 hour time penalty here, do we want to do the
 	// same?
-	sp.server.addrManager.AddAddresses(msg.AddrList, p.NA())
+
+	addresses := wireToAddrmgrNetAddresses(msg.AddrList)
+	srcAddr := wireToAddrmgrNetAddress(p.NA())
+	sp.server.addrManager.AddAddresses(addresses, srcAddr)
 }
 
 // OnRead is invoked when a peer receives a message and it is used to update
@@ -1735,7 +1769,9 @@ func (s *server) handleAddPeerMsg(state *peerState, sp *serverPeer) bool {
 				net = addrmgr.IPv6Address
 			}
 
-			valid, reach := s.addrManager.ValidatePeerNa(na, sp.NA())
+			localAddr := wireToAddrmgrNetAddress(na)
+			remoteAddr := wireToAddrmgrNetAddress(sp.NA())
+			valid, reach := s.addrManager.ValidatePeerNa(localAddr, remoteAddr)
 			if !valid {
 				return true
 			}
@@ -1802,7 +1838,8 @@ func (s *server) handleDonePeerMsg(state *peerState, sp *serverPeer) {
 	// Update the address' last seen time if the peer has acknowledged
 	// our version and has sent us its version as well.
 	if sp.VerAckReceived() && sp.VersionKnown() && sp.NA() != nil {
-		err := s.addrManager.Connected(sp.NA())
+		peerNetAddr := wireToAddrmgrNetAddress(sp.NA())
+		err := s.addrManager.Connected(peerNetAddr)
 		if err != nil {
 			srvrLog.Debugf("Marking address as connected failed: %v", err)
 		}
@@ -2131,8 +2168,15 @@ func newPeerConfig(sp *serverPeer) *peer.Config {
 			OnWrite:          sp.OnWrite,
 			OnNotFound:       sp.OnNotFound,
 		},
-		NewestBlock:       sp.newestBlock,
-		HostToNetAddress:  sp.server.addrManager.HostToNetAddress,
+		NewestBlock: sp.newestBlock,
+		HostToNetAddress: func(host string, port uint16, services wire.ServiceFlag) (*wire.NetAddress, error) {
+			address, err := sp.server.addrManager.HostToNetAddress(host, port,
+				addrmgr.ServiceFlag(services))
+			if err != nil {
+				return nil, err
+			}
+			return addrmgrToWireNetAddress(address), nil
+		},
 		Proxy:             cfg.Proxy,
 		UserAgentName:     userAgentName,
 		UserAgentVersion:  userAgentVersion,
@@ -2175,7 +2219,9 @@ func (s *server) outboundPeerConnected(c *connmgr.ConnReq, conn net.Conn) {
 	sp.isWhitelisted = isWhitelisted(conn.RemoteAddr())
 	sp.AssociateConnection(conn)
 	go s.peerDoneHandler(sp)
-	err = s.addrManager.Attempt(sp.NA())
+
+	peerNetAddr := wireToAddrmgrNetAddress(sp.NA())
+	err = s.addrManager.Attempt(peerNetAddr)
 	if err != nil {
 		srvrLog.Debugf("Marking address as attempted failed: %v", err)
 	}
@@ -2957,13 +3003,15 @@ func (s *server) querySeeders(ctx context.Context) {
 			// seeded addresses.  In the incredibly rare event that the lookup
 			// fails after it just succeeded, fall back to using the first
 			// returned address as the source.
-			srcAddr := addrs[0]
+			srcAddr := wireToAddrmgrNetAddress(addrs[0])
 			srcIPs, err := dcrdLookup(seeder)
 			if err == nil && len(srcIPs) > 0 {
 				const httpsPort = 443
-				srcAddr = wire.NewNetAddressIPPort(srcIPs[0], httpsPort, 0)
+				srcAddr = addrmgr.NewNetAddress(srcIPs[0], httpsPort, 0)
 			}
-			s.addrManager.AddAddresses(addrs, srcAddr)
+
+			addresses := wireToAddrmgrNetAddresses(addrs)
+			s.addrManager.AddAddresses(addresses, srcAddr)
 		}(seeder)
 	}
 }
@@ -3119,15 +3167,16 @@ out:
 					srvrLog.Warnf("UPnP can't get external address: %v", err)
 					continue out
 				}
-				na := wire.NewNetAddressIPPort(externalip, uint16(listenPort),
+				wireNA := wire.NewNetAddressIPPort(externalip, uint16(listenPort),
 					s.services)
-				err = s.addrManager.AddLocalAddress(na, addrmgr.UpnpPrio)
+				localAddr := wireToAddrmgrNetAddress(wireNA)
+				err = s.addrManager.AddLocalAddress(localAddr, addrmgr.UpnpPrio)
 				if err != nil {
 					srvrLog.Warnf("Failed to add UPnP local address %s: %v",
-						na.IP.String(), err)
+						wireNA.IP.String(), err)
 				} else {
 					srvrLog.Warnf("Successfully bound via UPnP to %s",
-						addrmgr.NetAddressKey(na))
+						localAddr.Key)
 					first = false
 				}
 			}
@@ -3606,7 +3655,8 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 				// in the same group so that we are not connecting
 				// to the same network segment at the expense of
 				// others.
-				key := addrmgr.GroupKey(addr.NetAddress().IP)
+				wireAddr := addr.NetAddress()
+				key := addrmgr.GroupKey(wireAddr.IP)
 				if s.OutboundGroupCount(key) != 0 {
 					continue
 				}
@@ -3623,8 +3673,7 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainP
 					continue
 				}
 
-				addrString := addrmgr.NetAddressKey(addr.NetAddress())
-				return addrStringToNetAddr(addrString)
+				return addrStringToNetAddr(wireAddr.Key())
 			}
 
 			return nil, errors.New("no valid connect address")
@@ -3792,7 +3841,9 @@ func initListeners(ctx context.Context, params *chaincfg.Params, amgr *addrmgr.A
 				}
 				eport = uint16(port)
 			}
-			na, err := amgr.HostToNetAddress(host, eport, services)
+
+			na, err := amgr.HostToNetAddress(host, eport,
+				addrmgr.ServiceFlag(services))
 			if err != nil {
 				srvrLog.Warnf("Not adding %s as externalip: %v", sip, err)
 				continue
@@ -3888,16 +3939,18 @@ func addLocalAddress(addrMgr *addrmgr.AddrManager, addr string, services wire.Se
 				continue
 			}
 
-			netAddr := wire.NewNetAddressIPPort(ifaceIP, uint16(port), services)
+			netAddr := addrmgr.NewNetAddress(ifaceIP, uint16(port),
+				addrmgr.ServiceFlag(services))
 			addrMgr.AddLocalAddress(netAddr, addrmgr.BoundPrio)
 		}
 	} else {
-		netAddr, err := addrMgr.HostToNetAddress(host, uint16(port), services)
+		na, err := addrMgr.HostToNetAddress(host, uint16(port),
+			addrmgr.ServiceFlag(services))
 		if err != nil {
 			return err
 		}
 
-		addrMgr.AddLocalAddress(netAddr, addrmgr.BoundPrio)
+		addrMgr.AddLocalAddress(na, addrmgr.BoundPrio)
 	}
 
 	return nil

--- a/server.go
+++ b/server.go
@@ -358,6 +358,36 @@ func (ps *peerState) forAllPeers(closure func(sp *serverPeer)) {
 	ps.forAllOutboundPeers(closure)
 }
 
+// hostToNetAddress parses and returns an address manager network address given
+// a hostname in a supported format (IPv4, IPv6, TORv2).  If the hostname
+// cannot be immediately converted from a known address format, it will be
+// resolved using a DNS lookup function. If it cannot be resolved, an error is
+// returned.
+func (cfg *config) hostToNetAddress(host string, port uint16, services wire.ServiceFlag) (*addrmgr.NetAddress, error) {
+	addrmgrServices := addrmgr.ServiceFlag(services)
+	networkID, addrBytes, err := addrmgr.HostToBytes(host)
+	if err != nil {
+		return nil, err
+	}
+	if networkID != addrmgr.UnknownAddressType {
+		// Since the host has been successfully decoded, there is no need to
+		// perform a DNS lookup.
+		now := time.Unix(time.Now().Unix(), 0)
+		return addrmgr.NewNetAddressByType(networkID, addrBytes, port,
+			now, addrmgrServices)
+	}
+
+	ips, err := cfg.dcrdLookup(host)
+	if err != nil {
+		return nil, err
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("no addresses found for %s", host)
+	}
+	na := addrmgr.NewNetAddress(ips[0], port, addrmgrServices)
+	return na, nil
+}
+
 // ResolveLocalAddress picks the best suggested network address from available
 // options, per the network interface key provided. The best suggestion, if
 // found, is added as a local address.
@@ -380,8 +410,7 @@ func (ps *peerState) ResolveLocalAddress(netType addrmgr.NetAddressType, addrMgr
 	}
 
 	addLocalAddress := func(bestSuggestion string, port uint16, services wire.ServiceFlag) {
-		na, err := addrMgr.HostToNetAddress(bestSuggestion, port,
-			addrmgr.ServiceFlag(services))
+		na, err := cfg.hostToNetAddress(bestSuggestion, port, services)
 		if err != nil {
 			amgrLog.Errorf("unable to generate network address using host %v: "+
 				"%v", bestSuggestion, err)
@@ -2170,8 +2199,7 @@ func newPeerConfig(sp *serverPeer) *peer.Config {
 		},
 		NewestBlock: sp.newestBlock,
 		HostToNetAddress: func(host string, port uint16, services wire.ServiceFlag) (*wire.NetAddress, error) {
-			address, err := sp.server.addrManager.HostToNetAddress(host, port,
-				addrmgr.ServiceFlag(services))
+			address, err := cfg.hostToNetAddress(host, port, services)
 			if err != nil {
 				return nil, err
 			}
@@ -3003,11 +3031,10 @@ func (s *server) querySeeders(ctx context.Context) {
 			// seeded addresses.  In the incredibly rare event that the lookup
 			// fails after it just succeeded, fall back to using the first
 			// returned address as the source.
-			srcAddr := wireToAddrmgrNetAddress(addrs[0])
-			srcIPs, err := dcrdLookup(seeder)
-			if err == nil && len(srcIPs) > 0 {
-				const httpsPort = 443
-				srcAddr = addrmgr.NewNetAddress(srcIPs[0], httpsPort, 0)
+			const httpsPort = 443
+			srcAddr, err := cfg.hostToNetAddress(seeder, httpsPort, 0)
+			if err != nil {
+				srcAddr = wireToAddrmgrNetAddress(addrs[0])
 			}
 
 			addresses := wireToAddrmgrNetAddresses(addrs)
@@ -3332,7 +3359,7 @@ func setupRPCListeners() ([]net.Listener, error) {
 // decred network type specified by chainParams.  Use start to begin accepting
 // connections from peers.
 func newServer(ctx context.Context, listenAddrs []string, db database.DB, chainParams *chaincfg.Params, dataDir string) (*server, error) {
-	amgr := addrmgr.New(cfg.DataDir, dcrdLookup)
+	amgr := addrmgr.New(cfg.DataDir)
 	services := defaultServices
 
 	var listeners []net.Listener
@@ -3842,8 +3869,7 @@ func initListeners(ctx context.Context, params *chaincfg.Params, amgr *addrmgr.A
 				eport = uint16(port)
 			}
 
-			na, err := amgr.HostToNetAddress(host, eport,
-				addrmgr.ServiceFlag(services))
+			na, err := cfg.hostToNetAddress(host, eport, services)
 			if err != nil {
 				srvrLog.Warnf("Not adding %s as externalip: %v", sip, err)
 				continue
@@ -3889,7 +3915,7 @@ func addrStringToNetAddr(addr string) (net.Addr, error) {
 	// Attempt to look up an IP address associated with the parsed host.
 	// The dcrdLookup function will transparently handle performing the
 	// lookup over Tor if necessary.
-	ips, err := dcrdLookup(host)
+	ips, err := cfg.dcrdLookup(host)
 	if err != nil {
 		return nil, err
 	}
@@ -3944,8 +3970,7 @@ func addLocalAddress(addrMgr *addrmgr.AddrManager, addr string, services wire.Se
 			addrMgr.AddLocalAddress(netAddr, addrmgr.BoundPrio)
 		}
 	} else {
-		na, err := addrMgr.HostToNetAddress(host, uint16(port),
-			addrmgr.ServiceFlag(services))
+		na, err := cfg.hostToNetAddress(host, uint16(port), services)
 		if err != nil {
 			return err
 		}

--- a/server.go
+++ b/server.go
@@ -686,7 +686,10 @@ func (sp *serverPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) {
 	remoteAddr := sp.NA()
 	addrManager := sp.server.addrManager
 	if !cfg.SimNet && !cfg.RegNet && !isInbound {
-		addrManager.SetServices(remoteAddr, msg.Services)
+		err := addrManager.SetServices(remoteAddr, msg.Services)
+		if err != nil {
+			srvrLog.Errorf("Setting services for address failed: %v", err)
+		}
 	}
 
 	// Reject peers that have a protocol version that is too old.
@@ -735,7 +738,10 @@ func (sp *serverPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) {
 		}
 
 		// Mark the address as a known good address.
-		addrManager.Good(remoteAddr)
+		err := addrManager.Good(remoteAddr)
+		if err != nil {
+			srvrLog.Errorf("Marking address as good failed: %v", err)
+		}
 	}
 
 	sp.peerNaMtx.Lock()
@@ -1796,7 +1802,10 @@ func (s *server) handleDonePeerMsg(state *peerState, sp *serverPeer) {
 	// Update the address' last seen time if the peer has acknowledged
 	// our version and has sent us its version as well.
 	if sp.VerAckReceived() && sp.VersionKnown() && sp.NA() != nil {
-		s.addrManager.Connected(sp.NA())
+		err := s.addrManager.Connected(sp.NA())
+		if err != nil {
+			srvrLog.Debugf("Marking address as connected failed: %v", err)
+		}
 	}
 
 	// If we get here it means that either we didn't know about the peer
@@ -2166,7 +2175,10 @@ func (s *server) outboundPeerConnected(c *connmgr.ConnReq, conn net.Conn) {
 	sp.isWhitelisted = isWhitelisted(conn.RemoteAddr())
 	sp.AssociateConnection(conn)
 	go s.peerDoneHandler(sp)
-	s.addrManager.Attempt(sp.NA())
+	err = s.addrManager.Attempt(sp.NA())
+	if err != nil {
+		srvrLog.Debugf("Marking address as attempted failed: %v", err)
+	}
 }
 
 // peerDoneHandler handles peer disconnects by notifying the server that it's

--- a/server.go
+++ b/server.go
@@ -190,8 +190,8 @@ type relayMsg struct {
 // naSubmission represents a network address submission from an outbound peer.
 type naSubmission struct {
 	na           *wire.NetAddress
-	netType      addrmgr.NetworkAddress
-	reach        int
+	netType      addrmgr.NetAddressType
+	reach        addrmgr.NetAddressReach
 	score        uint32
 	lastAccessed int64
 }
@@ -277,7 +277,7 @@ func (sc *naSubmissionCache) incrementScore(key string) error {
 
 // bestSubmission fetches the best scoring submission of the provided
 // network interface.
-func (sc *naSubmissionCache) bestSubmission(net addrmgr.NetworkAddress) *naSubmission {
+func (sc *naSubmissionCache) bestSubmission(net addrmgr.NetAddressType) *naSubmission {
 	sc.mtx.Lock()
 	defer sc.mtx.Unlock()
 
@@ -361,7 +361,7 @@ func (ps *peerState) forAllPeers(closure func(sp *serverPeer)) {
 // ResolveLocalAddress picks the best suggested network address from available
 // options, per the network interface key provided. The best suggestion, if
 // found, is added as a local address.
-func (ps *peerState) ResolveLocalAddress(netType addrmgr.NetworkAddress, addrMgr *addrmgr.AddrManager, services wire.ServiceFlag) {
+func (ps *peerState) ResolveLocalAddress(netType addrmgr.NetAddressType, addrMgr *addrmgr.AddrManager, services wire.ServiceFlag) {
 	best := ps.subCache.bestSubmission(netType)
 	if best == nil {
 		return

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"reflect"
+	"testing"
+
+	"github.com/decred/dcrd/addrmgr/v2"
+	"github.com/decred/dcrd/wire"
+)
+
+// TestHostToNetAddress ensures that HostToNetAddress behaves as expected
+// given valid and invalid host name arguments.
+func TestHostToNetAddress(t *testing.T) {
+	// Define a hostname that will cause a lookup to be performed using the
+	// lookupFunc provided to the address manager instance for each test.
+	const hostnameForLookup = "hostname.test"
+	const services = wire.SFNodeNetwork
+	const addrmgrServices = addrmgr.ServiceFlag(services)
+
+	tests := []struct {
+		name       string
+		host       string
+		port       uint16
+		lookupFunc func(host string) ([]net.IP, error)
+		wantErr    bool
+		want       *addrmgr.NetAddress
+	}{
+		{
+			name:       "valid onion address",
+			host:       "a5ccbdkubbr2jlcp.onion",
+			port:       8333,
+			lookupFunc: nil,
+			wantErr:    false,
+			want: addrmgr.NewNetAddress(
+				net.ParseIP("fd87:d87e:eb43:744:208d:5408:63a4:ac4f"), 8333,
+				addrmgrServices),
+		},
+		{
+			name:       "invalid onion address",
+			host:       "0000000000000000.onion",
+			port:       8333,
+			lookupFunc: nil,
+			wantErr:    true,
+			want:       nil,
+		},
+		{
+			name: "unresolvable host name",
+			host: hostnameForLookup,
+			port: 8333,
+			lookupFunc: func(host string) ([]net.IP, error) {
+				return nil, fmt.Errorf("unresolvable host %v", host)
+			},
+			wantErr: true,
+			want:    nil,
+		},
+		{
+			name: "not resolved host name",
+			host: hostnameForLookup,
+			port: 8333,
+			lookupFunc: func(host string) ([]net.IP, error) {
+				return nil, nil
+			},
+			wantErr: true,
+			want:    nil,
+		},
+		{
+			name: "resolved host name",
+			host: hostnameForLookup,
+			port: 8333,
+			lookupFunc: func(host string) ([]net.IP, error) {
+				return []net.IP{net.ParseIP("127.0.0.1")}, nil
+			},
+			wantErr: false,
+			want: addrmgr.NewNetAddress(net.ParseIP("127.0.0.1"), 8333,
+				addrmgrServices),
+		},
+		{
+			name:       "valid ip address",
+			host:       "12.1.2.3",
+			port:       8333,
+			lookupFunc: nil,
+			wantErr:    false,
+			want: addrmgr.NewNetAddress(net.ParseIP("12.1.2.3"), 8333,
+				addrmgrServices),
+		},
+	}
+
+	for _, test := range tests {
+		cfg := &config{
+			lookup:      test.lookupFunc,
+			onionlookup: test.lookupFunc,
+		}
+		result, err := cfg.hostToNetAddress(test.host, test.port, services)
+		if test.wantErr == true && err == nil {
+			t.Errorf("%q: expected error but one was not returned", test.name)
+		}
+		if !reflect.DeepEqual(result, test.want) {
+			t.Errorf("%q: unexpected result -- got %v, want %v", test.name,
+				result, test.want)
+		}
+	}
+}

--- a/wire/common.go
+++ b/wire/common.go
@@ -277,7 +277,7 @@ func readElement(r io.Reader, element interface{}) error {
 		*e = int64Time(time.Unix(int64(rv), 0))
 		return nil
 
-	// Message header checksum.
+	// Message header checksum or IPv4 address.
 	case *[4]byte:
 		_, err := io.ReadFull(r, e[:])
 		if err != nil {
@@ -286,6 +286,13 @@ func readElement(r io.Reader, element interface{}) error {
 		return nil
 
 	case *[6]byte:
+		_, err := io.ReadFull(r, e[:])
+		if err != nil {
+			return err
+		}
+		return nil
+
+	case *[10]byte:
 		_, err := io.ReadFull(r, e[:])
 		if err != nil {
 			return err
@@ -417,8 +424,15 @@ func writeElement(w io.Writer, element interface{}) error {
 		}
 		return nil
 
-	// Message header checksum.
+		// Message header checksum or IPv4 address.
 	case [4]byte:
+		_, err := w.Write(e[:])
+		if err != nil {
+			return err
+		}
+		return nil
+
+	case [10]byte:
 		_, err := w.Write(e[:])
 		if err != nil {
 			return err

--- a/wire/error.go
+++ b/wire/error.go
@@ -48,6 +48,9 @@ const (
 	// is received.
 	ErrPayloadChecksum
 
+	// ErrTooFewAddrs is returned when an address list has zero addresses.
+	ErrTooFewAddrs
+
 	// ErrTooManyAddrs is returned when an address list exceeds the maximum
 	// allowed.
 	ErrTooManyAddrs

--- a/wire/go.mod
+++ b/wire/go.mod
@@ -4,5 +4,8 @@ go 1.13
 
 require (
 	github.com/davecgh/go-spew v1.1.1
+	github.com/decred/dcrd/addrmgr/v2 v2.0.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 )
+
+replace github.com/decred/dcrd/addrmgr/v2 => ../addrmgr

--- a/wire/go.sum
+++ b/wire/go.sum
@@ -4,3 +4,5 @@ github.com/decred/dcrd/chaincfg/chainhash v1.0.2 h1:rt5Vlq/jM3ZawwiacWjPa+smINyL
 github.com/decred/dcrd/chaincfg/chainhash v1.0.2/go.mod h1:BpbrGgrPTr3YJYRN3Bm+D9NuaFd+zGyNeIKgrhCXK60=
 github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
+github.com/decred/slog v1.1.0 h1:uz5ZFfmaexj1rEDgZvzQ7wjGkoSPjw2LCh8K+K1VrW4=
+github.com/decred/slog v1.1.0/go.mod h1:kVXlGnt6DHy2fV5OjSeuvCJ0OmlmTF6LFpEPMu/fOY0=

--- a/wire/message.go
+++ b/wire/message.go
@@ -30,6 +30,8 @@ const MaxMessagePayload = (1024 * 1024 * 32) // 32MB
 const (
 	CmdVersion        = "version"
 	CmdVerAck         = "verack"
+	CmdGetAddrV2      = "getaddrv2"
+	CmdAddrV2         = "addrv2"
 	CmdGetAddr        = "getaddr"
 	CmdAddr           = "addr"
 	CmdGetBlocks      = "getblocks"
@@ -83,6 +85,12 @@ func makeEmptyMessage(command string) (Message, error) {
 
 	case CmdVerAck:
 		msg = &MsgVerAck{}
+
+	case CmdGetAddrV2:
+		msg = &MsgGetAddrV2{}
+
+	case CmdAddrV2:
+		msg = &MsgAddrV2{}
 
 	case CmdGetAddr:
 		msg = &MsgGetAddr{}

--- a/wire/message_test.go
+++ b/wire/message_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/decred/dcrd/addrmgr/v2"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 )
 
@@ -57,6 +58,11 @@ func TestMessage(t *testing.T) {
 	msgVersion := NewMsgVersion(me, you, 123123, 0)
 
 	msgVerack := NewMsgVerAck()
+	msgGetAddrV2 := NewMsgGetAddrV2()
+	msgAddrV2 := NewMsgAddrV2()
+	ipv4Addr := addrmgr.NewNetAddress(net.ParseIP("127.0.0.1"), 8333,
+		addrmgr.ServiceFlag(SFNodeNetwork))
+	msgAddrV2.AddAddress(ipv4Addr)
 	msgGetAddr := NewMsgGetAddr()
 	msgAddr := NewMsgAddr()
 	msgGetBlocks := NewMsgGetBlocks(&chainhash.Hash{})
@@ -90,8 +96,10 @@ func TestMessage(t *testing.T) {
 	}{
 		{msgVersion, msgVersion, pver, MainNet, 125},
 		{msgVerack, msgVerack, pver, MainNet, 24},
-		{msgGetAddr, msgGetAddr, pver, MainNet, 24},
-		{msgAddr, msgAddr, pver, MainNet, 25},
+		{msgGetAddrV2, msgGetAddrV2, pver, MainNet, 24},
+		{msgAddrV2, msgAddrV2, pver, MainNet, 48},
+		{msgGetAddr, msgGetAddr, AddrV2Version - 1, MainNet, 24},
+		{msgAddr, msgAddr, AddrV2Version - 1, MainNet, 25},
 		{msgGetBlocks, msgGetBlocks, pver, MainNet, 61},
 		{msgBlock, msgBlock, pver, MainNet, 522},
 		{msgInv, msgInv, pver, MainNet, 25},
@@ -287,7 +295,7 @@ func TestReadMessageWireErrors(t *testing.T) {
 		// Exceed max allowed payload for a message of a specific type.  [5]
 		{
 			exceedTypePayloadBytes,
-			pver,
+			AddrV2Version - 1,
 			dcrnet,
 			len(exceedTypePayloadBytes),
 			&MessageError{},
@@ -317,7 +325,7 @@ func TestReadMessageWireErrors(t *testing.T) {
 		// Message with a valid header, but wrong format. [8]
 		{
 			badMessageBytes,
-			pver,
+			AddrV2Version - 1,
 			dcrnet,
 			len(badMessageBytes),
 			&MessageError{},

--- a/wire/msgaddr.go
+++ b/wire/msgaddr.go
@@ -60,6 +60,12 @@ func (msg *MsgAddr) ClearAddresses() {
 // This is part of the Message interface implementation.
 func (msg *MsgAddr) BtcDecode(r io.Reader, pver uint32) error {
 	const op = "MsgAddr.BtcDecode"
+	if pver >= AddrV2Version {
+		msg := fmt.Sprintf("%s message invalid for protocol version %d",
+			msg.Command(), pver)
+		return messageError(op, ErrMsgInvalidForPVer, msg)
+	}
+
 	count, err := ReadVarInt(r, pver)
 	if err != nil {
 		return err
@@ -89,6 +95,12 @@ func (msg *MsgAddr) BtcDecode(r io.Reader, pver uint32) error {
 // This is part of the Message interface implementation.
 func (msg *MsgAddr) BtcEncode(w io.Writer, pver uint32) error {
 	const op = "MsgAddr.BtcEncode"
+	if pver >= AddrV2Version {
+		msg := fmt.Sprintf("%s message invalid for protocol version %d",
+			msg.Command(), pver)
+		return messageError(op, ErrMsgInvalidForPVer, msg)
+	}
+
 	// Protocol versions before MultipleAddressVersion only allowed 1 address
 	// per message.
 	count := len(msg.AddrList)
@@ -122,6 +134,9 @@ func (msg *MsgAddr) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgAddr) MaxPayloadLength(pver uint32) uint32 {
+	if pver >= AddrV2Version {
+		return 0
+	}
 	// Num addresses (size of varInt for max address per message) + max allowed
 	// addresses * max address size.
 	return uint32(VarIntSerializeSize(MaxAddrPerMsg)) +

--- a/wire/msgaddrv2.go
+++ b/wire/msgaddrv2.go
@@ -1,0 +1,293 @@
+// Copyright (c) 2013-2015 The btcsuite developers
+// Copyright (c) 2015-2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"time"
+
+	"github.com/decred/dcrd/addrmgr/v2"
+)
+
+// MaxAddrPerV2Msg is the maximum number of addresses that can be in a single
+// Decred addrv2 message (MsgAddrV2).
+const MaxAddrPerV2Msg = 1000
+
+// MsgAddrV2 implements the Message interface and represents a wire
+// addrv2 message.  It is used to provide a list of known active peers on the
+// network.  An active peer is considered one that has transmitted a message
+// within the last 3 hours.  Nodes which have not transmitted in that time
+// frame should be forgotten.  Each message is limited to a maximum number of
+// addresses, which is currently 1000.  As a result, multiple messages must
+// be used to relay the full list.
+//
+// Use the AddAddress function to build up the list of known addresses when
+// sending an addrv2 message to another peer.
+type MsgAddrV2 struct {
+	AddrList []*addrmgr.NetAddress
+}
+
+// AddAddress adds a known active peer to the message.
+func (msg *MsgAddrV2) AddAddress(na *addrmgr.NetAddress) error {
+	const op = "MsgAddrV2.AddAddress"
+	if len(msg.AddrList)+1 > MaxAddrPerV2Msg {
+		msg := fmt.Sprintf("too many addresses in message [max %v]", MaxAddrPerV2Msg)
+		return messageError(op, ErrTooManyAddrs, msg)
+	}
+
+	msg.AddrList = append(msg.AddrList, na)
+	return nil
+}
+
+// AddAddresses adds multiple known active peers to the message.
+func (msg *MsgAddrV2) AddAddresses(netAddrs ...*addrmgr.NetAddress) error {
+	for _, na := range netAddrs {
+		err := msg.AddAddress(na)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ClearAddresses removes all addresses from the message.
+func (msg *MsgAddrV2) ClearAddresses() {
+	msg.AddrList = []*addrmgr.NetAddress{}
+}
+
+// readAddrmgrNetAddress reads an encoded addrmgr.NetAddress from r depending on
+// the protocol version.
+func readAddrmgrNetAddress(op string, r io.Reader, pver uint32) (*addrmgr.NetAddress, error) {
+	type netAddress struct {
+		Timestamp time.Time
+		Services  ServiceFlag
+		Port      uint16
+		Type      addrmgr.NetAddressType
+	}
+	na := &netAddress{}
+
+	err := readElement(r, (*int64Time)(&na.Timestamp))
+	if err != nil {
+		return nil, err
+	}
+
+	// Read the service flags out.
+	err = readElement(r, &na.Services)
+	if err != nil {
+		return nil, err
+	}
+
+	// Read the network id to determine the expected length of the ip field.
+	err = readElement(r, &na.Type)
+	if err != nil {
+		return nil, err
+	}
+
+	// Read the ip bytes with a length varying by the network id type.
+	var ipBytes []byte
+	switch na.Type {
+	case addrmgr.IPv4Address:
+		var ip [4]byte
+		err := readElement(r, &ip)
+		if err != nil {
+			return nil, err
+		}
+		ipBytes = ip[:]
+
+	case addrmgr.TORv2Address:
+		var ip [10]byte
+		err := readElement(r, &ip)
+		if err != nil {
+			return nil, err
+		}
+		ipBytes = ip[:]
+	case addrmgr.IPv6Address:
+		var ip [16]byte
+		err := readElement(r, &ip)
+		if err != nil {
+			return nil, err
+		}
+		ipBytes = ip[:]
+	default:
+		msg := fmt.Sprintf("unsupported network address type %v", na.Type)
+		return nil, messageError(op, ErrInvalidMsg, msg)
+	}
+
+	err = readElement(r, &na.Port)
+	if err != nil {
+		return nil, err
+	}
+
+	return addrmgr.NewNetAddressByType(na.Type, ipBytes, na.Port,
+		na.Timestamp, addrmgr.ServiceFlag(na.Services))
+}
+
+// writeAddrmgrNetAddress serializes an address manager network address to w
+// depending on the protocol version.
+func writeAddrmgrNetAddress(op string, w io.Writer, pver uint32, na *addrmgr.NetAddress) error {
+	err := writeElement(w, na.Timestamp.Unix())
+	if err != nil {
+		return err
+	}
+
+	err = writeElements(w, na.Services, na.Type)
+	if err != nil {
+		return err
+	}
+
+	netAddrIP := na.IP
+	switch na.Type {
+	case addrmgr.IPv4Address:
+		var ip [4]byte
+		if netAddrIP != nil {
+			copy(ip[:], netAddrIP)
+		}
+		err = writeElement(w, ip)
+		if err != nil {
+			return err
+		}
+	case addrmgr.TORv2Address:
+		var ip [10]byte
+		if netAddrIP != nil {
+			pubkey := netAddrIP[6:]
+			copy(ip[:], pubkey)
+		}
+		err = writeElement(w, ip)
+		if err != nil {
+			return err
+		}
+	case addrmgr.IPv6Address:
+		var ip [16]byte
+		if netAddrIP != nil {
+			copy(ip[:], net.IP(netAddrIP).To16())
+		}
+		err = writeElement(w, ip)
+		if err != nil {
+			return err
+		}
+	default:
+		msg := fmt.Sprintf("unrecognized network address type %v", na.Type)
+		return messageError(op, ErrInvalidMsg, msg)
+	}
+
+	return writeElement(w, na.Port)
+}
+
+// maxNetAddressPayloadV2 returns the max payload size for an address manager
+// network address based on the protocol version.
+func maxNetAddressPayloadV2(pver uint32) uint32 {
+	const timestampSize = 8
+	const servicesSize = 8
+	const addressTypeSize = 1
+	const maxAddressSize = 16
+	const portSize = 2
+	return timestampSize + servicesSize + addressTypeSize + maxAddressSize +
+		portSize
+}
+
+// BtcDecode decodes r using the wire protocol encoding into the receiver.
+// This is part of the Message interface implementation.
+func (msg *MsgAddrV2) BtcDecode(r io.Reader, pver uint32) error {
+	const op = "MsgAddrV2.BtcDecode"
+
+	// Ensure peers sending msgaddrv2 are on the expected minimum version.
+	if pver < AddrV2Version {
+		msg := fmt.Sprintf("%s message invalid for protocol version %d",
+			msg.Command(), pver)
+		return messageError(op, ErrMsgInvalidForPVer, msg)
+	}
+
+	// Read the total number of addresses in this message.
+	count, err := ReadVarInt(r, pver)
+	if err != nil {
+		return err
+	}
+
+	if count == 0 {
+		return messageError(op, ErrTooFewAddrs,
+			"no addresses for message [count 0, min 1]")
+	}
+
+	// Limit to max addresses per message.
+	if count > MaxAddrPerV2Msg {
+		msg := fmt.Sprintf("too many addresses for message [count %v, max %v]",
+			count, MaxAddrPerV2Msg)
+		return messageError(op, ErrTooManyAddrs, msg)
+	}
+
+	msg.AddrList = make([]*addrmgr.NetAddress, 0, count)
+
+	for i := uint64(0); i < count; i++ {
+		netAddr, err := readAddrmgrNetAddress(op, r, pver)
+		if err != nil {
+			return err
+		}
+		msg.AddAddress(netAddr)
+	}
+	return nil
+}
+
+// BtcEncode encodes the receiver to w using the wire protocol encoding.
+// This is part of the Message interface implementation.
+func (msg *MsgAddrV2) BtcEncode(w io.Writer, pver uint32) error {
+	const op = "MsgAddrV2.BtcEncode"
+	if pver < AddrV2Version {
+		msg := fmt.Sprintf("%s message invalid for protocol version %d",
+			msg.Command(), pver)
+		return messageError(op, ErrMsgInvalidForPVer, msg)
+	}
+
+	count := len(msg.AddrList)
+	if count > MaxAddrPerV2Msg {
+		msg := fmt.Sprintf("too many addresses for message [count %v, max %v]",
+			count, MaxAddrPerV2Msg)
+		return messageError(op, ErrTooManyAddrs, msg)
+	}
+
+	if count == 0 {
+		return messageError(op, ErrTooFewAddrs,
+			"no addresses for message [count 0, min 1]")
+	}
+
+	err := WriteVarInt(w, pver, uint64(count))
+	if err != nil {
+		return err
+	}
+
+	for _, na := range msg.AddrList {
+		err = writeAddrmgrNetAddress(op, w, pver, na)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Command returns the protocol command string for the message.  This is part
+// of the Message interface implementation.
+func (msg *MsgAddrV2) Command() string {
+	return CmdAddrV2
+}
+
+// MaxPayloadLength returns the maximum length the payload can be for the
+// receiver.  This is part of the Message interface implementation.
+func (msg *MsgAddrV2) MaxPayloadLength(pver uint32) uint32 {
+	// Num addresses (size of varInt for max address per message) + max allowed
+	// addresses * max address size.
+	return uint32(VarIntSerializeSize(MaxAddrPerV2Msg)) +
+		(MaxAddrPerV2Msg * maxNetAddressPayloadV2(pver))
+}
+
+// NewMsgAddrV2 returns a new wire addrv2 message that conforms to the
+// Message interface.  See MsgAddr for details.
+func NewMsgAddrV2() *MsgAddrV2 {
+	return &MsgAddrV2{
+		AddrList: make([]*addrmgr.NetAddress, 0, MaxAddrPerV2Msg),
+	}
+}

--- a/wire/msgaddrv2_test.go
+++ b/wire/msgaddrv2_test.go
@@ -1,0 +1,284 @@
+// Copyright (c) 2013-2016 The btcsuite developers
+// Copyright (c) 2015-2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/decred/dcrd/addrmgr/v2"
+)
+
+// TestAddrV2 tests the MsgAddrV2 API.
+func TestAddrV2(t *testing.T) {
+	pver := ProtocolVersion
+
+	// Ensure the command is expected value.
+	wantCmd := "addrv2"
+	msg := NewMsgAddrV2()
+	if cmd := msg.Command(); cmd != wantCmd {
+		t.Errorf("NewMsgAddrV2: wrong command - got %v want %v",
+			cmd, wantCmd)
+	}
+
+	// Ensure max payload is expected value for latest protocol version.
+	wantPayload := uint32(35003)
+	maxPayload := msg.MaxPayloadLength(pver)
+	if maxPayload != wantPayload {
+		t.Errorf("MaxPayloadLength: wrong max payload length for "+
+			"protocol version %d - got %v, want %v", pver,
+			maxPayload, wantPayload)
+	}
+
+	// Ensure max payload length is not more than MaxMessagePayload.
+	if maxPayload > MaxMessagePayload {
+		t.Fatalf("MaxPayloadLength: payload length (%v) for protocol "+
+			"version %d exceeds MaxMessagePayload (%v).", maxPayload, pver,
+			MaxMessagePayload)
+	}
+
+	// Ensure NetAddresses are added properly.
+	na := addrmgr.NewNetAddress(net.ParseIP("127.0.0.1"), 8333,
+		addrmgr.ServiceFlag(SFNodeNetwork))
+	err := msg.AddAddress(na)
+	if err != nil {
+		t.Errorf("AddAddress: %v", err)
+	}
+	if msg.AddrList[0] != na {
+		t.Errorf("AddAddress: wrong address added - got %v, want %v",
+			spew.Sprint(msg.AddrList[0]), spew.Sprint(na))
+	}
+
+	// Ensure the address list is cleared properly.
+	msg.ClearAddresses()
+	if len(msg.AddrList) != 0 {
+		t.Errorf("ClearAddresses: address list is not empty - "+
+			"got %v [%v], want %v", len(msg.AddrList),
+			spew.Sprint(msg.AddrList[0]), 0)
+	}
+
+	// Ensure adding more than the max allowed addresses per message returns
+	// error.
+	for i := 0; i < MaxAddrPerMsg+1; i++ {
+		err = msg.AddAddress(na)
+	}
+	if err == nil {
+		t.Errorf("AddAddress: expected error on too many addresses " +
+			"not received")
+	}
+	err = msg.AddAddresses(na)
+	if err == nil {
+		t.Errorf("AddAddresses: expected error on too many addresses " +
+			"not received")
+	}
+}
+
+// newNetAddress is a convenience function for constructing a new network
+// address.
+func newNetAddress(host string, port uint16) *addrmgr.NetAddress {
+	timestamp := time.Unix(0x495fab29, 0) // 2009-01-03 12:15:05 -0600 CST
+	addrType, addrBytes, _ := addrmgr.HostToBytes(host)
+	netAddr, _ := addrmgr.NewNetAddressByType(addrType, addrBytes, port,
+		timestamp, addrmgr.ServiceFlag(SFNodeNetwork))
+	return netAddr
+}
+
+// TestAddrWire tests the MsgAddrV2 wire encode and decode for various numbers
+// of addresses at the latest protocol version.
+func TestAddrV2Wire(t *testing.T) {
+	pver := ProtocolVersion
+	ipv4Address := newNetAddress("127.0.0.1", 8333)
+	ipv6Address := newNetAddress("2620:100::1", 8334)
+	torv2Address := newNetAddress("aaaaaaaaaaaaaaaa.onion", 8335)
+
+	tests := []struct {
+		name      string
+		addrs     []*addrmgr.NetAddress
+		wantBytes []byte
+	}{
+		{
+			name: "latest protocol version with one address",
+			addrs: []*addrmgr.NetAddress{
+				ipv4Address,
+			},
+			wantBytes: []byte{
+				0x01,
+				0x29, 0xab, 0x5f, 0x49, 0x00, 0x00, 0x00, 0x00, // Timestamp
+				0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Services
+				0x01,                   // Address type
+				0x7f, 0x00, 0x00, 0x01, // Address bytes
+				0x8d, 0x20, // Port
+			},
+		},
+		{
+			name: "latest protocol version with multiple addresses",
+			addrs: []*addrmgr.NetAddress{
+				ipv4Address,
+				ipv6Address,
+				torv2Address,
+			},
+			wantBytes: []byte{
+				0x03,
+				// IPv4 address
+				0x29, 0xab, 0x5f, 0x49, 0x00, 0x00, 0x00, 0x00, // Timestamp
+				0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Services
+				0x01,                   // Address type
+				0x7f, 0x00, 0x00, 0x01, // Address bytes
+				0x8d, 0x20, // Port
+				// IPv6 address
+				0x29, 0xab, 0x5f, 0x49, 0x00, 0x00, 0x00, 0x00,
+				0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x02,
+				0x26, 0x20, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+				0x8e, 0x20,
+				// TORv2 address
+				0x29, 0xab, 0x5f, 0x49, 0x00, 0x00, 0x00, 0x00,
+				0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x03,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x8f, 0x20,
+			},
+		},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		subject := NewMsgAddrV2()
+		subject.AddAddresses(test.addrs...)
+
+		// Encode the message to the wire format and ensure it serializes
+		// correctly.
+		var buf bytes.Buffer
+		err := subject.BtcEncode(&buf, pver)
+		if err != nil {
+			t.Errorf("%q: error encoding message - %v", test.name, err)
+			continue
+		}
+		if !reflect.DeepEqual(buf.Bytes(), test.wantBytes) {
+			t.Errorf("%q: mismatched bytes -- got: %s want: %s", test.name,
+				spew.Sdump(buf.Bytes()), spew.Sdump(test.wantBytes))
+			continue
+		}
+
+		// Decode the message from wire format and ensure it deserializes
+		// correctly.
+		var msg MsgAddrV2
+		rbuf := bytes.NewReader(test.wantBytes)
+		err = msg.BtcDecode(rbuf, pver)
+		if err != nil {
+			t.Errorf("%q: error decoding message - %v", test.name, err)
+			continue
+		}
+		if !reflect.DeepEqual(&msg, subject) {
+			t.Errorf("%q: mismatched message - got: %s want: %s", i,
+				spew.Sdump(msg), spew.Sdump(subject))
+			continue
+		}
+	}
+}
+
+// TestAddrWireErrors performs negative tests against wire encode and decode
+// of MsgAddrV2 to confirm error paths work correctly.
+func TestAddrV2WireErrors(t *testing.T) {
+	pver := ProtocolVersion
+	na := newNetAddress("127.0.0.1", 8333)
+	addrs := []*addrmgr.NetAddress{na}
+
+	tests := []struct {
+		name     string
+		addrs    []*addrmgr.NetAddress // Value to encode
+		bytes    []byte                // Wire encoding
+		pver     uint32                // Protocol version for wire encoding
+		ioLimit  int                   // Max size of fixed buffer to induce errors
+		writeErr error                 // Expected write error
+		readErr  error                 // Expected read error
+	}{
+		{
+			name:     "unsupported protocol version",
+			pver:     AddrV2Version - 1,
+			addrs:    addrs,
+			bytes:    []byte{0x01},
+			ioLimit:  1,
+			writeErr: ErrMsgInvalidForPVer,
+			readErr:  ErrMsgInvalidForPVer,
+		},
+		{
+			name:     "zero byte i/o limit",
+			pver:     pver,
+			addrs:    addrs,
+			bytes:    []byte{0x00},
+			ioLimit:  0,
+			writeErr: io.ErrShortWrite,
+			readErr:  io.EOF,
+		},
+		{
+			name:     "one byte i/o limit",
+			pver:     pver,
+			addrs:    addrs,
+			bytes:    []byte{0x01},
+			ioLimit:  1,
+			writeErr: io.ErrShortWrite,
+			readErr:  io.EOF,
+		},
+		{
+			name:     "message with no addresses",
+			pver:     pver,
+			addrs:    nil,
+			bytes:    []byte{0x00},
+			ioLimit:  1,
+			writeErr: ErrTooFewAddrs,
+			readErr:  ErrTooFewAddrs,
+		},
+
+		{
+			name: "message with too many addresses",
+			pver: pver,
+			addrs: func() []*addrmgr.NetAddress {
+				var addrs []*addrmgr.NetAddress
+				for i := 0; i < MaxAddrPerMsg+1; i++ {
+					addrs = append(addrs, na)
+				}
+				return addrs
+			}(),
+			bytes:    []byte{0xfd, 0xe9, 0x03},
+			ioLimit:  3,
+			writeErr: ErrTooManyAddrs,
+			readErr:  ErrTooManyAddrs,
+		},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for _, test := range tests {
+		subject := NewMsgAddrV2()
+		subject.AddrList = test.addrs
+
+		// Encode to wire format.
+		w := newFixedWriter(test.ioLimit)
+		err := subject.BtcEncode(w, test.pver)
+		if !errors.Is(err, test.writeErr) {
+			t.Errorf("%q: wrong error - got: %v, want: %v", test.name, err,
+				test.writeErr)
+			continue
+		}
+
+		// Decode from wire format.
+		var msg MsgAddrV2
+		r := newFixedReader(test.ioLimit, test.bytes)
+		err = msg.BtcDecode(r, test.pver)
+		if !errors.Is(err, test.readErr) {
+			t.Errorf("%q: wrong error - got: %v, want: %v", test.name, err,
+				test.readErr)
+			continue
+		}
+	}
+}

--- a/wire/msggetaddrv2.go
+++ b/wire/msggetaddrv2.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -10,19 +10,19 @@ import (
 	"io"
 )
 
-// MsgGetAddr implements the Message interface and represents a decred
+// MsgGetAddrV2 implements the Message interface and represents a decred
 // getaddr message.  It is used to request a list of known active peers on the
 // network from a peer to help identify potential nodes.  The list is returned
-// via one or more addr messages (MsgAddr).
+// via one or more addrv2 messages (MsgAddrV2).
 //
 // This message has no payload.
-type MsgGetAddr struct{}
+type MsgGetAddrV2 struct{}
 
-// BtcDecode decodes r using the Decred protocol encoding into the receiver.
+// BtcDecode decodes r using the wire protocol encoding into the receiver.
 // This is part of the Message interface implementation.
-func (msg *MsgGetAddr) BtcDecode(r io.Reader, pver uint32) error {
-	const op = "MsgGetAddr.BtcDecode"
-	if pver >= AddrV2Version {
+func (msg *MsgGetAddrV2) BtcDecode(r io.Reader, pver uint32) error {
+	const op = "MsgGetAddrV2.BtcDecode"
+	if pver < AddrV2Version {
 		msg := fmt.Sprintf("%s message invalid for protocol version %d",
 			msg.Command(), pver)
 		return messageError(op, ErrMsgInvalidForPVer, msg)
@@ -31,11 +31,11 @@ func (msg *MsgGetAddr) BtcDecode(r io.Reader, pver uint32) error {
 	return nil
 }
 
-// BtcEncode encodes the receiver to w using the Decred protocol encoding.
+// BtcEncode encodes the receiver to w using the wire protocol encoding.
 // This is part of the Message interface implementation.
-func (msg *MsgGetAddr) BtcEncode(w io.Writer, pver uint32) error {
-	const op = "MsgGetAddr.BtcEncode"
-	if pver >= AddrV2Version {
+func (msg *MsgGetAddrV2) BtcEncode(w io.Writer, pver uint32) error {
+	const op = "MsgGetAddrV2.BtcEncode"
+	if pver < AddrV2Version {
 		msg := fmt.Sprintf("%s message invalid for protocol version %d",
 			msg.Command(), pver)
 		return messageError(op, ErrMsgInvalidForPVer, msg)
@@ -46,18 +46,18 @@ func (msg *MsgGetAddr) BtcEncode(w io.Writer, pver uint32) error {
 
 // Command returns the protocol command string for the message.  This is part
 // of the Message interface implementation.
-func (msg *MsgGetAddr) Command() string {
-	return CmdGetAddr
+func (msg *MsgGetAddrV2) Command() string {
+	return CmdGetAddrV2
 }
 
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
-func (msg *MsgGetAddr) MaxPayloadLength(pver uint32) uint32 {
+func (msg *MsgGetAddrV2) MaxPayloadLength(pver uint32) uint32 {
 	return 0
 }
 
-// NewMsgGetAddr returns a new Decred getaddr message that conforms to the
+// NewMsgGetAddrV2 returns a new Decred getaddr message that conforms to the
 // Message interface.  See MsgGetAddr for details.
-func NewMsgGetAddr() *MsgGetAddr {
-	return &MsgGetAddr{}
+func NewMsgGetAddrV2() *MsgGetAddrV2 {
+	return &MsgGetAddrV2{}
 }

--- a/wire/msggetaddrv2_test.go
+++ b/wire/msggetaddrv2_test.go
@@ -7,58 +7,25 @@ package wire
 
 import (
 	"bytes"
-	"errors"
 	"reflect"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
 )
 
-// TestGetAddrLatest tests the MsgGetAddr API against the latest protocol
-// version to ensure it is no longer valid.
-func TestGetAddrLatest(t *testing.T) {
-	pver := ProtocolVersion
-	msg := NewMsgGetAddr()
-
-	// Ensure max payload is expected value.
-	wantPayload := uint32(0)
-	maxPayload := msg.MaxPayloadLength(pver)
-	if maxPayload != wantPayload {
-		t.Errorf("MaxPayloadLength: wrong max payload length for protocol "+
-			"version %d - got %v, want %v", pver, maxPayload, wantPayload)
-	}
-
-	// Ensure encode fails with the latest protocol version.
-	var buf bytes.Buffer
-	err := msg.BtcEncode(&buf, pver)
-	if !errors.Is(err, ErrMsgInvalidForPVer) {
-		t.Errorf("MsgGetAddr encode unexpected err -- got %v, want %v", err,
-			ErrMsgInvalidForPVer)
-	}
-
-	// Ensure decode fails with the latest protocol version.
-	var readMsg MsgGetAddr
-	err = readMsg.BtcDecode(&buf, pver)
-	if !errors.Is(err, ErrMsgInvalidForPVer) {
-		t.Errorf("MsgGetAddr decode unexpected err -- got %v, want %v", err,
-			ErrMsgInvalidForPVer)
-	}
-}
-
 // TestGetAddr tests the MsgGetAddr API.
-func TestGetAddr(t *testing.T) {
+func TestGetAddrV2(t *testing.T) {
 	pver := ProtocolVersion
 
 	// Ensure the command is expected value.
-	wantCmd := "getaddr"
-	msg := NewMsgGetAddr()
+	wantCmd := "getaddrv2"
+	msg := NewMsgGetAddrV2()
 	if cmd := msg.Command(); cmd != wantCmd {
 		t.Errorf("NewMsgGetAddr: wrong command - got %v want %v",
 			cmd, wantCmd)
 	}
 
 	// Ensure max payload is expected value for latest protocol version.
-	// Num addresses (varInt) + max allowed addresses.
 	wantPayload := uint32(0)
 	maxPayload := msg.MaxPayloadLength(pver)
 	if maxPayload != wantPayload {
@@ -75,10 +42,9 @@ func TestGetAddr(t *testing.T) {
 	}
 }
 
-// TestGetAddrWireLastSupported tests the MsgGetAddr wire encode and decode for
-// the last supported protocol versions.
-func TestGetAddrWireLastSupported(t *testing.T) {
-	const lastSupportedProtocolVersion = AddrV2Version - 1
+// TestGetAddrV2Wire tests the MsgGetAddr wire encode and decode for various
+// protocol versions.
+func TestGetAddrV2Wire(t *testing.T) {
 	msgGetAddr := NewMsgGetAddr()
 	msgGetAddrEncoded := []byte{}
 
@@ -88,12 +54,12 @@ func TestGetAddrWireLastSupported(t *testing.T) {
 		buf  []byte      // Wire encoding
 		pver uint32      // Protocol version for wire encoding
 	}{
-		// Last supported protocol version.
+		// Latest protocol version.
 		{
 			msgGetAddr,
 			msgGetAddr,
 			msgGetAddrEncoded,
-			lastSupportedProtocolVersion,
+			AddrV2Version - 1,
 		},
 	}
 

--- a/wire/protocol.go
+++ b/wire/protocol.go
@@ -17,7 +17,7 @@ const (
 	InitialProcotolVersion uint32 = 1
 
 	// ProtocolVersion is the latest protocol version this package supports.
-	ProtocolVersion uint32 = 9
+	ProtocolVersion uint32 = 10
 
 	// NodeBloomVersion is the protocol version which added the SFNodeBloom
 	// service flag (unused).
@@ -51,6 +51,10 @@ const (
 	// RemoveRejectVersion is the protocol version which removes support for the
 	// reject message.
 	RemoveRejectVersion uint32 = 9
+
+	// AddrV2Version is the protocol version which adds the addrv2 and
+	// getaddrv2 messages.
+	AddrV2Version uint32 = 10
 )
 
 // ServiceFlag identifies services supported by a Decred peer.


### PR DESCRIPTION
This depends on #2596 and the removal of the reject wire message.

This PR modifies the wire protocol by adding two new message types addrv2 and getaddrv2 and bumps the wire protocol version to 10. It also removes the need to perform DNS lookups in the address manager through HostToNetAddress by pushing these calls up the call stack and further decoupling the address manager from its caller. It does not introduce any new network address types and is intended to implement the minimum framework necessary to facilitate easily adding new address types in the future.  The intention of this design is to allow supporting new address types through addrv2 through protocol version bumps moving forward.  Changes that are not transmitted across the peer to peer network should not require version bumps and may be implemented without doing so.

These two new message types are intended to eventually replace their older counterparts, which are getaddr and addr respectively.  A peer sending a getaddrv2 or addrv2 message with a protocol version less than 10 is in violation of the wire protocol and the peer is disconnected. Similarly, peers advertising a protocol version greater than or equal to 10 that send an addr or gettaddr message are in violation of the wire protocol and are disconnected.
    
A getaddrv2 message is similar in structure and purpose to a getaddr message in that it has no payload and functions as a request for a peer to reply with an addrv2 message it has addresses to share. An addrv2 message is similar in structure and function to an addr message with a few key differences:

- Port is now encoded as a little endian value rather than big endian.
- Timestamp is encoded as a 64 bit value rather than a 32 bit value.
- A network address type field is now serialized with each address to indicate the length and type of the address it precedes.
- A message with zero addresses is no longer serializable.
- Addresses are serialized their most compact form, rather than always being encoded into a 16 byte structure.