### PR TITLE
rpcserver: Remove unused help entry.

### DIFF
--- a/internal/rpcserver/rpcserverhelp.go
+++ b/internal/rpcserver/rpcserverhelp.go
@@ -684,7 +684,6 @@ var helpDescsEnUS = map[string]string{
 	"gettxoutresult-confirmations": "The number of confirmations",
 	"gettxoutresult-value":         "The transaction amount in DCR",
 	"gettxoutresult-scriptPubKey":  "The public key script used to pay coins as a JSON object",
-	"gettxoutresult-version":       "The transaction version",
 	"gettxoutresult-coinbase":      "Whether or not the transaction is a coinbase",
 
 	// GetTxOutCmd help.


### PR DESCRIPTION
This removes the `gettxoutresult-version` key from the RPC server help map since the field no longer exists in the actual output and is therefore no longer used.