### PR TITLE
contrib: Update OpenBSD rc script for 6.9 features.

### DIFF
--- a/contrib/services/rc.d/dcrd
+++ b/contrib/services/rc.d/dcrd
@@ -1,25 +1,23 @@
 #!/bin/ksh
 
 # OpenBSD rc.d service file for dcrd.
-# Assumes a _dcrd user is created with home directory /var/dcrd.
-# All logs and crash traces are written to syslog, with dcrd's built-in
-# file logging and log rotation disabled by default.
-# Save to /etc/rc.d/dcrd and enable with 'dcrd_flags=' in
+# Assumes a _dcrd user is created with home directory /home/_dcrd for block
+# data, and application configuration in /etc/dcrd.conf.
+# All logs and crash traces are written to the daemon.info syslog facility,
+# with dcrd's built-in file logging and log rotation disabled by default.
+# Save to /etc/rc.d/dcrd and enable with 'pkg_scripts=dcrd' in
 # /etc/rc.conf.local.
 
 daemon="/usr/local/bin/dcrd"
+daemon_flags="-C/etc/dcrd.conf -A/home/_dcrd --nofilelogging"
 daemon_user=_dcrd
-defaults="-A /var/dcrd --nofilelogging"
+daemon_logger=daemon.info
 
 . /etc/rc.d/rc.subr
 
-pexp="${daemon} ${defaults} ${daemon_flags}.*"
+daemon="env LOGFLAGS=nodatetime ${daemon}"
+
 rc_bg=YES
 rc_reload=NO
-
-rc_start() {
-	${rcexec} "${daemon} ${defaults} ${daemon_flags} 2>&1 | \
-		logger -p daemon.info -t dcrd"
-}
 
 rc_cmd $1


### PR DESCRIPTION
OpenBSD 6.9 includes a new daemon_logger variable which may be set to
automatically set the syslog facility that the process will write to.
This lets us simplify our example service by avoiding the need to
redefine the rc_start function.

While here, update some of the default flags to more closely match
what I now recommend.  /var is too small for block data on many
installations, so it is better to write all of the application data to
the /home partition instead.  This also fixes the comment for how to
enable the service, since just defining the flags is not sufficient
for this.