### PR TITLE
stake: Return StakeAddress from cmtmt conversion.

### DIFF
--- a/blockchain/stake/staketx.go
+++ b/blockchain/stake/staketx.go
@@ -395,7 +395,7 @@ func TxSStxStakeOutputInfo(tx *wire.MsgTx) ([]bool, [][]byte, []int64, []int64,
 
 // AddrFromSStxPkScrCommitment extracts a P2SH or P2PKH address from a ticket
 // commitment pkScript.
-func AddrFromSStxPkScrCommitment(pkScript []byte, params stdaddr.AddressParams) (stdaddr.Address, error) {
+func AddrFromSStxPkScrCommitment(pkScript []byte, params stdaddr.AddressParams) (stdaddr.StakeAddress, error) {
 	if len(pkScript) < SStxPKHMinOutSize {
 		str := "short read of sstx commit pkscript"
 		return nil, stakeRuleError(ErrSStxBadCommitAmount, str)


### PR DESCRIPTION
Ticket commitment scripts can only encode addresses which implement
the stdaddr.StakeAddress interface, so return that interface instead
of the more generic Address.