### PR TITLE
stake: Do not use standardness code in consensus.

### DIFF
--- a/blockchain/stake/staketx_test.go
+++ b/blockchain/stake/staketx_test.go
@@ -844,10 +844,8 @@ func TestSSGenTreasuryVotes(t *testing.T) {
 
 	// Check null data
 	lastTxOut := ssgenMsgTxValid.TxOut[len(ssgenMsgTxValid.TxOut)-1]
-	if sc := txscript.GetScriptClass(0, lastTxOut.PkScript,
-		true); sc != txscript.NullDataTy {
-		t.Fatalf("Invalid script class, expected %v got %v",
-			txscript.NullDataTy, sc)
+	if !IsNullDataScript(lastTxOut.Version, lastTxOut.PkScript) {
+		t.Fatal("Expected null data script for final output")
 	}
 
 	// Make sure ssgen is valid.

--- a/blockchain/stake/treasury.go
+++ b/blockchain/stake/treasury.go
@@ -86,8 +86,7 @@ func checkTAdd(mtx *wire.MsgTx) error {
 	// Only 1 stake change output allowed.
 	if len(mtx.TxOut) == 2 {
 		// Script length has been already verified.
-		if !txscript.IsStakeChangeScript(mtx.TxOut[1].Version,
-			mtx.TxOut[1].PkScript) {
+		if !IsStakeChangeScript(mtx.TxOut[1].Version, mtx.TxOut[1].PkScript) {
 			return stakeRuleError(ErrTAddInvalidChange,
 				"second output must be an OP_SSTXCHANGE script")
 		}
@@ -182,11 +181,11 @@ func CheckTSpend(mtx *wire.MsgTx) ([]byte, []byte, error) {
 				fmt.Sprintf("Output %v is not tagged with "+
 					"OP_TGEN", k+1))
 		}
-		if !(txscript.IsPubKeyHashScript(txOut.PkScript[1:]) ||
-			txscript.IsPayToScriptHash(txOut.PkScript[1:])) {
+		if !(isPubKeyHashScript(txOut.PkScript[1:]) ||
+			isScriptHashScript(txOut.PkScript[1:])) {
+
 			return nil, nil, stakeRuleError(ErrTSpendInvalidSpendScript,
-				fmt.Sprintf("Output %v is not P2SH or P2PKH",
-					k+1))
+				fmt.Sprintf("Output %v is not P2SH or P2PKH", k+1))
 		}
 	}
 


### PR DESCRIPTION
This modifies the treasury code in `stake` to avoid using standardness code since it is consensus level code which mean it must not change even though the policy regarding standardness can change.

The consensus-specific methods are all already available in the `stake` package, so the code is merely updated to use them instead.

An overview of the changes follows:

- Introduce an exported constant for the max data carrier size allowed in stake transactions set to match the current standardness value since that is now part of consensus for them
- Modify the calls to `txscript.GetScriptClass` used for determining null data scripts to use consensus-specific `IsNullDataScript` method
- Use the consensus-specific methods for the following:
  - `IsStakeChangeScript`
  - `isPubKeyHashScript`
  - `isScriptHashScript`