### PR TITLE
stdscript: Introduce pkg infra for std scripts.

### DIFF
--- a/internal/staging/stdscript/README.md
+++ b/internal/staging/stdscript/README.md
@@ -1,0 +1,218 @@
+stdscript
+=========
+
+[![Build Status](https://github.com/decred/dcrd/workflows/Build%20and%20Test/badge.svg)](https://github.com/decred/dcrd/actions)
+[![ISC License](https://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![Doc](https://img.shields.io/badge/doc-reference-blue.svg)](https://pkg.go.dev/github.com/decred/dcrd/internal/staging/stdscript)
+
+## Overview
+
+This package provides facilities for identifying and extracting data from
+[transaction scripts](https://devdocs.decred.org/developer-guides/transactions/txscript/overview/)
+that are considered standard by the default policy of most nodes.
+
+### Understanding Standardness Versus Consensus
+
+Under the hood, all regular transactions make use of transaction scripts with
+consensus-enforced semantics determined by an associated scripting language
+version in order to create smart contracts that impose constraints required to
+redeem funds.
+
+The consensus rules consist of executing these transaction scripts in a virtual
+machine and further dictate that the result of the execution must evaluate to
+true.  In particular, this means that scripts may be composed of any sequence of
+supported
+[opcodes](https://devdocs.decred.org/developer-guides/transactions/txscript/opcodes/)
+so long as they evaluate to true.
+
+Recall that the full transaction script that is executed is the concatenation of
+two parts:
+
+1. The output script of a transaction (also known as the public key script)
+2. The input script of a transaction spending the aforementioned output (also
+   known as the signature script)
+
+Standard transaction scripts are **public key scripts** which are only composed
+of a well-defined sequence of opcodes that are widely used to achieve a specific
+goal such as requiring signatures to spend funds or anchoring data into the
+chain.  In other words, standard scripts are a restricted subset of all possible
+public key scripts such that they conform to well-defined templates of a
+recognized form.
+
+In addition, in order to improve overall efficiency of the network and limit
+potential denial of service attacks, the default **policy** of most nodes is to
+only accept and relay scripts which are considered standard, however, that in no
+way implies a transaction with non-standard scripts (any script that is not one
+of the recognized forms) is invalid per the consensus rules.
+
+This distinction between standardness and consensus is extremely important for
+developers working on the consensus rules since what is considered a standard
+script can change at any time, while script execution for a given scripting
+language version must remain valid forever!  To be explicit, the consensus rules
+must **NOT** reference or interact with code dealing with standard scripts
+directly in any way as that would lead to breaking perfectly valid scripts that
+may no longer be considered standard by policy.
+
+This package is named `stdscript` to clearly convey that these scripts are
+particular recognized forms that most software considers standard by policy and
+therefore, as previously stated, must **NOT** be referenced by consensus code.
+
+### Pitfall with Special Script Types Enforced by Consensus
+
+One important point of potential confusion to be cognizant of is that some of
+the script types, such as pay-to-script-hash, as well as all of the
+stake-related scripts, additionally have special consensus enforcement which
+means the consensus rules must also recognize them.  In other words, they are
+both consensus scripts as well as recognized standard scripts.
+
+This is particularly relevant to the Decred staking system since a
+distinguishing aspect of it is that its scripts are tightly controlled by
+consensus to only permit very specific scripts, unlike regular transactions
+which allow scripts composed of any sequence of opcodes that evaluate to true.
+
+Consequently, it might be tempting to make use of the code in this package for
+identifying them for the purposes of enforcement since it is conveniently
+available, however, as previously stated, developers must **NOT** reference any
+code in this package from code that enforces consensus rules as this package
+will change with policy over time and therefore would lead to breaking the
+consensus rules.
+
+### Recognized Version 0 Standard Scripts
+
+The following table lists the `version 0` script types this package recognizes
+along with whether the type only applies to the staking system, and the type of
+the raw data that can be extracted:
+
+Version 0 Script Type     | Stake? | Data Type
+--------------------------|--------|--------------------
+p2pk-ecdsa-secp256k1      |    N   | `[]byte`
+p2pk-ed25519              |    N   | `[]byte`
+p2pk-schnorr-secp256k1    |    N   | `[]byte`
+p2pkh-ecdsa-secp256k1     |    N   | `[]byte`
+p2pkh-ed25519             |    N   | `[]byte`
+p2pkh-schnorr-secp256k1   |    N   | `[]byte`
+p2sh                      |    N   | `[]byte`
+ecdsa-multisig            |    N   | `MultiSigDetailsV0`
+nulldata                  |    N   | `[]byte`
+stake submission p2pkh    |    Y   | `[]byte`
+stake submission p2sh     |    Y   | `[]byte`
+stake generation p2pkh    |    Y   | `[]byte`
+stake generation p2sh     |    Y   | `[]byte`
+stake revocation p2pkh    |    Y   | `[]byte`
+stake revocation p2sh     |    Y   | `[]byte`
+stake change p2pkh        |    Y   | `[]byte`
+stake change p2sh         |    Y   | `[]byte`
+treasury add              |    Y   | -
+treasury generation p2pkh |    Y   | `[]byte`
+treasury generation p2sh  |    Y   | `[]byte`
+
+Abbreviations:
+
+* p2pk = Pay-to-public-key
+* p2pkh = Pay-to-public-key-hash
+* p2sh = Pay-to-script-hash
+
+## Package Usage Primer
+
+Interacting with existing standard scripts typically falls into the following
+categories:
+
+- Analyzing them to determine their type
+- Extracting data
+
+### Determining Script Type
+
+In order to provide a more ergonomic and efficient API depending on the specific
+needs of callers, this package offers three approaches to determining script
+types:
+
+1. Determining the script type as a `ScriptType` enum.  For example,
+   `DetermineScriptType` and `DetermineScriptTypeV0`.
+2. Determining if a script is a specific type directly.  For example,
+   `IsPubKeyHashScript`, `IsPubKeyHashScriptV0`, and `IsScriptHashScript`.
+3. Determining if a script is a specific type by checking if the relevant
+   version-specific data was extracted.  For example, `ExtractPubKeyHashV0` and
+   `ExtractScriptHashV0`.
+
+The first approach is most suitable for callers that want to work with and
+display information about a wide variety of script types, such as block
+explorers.
+
+The second approach is better suited to callers that are looking for a very
+specific script type as it is more efficient to check for a single type instead
+of checking all types to produce an enum as in the first approach.
+
+The third approach is aimed more at callers that need access to the relevant
+data from the script in addition to merely determining the type.  Unless noted
+otherwise in the documentation for a specific method, the data extraction
+methods only return data if the provided script is actually of the associated
+type.  For example, when a wallet needs to determine if a transaction script is
+a pay-to-pubkey-hash script that involves a particular public key hash, instead
+of calling `IsPubKeyHashScriptV0` (or worse calling `DetermineScriptType` and
+checking the returned enum type) followed by `ExtractPubKeyHashV0`, it is more
+efficient to simply call `ExtractPubKeyHashV0` and check if the data returned is
+not `nil` followed by using said data.
+
+It is also worth noting that the first two approaches offer API methods that
+accept the scripting language version as a parameter as well as their
+version-specific variants that make it clear from the API exactly which script
+types are supported for a given version at compile time.  The third method, on
+the other hand, only offers version-specific methods.  This is discussed further
+in the [Extracting Data](#extracting-data) section.
+
+### Extracting Data
+
+Callers that work with standard scripts often need to obtain the type and
+version-specific data.  For example, a caller will likely need to be able to
+determine the number of required signatures and individual public keys from a
+version 0 ECDSA multisignature script for further processing.
+
+This package provides several version-specific data extraction methods, such as
+`ExtractPubKeyHashV0` and `ExtractMultiSigScriptDetailsV0`, for this purpose.
+
+It should be noted that unlike the script type determination methods, this
+package does not offer version-agnostic variants of the data extraction methods
+that accept a dynamic version.  This is a deliberate design choice that was made
+because the associated data is highly dependent on both the specific type of
+script and the scripting language version, so any version-agnostic methods would
+need to return interfaces that callers would have to type assert based on the
+version thereby defeating the original intention of using a version-agnostic
+method to begin with.
+
+### Additional Convenience Methods
+
+As mentioned in the overview, standardness only applies to public key scripts.
+However, despite perhaps not fitting well with the name of the package, some
+additional convenience methods are provided for detecting and extracting data
+from common redeem scripts (the target script of a standard pay-to-script-hash
+script) as follows:
+
+- Version 0 ECDSA multisignature redeem scripts
+- Version 0 atomic swap redeem scripts
+
+## Installation and Updating
+
+This package is internal and therefore is neither directly installed nor needs
+to be manually updated.
+
+## Examples
+
+* [DetermineScriptType](https://pkg.go.dev/github.com/decred/dcrd/internal/staging/stdscript#example-DeterminScriptType)
+
+  Demonstrates determining the type of a script for a given scripting language
+  version.
+
+* [ExtractPubKeyHashV0](https://pkg.go.dev/github.com/decred/dcrd/internal/staging/stdscript#example-ExtractPubKeyHashV0)
+
+  Demonstrates extracting a public key hash from a standard pay-to-pubkey-hash
+  script for scripting language version 0.
+
+* [ExtractScriptHashV0](https://pkg.go.dev/github.com/decred/dcrd/internal/staging/stdscript#example-ExtractScriptHashV0)
+
+  Demonstrates extracting a script hash from a standard pay-to-script-hash
+  script for scripting language version 0.
+
+## License
+
+Package stdscript is licensed under the [copyfree](http://copyfree.org) ISC
+License.

--- a/internal/staging/stdscript/error.go
+++ b/internal/staging/stdscript/error.go
@@ -12,6 +12,14 @@ const (
 	// ErrUnsupportedScriptVersion indicates that a given script version is not
 	// supported.
 	ErrUnsupportedScriptVersion = ErrorKind("ErrUnsupportedScriptVersion")
+
+	// ErrTooManyRequiredSigs is returned from MultiSigScript when the
+	// specified number of required signatures is larger than the number of
+	// provided public keys.
+	ErrTooManyRequiredSigs = ErrorKind("ErrTooManyRequiredSigs")
+
+	// ErrPubKeyType is returned when a script contains invalid public keys.
+	ErrPubKeyType = ErrorKind("ErrPubKeyType")
 )
 
 // Error satisfies the error interface and prints human-readable errors.

--- a/internal/staging/stdscript/error.go
+++ b/internal/staging/stdscript/error.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package stdscript
+
+// ErrorKind identifies a kind of error.
+type ErrorKind string
+
+// These constants are used to identify a specific ErrorKind.
+const (
+	// ErrUnsupportedScriptVersion indicates that a given script version is not
+	// supported.
+	ErrUnsupportedScriptVersion = ErrorKind("ErrUnsupportedScriptVersion")
+)
+
+// Error satisfies the error interface and prints human-readable errors.
+func (e ErrorKind) Error() string {
+	return string(e)
+}
+
+// Error identifies an script-related error.
+//
+// It has full support for errors.Is and errors.As, so the caller can ascertain
+// the specific reason for the error by checking the underlying error.
+type Error struct {
+	Err         error
+	Description string
+}
+
+// Error satisfies the error interface and prints human-readable errors.
+func (e Error) Error() string {
+	return e.Description
+}
+
+// Unwrap returns the underlying wrapped error.
+func (e Error) Unwrap() error {
+	return e.Err
+}
+
+// makeError creates an Error given a set of arguments.
+func makeError(kind ErrorKind, desc string) Error {
+	return Error{Err: kind, Description: desc}
+}

--- a/internal/staging/stdscript/error_test.go
+++ b/internal/staging/stdscript/error_test.go
@@ -17,6 +17,8 @@ func TestErrorKindStringer(t *testing.T) {
 		want string
 	}{
 		{ErrUnsupportedScriptVersion, "ErrUnsupportedScriptVersion"},
+		{ErrTooManyRequiredSigs, "ErrTooManyRequiredSigs"},
+		{ErrPubKeyType, "ErrPubKeyType"},
 	}
 
 	for i, test := range tests {
@@ -73,6 +75,30 @@ func TestErrorKindIsAs(t *testing.T) {
 		target:    ErrUnsupportedScriptVersion,
 		wantMatch: true,
 		wantAs:    ErrUnsupportedScriptVersion,
+	}, {
+		name:      "ErrTooManyRequiredSigs != ErrPubKeyType",
+		err:       ErrTooManyRequiredSigs,
+		target:    ErrPubKeyType,
+		wantMatch: false,
+		wantAs:    ErrTooManyRequiredSigs,
+	}, {
+		name:      "Error.ErrTooManyRequiredSigs != ErrPubKeyType",
+		err:       makeError(ErrTooManyRequiredSigs, ""),
+		target:    ErrPubKeyType,
+		wantMatch: false,
+		wantAs:    ErrTooManyRequiredSigs,
+	}, {
+		name:      "ErrTooManyRequiredSigs != Error.ErrPubKeyType",
+		err:       ErrTooManyRequiredSigs,
+		target:    makeError(ErrPubKeyType, ""),
+		wantMatch: false,
+		wantAs:    ErrTooManyRequiredSigs,
+	}, {
+		name:      "Error.ErrTooManyRequiredSigs != Error.ErrPubKeyType",
+		err:       makeError(ErrTooManyRequiredSigs, ""),
+		target:    makeError(ErrPubKeyType, ""),
+		wantMatch: false,
+		wantAs:    ErrTooManyRequiredSigs,
 	}, {
 		name:      "Error.ErrUnsupportedScriptVersion != io.EOF",
 		err:       makeError(ErrUnsupportedScriptVersion, ""),

--- a/internal/staging/stdscript/error_test.go
+++ b/internal/staging/stdscript/error_test.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package stdscript
+
+import (
+	"errors"
+	"io"
+	"testing"
+)
+
+// TestErrorKindStringer tests the stringized output for the ErrorKind type.
+func TestErrorKindStringer(t *testing.T) {
+	tests := []struct {
+		in   ErrorKind
+		want string
+	}{
+		{ErrUnsupportedScriptVersion, "ErrUnsupportedScriptVersion"},
+	}
+
+	for i, test := range tests {
+		result := test.in.Error()
+		if result != test.want {
+			t.Errorf("#%d: got: %s want: %s", i, result, test.want)
+			continue
+		}
+	}
+}
+
+// TestError tests the error output for the Error type.
+func TestError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   Error
+		want string
+	}{{
+		Error{Description: "some error"},
+		"some error",
+	}, {
+		Error{Description: "human-readable error"},
+		"human-readable error",
+	}}
+
+	for i, test := range tests {
+		result := test.in.Error()
+		if result != test.want {
+			t.Errorf("#%d: got: %s want: %s", i, result, test.want)
+			continue
+		}
+	}
+}
+
+// TestErrorKindIsAs ensures both ErrorKind and Error can be identified as being
+// a specific error kind via errors.Is and unwrapped via errors.As.
+func TestErrorKindIsAs(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		target    error
+		wantMatch bool
+		wantAs    ErrorKind
+	}{{
+		name:      "ErrUnsupportedScriptVersion == ErrUnsupportedScriptVersion",
+		err:       ErrUnsupportedScriptVersion,
+		target:    ErrUnsupportedScriptVersion,
+		wantMatch: true,
+		wantAs:    ErrUnsupportedScriptVersion,
+	}, {
+		name:      "Error.ErrUnsupportedScriptVersion == ErrUnsupportedScriptVersion",
+		err:       makeError(ErrUnsupportedScriptVersion, ""),
+		target:    ErrUnsupportedScriptVersion,
+		wantMatch: true,
+		wantAs:    ErrUnsupportedScriptVersion,
+	}, {
+		name:      "Error.ErrUnsupportedScriptVersion != io.EOF",
+		err:       makeError(ErrUnsupportedScriptVersion, ""),
+		target:    io.EOF,
+		wantMatch: false,
+		wantAs:    ErrUnsupportedScriptVersion,
+	}}
+
+	for _, test := range tests {
+		// Ensure the error matches or not depending on the expected result.
+		result := errors.Is(test.err, test.target)
+		if result != test.wantMatch {
+			t.Errorf("%s: incorrect error identification -- got %v, want %v",
+				test.name, result, test.wantMatch)
+			continue
+		}
+
+		// Ensure the underlying error kind can be unwrapped is and is the
+		// expected kind.
+		var kind ErrorKind
+		if !errors.As(test.err, &kind) {
+			t.Errorf("%s: unable to unwrap to error kind", test.name)
+			continue
+		}
+		if kind != test.wantAs {
+			t.Errorf("%s: unexpected unwrapped error kind -- got %v, want %v",
+				test.name, kind, test.wantAs)
+			continue
+		}
+	}
+}

--- a/internal/staging/stdscript/example_test.go
+++ b/internal/staging/stdscript/example_test.go
@@ -57,3 +57,17 @@ func ExampleExtractPubKeyHashV0() {
 	// Output:
 	// public key hash: e280cb6e66b96679aec288b1fbdbd4db08077a1b
 }
+
+// This example demonstrates extracting a script hash from a standard
+// pay-to-script-hash script for script language version 0.
+func ExampleExtractScriptHashV0() {
+	// Ordinarily the script version and script would be obtained from the
+	// output of a transaction, but the version is assumed to be zero and the
+	// script is hard coded here for the purposes of this example.
+	script := hexToBytes("a914433ec2ac1ffa1b7b7d027f564529c57197f9ae8887")
+	scriptHash := stdscript.ExtractScriptHashV0(script)
+	fmt.Printf("script hash: %x\n", scriptHash)
+
+	// Output:
+	// script hash: 433ec2ac1ffa1b7b7d027f564529c57197f9ae88
+}

--- a/internal/staging/stdscript/example_test.go
+++ b/internal/staging/stdscript/example_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package stdscript_test
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/decred/dcrd/internal/staging/stdscript"
+)
+
+// hexToBytes converts the passed hex string into bytes and will panic if there
+// is an error.  This is only provided for the hard-coded constants so errors in
+// the source code can be detected. It will only (and must only) be called with
+// hard-coded values.
+func hexToBytes(s string) []byte {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		panic("invalid hex in source file: " + s)
+	}
+	return b
+}
+
+// This example demonstrates determining the type of a script for a given
+// scripting language version.
+func ExampleDetermineScriptType() {
+	// Ordinarily the script version and script would be obtained from the
+	// output of a transaction, but they are hard coded here for the purposes of
+	// this example.
+	const scriptVersion = 0
+	script := hexToBytes("76a914e280cb6e66b96679aec288b1fbdbd4db08077a1b88ac")
+	scriptType := stdscript.DetermineScriptType(scriptVersion, script)
+	switch scriptType {
+	case stdscript.STPubKeyHashEcdsaSecp256k1:
+		fmt.Printf("standard version %d %v script\n", scriptVersion, scriptType)
+
+	default:
+		fmt.Printf("other script type: %v\n", scriptType)
+	}
+
+	// Output:
+	// standard version 0 pubkeyhash script
+}

--- a/internal/staging/stdscript/example_test.go
+++ b/internal/staging/stdscript/example_test.go
@@ -43,3 +43,17 @@ func ExampleDetermineScriptType() {
 	// Output:
 	// standard version 0 pubkeyhash script
 }
+
+// This example demonstrates extracting a public key hash from a standard
+// pay-to-pubkey-hash script for scripting language version 0.
+func ExampleExtractPubKeyHashV0() {
+	// Ordinarily the script version and script would be obtained from the
+	// output of a transaction, but the version is assumed to be zero and the
+	// script is hard coded here for the purposes of this example.
+	script := hexToBytes("76a914e280cb6e66b96679aec288b1fbdbd4db08077a1b88ac")
+	pkHash := stdscript.ExtractPubKeyHashV0(script)
+	fmt.Printf("public key hash: %x\n", pkHash)
+
+	// Output:
+	// public key hash: e280cb6e66b96679aec288b1fbdbd4db08077a1b
+}

--- a/internal/staging/stdscript/script.go
+++ b/internal/staging/stdscript/script.go
@@ -123,6 +123,14 @@ const (
 	// public key.
 	STStakeRevocationPubKeyHash
 
+	// STStakeRevocationScriptHash identifies a script that is only valid when
+	// used as part of a revocation transaction in the staking system.
+	//
+	// It imposes an encumbrance that requires a script that hashes to a
+	// specific value along with all of the encumbrances that script itself
+	// imposes.  The script is commonly referred to as a redeem script.
+	STStakeRevocationScriptHash
+
 	// numScriptTypes is the maximum script type number used in tests.  This
 	// entry MUST be the last entry in the enum.
 	numScriptTypes
@@ -146,6 +154,7 @@ var scriptTypeToName = []string{
 	STStakeGenPubKeyHash:         "stakegen-pubkeyhash",
 	STStakeGenScriptHash:         "stakegen-scripthash",
 	STStakeRevocationPubKeyHash:  "stakerevoke-pubkeyhash",
+	STStakeRevocationScriptHash:  "stakerevoke-scripthash",
 }
 
 // String returns the ScriptType as a human-readable name.
@@ -368,6 +377,20 @@ func IsStakeRevocationPubKeyHashScript(scriptVersion uint16, script []byte) bool
 	switch scriptVersion {
 	case 0:
 		return IsStakeRevocationPubKeyHashScriptV0(script)
+	}
+
+	return false
+}
+
+// IsStakeRevocationScriptHashScript returns whether or not the passed script is
+// a standard stake revocation pay-to-script-hash script.
+//
+// NOTE: Version 0 scripts are the only currently supported version.  It will
+// always return false for other script versions.
+func IsStakeRevocationScriptHashScript(scriptVersion uint16, script []byte) bool {
+	switch scriptVersion {
+	case 0:
+		return IsStakeRevocationScriptHashScriptV0(script)
 	}
 
 	return false

--- a/internal/staging/stdscript/script.go
+++ b/internal/staging/stdscript/script.go
@@ -90,6 +90,15 @@ const (
 	// public key.
 	STStakeSubmissionPubKeyHash
 
+	// STStakeSubmissionScriptHash identifies a script that is only valid when
+	// used as part of a ticket purchase transaction in the staking system and
+	// is used for imposing voting rights.
+	//
+	// It imposes an encumbrance that requires a script that hashes to a
+	// specific value along with all of the encumbrances that script itself
+	// imposes.  The script is commonly referred to as a redeem script.
+	STStakeSubmissionScriptHash
+
 	// numScriptTypes is the maximum script type number used in tests.  This
 	// entry MUST be the last entry in the enum.
 	numScriptTypes
@@ -109,6 +118,7 @@ var scriptTypeToName = []string{
 	STMultiSig:                   "multisig",
 	STNullData:                   "nulldata",
 	STStakeSubmissionPubKeyHash:  "stakesubmission-pubkeyhash",
+	STStakeSubmissionScriptHash:  "stakesubmission-scripthash",
 }
 
 // String returns the ScriptType as a human-readable name.
@@ -275,6 +285,20 @@ func IsStakeSubmissionPubKeyHashScript(scriptVersion uint16, script []byte) bool
 	switch scriptVersion {
 	case 0:
 		return IsStakeSubmissionPubKeyHashScriptV0(script)
+	}
+
+	return false
+}
+
+// IsStakeSubmissionScriptHashScript returns whether or not the passed script is
+// a standard stake submission pay-to-script-hash script.
+//
+// NOTE: Version 0 scripts are the only currently supported version.  It will
+// always return false for other script versions.
+func IsStakeSubmissionScriptHashScript(scriptVersion uint16, script []byte) bool {
+	switch scriptVersion {
+	case 0:
+		return IsStakeSubmissionScriptHashScriptV0(script)
 	}
 
 	return false

--- a/internal/staging/stdscript/script.go
+++ b/internal/staging/stdscript/script.go
@@ -161,6 +161,15 @@ const (
 	// public key.
 	STTreasuryGenPubKeyHash
 
+	// STTreasuryGenScriptHash identifies a script that is only valid when used
+	// as part supported transactions in the staking system and generates utxos
+	// from the treasury account.
+	//
+	// It imposes an encumbrance that requires a script that hashes to a
+	// specific value along with all of the encumbrances that script itself
+	// imposes.  The script is commonly referred to as a redeem script.
+	STTreasuryGenScriptHash
+
 	// numScriptTypes is the maximum script type number used in tests.  This
 	// entry MUST be the last entry in the enum.
 	numScriptTypes
@@ -189,6 +198,7 @@ var scriptTypeToName = []string{
 	STStakeChangeScriptHash:      "stakechange-scripthash",
 	STTreasuryAdd:                "treasuryadd",
 	STTreasuryGenPubKeyHash:      "treasurygen-pubkeyhash",
+	STTreasuryGenScriptHash:      "treasurygen-scripthash",
 }
 
 // String returns the ScriptType as a human-readable name.
@@ -481,6 +491,20 @@ func IsTreasuryGenPubKeyHashScript(scriptVersion uint16, script []byte) bool {
 	switch scriptVersion {
 	case 0:
 		return IsTreasuryGenPubKeyHashScriptV0(script)
+	}
+
+	return false
+}
+
+// IsTreasuryGenScriptHashScript returns whether or not the passed script is a
+// standard treasury generation pay-to-script-hash script.
+//
+// NOTE: Version 0 scripts are the only currently supported version.  It will
+// always return false for other script versions.
+func IsTreasuryGenScriptHashScript(scriptVersion uint16, script []byte) bool {
+	switch scriptVersion {
+	case 0:
+		return IsTreasuryGenScriptHashScriptV0(script)
 	}
 
 	return false

--- a/internal/staging/stdscript/script.go
+++ b/internal/staging/stdscript/script.go
@@ -30,6 +30,13 @@ const (
 	// This is commonly referred to as a pay-to-pubkey-ed25519 script.
 	STPubKeyEd25519
 
+	// STPubKeySchnorrSecp256k1 identifies a standard script that imposes an
+	// encumbrance that requires a valid EC-Schnorr-DCRv0 signature for a
+	// specific secp256k1 public key.
+	//
+	// This is commonly referred to as a pay-to-pubkey-schnorr-secp256k1 script.
+	STPubKeySchnorrSecp256k1
+
 	// numScriptTypes is the maximum script type number used in tests.  This
 	// entry MUST be the last entry in the enum.
 	numScriptTypes
@@ -38,9 +45,10 @@ const (
 // scriptTypeToName houses the human-readable strings which describe each script
 // type.
 var scriptTypeToName = []string{
-	STNonStandard:          "nonstandard",
-	STPubKeyEcdsaSecp256k1: "pubkey",
-	STPubKeyEd25519:        "pubkey-ed25519",
+	STNonStandard:            "nonstandard",
+	STPubKeyEcdsaSecp256k1:   "pubkey",
+	STPubKeyEd25519:          "pubkey-ed25519",
+	STPubKeySchnorrSecp256k1: "pubkey-schnorr-secp256k1",
 }
 
 // String returns the ScriptType as a human-readable name.
@@ -75,6 +83,20 @@ func IsPubKeyEd25519Script(scriptVersion uint16, script []byte) bool {
 	switch scriptVersion {
 	case 0:
 		return IsPubKeyEd25519ScriptV0(script)
+	}
+
+	return false
+}
+
+// IsPubKeySchnorrSecp256k1Script returns whether or not the passed script is a
+// standard pay-to-schnorr-secp256k1-pubkey script.
+//
+// NOTE: Version 0 scripts are the only currently supported version.  It will
+// always return false for other script versions.
+func IsPubKeySchnorrSecp256k1Script(scriptVersion uint16, script []byte) bool {
+	switch scriptVersion {
+	case 0:
+		return IsPubKeySchnorrSecp256k1ScriptV0(script)
 	}
 
 	return false

--- a/internal/staging/stdscript/script.go
+++ b/internal/staging/stdscript/script.go
@@ -152,6 +152,15 @@ const (
 	// treasury account.
 	STTreasuryAdd
 
+	// STTreasuryGenPubKeyHash identifies a script that is only valid when used
+	// as part supported transactions in the staking system and generates utxos
+	// from the treasury account.
+	//
+	// It imposes an encumbrance that requires a secp256k1 public key that
+	// hashes to a specific value along with a valid ECDSA signature for that
+	// public key.
+	STTreasuryGenPubKeyHash
+
 	// numScriptTypes is the maximum script type number used in tests.  This
 	// entry MUST be the last entry in the enum.
 	numScriptTypes
@@ -179,6 +188,7 @@ var scriptTypeToName = []string{
 	STStakeChangePubKeyHash:      "stakechange-pubkeyhash",
 	STStakeChangeScriptHash:      "stakechange-scripthash",
 	STTreasuryAdd:                "treasuryadd",
+	STTreasuryGenPubKeyHash:      "treasurygen-pubkeyhash",
 }
 
 // String returns the ScriptType as a human-readable name.
@@ -457,6 +467,20 @@ func IsTreasuryAddScript(scriptVersion uint16, script []byte) bool {
 	switch scriptVersion {
 	case 0:
 		return IsTreasuryAddScriptV0(script)
+	}
+
+	return false
+}
+
+// IsTreasuryGenPubKeyHashScript returns whether or not the passed script is a
+// standard treasury generation pay-to-pubkey-hash script.
+//
+// NOTE: Version 0 scripts are the only currently supported version.  It will
+// always return false for other script versions.
+func IsTreasuryGenPubKeyHashScript(scriptVersion uint16, script []byte) bool {
+	switch scriptVersion {
+	case 0:
+		return IsTreasuryGenPubKeyHashScriptV0(script)
 	}
 
 	return false

--- a/internal/staging/stdscript/script.go
+++ b/internal/staging/stdscript/script.go
@@ -45,6 +45,13 @@ const (
 	// script or the more specific pay-to-pubkey-hash-ecdsa-secp256k1 script.
 	STPubKeyHashEcdsaSecp256k1
 
+	// STPubKeyHashEd25519 identifies a standard script that imposes an
+	// encumbrance that requires an Ed25519 public key that hashes to a specific
+	// value along with a valid Ed25519 signature for that public key.
+	//
+	// This is commonly referred to as a pay-to-pubkey-hash-ed25519 script.
+	STPubKeyHashEd25519
+
 	// numScriptTypes is the maximum script type number used in tests.  This
 	// entry MUST be the last entry in the enum.
 	numScriptTypes
@@ -58,6 +65,7 @@ var scriptTypeToName = []string{
 	STPubKeyEd25519:            "pubkey-ed25519",
 	STPubKeySchnorrSecp256k1:   "pubkey-schnorr-secp256k1",
 	STPubKeyHashEcdsaSecp256k1: "pubkeyhash",
+	STPubKeyHashEd25519:        "pubkeyhash-ed25519",
 }
 
 // String returns the ScriptType as a human-readable name.
@@ -120,6 +128,20 @@ func IsPubKeyHashScript(scriptVersion uint16, script []byte) bool {
 	switch scriptVersion {
 	case 0:
 		return IsPubKeyHashScriptV0(script)
+	}
+
+	return false
+}
+
+// IsPubKeyHashEd25519Script returns whether or not the passed script is a
+// standard pay-to-pubkey-hash-ed25519 script.
+//
+// NOTE: Version 0 scripts are the only currently supported version.  It will
+// always return false for other script versions.
+func IsPubKeyHashEd25519Script(scriptVersion uint16, script []byte) bool {
+	switch scriptVersion {
+	case 0:
+		return IsPubKeyHashEd25519ScriptV0(script)
 	}
 
 	return false

--- a/internal/staging/stdscript/script.go
+++ b/internal/staging/stdscript/script.go
@@ -37,6 +37,14 @@ const (
 	// This is commonly referred to as a pay-to-pubkey-schnorr-secp256k1 script.
 	STPubKeySchnorrSecp256k1
 
+	// STPubKeyHashEcdsaSecp256k1 identifies a standard script that imposes an
+	// encumbrance that requires a secp256k1 public key that hashes to a
+	// specific value along with a valid ECDSA signature for that public key.
+	//
+	// This is commonly referred to as either a pay-to-pubkey-hash (P2PKH)
+	// script or the more specific pay-to-pubkey-hash-ecdsa-secp256k1 script.
+	STPubKeyHashEcdsaSecp256k1
+
 	// numScriptTypes is the maximum script type number used in tests.  This
 	// entry MUST be the last entry in the enum.
 	numScriptTypes
@@ -45,10 +53,11 @@ const (
 // scriptTypeToName houses the human-readable strings which describe each script
 // type.
 var scriptTypeToName = []string{
-	STNonStandard:            "nonstandard",
-	STPubKeyEcdsaSecp256k1:   "pubkey",
-	STPubKeyEd25519:          "pubkey-ed25519",
-	STPubKeySchnorrSecp256k1: "pubkey-schnorr-secp256k1",
+	STNonStandard:              "nonstandard",
+	STPubKeyEcdsaSecp256k1:     "pubkey",
+	STPubKeyEd25519:            "pubkey-ed25519",
+	STPubKeySchnorrSecp256k1:   "pubkey-schnorr-secp256k1",
+	STPubKeyHashEcdsaSecp256k1: "pubkeyhash",
 }
 
 // String returns the ScriptType as a human-readable name.
@@ -97,6 +106,20 @@ func IsPubKeySchnorrSecp256k1Script(scriptVersion uint16, script []byte) bool {
 	switch scriptVersion {
 	case 0:
 		return IsPubKeySchnorrSecp256k1ScriptV0(script)
+	}
+
+	return false
+}
+
+// IsPubKeyHashScript returns whether or not the passed script is a standard
+// pay-to-pubkey-hash-ecdsa-secp256k1 script.
+//
+// NOTE: Version 0 scripts are the only currently supported version.  It will
+// always return false for other script versions.
+func IsPubKeyHashScript(scriptVersion uint16, script []byte) bool {
+	switch scriptVersion {
+	case 0:
+		return IsPubKeyHashScriptV0(script)
 	}
 
 	return false

--- a/internal/staging/stdscript/script.go
+++ b/internal/staging/stdscript/script.go
@@ -217,6 +217,26 @@ func IsMultiSigScript(scriptVersion uint16, script []byte) bool {
 	return false
 }
 
+// IsMultiSigSigScript returns whether or not the passed script appears to be a
+// signature script which consists of a pay-to-script-hash multi-signature
+// redeem script.  Determining if a signature script is actually a redemption of
+// pay-to-script-hash requires the associated public key script which is often
+// expensive to obtain.  Therefore, this makes a fast best effort guess that has
+// a high probability of being correct by checking if the signature script ends
+// with a data push and treating that data push as if it were a p2sh redeem
+// script.
+//
+// NOTE: Version 0 scripts are the only currently supported version.  It will
+// always return false for other script versions.
+func IsMultiSigSigScript(scriptVersion uint16, script []byte) bool {
+	switch scriptVersion {
+	case 0:
+		return IsMultiSigSigScriptV0(script)
+	}
+
+	return false
+}
+
 // DetermineScriptType returns the type of the script passed.
 //
 // NOTE: Version 0 scripts are the only currently supported version.  It will

--- a/internal/staging/stdscript/script.go
+++ b/internal/staging/stdscript/script.go
@@ -99,6 +99,14 @@ const (
 	// imposes.  The script is commonly referred to as a redeem script.
 	STStakeSubmissionScriptHash
 
+	// STStakeGenPubKeyHash identifies a script that is only valid when used as
+	// part of a vote transaction in the staking system.
+	//
+	// It imposes an encumbrance that requires a secp256k1 public key that
+	// hashes to a specific value along with a valid ECDSA signature for that
+	// public key.
+	STStakeGenPubKeyHash
+
 	// numScriptTypes is the maximum script type number used in tests.  This
 	// entry MUST be the last entry in the enum.
 	numScriptTypes
@@ -119,6 +127,7 @@ var scriptTypeToName = []string{
 	STNullData:                   "nulldata",
 	STStakeSubmissionPubKeyHash:  "stakesubmission-pubkeyhash",
 	STStakeSubmissionScriptHash:  "stakesubmission-scripthash",
+	STStakeGenPubKeyHash:         "stakegen-pubkeyhash",
 }
 
 // String returns the ScriptType as a human-readable name.
@@ -299,6 +308,20 @@ func IsStakeSubmissionScriptHashScript(scriptVersion uint16, script []byte) bool
 	switch scriptVersion {
 	case 0:
 		return IsStakeSubmissionScriptHashScriptV0(script)
+	}
+
+	return false
+}
+
+// IsStakeGenPubKeyHashScript returns whether or not the passed script is a
+// standard stake generation pay-to-pubkey-hash script.
+//
+// NOTE: Version 0 scripts are the only currently supported version.  It will
+// always return false for other script versions.
+func IsStakeGenPubKeyHashScript(scriptVersion uint16, script []byte) bool {
+	switch scriptVersion {
+	case 0:
+		return IsStakeGenPubKeyHashScriptV0(script)
 	}
 
 	return false

--- a/internal/staging/stdscript/script.go
+++ b/internal/staging/stdscript/script.go
@@ -131,6 +131,14 @@ const (
 	// imposes.  The script is commonly referred to as a redeem script.
 	STStakeRevocationScriptHash
 
+	// STStakeChangePubKeyHash identifies a script that is only valid when used
+	// as part of supported transactions in the staking system.
+	//
+	// It imposes an encumbrance that requires a secp256k1 public key that
+	// hashes to a specific value along with a valid ECDSA signature for that
+	// public key.
+	STStakeChangePubKeyHash
+
 	// numScriptTypes is the maximum script type number used in tests.  This
 	// entry MUST be the last entry in the enum.
 	numScriptTypes
@@ -155,6 +163,7 @@ var scriptTypeToName = []string{
 	STStakeGenScriptHash:         "stakegen-scripthash",
 	STStakeRevocationPubKeyHash:  "stakerevoke-pubkeyhash",
 	STStakeRevocationScriptHash:  "stakerevoke-scripthash",
+	STStakeChangePubKeyHash:      "stakechange-pubkeyhash",
 }
 
 // String returns the ScriptType as a human-readable name.
@@ -391,6 +400,20 @@ func IsStakeRevocationScriptHashScript(scriptVersion uint16, script []byte) bool
 	switch scriptVersion {
 	case 0:
 		return IsStakeRevocationScriptHashScriptV0(script)
+	}
+
+	return false
+}
+
+// IsStakeChangePubKeyHashScript returns whether or not the passed script is a
+// standard stake change pay-to-pubkey-hash script.
+//
+// NOTE: Version 0 scripts are the only currently supported version.  It will
+// always return false for other script versions.
+func IsStakeChangePubKeyHashScript(scriptVersion uint16, script []byte) bool {
+	switch scriptVersion {
+	case 0:
+		return IsStakeChangePubKeyHashScriptV0(script)
 	}
 
 	return false

--- a/internal/staging/stdscript/script.go
+++ b/internal/staging/stdscript/script.go
@@ -139,6 +139,14 @@ const (
 	// public key.
 	STStakeChangePubKeyHash
 
+	// STStakeChangeScriptHash identifies a script that is only valid when used
+	// as part of supported transactions in the staking system.
+	//
+	// It imposes an encumbrance that requires a script that hashes to a
+	// specific value along with all of the encumbrances that script itself
+	// imposes.  The script is commonly referred to as a redeem script.
+	STStakeChangeScriptHash
+
 	// numScriptTypes is the maximum script type number used in tests.  This
 	// entry MUST be the last entry in the enum.
 	numScriptTypes
@@ -164,6 +172,7 @@ var scriptTypeToName = []string{
 	STStakeRevocationPubKeyHash:  "stakerevoke-pubkeyhash",
 	STStakeRevocationScriptHash:  "stakerevoke-scripthash",
 	STStakeChangePubKeyHash:      "stakechange-pubkeyhash",
+	STStakeChangeScriptHash:      "stakechange-scripthash",
 }
 
 // String returns the ScriptType as a human-readable name.
@@ -414,6 +423,20 @@ func IsStakeChangePubKeyHashScript(scriptVersion uint16, script []byte) bool {
 	switch scriptVersion {
 	case 0:
 		return IsStakeChangePubKeyHashScriptV0(script)
+	}
+
+	return false
+}
+
+// IsStakeChangeScriptHashScript returns whether or not the passed script is a
+// standard stake change pay-to-script-hash script.
+//
+// NOTE: Version 0 scripts are the only currently supported version.  It will
+// always return false for other script versions.
+func IsStakeChangeScriptHashScript(scriptVersion uint16, script []byte) bool {
+	switch scriptVersion {
+	case 0:
+		return IsStakeChangeScriptHashScriptV0(script)
 	}
 
 	return false

--- a/internal/staging/stdscript/script.go
+++ b/internal/staging/stdscript/script.go
@@ -115,6 +115,14 @@ const (
 	// imposes.  The script is commonly referred to as a redeem script.
 	STStakeGenScriptHash
 
+	// STStakeRevocationPubKeyHash identifies a script that is only valid when
+	// used as part of a revocation transaction in the staking system.
+	//
+	// It imposes an encumbrance that requires a secp256k1 public key that
+	// hashes to a specific value along with a valid ECDSA signature for that
+	// public key.
+	STStakeRevocationPubKeyHash
+
 	// numScriptTypes is the maximum script type number used in tests.  This
 	// entry MUST be the last entry in the enum.
 	numScriptTypes
@@ -137,6 +145,7 @@ var scriptTypeToName = []string{
 	STStakeSubmissionScriptHash:  "stakesubmission-scripthash",
 	STStakeGenPubKeyHash:         "stakegen-pubkeyhash",
 	STStakeGenScriptHash:         "stakegen-scripthash",
+	STStakeRevocationPubKeyHash:  "stakerevoke-pubkeyhash",
 }
 
 // String returns the ScriptType as a human-readable name.
@@ -345,6 +354,20 @@ func IsStakeGenScriptHashScript(scriptVersion uint16, script []byte) bool {
 	switch scriptVersion {
 	case 0:
 		return IsStakeGenScriptHashScriptV0(script)
+	}
+
+	return false
+}
+
+// IsStakeRevocationPubKeyHashScript returns whether or not the passed script is
+// a standard stake revocation pay-to-pubkey-hash script.
+//
+// NOTE: Version 0 scripts are the only currently supported version.  It will
+// always return false for other script versions.
+func IsStakeRevocationPubKeyHashScript(scriptVersion uint16, script []byte) bool {
+	switch scriptVersion {
+	case 0:
+		return IsStakeRevocationPubKeyHashScriptV0(script)
 	}
 
 	return false

--- a/internal/staging/stdscript/script.go
+++ b/internal/staging/stdscript/script.go
@@ -23,6 +23,13 @@ const (
 	// the more specific pay-to-pubkey-ecdsa-secp256k1 script.
 	STPubKeyEcdsaSecp256k1
 
+	// STPubKeyEd25519 identifies a standard script that imposes an encumbrance
+	// that requires a valid Ed25519 signature for a specific Ed25519 public
+	// key.
+	//
+	// This is commonly referred to as a pay-to-pubkey-ed25519 script.
+	STPubKeyEd25519
+
 	// numScriptTypes is the maximum script type number used in tests.  This
 	// entry MUST be the last entry in the enum.
 	numScriptTypes
@@ -33,6 +40,7 @@ const (
 var scriptTypeToName = []string{
 	STNonStandard:          "nonstandard",
 	STPubKeyEcdsaSecp256k1: "pubkey",
+	STPubKeyEd25519:        "pubkey-ed25519",
 }
 
 // String returns the ScriptType as a human-readable name.
@@ -53,6 +61,20 @@ func IsPubKeyScript(scriptVersion uint16, script []byte) bool {
 	switch scriptVersion {
 	case 0:
 		return IsPubKeyScriptV0(script)
+	}
+
+	return false
+}
+
+// IsPubKeyEd25519Script returns whether or not the passed script is a standard
+// pay-to-ed25519-pubkey script.
+//
+// NOTE: Version 0 scripts are the only currently supported version.  It will
+// always return false for other script versions.
+func IsPubKeyEd25519Script(scriptVersion uint16, script []byte) bool {
+	switch scriptVersion {
+	case 0:
+		return IsPubKeyEd25519ScriptV0(script)
 	}
 
 	return false

--- a/internal/staging/stdscript/script.go
+++ b/internal/staging/stdscript/script.go
@@ -52,6 +52,15 @@ const (
 	// This is commonly referred to as a pay-to-pubkey-hash-ed25519 script.
 	STPubKeyHashEd25519
 
+	// STPubKeyHashSchnorrSecp256k1 identifies a standard script that imposes an
+	// encumbrance that requires a secp256k1 public key that hashes to a
+	// specific value along with a valid EC-Schnorr-DCRv0 signature for that
+	// public key.
+	//
+	// This is commonly referred to as a pay-to-pubkey-hash-schnorr-secp256k1
+	// script.
+	STPubKeyHashSchnorrSecp256k1
+
 	// numScriptTypes is the maximum script type number used in tests.  This
 	// entry MUST be the last entry in the enum.
 	numScriptTypes
@@ -60,12 +69,13 @@ const (
 // scriptTypeToName houses the human-readable strings which describe each script
 // type.
 var scriptTypeToName = []string{
-	STNonStandard:              "nonstandard",
-	STPubKeyEcdsaSecp256k1:     "pubkey",
-	STPubKeyEd25519:            "pubkey-ed25519",
-	STPubKeySchnorrSecp256k1:   "pubkey-schnorr-secp256k1",
-	STPubKeyHashEcdsaSecp256k1: "pubkeyhash",
-	STPubKeyHashEd25519:        "pubkeyhash-ed25519",
+	STNonStandard:                "nonstandard",
+	STPubKeyEcdsaSecp256k1:       "pubkey",
+	STPubKeyEd25519:              "pubkey-ed25519",
+	STPubKeySchnorrSecp256k1:     "pubkey-schnorr-secp256k1",
+	STPubKeyHashEcdsaSecp256k1:   "pubkeyhash",
+	STPubKeyHashEd25519:          "pubkeyhash-ed25519",
+	STPubKeyHashSchnorrSecp256k1: "pubkeyhash-schnorr-secp256k1",
 }
 
 // String returns the ScriptType as a human-readable name.
@@ -142,6 +152,20 @@ func IsPubKeyHashEd25519Script(scriptVersion uint16, script []byte) bool {
 	switch scriptVersion {
 	case 0:
 		return IsPubKeyHashEd25519ScriptV0(script)
+	}
+
+	return false
+}
+
+// IsPubKeyHashSchnorrSecp256k1Script returns whether or not the passed script
+// is a standard pay-to-pubkey-hash-schnorr-secp256k1 script.
+//
+// NOTE: Version 0 scripts are the only currently supported version.  It will
+// always return false for other script versions.
+func IsPubKeyHashSchnorrSecp256k1Script(scriptVersion uint16, script []byte) bool {
+	switch scriptVersion {
+	case 0:
+		return IsPubKeyHashSchnorrSecp256k1ScriptV0(script)
 	}
 
 	return false

--- a/internal/staging/stdscript/script.go
+++ b/internal/staging/stdscript/script.go
@@ -147,6 +147,11 @@ const (
 	// imposes.  The script is commonly referred to as a redeem script.
 	STStakeChangeScriptHash
 
+	// STTreasuryAdd identifies a script that is only valid when used as part
+	// supported transactions in the staking system and adds value to the
+	// treasury account.
+	STTreasuryAdd
+
 	// numScriptTypes is the maximum script type number used in tests.  This
 	// entry MUST be the last entry in the enum.
 	numScriptTypes
@@ -173,6 +178,7 @@ var scriptTypeToName = []string{
 	STStakeRevocationScriptHash:  "stakerevoke-scripthash",
 	STStakeChangePubKeyHash:      "stakechange-pubkeyhash",
 	STStakeChangeScriptHash:      "stakechange-scripthash",
+	STTreasuryAdd:                "treasuryadd",
 }
 
 // String returns the ScriptType as a human-readable name.
@@ -437,6 +443,20 @@ func IsStakeChangeScriptHashScript(scriptVersion uint16, script []byte) bool {
 	switch scriptVersion {
 	case 0:
 		return IsStakeChangeScriptHashScriptV0(script)
+	}
+
+	return false
+}
+
+// IsTreasuryAddScript returns whether or not the passed script is a supported
+// treasury add script.
+//
+// NOTE: Version 0 scripts are the only currently supported version.  It will
+// always return false for other script versions.
+func IsTreasuryAddScript(scriptVersion uint16, script []byte) bool {
+	switch scriptVersion {
+	case 0:
+		return IsTreasuryAddScriptV0(script)
 	}
 
 	return false

--- a/internal/staging/stdscript/script.go
+++ b/internal/staging/stdscript/script.go
@@ -15,6 +15,14 @@ const (
 	// forms.
 	STNonStandard ScriptType = iota
 
+	// STPubKeyEcdsaSecp256k1 identifies a standard script that imposes an
+	// encumbrance that requires a valid ECDSA signature for a specific
+	// secp256k1 public key.
+	//
+	// This is commonly referred to as either a pay-to-pubkey (P2PK) script or
+	// the more specific pay-to-pubkey-ecdsa-secp256k1 script.
+	STPubKeyEcdsaSecp256k1
+
 	// numScriptTypes is the maximum script type number used in tests.  This
 	// entry MUST be the last entry in the enum.
 	numScriptTypes
@@ -23,7 +31,8 @@ const (
 // scriptTypeToName houses the human-readable strings which describe each script
 // type.
 var scriptTypeToName = []string{
-	STNonStandard: "nonstandard",
+	STNonStandard:          "nonstandard",
+	STPubKeyEcdsaSecp256k1: "pubkey",
 }
 
 // String returns the ScriptType as a human-readable name.
@@ -32,6 +41,21 @@ func (t ScriptType) String() string {
 		return "invalid"
 	}
 	return scriptTypeToName[t]
+}
+
+// IsPubKeyScript returns whether or not the passed script is either a standard
+// pay-to-compressed-secp256k1-pubkey or pay-to-uncompressed-secp256k1-pubkey
+// script.
+//
+// NOTE: Version 0 scripts are the only currently supported version.  It will
+// always return false for other script versions.
+func IsPubKeyScript(scriptVersion uint16, script []byte) bool {
+	switch scriptVersion {
+	case 0:
+		return IsPubKeyScriptV0(script)
+	}
+
+	return false
 }
 
 // DetermineScriptType returns the type of the script passed.

--- a/internal/staging/stdscript/script.go
+++ b/internal/staging/stdscript/script.go
@@ -61,6 +61,14 @@ const (
 	// script.
 	STPubKeyHashSchnorrSecp256k1
 
+	// STScriptHash identifies a standard script that imposes an encumbrance
+	// that requires a script that hashes to a specific value along with all of
+	// the encumbrances that script itself imposes.  The script is commonly
+	// referred to as a redeem script.
+	//
+	// This is commonly referred to as pay-to-script-hash (P2SH).
+	STScriptHash
+
 	// numScriptTypes is the maximum script type number used in tests.  This
 	// entry MUST be the last entry in the enum.
 	numScriptTypes
@@ -76,6 +84,7 @@ var scriptTypeToName = []string{
 	STPubKeyHashEcdsaSecp256k1:   "pubkeyhash",
 	STPubKeyHashEd25519:          "pubkeyhash-ed25519",
 	STPubKeyHashSchnorrSecp256k1: "pubkeyhash-schnorr-secp256k1",
+	STScriptHash:                 "scripthash",
 }
 
 // String returns the ScriptType as a human-readable name.
@@ -166,6 +175,20 @@ func IsPubKeyHashSchnorrSecp256k1Script(scriptVersion uint16, script []byte) boo
 	switch scriptVersion {
 	case 0:
 		return IsPubKeyHashSchnorrSecp256k1ScriptV0(script)
+	}
+
+	return false
+}
+
+// IsScriptHashScript returns whether or not the passed script is a standard
+// pay-to-script-hash script.
+//
+// NOTE: Version 0 scripts are the only currently supported version.  It will
+// always return false for other script versions.
+func IsScriptHashScript(scriptVersion uint16, script []byte) bool {
+	switch scriptVersion {
+	case 0:
+		return IsScriptHashScriptV0(script)
 	}
 
 	return false

--- a/internal/staging/stdscript/script.go
+++ b/internal/staging/stdscript/script.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+// Package stdscript provides facilities for working with standard scripts.
+package stdscript
+
+// ScriptType identifies the type of known scripts in the blockchain that are
+// typically considered standard by the default policy of most nodes.  All other
+// scripts are considered non-standard.
+type ScriptType byte
+
+const (
+	// STNonStandard indicates a script is none of the recognized standard
+	// forms.
+	STNonStandard ScriptType = iota
+
+	// numScriptTypes is the maximum script type number used in tests.  This
+	// entry MUST be the last entry in the enum.
+	numScriptTypes
+)
+
+// scriptTypeToName houses the human-readable strings which describe each script
+// type.
+var scriptTypeToName = []string{
+	STNonStandard: "nonstandard",
+}
+
+// String returns the ScriptType as a human-readable name.
+func (t ScriptType) String() string {
+	if t >= numScriptTypes {
+		return "invalid"
+	}
+	return scriptTypeToName[t]
+}
+
+// DetermineScriptType returns the type of the script passed.
+//
+// NOTE: Version 0 scripts are the only currently supported version.  It will
+// always return STNonStandard for other script versions.
+//
+// Similarly, STNonStandard is returned when the script does not parse.
+func DetermineScriptType(scriptVersion uint16, script []byte) ScriptType {
+	switch scriptVersion {
+	case 0:
+		return DetermineScriptTypeV0(script)
+	}
+
+	// All scripts with newer versions are considered non standard.
+	return STNonStandard
+}

--- a/internal/staging/stdscript/script.go
+++ b/internal/staging/stdscript/script.go
@@ -81,6 +81,15 @@ const (
 	// prunable.
 	STNullData
 
+	// STStakeSubmissionPubKeyHash identifies a script that is only valid when
+	// used as part of a ticket purchase transaction in the staking system and
+	// is used for imposing voting rights.
+	//
+	// It imposes an encumbrance that requires a secp256k1 public key that
+	// hashes to a specific value along with a valid ECDSA signature for that
+	// public key.
+	STStakeSubmissionPubKeyHash
+
 	// numScriptTypes is the maximum script type number used in tests.  This
 	// entry MUST be the last entry in the enum.
 	numScriptTypes
@@ -99,6 +108,7 @@ var scriptTypeToName = []string{
 	STScriptHash:                 "scripthash",
 	STMultiSig:                   "multisig",
 	STNullData:                   "nulldata",
+	STStakeSubmissionPubKeyHash:  "stakesubmission-pubkeyhash",
 }
 
 // String returns the ScriptType as a human-readable name.
@@ -251,6 +261,20 @@ func IsNullDataScript(scriptVersion uint16, script []byte) bool {
 	switch scriptVersion {
 	case 0:
 		return IsNullDataScriptV0(script)
+	}
+
+	return false
+}
+
+// IsStakeSubmissionPubKeyHashScript returns whether or not the passed script is
+// a standard stake submission pay-to-pubkey-hash script.
+//
+// NOTE: Version 0 scripts are the only currently supported version.  It will
+// always return false for other script versions.
+func IsStakeSubmissionPubKeyHashScript(scriptVersion uint16, script []byte) bool {
+	switch scriptVersion {
+	case 0:
+		return IsStakeSubmissionPubKeyHashScriptV0(script)
 	}
 
 	return false

--- a/internal/staging/stdscript/script.go
+++ b/internal/staging/stdscript/script.go
@@ -69,6 +69,14 @@ const (
 	// This is commonly referred to as pay-to-script-hash (P2SH).
 	STScriptHash
 
+	// STMultiSig identifies a standard script that imposes an encumbrance that
+	// requires a given number of valid ECDSA signatures which correspond to
+	// given secp256k1 public keys.
+	//
+	// This is commonly referred to as a standard ECDSA n-of-m multi-signature
+	// script.
+	STMultiSig
+
 	// numScriptTypes is the maximum script type number used in tests.  This
 	// entry MUST be the last entry in the enum.
 	numScriptTypes
@@ -85,6 +93,7 @@ var scriptTypeToName = []string{
 	STPubKeyHashEd25519:          "pubkeyhash-ed25519",
 	STPubKeyHashSchnorrSecp256k1: "pubkeyhash-schnorr-secp256k1",
 	STScriptHash:                 "scripthash",
+	STMultiSig:                   "multisig",
 }
 
 // String returns the ScriptType as a human-readable name.
@@ -189,6 +198,20 @@ func IsScriptHashScript(scriptVersion uint16, script []byte) bool {
 	switch scriptVersion {
 	case 0:
 		return IsScriptHashScriptV0(script)
+	}
+
+	return false
+}
+
+// IsMultiSigScript returns whether or not the passed script is a standard
+// ECDSA multisig script.
+//
+// NOTE: Version 0 scripts are the only currently supported version.  It will
+// always return false for other script versions.
+func IsMultiSigScript(scriptVersion uint16, script []byte) bool {
+	switch scriptVersion {
+	case 0:
+		return IsMultiSigScriptV0(script)
 	}
 
 	return false

--- a/internal/staging/stdscript/script.go
+++ b/internal/staging/stdscript/script.go
@@ -77,6 +77,10 @@ const (
 	// script.
 	STMultiSig
 
+	// STNullData identifies a standard null data script that is provably
+	// prunable.
+	STNullData
+
 	// numScriptTypes is the maximum script type number used in tests.  This
 	// entry MUST be the last entry in the enum.
 	numScriptTypes
@@ -94,6 +98,7 @@ var scriptTypeToName = []string{
 	STPubKeyHashSchnorrSecp256k1: "pubkeyhash-schnorr-secp256k1",
 	STScriptHash:                 "scripthash",
 	STMultiSig:                   "multisig",
+	STNullData:                   "nulldata",
 }
 
 // String returns the ScriptType as a human-readable name.
@@ -232,6 +237,20 @@ func IsMultiSigSigScript(scriptVersion uint16, script []byte) bool {
 	switch scriptVersion {
 	case 0:
 		return IsMultiSigSigScriptV0(script)
+	}
+
+	return false
+}
+
+// IsNullDataScript returns whether or not the passed script is a standard
+// null data script.
+//
+// NOTE: Version 0 scripts are the only currently supported version.  It will
+// always return false for other script versions.
+func IsNullDataScript(scriptVersion uint16, script []byte) bool {
+	switch scriptVersion {
+	case 0:
+		return IsNullDataScriptV0(script)
 	}
 
 	return false

--- a/internal/staging/stdscript/script.go
+++ b/internal/staging/stdscript/script.go
@@ -107,6 +107,14 @@ const (
 	// public key.
 	STStakeGenPubKeyHash
 
+	// STStakeGenScriptHash identifies a script that is only valid when used as
+	// part of a vote transaction in the staking system.
+	//
+	// It imposes an encumbrance that requires a script that hashes to a
+	// specific value along with all of the encumbrances that script itself
+	// imposes.  The script is commonly referred to as a redeem script.
+	STStakeGenScriptHash
+
 	// numScriptTypes is the maximum script type number used in tests.  This
 	// entry MUST be the last entry in the enum.
 	numScriptTypes
@@ -128,6 +136,7 @@ var scriptTypeToName = []string{
 	STStakeSubmissionPubKeyHash:  "stakesubmission-pubkeyhash",
 	STStakeSubmissionScriptHash:  "stakesubmission-scripthash",
 	STStakeGenPubKeyHash:         "stakegen-pubkeyhash",
+	STStakeGenScriptHash:         "stakegen-scripthash",
 }
 
 // String returns the ScriptType as a human-readable name.
@@ -322,6 +331,20 @@ func IsStakeGenPubKeyHashScript(scriptVersion uint16, script []byte) bool {
 	switch scriptVersion {
 	case 0:
 		return IsStakeGenPubKeyHashScriptV0(script)
+	}
+
+	return false
+}
+
+// IsStakeGenScriptHashScript returns whether or not the passed script is a
+// standard stake generation pay-to-script-hash script.
+//
+// NOTE: Version 0 scripts are the only currently supported version.  It will
+// always return false for other script versions.
+func IsStakeGenScriptHashScript(scriptVersion uint16, script []byte) bool {
+	switch scriptVersion {
+	case 0:
+		return IsStakeGenScriptHashScriptV0(script)
 	}
 
 	return false

--- a/internal/staging/stdscript/script_bench_test.go
+++ b/internal/staging/stdscript/script_bench_test.go
@@ -184,3 +184,12 @@ func BenchmarkMultiSigRedeemScriptFromScriptSigV0(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkIsNullDataScript benchmarks the performance of analyzing various
+// public key scripts to determine if they are nulldata scripts.
+func BenchmarkIsNullDataScript(b *testing.B) {
+	filterFn := func(test scriptTest) bool {
+		return test.wantType == STNullData
+	}
+	benchIsX(b, filterFn, IsNullDataScript)
+}

--- a/internal/staging/stdscript/script_bench_test.go
+++ b/internal/staging/stdscript/script_bench_test.go
@@ -242,3 +242,13 @@ func BenchmarkIsStakeRevocationPubKeyHashScript(b *testing.B) {
 	}
 	benchIsX(b, filterFn, IsStakeRevocationPubKeyHashScript)
 }
+
+// BenchmarkIsStakeRevocationScriptHashScript benchmarks the performance of
+// various public key scripts to determine if they are stake revocation p2sh
+// scripts.
+func BenchmarkIsStakeRevocationScriptHashScript(b *testing.B) {
+	filterFn := func(test scriptTest) bool {
+		return test.wantType == STStakeRevocationScriptHash
+	}
+	benchIsX(b, filterFn, IsStakeRevocationScriptHashScript)
+}

--- a/internal/staging/stdscript/script_bench_test.go
+++ b/internal/staging/stdscript/script_bench_test.go
@@ -151,3 +151,13 @@ func BenchmarkIsMultiSigScript(b *testing.B) {
 	}
 	benchIsX(b, filterFn, IsMultiSigScript)
 }
+
+// BenchmarkIsMultiSigSigScript benchmarks the performance of analyzing various
+// signature scripts to determine if they are likely to be multisignature redeem
+// scripts.
+func BenchmarkIsMultiSigSigScript(b *testing.B) {
+	filterFn := func(test scriptTest) bool {
+		return test.wantType == STMultiSig && test.isSig
+	}
+	benchIsX(b, filterFn, IsMultiSigSigScript)
+}

--- a/internal/staging/stdscript/script_bench_test.go
+++ b/internal/staging/stdscript/script_bench_test.go
@@ -105,3 +105,12 @@ func BenchmarkIsPubKeySchnorrSecp256k1Script(b *testing.B) {
 	}
 	benchIsX(b, filterFn, IsPubKeySchnorrSecp256k1Script)
 }
+
+// BenchmarkIsPubKeyHashScript benchmarks the performance of analyzing various
+// public key scripts to determine if they are p2pkh-ecdsa-secp256k1 scripts.
+func BenchmarkIsPubKeyHashScript(b *testing.B) {
+	filterFn := func(test scriptTest) bool {
+		return test.wantType == STPubKeyHashEcdsaSecp256k1
+	}
+	benchIsX(b, filterFn, IsPubKeyHashScript)
+}

--- a/internal/staging/stdscript/script_bench_test.go
+++ b/internal/staging/stdscript/script_bench_test.go
@@ -232,3 +232,13 @@ func BenchmarkIsStakeGenScriptHashScript(b *testing.B) {
 	}
 	benchIsX(b, filterFn, IsStakeGenScriptHashScript)
 }
+
+// BenchmarkIsStakeRevocationPubKeyHashScript benchmarks the performance of
+// analyzing various public key scripts to determine if they are stake
+// revocation p2pkh-ecdsa-secp256k1 scripts.
+func BenchmarkIsStakeRevocationPubKeyHashScript(b *testing.B) {
+	filterFn := func(test scriptTest) bool {
+		return test.wantType == STStakeRevocationPubKeyHash
+	}
+	benchIsX(b, filterFn, IsStakeRevocationPubKeyHashScript)
+}

--- a/internal/staging/stdscript/script_bench_test.go
+++ b/internal/staging/stdscript/script_bench_test.go
@@ -123,3 +123,13 @@ func BenchmarkIsPubKeyHashEd25519Script(b *testing.B) {
 	}
 	benchIsX(b, filterFn, IsPubKeyHashEd25519Script)
 }
+
+// BenchmarkIsPubKeyHashSchnorrSecp256k1Script benchmarks the performance of
+// analyzing various public key scripts to determine if they are
+// p2pkh-schnorr-secp256k1 scripts.
+func BenchmarkIsPubKeyHashSchnorrSecp256k1Script(b *testing.B) {
+	filterFn := func(test scriptTest) bool {
+		return test.wantType == STPubKeyHashSchnorrSecp256k1
+	}
+	benchIsX(b, filterFn, IsPubKeyHashSchnorrSecp256k1Script)
+}

--- a/internal/staging/stdscript/script_bench_test.go
+++ b/internal/staging/stdscript/script_bench_test.go
@@ -114,3 +114,12 @@ func BenchmarkIsPubKeyHashScript(b *testing.B) {
 	}
 	benchIsX(b, filterFn, IsPubKeyHashScript)
 }
+
+// BenchmarkIsPubKeyHashEd25519Script benchmarks the performance of analyzing
+// various public key scripts to determine if they are p2pkh-ed25519 scripts.
+func BenchmarkIsPubKeyHashEd25519Script(b *testing.B) {
+	filterFn := func(test scriptTest) bool {
+		return test.wantType == STPubKeyHashEd25519
+	}
+	benchIsX(b, filterFn, IsPubKeyHashEd25519Script)
+}

--- a/internal/staging/stdscript/script_bench_test.go
+++ b/internal/staging/stdscript/script_bench_test.go
@@ -95,3 +95,13 @@ func BenchmarkIsPubKeyEd25519Script(b *testing.B) {
 	}
 	benchIsX(b, filterFn, IsPubKeyEd25519Script)
 }
+
+// BenchmarkIsPubKeySchnorrSecp256k1Script benchmarks the performance of
+// analyzing various public key scripts to determine if they are
+// p2pkh-schnorr-secp256k1 scripts.
+func BenchmarkIsPubKeySchnorrSecp256k1Script(b *testing.B) {
+	filterFn := func(test scriptTest) bool {
+		return test.wantType == STPubKeySchnorrSecp256k1
+	}
+	benchIsX(b, filterFn, IsPubKeySchnorrSecp256k1Script)
+}

--- a/internal/staging/stdscript/script_bench_test.go
+++ b/internal/staging/stdscript/script_bench_test.go
@@ -291,3 +291,13 @@ func BenchmarkIsTreasuryGenPubKeyHashScript(b *testing.B) {
 	}
 	benchIsX(b, filterFn, IsTreasuryGenPubKeyHashScript)
 }
+
+// BenchmarkIsTreasuryGenScriptHashScript benchmarks the performance of
+// analyzing various public key scripts to determine if they are treasury
+// generation p2sh scripts.
+func BenchmarkIsTreasuryGenScriptHashScript(b *testing.B) {
+	filterFn := func(test scriptTest) bool {
+		return test.wantType == STTreasuryGenScriptHash
+	}
+	benchIsX(b, filterFn, IsTreasuryGenScriptHashScript)
+}

--- a/internal/staging/stdscript/script_bench_test.go
+++ b/internal/staging/stdscript/script_bench_test.go
@@ -272,3 +272,12 @@ func BenchmarkIsStakeChangeScriptHash(b *testing.B) {
 	}
 	benchIsX(b, filterFn, IsStakeChangeScriptHashScript)
 }
+
+// BenchmarkIsTreasuryAddScript benchmarks the performance of analyzing various
+// public key scripts to determine if they are treasury add scripts.
+func BenchmarkIsTreasuryAddScript(b *testing.B) {
+	filterFn := func(test scriptTest) bool {
+		return test.wantType == STTreasuryAdd
+	}
+	benchIsX(b, filterFn, IsTreasuryAddScript)
+}

--- a/internal/staging/stdscript/script_bench_test.go
+++ b/internal/staging/stdscript/script_bench_test.go
@@ -281,3 +281,13 @@ func BenchmarkIsTreasuryAddScript(b *testing.B) {
 	}
 	benchIsX(b, filterFn, IsTreasuryAddScript)
 }
+
+// BenchmarkIsTreasuryGenPubKeyHashScript benchmarks the performance of
+// analyzing various public key scripts to determine if they are treasury
+// generation p2pkh-ecdsa-secp256k1 scripts.
+func BenchmarkIsTreasuryGenPubKeyHashScript(b *testing.B) {
+	filterFn := func(test scriptTest) bool {
+		return test.wantType == STTreasuryGenPubKeyHash
+	}
+	benchIsX(b, filterFn, IsTreasuryGenPubKeyHashScript)
+}

--- a/internal/staging/stdscript/script_bench_test.go
+++ b/internal/staging/stdscript/script_bench_test.go
@@ -203,3 +203,13 @@ func BenchmarkIsStakeSubmissionPubKeyHashScript(b *testing.B) {
 	}
 	benchIsX(b, filterFn, IsStakeSubmissionPubKeyHashScript)
 }
+
+// BenchmarkIsStakeSubmissionScriptHashScript benchmarks the performance of
+// analyzing various public key scripts to determine if they are stake
+// submission p2sh scripts.
+func BenchmarkIsStakeSubmissionScriptHashScript(b *testing.B) {
+	filterFn := func(test scriptTest) bool {
+		return test.wantType == STStakeSubmissionScriptHash
+	}
+	benchIsX(b, filterFn, IsStakeSubmissionScriptHashScript)
+}

--- a/internal/staging/stdscript/script_bench_test.go
+++ b/internal/staging/stdscript/script_bench_test.go
@@ -161,3 +161,26 @@ func BenchmarkIsMultiSigSigScript(b *testing.B) {
 	}
 	benchIsX(b, filterFn, IsMultiSigSigScript)
 }
+
+// BenchmarkMultiSigRedeemScriptFromScriptSigV0 benchmarks the performance of
+// extracting the redeem script from various version 0 signature scripts.
+func BenchmarkMultiSigRedeemScriptFromScriptSigV0(b *testing.B) {
+	for _, test := range scriptV0Tests {
+		if test.version != 0 || test.wantType != STMultiSig || !test.isSig {
+			continue
+		}
+		want := test.wantData.([]byte)
+
+		b.Run(test.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				got := MultiSigRedeemScriptFromScriptSigV0(test.script)
+				if !bytes.Equal(got, want) {
+					b.Fatalf("%q: unexpected result -- got %x, want %x",
+						test.name, got, want)
+				}
+			}
+		})
+	}
+}

--- a/internal/staging/stdscript/script_bench_test.go
+++ b/internal/staging/stdscript/script_bench_test.go
@@ -223,3 +223,12 @@ func BenchmarkIsStakeGenPubKeyHashScript(b *testing.B) {
 	}
 	benchIsX(b, filterFn, IsStakeGenPubKeyHashScript)
 }
+
+// BenchmarkIsStakeGenScriptHashScript benchmarks the performance of analyzing various
+// public key scripts to determine if they are stake generation p2sh scripts.
+func BenchmarkIsStakeGenScriptHashScript(b *testing.B) {
+	filterFn := func(test scriptTest) bool {
+		return test.wantType == STStakeGenScriptHash
+	}
+	benchIsX(b, filterFn, IsStakeGenScriptHashScript)
+}

--- a/internal/staging/stdscript/script_bench_test.go
+++ b/internal/staging/stdscript/script_bench_test.go
@@ -252,3 +252,13 @@ func BenchmarkIsStakeRevocationScriptHashScript(b *testing.B) {
 	}
 	benchIsX(b, filterFn, IsStakeRevocationScriptHashScript)
 }
+
+// BenchmarkIsStakeChangePubKeyHash benchmarks the performance of analyzing
+// various public key scripts to determine if they are stake change
+// p2pkh-ecdsa-secp256k1 scripts.
+func BenchmarkIsStakeChangePubKeyHash(b *testing.B) {
+	filterFn := func(test scriptTest) bool {
+		return test.wantType == STStakeChangePubKeyHash
+	}
+	benchIsX(b, filterFn, IsStakeChangePubKeyHashScript)
+}

--- a/internal/staging/stdscript/script_bench_test.go
+++ b/internal/staging/stdscript/script_bench_test.go
@@ -142,3 +142,12 @@ func BenchmarkIsScriptHashScript(b *testing.B) {
 	}
 	benchIsX(b, filterFn, IsScriptHashScript)
 }
+
+// BenchmarkIsMultiSigScript benchmarks the performance of analyzing various
+// public key scripts to determine if they are multisignature scripts.
+func BenchmarkIsMultiSigScript(b *testing.B) {
+	filterFn := func(test scriptTest) bool {
+		return test.wantType == STMultiSig && !test.isSig
+	}
+	benchIsX(b, filterFn, IsMultiSigScript)
+}

--- a/internal/staging/stdscript/script_bench_test.go
+++ b/internal/staging/stdscript/script_bench_test.go
@@ -193,3 +193,13 @@ func BenchmarkIsNullDataScript(b *testing.B) {
 	}
 	benchIsX(b, filterFn, IsNullDataScript)
 }
+
+// BenchmarkIsStakeSubmissionPubKeyHashScript benchmarks the performance of
+// analyzing various public key scripts to determine if they are stake
+// submission p2pkh-ecdsa-secp256k1 scripts.
+func BenchmarkIsStakeSubmissionPubKeyHashScript(b *testing.B) {
+	filterFn := func(test scriptTest) bool {
+		return test.wantType == STStakeSubmissionPubKeyHash
+	}
+	benchIsX(b, filterFn, IsStakeSubmissionPubKeyHashScript)
+}

--- a/internal/staging/stdscript/script_bench_test.go
+++ b/internal/staging/stdscript/script_bench_test.go
@@ -133,3 +133,12 @@ func BenchmarkIsPubKeyHashSchnorrSecp256k1Script(b *testing.B) {
 	}
 	benchIsX(b, filterFn, IsPubKeyHashSchnorrSecp256k1Script)
 }
+
+// BenchmarkIsScriptHashScript benchmarks the performance of analyzing various
+// public key scripts to determine if they are p2sh scripts.
+func BenchmarkIsScriptHashScript(b *testing.B) {
+	filterFn := func(test scriptTest) bool {
+		return test.wantType == STScriptHash
+	}
+	benchIsX(b, filterFn, IsScriptHashScript)
+}

--- a/internal/staging/stdscript/script_bench_test.go
+++ b/internal/staging/stdscript/script_bench_test.go
@@ -59,6 +59,8 @@ func makeBenchmarks(filterFn func(test scriptTest) bool) []scriptTest {
 // match the provided filter function using the given script type determination
 // function and ensures the result matches the expected one.
 func benchIsX(b *testing.B, filterFn func(test scriptTest) bool, isXFn func(scriptVersion uint16, script []byte) bool) {
+	b.Helper()
+
 	benches := makeBenchmarks(filterFn)
 	for _, bench := range benches {
 		want := filterFn(bench)
@@ -83,4 +85,13 @@ func BenchmarkIsPubKeyScript(b *testing.B) {
 		return test.wantType == STPubKeyEcdsaSecp256k1
 	}
 	benchIsX(b, filterFn, IsPubKeyScript)
+}
+
+// BenchmarkIsPubKeyEd25519Script benchmarks the performance of analyzing
+// various public key scripts to determine if they are p2pkh-ed25519 scripts.
+func BenchmarkIsPubKeyEd25519Script(b *testing.B) {
+	filterFn := func(test scriptTest) bool {
+		return test.wantType == STPubKeyEd25519
+	}
+	benchIsX(b, filterFn, IsPubKeyEd25519Script)
 }

--- a/internal/staging/stdscript/script_bench_test.go
+++ b/internal/staging/stdscript/script_bench_test.go
@@ -262,3 +262,13 @@ func BenchmarkIsStakeChangePubKeyHash(b *testing.B) {
 	}
 	benchIsX(b, filterFn, IsStakeChangePubKeyHashScript)
 }
+
+// BenchmarkIsStakeChangeScriptHash benchmarks the performance of analyzing
+// various public key scripts to determine if they are stake change p2sh
+// scripts.
+func BenchmarkIsStakeChangeScriptHash(b *testing.B) {
+	filterFn := func(test scriptTest) bool {
+		return test.wantType == STStakeChangeScriptHash
+	}
+	benchIsX(b, filterFn, IsStakeChangeScriptHashScript)
+}

--- a/internal/staging/stdscript/script_bench_test.go
+++ b/internal/staging/stdscript/script_bench_test.go
@@ -213,3 +213,13 @@ func BenchmarkIsStakeSubmissionScriptHashScript(b *testing.B) {
 	}
 	benchIsX(b, filterFn, IsStakeSubmissionScriptHashScript)
 }
+
+// BenchmarkIsStakeGenPubKeyHashScript benchmarks the performance of analyzing
+// various public key scripts to determine if they are stake generation
+// p2pkh-ecdsa-secp256k1 scripts.
+func BenchmarkIsStakeGenPubKeyHashScript(b *testing.B) {
+	filterFn := func(test scriptTest) bool {
+		return test.wantType == STStakeGenPubKeyHash
+	}
+	benchIsX(b, filterFn, IsStakeGenPubKeyHashScript)
+}

--- a/internal/staging/stdscript/script_test.go
+++ b/internal/staging/stdscript/script_test.go
@@ -25,6 +25,7 @@ func TestScriptTypeStringer(t *testing.T) {
 		{STPubKeyHashSchnorrSecp256k1, "pubkeyhash-schnorr-secp256k1"},
 		{STScriptHash, "scripthash"},
 		{STMultiSig, "multisig"},
+		{STNullData, "nulldata"},
 		{0xff, "invalid"},
 	}
 
@@ -141,6 +142,7 @@ func TestDetermineScriptType(t *testing.T) {
 		testIsX(IsPubKeyHashSchnorrSecp256k1Script, STPubKeyHashSchnorrSecp256k1)
 		testIsX(IsScriptHashScript, STScriptHash)
 		testIsX(IsMultiSigScript, STMultiSig)
+		testIsX(IsNullDataScript, STNullData)
 
 		// Ensure the special case of determining if a signature script appears
 		// to be a signature script which consists of a pay-to-script-hash

--- a/internal/staging/stdscript/script_test.go
+++ b/internal/staging/stdscript/script_test.go
@@ -18,6 +18,7 @@ func TestScriptTypeStringer(t *testing.T) {
 	}{
 		{STNonStandard, "nonstandard"},
 		{STPubKeyEcdsaSecp256k1, "pubkey"},
+		{STPubKeyEd25519, "pubkey-ed25519"},
 		{0xff, "invalid"},
 	}
 
@@ -123,5 +124,6 @@ func TestDetermineScriptType(t *testing.T) {
 		// Ensure the individual determination methods produce the expected
 		// results.
 		testIsX(IsPubKeyScript, STPubKeyEcdsaSecp256k1)
+		testIsX(IsPubKeyEd25519Script, STPubKeyEd25519)
 	}
 }

--- a/internal/staging/stdscript/script_test.go
+++ b/internal/staging/stdscript/script_test.go
@@ -33,6 +33,7 @@ func TestScriptTypeStringer(t *testing.T) {
 		{STStakeRevocationPubKeyHash, "stakerevoke-pubkeyhash"},
 		{STStakeRevocationScriptHash, "stakerevoke-scripthash"},
 		{STStakeChangePubKeyHash, "stakechange-pubkeyhash"},
+		{STStakeChangeScriptHash, "stakechange-scripthash"},
 		{0xff, "invalid"},
 	}
 
@@ -157,6 +158,7 @@ func TestDetermineScriptType(t *testing.T) {
 		testIsX(IsStakeRevocationPubKeyHashScript, STStakeRevocationPubKeyHash)
 		testIsX(IsStakeRevocationScriptHashScript, STStakeRevocationScriptHash)
 		testIsX(IsStakeChangePubKeyHashScript, STStakeChangePubKeyHash)
+		testIsX(IsStakeChangeScriptHashScript, STStakeChangeScriptHash)
 
 		// Ensure the special case of determining if a signature script appears
 		// to be a signature script which consists of a pay-to-script-hash

--- a/internal/staging/stdscript/script_test.go
+++ b/internal/staging/stdscript/script_test.go
@@ -29,6 +29,7 @@ func TestScriptTypeStringer(t *testing.T) {
 		{STStakeSubmissionPubKeyHash, "stakesubmission-pubkeyhash"},
 		{STStakeSubmissionScriptHash, "stakesubmission-scripthash"},
 		{STStakeGenPubKeyHash, "stakegen-pubkeyhash"},
+		{STStakeGenScriptHash, "stakegen-scripthash"},
 		{0xff, "invalid"},
 	}
 
@@ -149,6 +150,7 @@ func TestDetermineScriptType(t *testing.T) {
 		testIsX(IsStakeSubmissionPubKeyHashScript, STStakeSubmissionPubKeyHash)
 		testIsX(IsStakeSubmissionScriptHashScript, STStakeSubmissionScriptHash)
 		testIsX(IsStakeGenPubKeyHashScript, STStakeGenPubKeyHash)
+		testIsX(IsStakeGenScriptHashScript, STStakeGenScriptHash)
 
 		// Ensure the special case of determining if a signature script appears
 		// to be a signature script which consists of a pay-to-script-hash

--- a/internal/staging/stdscript/script_test.go
+++ b/internal/staging/stdscript/script_test.go
@@ -27,6 +27,7 @@ func TestScriptTypeStringer(t *testing.T) {
 		{STMultiSig, "multisig"},
 		{STNullData, "nulldata"},
 		{STStakeSubmissionPubKeyHash, "stakesubmission-pubkeyhash"},
+		{STStakeSubmissionScriptHash, "stakesubmission-scripthash"},
 		{0xff, "invalid"},
 	}
 
@@ -145,6 +146,7 @@ func TestDetermineScriptType(t *testing.T) {
 		testIsX(IsMultiSigScript, STMultiSig)
 		testIsX(IsNullDataScript, STNullData)
 		testIsX(IsStakeSubmissionPubKeyHashScript, STStakeSubmissionPubKeyHash)
+		testIsX(IsStakeSubmissionScriptHashScript, STStakeSubmissionScriptHash)
 
 		// Ensure the special case of determining if a signature script appears
 		// to be a signature script which consists of a pay-to-script-hash

--- a/internal/staging/stdscript/script_test.go
+++ b/internal/staging/stdscript/script_test.go
@@ -31,6 +31,7 @@ func TestScriptTypeStringer(t *testing.T) {
 		{STStakeGenPubKeyHash, "stakegen-pubkeyhash"},
 		{STStakeGenScriptHash, "stakegen-scripthash"},
 		{STStakeRevocationPubKeyHash, "stakerevoke-pubkeyhash"},
+		{STStakeRevocationScriptHash, "stakerevoke-scripthash"},
 		{0xff, "invalid"},
 	}
 
@@ -153,6 +154,7 @@ func TestDetermineScriptType(t *testing.T) {
 		testIsX(IsStakeGenPubKeyHashScript, STStakeGenPubKeyHash)
 		testIsX(IsStakeGenScriptHashScript, STStakeGenScriptHash)
 		testIsX(IsStakeRevocationPubKeyHashScript, STStakeRevocationPubKeyHash)
+		testIsX(IsStakeRevocationScriptHashScript, STStakeRevocationScriptHash)
 
 		// Ensure the special case of determining if a signature script appears
 		// to be a signature script which consists of a pay-to-script-hash

--- a/internal/staging/stdscript/script_test.go
+++ b/internal/staging/stdscript/script_test.go
@@ -28,6 +28,7 @@ func TestScriptTypeStringer(t *testing.T) {
 		{STNullData, "nulldata"},
 		{STStakeSubmissionPubKeyHash, "stakesubmission-pubkeyhash"},
 		{STStakeSubmissionScriptHash, "stakesubmission-scripthash"},
+		{STStakeGenPubKeyHash, "stakegen-pubkeyhash"},
 		{0xff, "invalid"},
 	}
 
@@ -147,6 +148,7 @@ func TestDetermineScriptType(t *testing.T) {
 		testIsX(IsNullDataScript, STNullData)
 		testIsX(IsStakeSubmissionPubKeyHashScript, STStakeSubmissionPubKeyHash)
 		testIsX(IsStakeSubmissionScriptHashScript, STStakeSubmissionScriptHash)
+		testIsX(IsStakeGenPubKeyHashScript, STStakeGenPubKeyHash)
 
 		// Ensure the special case of determining if a signature script appears
 		// to be a signature script which consists of a pay-to-script-hash

--- a/internal/staging/stdscript/script_test.go
+++ b/internal/staging/stdscript/script_test.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package stdscript
+
+import (
+	"testing"
+)
+
+// TestScriptTypeStringer tests the stringized output for the ScriptType type.
+func TestScriptTypeStringer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   ScriptType
+		want string
+	}{
+		{STNonStandard, "nonstandard"},
+		{0xff, "invalid"},
+	}
+
+	// Detect additional error codes that don't have the stringer added.
+	if len(tests)-1 != int(numScriptTypes) {
+		t.Error("It appears a script type was added without adding an " +
+			"associated stringer test")
+	}
+
+	for _, test := range tests {
+		result := test.in.String()
+		if result != test.want {
+			t.Errorf("%q: unexpected string -- got: %s", test.want, result)
+			continue
+		}
+	}
+}
+
+// scriptTest describes tests for scripts that are used to ensure various script
+// types and data extraction is working as expected.  It's defined separately
+// since it is intended for use in multiple shared per-version tests.
+type scriptTest struct {
+	name     string      // test description
+	version  uint16      // version of script to analyze
+	script   []byte      // script to analyze
+	isSig    bool        // treat as a signature script instead
+	wantType ScriptType  // expected script type
+	wantData interface{} // expected extracted data when applicable
+}
+
+// TestDetermineScriptType ensures a wide variety of scripts for various script
+// versions are identified with the expected script type.
+func TestDetermineScriptType(t *testing.T) {
+	t.Parallel()
+
+	// Specify the per-version tests to include in the overall tests here.
+	// This is done to make it easy to add independent tests for new script
+	// versions while still testing them all through the API that accepts a
+	// specific version versus the exported variant that is specific to a given
+	// version per its exported name.
+	//
+	// NOTE: Maintainers should add tests for new script versions following the
+	// way scriptV0Tests is handled and add the resulting per-version tests
+	// here.
+	perVersionTests := [][]scriptTest{
+		scriptV0Tests,
+	}
+
+	// Flatten all of the per-version tests into a single set of tests.
+	var tests []scriptTest
+	for _, bundle := range perVersionTests {
+		tests = append(tests, bundle...)
+	}
+
+	for _, test := range tests {
+		// Ensure that the script is considered non standard for unsupported
+		// script versions regardless.
+		const unsupportedScriptVer = 9999
+		gotType := DetermineScriptType(unsupportedScriptVer, test.script)
+		if gotType != STNonStandard {
+			t.Errorf("%q -- unsupported script version: mismatched type -- "+
+				"got %s, want %s (script %x)", test.name, gotType,
+				STNonStandard, test.script)
+			continue
+		}
+
+		// Ensure the overall type determination produces the expected result.
+		gotType = DetermineScriptType(test.version, test.script)
+		if !test.isSig && gotType != test.wantType {
+			t.Errorf("%q: mismatched type -- got %s, want %s (script %x)",
+				test.name, gotType, test.wantType, test.script)
+			continue
+		}
+
+		// TODO: Remove once used.
+		_ = test.wantData
+	}
+}

--- a/internal/staging/stdscript/script_test.go
+++ b/internal/staging/stdscript/script_test.go
@@ -19,6 +19,7 @@ func TestScriptTypeStringer(t *testing.T) {
 		{STNonStandard, "nonstandard"},
 		{STPubKeyEcdsaSecp256k1, "pubkey"},
 		{STPubKeyEd25519, "pubkey-ed25519"},
+		{STPubKeySchnorrSecp256k1, "pubkey-schnorr-secp256k1"},
 		{0xff, "invalid"},
 	}
 
@@ -125,5 +126,6 @@ func TestDetermineScriptType(t *testing.T) {
 		// results.
 		testIsX(IsPubKeyScript, STPubKeyEcdsaSecp256k1)
 		testIsX(IsPubKeyEd25519Script, STPubKeyEd25519)
+		testIsX(IsPubKeySchnorrSecp256k1Script, STPubKeySchnorrSecp256k1)
 	}
 }

--- a/internal/staging/stdscript/script_test.go
+++ b/internal/staging/stdscript/script_test.go
@@ -34,6 +34,7 @@ func TestScriptTypeStringer(t *testing.T) {
 		{STStakeRevocationScriptHash, "stakerevoke-scripthash"},
 		{STStakeChangePubKeyHash, "stakechange-pubkeyhash"},
 		{STStakeChangeScriptHash, "stakechange-scripthash"},
+		{STTreasuryAdd, "treasuryadd"},
 		{0xff, "invalid"},
 	}
 
@@ -159,6 +160,7 @@ func TestDetermineScriptType(t *testing.T) {
 		testIsX(IsStakeRevocationScriptHashScript, STStakeRevocationScriptHash)
 		testIsX(IsStakeChangePubKeyHashScript, STStakeChangePubKeyHash)
 		testIsX(IsStakeChangeScriptHashScript, STStakeChangeScriptHash)
+		testIsX(IsTreasuryAddScript, STTreasuryAdd)
 
 		// Ensure the special case of determining if a signature script appears
 		// to be a signature script which consists of a pay-to-script-hash

--- a/internal/staging/stdscript/script_test.go
+++ b/internal/staging/stdscript/script_test.go
@@ -22,6 +22,7 @@ func TestScriptTypeStringer(t *testing.T) {
 		{STPubKeySchnorrSecp256k1, "pubkey-schnorr-secp256k1"},
 		{STPubKeyHashEcdsaSecp256k1, "pubkeyhash"},
 		{STPubKeyHashEd25519, "pubkeyhash-ed25519"},
+		{STPubKeyHashSchnorrSecp256k1, "pubkeyhash-schnorr-secp256k1"},
 		{0xff, "invalid"},
 	}
 
@@ -131,5 +132,6 @@ func TestDetermineScriptType(t *testing.T) {
 		testIsX(IsPubKeySchnorrSecp256k1Script, STPubKeySchnorrSecp256k1)
 		testIsX(IsPubKeyHashScript, STPubKeyHashEcdsaSecp256k1)
 		testIsX(IsPubKeyHashEd25519Script, STPubKeyHashEd25519)
+		testIsX(IsPubKeyHashSchnorrSecp256k1Script, STPubKeyHashSchnorrSecp256k1)
 	}
 }

--- a/internal/staging/stdscript/script_test.go
+++ b/internal/staging/stdscript/script_test.go
@@ -20,6 +20,7 @@ func TestScriptTypeStringer(t *testing.T) {
 		{STPubKeyEcdsaSecp256k1, "pubkey"},
 		{STPubKeyEd25519, "pubkey-ed25519"},
 		{STPubKeySchnorrSecp256k1, "pubkey-schnorr-secp256k1"},
+		{STPubKeyHashEcdsaSecp256k1, "pubkeyhash"},
 		{0xff, "invalid"},
 	}
 
@@ -127,5 +128,6 @@ func TestDetermineScriptType(t *testing.T) {
 		testIsX(IsPubKeyScript, STPubKeyEcdsaSecp256k1)
 		testIsX(IsPubKeyEd25519Script, STPubKeyEd25519)
 		testIsX(IsPubKeySchnorrSecp256k1Script, STPubKeySchnorrSecp256k1)
+		testIsX(IsPubKeyHashScript, STPubKeyHashEcdsaSecp256k1)
 	}
 }

--- a/internal/staging/stdscript/script_test.go
+++ b/internal/staging/stdscript/script_test.go
@@ -36,6 +36,7 @@ func TestScriptTypeStringer(t *testing.T) {
 		{STStakeChangeScriptHash, "stakechange-scripthash"},
 		{STTreasuryAdd, "treasuryadd"},
 		{STTreasuryGenPubKeyHash, "treasurygen-pubkeyhash"},
+		{STTreasuryGenScriptHash, "treasurygen-scripthash"},
 		{0xff, "invalid"},
 	}
 
@@ -163,6 +164,7 @@ func TestDetermineScriptType(t *testing.T) {
 		testIsX(IsStakeChangeScriptHashScript, STStakeChangeScriptHash)
 		testIsX(IsTreasuryAddScript, STTreasuryAdd)
 		testIsX(IsTreasuryGenPubKeyHashScript, STTreasuryGenPubKeyHash)
+		testIsX(IsTreasuryGenScriptHashScript, STTreasuryGenScriptHash)
 
 		// Ensure the special case of determining if a signature script appears
 		// to be a signature script which consists of a pay-to-script-hash

--- a/internal/staging/stdscript/script_test.go
+++ b/internal/staging/stdscript/script_test.go
@@ -24,6 +24,7 @@ func TestScriptTypeStringer(t *testing.T) {
 		{STPubKeyHashEd25519, "pubkeyhash-ed25519"},
 		{STPubKeyHashSchnorrSecp256k1, "pubkeyhash-schnorr-secp256k1"},
 		{STScriptHash, "scripthash"},
+		{STMultiSig, "multisig"},
 		{0xff, "invalid"},
 	}
 
@@ -135,5 +136,6 @@ func TestDetermineScriptType(t *testing.T) {
 		testIsX(IsPubKeyHashEd25519Script, STPubKeyHashEd25519)
 		testIsX(IsPubKeyHashSchnorrSecp256k1Script, STPubKeyHashSchnorrSecp256k1)
 		testIsX(IsScriptHashScript, STScriptHash)
+		testIsX(IsMultiSigScript, STMultiSig)
 	}
 }

--- a/internal/staging/stdscript/script_test.go
+++ b/internal/staging/stdscript/script_test.go
@@ -30,6 +30,7 @@ func TestScriptTypeStringer(t *testing.T) {
 		{STStakeSubmissionScriptHash, "stakesubmission-scripthash"},
 		{STStakeGenPubKeyHash, "stakegen-pubkeyhash"},
 		{STStakeGenScriptHash, "stakegen-scripthash"},
+		{STStakeRevocationPubKeyHash, "stakerevoke-pubkeyhash"},
 		{0xff, "invalid"},
 	}
 
@@ -151,6 +152,7 @@ func TestDetermineScriptType(t *testing.T) {
 		testIsX(IsStakeSubmissionScriptHashScript, STStakeSubmissionScriptHash)
 		testIsX(IsStakeGenPubKeyHashScript, STStakeGenPubKeyHash)
 		testIsX(IsStakeGenScriptHashScript, STStakeGenScriptHash)
+		testIsX(IsStakeRevocationPubKeyHashScript, STStakeRevocationPubKeyHash)
 
 		// Ensure the special case of determining if a signature script appears
 		// to be a signature script which consists of a pay-to-script-hash

--- a/internal/staging/stdscript/script_test.go
+++ b/internal/staging/stdscript/script_test.go
@@ -32,6 +32,7 @@ func TestScriptTypeStringer(t *testing.T) {
 		{STStakeGenScriptHash, "stakegen-scripthash"},
 		{STStakeRevocationPubKeyHash, "stakerevoke-pubkeyhash"},
 		{STStakeRevocationScriptHash, "stakerevoke-scripthash"},
+		{STStakeChangePubKeyHash, "stakechange-pubkeyhash"},
 		{0xff, "invalid"},
 	}
 
@@ -155,6 +156,7 @@ func TestDetermineScriptType(t *testing.T) {
 		testIsX(IsStakeGenScriptHashScript, STStakeGenScriptHash)
 		testIsX(IsStakeRevocationPubKeyHashScript, STStakeRevocationPubKeyHash)
 		testIsX(IsStakeRevocationScriptHashScript, STStakeRevocationScriptHash)
+		testIsX(IsStakeChangePubKeyHashScript, STStakeChangePubKeyHash)
 
 		// Ensure the special case of determining if a signature script appears
 		// to be a signature script which consists of a pay-to-script-hash

--- a/internal/staging/stdscript/script_test.go
+++ b/internal/staging/stdscript/script_test.go
@@ -23,6 +23,7 @@ func TestScriptTypeStringer(t *testing.T) {
 		{STPubKeyHashEcdsaSecp256k1, "pubkeyhash"},
 		{STPubKeyHashEd25519, "pubkeyhash-ed25519"},
 		{STPubKeyHashSchnorrSecp256k1, "pubkeyhash-schnorr-secp256k1"},
+		{STScriptHash, "scripthash"},
 		{0xff, "invalid"},
 	}
 
@@ -133,5 +134,6 @@ func TestDetermineScriptType(t *testing.T) {
 		testIsX(IsPubKeyHashScript, STPubKeyHashEcdsaSecp256k1)
 		testIsX(IsPubKeyHashEd25519Script, STPubKeyHashEd25519)
 		testIsX(IsPubKeyHashSchnorrSecp256k1Script, STPubKeyHashSchnorrSecp256k1)
+		testIsX(IsScriptHashScript, STScriptHash)
 	}
 }

--- a/internal/staging/stdscript/script_test.go
+++ b/internal/staging/stdscript/script_test.go
@@ -126,6 +126,10 @@ func TestDetermineScriptType(t *testing.T) {
 			t.Helper()
 			testIsXInternal(fn, false, wantType)
 		}
+		testIsSigX := func(fn isXFn, wantType ScriptType) {
+			t.Helper()
+			testIsXInternal(fn, true, wantType)
+		}
 
 		// Ensure the individual determination methods produce the expected
 		// results.
@@ -137,5 +141,10 @@ func TestDetermineScriptType(t *testing.T) {
 		testIsX(IsPubKeyHashSchnorrSecp256k1Script, STPubKeyHashSchnorrSecp256k1)
 		testIsX(IsScriptHashScript, STScriptHash)
 		testIsX(IsMultiSigScript, STMultiSig)
+
+		// Ensure the special case of determining if a signature script appears
+		// to be a signature script which consists of a pay-to-script-hash
+		// multi-signature redeem script.
+		testIsSigX(IsMultiSigSigScript, STMultiSig)
 	}
 }

--- a/internal/staging/stdscript/script_test.go
+++ b/internal/staging/stdscript/script_test.go
@@ -35,6 +35,7 @@ func TestScriptTypeStringer(t *testing.T) {
 		{STStakeChangePubKeyHash, "stakechange-pubkeyhash"},
 		{STStakeChangeScriptHash, "stakechange-scripthash"},
 		{STTreasuryAdd, "treasuryadd"},
+		{STTreasuryGenPubKeyHash, "treasurygen-pubkeyhash"},
 		{0xff, "invalid"},
 	}
 
@@ -161,6 +162,7 @@ func TestDetermineScriptType(t *testing.T) {
 		testIsX(IsStakeChangePubKeyHashScript, STStakeChangePubKeyHash)
 		testIsX(IsStakeChangeScriptHashScript, STStakeChangeScriptHash)
 		testIsX(IsTreasuryAddScript, STTreasuryAdd)
+		testIsX(IsTreasuryGenPubKeyHashScript, STTreasuryGenPubKeyHash)
 
 		// Ensure the special case of determining if a signature script appears
 		// to be a signature script which consists of a pay-to-script-hash

--- a/internal/staging/stdscript/script_test.go
+++ b/internal/staging/stdscript/script_test.go
@@ -21,6 +21,7 @@ func TestScriptTypeStringer(t *testing.T) {
 		{STPubKeyEd25519, "pubkey-ed25519"},
 		{STPubKeySchnorrSecp256k1, "pubkey-schnorr-secp256k1"},
 		{STPubKeyHashEcdsaSecp256k1, "pubkeyhash"},
+		{STPubKeyHashEd25519, "pubkeyhash-ed25519"},
 		{0xff, "invalid"},
 	}
 
@@ -129,5 +130,6 @@ func TestDetermineScriptType(t *testing.T) {
 		testIsX(IsPubKeyEd25519Script, STPubKeyEd25519)
 		testIsX(IsPubKeySchnorrSecp256k1Script, STPubKeySchnorrSecp256k1)
 		testIsX(IsPubKeyHashScript, STPubKeyHashEcdsaSecp256k1)
+		testIsX(IsPubKeyHashEd25519Script, STPubKeyHashEd25519)
 	}
 }

--- a/internal/staging/stdscript/script_test.go
+++ b/internal/staging/stdscript/script_test.go
@@ -26,6 +26,7 @@ func TestScriptTypeStringer(t *testing.T) {
 		{STScriptHash, "scripthash"},
 		{STMultiSig, "multisig"},
 		{STNullData, "nulldata"},
+		{STStakeSubmissionPubKeyHash, "stakesubmission-pubkeyhash"},
 		{0xff, "invalid"},
 	}
 
@@ -143,6 +144,7 @@ func TestDetermineScriptType(t *testing.T) {
 		testIsX(IsScriptHashScript, STScriptHash)
 		testIsX(IsMultiSigScript, STMultiSig)
 		testIsX(IsNullDataScript, STNullData)
+		testIsX(IsStakeSubmissionPubKeyHashScript, STStakeSubmissionPubKeyHash)
 
 		// Ensure the special case of determining if a signature script appears
 		// to be a signature script which consists of a pay-to-script-hash

--- a/internal/staging/stdscript/scriptshortform_test.go
+++ b/internal/staging/stdscript/scriptshortform_test.go
@@ -1,0 +1,215 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package stdscript
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/decred/dcrd/txscript/v4"
+)
+
+var (
+	// tokenRE is a regular expression used to parse tokens from short form
+	// scripts.  It splits on repeated tokens and spaces.  Repeated tokens are
+	// denoted by being wrapped in angular brackets followed by a suffix which
+	// consists of a number inside braces.
+	tokenRE = regexp.MustCompile(`\<.+?\>\{[0-9]+\}|[^\s]+`)
+
+	// repTokenRE is a regular expression used to parse short form scripts for a
+	// series of tokens repeated a specified number of times.
+	repTokenRE = regexp.MustCompile(`^\<(.+)\>\{([0-9]+)\}$`)
+
+	// repRawRE is a regular expression used to parse short form scripts for raw
+	// data that is to be repeated a specified number of times.
+	repRawRE = regexp.MustCompile(`^(0[xX][0-9a-fA-F]+)\{([0-9]+)\}$`)
+
+	// repQuoteRE is a regular expression used to parse short form scripts for
+	// quoted data that is to be repeated a specified number of times.
+	repQuoteRE = regexp.MustCompile(`^'(.*)'\{([0-9]+)\}$`)
+)
+
+// shortFormOps holds a map of opcode names to values for use in short form
+// parsing.  It is declared here so it only needs to be created once.
+var shortFormOps map[string]byte
+
+// parseHex parses a hex string token into raw bytes.
+func parseHex(tok string) ([]byte, error) {
+	if !strings.HasPrefix(tok, "0x") {
+		return nil, errors.New("not a hex number")
+	}
+	return hex.DecodeString(tok[2:])
+}
+
+// parseShortFormV0 parses a version 0 script from a human-readable format that
+// allows for convenient testing into the associated raw script bytes.
+//
+// The format used is as follows:
+//   - Opcodes other than the push opcodes and unknown are present as either
+//     OP_NAME or just NAME
+//   - Plain numbers are made into push operations
+//   - Numbers beginning with 0x are inserted into the []byte without
+//     modification (so 0x14 is OP_DATA_20)
+//   - Numbers beginning with 0x which have a suffix which consists of a number
+//     in braces (e.g. 0x6161{10}) repeat the raw bytes the specified number of
+//     times and are inserted without modification
+//   - Single quoted strings are pushed as data
+//   - Single quoted strings that have a suffix which consists of a number in
+//     braces (e.g. 'b'{10}) repeat the data the specified number of times and
+//     are pushed as a single data push
+//   - Tokens inside of angular brackets with a suffix which consists of a
+//     number in braces (e.g. <0 0 CHECKMULTSIG>{5}) is parsed as if the tokens
+//     inside the angular brackets were manually repeated the specified number
+//     of times
+//   - Anything else is an error
+func parseShortFormV0(script string) ([]byte, error) {
+	// Only create the short form opcode map once.
+	if shortFormOps == nil {
+		ops := make(map[string]byte)
+		for opcodeName, opcodeValue := range txscript.OpcodeByName {
+			if strings.Contains(opcodeName, "OP_UNKNOWN") {
+				continue
+			}
+			ops[opcodeName] = opcodeValue
+
+			// The opcodes named OP_# can't have the OP_ prefix stripped or they
+			// would conflict with the plain numbers.  Also, since OP_FALSE and
+			// OP_TRUE are aliases for the OP_0, and OP_1, respectively, they
+			// have the same value, so detect those by name and allow them.
+			if (opcodeName == "OP_FALSE" || opcodeName == "OP_TRUE") ||
+				(opcodeValue != txscript.OP_0 && (opcodeValue < txscript.OP_1 ||
+					opcodeValue > txscript.OP_16)) {
+
+				ops[strings.TrimPrefix(opcodeName, "OP_")] = opcodeValue
+			}
+		}
+		shortFormOps = ops
+	}
+
+	builder := txscript.NewScriptBuilder()
+
+	var handleToken func(tok string) error
+	handleToken = func(tok string) error {
+		// Multiple repeated tokens.
+		if m := repTokenRE.FindStringSubmatch(tok); m != nil {
+			count, err := strconv.ParseInt(m[2], 10, 32)
+			if err != nil {
+				return fmt.Errorf("bad token %q", tok)
+			}
+			tokens := tokenRE.FindAllStringSubmatch(m[1], -1)
+			for i := 0; i < int(count); i++ {
+				for _, t := range tokens {
+					if err := handleToken(t[0]); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		}
+
+		// Plain number.
+		if num, err := strconv.ParseInt(tok, 10, 64); err == nil {
+			builder.AddInt64(num)
+			return nil
+		}
+
+		// Raw data.
+		if bts, err := parseHex(tok); err == nil {
+			// Use the unchecked variant since the test code intentionally
+			// creates scripts that are too large and would cause the builder to
+			// error otherwise.
+			builder.AddOpsUnchecked(bts)
+			return nil
+		}
+
+		// Repeated raw bytes.
+		if m := repRawRE.FindStringSubmatch(tok); m != nil {
+			bts, err := parseHex(m[1])
+			if err != nil {
+				return fmt.Errorf("bad token %q", tok)
+			}
+			count, err := strconv.ParseInt(m[2], 10, 32)
+			if err != nil {
+				return fmt.Errorf("bad token %q", tok)
+			}
+
+			// Use the unchecked variant since the test code intentionally
+			// creates scripts that are too large and would cause the builder to
+			// error otherwise.
+			bts = bytes.Repeat(bts, int(count))
+			builder.AddOpsUnchecked(bts)
+			return nil
+		}
+
+		// Quoted data.
+		if len(tok) >= 2 && tok[0] == '\'' && tok[len(tok)-1] == '\'' {
+			builder.AddDataUnchecked([]byte(tok[1 : len(tok)-1]))
+			return nil
+		}
+
+		// Repeated quoted data.
+		if m := repQuoteRE.FindStringSubmatch(tok); m != nil {
+			count, err := strconv.ParseInt(m[2], 10, 32)
+			if err != nil {
+				return fmt.Errorf("bad token %q", tok)
+			}
+			data := strings.Repeat(m[1], int(count))
+			builder.AddDataUnchecked([]byte(data))
+			return nil
+		}
+
+		// Named opcode.
+		if opcode, ok := shortFormOps[tok]; ok {
+			builder.AddOp(opcode)
+			return nil
+		}
+
+		return fmt.Errorf("bad token %q", tok)
+	}
+
+	for _, tokens := range tokenRE.FindAllStringSubmatch(script, -1) {
+		if err := handleToken(tokens[0]); err != nil {
+			return nil, err
+		}
+	}
+	return builder.Script()
+}
+
+// parseShortForm parses a script from a human-readable format for the given
+// script version that allows for convenient testing into the associated raw
+// script bytes.
+//
+// See the associated version-specific short form parsing function for each
+// version for details regarding the format since it may or may not differ
+// between script version.
+func parseShortForm(scriptVersion uint16, script string) ([]byte, error) {
+	switch scriptVersion {
+	case 0:
+		return parseShortFormV0(script)
+	}
+
+	str := fmt.Sprintf("parsing short form for version %d scripts is not "+
+		"supported", scriptVersion)
+	return nil, makeError(ErrUnsupportedScriptVersion, str)
+}
+
+// mustParseShortForm parses the passed short form script and returns the
+// resulting bytes.  It panics if an error occurs.  This is only used in the
+// tests as a helper since the only way it can fail is if there is an error in
+// the test source code.
+func mustParseShortForm(scriptVersion uint16, script string) []byte {
+	s, err := parseShortForm(scriptVersion, script)
+	if err != nil {
+		panic("invalid short form script in test source: err " + err.Error() +
+			", script: " + script)
+	}
+
+	return s
+}

--- a/internal/staging/stdscript/scriptv0.go
+++ b/internal/staging/stdscript/scriptv0.go
@@ -148,9 +148,8 @@ func IsStandardAltSignatureTypeV0(op byte) bool {
 		return false
 	}
 
-	// TODO: Check Schnorr+secp too.
 	sigType := txscript.AsSmallInt(op)
-	return sigType == dcrec.STEd25519
+	return sigType == dcrec.STEd25519 || sigType == dcrec.STSchnorrSecp256k1
 }
 
 // ExtractPubKeyHashAltDetailsV0 extracts the public key hash and signature type
@@ -188,6 +187,13 @@ func IsPubKeyHashEd25519ScriptV0(script []byte) bool {
 	return pk != nil && sigType == dcrec.STEd25519
 }
 
+// IsPubKeyHashSchnorrSecp256k1ScriptV0 returns whether or not the passed script
+// is a standard version 0 pay-to-pubkey-hash-schnorr-secp256k1 script.
+func IsPubKeyHashSchnorrSecp256k1ScriptV0(script []byte) bool {
+	pk, sigType := ExtractPubKeyHashAltDetailsV0(script)
+	return pk != nil && sigType == dcrec.STSchnorrSecp256k1
+}
+
 // DetermineScriptTypeV0 returns the type of the passed version 0 script from
 // the known standard types.  This includes both types that are required by
 // consensus as well as those which are not.
@@ -205,6 +211,8 @@ func DetermineScriptTypeV0(script []byte) ScriptType {
 		return STPubKeyHashEcdsaSecp256k1
 	case IsPubKeyHashEd25519ScriptV0(script):
 		return STPubKeyHashEd25519
+	case IsPubKeyHashSchnorrSecp256k1ScriptV0(script):
+		return STPubKeyHashSchnorrSecp256k1
 	}
 
 	return STNonStandard

--- a/internal/staging/stdscript/scriptv0.go
+++ b/internal/staging/stdscript/scriptv0.go
@@ -574,6 +574,22 @@ func IsStakeChangePubKeyHashScriptV0(script []byte) bool {
 	return ExtractStakeChangePubKeyHashV0(script) != nil
 }
 
+// ExtractStakeChangeScriptHashV0 extracts the script hash from the passed
+// script if it is a standard version 0 stake change pay-to-script-hash
+// script.  It will return nil otherwise.
+func ExtractStakeChangeScriptHashV0(script []byte) []byte {
+	// A stake change pay-to-script-hash script is of the form:
+	//  OP_SSTXCHANGE <standard-pay-to-script-hash script>
+	const stakeOpcode = txscript.OP_SSTXCHANGE
+	return extractStakeScriptHashV0(script, stakeOpcode)
+}
+
+// IsStakeChangeScriptHashScriptV0 returns whether or not the passed script is a
+// standard version 0 stake change pay-to-script-hash script.
+func IsStakeChangeScriptHashScriptV0(script []byte) bool {
+	return ExtractStakeChangeScriptHashV0(script) != nil
+}
+
 // DetermineScriptTypeV0 returns the type of the passed version 0 script from
 // the known standard types.  This includes both types that are required by
 // consensus as well as those which are not.
@@ -613,6 +629,8 @@ func DetermineScriptTypeV0(script []byte) ScriptType {
 		return STStakeRevocationScriptHash
 	case IsStakeChangePubKeyHashScriptV0(script):
 		return STStakeChangePubKeyHash
+	case IsStakeChangeScriptHashScriptV0(script):
+		return STStakeChangeScriptHash
 	}
 
 	return STNonStandard

--- a/internal/staging/stdscript/scriptv0.go
+++ b/internal/staging/stdscript/scriptv0.go
@@ -596,6 +596,22 @@ func IsTreasuryAddScriptV0(script []byte) bool {
 	return len(script) == 1 && script[0] == txscript.OP_TADD
 }
 
+// ExtractTreasuryGenPubKeyHashV0 extracts the public key hash from the
+// passed script if it is a standard version 0 treasury generation
+// pay-to-pubkey-hash script.  It will return nil otherwise.
+func ExtractTreasuryGenPubKeyHashV0(script []byte) []byte {
+	// A treasury generation pay-to-pubkey-hash script is of the form:
+	//  OP_TGEN <standard-pay-to-pubkey-hash script>
+	const stakeOpcode = txscript.OP_TGEN
+	return extractStakePubKeyHashV0(script, stakeOpcode)
+}
+
+// IsTreasuryGenPubKeyHashScriptV0 returns whether or not the passed script is a
+// standard version 0 treasury generation pay-to-pubkey-hash script.
+func IsTreasuryGenPubKeyHashScriptV0(script []byte) bool {
+	return ExtractTreasuryGenPubKeyHashV0(script) != nil
+}
+
 // DetermineScriptTypeV0 returns the type of the passed version 0 script from
 // the known standard types.  This includes both types that are required by
 // consensus as well as those which are not.
@@ -639,6 +655,8 @@ func DetermineScriptTypeV0(script []byte) ScriptType {
 		return STStakeChangeScriptHash
 	case IsTreasuryAddScriptV0(script):
 		return STTreasuryAdd
+	case IsTreasuryGenPubKeyHashScriptV0(script):
+		return STTreasuryGenPubKeyHash
 	}
 
 	return STNonStandard

--- a/internal/staging/stdscript/scriptv0.go
+++ b/internal/staging/stdscript/scriptv0.go
@@ -510,6 +510,22 @@ func IsStakeGenPubKeyHashScriptV0(script []byte) bool {
 	return ExtractStakeGenPubKeyHashV0(script) != nil
 }
 
+// ExtractStakeGenScriptHashV0 extracts the script hash from the passed
+// script if it is a standard version 0 stake generation pay-to-script-hash
+// script.  It will return nil otherwise.
+func ExtractStakeGenScriptHashV0(script []byte) []byte {
+	// A stake generation pay-to-script-hash script is of the form:
+	//  OP_SSGEN <standard-pay-to-script-hash script>
+	const stakeOpcode = txscript.OP_SSGEN
+	return extractStakeScriptHashV0(script, stakeOpcode)
+}
+
+// IsStakeGenScriptHashScriptV0 returns whether or not the passed script is a
+// standard version 0 stake generation pay-to-script-hash script.
+func IsStakeGenScriptHashScriptV0(script []byte) bool {
+	return ExtractStakeGenScriptHashV0(script) != nil
+}
+
 // DetermineScriptTypeV0 returns the type of the passed version 0 script from
 // the known standard types.  This includes both types that are required by
 // consensus as well as those which are not.
@@ -541,6 +557,8 @@ func DetermineScriptTypeV0(script []byte) ScriptType {
 		return STStakeSubmissionScriptHash
 	case IsStakeGenPubKeyHashScriptV0(script):
 		return STStakeGenPubKeyHash
+	case IsStakeGenScriptHashScriptV0(script):
+		return STStakeGenScriptHash
 	}
 
 	return STNonStandard

--- a/internal/staging/stdscript/scriptv0.go
+++ b/internal/staging/stdscript/scriptv0.go
@@ -494,6 +494,22 @@ func IsStakeSubmissionScriptHashScriptV0(script []byte) bool {
 	return ExtractStakeSubmissionScriptHashV0(script) != nil
 }
 
+// ExtractStakeGenPubKeyHashV0 extracts the public key hash from the
+// passed script if it is a standard version 0 stake generation
+// pay-to-pubkey-hash script.  It will return nil otherwise.
+func ExtractStakeGenPubKeyHashV0(script []byte) []byte {
+	// A stake generation pay-to-pubkey-hash script is of the form:
+	//  OP_SSGEN <standard-pay-to-pubkey-hash script>
+	const stakeOpcode = txscript.OP_SSGEN
+	return extractStakePubKeyHashV0(script, stakeOpcode)
+}
+
+// IsStakeGenPubKeyHashScriptV0 returns whether or not the passed script is a
+// standard version 0 stake generation pay-to-pubkey-hash script.
+func IsStakeGenPubKeyHashScriptV0(script []byte) bool {
+	return ExtractStakeGenPubKeyHashV0(script) != nil
+}
+
 // DetermineScriptTypeV0 returns the type of the passed version 0 script from
 // the known standard types.  This includes both types that are required by
 // consensus as well as those which are not.
@@ -523,6 +539,8 @@ func DetermineScriptTypeV0(script []byte) ScriptType {
 		return STStakeSubmissionPubKeyHash
 	case IsStakeSubmissionScriptHashScriptV0(script):
 		return STStakeSubmissionScriptHash
+	case IsStakeGenPubKeyHashScriptV0(script):
+		return STStakeGenPubKeyHash
 	}
 
 	return STNonStandard

--- a/internal/staging/stdscript/scriptv0.go
+++ b/internal/staging/stdscript/scriptv0.go
@@ -612,6 +612,22 @@ func IsTreasuryGenPubKeyHashScriptV0(script []byte) bool {
 	return ExtractTreasuryGenPubKeyHashV0(script) != nil
 }
 
+// ExtractTreasuryGenScriptHashV0 extracts the script hash from the passed
+// script if it is a standard version 0 treasury generation pay-to-script-hash
+// script.  It will return nil otherwise.
+func ExtractTreasuryGenScriptHashV0(script []byte) []byte {
+	// A treasury generation pay-to-script-hash script is of the form:
+	//  OP_TGEN <standard-pay-to-script-hash script>
+	const stakeOpcode = txscript.OP_TGEN
+	return extractStakeScriptHashV0(script, stakeOpcode)
+}
+
+// IsTreasuryGenScriptHashScriptV0 returns whether or not the passed script is a
+// standard version 0 treasury generation pay-to-script-hash script.
+func IsTreasuryGenScriptHashScriptV0(script []byte) bool {
+	return ExtractTreasuryGenScriptHashV0(script) != nil
+}
+
 // DetermineScriptTypeV0 returns the type of the passed version 0 script from
 // the known standard types.  This includes both types that are required by
 // consensus as well as those which are not.
@@ -657,6 +673,8 @@ func DetermineScriptTypeV0(script []byte) ScriptType {
 		return STTreasuryAdd
 	case IsTreasuryGenPubKeyHashScriptV0(script):
 		return STTreasuryGenPubKeyHash
+	case IsTreasuryGenScriptHashScriptV0(script):
+		return STTreasuryGenScriptHash
 	}
 
 	return STNonStandard

--- a/internal/staging/stdscript/scriptv0.go
+++ b/internal/staging/stdscript/scriptv0.go
@@ -194,6 +194,20 @@ func IsPubKeyHashSchnorrSecp256k1ScriptV0(script []byte) bool {
 	return pk != nil && sigType == dcrec.STSchnorrSecp256k1
 }
 
+// ExtractScriptHashV0 extracts the script hash from the passed script if it is
+// a standard version 0 pay-to-script-hash script.  It will return nil
+// otherwise.
+func ExtractScriptHashV0(script []byte) []byte {
+	// Defer to consensus code.
+	return txscript.ExtractScriptHash(script)
+}
+
+// IsScriptHashScriptV0 returns whether or not the passed script is a standard
+// version 0 pay-to-script-hash script.
+func IsScriptHashScriptV0(script []byte) bool {
+	return ExtractScriptHashV0(script) != nil
+}
+
 // DetermineScriptTypeV0 returns the type of the passed version 0 script from
 // the known standard types.  This includes both types that are required by
 // consensus as well as those which are not.
@@ -213,6 +227,8 @@ func DetermineScriptTypeV0(script []byte) ScriptType {
 		return STPubKeyHashEd25519
 	case IsPubKeyHashSchnorrSecp256k1ScriptV0(script):
 		return STPubKeyHashSchnorrSecp256k1
+	case IsScriptHashScriptV0(script):
+		return STScriptHash
 	}
 
 	return STNonStandard

--- a/internal/staging/stdscript/scriptv0.go
+++ b/internal/staging/stdscript/scriptv0.go
@@ -590,6 +590,12 @@ func IsStakeChangeScriptHashScriptV0(script []byte) bool {
 	return ExtractStakeChangeScriptHashV0(script) != nil
 }
 
+// IsTreasuryAddScriptV0 returns whether or not the passed script is a supported
+// version 0 treasury add script.
+func IsTreasuryAddScriptV0(script []byte) bool {
+	return len(script) == 1 && script[0] == txscript.OP_TADD
+}
+
 // DetermineScriptTypeV0 returns the type of the passed version 0 script from
 // the known standard types.  This includes both types that are required by
 // consensus as well as those which are not.
@@ -631,6 +637,8 @@ func DetermineScriptTypeV0(script []byte) ScriptType {
 		return STStakeChangePubKeyHash
 	case IsStakeChangeScriptHashScriptV0(script):
 		return STStakeChangeScriptHash
+	case IsTreasuryAddScriptV0(script):
+		return STTreasuryAdd
 	}
 
 	return STNonStandard

--- a/internal/staging/stdscript/scriptv0.go
+++ b/internal/staging/stdscript/scriptv0.go
@@ -116,6 +116,31 @@ func IsPubKeySchnorrSecp256k1ScriptV0(script []byte) bool {
 	return pk != nil && sigType == dcrec.STSchnorrSecp256k1
 }
 
+// ExtractPubKeyHashV0 extracts the public key hash from the passed script if it
+// is a standard version 0 pay-to-pubkey-hash-ecdsa-secp256k1 script.  It will
+// return nil otherwise.
+func ExtractPubKeyHashV0(script []byte) []byte {
+	// A pay-to-pubkey-hash script is of the form:
+	//  OP_DUP OP_HASH160 <20-byte hash> OP_EQUALVERIFY OP_CHECKSIG
+	if len(script) == 25 &&
+		script[0] == txscript.OP_DUP &&
+		script[1] == txscript.OP_HASH160 &&
+		script[2] == txscript.OP_DATA_20 &&
+		script[23] == txscript.OP_EQUALVERIFY &&
+		script[24] == txscript.OP_CHECKSIG {
+
+		return script[3:23]
+	}
+
+	return nil
+}
+
+// IsPubKeyHashScriptV0 returns whether or not the passed script is a standard
+// version 0 pay-to-pubkey-hash-ecdsa-secp256k1 script.
+func IsPubKeyHashScriptV0(script []byte) bool {
+	return ExtractPubKeyHashV0(script) != nil
+}
+
 // DetermineScriptTypeV0 returns the type of the passed version 0 script from
 // the known standard types.  This includes both types that are required by
 // consensus as well as those which are not.
@@ -129,6 +154,8 @@ func DetermineScriptTypeV0(script []byte) ScriptType {
 		return STPubKeyEd25519
 	case IsPubKeySchnorrSecp256k1ScriptV0(script):
 		return STPubKeySchnorrSecp256k1
+	case IsPubKeyHashScriptV0(script):
+		return STPubKeyHashEcdsaSecp256k1
 	}
 
 	return STNonStandard

--- a/internal/staging/stdscript/scriptv0.go
+++ b/internal/staging/stdscript/scriptv0.go
@@ -4,11 +4,74 @@
 
 package stdscript
 
+import (
+	"github.com/decred/dcrd/txscript/v4"
+)
+
+// ExtractCompressedPubKeyV0 extracts a compressed public key from the passed
+// script if it is a standard version 0 pay-to-compressed-secp256k1-pubkey
+// script.  It will return nil otherwise.
+func ExtractCompressedPubKeyV0(script []byte) []byte {
+	// A pay-to-compressed-pubkey script is of the form:
+	//  OP_DATA_33 <33-byte compressed pubkey> OP_CHECKSIG
+
+	// All compressed secp256k1 public keys must start with 0x02 or 0x03.
+	if len(script) == 35 &&
+		script[34] == txscript.OP_CHECKSIG &&
+		script[0] == txscript.OP_DATA_33 &&
+		(script[1] == 0x02 || script[1] == 0x03) {
+
+		return script[1:34]
+	}
+	return nil
+}
+
+// ExtractUncompressedPubKeyV0 extracts an uncompressed public key from the
+// passed script if it is a standard version 0
+// pay-to-uncompressed-secp256k1-pubkey script.  It will return nil otherwise.
+func ExtractUncompressedPubKeyV0(script []byte) []byte {
+	// A pay-to-uncompressed-pubkey script is of the form:
+	//  OP_DATA_65 <65-byte uncompressed pubkey> OP_CHECKSIG
+
+	// All non-hybrid uncompressed secp256k1 public keys must start with 0x04.
+	if len(script) == 67 &&
+		script[66] == txscript.OP_CHECKSIG &&
+		script[0] == txscript.OP_DATA_65 &&
+		script[1] == 0x04 {
+
+		return script[1:66]
+	}
+	return nil
+}
+
+// ExtractPubKeyV0 extracts either a compressed or uncompressed public key from
+// the passed script if it is either a standard version 0
+// pay-to-compressed-secp256k1-pubkey or pay-to-uncompressed-secp256k1-pubkey
+// script, respectively.  It will return nil otherwise.
+func ExtractPubKeyV0(script []byte) []byte {
+	if pubKey := ExtractCompressedPubKeyV0(script); pubKey != nil {
+		return pubKey
+	}
+	return ExtractUncompressedPubKeyV0(script)
+}
+
+// IsPubKeyScriptV0 returns whether or not the passed script is either a
+// standard version 0 pay-to-compressed-secp256k1-pubkey or
+// pay-to-uncompressed-secp256k1-pubkey script.
+func IsPubKeyScriptV0(script []byte) bool {
+	return ExtractPubKeyV0(script) != nil
+}
+
 // DetermineScriptTypeV0 returns the type of the passed version 0 script from
 // the known standard types.  This includes both types that are required by
 // consensus as well as those which are not.
 //
 // STNonStandard will be returned when the script does not parse.
 func DetermineScriptTypeV0(script []byte) ScriptType {
+	switch {
+	case IsPubKeyScriptV0(script):
+		return STPubKeyEcdsaSecp256k1
+	}
+
 	return STNonStandard
 }

--- a/internal/staging/stdscript/scriptv0.go
+++ b/internal/staging/stdscript/scriptv0.go
@@ -558,6 +558,22 @@ func IsStakeRevocationScriptHashScriptV0(script []byte) bool {
 	return ExtractStakeRevocationScriptHashV0(script) != nil
 }
 
+// ExtractStakeChangePubKeyHashV0 extracts the public key hash from the
+// passed script if it is a standard version 0 stake change pay-to-pubkey-hash
+// script.  It will return nil otherwise.
+func ExtractStakeChangePubKeyHashV0(script []byte) []byte {
+	// A stake change pay-to-pubkey-hash script is of the form:
+	//  OP_SSTXCHANGE <standard-pay-to-pubkey-hash script>
+	const stakeOpcode = txscript.OP_SSTXCHANGE
+	return extractStakePubKeyHashV0(script, stakeOpcode)
+}
+
+// IsStakeChangePubKeyHashScriptV0 returns whether or not the passed script is a
+// standard version 0 stake change pay-to-pubkey-hash script.
+func IsStakeChangePubKeyHashScriptV0(script []byte) bool {
+	return ExtractStakeChangePubKeyHashV0(script) != nil
+}
+
 // DetermineScriptTypeV0 returns the type of the passed version 0 script from
 // the known standard types.  This includes both types that are required by
 // consensus as well as those which are not.
@@ -595,6 +611,8 @@ func DetermineScriptTypeV0(script []byte) ScriptType {
 		return STStakeRevocationPubKeyHash
 	case IsStakeRevocationScriptHashScriptV0(script):
 		return STStakeRevocationScriptHash
+	case IsStakeChangePubKeyHashScriptV0(script):
+		return STStakeChangePubKeyHash
 	}
 
 	return STNonStandard

--- a/internal/staging/stdscript/scriptv0.go
+++ b/internal/staging/stdscript/scriptv0.go
@@ -526,6 +526,22 @@ func IsStakeGenScriptHashScriptV0(script []byte) bool {
 	return ExtractStakeGenScriptHashV0(script) != nil
 }
 
+// ExtractStakeRevocationPubKeyHashV0 extracts the public key hash from
+// the passed script if it is a standard version 0 stake revocation
+// pay-to-pubkey-hash script.  It will return nil otherwise.
+func ExtractStakeRevocationPubKeyHashV0(script []byte) []byte {
+	// A stake revocation pay-to-pubkey-hash script is of the form:
+	//  OP_SSRTX <standard-pay-to-pubkey-hash script>
+	const stakeOpcode = txscript.OP_SSRTX
+	return extractStakePubKeyHashV0(script, stakeOpcode)
+}
+
+// IsStakeRevocationPubKeyHashScriptV0 returns whether or not the passed script
+// is a standard version 0 stake revocation pay-to-pubkey-hash script.
+func IsStakeRevocationPubKeyHashScriptV0(script []byte) bool {
+	return ExtractStakeRevocationPubKeyHashV0(script) != nil
+}
+
 // DetermineScriptTypeV0 returns the type of the passed version 0 script from
 // the known standard types.  This includes both types that are required by
 // consensus as well as those which are not.
@@ -559,6 +575,8 @@ func DetermineScriptTypeV0(script []byte) ScriptType {
 		return STStakeGenPubKeyHash
 	case IsStakeGenScriptHashScriptV0(script):
 		return STStakeGenScriptHash
+	case IsStakeRevocationPubKeyHashScriptV0(script):
+		return STStakeRevocationPubKeyHash
 	}
 
 	return STNonStandard

--- a/internal/staging/stdscript/scriptv0.go
+++ b/internal/staging/stdscript/scriptv0.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package stdscript
+
+// DetermineScriptTypeV0 returns the type of the passed version 0 script from
+// the known standard types.  This includes both types that are required by
+// consensus as well as those which are not.
+//
+// STNonStandard will be returned when the script does not parse.
+func DetermineScriptTypeV0(script []byte) ScriptType {
+	return STNonStandard
+}

--- a/internal/staging/stdscript/scriptv0.go
+++ b/internal/staging/stdscript/scriptv0.go
@@ -542,6 +542,22 @@ func IsStakeRevocationPubKeyHashScriptV0(script []byte) bool {
 	return ExtractStakeRevocationPubKeyHashV0(script) != nil
 }
 
+// ExtractStakeRevocationScriptHashV0 extracts the script hash from the
+// passed script if it is a standard version 0 stake revocation
+// pay-to-script-hash script.  It will return nil otherwise.
+func ExtractStakeRevocationScriptHashV0(script []byte) []byte {
+	// A stake revocation pay-to-script-hash script is of the form:
+	//  OP_SSRTX <standard-pay-to-script-hash script>
+	const stakeOpcode = txscript.OP_SSRTX
+	return extractStakeScriptHashV0(script, stakeOpcode)
+}
+
+// IsStakeRevocationScriptHashScript returns whether or not the passed script is
+// a standard version 0 stake revocation pay-to-script-hash script.
+func IsStakeRevocationScriptHashScriptV0(script []byte) bool {
+	return ExtractStakeRevocationScriptHashV0(script) != nil
+}
+
 // DetermineScriptTypeV0 returns the type of the passed version 0 script from
 // the known standard types.  This includes both types that are required by
 // consensus as well as those which are not.
@@ -577,6 +593,8 @@ func DetermineScriptTypeV0(script []byte) ScriptType {
 		return STStakeGenScriptHash
 	case IsStakeRevocationPubKeyHashScriptV0(script):
 		return STStakeRevocationPubKeyHash
+	case IsStakeRevocationScriptHashScriptV0(script):
+		return STStakeRevocationScriptHash
 	}
 
 	return STNonStandard

--- a/internal/staging/stdscript/scriptv0_test.go
+++ b/internal/staging/stdscript/scriptv0_test.go
@@ -49,6 +49,7 @@ var scriptV0Tests = func() []scriptTest {
 		"56ae12777aacfbb620f3be96017f45c560de80f0f6518fe4a03c870c36b075f297"
 	pkCE := "02" + pkUE[2:66]
 	h160CE := "e280cb6e66b96679aec288b1fbdbd4db08077a1b"
+	h160CE2 := "01557763e0252dc0ff9e0996ad1d04b167bb993c"
 	pkCO := "03" + pkUO[2:66]
 	pkHE := "05" + pkUE[2:]
 	pkHO := "06" + pkUO[2:]
@@ -259,6 +260,31 @@ var scriptV0Tests = func() []scriptTest {
 			h160Ed),
 		wantType: STPubKeyHashEd25519,
 		wantData: hexToBytes(h160Ed),
+	}, {
+		// ---------------------------------------------------------------------
+		// Negative P2PKH Schnorr secp256k1 tests.
+		// ---------------------------------------------------------------------
+
+		name: "almost v0 p2pkh-schnorr-secp256k1 -- wrong hash length",
+		script: p("DUP HASH160 DATA_21 0x00%s EQUALVERIFY 2 CHECKSIGALT",
+			h160CE),
+		wantType: STNonStandard,
+	}, {
+		// ---------------------------------------------------------------------
+		// Positive P2PKH Schnorr secp256k1 tests.
+		// ---------------------------------------------------------------------
+
+		name: "v0 p2pkh-schnorr-secp256k1",
+		script: p("DUP HASH160 DATA_20 0x%s EQUALVERIFY 2 CHECKSIGALT",
+			h160CE),
+		wantType: STPubKeyHashSchnorrSecp256k1,
+		wantData: hexToBytes(h160CE),
+	}, {
+		name: "v0 p2pkh-schnorr-secp256k1 2",
+		script: p("DUP HASH160 DATA_20 0x%s EQUALVERIFY 2 CHECKSIGALT",
+			h160CE2),
+		wantType: STPubKeyHashSchnorrSecp256k1,
+		wantData: hexToBytes(h160CE2),
 	}}
 }()
 
@@ -374,6 +400,10 @@ func TestExtractPubKeyHashAltDetailsV0(t *testing.T) {
 		case STPubKeyHashEd25519:
 			wantBytes = asByteSlice(t, test)
 			wantSigType = dcrec.STEd25519
+
+		case STPubKeyHashSchnorrSecp256k1:
+			wantBytes = asByteSlice(t, test)
+			wantSigType = dcrec.STSchnorrSecp256k1
 		}
 
 		gotBytes, gotSigType := ExtractPubKeyHashAltDetailsV0(test.script)

--- a/internal/staging/stdscript/scriptv0_test.go
+++ b/internal/staging/stdscript/scriptv0_test.go
@@ -683,6 +683,25 @@ var scriptV0Tests = func() []scriptTest {
 		name:     "v0 treasury add",
 		script:   p("TADD"),
 		wantType: STTreasuryAdd,
+	}, {
+		// ---------------------------------------------------------------------
+		// Negative treasury generation P2PKH tests.
+		// ---------------------------------------------------------------------
+
+		name: "almost v0 trsy gen p2pkh-ecdsa-secp256k1 -- wrong hash length",
+		script: p("TGEN DUP HASH160 DATA_21 0x00%s EQUALVERIFY CHECKSIG",
+			h160CE),
+		wantType: STNonStandard,
+	}, {
+		// ---------------------------------------------------------------------
+		// Positive treasury generation P2PKH tests.
+		// ---------------------------------------------------------------------
+
+		name: "v0 treasury generation p2pkh-ecdsa-secp256k1",
+		script: p("TGEN DUP HASH160 DATA_20 0x%s EQUALVERIFY CHECKSIG",
+			h160CE),
+		wantType: STTreasuryGenPubKeyHash,
+		wantData: hexToBytes(h160CE),
 	}}
 }()
 
@@ -1078,6 +1097,27 @@ func TestExtractStakeChangeScriptHashV0(t *testing.T) {
 		got := ExtractStakeChangeScriptHashV0(test.script)
 		if !bytes.Equal(got, want) {
 			t.Errorf("%q: unexpected script hash -- got %x, want %x", test.name,
+				got, want)
+			continue
+		}
+	}
+}
+
+// TestExtractTreasuryGenPubKeyHashV0 ensures that extracting a public key hash
+// from a version 0 treasury generation pay-to-pubkey-hash script works as
+// intended for all of the version 0 test scripts.
+func TestExtractTreasuryGenPubKeyHashV0(t *testing.T) {
+	for _, test := range scriptV0Tests {
+		// Determine the expected data based on the expected script type and
+		// data specified in the test.
+		var want []byte
+		if test.wantType == STTreasuryGenPubKeyHash {
+			want = asByteSlice(t, test)
+		}
+
+		got := ExtractTreasuryGenPubKeyHashV0(test.script)
+		if !bytes.Equal(got, want) {
+			t.Errorf("%q: unexpected pubkey hash -- got %x, want %x", test.name,
 				got, want)
 			continue
 		}

--- a/internal/staging/stdscript/scriptv0_test.go
+++ b/internal/staging/stdscript/scriptv0_test.go
@@ -5,8 +5,23 @@
 package stdscript
 
 import (
+	"bytes"
+	"encoding/hex"
 	"fmt"
+	"testing"
 )
+
+// hexToBytes converts the passed hex string into bytes and will panic if there
+// is an error.  This is only provided for the hard-coded constants so errors in
+// the source code can be detected. It will only (and must only) be called with
+// hard-coded values.
+func hexToBytes(s string) []byte {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		panic("invalid hex in source file: " + s)
+	}
+	return b
+}
 
 // scriptV0Tests houses several version 0 test scripts used to ensure various
 // script types and data extraction is working as expected.  It's defined as a
@@ -20,6 +35,20 @@ var scriptV0Tests = func() []scriptTest {
 		return mustParseShortForm(scriptVersion, fmt.Sprintf(format, a...))
 	}
 
+	// ---------------------------------------------------------------------
+	// Define some data shared in the tests for convenience.
+	// ---------------------------------------------------------------------
+
+	// Uncompressed and compressed/hybrid even/odd secp256k1 public keys.
+	pkUE := "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f817" +
+		"98483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
+	pkUO := "04fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a14602975" +
+		"56ae12777aacfbb620f3be96017f45c560de80f0f6518fe4a03c870c36b075f297"
+	pkCE := "02" + pkUE[2:66]
+	pkCO := "03" + pkUO[2:66]
+	pkHE := "05" + pkUE[2:]
+	pkHO := "06" + pkUO[2:]
+
 	return []scriptTest{{
 		// ---------------------------------------------------------------------
 		// Misc negative tests.
@@ -32,5 +61,93 @@ var scriptV0Tests = func() []scriptTest {
 		name:     "empty v0 script",
 		script:   nil,
 		wantType: STNonStandard,
+	}, {
+		// ---------------------------------------------------------------------
+		// Negative P2PK ECDSA secp256k1 tests.
+		// ---------------------------------------------------------------------
+
+		name:     "v0 p2pk-ecdsa-secp256k1 hybrid odd",
+		script:   p("DATA_33 0x%s CHECKSIG", pkHO),
+		wantType: STNonStandard,
+	}, {
+		name:     "v0 p2pk-ecdsa-secp256k1 hybrid even",
+		script:   p("DATA_33 0x%s CHECKSIG", pkHE),
+		wantType: STNonStandard,
+	}, {
+		name:     "almost v0 p2pk-ecdsa-secp256k1 -- trailing opcode",
+		script:   p("DATA_33 0x%s CHECKSIG TRUE", pkCE),
+		wantType: STNonStandard,
+	}, {
+		name:     "almost v0 p2pk-ecdsa-secp256k1 -- pubkey not pushed",
+		script:   p("0x%s CHECKSIG", pkCE),
+		wantType: STNonStandard,
+	}, {
+		name:     "almost v0 p2pk-ecdsa-secp256k1 -- malformed pubkey prefix",
+		script:   p("DATA_33 0x08%s CHECKSIG", pkCE[2:]),
+		wantType: STNonStandard,
+	}, {
+		// ---------------------------------------------------------------------
+		// Positive P2PK ECDSA secp256k1 tests.
+		// ---------------------------------------------------------------------
+
+		name:     "v0 p2pk-ecdsa-secp256k1 uncompressed",
+		script:   p("DATA_65 0x%s CHECKSIG", pkUE),
+		wantType: STPubKeyEcdsaSecp256k1,
+		wantData: hexToBytes(pkUE),
+	}, {
+		name:     "v0 p2pk-ecdsa-secp256k1 compressed even",
+		script:   p("DATA_33 0x%s CHECKSIG", pkCE),
+		wantType: STPubKeyEcdsaSecp256k1,
+		wantData: hexToBytes(pkCE),
+	}, {
+		name:     "v0 p2pk-ecdsa-secp256k1 compressed odd",
+		script:   p("DATA_33 0x%s CHECKSIG", pkCO),
+		wantType: STPubKeyEcdsaSecp256k1,
+		wantData: hexToBytes(pkCO),
 	}}
 }()
+
+// asByteSlice attempts to convert the data associated with the passed script
+// test to a byte slice or causes a fatal test error.
+func asByteSlice(t *testing.T, test scriptTest) []byte {
+	t.Helper()
+
+	want, ok := test.wantData.([]byte)
+	if !ok {
+		t.Fatalf("%q: unexpected want data type -- got %T", test.name,
+			test.wantData)
+	}
+	return want
+}
+
+// TestExtractPubKeysV0 ensures that extracting a public key from the various
+// version 0 pay-to-pubkey-ecdsa-secp256k1 style scripts works as intended
+// for all of the version 0 test scripts.
+func TestExtractPubKeysV0(t *testing.T) {
+	for _, test := range scriptV0Tests {
+		// Determine the expected data based on the expected script type and
+		// data specified in the test.
+		var want, wantCompressed, wantUncompressed []byte
+		if test.wantType == STPubKeyEcdsaSecp256k1 {
+			want = asByteSlice(t, test)
+			if len(want) == 33 {
+				wantCompressed = want
+			} else if len(want) == 65 {
+				wantUncompressed = want
+			}
+		}
+
+		testExtract := func(fn func(script []byte) []byte, want []byte) {
+			t.Helper()
+
+			got := fn(test.script)
+			if !bytes.Equal(got, want) {
+				t.Errorf("%q: unexpected pubkey -- got %x, want %x (script %x)",
+					test.name, got, want, test.script)
+			}
+		}
+		testExtract(ExtractPubKeyV0, want)
+		testExtract(ExtractCompressedPubKeyV0, wantCompressed)
+		testExtract(ExtractUncompressedPubKeyV0, wantUncompressed)
+	}
+}

--- a/internal/staging/stdscript/scriptv0_test.go
+++ b/internal/staging/stdscript/scriptv0_test.go
@@ -154,6 +154,48 @@ var scriptV0Tests = func() []scriptTest {
 		script:   p("DATA_32 0x%s 1 CHECKSIGALT", pkEd),
 		wantType: STPubKeyEd25519,
 		wantData: hexToBytes(pkEd),
+	}, {
+		// ---------------------------------------------------------------------
+		// Negative P2PK Schnorr secp256k1 tests.
+		// ---------------------------------------------------------------------
+
+		name:     "v0 p2pk-schnorr-secp256k1 uncompressed",
+		script:   p("DATA_65 0x%s 2 CHECKSIGALT", pkUE),
+		wantType: STNonStandard,
+	}, {
+		name:     "v0 p2pk-schnorr-secp256k1 hybrid odd",
+		script:   p("DATA_65 0x%s 2 CHECKSIGALT", pkHO),
+		wantType: STNonStandard,
+	}, {
+		name:     "v0 p2pk-schnorr-secp256k1 hybrid even",
+		script:   p("DATA_65 0x%s 2 CHECKSIGALT", pkHE),
+		wantType: STNonStandard,
+	}, {
+		name:     "almost v0 p2pk-schnorr-secp256k1 -- trailing opcode",
+		script:   p("DATA_33 0x%s 2 CHECKSIGALT TRUE", pkCE),
+		wantType: STNonStandard,
+	}, {
+		name:     "almost v0 p2pk-schnorr-secp256k1 -- pubkey not pushed",
+		script:   p("0x%s 2 CHECKSIGALT", pkCE),
+		wantType: STNonStandard,
+	}, {
+		name:     "almost v0 p2pk-schnorr-secp256k1 -- malformed pubkey prefix",
+		script:   p("DATA_33 0x08%s 2 CHECKSIGALT", pkCE[2:]),
+		wantType: STNonStandard,
+	}, {
+		// ---------------------------------------------------------------------
+		// Positive P2PK Schnorr secp256k1 tests.
+		// ---------------------------------------------------------------------
+
+		name:     "v0 p2pk-schnorr-secp256k1 compressed even",
+		script:   p("DATA_33 0x%s 2 CHECKSIGALT", pkCE),
+		wantType: STPubKeySchnorrSecp256k1,
+		wantData: hexToBytes(pkCE),
+	}, {
+		name:     "v0 p2pk-schnorr-secp256k1 compressed odd",
+		script:   p("DATA_33 0x%s 2 CHECKSIGALT", pkCO),
+		wantType: STPubKeySchnorrSecp256k1,
+		wantData: hexToBytes(pkCO),
 	}}
 }()
 
@@ -215,6 +257,10 @@ func TestExtractPubKeyAltDetailsV0(t *testing.T) {
 		case STPubKeyEd25519:
 			wantBytes = asByteSlice(t, test)
 			wantSigType = dcrec.STEd25519
+
+		case STPubKeySchnorrSecp256k1:
+			wantBytes = asByteSlice(t, test)
+			wantSigType = dcrec.STSchnorrSecp256k1
 		}
 
 		gotBytes, gotSigType := ExtractPubKeyAltDetailsV0(test.script)

--- a/internal/staging/stdscript/scriptv0_test.go
+++ b/internal/staging/stdscript/scriptv0_test.go
@@ -646,6 +646,23 @@ var scriptV0Tests = func() []scriptTest {
 			h160CE),
 		wantType: STStakeChangePubKeyHash,
 		wantData: hexToBytes(h160CE),
+	}, {
+		// ---------------------------------------------------------------------
+		// Negative stake submission change P2SH tests.
+		// ---------------------------------------------------------------------
+
+		name:     "almost v0 stake change p2sh -- wrong hash length",
+		script:   p("SSTXCHANGE HASH160 DATA_21 0x00%s EQUAL", p2sh),
+		wantType: STNonStandard,
+	}, {
+		// ---------------------------------------------------------------------
+		// Positive stake submission change P2SH tests.
+		// ---------------------------------------------------------------------
+
+		name:     "v0 stake change p2sh",
+		script:   p("SSTXCHANGE HASH160 DATA_20 0x%s EQUAL", p2sh),
+		wantType: STStakeChangeScriptHash,
+		wantData: hexToBytes(p2sh),
 	}}
 }()
 
@@ -1020,6 +1037,27 @@ func TestExtractStakeChangePubKeyHashV0(t *testing.T) {
 		got := ExtractStakeChangePubKeyHashV0(test.script)
 		if !bytes.Equal(got, want) {
 			t.Errorf("%q: unexpected pubkey hash -- got %x, want %x", test.name,
+				got, want)
+			continue
+		}
+	}
+}
+
+// TestExtractStakeChangeScriptHashV0 ensures that extracting a script hash from
+// a version 0 stake change pay-to-script-hash script works as intended for all
+// of the version 0 test scripts.
+func TestExtractStakeChangeScriptHashV0(t *testing.T) {
+	for _, test := range scriptV0Tests {
+		// Determine the expected data based on the expected script type and
+		// data specified in the test.
+		var want []byte
+		if test.wantType == STStakeChangeScriptHash {
+			want = asByteSlice(t, test)
+		}
+
+		got := ExtractStakeChangeScriptHashV0(test.script)
+		if !bytes.Equal(got, want) {
+			t.Errorf("%q: unexpected script hash -- got %x, want %x", test.name,
 				got, want)
 			continue
 		}

--- a/internal/staging/stdscript/scriptv0_test.go
+++ b/internal/staging/stdscript/scriptv0_test.go
@@ -627,6 +627,25 @@ var scriptV0Tests = func() []scriptTest {
 		script:   p("SSRTX HASH160 DATA_20 0x%s EQUAL", p2sh),
 		wantType: STStakeRevocationScriptHash,
 		wantData: hexToBytes(p2sh),
+	}, {
+		// ---------------------------------------------------------------------
+		// Negative stake submission change P2PKH tests.
+		// ---------------------------------------------------------------------
+
+		name: "almost v0 stake change p2pkh-ecdsa-secp256k1 -- wrong hash length",
+		script: p("SSTXCHANGE DUP HASH160 DATA_21 0x00%s EQUALVERIFY CHECKSIG",
+			h160CE),
+		wantType: STNonStandard,
+	}, {
+		// ---------------------------------------------------------------------
+		// Positive stake submission change P2PKH tests.
+		// ---------------------------------------------------------------------
+
+		name: "v0 stake change p2pkh-ecdsa-secp256k1",
+		script: p("SSTXCHANGE DUP HASH160 DATA_20 0x%s EQUALVERIFY CHECKSIG",
+			h160CE),
+		wantType: STStakeChangePubKeyHash,
+		wantData: hexToBytes(h160CE),
 	}}
 }()
 
@@ -980,6 +999,27 @@ func TestExtractStakeRevocationScriptHashV0(t *testing.T) {
 		got := ExtractStakeRevocationScriptHashV0(test.script)
 		if !bytes.Equal(got, want) {
 			t.Errorf("%q: unexpected script hash -- got %x, want %x", test.name,
+				got, want)
+			continue
+		}
+	}
+}
+
+// TestExtractStakeChangePubKeyHashV0 ensures that extracting a public key hash
+// from a version 0 stake change pay-to-pubkey-hash script works as intended for
+// all of the version 0 test scripts.
+func TestExtractStakeChangePubKeyHashV0(t *testing.T) {
+	for _, test := range scriptV0Tests {
+		// Determine the expected data based on the expected script type and
+		// data specified in the test.
+		var want []byte
+		if test.wantType == STStakeChangePubKeyHash {
+			want = asByteSlice(t, test)
+		}
+
+		got := ExtractStakeChangePubKeyHashV0(test.script)
+		if !bytes.Equal(got, want) {
+			t.Errorf("%q: unexpected pubkey hash -- got %x, want %x", test.name,
 				got, want)
 			continue
 		}

--- a/internal/staging/stdscript/scriptv0_test.go
+++ b/internal/staging/stdscript/scriptv0_test.go
@@ -610,6 +610,23 @@ var scriptV0Tests = func() []scriptTest {
 			h160CE),
 		wantType: STStakeRevocationPubKeyHash,
 		wantData: hexToBytes(h160CE),
+	}, {
+		// ---------------------------------------------------------------------
+		// Negative stake submission revocation P2SH tests.
+		// ---------------------------------------------------------------------
+
+		name:     "almost v0 stake revoke p2sh -- wrong hash length",
+		script:   p("SSRTX HASH160 DATA_21 0x00%s EQUAL", p2sh),
+		wantType: STNonStandard,
+	}, {
+		// ---------------------------------------------------------------------
+		// Positive stake submission revocation P2SH tests.
+		// ---------------------------------------------------------------------
+
+		name:     "v0 stake revoke p2sh",
+		script:   p("SSRTX HASH160 DATA_20 0x%s EQUAL", p2sh),
+		wantType: STStakeRevocationScriptHash,
+		wantData: hexToBytes(p2sh),
 	}}
 }()
 
@@ -942,6 +959,27 @@ func TestExtractStakeRevocationPubKeyHashV0(t *testing.T) {
 		got := ExtractStakeRevocationPubKeyHashV0(test.script)
 		if !bytes.Equal(got, want) {
 			t.Errorf("%q: unexpected pubkey hash -- got %x, want %x", test.name,
+				got, want)
+			continue
+		}
+	}
+}
+
+// TestExtractStakeRevocationScriptHashV0 ensures that extracting a script hash
+// from a version 0 stake revocation pay-to-script-hash script works as intended
+// for all of the version 0 test scripts.
+func TestExtractStakeRevocationScriptHashV0(t *testing.T) {
+	for _, test := range scriptV0Tests {
+		// Determine the expected data based on the expected script type and
+		// data specified in the test.
+		var want []byte
+		if test.wantType == STStakeRevocationScriptHash {
+			want = asByteSlice(t, test)
+		}
+
+		got := ExtractStakeRevocationScriptHashV0(test.script)
+		if !bytes.Equal(got, want) {
+			t.Errorf("%q: unexpected script hash -- got %x, want %x", test.name,
 				got, want)
 			continue
 		}

--- a/internal/staging/stdscript/scriptv0_test.go
+++ b/internal/staging/stdscript/scriptv0_test.go
@@ -448,6 +448,78 @@ var scriptV0Tests = func() []scriptTest {
 		isSig:    true,
 		wantType: STMultiSig,
 		wantData: p("1 DATA_33 0x%s DATA_33 0x%s 2 CHECKMULTISIG", pkCE, pkCE2),
+	}, {
+		// ---------------------------------------------------------------------
+		// Negative nulldata tests.
+		// ---------------------------------------------------------------------
+
+		name:     "almost v0 nulldata -- NOP instead of data push",
+		script:   p("RETURN NOP"),
+		wantType: STNonStandard,
+	}, {
+		name:     "almost v0 nulldata -- non-canonical small int push (DATA_1 vs 12)",
+		script:   p("RETURN DATA_1 0x0c"),
+		wantType: STNonStandard,
+	}, {
+		name:     "almost v0 nulldata -- non-canonical small int push (PUSHDATA1 vs 12)",
+		script:   p("RETURN PUSHDATA1 0x01 0x0c"),
+		wantType: STNonStandard,
+	}, {
+		name: "almost v0 nulldata -- non-canonical 60-byte push (PUSHDATA1 vs DATA_60)",
+		script: p("RETURN PUSHDATA1 0x3c 0x046708afdb0fe5548271967f1a67130b7105" +
+			"cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3046708afdb0fe5548271" +
+			"967f1a67130b7105cd6a"),
+		wantType: STNonStandard,
+	}, {
+		name:     "almost v0 nulldata -- non-canonical 12-byte push (PUSHDATA2)",
+		script:   p("RETURN PUSHDATA2 0x0c00 0x046708afdb0fe5548271967f"),
+		wantType: STNonStandard,
+	}, {
+		name:     "almost v0 nulldata -- non-canonical 12-byte push (PUSHDATA4)",
+		script:   p("RETURN PUSHDATA4 0x0c000000 0x046708afdb0fe5548271967f"),
+		wantType: STNonStandard,
+	}, {
+		name:     "almost v0 nulldata -- exceeds max standard push",
+		script:   p("RETURN PUSHDATA2 0x0101 0x01{257}"),
+		wantType: STNonStandard,
+	}, {
+		name:     "almost v0 nulldata -- trailing opcode",
+		script:   p("RETURN 4 TRUE"),
+		wantType: STNonStandard,
+	}, {
+		// ---------------------------------------------------------------------
+		// Positive nulldata tests.
+		// ---------------------------------------------------------------------
+
+		name:     "v0 nulldata no data push",
+		script:   p("RETURN"),
+		wantType: STNullData,
+	}, {
+		name:     "v0 nulldata single zero push",
+		script:   p("RETURN 0"),
+		wantType: STNullData,
+	}, {
+		name:     "v0 nulldata small int push",
+		script:   p("RETURN 1"),
+		wantType: STNullData,
+	}, {
+		name:     "v0 nulldata max small int push",
+		script:   p("RETURN 16"),
+		wantType: STNullData,
+	}, {
+		name:     "v0 nulldata small data push",
+		script:   p("RETURN DATA_8 0x046708afdb0fe554"),
+		wantType: STNullData,
+	}, {
+		name: "v0 nulldata 60-byte push",
+		script: p("RETURN 0x3c 0x046708afdb0fe5548271967f1a67130b7105cd6a828e03" +
+			"909a67962e0ea1f61deb649f6bc3f4cef3046708afdb0fe5548271967f1a6713" +
+			"0b7105cd6a"),
+		wantType: STNullData,
+	}, {
+		name:     "v0 nulldata max standard push",
+		script:   p("RETURN PUSHDATA2 0x0001 0x01{256}"),
+		wantType: STNullData,
 	}}
 }()
 

--- a/internal/staging/stdscript/scriptv0_test.go
+++ b/internal/staging/stdscript/scriptv0_test.go
@@ -591,6 +591,25 @@ var scriptV0Tests = func() []scriptTest {
 		script:   p("SSGEN HASH160 DATA_20 0x%s EQUAL", p2sh),
 		wantType: STStakeGenScriptHash,
 		wantData: hexToBytes(p2sh),
+	}, {
+		// ---------------------------------------------------------------------
+		// Negative stake submission revocation P2PKH tests.
+		// ---------------------------------------------------------------------
+
+		name: "almost v0 stake revoke p2pkh-ecdsa-secp256k1 -- wrong hash length",
+		script: p("SSRTX DUP HASH160 DATA_21 0x00%s EQUALVERIFY CHECKSIG",
+			h160CE),
+		wantType: STNonStandard,
+	}, {
+		// ---------------------------------------------------------------------
+		// Positive stake submission revocation P2PKH tests.
+		// ---------------------------------------------------------------------
+
+		name: "v0 stake revoke p2pkh-ecdsa-secp256k1",
+		script: p("SSRTX DUP HASH160 DATA_20 0x%s EQUALVERIFY CHECKSIG",
+			h160CE),
+		wantType: STStakeRevocationPubKeyHash,
+		wantData: hexToBytes(h160CE),
 	}}
 }()
 
@@ -902,6 +921,27 @@ func TestExtractStakeGenScriptHashV0(t *testing.T) {
 		got := ExtractStakeGenScriptHashV0(test.script)
 		if !bytes.Equal(got, want) {
 			t.Errorf("%q: unexpected script hash -- got %x, want %x", test.name,
+				got, want)
+			continue
+		}
+	}
+}
+
+// TestExtractStakeRevocationPubKeyHashV0 ensures that extracting a public key
+// hash from a version 0 stake revocation pay-to-pubkey-hash script works as
+// intended for all of the version 0 test scripts.
+func TestExtractStakeRevocationPubKeyHashV0(t *testing.T) {
+	for _, test := range scriptV0Tests {
+		// Determine the expected data based on the expected script type and
+		// data specified in the test.
+		var want []byte
+		if test.wantType == STStakeRevocationPubKeyHash {
+			want = asByteSlice(t, test)
+		}
+
+		got := ExtractStakeRevocationPubKeyHashV0(test.script)
+		if !bytes.Equal(got, want) {
+			t.Errorf("%q: unexpected pubkey hash -- got %x, want %x", test.name,
 				got, want)
 			continue
 		}

--- a/internal/staging/stdscript/scriptv0_test.go
+++ b/internal/staging/stdscript/scriptv0_test.go
@@ -574,6 +574,23 @@ var scriptV0Tests = func() []scriptTest {
 			h160CE),
 		wantType: STStakeGenPubKeyHash,
 		wantData: hexToBytes(h160CE),
+	}, {
+		// ---------------------------------------------------------------------
+		// Negative stake submission generation P2SH tests.
+		// ---------------------------------------------------------------------
+
+		name:     "almost v0 stake gen p2sh -- wrong hash length",
+		script:   p("SSGEN HASH160 DATA_21 0x00%s EQUAL", p2sh),
+		wantType: STNonStandard,
+	}, {
+		// ---------------------------------------------------------------------
+		// Positive stake submission generation P2SH tests.
+		// ---------------------------------------------------------------------
+
+		name:     "v0 stake gen p2sh",
+		script:   p("SSGEN HASH160 DATA_20 0x%s EQUAL", p2sh),
+		wantType: STStakeGenScriptHash,
+		wantData: hexToBytes(p2sh),
 	}}
 }()
 
@@ -864,6 +881,27 @@ func TestExtractStakeGenPubKeyHashV0(t *testing.T) {
 		got := ExtractStakeGenPubKeyHashV0(test.script)
 		if !bytes.Equal(got, want) {
 			t.Errorf("%q: unexpected pubkey hash -- got %x, want %x", test.name,
+				got, want)
+			continue
+		}
+	}
+}
+
+// TestExtractStakeGenScriptHashV0 ensures that extracting a script hash
+// from a version 0 stake generation pay-to-script-hash script works as intended
+// for all of the version 0 test scripts.
+func TestExtractStakeGenScriptHashV0(t *testing.T) {
+	for _, test := range scriptV0Tests {
+		// Determine the expected data based on the expected script type and
+		// data specified in the test.
+		var want []byte
+		if test.wantType == STStakeGenScriptHash {
+			want = asByteSlice(t, test)
+		}
+
+		got := ExtractStakeGenScriptHashV0(test.script)
+		if !bytes.Equal(got, want) {
+			t.Errorf("%q: unexpected script hash -- got %x, want %x", test.name,
 				got, want)
 			continue
 		}

--- a/internal/staging/stdscript/scriptv0_test.go
+++ b/internal/staging/stdscript/scriptv0_test.go
@@ -538,6 +538,23 @@ var scriptV0Tests = func() []scriptTest {
 		script:   p("SSTX DUP HASH160 DATA_20 0x%s EQUALVERIFY CHECKSIG", h160CE),
 		wantType: STStakeSubmissionPubKeyHash,
 		wantData: hexToBytes(h160CE),
+	}, {
+		// ---------------------------------------------------------------------
+		// Negative stake submission P2SH tests.
+		// ---------------------------------------------------------------------
+
+		name:     "almost v0 stake submission p2sh -- wrong hash length",
+		script:   p("SSTX HASH160 DATA_21 0x00%s EQUAL", p2sh),
+		wantType: STNonStandard,
+	}, {
+		// ---------------------------------------------------------------------
+		// Positive stake submission P2SH tests.
+		// ---------------------------------------------------------------------
+
+		name:     "v0 stake submission p2sh",
+		script:   p("SSTX HASH160 DATA_20 0x%s EQUAL", p2sh),
+		wantType: STStakeSubmissionScriptHash,
+		wantData: hexToBytes(p2sh),
 	}}
 }()
 
@@ -786,6 +803,27 @@ func TestExtractStakeSubmissionPubKeyHashV0(t *testing.T) {
 		got := ExtractStakeSubmissionPubKeyHashV0(test.script)
 		if !bytes.Equal(got, want) {
 			t.Errorf("%q: unexpected pubkey hash -- got %x, want %x", test.name,
+				got, want)
+			continue
+		}
+	}
+}
+
+// TestExtractStakeSubmissionScriptHashV0 ensures that extracting a script hash
+// from a version 0 stake submission pay-to-script-hash script works as intended
+// for all of the version 0 test scripts.
+func TestExtractStakeSubmissionScriptHashV0(t *testing.T) {
+	for _, test := range scriptV0Tests {
+		// Determine the expected data based on the expected script type and
+		// data specified in the test.
+		var want []byte
+		if test.wantType == STStakeSubmissionScriptHash {
+			want = asByteSlice(t, test)
+		}
+
+		got := ExtractStakeSubmissionScriptHashV0(test.script)
+		if !bytes.Equal(got, want) {
+			t.Errorf("%q: unexpected script hash -- got %x, want %x", test.name,
 				got, want)
 			continue
 		}

--- a/internal/staging/stdscript/scriptv0_test.go
+++ b/internal/staging/stdscript/scriptv0_test.go
@@ -702,6 +702,23 @@ var scriptV0Tests = func() []scriptTest {
 			h160CE),
 		wantType: STTreasuryGenPubKeyHash,
 		wantData: hexToBytes(h160CE),
+	}, {
+		// ---------------------------------------------------------------------
+		// Negative treasury generation P2SH tests.
+		// ---------------------------------------------------------------------
+
+		name:     "almost v0 treasury generation p2sh -- wrong hash length",
+		script:   p("TGEN HASH160 DATA_21 0x00%s EQUAL", p2sh),
+		wantType: STNonStandard,
+	}, {
+		// ---------------------------------------------------------------------
+		// Positive treasury generation P2SH tests.
+		// ---------------------------------------------------------------------
+
+		name:     "v0 treasury generation p2sh",
+		script:   p("TGEN HASH160 DATA_20 0x%s EQUAL", p2sh),
+		wantType: STTreasuryGenScriptHash,
+		wantData: hexToBytes(p2sh),
 	}}
 }()
 
@@ -1118,6 +1135,27 @@ func TestExtractTreasuryGenPubKeyHashV0(t *testing.T) {
 		got := ExtractTreasuryGenPubKeyHashV0(test.script)
 		if !bytes.Equal(got, want) {
 			t.Errorf("%q: unexpected pubkey hash -- got %x, want %x", test.name,
+				got, want)
+			continue
+		}
+	}
+}
+
+// TestExtractTreasuryGenScriptHashV0 ensures that extracting a script hash from
+// a version 0 treasury generation pay-to-script-hash script works as intended
+// for all of the version 0 test scripts.
+func TestExtractTreasuryGenScriptHashV0(t *testing.T) {
+	for _, test := range scriptV0Tests {
+		// Determine the expected data based on the expected script type and
+		// data specified in the test.
+		var want []byte
+		if test.wantType == STTreasuryGenScriptHash {
+			want = asByteSlice(t, test)
+		}
+
+		got := ExtractTreasuryGenScriptHashV0(test.script)
+		if !bytes.Equal(got, want) {
+			t.Errorf("%q: unexpected script hash -- got %x, want %x", test.name,
 				got, want)
 			continue
 		}

--- a/internal/staging/stdscript/scriptv0_test.go
+++ b/internal/staging/stdscript/scriptv0_test.go
@@ -555,6 +555,25 @@ var scriptV0Tests = func() []scriptTest {
 		script:   p("SSTX HASH160 DATA_20 0x%s EQUAL", p2sh),
 		wantType: STStakeSubmissionScriptHash,
 		wantData: hexToBytes(p2sh),
+	}, {
+		// ---------------------------------------------------------------------
+		// Negative stake submission generation P2PKH tests.
+		// ---------------------------------------------------------------------
+
+		name: "almost v0 stake gen p2pkh-ecdsa-secp256k1 -- wrong hash length",
+		script: p("SSGEN DUP HASH160 DATA_21 0x00%s EQUALVERIFY CHECKSIG",
+			h160CE),
+		wantType: STNonStandard,
+	}, {
+		// ---------------------------------------------------------------------
+		// Positive stake submission generation P2PKH tests.
+		// ---------------------------------------------------------------------
+
+		name: "v0 stake gen p2pkh-ecdsa-secp256k1",
+		script: p("SSGEN DUP HASH160 DATA_20 0x%s EQUALVERIFY CHECKSIG",
+			h160CE),
+		wantType: STStakeGenPubKeyHash,
+		wantData: hexToBytes(h160CE),
 	}}
 }()
 
@@ -824,6 +843,27 @@ func TestExtractStakeSubmissionScriptHashV0(t *testing.T) {
 		got := ExtractStakeSubmissionScriptHashV0(test.script)
 		if !bytes.Equal(got, want) {
 			t.Errorf("%q: unexpected script hash -- got %x, want %x", test.name,
+				got, want)
+			continue
+		}
+	}
+}
+
+// TestExtractStakeGenPubKeyHashV0 ensures that extracting a public key
+// hash from a version 0 stake generation pay-to-pubkey-hash script works as
+// intended for all of the version 0 test scripts.
+func TestExtractStakeGenPubKeyHashV0(t *testing.T) {
+	for _, test := range scriptV0Tests {
+		// Determine the expected data based on the expected script type and
+		// data specified in the test.
+		var want []byte
+		if test.wantType == STStakeGenPubKeyHash {
+			want = asByteSlice(t, test)
+		}
+
+		got := ExtractStakeGenPubKeyHashV0(test.script)
+		if !bytes.Equal(got, want) {
+			t.Errorf("%q: unexpected pubkey hash -- got %x, want %x", test.name,
 				got, want)
 			continue
 		}

--- a/internal/staging/stdscript/scriptv0_test.go
+++ b/internal/staging/stdscript/scriptv0_test.go
@@ -663,6 +663,26 @@ var scriptV0Tests = func() []scriptTest {
 		script:   p("SSTXCHANGE HASH160 DATA_20 0x%s EQUAL", p2sh),
 		wantType: STStakeChangeScriptHash,
 		wantData: hexToBytes(p2sh),
+	}, {
+		// ---------------------------------------------------------------------
+		// Negative treasury add tests.
+		// ---------------------------------------------------------------------
+
+		name:     "almost v0 treasury add -- trailing opcode",
+		script:   p("TADD TRUE"),
+		wantType: STNonStandard,
+	}, {
+		name:     "almost v0 treasury add -- two TADD",
+		script:   p("TADD TADD"),
+		wantType: STNonStandard,
+	}, {
+		// ---------------------------------------------------------------------
+		// Positive treasury add tests.
+		// ---------------------------------------------------------------------
+
+		name:     "v0 treasury add",
+		script:   p("TADD"),
+		wantType: STTreasuryAdd,
 	}}
 }()
 

--- a/internal/staging/stdscript/scriptv0_test.go
+++ b/internal/staging/stdscript/scriptv0_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package stdscript
+
+import (
+	"fmt"
+)
+
+// scriptV0Tests houses several version 0 test scripts used to ensure various
+// script types and data extraction is working as expected.  It's defined as a
+// test global versus inside a specific test function scope since it spans
+// multiple tests and benchmarks.
+var scriptV0Tests = func() []scriptTest {
+	// Convience function that combines fmt.Sprintf with mustParseShortForm
+	// to create more compact tests.
+	p := func(format string, a ...interface{}) []byte {
+		const scriptVersion = 0
+		return mustParseShortForm(scriptVersion, fmt.Sprintf(format, a...))
+	}
+
+	return []scriptTest{{
+		// ---------------------------------------------------------------------
+		// Misc negative tests.
+		// ---------------------------------------------------------------------
+
+		name:     "malformed v0 script that does not parse",
+		script:   p("DATA_5 0x01020304"),
+		wantType: STNonStandard,
+	}, {
+		name:     "empty v0 script",
+		script:   nil,
+		wantType: STNonStandard,
+	}}
+}()


### PR DESCRIPTION
Similar to the code for handling standard addresses prior to the recent updates which implemented the `stdaddr` package, the current code for handling standard scripts implemented in `txscript` was written many years ago prior a wide variety of changes and several new features added by Decred.  As a result, it entirely lacks support for some features and supports others in a roundabout and non-intuitive way.

Specifically, it does not support or provide a clean path to enable support for different script versions.

Finally, the code being implemented in `txscript` (which was necessary back when the original code was implemented, but no longer is due to changes since) has led to confusion regarding what is considered standard and what is considered consensus which has tripped up several contributors over the years.

This aims to resolve all of the aforementioned issues by introducing a new package named `stdscript` which reworks the way standard scripts are handled.

It is split up into a series of commits to help ease the review process such that the initial generic infrastructure is introduced first, followed by each supported version 0 script and associated benchmark, followed by examples, and finally what I hope is a fairly complete `README.md` that describes the architecture. Comprehensive tests are included.

For the time being, the package is introduced into the internal staging area for initial review.

The following provides an overview of some of the key features of the new design:

- Supports versioned scripts
- Provides the ability to efficiently extract version-specific relevant data, such as public keys, public keys hashes, and script hashes from standard scripts
- Allows callers to choose between using version-specific or dynamic type determination methods
- Implements several new types, as compared to the existing code, which leads to an easier to use API
- Clearly denotes that these scripts are a standardized construction the must not be used directly in consensus code
- Provides additional convenience methods for working with typical version 0 atomic swap and multisignature scripts

Additionally, this includes a few changes to the standardness policy versus the existing code as follows:

- Version 0 ECDSA multisignature scripts:
  - Only compressed public keys are now considered standard (existing code allows both compressed and uncompressed public keys)
  - At least one signature is now required (existing code only requires any small integer, which implicitly includes 0)
- Version 0 nulldata scripts:
  - Only canonical data pushes up to the maximum allowed length are now considered standard

These changes do not affect consensus in any way since consensus independently enforces all details related to the associated opcodes as required, but they help ensure the typical standard scripts occupy less space on chain and further restrict cases that don't make sense.  Further, all known software already creates scripts that conform to these more stringent requirements and has since launch, so these changes are unlikely to even be noticed in practice.

Test Coverage:
```
$ go test -coverprofile=cov.out | go tool cover -func=cov.out
error.go:26:          Error                                   100.0%
error.go:40:          Error                                   100.0%
error.go:45:          Unwrap                                  100.0%
error.go:50:          makeError                               100.0%
script.go:204:        String                                  100.0%
script.go:217:        IsPubKeyScript                          100.0%
script.go:231:        IsPubKeyEd25519Script                   100.0%
script.go:245:        IsPubKeySchnorrSecp256k1Script          100.0%
script.go:259:        IsPubKeyHashScript                      100.0%
script.go:273:        IsPubKeyHashEd25519Script               100.0%
script.go:287:        IsPubKeyHashSchnorrSecp256k1Script      100.0%
script.go:301:        IsScriptHashScript                      100.0%
script.go:315:        IsMultiSigScript                        100.0%
script.go:335:        IsMultiSigSigScript                     100.0%
script.go:349:        IsNullDataScript                        100.0%
script.go:363:        IsStakeSubmissionPubKeyHashScript       100.0%
script.go:377:        IsStakeSubmissionScriptHashScript       100.0%
script.go:391:        IsStakeGenPubKeyHashScript              100.0%
script.go:405:        IsStakeGenScriptHashScript              100.0%
script.go:419:        IsStakeRevocationPubKeyHashScript       100.0%
script.go:433:        IsStakeRevocationScriptHashScript       100.0%
script.go:447:        IsStakeChangePubKeyHashScript           100.0%
script.go:461:        IsStakeChangeScriptHashScript           100.0%
script.go:475:        IsTreasuryAddScript                     100.0%
script.go:489:        IsTreasuryGenPubKeyHashScript           100.0%
script.go:503:        IsTreasuryGenScriptHashScript           100.0%
script.go:518:        DetermineScriptType                     100.0%
scriptv0.go:17:       ExtractCompressedPubKeyV0               100.0%
scriptv0.go:35:       ExtractUncompressedPubKeyV0             100.0%
scriptv0.go:54:       ExtractPubKeyV0                         100.0%
scriptv0.go:64:       IsPubKeyScriptV0                        100.0%
scriptv0.go:71:       ExtractPubKeyAltDetailsV0               100.0%
scriptv0.go:109:      IsPubKeyEd25519ScriptV0                 100.0%
scriptv0.go:116:      IsPubKeySchnorrSecp256k1ScriptV0        100.0%
scriptv0.go:124:      ExtractPubKeyHashV0                     100.0%
scriptv0.go:142:      IsPubKeyHashScriptV0                    100.0%
scriptv0.go:148:      IsStandardAltSignatureTypeV0            100.0%
scriptv0.go:160:      ExtractPubKeyHashAltDetailsV0           100.0%
scriptv0.go:187:      IsPubKeyHashEd25519ScriptV0             100.0%
scriptv0.go:194:      IsPubKeyHashSchnorrSecp256k1ScriptV0    100.0%
scriptv0.go:202:      ExtractScriptHashV0                     100.0%
scriptv0.go:209:      IsScriptHashScriptV0                    100.0%
scriptv0.go:230:      ExtractMultiSigScriptDetailsV0          100.0%
scriptv0.go:310:      IsMultiSigScriptV0                      100.0%
scriptv0.go:319:      finalOpcodeDataV0                       100.0%
scriptv0.go:345:      IsMultiSigSigScriptV0                   100.0%
scriptv0.go:370:      MultiSigRedeemScriptFromScriptSigV0     100.0%
scriptv0.go:383:      isCanonicalPushV0                       100.0%
scriptv0.go:406:      IsNullDataScriptV0                      100.0%
scriptv0.go:436:      extractStakePubKeyHashV0                100.0%
scriptv0.go:453:      ExtractStakeSubmissionPubKeyHashV0      100.0%
scriptv0.go:462:      IsStakeSubmissionPubKeyHashScriptV0     100.0%
scriptv0.go:469:      extractStakeScriptHashV0                100.0%
scriptv0.go:486:      ExtractStakeSubmissionScriptHashV0      100.0%
scriptv0.go:495:      IsStakeSubmissionScriptHashScriptV0     100.0%
scriptv0.go:502:      ExtractStakeGenPubKeyHashV0             100.0%
scriptv0.go:511:      IsStakeGenPubKeyHashScriptV0            100.0%
scriptv0.go:518:      ExtractStakeGenScriptHashV0             100.0%
scriptv0.go:527:      IsStakeGenScriptHashScriptV0            100.0%
scriptv0.go:534:      ExtractStakeRevocationPubKeyHashV0      100.0%
scriptv0.go:543:      IsStakeRevocationPubKeyHashScriptV0     100.0%
scriptv0.go:550:      ExtractStakeRevocationScriptHashV0      100.0%
scriptv0.go:559:      IsStakeRevocationScriptHashScriptV0     100.0%
scriptv0.go:566:      ExtractStakeChangePubKeyHashV0          100.0%
scriptv0.go:575:      IsStakeChangePubKeyHashScriptV0         100.0%
scriptv0.go:582:      ExtractStakeChangeScriptHashV0          100.0%
scriptv0.go:591:      IsStakeChangeScriptHashScriptV0         100.0%
scriptv0.go:597:      IsTreasuryAddScriptV0                   100.0%
scriptv0.go:604:      ExtractTreasuryGenPubKeyHashV0          100.0%
scriptv0.go:613:      IsTreasuryGenPubKeyHashScriptV0         100.0%
scriptv0.go:620:      ExtractTreasuryGenScriptHashV0          100.0%
scriptv0.go:629:      IsTreasuryGenScriptHashScriptV0         100.0%
scriptv0.go:638:      DetermineScriptTypeV0                   100.0%
scriptv0.go:694:      MultiSigScriptV0                        100.0%
scriptv0.go:734:      ExtractAtomicSwapDataPushesV0           100.0%
total:                (statements)                            100.0%
```