### PR TITLE
main: Handle SIGHUP with clean shutdown.

### DIFF
--- a/signal_unix.go
+++ b/signal_unix.go
@@ -1,4 +1,5 @@
 // Copyright (c) 2016 The btcsuite developers
+// Copyright (c) 2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -12,5 +13,9 @@ import (
 )
 
 func init() {
-	interruptSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}
+	interruptSignals = []os.Signal{
+		os.Interrupt,
+		syscall.SIGTERM,
+		syscall.SIGHUP,
+	}
 }


### PR DESCRIPTION
When the SIGHUP signal is received, the process should perform
graceful shut down rather than dying from the unhandled signal.

For clarity, the signals which will cause shutdown have been moved to
new filename so it does not remain specific to only SIGTERM handling.

Closes #2644.