### PR TITLE
blockchain: Bump database module minor version.

### DIFF
--- a/blockchain/go.mod
+++ b/blockchain/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/decred/dcrd/blockchain/standalone/v2 v2.0.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/chaincfg/v3 v3.0.0
-	github.com/decred/dcrd/database/v2 v2.0.3-0.20210129190127-4ebd135a82f1
+	github.com/decred/dcrd/database/v2 v2.0.3-0.20210514034330-bdccd3e3f7b0
 	github.com/decred/dcrd/dcrec v1.0.0
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210127014238-b33b46cf1a24
 	github.com/decred/dcrd/dcrutil/v4 v4.0.0-20210129181600-6ae0142d3b28

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/decred/dcrd/connmgr/v3 v3.0.0
 	github.com/decred/dcrd/container/apbf v1.0.0
 	github.com/decred/dcrd/crypto/ripemd160 v1.0.1
-	github.com/decred/dcrd/database/v2 v2.0.3-0.20210129190127-4ebd135a82f1
+	github.com/decred/dcrd/database/v2 v2.0.3-0.20210514034330-bdccd3e3f7b0
 	github.com/decred/dcrd/dcrec v1.0.0
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210127014238-b33b46cf1a24
 	github.com/decred/dcrd/dcrjson/v3 v3.1.0


### PR DESCRIPTION
This bumps the minor version for the `database` module in the `blockchain` `go.mod` since it is using a new method introduced in the `database` package.

For reference, this was done by running the following command in `blockchain`, where [bdccd3e3f7b0738007a7d63e66ea6b6ab823e023](https://github.com/decred/dcrd/commit/bdccd3e3f7b0738007a7d63e66ea6b6ab823e023) is the commit that introduced the new public method in the `database` package that `blockchain` is now using:

`go get github.com/decred/dcrd/database/v2@bdccd3e3f7b0738007a7d63e66ea6b6ab823e023`