### PR TITLE
txscript: Split signing code to sign subpackage.

### DIFF
--- a/blockchain/chaingen/generator.go
+++ b/blockchain/chaingen/generator.go
@@ -19,6 +19,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/txscript/v4"
+	"github.com/decred/dcrd/txscript/v4/sign"
 	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 )
@@ -620,7 +621,7 @@ func (g *Generator) CreateTreasuryTSpend(privKey []byte, payouts []AddressAmount
 	})
 
 	// Calculate TSpend signature without SigHashType.
-	sigscript, err := txscript.TSpendSignatureScript(msgTx, privKey)
+	sigscript, err := sign.TSpendSignatureScript(msgTx, privKey)
 	if err != nil {
 		panic(err)
 	}

--- a/blockchain/common_test.go
+++ b/blockchain/common_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/lru"
 	"github.com/decred/dcrd/txscript/v4"
+	"github.com/decred/dcrd/txscript/v4/sign"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -345,7 +346,7 @@ func newFakeCreateTSpend(privKey []byte, payouts []dcrutil.Amount, fee dcrutil.A
 	})
 
 	// Calculate TSpend signature without SigHashType.
-	sigscript, err := txscript.TSpendSignatureScript(msgTx, privKey)
+	sigscript, err := sign.TSpendSignatureScript(msgTx, privKey)
 	if err != nil {
 		panic(err)
 	}

--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -20,6 +20,7 @@ import (
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/txscript/v4"
+	"github.com/decred/dcrd/txscript/v4/sign"
 	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 )
@@ -1561,9 +1562,8 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 			// associated p2sh output in bshso0.
 			spend := chaingen.MakeSpendableOut(bshso0, uint32(i+2), 2)
 			tx := g.CreateSpendTx(&spend, lowFee)
-			sig, err := txscript.RawTxInSignature(tx, 0,
-				redeemScript, txscript.SigHashAll, privKeyBytes,
-				dcrec.STEcdsaSecp256k1)
+			sig, err := sign.RawTxInSignature(tx, 0, redeemScript,
+				txscript.SigHashAll, privKeyBytes, dcrec.STEcdsaSecp256k1)
 			if err != nil {
 				panic(err)
 			}
@@ -1597,9 +1597,8 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 			// associated p2sh output in bshso0.
 			spend := chaingen.MakeSpendableOut(bshso0, uint32(i+2), 2)
 			tx := g.CreateSpendTx(&spend, lowFee)
-			sig, err := txscript.RawTxInSignature(tx, 0,
-				redeemScript, txscript.SigHashAll, privKeyBytes,
-				dcrec.STEcdsaSecp256k1)
+			sig, err := sign.RawTxInSignature(tx, 0, redeemScript,
+				txscript.SigHashAll, privKeyBytes, dcrec.STEcdsaSecp256k1)
 			if err != nil {
 				panic(err)
 			}

--- a/blockchain/treasury_test.go
+++ b/blockchain/treasury_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/decred/dcrd/gcs/v3/blockcf2"
 	"github.com/decred/dcrd/lru"
 	"github.com/decred/dcrd/txscript/v4"
+	"github.com/decred/dcrd/txscript/v4/sign"
 	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 )
@@ -2044,18 +2045,18 @@ func TestSpendableTreasuryTxs(t *testing.T) {
 	})
 
 	// Generate the valid signature for the first input, which is a P2PKH.
-	sig, err := txscript.SignatureScript(tx, 0, tspend.TxOut[1].PkScript,
-		txscript.SigHashAll, spendPrivKey.Serialize(),
-		dcrec.STEcdsaSecp256k1, true)
+	sig, err := sign.SignatureScript(tx, 0, tspend.TxOut[1].PkScript,
+		txscript.SigHashAll, spendPrivKey.Serialize(), dcrec.STEcdsaSecp256k1,
+		true)
 	if err != nil {
 		t.Fatalf("unable to generate sig: %v", err)
 	}
 	tx.TxIn[0].SignatureScript = sig
 
 	// Generate the valid signature for the third input, which is a P2PKH.
