### PR TITLE
blockchain: Remove unneeded OP_TADD maturity check.

### DIFF
--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -2729,25 +2729,20 @@ func CheckTransactionInputs(subsidyCache *standalone.SubsidyCache, tx *dcrutil.T
 			}
 		}
 
-		// OP_TADD and OP_TGEN tagged outputs can only be spent after
-		// CoinbaseMaturity blocks.
+		// OP_TGEN tagged outputs can only be spent after coinbase maturity
+		// many blocks.
 		if isTreasuryEnabled {
 			scriptClass := txscript.GetScriptClass(utxoEntry.ScriptVersion(),
 				utxoEntry.PkScript(), isTreasuryEnabled)
-			if scriptClass == txscript.TreasuryAddTy ||
-				scriptClass == txscript.TreasuryGenTy {
+			if scriptClass == txscript.TreasuryGenTy {
 				originHeight := utxoEntry.BlockHeight()
 				blocksSincePrev := txHeight - originHeight
 				if blocksSincePrev < coinbaseMaturity {
-					str := fmt.Sprintf("tried to spend "+
-						"OP_TADD or OP_TGEN output "+
-						"from tx %v from height %v at"+
-						"height %v before required "+
-						"maturity of %v blocks",
-						txInHash, originHeight,
+					str := fmt.Sprintf("tried to spend OP_TGEN output from tx "+
+						"%v from height %v at height %v before required "+
+						"maturity of %v blocks", txInHash, originHeight,
 						txHeight, coinbaseMaturity)
-					return 0, ruleError(ErrImmatureSpend,
-						str)
+					return 0, ruleError(ErrImmatureSpend, str)
 				}
 			}
 		}


### PR DESCRIPTION
This removes the unnecessary `OP_TADD` coinbase maturity check because `OP_TADD` is not a spendable utxo and therefore it can never have a maturity applied to it.  Recall that treasurybase and treasury add stake transactions are the only place an `OP_TADD` is valid and in both cases they result in increasing the balance of the treasury account and are never directly spendable.