### PR TITLE
blockchain: Prerel module release ver updates.

### DIFF
--- a/blockchain/go.mod
+++ b/blockchain/go.mod
@@ -3,7 +3,7 @@ module github.com/decred/dcrd/blockchain/v4
 go 1.14
 
 require (
-	github.com/decred/dcrd/blockchain/stake/v4 v4.0.0-20210129192908-660d0518b4cf
+	github.com/decred/dcrd/blockchain/stake/v4 v4.0.0-20210409183916-7f402345f0a6
 	github.com/decred/dcrd/blockchain/standalone/v2 v2.0.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/chaincfg/v3 v3.0.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/decred/base58 v1.0.3
 	github.com/decred/dcrd/addrmgr/v2 v2.0.0
 	github.com/decred/dcrd/bech32 v1.1.1
-	github.com/decred/dcrd/blockchain/stake/v4 v4.0.0-20210129192908-660d0518b4cf
+	github.com/decred/dcrd/blockchain/stake/v4 v4.0.0-20210409183916-7f402345f0a6
 	github.com/decred/dcrd/blockchain/standalone/v2 v2.0.0
 	github.com/decred/dcrd/blockchain/v4 v4.0.0-20210129200153-14fd1a785bf2
 	github.com/decred/dcrd/certgen v1.1.1


### PR DESCRIPTION
This modifies the recently-updated blockchain module to use a valid prerelease version of the blockchain/stake module so it can be used in require statements in consumer code that is also under development.

The updated direct dependencies are as follows:

- github.com/decred/dcrd/blockchain/stake/v4@v4.0.0-20210409183916-7f402345f0a6