-	sig, err = txscript.SignatureScript(tx, 2, tadd1.TxOut[1].PkScript,
-		txscript.SigHashAll, addPrivKey.Serialize(),
-		dcrec.STEcdsaSecp256k1, true)
+	sig, err = sign.SignatureScript(tx, 2, tadd1.TxOut[1].PkScript,
+		txscript.SigHashAll, addPrivKey.Serialize(), dcrec.STEcdsaSecp256k1,
+		true)
 	if err != nil {
 		t.Fatalf("unable to generate sig: %v", err)
 	}

--- a/internal/mining/mining_harness_test.go
+++ b/internal/mining/mining_harness_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/txscript/v4"
+	"github.com/decred/dcrd/txscript/v4/sign"
 	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 )
@@ -1003,9 +1004,8 @@ func (m *miningHarness) CreateTxChain(firstOutput spendableOutput, numTxns uint3
 			m.payScript))
 
 		// Sign the new transaction.
-		sigScript, err := txscript.SignatureScript(tx, 0,
-			m.payScript, txscript.SigHashAll, m.signKey,
-			dcrec.STEcdsaSecp256k1, true)
+		sigScript, err := sign.SignatureScript(tx, 0, m.payScript,
+			txscript.SigHashAll, m.signKey, dcrec.STEcdsaSecp256k1, true)
 		if err != nil {
 			return nil, err
 		}
