### PR TITLE
stake: Add is treasury gen script.

### DIFF
--- a/blockchain/stake/scripttype.go
+++ b/blockchain/stake/scripttype.go
@@ -74,3 +74,9 @@ func IsStakeChangeScript(version uint16, script []byte) bool {
 func IsVoteScript(version uint16, script []byte) bool {
 	return isTaggedScript(version, script, txscript.OP_SSGEN)
 }
+
+// IsTreasuryGenScript checks if the provided script is a treasury generation
+// script.
+func IsTreasuryGenScript(version uint16, script []byte) bool {
+	return isTaggedScript(version, script, txscript.OP_TGEN)
+}

--- a/blockchain/stake/scripttype_test.go
+++ b/blockchain/stake/scripttype_test.go
@@ -350,3 +350,111 @@ func TestIsStakeChangeScript(t *testing.T) {
 		}
 	}
 }
+
+// TestIsTreasuryGenScript ensures the method to determine if a script is a
+// treasury generation script works as intended.
+func TestIsTreasuryGenScript(t *testing.T) {
+	tests := []struct {
+		name         string
+		scriptSource *txscript.ScriptBuilder
+		version      uint16
+		expected     bool
+	}{{
+		name: "treasurygen-tagged p2pkh script",
+		scriptSource: txscript.NewScriptBuilder().
+			AddOp(txscript.OP_TGEN).AddOp(txscript.OP_DUP).
+			AddOp(txscript.OP_HASH160).AddData(hash160).
+			AddOp(txscript.OP_EQUALVERIFY).AddOp(txscript.OP_CHECKSIG),
+		version:  0,
+		expected: true,
+	}, {
+		name: "treasurygen-tagged p2pkh script with unsupported version",
+		scriptSource: txscript.NewScriptBuilder().
+			AddOp(txscript.OP_TGEN).AddOp(txscript.OP_DUP).
+			AddOp(txscript.OP_HASH160).AddData(hash160).
+			AddOp(txscript.OP_EQUALVERIFY).AddOp(txscript.OP_CHECKSIG),
+		version:  9999,
+		expected: false,
+	}, {
+		name: "stake change-tagged p2pkh script",
+		scriptSource: txscript.NewScriptBuilder().
+			AddOp(txscript.OP_SSTXCHANGE).AddOp(txscript.OP_DUP).
+			AddOp(txscript.OP_HASH160).AddData(hash160).
+			AddOp(txscript.OP_EQUALVERIFY).AddOp(txscript.OP_CHECKSIG),
+		version:  0,
+		expected: false,
+	}, {
+		name: "stake change-tagged p2pkh script with unsupported version",
+		scriptSource: txscript.NewScriptBuilder().
+			AddOp(txscript.OP_SSTXCHANGE).AddOp(txscript.OP_DUP).
+			AddOp(txscript.OP_HASH160).AddData(hash160).
+			AddOp(txscript.OP_EQUALVERIFY).AddOp(txscript.OP_CHECKSIG),
+		version:  1,
+		expected: false,
+	}, {
+		name: "vote-tagged p2pkh script",
+		scriptSource: txscript.NewScriptBuilder().
+			AddOp(txscript.OP_SSGEN).AddOp(txscript.OP_DUP).
+			AddOp(txscript.OP_HASH160).AddData(hash160).
+			AddOp(txscript.OP_EQUALVERIFY).AddOp(txscript.OP_CHECKSIG),
+		version:  0,
+		expected: false,
+	}, {
+		name: "vote-tagged p2pkh script with unsupported version",
+		scriptSource: txscript.NewScriptBuilder().
+			AddOp(txscript.OP_SSGEN).AddOp(txscript.OP_DUP).
+			AddOp(txscript.OP_HASH160).AddData(hash160).
+			AddOp(txscript.OP_EQUALVERIFY).AddOp(txscript.OP_CHECKSIG),
+		version:  1,
+		expected: false,
+	}, {
+		name: "treasurygen-tagged p2sh script",
+		scriptSource: txscript.NewScriptBuilder().
+			AddOp(txscript.OP_TGEN).AddOp(txscript.OP_HASH160).
+			AddData(hash160).AddOp(txscript.OP_EQUAL),
+		version:  0,
+		expected: true,
+	}, {
+		name: "treasurygen-tagged p2sh script with unsupported version",
+		scriptSource: txscript.NewScriptBuilder().
+			AddOp(txscript.OP_TGEN).AddOp(txscript.OP_HASH160).
+			AddData(hash160).AddOp(txscript.OP_EQUAL),
+		version:  100,
+		expected: false,
+	}, {
+		name: "stake change-tagged p2sh script",
+		scriptSource: txscript.NewScriptBuilder().
+			AddOp(txscript.OP_SSTXCHANGE).AddOp(txscript.OP_HASH160).
+			AddData(hash160).AddOp(txscript.OP_EQUAL),
+		version:  0,
+		expected: false,
+	}, {
+		name: "stake change-tagged p2sh script with unsupported version",
+		scriptSource: txscript.NewScriptBuilder().
+			AddOp(txscript.OP_SSTXCHANGE).AddOp(txscript.OP_HASH160).
+			AddData(hash160).AddOp(txscript.OP_EQUAL),
+		version:  100,
+		expected: false,
+	}, {
+		name: "revocation-tagged p2sh script",
+		scriptSource: txscript.NewScriptBuilder().
+			AddOp(txscript.OP_SSRTX).AddOp(txscript.OP_HASH160).
+			AddData(hash160).AddOp(txscript.OP_EQUAL),
+		version:  0,
+		expected: false,
+	}}
+
+	for _, test := range tests {
+		script, err := test.scriptSource.Script()
+		if err != nil {
+			t.Fatalf("%q: unexpected script generation error: %s", test.name,
+				err)
+		}
+
+		result := IsTreasuryGenScript(test.version, script)
+		if result != test.expected {
+			t.Fatalf("%q: unexpected result -- got %v, want %v", test.name,
+				result, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
This adds a method to stake which allow treasury generation scripts that are enforced by consensus to be identified via a consensus-specific method versus relying on the policy-based variant that is subject to change.

This is consistent with the other consensus-enforced stake-related scripts exported from the package.