### PR TITLE
stdaddr: Replace Address method with String

### DIFF
--- a/blockchain/stakeext.go
+++ b/blockchain/stakeext.go
@@ -109,7 +109,7 @@ func (b *BlockChain) TicketsWithAddress(address stdaddr.Address, isTreasuryEnabl
 
 	tickets := sn.LiveTickets()
 
-	encodedAddr := address.Address()
+	encodedAddr := address.String()
 	var ticketsWithAddr []chainhash.Hash
 	err := b.db.View(func(dbTx database.Tx) error {
 		for _, hash := range tickets {
@@ -124,7 +124,7 @@ func (b *BlockChain) TicketsWithAddress(address stdaddr.Address, isTreasuryEnabl
 			if err != nil {
 				return err
 			}
-			if addrs[0].Address() == encodedAddr {
+			if addrs[0].String() == encodedAddr {
 				ticketsWithAddr = append(ticketsWithAddr, hash)
 			}
 		}

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -1192,7 +1192,7 @@ func createVoutList(mtx *wire.MsgTx, chainParams *chaincfg.Params, filterAddrMap
 		passesFilter := len(filterAddrMap) == 0
 		encodedAddrs := make([]string, len(addrs))
 		for j, addr := range addrs {
-			encodedAddr := addr.Address()
+			encodedAddr := addr.String()
 			encodedAddrs[j] = encodedAddr
 
 			// No need to check the map again if the filter already
@@ -1349,7 +1349,7 @@ func handleDecodeScript(_ context.Context, s *Server, cmd interface{}) (interfac
 		if pkHasher, ok := addr.(stdaddr.AddressPubKeyHasher); ok {
 			addr = pkHasher.AddressPubKeyHash()
 		}
-		addresses[i] = addr.Address()
+		addresses[i] = addr.String()
 	}
 
 	// Convert the script itself to a pay-to-script-hash address.
@@ -1368,7 +1368,7 @@ func handleDecodeScript(_ context.Context, s *Server, cmd interface{}) (interfac
 		Addresses: addresses,
 	}
 	if scriptClass != txscript.ScriptHashTy {
-		reply.P2sh = p2sh.Address()
+		reply.P2sh = p2sh.String()
 	}
 	return reply, nil
 }
@@ -3526,7 +3526,7 @@ func handleGetTxOut(_ context.Context, s *Server, cmd interface{}) (interface{},
 		scriptVersion, script, s.cfg.ChainParams, isTreasuryEnabled)
 	addresses := make([]string, len(addrs))
 	for i, addr := range addrs {
-		addresses[i] = addr.Address()
+		addresses[i] = addr.String()
 	}
 
 	txOutReply := &types.GetTxOutResult{
@@ -4244,7 +4244,7 @@ func createVinListPrevOut(s *Server, mtx *wire.MsgTx,
 		// the filter when needed.
 		encodedAddrs := make([]string, len(addrs))
 		for j, addr := range addrs {
-			encodedAddr := addr.Address()
+			encodedAddr := addr.String()
 			encodedAddrs[j] = encodedAddr
 
 			// No need to check the map again if the filter already
@@ -5237,7 +5237,7 @@ func handleValidateAddress(_ context.Context, s *Server, cmd interface{}) (inter
 		return result, nil
 	}
 
-	result.Address = addr.Address()
+	result.Address = addr.String()
 	result.IsValid = true
 	return result, nil
 }
@@ -5348,7 +5348,7 @@ func handleVerifyMessage(_ context.Context, s *Server, cmd interface{}) (interfa
 	}
 
 	// Return boolean if addresses match.
-	return address.Address() == c.Address, nil
+	return address.String() == c.Address, nil
 }
 
 // handleVersion implements the version command.

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -4859,7 +4859,7 @@ func TestHandleGetTxOut(t *testing.T) {
 		scriptVersion, script, defaultChainParams, false)
 	addresses := make([]string, len(addrs))
 	for i, addr := range addrs {
-		addresses[i] = addr.Address()
+		addresses[i] = addr.String()
 	}
 	txOutResultMempool := types.GetTxOutResult{
 		BestBlock:     block432100.BlockHash().String(),

--- a/internal/rpcserver/rpcwebsocket.go
+++ b/internal/rpcserver/rpcwebsocket.go
@@ -358,7 +358,7 @@ func (f *wsClientFilter) addAddress(a stdaddr.Address) {
 		}
 	}
 
-	f.otherAddresses[a.Address()] = struct{}{}
+	f.otherAddresses[a.String()] = struct{}{}
 }
 
 func (f *wsClientFilter) addAddressStr(s string) {
@@ -395,7 +395,7 @@ func (f *wsClientFilter) existsAddress(a stdaddr.Address) bool {
 		}
 	}
 
-	_, ok := f.otherAddresses[a.Address()]
+	_, ok := f.otherAddresses[a.String()]
 	return ok
 }
 

--- a/rpcclient/chain.go
+++ b/rpcclient/chain.go
@@ -630,7 +630,7 @@ func (r *FutureValidateAddressResult) Receive() (*chainjson.ValidateAddressChain
 //
 // See ValidateAddress for the blocking version and more details.
 func (c *Client) ValidateAddressAsync(ctx context.Context, address stdaddr.Address) *FutureValidateAddressResult {
-	addr := address.Address()
+	addr := address.String()
 	cmd := chainjson.NewValidateAddressCmd(addr)
 	return (*FutureValidateAddressResult)(c.sendCmd(ctx, cmd))
 }
@@ -668,7 +668,7 @@ func (r *FutureVerifyMessageResult) Receive() (bool, error) {
 //
 // See VerifyMessage for the blocking version and more details.
 func (c *Client) VerifyMessageAsync(ctx context.Context, address stdaddr.Address, signature, message string) *FutureVerifyMessageResult {
-	addr := address.Address()
+	addr := address.String()
 	cmd := chainjson.NewVerifyMessageCmd(addr, signature, message)
 	return (*FutureVerifyMessageResult)(c.sendCmd(ctx, cmd))
 }

--- a/rpcclient/extensions.go
+++ b/rpcclient/extensions.go
@@ -136,7 +136,7 @@ func (r *FutureExistsAddressResult) Receive() (bool, error) {
 // result of the RPC at some future time by invoking the Receive function on the
 // returned instance.
 func (c *Client) ExistsAddressAsync(ctx context.Context, address stdaddr.Address) *FutureExistsAddressResult {
-	cmd := chainjson.NewExistsAddressCmd(address.Address())
+	cmd := chainjson.NewExistsAddressCmd(address.String())
 	return (*FutureExistsAddressResult)(c.sendCmd(ctx, cmd))
 }
 
@@ -176,7 +176,7 @@ func (r *FutureExistsAddressesResult) Receive() (string, error) {
 func (c *Client) ExistsAddressesAsync(ctx context.Context, addresses []stdaddr.Address) *FutureExistsAddressesResult {
 	addrsStr := make([]string, len(addresses))
 	for i := range addresses {
-		addrsStr[i] = addresses[i].Address()
+		addrsStr[i] = addresses[i].String()
 	}
 
 	cmd := chainjson.NewExistsAddressesCmd(addrsStr)

--- a/rpcclient/notify.go
+++ b/rpcclient/notify.go
@@ -1145,7 +1145,7 @@ func (c *Client) LoadTxFilterAsync(ctx context.Context, reload bool, addresses [
 
 	addrStrs := make([]string, len(addresses))
 	for i, a := range addresses {
-		addrStrs[i] = a.Address()
+		addrStrs[i] = a.String()
 	}
 	outPointObjects := make([]chainjson.OutPoint, len(outPoints))
 	for i := range outPoints {

--- a/rpcclient/rawtransactions.go
+++ b/rpcclient/rawtransactions.go
@@ -204,7 +204,7 @@ func (c *Client) CreateRawTransactionAsync(ctx context.Context, inputs []chainjs
 
 	convertedAmts := make(map[string]float64, len(amounts))
 	for addr, amount := range amounts {
-		convertedAmts[addr.Address()] = amount.ToCoin()
+		convertedAmts[addr.String()] = amount.ToCoin()
 	}
 	cmd := chainjson.NewCreateRawTransactionCmd(inputs, convertedAmts, lockTime, expiry)
 	return (*FutureCreateRawTransactionResult)(c.sendCmd(ctx, cmd))
@@ -273,13 +273,13 @@ func (c *Client) CreateRawSStxAsync(ctx context.Context, inputs []chainjson.SStx
 
 	convertedAmt := make(map[string]int64, len(amount))
 	for addr, amt := range amount {
-		convertedAmt[addr.Address()] = int64(amt)
+		convertedAmt[addr.String()] = int64(amt)
 	}
 	convertedCouts := make([]chainjson.SStxCommitOut, len(couts))
 	for i, cout := range couts {
-		convertedCouts[i].Addr = cout.Addr.Address()
+		convertedCouts[i].Addr = cout.Addr.String()
 		convertedCouts[i].CommitAmt = int64(cout.CommitAmt)
-		convertedCouts[i].ChangeAddr = cout.ChangeAddr.Address()
+		convertedCouts[i].ChangeAddr = cout.ChangeAddr.String()
 		convertedCouts[i].ChangeAmt = int64(cout.ChangeAmt)
 	}
 
@@ -444,7 +444,7 @@ func (c *Client) SearchRawTransactionsAsync(ctx context.Context,
 	address stdaddr.Address, skip, count int, reverse bool,
 	filterAddrs []string) *FutureSearchRawTransactionsResult {
 
-	addr := address.Address()
+	addr := address.String()
 	verbose := dcrjson.Int(0)
 	prevOut := dcrjson.Int(0)
 	cmd := chainjson.NewSearchRawTransactionsCmd(addr, verbose, &skip, &count,
@@ -499,7 +499,7 @@ func (c *Client) SearchRawTransactionsVerboseAsync(ctx context.Context,
 	address stdaddr.Address, skip, count int, includePrevOut bool, reverse bool,
 	filterAddrs *[]string) *FutureSearchRawTransactionsVerboseResult {
 
-	addr := address.Address()
+	addr := address.String()
 	verbose := dcrjson.Int(1)
 	prevOut := dcrjson.Int(0)
 	if includePrevOut {

--- a/txscript/sign.go
+++ b/txscript/sign.go
@@ -403,7 +403,7 @@ sigLoop:
 			// can take one signature per public key so if we
 			// already have one, we can throw this away.
 			if pSig.Verify(hash, pubKey) {
-				aStr := addr.Address()
+				aStr := addr.String()
 				if _, ok := addrToSig[aStr]; !ok {
 					addrToSig[aStr] = sig
 				}
@@ -416,7 +416,7 @@ sigLoop:
 	doneSigs := 0
 	// This assumes that addresses are in the same order as in the script.
 	for _, addr := range addresses {
-		sig, ok := addrToSig[addr.Address()]
+		sig, ok := addrToSig[addr.String()]
 		if !ok {
 			continue
 		}

--- a/txscript/sign_test.go
+++ b/txscript/sign_test.go
@@ -54,7 +54,7 @@ func mkGetKey(keys map[string]addressToKey) KeyDB {
 	}
 	return KeyClosure(func(addr stdaddr.Address) ([]byte,
 		dcrec.SignatureType, bool, error) {
-		a2k, ok := keys[addr.Address()]
+		a2k, ok := keys[addr.String()]
 		if !ok {
 			return nil, 0, false, errors.New("nope 2")
 		}
@@ -71,7 +71,7 @@ func mkGetKeyPub(keys map[string]addressToKey) KeyDB {
 	}
 	return KeyClosure(func(addr stdaddr.Address) ([]byte,
 		dcrec.SignatureType, bool, error) {
-		a2k, ok := keys[addr.Address()]
+		a2k, ok := keys[addr.String()]
 		if !ok {
 			return nil, 0, false, errors.New("nope 2")
 		}
@@ -88,7 +88,7 @@ func mkGetScript(scripts map[string][]byte) ScriptDB {
 	}
 	return ScriptClosure(func(addr stdaddr.Address) ([]byte,
 		error) {
-		script, ok := scripts[addr.Address()]
+		script, ok := scripts[addr.String()]
 		if !ok {
 			return nil, errors.New("nope 4")
 		}
@@ -267,7 +267,7 @@ func TestSignTxOutput(t *testing.T) {
 				// Without treasury agenda.
 				if err := signAndCheck(msg, tx, i, pkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(nil), noTreasury); err != nil {
 					t.Error(err)
 					break
@@ -275,7 +275,7 @@ func TestSignTxOutput(t *testing.T) {
 
 				if err := signBadAndCheck(msg, tx, i, pkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(nil), noTreasury); err == nil {
 					t.Errorf("corrupted signature validated: %s", msg)
 					break
@@ -284,7 +284,7 @@ func TestSignTxOutput(t *testing.T) {
 				// With treasury agenda.
 				if err := signAndCheck(msg, tx, i, pkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(nil), withTreasury); err != nil {
 					t.Error(err)
 					break
@@ -292,7 +292,7 @@ func TestSignTxOutput(t *testing.T) {
 
 				if err := signBadAndCheck(msg, tx, i, pkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(nil), withTreasury); err == nil {
 					t.Errorf("corrupted signature validated: %s", msg)
 					break
@@ -346,7 +346,7 @@ func TestSignTxOutput(t *testing.T) {
 				sigScript, err := SignTxOutput(
 					testingParams, tx, i, pkScript,
 					hashType, mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(nil), nil, noTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s: %v", msg,
@@ -359,7 +359,7 @@ func TestSignTxOutput(t *testing.T) {
 				sigScript, err = SignTxOutput(
 					testingParams, tx, i, pkScript,
 					hashType, mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(nil), sigScript, noTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s a "+
@@ -378,7 +378,7 @@ func TestSignTxOutput(t *testing.T) {
 				sigScript, err = SignTxOutput(
 					testingParams, tx, i, pkScript,
 					hashType, mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(nil), nil, withTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s: %v", msg,
@@ -391,7 +391,7 @@ func TestSignTxOutput(t *testing.T) {
 				sigScript, err = SignTxOutput(
 					testingParams, tx, i, pkScript,
 					hashType, mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(nil), sigScript, withTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s a "+
@@ -453,7 +453,7 @@ func TestSignTxOutput(t *testing.T) {
 				// Without treasury agenda.
 				if err := signAndCheck(msg, tx, i, pkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(nil), noTreasury); err != nil {
 					t.Error(err)
 					break
@@ -461,7 +461,7 @@ func TestSignTxOutput(t *testing.T) {
 
 				if err := signBadAndCheck(msg, tx, i, pkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(nil), noTreasury); err == nil {
 					t.Errorf("corrupted signature validated: %s", msg)
 					break
@@ -470,7 +470,7 @@ func TestSignTxOutput(t *testing.T) {
 				// With treasury agenda.
 				if err := signAndCheck(msg, tx, i, pkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(nil), withTreasury); err != nil {
 					t.Error(err)
 					break
@@ -478,7 +478,7 @@ func TestSignTxOutput(t *testing.T) {
 
 				if err := signBadAndCheck(msg, tx, i, pkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(nil), withTreasury); err == nil {
 					t.Errorf("corrupted signature validated: %s", msg)
 					break
@@ -532,7 +532,7 @@ func TestSignTxOutput(t *testing.T) {
 				sigScript, err := SignTxOutput(testingParams,
 					tx, i, pkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(nil), nil, noTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s: %v", msg,
@@ -545,7 +545,7 @@ func TestSignTxOutput(t *testing.T) {
 				sigScript, err = SignTxOutput(testingParams,
 					tx, i, pkScript,
 					hashType, mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(nil), sigScript, noTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s a "+
@@ -564,7 +564,7 @@ func TestSignTxOutput(t *testing.T) {
 				sigScript, err = SignTxOutput(testingParams,
 					tx, i, pkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(nil), nil, withTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s: %v", msg,
@@ -577,7 +577,7 @@ func TestSignTxOutput(t *testing.T) {
 				sigScript, err = SignTxOutput(testingParams,
 					tx, i, pkScript,
 					hashType, mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(nil), sigScript, withTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s a "+
@@ -620,7 +620,7 @@ func TestSignTxOutput(t *testing.T) {
 			suite := dcrec.STEcdsaSecp256k1
 			if err := signAndCheck(msg, tx, i, pkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address.Address(): {keyDB, suite, true},
+					address.String(): {keyDB, suite, true},
 				}), mkGetScript(nil), noTreasury); err != nil {
 				t.Error(err)
 				break
@@ -628,7 +628,7 @@ func TestSignTxOutput(t *testing.T) {
 
 			if err := signBadAndCheck(msg, tx, i, pkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address.Address(): {keyDB, suite, true},
+					address.String(): {keyDB, suite, true},
 				}), mkGetScript(nil), noTreasury); err == nil {
 				t.Errorf("corrupted signature validated: %s", msg)
 				break
@@ -637,7 +637,7 @@ func TestSignTxOutput(t *testing.T) {
 			// With treasury agenda.
 			if err := signAndCheck(msg, tx, i, pkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address.Address(): {keyDB, suite, true},
+					address.String(): {keyDB, suite, true},
 				}), mkGetScript(nil), withTreasury); err != nil {
 				t.Error(err)
 				break
@@ -645,7 +645,7 @@ func TestSignTxOutput(t *testing.T) {
 
 			if err := signBadAndCheck(msg, tx, i, pkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address.Address(): {keyDB, suite, true},
+					address.String(): {keyDB, suite, true},
 				}), mkGetScript(nil), withTreasury); err == nil {
 				t.Errorf("corrupted signature validated: %s", msg)
 				break
@@ -679,7 +679,7 @@ func TestSignTxOutput(t *testing.T) {
 			suite := dcrec.STEcdsaSecp256k1
 			if err := signAndCheck(msg, tx, i, pkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address.Address(): {keyDB, suite, true},
+					address.String(): {keyDB, suite, true},
 				}), mkGetScript(nil), noTreasury); err != nil {
 				t.Error(err)
 				break
@@ -687,7 +687,7 @@ func TestSignTxOutput(t *testing.T) {
 
 			if err := signBadAndCheck(msg, tx, i, pkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address.Address(): {keyDB, suite, true},
+					address.String(): {keyDB, suite, true},
 				}), mkGetScript(nil), noTreasury); err == nil {
 				t.Errorf("corrupted signature validated: %s", msg)
 				break
@@ -696,7 +696,7 @@ func TestSignTxOutput(t *testing.T) {
 			// With treasury agenda.
 			if err := signAndCheck(msg, tx, i, pkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address.Address(): {keyDB, suite, true},
+					address.String(): {keyDB, suite, true},
 				}), mkGetScript(nil), withTreasury); err != nil {
 				t.Error(err)
 				break
@@ -704,7 +704,7 @@ func TestSignTxOutput(t *testing.T) {
 
 			if err := signBadAndCheck(msg, tx, i, pkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address.Address(): {keyDB, suite, true},
+					address.String(): {keyDB, suite, true},
 				}), mkGetScript(nil), withTreasury); err == nil {
 				t.Errorf("corrupted signature validated: %s", msg)
 				break
@@ -738,7 +738,7 @@ func TestSignTxOutput(t *testing.T) {
 			suite := dcrec.STEcdsaSecp256k1
 			if err := signAndCheck(msg, tx, i, pkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address.Address(): {keyDB, suite, true},
+					address.String(): {keyDB, suite, true},
 				}), mkGetScript(nil), noTreasury); err != nil {
 				t.Error(err)
 				break
@@ -746,7 +746,7 @@ func TestSignTxOutput(t *testing.T) {
 
 			if err := signBadAndCheck(msg, tx, i, pkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address.Address(): {keyDB, suite, true},
+					address.String(): {keyDB, suite, true},
 				}), mkGetScript(nil), noTreasury); err == nil {
 				t.Errorf("corrupted signature validated: %s", msg)
 				break
@@ -755,7 +755,7 @@ func TestSignTxOutput(t *testing.T) {
 			// With treasury agenda.
 			if err := signAndCheck(msg, tx, i, pkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address.Address(): {keyDB, suite, true},
+					address.String(): {keyDB, suite, true},
 				}), mkGetScript(nil), withTreasury); err != nil {
 				t.Error(err)
 				break
@@ -763,7 +763,7 @@ func TestSignTxOutput(t *testing.T) {
 
 			if err := signBadAndCheck(msg, tx, i, pkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address.Address(): {keyDB, suite, true},
+					address.String(): {keyDB, suite, true},
 				}), mkGetScript(nil), withTreasury); err == nil {
 				t.Errorf("corrupted signature validated: %s", msg)
 				break
@@ -798,7 +798,7 @@ func TestSignTxOutput(t *testing.T) {
 			suite := dcrec.STEcdsaSecp256k1
 			if err := signAndCheck(msg, tx, i, pkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address.Address(): {keyDB, suite, true},
+					address.String(): {keyDB, suite, true},
 				}), mkGetScript(nil), noTreasury); err != nil {
 				t.Error(err)
 				break
@@ -806,7 +806,7 @@ func TestSignTxOutput(t *testing.T) {
 
 			if err := signBadAndCheck(msg, tx, i, pkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address.Address(): {keyDB, suite, true},
+					address.String(): {keyDB, suite, true},
 				}), mkGetScript(nil), noTreasury); err == nil {
 				t.Errorf("corrupted signature validated: %s", msg)
 				break
@@ -815,7 +815,7 @@ func TestSignTxOutput(t *testing.T) {
 			// With treasury agenda.
 			if err := signAndCheck(msg, tx, i, pkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address.Address(): {keyDB, suite, true},
+					address.String(): {keyDB, suite, true},
 				}), mkGetScript(nil), withTreasury); err != nil {
 				t.Error(err)
 				break
@@ -823,7 +823,7 @@ func TestSignTxOutput(t *testing.T) {
 
 			if err := signBadAndCheck(msg, tx, i, pkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address.Address(): {keyDB, suite, true},
+					address.String(): {keyDB, suite, true},
 				}), mkGetScript(nil), withTreasury); err == nil {
 				t.Errorf("corrupted signature validated: %s", msg)
 				break
@@ -856,7 +856,7 @@ func TestSignTxOutput(t *testing.T) {
 			suite := dcrec.STEcdsaSecp256k1
 			if err := signAndCheck(msg, tx, i, pkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address.Address(): {keyDB, suite, false},
+					address.String(): {keyDB, suite, false},
 				}), mkGetScript(nil), noTreasury); err != nil {
 				t.Error(err)
 				break
@@ -864,7 +864,7 @@ func TestSignTxOutput(t *testing.T) {
 
 			if err := signBadAndCheck(msg, tx, i, pkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address.Address(): {keyDB, dcrec.STEcdsaSecp256k1, false},
+					address.String(): {keyDB, dcrec.STEcdsaSecp256k1, false},
 				}), mkGetScript(nil), noTreasury); err == nil {
 				t.Errorf("corrupted signature validated: %s", msg)
 				break
@@ -873,7 +873,7 @@ func TestSignTxOutput(t *testing.T) {
 			// With treasury agenda.
 			if err := signAndCheck(msg, tx, i, pkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address.Address(): {keyDB, suite, false},
+					address.String(): {keyDB, suite, false},
 				}), mkGetScript(nil), withTreasury); err != nil {
 				t.Error(err)
 				break
@@ -881,7 +881,7 @@ func TestSignTxOutput(t *testing.T) {
 
 			if err := signBadAndCheck(msg, tx, i, pkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address.Address(): {keyDB, dcrec.STEcdsaSecp256k1, false},
+					address.String(): {keyDB, dcrec.STEcdsaSecp256k1, false},
 				}), mkGetScript(nil), withTreasury); err == nil {
 				t.Errorf("corrupted signature validated: %s", msg)
 				break
@@ -936,7 +936,7 @@ func TestSignTxOutput(t *testing.T) {
 				sigScript, err := SignTxOutput(testingParams,
 					tx, i, pkScript, hashType,
 					mkGetKeyPub(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(nil), nil, noTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s: %v", msg,
@@ -948,7 +948,7 @@ func TestSignTxOutput(t *testing.T) {
 				sigScript, err = SignTxOutput(testingParams,
 					tx, i, pkScript, hashType,
 					mkGetKeyPub(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(nil), sigScript, noTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s a "+
@@ -965,7 +965,7 @@ func TestSignTxOutput(t *testing.T) {
 				sigScript, err = SignTxOutput(testingParams,
 					tx, i, pkScript, hashType,
 					mkGetKeyPub(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(nil), nil, withTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s: %v", msg,
@@ -977,7 +977,7 @@ func TestSignTxOutput(t *testing.T) {
 				sigScript, err = SignTxOutput(testingParams,
 					tx, i, pkScript, hashType,
 					mkGetKeyPub(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(nil), sigScript, withTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s a "+
@@ -1039,7 +1039,7 @@ func TestSignTxOutput(t *testing.T) {
 				// Without treasury agenda.
 				if err := signAndCheck(msg, tx, i, pkScript, hashType,
 					mkGetKeyPub(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(nil), noTreasury); err != nil {
 					t.Error(err)
 					break
@@ -1047,7 +1047,7 @@ func TestSignTxOutput(t *testing.T) {
 
 				if err := signBadAndCheck(msg, tx, i, pkScript, hashType,
 					mkGetKeyPub(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(nil), noTreasury); err == nil {
 					t.Errorf("corrupted signature validated: %s", msg)
 					break
@@ -1056,7 +1056,7 @@ func TestSignTxOutput(t *testing.T) {
 				// With treasury agenda.
 				if err := signAndCheck(msg, tx, i, pkScript, hashType,
 					mkGetKeyPub(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(nil), withTreasury); err != nil {
 					t.Error(err)
 					break
@@ -1064,7 +1064,7 @@ func TestSignTxOutput(t *testing.T) {
 
 				if err := signBadAndCheck(msg, tx, i, pkScript, hashType,
 					mkGetKeyPub(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(nil), withTreasury); err == nil {
 					t.Errorf("corrupted signature validated: %s", msg)
 					break
@@ -1120,7 +1120,7 @@ func TestSignTxOutput(t *testing.T) {
 				sigScript, err := SignTxOutput(testingParams,
 					tx, i, pkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(nil), nil, noTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s: %v", msg,
@@ -1133,7 +1133,7 @@ func TestSignTxOutput(t *testing.T) {
 				sigScript, err = SignTxOutput(testingParams,
 					tx, i, pkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(nil), sigScript, noTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s a "+
@@ -1152,7 +1152,7 @@ func TestSignTxOutput(t *testing.T) {
 				sigScript, err = SignTxOutput(testingParams,
 					tx, i, pkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(nil), nil, withTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s: %v", msg,
@@ -1165,7 +1165,7 @@ func TestSignTxOutput(t *testing.T) {
 				sigScript, err = SignTxOutput(testingParams,
 					tx, i, pkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(nil), sigScript, withTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s a "+
@@ -1238,9 +1238,9 @@ func TestSignTxOutput(t *testing.T) {
 				if err := signAndCheck(msg, tx, i, scriptPkScript,
 					hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(map[string][]byte{
-						scriptAddr.Address(): pkScript,
+						scriptAddr.String(): pkScript,
 					}), noTreasury); err != nil {
 					t.Error(err)
 					break
@@ -1248,7 +1248,7 @@ func TestSignTxOutput(t *testing.T) {
 
 				if err := signBadAndCheck(msg, tx, i, pkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(nil), noTreasury); err == nil {
 					t.Errorf("corrupted signature validated: %s", msg)
 					break
@@ -1258,9 +1258,9 @@ func TestSignTxOutput(t *testing.T) {
 				if err := signAndCheck(msg, tx, i, scriptPkScript,
 					hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(map[string][]byte{
-						scriptAddr.Address(): pkScript,
+						scriptAddr.String(): pkScript,
 					}), withTreasury); err != nil {
 					t.Error(err)
 					break
@@ -1268,7 +1268,7 @@ func TestSignTxOutput(t *testing.T) {
 
 				if err := signBadAndCheck(msg, tx, i, pkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(nil), withTreasury); err == nil {
 					t.Errorf("corrupted signature validated: %s", msg)
 					break
@@ -1331,9 +1331,9 @@ func TestSignTxOutput(t *testing.T) {
 				_, err = SignTxOutput(testingParams, tx, i,
 					scriptPkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(map[string][]byte{
-						scriptAddr.Address(): pkScript}), nil, noTreasury)
+						scriptAddr.String(): pkScript}), nil, noTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s: %v", msg,
 						err)
@@ -1345,9 +1345,9 @@ func TestSignTxOutput(t *testing.T) {
 				sigScript, err := SignTxOutput(testingParams,
 					tx, i, scriptPkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(map[string][]byte{
-						scriptAddr.Address(): pkScript,
+						scriptAddr.String(): pkScript,
 					}), nil, noTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s a "+
@@ -1366,9 +1366,9 @@ func TestSignTxOutput(t *testing.T) {
 				_, err = SignTxOutput(testingParams, tx, i,
 					scriptPkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(map[string][]byte{
-						scriptAddr.Address(): pkScript}), nil, withTreasury)
+						scriptAddr.String(): pkScript}), nil, withTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s: %v", msg,
 						err)
@@ -1380,9 +1380,9 @@ func TestSignTxOutput(t *testing.T) {
 				sigScript, err = SignTxOutput(testingParams,
 					tx, i, scriptPkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(map[string][]byte{
-						scriptAddr.Address(): pkScript,
+						scriptAddr.String(): pkScript,
 					}), nil, withTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s a "+
@@ -1454,9 +1454,9 @@ func TestSignTxOutput(t *testing.T) {
 				if err := signAndCheck(msg, tx, i, scriptPkScript,
 					hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(map[string][]byte{
-						scriptAddr.Address(): pkScript,
+						scriptAddr.String(): pkScript,
 					}), noTreasury); err != nil {
 					t.Error(err)
 					break
@@ -1464,7 +1464,7 @@ func TestSignTxOutput(t *testing.T) {
 
 				if err := signBadAndCheck(msg, tx, i, pkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(nil), noTreasury); err == nil {
 					t.Errorf("corrupted signature validated: %s", msg)
 					break
@@ -1474,9 +1474,9 @@ func TestSignTxOutput(t *testing.T) {
 				if err := signAndCheck(msg, tx, i, scriptPkScript,
 					hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(map[string][]byte{
-						scriptAddr.Address(): pkScript,
+						scriptAddr.String(): pkScript,
 					}), withTreasury); err != nil {
 					t.Error(err)
 					break
@@ -1484,7 +1484,7 @@ func TestSignTxOutput(t *testing.T) {
 
 				if err := signBadAndCheck(msg, tx, i, pkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(nil), withTreasury); err == nil {
 					t.Errorf("corrupted signature validated: %s", msg)
 					break
@@ -1547,9 +1547,9 @@ func TestSignTxOutput(t *testing.T) {
 				_, err = SignTxOutput(testingParams,
 					tx, i, scriptPkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(map[string][]byte{
-						scriptAddr.Address(): pkScript,
+						scriptAddr.String(): pkScript,
 					}), nil, noTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s: %v", msg,
@@ -1562,9 +1562,9 @@ func TestSignTxOutput(t *testing.T) {
 				sigScript, err := SignTxOutput(testingParams,
 					tx, i, scriptPkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(map[string][]byte{
-						scriptAddr.Address(): pkScript,
+						scriptAddr.String(): pkScript,
 					}), nil, noTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s a "+
@@ -1583,9 +1583,9 @@ func TestSignTxOutput(t *testing.T) {
 				_, err = SignTxOutput(testingParams,
 					tx, i, scriptPkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(map[string][]byte{
-						scriptAddr.Address(): pkScript,
+						scriptAddr.String(): pkScript,
 					}), nil, withTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s: %v", msg,
@@ -1598,9 +1598,9 @@ func TestSignTxOutput(t *testing.T) {
 				sigScript, err = SignTxOutput(testingParams,
 					tx, i, scriptPkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(map[string][]byte{
-						scriptAddr.Address(): pkScript,
+						scriptAddr.String(): pkScript,
 					}), nil, withTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s a "+
@@ -1668,16 +1668,16 @@ func TestSignTxOutput(t *testing.T) {
 				if err := signAndCheck(msg, tx, i, scriptPkScript,
 					hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(map[string][]byte{
-						scriptAddr.Address(): pkScript,
+						scriptAddr.String(): pkScript,
 					}), noTreasury); err != nil {
 					t.Error(err)
 				}
 
 				if err := signBadAndCheck(msg, tx, i, pkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(nil), noTreasury); err == nil {
 					t.Errorf("corrupted signature validated: %s", msg)
 					break
@@ -1687,16 +1687,16 @@ func TestSignTxOutput(t *testing.T) {
 				if err := signAndCheck(msg, tx, i, scriptPkScript,
 					hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(map[string][]byte{
-						scriptAddr.Address(): pkScript,
+						scriptAddr.String(): pkScript,
 					}), withTreasury); err != nil {
 					t.Error(err)
 				}
 
 				if err := signBadAndCheck(msg, tx, i, pkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(nil), withTreasury); err == nil {
 					t.Errorf("corrupted signature validated: %s", msg)
 					break
@@ -1755,9 +1755,9 @@ func TestSignTxOutput(t *testing.T) {
 				_, err = SignTxOutput(testingParams,
 					tx, i, scriptPkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(map[string][]byte{
-						scriptAddr.Address(): pkScript,
+						scriptAddr.String(): pkScript,
 					}), nil, noTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s: %v", msg,
@@ -1770,9 +1770,9 @@ func TestSignTxOutput(t *testing.T) {
 				sigScript, err := SignTxOutput(testingParams,
 					tx, i, scriptPkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(map[string][]byte{
-						scriptAddr.Address(): pkScript,
+						scriptAddr.String(): pkScript,
 					}), nil, noTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s a "+
@@ -1791,9 +1791,9 @@ func TestSignTxOutput(t *testing.T) {
 				_, err = SignTxOutput(testingParams,
 					tx, i, scriptPkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(map[string][]byte{
-						scriptAddr.Address(): pkScript,
+						scriptAddr.String(): pkScript,
 					}), nil, withTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s: %v", msg,
@@ -1806,9 +1806,9 @@ func TestSignTxOutput(t *testing.T) {
 				sigScript, err = SignTxOutput(testingParams,
 					tx, i, scriptPkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(map[string][]byte{
-						scriptAddr.Address(): pkScript,
+						scriptAddr.String(): pkScript,
 					}), nil, withTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s a "+
@@ -1877,9 +1877,9 @@ func TestSignTxOutput(t *testing.T) {
 				if err := signAndCheck(msg, tx, i, scriptPkScript,
 					hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(map[string][]byte{
-						scriptAddr.Address(): pkScript,
+						scriptAddr.String(): pkScript,
 					}), noTreasury); err != nil {
 					t.Error(err)
 					break
@@ -1887,7 +1887,7 @@ func TestSignTxOutput(t *testing.T) {
 
 				if err := signBadAndCheck(msg, tx, i, pkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(nil), noTreasury); err == nil {
 					t.Errorf("corrupted signature validated: %s", msg)
 					break
@@ -1897,9 +1897,9 @@ func TestSignTxOutput(t *testing.T) {
 				if err := signAndCheck(msg, tx, i, scriptPkScript,
 					hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(map[string][]byte{
-						scriptAddr.Address(): pkScript,
+						scriptAddr.String(): pkScript,
 					}), withTreasury); err != nil {
 					t.Error(err)
 					break
@@ -1907,7 +1907,7 @@ func TestSignTxOutput(t *testing.T) {
 
 				if err := signBadAndCheck(msg, tx, i, pkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, false},
+						address.String(): {keyDB, suite, false},
 					}), mkGetScript(nil), withTreasury); err == nil {
 					t.Errorf("corrupted signature validated: %s", msg)
 					break
@@ -1967,9 +1967,9 @@ func TestSignTxOutput(t *testing.T) {
 				_, err = SignTxOutput(testingParams,
 					tx, i, scriptPkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(map[string][]byte{
-						scriptAddr.Address(): pkScript,
+						scriptAddr.String(): pkScript,
 					}), nil, noTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s: %v", msg,
@@ -1982,9 +1982,9 @@ func TestSignTxOutput(t *testing.T) {
 				sigScript, err := SignTxOutput(testingParams,
 					tx, i, scriptPkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(map[string][]byte{
-						scriptAddr.Address(): pkScript,
+						scriptAddr.String(): pkScript,
 					}), nil, noTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s a "+
@@ -2003,9 +2003,9 @@ func TestSignTxOutput(t *testing.T) {
 				_, err = SignTxOutput(testingParams,
 					tx, i, scriptPkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(map[string][]byte{
-						scriptAddr.Address(): pkScript,
+						scriptAddr.String(): pkScript,
 					}), nil, withTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s: %v", msg,
@@ -2018,9 +2018,9 @@ func TestSignTxOutput(t *testing.T) {
 				sigScript, err = SignTxOutput(testingParams,
 					tx, i, scriptPkScript, hashType,
 					mkGetKey(map[string]addressToKey{
-						address.Address(): {keyDB, suite, true},
+						address.String(): {keyDB, suite, true},
 					}), mkGetScript(map[string][]byte{
-						scriptAddr.Address(): pkScript,
+						scriptAddr.String(): pkScript,
 					}), nil, withTreasury)
 				if err != nil {
 					t.Errorf("failed to sign output %s a "+
@@ -2094,10 +2094,10 @@ func TestSignTxOutput(t *testing.T) {
 			if err := signAndCheck(msg, tx, i, scriptPkScript,
 				hashType,
 				mkGetKey(map[string]addressToKey{
-					address1.Address(): {keyDB1, suite1, true},
-					address2.Address(): {keyDB2, suite2, true},
+					address1.String(): {keyDB1, suite1, true},
+					address2.String(): {keyDB2, suite2, true},
 				}), mkGetScript(map[string][]byte{
-					scriptAddr.Address(): pkScript,
+					scriptAddr.String(): pkScript,
 				}), noTreasury); err != nil {
 				t.Error(err)
 				break
@@ -2105,8 +2105,8 @@ func TestSignTxOutput(t *testing.T) {
 
 			if err := signBadAndCheck(msg, tx, i, pkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address1.Address(): {keyDB1, suite1, true},
-					address2.Address(): {keyDB2, suite2, true},
+					address1.String(): {keyDB1, suite1, true},
+					address2.String(): {keyDB2, suite2, true},
 				}), mkGetScript(nil), noTreasury); err == nil {
 				t.Errorf("corrupted signature validated: %s", msg)
 				break
@@ -2116,10 +2116,10 @@ func TestSignTxOutput(t *testing.T) {
 			if err := signAndCheck(msg, tx, i, scriptPkScript,
 				hashType,
 				mkGetKey(map[string]addressToKey{
-					address1.Address(): {keyDB1, suite1, true},
-					address2.Address(): {keyDB2, suite2, true},
+					address1.String(): {keyDB1, suite1, true},
+					address2.String(): {keyDB2, suite2, true},
 				}), mkGetScript(map[string][]byte{
-					scriptAddr.Address(): pkScript,
+					scriptAddr.String(): pkScript,
 				}), withTreasury); err != nil {
 				t.Error(err)
 				break
@@ -2127,8 +2127,8 @@ func TestSignTxOutput(t *testing.T) {
 
 			if err := signBadAndCheck(msg, tx, i, pkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address1.Address(): {keyDB1, suite1, true},
-					address2.Address(): {keyDB2, suite2, true},
+					address1.String(): {keyDB1, suite1, true},
+					address2.String(): {keyDB2, suite2, true},
 				}), mkGetScript(nil), withTreasury); err == nil {
 				t.Errorf("corrupted signature validated: %s", msg)
 				break
@@ -2193,9 +2193,9 @@ func TestSignTxOutput(t *testing.T) {
 			sigScript, err := SignTxOutput(testingParams, tx, i,
 				scriptPkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address1.Address(): {keyDB1, suite1, true},
+					address1.String(): {keyDB1, suite1, true},
 				}), mkGetScript(map[string][]byte{
-					scriptAddr.Address(): pkScript,
+					scriptAddr.String(): pkScript,
 				}), nil, noTreasury)
 			if err != nil {
 				t.Errorf("failed to sign output %s: %v", msg,
@@ -2214,9 +2214,9 @@ func TestSignTxOutput(t *testing.T) {
 			sigScript, err = SignTxOutput(testingParams, tx, i,
 				scriptPkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address2.Address(): {keyDB2, suite2, true},
+					address2.String(): {keyDB2, suite2, true},
 				}), mkGetScript(map[string][]byte{
-					scriptAddr.Address(): pkScript,
+					scriptAddr.String(): pkScript,
 				}), sigScript, noTreasury)
 			if err != nil {
 				t.Errorf("failed to sign output %s: %v", msg, err)
@@ -2235,9 +2235,9 @@ func TestSignTxOutput(t *testing.T) {
 			sigScript, err = SignTxOutput(testingParams, tx, i,
 				scriptPkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address1.Address(): {keyDB1, suite1, true},
+					address1.String(): {keyDB1, suite1, true},
 				}), mkGetScript(map[string][]byte{
-					scriptAddr.Address(): pkScript,
+					scriptAddr.String(): pkScript,
 				}), nil, withTreasury)
 			if err != nil {
 				t.Errorf("failed to sign output %s: %v", msg,
@@ -2256,9 +2256,9 @@ func TestSignTxOutput(t *testing.T) {
 			sigScript, err = SignTxOutput(testingParams, tx, i,
 				scriptPkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address2.Address(): {keyDB2, suite2, true},
+					address2.String(): {keyDB2, suite2, true},
 				}), mkGetScript(map[string][]byte{
-					scriptAddr.Address(): pkScript,
+					scriptAddr.String(): pkScript,
 				}), sigScript, withTreasury)
 			if err != nil {
 				t.Errorf("failed to sign output %s: %v", msg, err)
@@ -2335,9 +2335,9 @@ func TestSignTxOutput(t *testing.T) {
 			sigScript, err := SignTxOutput(testingParams, tx, i,
 				scriptPkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address1.Address(): {keyDB1, suite1, true},
+					address1.String(): {keyDB1, suite1, true},
 				}), mkGetScript(map[string][]byte{
-					scriptAddr.Address(): pkScript,
+					scriptAddr.String(): pkScript,
 				}), nil, noTreasury)
 			if err != nil {
 				t.Errorf("failed to sign output %s: %v", msg,
@@ -2356,10 +2356,10 @@ func TestSignTxOutput(t *testing.T) {
 			sigScript, err = SignTxOutput(testingParams, tx, i,
 				scriptPkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address1.Address(): {keyDB1, suite1, true},
-					address2.Address(): {keyDB2, suite2, true},
+					address1.String(): {keyDB1, suite1, true},
+					address2.String(): {keyDB2, suite2, true},
 				}), mkGetScript(map[string][]byte{
-					scriptAddr.Address(): pkScript,
+					scriptAddr.String(): pkScript,
 				}), sigScript, noTreasury)
 			if err != nil {
 				t.Errorf("failed to sign output %s: %v", msg, err)
@@ -2379,9 +2379,9 @@ func TestSignTxOutput(t *testing.T) {
 			sigScript, err = SignTxOutput(testingParams, tx, i,
 				scriptPkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address1.Address(): {keyDB1, suite1, true},
+					address1.String(): {keyDB1, suite1, true},
 				}), mkGetScript(map[string][]byte{
-					scriptAddr.Address(): pkScript,
+					scriptAddr.String(): pkScript,
 				}), nil, withTreasury)
 			if err != nil {
 				t.Errorf("failed to sign output %s: %v", msg,
@@ -2400,10 +2400,10 @@ func TestSignTxOutput(t *testing.T) {
 			sigScript, err = SignTxOutput(testingParams, tx, i,
 				scriptPkScript, hashType,
 				mkGetKey(map[string]addressToKey{
-					address1.Address(): {keyDB1, suite1, true},
-					address2.Address(): {keyDB2, suite2, true},
+					address1.String(): {keyDB1, suite1, true},
+					address2.String(): {keyDB2, suite2, true},
 				}), mkGetScript(map[string][]byte{
-					scriptAddr.Address(): pkScript,
+					scriptAddr.String(): pkScript,
 				}), sigScript, withTreasury)
 			if err != nil {
 				t.Errorf("failed to sign output %s: %v", msg, err)

--- a/txscript/stdaddr/README.md
+++ b/txscript/stdaddr/README.md
@@ -142,7 +142,7 @@ implemented by all supported address types.
 
 Use the `PaymentScript` method to obtain the scripting language version
 associated with the address along with a script to pay a transaction output to
-the address and the `Address` method to get the human-readable string encoding
+the address and the `String` method to get the human-readable string encoding
 of the address.
 
 ### Address Use in the Staking System

--- a/txscript/stdaddr/address.go
+++ b/txscript/stdaddr/address.go
@@ -25,9 +25,9 @@ type AddressParams interface {
 // other kinds of addresses may be added in the future without changing the
 // decoding and encoding API.
 type Address interface {
-	// Address returns the string encoding of the payment address for the
+	// String returns the string encoding of the payment address for the
 	// associated script version and payment script.
-	Address() string
+	String() string
 
 	// PaymentScript returns the script version associated with the address
 	// along with a script to pay a transaction output to the address.

--- a/txscript/stdaddr/address_test.go
+++ b/txscript/stdaddr/address_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/decred/base58"
@@ -1049,7 +1048,7 @@ func TestAddresses(t *testing.T) {
 			}
 
 			// Ensure encoding the address is the same as the original.
-			encoded := addr.Address()
+			encoded := addr.String()
 			if encoded != test.addr {
 				t.Errorf("%s: unexpected address -- got %v, want %v", test.name,
 					encoded, test.addr)
@@ -1207,17 +1206,10 @@ func TestAddresses(t *testing.T) {
 		}
 
 		// Ensure encoding the address is the same as the original.
-		encoded := decodedAddr.Address()
+		encoded := decodedAddr.String()
 		if encoded != test.addr {
 			t.Errorf("%s: decoding and encoding produced different addresses "+
 				"-- got %v, want %v", test.name, encoded, test.addr)
-			continue
-		}
-
-		// Ensure the stringer returns the same address as the original.
-		if ds, ok := decodedAddr.(fmt.Stringer); ok && ds.String() != test.addr {
-			t.Errorf("%s: mismatched decoded stringer -- got %v, want %v",
-				test.name, ds.String(), test.addr)
 			continue
 		}
 
@@ -1258,7 +1250,7 @@ func TestAddresses(t *testing.T) {
 			pkhAddr = a.AddressPubKeyHash()
 		}
 		if pkhAddr != nil {
-			gotAddr := pkhAddr.Address()
+			gotAddr := pkhAddr.String()
 			if gotAddr != wantPkhAddr {
 				t.Errorf("%s: mismatched pkh address -- got %s, want %s",
 					test.name, gotAddr, wantPkhAddr)

--- a/txscript/stdaddr/addressv0.go
+++ b/txscript/stdaddr/addressv0.go
@@ -203,11 +203,11 @@ func NewAddressPubKeyEcdsaSecp256k1V0(pubKey Secp256k1PublicKey,
 	}, nil
 }
 
-// Address returns the string encoding of the payment address for the associated
+// String returns the string encoding of the payment address for the associated
 // script version and payment script.
 //
 // This is part of the Address interface implementation.
-func (addr *AddressPubKeyEcdsaSecp256k1V0) Address() string {
+func (addr *AddressPubKeyEcdsaSecp256k1V0) String() string {
 	// The format for the data portion of a public key address used with
 	// elliptic curves is:
 	//   identifier byte || 32-byte X coordinate
@@ -263,14 +263,6 @@ func (addr *AddressPubKeyEcdsaSecp256k1V0) AddressPubKeyHash() Address {
 // key.  The bytes must not be modified.
 func (addr *AddressPubKeyEcdsaSecp256k1V0) SerializedPubKey() []byte {
 	return addr.serializedPubKey
-}
-
-// String returns a human-readable string for the address.
-//
-// This is equivalent to calling Address, but is provided so the type can be
-// used as a fmt.Stringer.
-func (addr *AddressPubKeyEcdsaSecp256k1V0) String() string {
-	return addr.Address()
 }
 
 // AddressPubKeyEd25519V0 specifies an address that represents a payment
@@ -331,11 +323,11 @@ func NewAddressPubKeyEd25519V0(pubKey Ed25519PublicKey,
 	}, nil
 }
 
-// Address returns the string encoding of the payment address for the associated
+// String returns the string encoding of the payment address for the associated
 // script version and payment script.
 //
 // This is part of the Address interface implementation.
-func (addr *AddressPubKeyEd25519V0) Address() string {
+func (addr *AddressPubKeyEd25519V0) String() string {
 	// The format for the data portion of a public key address used with
 	// elliptic curves is:
 	//   identifier byte || 32-byte X coordinate
@@ -384,14 +376,6 @@ func (addr *AddressPubKeyEd25519V0) AddressPubKeyHash() Address {
 // bytes must not be modified.
 func (addr *AddressPubKeyEd25519V0) SerializedPubKey() []byte {
 	return addr.serializedPubKey
-}
-
-// String returns a human-readable string for the address.
-//
-// This is equivalent to calling Address, but is provided so the type can be
-// used as a fmt.Stringer.
-func (addr *AddressPubKeyEd25519V0) String() string {
-	return addr.Address()
 }
 
 // AddressPubKeySchnorrSecp256k1V0 specifies an address that represents a
@@ -476,11 +460,11 @@ func NewAddressPubKeySchnorrSecp256k1V0(pubKey Secp256k1PublicKey,
 	}, nil
 }
 
-// Address returns the string encoding of the payment address for the associated
+// String returns the string encoding of the payment address for the associated
 // script version and payment script.
 //
 // This is part of the Address interface implementation.
-func (addr *AddressPubKeySchnorrSecp256k1V0) Address() string {
+func (addr *AddressPubKeySchnorrSecp256k1V0) String() string {
 	// The format for the data portion of a public key address used with
 	// elliptic curves is:
 	//   identifier byte || 32-byte X coordinate
@@ -536,14 +520,6 @@ func (addr *AddressPubKeySchnorrSecp256k1V0) SerializedPubKey() []byte {
 	return addr.serializedPubKey
 }
 
-// String returns a human-readable string for the address.
-//
-// This is equivalent to calling Address, but is provided so the type can be
-// used as a fmt.Stringer.
-func (addr *AddressPubKeySchnorrSecp256k1V0) String() string {
-	return addr.Address()
-}
-
 // AddressPubKeyHashEcdsaSecp256k1V0 specifies an address that represents a
 // payment destination which imposes an encumbrance that requires a secp256k1
 // public key that hashes to the given public key hash along with a valid ECDSA
@@ -597,11 +573,11 @@ func NewAddressPubKeyHashEcdsaSecp256k1V0(pkHash []byte,
 	return addr, nil
 }
 
-// Address returns the string encoding of the payment address for the associated
+// String returns the string encoding of the payment address for the associated
 // script version and payment script.
 //
 // This is part of the Address interface implementation.
-func (addr *AddressPubKeyHashEcdsaSecp256k1V0) Address() string {
+func (addr *AddressPubKeyHashEcdsaSecp256k1V0) String() string {
 	// The format for the data portion of addresses that encode 160-bit hashes
 	// is merely the hash itself:
 	//   20-byte ripemd160 hash
@@ -771,14 +747,6 @@ func (addr *AddressPubKeyHashEcdsaSecp256k1V0) Hash160() *[ripemd160.Size]byte {
 	return &addr.hash
 }
 
-// String returns a human-readable string for the address.
-//
-// This is equivalent to calling Address, but is provided so the type can be
-// used as a fmt.Stringer.
-func (addr *AddressPubKeyHashEcdsaSecp256k1V0) String() string {
-	return addr.Address()
-}
-
 // AddressPubKeyHashEd25519V0 specifies an address that represents a a payment
 // destination which imposes an encumbrance that requires an Ed25519 public key
 // that hashes to the given public key hash along with a valid Ed25519 signature
@@ -821,11 +789,11 @@ func NewAddressPubKeyHashEd25519V0(pkHash []byte,
 	return addr, nil
 }
 
-// Address returns the string encoding of the payment address for the associated
+// String returns the string encoding of the payment address for the associated
 // script version and payment script.
 //
 // This is part of the Address interface implementation.
-func (addr *AddressPubKeyHashEd25519V0) Address() string {
+func (addr *AddressPubKeyHashEd25519V0) String() string {
 	// The format for the data portion of addresses that encode 160-bit hashes
 	// is merely the hash itself:
 	//   20-byte ripemd160 hash
@@ -857,14 +825,6 @@ func (addr *AddressPubKeyHashEd25519V0) PaymentScript() (uint16, []byte) {
 // keys).
 func (addr *AddressPubKeyHashEd25519V0) Hash160() *[ripemd160.Size]byte {
 	return &addr.hash
-}
-
-// String returns a human-readable string for the address.
-//
-// This is equivalent to calling Address, but is provided so the type can be
-// used as a fmt.Stringer.
-func (addr *AddressPubKeyHashEd25519V0) String() string {
-	return addr.Address()
 }
 
 // AddressPubKeyHashSchnorrSecp256k1V0 specifies address that represents a
@@ -916,11 +876,11 @@ func NewAddressPubKeyHashSchnorrSecp256k1V0(pkHash []byte,
 	return addr, nil
 }
 
-// Address returns the string encoding of the payment address for the associated
+// String returns the string encoding of the payment address for the associated
 // script version and payment script.
 //
 // This is part of the Address interface implementation.
-func (addr *AddressPubKeyHashSchnorrSecp256k1V0) Address() string {
+func (addr *AddressPubKeyHashSchnorrSecp256k1V0) String() string {
 	// The format for the data portion of addresses that encode 160-bit hashes
 	// is merely the hash itself:
 	//   20-byte ripemd160 hash
@@ -952,14 +912,6 @@ func (addr *AddressPubKeyHashSchnorrSecp256k1V0) PaymentScript() (uint16, []byte
 // keys).
 func (addr *AddressPubKeyHashSchnorrSecp256k1V0) Hash160() *[ripemd160.Size]byte {
 	return &addr.hash
-}
-
-// String returns a human-readable string for the address.
-//
-// This is equivalent to calling Address, but is provided so the type can be
-// used as a fmt.Stringer.
-func (addr *AddressPubKeyHashSchnorrSecp256k1V0) String() string {
-	return addr.Address()
 }
 
 // AddressScriptHashV0 specifies an address that represents a payment
@@ -1024,11 +976,11 @@ func NewAddressScriptHashV0(redeemScript []byte,
 	return NewAddressScriptHashV0FromHash(scriptHash, params)
 }
 
-// Address returns the string encoding of the payment address for the associated
+// String returns the string encoding of the payment address for the associated
 // script version and payment script.
 //
 // This is part of the Address interface implementation.
-func (addr *AddressScriptHashV0) Address() string {
+func (addr *AddressScriptHashV0) String() string {
 	// The format for the data portion of addresses that encode 160-bit hashes
 	// is merely the hash itself:
 	//   20-byte ripemd160 hash
@@ -1173,14 +1125,6 @@ func (addr *AddressScriptHashV0) PayFromTreasuryScript() (uint16, []byte) {
 // is more appropriate than a slice (for example, when used as map keys).
 func (addr *AddressScriptHashV0) Hash160() *[ripemd160.Size]byte {
 	return &addr.hash
-}
-
-// String returns a human-readable string for the address.
-//
-// This is equivalent to calling Address, but is provided so the type can be
-// used as a fmt.Stringer.
-func (addr *AddressScriptHashV0) String() string {
-	return addr.Address()
 }
 
 // DecodeAddressV0 decodes the string encoding of an address and returns the


### PR DESCRIPTION
An address is conceptually a human-readable string encoding of a payment script, so the two methods `String` and `PaymentScript` should be sufficient to provide basic address functionality.  This also avoids some stutter/repetition (e.g. `ma.Address().Address()`) in wallet code, where wrapper types are used around the Address interface, and additionally allows the wrapper types to implement the `stdaddr.Address` interface directly while still providing their own `Address` method to return the underlying interface type.