### PR TITLE
blockchain: Trsy always inactive for genesis blk.

### DIFF
--- a/blockchain/thresholdstate.go
+++ b/blockchain/thresholdstate.go
@@ -717,6 +717,11 @@ func (b *BlockChain) isTreasuryAgendaActive(prevNode *blockNode) (bool, error) {
 //
 // This function is safe for concurrent access.
 func (b *BlockChain) IsTreasuryAgendaActive(prevHash *chainhash.Hash) (bool, error) {
+	// The treasury agenda is never active for the genesis block.
+	if *prevHash == *zeroHash {
+		return false, nil
+	}
+
 	prevNode := b.index.LookupNode(prevHash)
 	if prevNode == nil || !b.index.CanValidate(prevNode) {
 		return false, unknownBlockError(prevHash)


### PR DESCRIPTION
This modifies the `IsTreasuryAgendaActive` method to return false when a zero hash is provided since that indicates the next block is the genesis block and the treasury agenda is always inactive for the genesis block.

This has the effect of fixing a few RPC handlers, such as `getblock`, when working with the genesis block.

Fixes #2635.