### PR TITLE
blockchain: Use scripts in tickets address query.

### DIFF
--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -127,7 +127,7 @@ func TestBlockchainFunctions(t *testing.T) {
 	}
 
 	a, _ := stdaddr.DecodeAddress("SsbKpMkPnadDcZFFZqRPY8nvdFagrktKuzB", params)
-	hs, err := chain.TicketsWithAddress(a, noTreasury)
+	hs, err := chain.TicketsWithAddress(a.(stdaddr.StakeAddress))
 	if err != nil {
 		t.Errorf("Failed to do TicketsWithAddress: %v", err)
 	}

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -377,7 +377,7 @@ type Chain interface {
 
 	// TicketsWithAddress returns a slice of ticket hashes that are currently
 	// live corresponding to the given address.
-	TicketsWithAddress(address stdaddr.Address, isTreasuryEnabled bool) ([]chainhash.Hash, error)
+	TicketsWithAddress(address stdaddr.StakeAddress) ([]chainhash.Hash, error)
 
 	// TipGeneration returns the entire generation of blocks stemming from the
 	// parent of the current tip.

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -5100,15 +5100,14 @@ func handleTicketsForAddress(_ context.Context, s *Server, cmd interface{}) (int
 		return nil, rpcInvalidError("Invalid address: %v", err)
 	}
 
-	// Determine if the treasury rules are active as of the current best tip.
-	chain := s.cfg.Chain
-	prevBlkHash := chain.BestSnapshot().Hash
-	isTreasuryEnabled, err := s.isTreasuryAgendaActive(&prevBlkHash)
-	if err != nil {
-		return nil, err
+	stakeAddr, ok := addr.(stdaddr.StakeAddress)
+	if !ok {
+		return nil, rpcInvalidError("Address is not valid for use in the " +
+			"staking system")
 	}
 
-	tickets, err := chain.TicketsWithAddress(addr, isTreasuryEnabled)
+	chain := s.cfg.Chain
+	tickets, err := chain.TicketsWithAddress(stakeAddr)
 	if err != nil {
 		return nil, rpcInternalError(err.Error(), "could not obtain tickets")
 	}

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -401,7 +401,7 @@ func (c *testRPCChain) TicketPoolValue() (dcrutil.Amount, error) {
 
 // TicketsWithAddress returns a mocked slice of ticket hashes that are currently
 // live corresponding to the given address.
-func (c *testRPCChain) TicketsWithAddress(address stdaddr.Address, isTreasuryEnabled bool) ([]chainhash.Hash, error) {
+func (c *testRPCChain) TicketsWithAddress(address stdaddr.StakeAddress) ([]chainhash.Hash, error) {
 	return c.ticketsWithAddress, c.ticketsWithAddressErr
 }
 
@@ -6607,20 +6607,14 @@ func TestTicketsForAddress(t *testing.T) {
 		wantErr: true,
 		errCode: dcrjson.ErrRPCInvalidParameter,
 	}, {
-		name:    "handleTicketsForAddress: unable to fetch treasury agenda status",
+		name:    "handleTicketsForAddress: non-stake address",
 		handler: handleTicketsForAddress,
 		cmd: &types.TicketsForAddressCmd{
-			Address: addr,
+			// v0 pay-to-pubkey ecdsa.
+			Address: "SkLUJQxtYoVrewN6fwqsU6JQjxLs5a6xfcTsGfUYiLr2AUY6HuLMN",
 		},
-		mockChain: func() *testRPCChain {
-			chain := defaultMockRPCChain()
-			chain.treasuryActive = false
-			chain.treasuryActiveErr =
-				errors.New("unable to fetch treasury agenda status")
-			return chain
-		}(),
 		wantErr: true,
-		errCode: dcrjson.ErrRPCInternal.Code,
+		errCode: dcrjson.ErrRPCInvalidParameter,
 	}, {
 		name:    "handleTicketsForAddress: unable to fetch tickets for address",
 		handler: handleTicketsForAddress,


### PR DESCRIPTION
This modifies the `TicketsWithAddress` query method in `blockchain` to accept the more specific `stdaddr.StakeAddress` since only stake-capable addresses can be used in tickets and modifies the logic to compare the expected voting rights script and associated script version directly instead of extracting and comparing encoded addresses.  It also updates the callers and plumbing in `rpcserver` accordingly as well as adds a test for the new non-stake address error in the RPC handler.

Not only is this approach more efficient, it also removes the reliance on address extraction which in turn removes the need for the flag which specifies whether or not the treasury is active.