### PR TITLE
multi: Flush block DB before UTXO DB.

### DIFF
--- a/blockchain/common_test.go
+++ b/blockchain/common_test.go
@@ -144,7 +144,12 @@ func chainSetup(dbName string, params *chaincfg.Params) (*BlockChain, func(), er
 			TimeSource:  NewMedianTime(),
 			SigCache:    sigCache,
 			UtxoCache: NewUtxoCache(&UtxoCacheConfig{
-				DB:      utxoDb,
+				DB: utxoDb,
+				FlushBlockDB: func() error {
+					// Don't flush to disk since it is slow and this is used in a lot of
+					// tests.
+					return nil
+				},
 				MaxSize: 100 * 1024 * 1024, // 100 MiB
 			}),
 		})

--- a/blockchain/example_test.go
+++ b/blockchain/example_test.go
@@ -53,7 +53,10 @@ func ExampleBlockChain_ProcessBlock() {
 			ChainParams: mainNetParams,
 			TimeSource:  blockchain.NewMedianTime(),
 			UtxoCache: blockchain.NewUtxoCache(&blockchain.UtxoCacheConfig{
-				DB:      db,
+				DB: db,
+				FlushBlockDB: func() error {
+					return nil
+				},
 				MaxSize: 100 * 1024 * 1024, // 100 MiB
 			}),
 		})

--- a/blockchain/fullblocks_test.go
+++ b/blockchain/fullblocks_test.go
@@ -137,7 +137,12 @@ func chainSetup(dbName string, params *chaincfg.Params) (*blockchain.BlockChain,
 			TimeSource:  blockchain.NewMedianTime(),
 			SigCache:    sigCache,
 			UtxoCache: blockchain.NewUtxoCache(&blockchain.UtxoCacheConfig{
-				DB:      utxoDb,
+				DB: utxoDb,
+				FlushBlockDB: func() error {
+					// Don't flush to disk since it is slow and this is used in a lot of
+					// tests.
+					return nil
+				},
 				MaxSize: 100 * 1024 * 1024, // 100 MiB
 			}),
 		})

--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -717,6 +717,15 @@ func (c *UtxoCache) Initialize(b *BlockChain, tip *blockNode) error {
 		if err != nil {
 			return err
 		}
+
+		// Flush the UTXO database to persist the initialized state.  This is
+		// necessary so that if the block database is flushed, and then an unclean
+		// shutdown occurs, the UTXO cache will know where to start from when
+		// recovering on startup.
+		err = c.db.Flush()
+		if err != nil {
+			return err
+		}
 	}
 
 	// Set the last flush hash and the last eviction height from the saved state

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -298,7 +298,10 @@ func TestCheckBlockHeaderContext(t *testing.T) {
 			ChainParams: params,
 			TimeSource:  NewMedianTime(),
 			UtxoCache: NewUtxoCache(&UtxoCacheConfig{
-				DB:      utxoDb,
+				DB: utxoDb,
+				FlushBlockDB: func() error {
+					return nil
+				},
 				MaxSize: 100 * 1024 * 1024, // 100 MiB
 			}),
 		})

--- a/database/ffldb/dbcache.go
+++ b/database/ffldb/dbcache.go
@@ -511,6 +511,15 @@ func (c *dbCache) flush() error {
 	return nil
 }
 
+// Flush flushes the database cache to persistent storage.  This involves
+// syncing the block store and replaying all transactions that have been
+// applied to the cache to the underlying database.
+//
+// This function MUST be called with the database write lock held.
+func (c *dbCache) Flush() error {
+	return c.flush()
+}
+
 // needsFlush returns whether or not the database cache needs to be flushed to
 // persistent storage based on its current size, whether or not adding all of
 // the entries in the passed database transaction would cause it to exceed the

--- a/database/interface.go
+++ b/database/interface.go
@@ -475,4 +475,7 @@ type DB interface {
 	// block until all database transactions have been finalized (rolled
 	// back or committed).
 	Close() error
+
+	// Flush writes all outstanding cached entries to disk.
+	Flush() error
 }

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -609,6 +609,7 @@ type testDB struct {
 	viewTx   database.Tx
 	updateTx database.Tx
 	closeErr error
+	flushErr error
 }
 
 // Type returns the mocked database driver type.
@@ -636,6 +637,11 @@ func (d *testDB) Update(fn func(tx database.Tx) error) error {
 // Close provides a mock implementation for the shut down of the database.
 func (d *testDB) Close() error {
 	return d.closeErr
+}
+
+// Flush provides a mock implementation for the flushing of the database cache.
+func (d *testDB) Flush() error {
+	return d.flushErr
 }
 
 // testDatabaseTx provides a mock database transaction by implementing the

--- a/server.go
+++ b/server.go
@@ -3403,8 +3403,9 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB,
 
 	// Create a new block chain instance with the appropriate configuration.
 	utxoCache := blockchain.NewUtxoCache(&blockchain.UtxoCacheConfig{
-		DB:      utxoDb,
-		MaxSize: uint64(cfg.UtxoCacheMaxSize) * 1024 * 1024,
+		DB:           utxoDb,
+		FlushBlockDB: s.db.Flush,
+		MaxSize:      uint64(cfg.UtxoCacheMaxSize) * 1024 * 1024,
 	})
 	s.chain, err = blockchain.New(ctx,
 		&blockchain.Config{


### PR DESCRIPTION
This ensures that the block database is always at least as far along as the UTXO database which keeps the UTXO database in a recoverable state in the event of an unclean shutdown.

An overview of the changes is as follows:
- Add `Flush` to the `database.DB` interface
  - This adds a `Flush` method to the `database.DB` interface so that users of the `database.DB` type can flush the underlying database to disk as needed
- Flush block DB before UTXO DB
  - This adds a `flushBlockDB` function to the UTXO cache.  The `flushBlockDB` function is used to flush the block database to disk prior to flushing the UTXO cache to the UTXO database
  - This ensures that the block database is always at least as far along as the UTXO database which keeps the UTXO database in a recoverable state in the event of an unclean shutdown
- Flush UTXO DB after init `utxoSetState`
  - This forces the UTXO database to flush to disk after initializing the UTXO set state for the first time.  This is necessary so that if the block database is flushed, and then an unclean shutdown occurs, the UTXO cache will know where to start from when recovering on startup
- Force flush in `separateUtxoDatabase` upgrade
  - This modifies the `separateUtxoDatabase` upgrade to force the UTXO database to flush to disk prior to removing the UTXO set and state from the block database
  - This prevents a scenario where the UTXO set is removed from the block database and the block database is flushed to disk, but an unclean shutdown occurs before the UTXO database flushes to disk, leaving the UTXO database in an unrecoverable state

**Fixes https://github.com/decred/dcrd/issues/2643.**