### PR TITLE
blockchain: No standardness code in consensus.

### DIFF
--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -2731,19 +2731,17 @@ func CheckTransactionInputs(subsidyCache *standalone.SubsidyCache, tx *dcrutil.T
 
 		// OP_TGEN tagged outputs can only be spent after coinbase maturity
 		// many blocks.
-		if isTreasuryEnabled {
-			scriptClass := txscript.GetScriptClass(utxoEntry.ScriptVersion(),
-				utxoEntry.PkScript(), isTreasuryEnabled)
-			if scriptClass == txscript.TreasuryGenTy {
-				originHeight := utxoEntry.BlockHeight()
-				blocksSincePrev := txHeight - originHeight
-				if blocksSincePrev < coinbaseMaturity {
-					str := fmt.Sprintf("tried to spend OP_TGEN output from tx "+
-						"%v from height %v at height %v before required "+
-						"maturity of %v blocks", txInHash, originHeight,
-						txHeight, coinbaseMaturity)
-					return 0, ruleError(ErrImmatureSpend, str)
-				}
+		if isTreasuryEnabled && stake.IsTreasuryGenScript(
+			utxoEntry.ScriptVersion(), utxoEntry.PkScript()) {
+
+			originHeight := utxoEntry.BlockHeight()
+			blocksSincePrev := txHeight - originHeight
+			if blocksSincePrev < coinbaseMaturity {
+				str := fmt.Sprintf("tried to spend OP_TGEN output from tx %v "+
+					"from height %v at height %v before required maturity of "+
+					"%v blocks", txInHash, originHeight, txHeight,
+					coinbaseMaturity)
+				return 0, ruleError(ErrImmatureSpend, str)
 			}
 		}
 


### PR DESCRIPTION
**This requires #2659 and #2660**.

This modifies the treasury code in `blockchain` which enforces the treasury generation spending maturity to avoid using standardness code since it is consensus level code which mean it must not change even though the policy regarding standardness can change.