@@ -1076,9 +1076,8 @@ func (m *miningHarness) CreateSignedTx(inputs []spendableOutput, numOutputs uint
 
 	// Sign the new transaction.
 	for i := range tx.TxIn {
-		sigScript, err := txscript.SignatureScript(tx,
-			i, m.payScript, txscript.SigHashAll, m.signKey,
-			dcrec.STEcdsaSecp256k1, true)
+		sigScript, err := sign.SignatureScript(tx, i, m.payScript,
+			txscript.SigHashAll, m.signKey, dcrec.STEcdsaSecp256k1, true)
 		if err != nil {
 			return nil, err
 		}
@@ -1128,9 +1127,9 @@ func (m *miningHarness) CreateTicketPurchase(sourceTx *dcrutil.Tx, cost int64) (
 	tx.AddTxOut(newTxOut(change, changeScriptVer, changeScript))
 
 	// Sign the ticket purchase.
-	sigScript, err := txscript.SignatureScript(tx, 0,
-		sourceTx.MsgTx().TxOut[0].PkScript, txscript.SigHashAll,
-		m.signKey, dcrec.STEcdsaSecp256k1, true)
+	sigScript, err := sign.SignatureScript(tx, 0,
+		sourceTx.MsgTx().TxOut[0].PkScript, txscript.SigHashAll, m.signKey,
+		dcrec.STEcdsaSecp256k1, true)
 	if err != nil {
 		return nil, err
 	}
@@ -1215,7 +1214,7 @@ func (m *miningHarness) CreateVote(ticket *dcrutil.Tx, mungers ...func(*wire.Msg
 	// Sign the input.
 	inputToSign := 1
 	redeemTicketScript := ticket.MsgTx().TxOut[0].PkScript
-	signedScript, err := txscript.SignTxOutput(params, vote, inputToSign,
+	signedScript, err := sign.SignTxOutput(params, vote, inputToSign,
 		redeemTicketScript, txscript.SigHashAll, m, m,
 		vote.TxIn[inputToSign].SignatureScript, m.chain.isTreasuryAgendaActive)
 	if err != nil {

--- a/internal/rpcserver/treasury_test.go
+++ b/internal/rpcserver/treasury_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/decred/dcrd/rpcclient/v7"
 	"github.com/decred/dcrd/rpctest"
 	"github.com/decred/dcrd/txscript/v4"
+	"github.com/decred/dcrd/txscript/v4/sign"
 	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 )
@@ -92,7 +93,7 @@ func createTSpend(privKey []byte, payouts []tspendPayout, fee dcrutil.Amount, ex
 	})
 
 	// Calculate TSpend signature without SigHashType.
-	sigscript, err := txscript.TSpendSignatureScript(msgTx, privKey)
+	sigscript, err := sign.TSpendSignatureScript(msgTx, privKey)
 	if err != nil {
 		panic(err)
 	}
@@ -120,9 +121,8 @@ func createTAdd(t testing.TB, privKey []byte, prevOut *wire.OutPoint, pkScript [
 	}
 	tx.Version = wire.TxVersionTreasury
 
-	sig, err := txscript.SignatureScript(tx, 0, pkScript,
-		txscript.SigHashAll, privKey,
-		dcrec.STEcdsaSecp256k1, true)
+	sig, err := sign.SignatureScript(tx, 0, pkScript, txscript.SigHashAll,
+		privKey, dcrec.STEcdsaSecp256k1, true)
 	if err != nil {
 		t.Fatalf("unable to generate sig: %v", err)
 	}
@@ -473,17 +473,15 @@ func TestTreasury(t *testing.T) {
 	})
 
 	// Generate signatures for the P2PKH inputs.
-	sig, err := txscript.SignatureScript(tx, 0, tspendYes.TxOut[1].PkScript,
-		txscript.SigHashAll, privKey.Serialize(),
-		dcrec.STEcdsaSecp256k1, true)
+	sig, err := sign.SignatureScript(tx, 0, tspendYes.TxOut[1].PkScript,
+		txscript.SigHashAll, privKey.Serialize(), dcrec.STEcdsaSecp256k1, true)
 	if err != nil {
 		t.Fatalf("unable to generate sig: %v", err)
 	}
 	tx.TxIn[0].SignatureScript = sig
 
-	sig, err = txscript.SignatureScript(tx, 2, tadd1.TxOut[1].PkScript,
-		txscript.SigHashAll, privKey.Serialize(),
-		dcrec.STEcdsaSecp256k1, true)
+	sig, err = sign.SignatureScript(tx, 2, tadd1.TxOut[1].PkScript,
+		txscript.SigHashAll, privKey.Serialize(), dcrec.STEcdsaSecp256k1, true)
 	if err != nil {
 		t.Fatalf("unable to generate sig: %v", err)
 	}

--- a/rpctest/memwallet.go
+++ b/rpctest/memwallet.go
@@ -22,6 +22,7 @@ import (
 	"github.com/decred/dcrd/hdkeychain/v3"
 	"github.com/decred/dcrd/rpcclient/v7"
 	"github.com/decred/dcrd/txscript/v4"
+	"github.com/decred/dcrd/txscript/v4/sign"
 	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 )
@@ -529,7 +530,7 @@ func (m *memWallet) CreateTransaction(outputs []*wire.TxOut, feeRate dcrutil.Amo
 			return nil, err
 		}
 
-		sigScript, err := txscript.SignatureScript(tx, i, utxo.pkScript,
+		sigScript, err := sign.SignatureScript(tx, i, utxo.pkScript,
 			txscript.SigHashAll, privKey, dcrec.STEcdsaSecp256k1, true)
 		if err != nil {
 			return nil, err

--- a/rpctest/votingwallet.go
+++ b/rpctest/votingwallet.go
@@ -21,6 +21,7 @@ import (
 	dcrdtypes "github.com/decred/dcrd/rpc/jsonrpc/types/v3"
 	"github.com/decred/dcrd/rpcclient/v7"
 	"github.com/decred/dcrd/txscript/v4"
+	"github.com/decred/dcrd/txscript/v4/sign"
 	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 )
@@ -456,7 +457,7 @@ func (w *VotingWallet) handleBlockConnectedNtfn(ntfn *blockConnectedNtfn) {
 			prevScript = w.voteRetScript
 		}
 
-		sig, err := txscript.SignatureScript(t, 0, prevScript, txscript.SigHashAll,
+		sig, err := sign.SignatureScript(t, 0, prevScript, txscript.SigHashAll,
 			w.privateKey, dcrec.STEcdsaSecp256k1, true)
 		if err != nil {
 			w.logError(fmt.Errorf("failed to sign ticket tx: %v", err))
@@ -565,7 +566,7 @@ func (w *VotingWallet) handleWinningTicketsNtfn(ntfn *winningTicketsNtfn) {
 			vote.Version = wire.TxVersionTreasury
 		}
 
-		sig, err := txscript.SignatureScript(vote, 1, w.p2sstx, txscript.SigHashAll,
+		sig, err := sign.SignatureScript(vote, 1, w.p2sstx, txscript.SigHashAll,
 			w.privateKey, dcrec.STEcdsaSecp256k1, true)
 		if err != nil {
 			w.logError(fmt.Errorf("failed to sign ticket tx: %v", err))

--- a/txscript/README.md
+++ b/txscript/README.md
@@ -32,9 +32,6 @@ the standard go tooling for working with modules to incorporate it.
 * [Extracting Details from Standard Scripts](https://pkg.go.dev/github.com/decred/dcrd/txscript/v4#example-ExtractPkScriptAddrs)
   Demonstrates extracting information from a standard public key script.
 
-* [Manually Signing a Transaction Output](https://pkg.go.dev/github.com/decred/dcrd/txscript/v4#example-SignTxOutput)
-  Demonstrates manually creating and signing a redeem transaction.
-
 * [Counting Opcodes in Scripts](https://pkg.go.dev/github.com/decred/dcrd/txscript/v4#example-ScriptTokenizer)
   Demonstrates creating a script tokenizer instance and using it to count the
   number of opcodes a script contains.

--- a/txscript/bench_test.go
+++ b/txscript/bench_test.go
@@ -13,6 +13,18 @@ import (
 	"github.com/decred/dcrd/wire"
 )
 
+const (
+	// noTreasury signifies the treasury agenda should be treated as though
+	// it is inactive.  It is used to increase the readability of the
+	// tests.
+	noTreasury = false
+
+	// withTreasury signifies the treasury agenda should be treated as
+	// though it is active.  It is used to increase the readability of
+	// the tests.
+	withTreasury = true
+)
+
 var (
 	// manyInputsBenchTx is a transaction that contains a lot of inputs which is
 	// useful for benchmarking signature hash calculation.

--- a/txscript/example_test.go
+++ b/txscript/example_test.go
@@ -9,13 +9,9 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v3"
-	"github.com/decred/dcrd/dcrec"
-	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/txscript/v4"
 	"github.com/decred/dcrd/txscript/v4/stdaddr"
-	"github.com/decred/dcrd/wire"
 )
 
 const (
@@ -53,106 +49,6 @@ func ExampleExtractPkScriptAddrs() {
 	// Script Class: pubkeyhash
 	// Addresses: [DsSej1qR3Fyc8kV176DCh9n9cY9nqf9Quxk]
 	// Required Signatures: 1
-}
-
-// This example demonstrates manually creating and signing a redeem transaction.
-func ExampleSignTxOutput() {
-	// Ordinarily the private key would come from whatever storage mechanism
-	// is being used, but for this example just hard code it.
-	privKeyBytes, err := hex.DecodeString("22a47fa09a223f2aa079edf85a7c2" +
-		"d4f8720ee63e502ee2869afab7de234b80c")
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-	pubKey := secp256k1.PrivKeyFromBytes(privKeyBytes).PubKey()
-	pubKeyHash := stdaddr.Hash160(pubKey.SerializeCompressed())
-	mainNetParams := chaincfg.MainNetParams()
-	addr, err := stdaddr.NewAddressPubKeyHashEcdsaSecp256k1V0(pubKeyHash,
-		mainNetParams)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-
-	// For this example, create a fake transaction that represents what
-	// would ordinarily be the real transaction that is being spent.  It
-	// contains a single output that pays to address in the amount of 1 DCR.
-	originTx := wire.NewMsgTx()
-	prevOut := wire.NewOutPoint(&chainhash.Hash{}, ^uint32(0), wire.TxTreeRegular)
-	txIn := wire.NewTxIn(prevOut, 100000000, []byte{txscript.OP_0, txscript.OP_0})
-	originTx.AddTxIn(txIn)
-	pkScriptVer, pkScript := addr.PaymentScript()
-	txOut := wire.NewTxOut(100000000, pkScript)
-	txOut.Version = pkScriptVer
-	originTx.AddTxOut(txOut)
-	originTxHash := originTx.TxHash()
-
-	// Create the transaction to redeem the fake transaction.
-	redeemTx := wire.NewMsgTx()
-
-	// Add the input(s) the redeeming transaction will spend.  There is no
-	// signature script at this point since it hasn't been created or signed
-	// yet, hence nil is provided for it.
-	prevOut = wire.NewOutPoint(&originTxHash, 0, wire.TxTreeRegular)
-	txIn = wire.NewTxIn(prevOut, 100000000, nil)
-	redeemTx.AddTxIn(txIn)
-
-	// Ordinarily this would contain that actual destination of the funds,
-	// but for this example don't bother.
-	txOut = wire.NewTxOut(0, nil)
-	redeemTx.AddTxOut(txOut)
-
-	// Sign the redeeming transaction.
-	sigType := dcrec.STEcdsaSecp256k1
-	lookupKey := func(a stdaddr.Address) ([]byte, dcrec.SignatureType, bool, error) {
-		// Ordinarily this function would involve looking up the private
-		// key for the provided address, but since the only thing being
-		// signed in this example uses the address associated with the
-		// private key from above, simply return it with the compressed
-		// flag set since the address is using the associated compressed
-		// public key.
-		//
-		// NOTE: If you want to prove the code is actually signing the
-		// transaction properly, uncomment the following line which
-		// intentionally returns an invalid key to sign with, which in
-		// turn will result in a failure during the script execution
-		// when verifying the signature.
-		//
-		// privKey.D.SetInt64(12345)
-		//
-		return privKeyBytes, sigType, true, nil
-	}
-	// Notice that the script database parameter is nil here since it isn't
-	// used.  It must be specified when pay-to-script-hash transactions are
-	// being signed.
-	sigScript, err := txscript.SignTxOutput(mainNetParams, redeemTx, 0,
-		originTx.TxOut[0].PkScript, txscript.SigHashAll,
-		txscript.KeyClosure(lookupKey), nil, nil, noTreasury)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-	redeemTx.TxIn[0].SignatureScript = sigScript
-
-	// Prove that the transaction has been validly signed by executing the
-	// script pair.
-
-	flags := txscript.ScriptDiscourageUpgradableNops
-	vm, err := txscript.NewEngine(originTx.TxOut[0].PkScript, redeemTx, 0,
-		flags, 0, nil)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-	if err := vm.Execute(); err != nil {
-		fmt.Println(err)
-		return
-	}
-	fmt.Println("Transaction successfully signed")
-
-	// Output:
-	// Transaction successfully signed
 }
 
 // This example demonstrates creating a script tokenizer instance and using it

--- a/txscript/sign/example_test.go
+++ b/txscript/sign/example_test.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2014-2016 The btcsuite developers
+// Copyright (c) 2015-2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package sign_test
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/chaincfg/v3"
+	"github.com/decred/dcrd/dcrec"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/decred/dcrd/txscript/v4"
+	"github.com/decred/dcrd/txscript/v4/sign"
+	"github.com/decred/dcrd/txscript/v4/stdaddr"
+	"github.com/decred/dcrd/wire"
+)
+
+const (
+	// noTreasury signifies the treasury agenda should be treated as though
+	// it is inactive.  It is used to increase the readability of the
+	// tests.
+	noTreasury = false
+)
+
+// This example demonstrates manually creating and signing a redeem transaction.
+func ExampleSignTxOutput() {
+	// Ordinarily the private key would come from whatever storage mechanism
+	// is being used, but for this example just hard code it.
+	privKeyBytes, err := hex.DecodeString("22a47fa09a223f2aa079edf85a7c2" +
+		"d4f8720ee63e502ee2869afab7de234b80c")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	pubKey := secp256k1.PrivKeyFromBytes(privKeyBytes).PubKey()
+	pubKeyHash := stdaddr.Hash160(pubKey.SerializeCompressed())
+	mainNetParams := chaincfg.MainNetParams()
+	addr, err := stdaddr.NewAddressPubKeyHashEcdsaSecp256k1V0(pubKeyHash,
+		mainNetParams)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	// For this example, create a fake transaction that represents what
+	// would ordinarily be the real transaction that is being spent.  It
+	// contains a single output that pays to address in the amount of 1 DCR.
+	originTx := wire.NewMsgTx()
+	prevOut := wire.NewOutPoint(&chainhash.Hash{}, ^uint32(0), wire.TxTreeRegular)
+	txIn := wire.NewTxIn(prevOut, 100000000, []byte{txscript.OP_0, txscript.OP_0})
+	originTx.AddTxIn(txIn)
+	pkScriptVer, pkScript := addr.PaymentScript()
+	txOut := wire.NewTxOut(100000000, pkScript)
+	txOut.Version = pkScriptVer
+	originTx.AddTxOut(txOut)
+	originTxHash := originTx.TxHash()
+
+	// Create the transaction to redeem the fake transaction.
+	redeemTx := wire.NewMsgTx()
+
+	// Add the input(s) the redeeming transaction will spend.  There is no
+	// signature script at this point since it hasn't been created or signed
+	// yet, hence nil is provided for it.
+	prevOut = wire.NewOutPoint(&originTxHash, 0, wire.TxTreeRegular)
+	txIn = wire.NewTxIn(prevOut, 100000000, nil)
+	redeemTx.AddTxIn(txIn)
+
+	// Ordinarily this would contain that actual destination of the funds,
+	// but for this example don't bother.
+	txOut = wire.NewTxOut(0, nil)
+	redeemTx.AddTxOut(txOut)
+
+	// Sign the redeeming transaction.
+	sigType := dcrec.STEcdsaSecp256k1
+	lookupKey := func(a stdaddr.Address) ([]byte, dcrec.SignatureType, bool, error) {
+		// Ordinarily this function would involve looking up the private
+		// key for the provided address, but since the only thing being
+		// signed in this example uses the address associated with the
+		// private key from above, simply return it with the compressed
+		// flag set since the address is using the associated compressed
+		// public key.
+		//
+		// NOTE: If you want to prove the code is actually signing the
+		// transaction properly, uncomment the following line which
+		// intentionally returns an invalid key to sign with, which in
+		// turn will result in a failure during the script execution
+		// when verifying the signature.
+		//
+		// privKey.D.SetInt64(12345)
+		//
+		return privKeyBytes, sigType, true, nil
+	}
+	// Notice that the script database parameter is nil here since it isn't
+	// used.  It must be specified when pay-to-script-hash transactions are
+	// being signed.
+	sigScript, err := sign.SignTxOutput(mainNetParams, redeemTx, 0,
+		originTx.TxOut[0].PkScript, txscript.SigHashAll,
+		sign.KeyClosure(lookupKey), nil, nil, noTreasury)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	redeemTx.TxIn[0].SignatureScript = sigScript
+
+	// Prove that the transaction has been validly signed by executing the
+	// script pair.
+
+	flags := txscript.ScriptDiscourageUpgradableNops
+	vm, err := txscript.NewEngine(originTx.TxOut[0].PkScript, redeemTx, 0,
+		flags, 0, nil)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	if err := vm.Execute(); err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println("Transaction successfully signed")
+
+	// Output:
+	// Transaction successfully signed
+}


### PR DESCRIPTION
The current code for handling signing standard scripts resides in `txscript` and depends on parsing and creating standard scripts.  This poses a problem for future work which intends to split the standard script handling from the consensus critical code since that code will also need to depend on `txscript` and therefore would result in a circular dependency.

In order to pave the way for splitting the standard script handling without running into the aforementioned issue, this moves all of the signing code in the `txscript` package to a new subpackage named `sign`.

As an aside, the signing code really never fit very well in the `txscript` package anyway and it only exists there because it was not possible to parse scripts outside of the package back when the original code was implemented.  However, that limitation no longer exists.

It should also be noted that this only does the minimum work necessary to move the code and does not update it otherwise since future work plans to replace it with a much more robust architecture that properly handles things such as different script versions and non-standard scripts which the current code does not handle.