### PR TITLE
txscript: Standardness vs consensus cleanup.

### DIFF
--- a/txscript/bench_test.go
+++ b/txscript/bench_test.go
@@ -553,23 +553,6 @@ func BenchmarkMultisigRedeemScript(b *testing.B) {
 	}
 }
 
-// BenchmarkPushedData benchmarks how long it takes to extract the pushed data
-// from a very large script.
-func BenchmarkPushedData(b *testing.B) {
-	script, err := genComplexScript()
-	if err != nil {
-		b.Fatalf("failed to create benchmark script: %v", err)
-	}
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, err := PushedData(script)
-		if err != nil {
-			b.Fatalf("unexpected err: %v", err)
-		}
-	}
-}
-
 // BenchmarkIsUnspendable benchmarks how long it takes IsUnspendable to analyze
 // a very large script.
 func BenchmarkIsUnspendable(b *testing.B) {

--- a/txscript/consensus.go
+++ b/txscript/consensus.go
@@ -286,21 +286,3 @@ func IsStrictNullData(scriptVersion uint16, script []byte, requiredLen uint32) b
 			(tokenizer.Opcode() <= OP_DATA_75 &&
 				uint32(len(tokenizer.Data())) == requiredLen))
 }
-
-// IsStakeChangeScript returns whether or not the passed script is a supported
-// stake change script.
-//
-// NOTE: This function is only valid for version 0 scripts.  It will always
-// return false for other script versions.
-func IsStakeChangeScript(scriptVersion uint16, script []byte) bool {
-	// The only currently supported script version is 0.
-	if scriptVersion != 0 {
-		return false
-	}
-
-	// The only supported stake change scripts are pay-to-pubkey-hash and
-	// pay-to-script-hash tagged with the stake submission opcode.
-	const stakeOpcode = OP_SSTXCHANGE
-	return extractStakePubKeyHash(script, stakeOpcode) != nil ||
-		extractStakeScriptHash(script, stakeOpcode) != nil
-}

--- a/txscript/consensus.go
+++ b/txscript/consensus.go
@@ -287,12 +287,6 @@ func IsStrictNullData(scriptVersion uint16, script []byte, requiredLen uint32) b
 				uint32(len(tokenizer.Data())) == requiredLen))
 }
 
-// IsPubKeyHashScript returns whether or not the passed script is a standard
-// pay-to-pubkey-hash script.
-func IsPubKeyHashScript(script []byte) bool {
-	return extractPubKeyHash(script) != nil
-}
-
 // IsStakeChangeScript returns whether or not the passed script is a supported
 // stake change script.
 //

--- a/txscript/reference_test.go
+++ b/txscript/reference_test.go
@@ -12,33 +12,11 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"regexp"
-	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/wire"
-)
-
-var (
-	// tokenRE is a regular expression used to parse tokens from short form
-	// scripts.  It splits on repeated tokens and spaces.  Repeated tokens are
-	// denoted by being wrapped in angular brackets followed by a suffix which
-	// consists of a number inside braces.
-	tokenRE = regexp.MustCompile(`\<.+?\>\{[0-9]+\}|[^\s]+`)
-
-	// repTokenRE is a regular expression used to parse short form scripts
-	// for a series of tokens repeated a specified number of times.
-	repTokenRE = regexp.MustCompile(`^\<(.+)\>\{([0-9]+)\}$`)
-
-	// repRawRE is a regular expression used to parse short form scripts
-	// for raw data that is to be repeated a specified number of times.
-	repRawRE = regexp.MustCompile(`^(0[xX][0-9a-fA-F]+)\{([0-9]+)\}$`)
-
-	// repQuoteRE is a regular expression used to parse short form scripts for
-	// quoted data that is to be repeated a specified number of times.
-	repQuoteRE = regexp.MustCompile(`^'(.*)'\{([0-9]+)\}$`)
 )
 
 // scriptTestName returns a descriptive test name for the given reference script
@@ -62,154 +40,6 @@ func scriptTestName(test []string) (string, error) {
 			test[2])
 	}
 	return name, nil
-}
-
-// parse hex string into a []byte.
-func parseHex(tok string) ([]byte, error) {
-	if !strings.HasPrefix(tok, "0x") {
-		return nil, errors.New("not a hex number")
-	}
-	return hex.DecodeString(tok[2:])
-}
-
-// shortFormOps holds a map of opcode names to values for use in short form
-// parsing.  It is declared here so it only needs to be created once.
-var shortFormOps map[string]byte
-
-// parseShortForm parses a string as used in the reference tests into the
-// script it came from.
-//
-// The format used for these tests is pretty simple if ad-hoc:
-//   - Opcodes other than the push opcodes and unknown are present as either
-//     OP_NAME or just NAME
-//   - Plain numbers are made into push operations
-//   - Numbers beginning with 0x are inserted into the []byte as-is (so 0x14 is
-//     OP_DATA_20)
-//   - Numbers beginning with 0x which have a suffix which consists of a number
-//     in braces (e.g. 0x6161{10}) repeat the raw bytes the specified number of
-//     times and are inserted as-is
-//   - Single quoted strings are pushed as data
-//   - Single quoted strings that have a suffix which consists of a number in
-//     braces (e.g. 'b'{10}) repeat the data the specified number of times and
-//     are pushed as a single data push
-//   - Tokens inside of angular brackets with a suffix which consists of a
-//     number in braces (e.g. <0 0 CHECKMULTSIG>{5}) is parsed as if the tokens
-//     inside the angular brackets were manually repeated the specified number
-//     of times
-//   - Anything else is an error
-func parseShortForm(script string) ([]byte, error) {
-	// Only create the short form opcode map once.
-	if shortFormOps == nil {
-		ops := make(map[string]byte)
-		for opcodeName, opcodeValue := range OpcodeByName {
-			if strings.Contains(opcodeName, "OP_UNKNOWN") {
-				continue
-			}
-			ops[opcodeName] = opcodeValue
-
-			// The opcodes named OP_# can't have the OP_ prefix
-			// stripped or they would conflict with the plain
-			// numbers.  Also, since OP_FALSE and OP_TRUE are
-			// aliases for the OP_0, and OP_1, respectively, they
-			// have the same value, so detect those by name and
-			// allow them.
-			if (opcodeName == "OP_FALSE" || opcodeName == "OP_TRUE") ||
-				(opcodeValue != OP_0 && (opcodeValue < OP_1 ||
-					opcodeValue > OP_16)) {
-
-				ops[strings.TrimPrefix(opcodeName, "OP_")] = opcodeValue
-			}
-		}
-		shortFormOps = ops
-	}
-
-	builder := NewScriptBuilder()
-
-	var handleToken func(tok string) error
-	handleToken = func(tok string) error {
-		// Multiple repeated tokens.
-		if m := repTokenRE.FindStringSubmatch(tok); m != nil {
-			count, err := strconv.ParseInt(m[2], 10, 32)
-			if err != nil {
-				return fmt.Errorf("bad token %q", tok)
-			}
-			tokens := tokenRE.FindAllStringSubmatch(m[1], -1)
-			for i := 0; i < int(count); i++ {
-				for _, t := range tokens {
-					if err := handleToken(t[0]); err != nil {
-						return err
-					}
-				}
-			}
-			return nil
-		}
-
-		// Plain number.
-		if num, err := strconv.ParseInt(tok, 10, 64); err == nil {
-			builder.AddInt64(num)
-			return nil
-		}
-
-		// Raw data.
-		if bts, err := parseHex(tok); err == nil {
-			// Use the unchecked variant since the test code
-			// intentionally creates scripts that are too large and
-			// would cause the builder to error otherwise.
-			builder.AddOpsUnchecked(bts)
-			return nil
-		}
-
-		// Repeated raw bytes.
-		if m := repRawRE.FindStringSubmatch(tok); m != nil {
-			bts, err := parseHex(m[1])
-			if err != nil {
-				return fmt.Errorf("bad token %q", tok)
-			}
-			count, err := strconv.ParseInt(m[2], 10, 32)
-			if err != nil {
-				return fmt.Errorf("bad token %q", tok)
-			}
-
-			// Use the unchecked variant since the test code
-			// intentionally creates scripts that are too large and
-			// would cause the builder to error otherwise.
-			bts = bytes.Repeat(bts, int(count))
-			builder.AddOpsUnchecked(bts)
-			return nil
-		}
-
-		// Quoted data.
-		if len(tok) >= 2 && tok[0] == '\'' && tok[len(tok)-1] == '\'' {
-			builder.AddDataUnchecked([]byte(tok[1 : len(tok)-1]))
-			return nil
-		}
-
-		// Repeated quoted data.
-		if m := repQuoteRE.FindStringSubmatch(tok); m != nil {
-			count, err := strconv.ParseInt(m[2], 10, 32)
-			if err != nil {
-				return fmt.Errorf("bad token %q", tok)
-			}
-			data := strings.Repeat(m[1], int(count))
-			builder.AddDataUnchecked([]byte(data))
-			return nil
-		}
-
-		// Named opcode.
-		if opcode, ok := shortFormOps[tok]; ok {
-			builder.AddOp(opcode)
-			return nil
-		}
-
-		return fmt.Errorf("bad token %q", tok)
-	}
-
-	for _, tokens := range tokenRE.FindAllStringSubmatch(script, -1) {
-		if err := handleToken(tokens[0]); err != nil {
-			return nil, err
-		}
-	}
-	return builder.Script()
 }
 
 // parseScriptFlags parses the provided flags string from the format used in the

--- a/txscript/script.go
+++ b/txscript/script.go
@@ -7,7 +7,10 @@ package txscript
 
 import (
 	"bytes"
+	"encoding/binary"
 	"strings"
+
+	"github.com/decred/dcrd/chaincfg/chainhash"
 )
 
 // These are the constants specified for maximums in individual scripts.
@@ -465,4 +468,16 @@ func IsUnspendable(amount int64, pkScript []byte) bool {
 	// The script is unspendable if it is guaranteed to fail at execution.
 	const scriptVersion = 0
 	return checkScriptParses(scriptVersion, pkScript) != nil
+}
+
+// GenerateSSGenBlockRef generates a block reference script for the given block
+// hash and height which a block votes on.  The script is for use in stake vote
+// transactions.
+func GenerateSSGenBlockRef(blockHash chainhash.Hash, height uint32) ([]byte, error) {
+	// Serialize the block hash and height
+	brBytes := make([]byte, 32+4)
+	copy(brBytes[0:32], blockHash[:])
+	binary.LittleEndian.PutUint32(brBytes[32:36], height)
+
+	return NewScriptBuilder().AddOp(OP_RETURN).AddData(brBytes).Script()
 }

--- a/txscript/script.go
+++ b/txscript/script.go
@@ -481,3 +481,13 @@ func GenerateSSGenBlockRef(blockHash chainhash.Hash, height uint32) ([]byte, err
 
 	return NewScriptBuilder().AddOp(OP_RETURN).AddData(brBytes).Script()
 }
+
+// GenerateSSGenVotes generates a vote script for the given vote bits.  The
+// script is for use in stake vote transactions.
+func GenerateSSGenVotes(votebits uint16) ([]byte, error) {
+	// Serialize the votebits
+	vbBytes := make([]byte, 2)
+	binary.LittleEndian.PutUint16(vbBytes, votebits)
+
+	return NewScriptBuilder().AddOp(OP_RETURN).AddData(vbBytes).Script()
+}

--- a/txscript/script.go
+++ b/txscript/script.go
@@ -115,6 +115,24 @@ func (vm *Engine) isAnyKindOfScriptHash(script []byte) bool {
 	return isScriptHashScript(script) || vm.isStakeScriptHashScript(script)
 }
 
+// ContainsStakeOpCodes returns whether or not a public key script contains any
+// stake tagging opcodes.
+//
+// NOTE: This function is only valid for version 0 scripts.  Since the function
+// does not accept a script version, the results are undefined for other script
+// versions.
+func ContainsStakeOpCodes(pkScript []byte, isTreasuryEnabled bool) (bool, error) {
+	const scriptVersion = 0
+	tokenizer := MakeScriptTokenizer(scriptVersion, pkScript)
+	for tokenizer.Next() {
+		if isStakeOpcode(tokenizer.Opcode(), isTreasuryEnabled) {
+			return true, nil
+		}
+	}
+
+	return false, tokenizer.Err()
+}
+
 // hasP2SHRedeemScriptStakeOpCodes returns an error if the provided public key
 // script is a regular pay-to-script-hash or a stake-tagged pay-to-script and,
 // when it is, that the redeem script within the provided signature script

--- a/txscript/script_test.go
+++ b/txscript/script_test.go
@@ -712,3 +712,28 @@ func TestGenerateSSGenBlockRef(t *testing.T) {
 		}
 	}
 }
+
+// TestGenerateSSGenVotes ensures the expected vote script for use in stake
+// vote transactions is generated correctly for various vote bits.
+func TestGenerateSSGenVotes(t *testing.T) {
+	var tests = []struct {
+		votebits uint16
+		expected []byte
+	}{
+		{65535, hexToBytes("6a02ffff")},
+		{256, hexToBytes("6a020001")},
+		{127, hexToBytes("6a027f00")},
+		{0, hexToBytes("6a020000")},
+	}
+	for _, test := range tests {
+		s, err := GenerateSSGenVotes(test.votebits)
+		if err != nil {
+			t.Errorf("unexpected err: %v", err)
+			continue
+		}
+		if !bytes.Equal(s, test.expected) {
+			t.Errorf("unexpected script -- got %x, want %x", s, test.expected)
+			continue
+		}
+	}
+}

--- a/txscript/script_test.go
+++ b/txscript/script_test.go
@@ -9,72 +9,10 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 )
-
-// TestPushedData ensured the PushedData function extracts the expected data out
-// of various scripts.
-func TestPushedData(t *testing.T) {
-	t.Parallel()
-
-	var tests = []struct {
-		script string
-		out    [][]byte
-		valid  bool
-	}{
-		{
-			"0 IF 0 ELSE 2 ENDIF",
-			[][]byte{nil, nil},
-			true,
-		},
-		{
-			"16777216 10000000",
-			[][]byte{
-				{0x00, 0x00, 0x00, 0x01}, // 16777216
-				{0x80, 0x96, 0x98, 0x00}, // 10000000
-			},
-			true,
-		},
-		{
-			"DUP HASH160 '17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem' EQUALVERIFY CHECKSIG",
-			[][]byte{
-				// 17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem
-				{
-					0x31, 0x37, 0x56, 0x5a, 0x4e, 0x58, 0x31, 0x53, 0x4e, 0x35,
-					0x4e, 0x74, 0x4b, 0x61, 0x38, 0x55, 0x51, 0x46, 0x78, 0x77,
-					0x51, 0x62, 0x46, 0x65, 0x46, 0x63, 0x33, 0x69, 0x71, 0x52,
-					0x59, 0x68, 0x65, 0x6d,
-				},
-			},
-			true,
-		},
-		{
-			"PUSHDATA4 1000 EQUAL",
-			nil,
-			false,
-		},
-	}
-
-	for i, test := range tests {
-		script := mustParseShortForm(test.script)
-		data, err := PushedData(script)
-		if test.valid && err != nil {
-			t.Errorf("TestPushedData failed test #%d: %v\n", i, err)
-			continue
-		} else if !test.valid && err == nil {
-			t.Errorf("TestPushedData failed test #%d: test should "+
-				"be invalid\n", i)
-			continue
-		}
-		if !reflect.DeepEqual(data, test.out) {
-			t.Errorf("TestPushedData failed test #%d: want: %x "+
-				"got: %x\n", i, test.out, data)
-		}
-	}
-}
 
 // TestHasCanonicalPush ensures the isCanonicalPush function works as expected.
 func TestHasCanonicalPush(t *testing.T) {

--- a/txscript/scriptshortform_test.go
+++ b/txscript/scriptshortform_test.go
@@ -1,0 +1,196 @@
+// Copyright (c) 2013-2017 The btcsuite developers
+// Copyright (c) 2015-2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package txscript
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	// tokenRE is a regular expression used to parse tokens from short form
+	// scripts.  It splits on repeated tokens and spaces.  Repeated tokens are
+	// denoted by being wrapped in angular brackets followed by a suffix which
+	// consists of a number inside braces.
+	tokenRE = regexp.MustCompile(`\<.+?\>\{[0-9]+\}|[^\s]+`)
+
+	// repTokenRE is a regular expression used to parse short form scripts for a
+	// series of tokens repeated a specified number of times.
+	repTokenRE = regexp.MustCompile(`^\<(.+)\>\{([0-9]+)\}$`)
+
+	// repRawRE is a regular expression used to parse short form scripts for raw
+	// data that is to be repeated a specified number of times.
+	repRawRE = regexp.MustCompile(`^(0[xX][0-9a-fA-F]+)\{([0-9]+)\}$`)
+
+	// repQuoteRE is a regular expression used to parse short form scripts for
+	// quoted data that is to be repeated a specified number of times.
+	repQuoteRE = regexp.MustCompile(`^'(.*)'\{([0-9]+)\}$`)
+)
+
+// shortFormOps holds a map of opcode names to values for use in short form
+// parsing.  It is declared here so it only needs to be created once.
+var shortFormOps map[string]byte
+
+// parseHex parses a hex string token into raw bytes.
+func parseHex(tok string) ([]byte, error) {
+	if !strings.HasPrefix(tok, "0x") {
+		return nil, errors.New("not a hex number")
+	}
+	return hex.DecodeString(tok[2:])
+}
+
+// parseShortForm parses a script from a human-readable format that allows for
+// convenient testing into the associated raw script bytes.
+//
+// The format used is as follows:
+//   - Opcodes other than the push opcodes and unknown are present as either
+//     OP_NAME or just NAME
+//   - Plain numbers are made into push operations
+//   - Numbers beginning with 0x are inserted into the []byte without
+//     modification (so 0x14 is OP_DATA_20)
+//   - Numbers beginning with 0x which have a suffix which consists of a number
+//     in braces (e.g. 0x6161{10}) repeat the raw bytes the specified number of
+//     times and are inserted without modification
+//   - Single quoted strings are pushed as data
+//   - Single quoted strings that have a suffix which consists of a number in
+//     braces (e.g. 'b'{10}) repeat the data the specified number of times and
+//     are pushed as a single data push
+//   - Tokens inside of angular brackets with a suffix which consists of a
+//     number in braces (e.g. <0 0 CHECKMULTSIG>{5}) is parsed as if the tokens
+//     inside the angular brackets were manually repeated the specified number
+//     of times
+//   - Anything else is an error
+func parseShortForm(script string) ([]byte, error) {
+	// Only create the short form opcode map once.
+	if shortFormOps == nil {
+		ops := make(map[string]byte)
+		for opcodeName, opcodeValue := range OpcodeByName {
+			if strings.Contains(opcodeName, "OP_UNKNOWN") {
+				continue
+			}
+			ops[opcodeName] = opcodeValue
+
+			// The opcodes named OP_# can't have the OP_ prefix stripped or they
+			// would conflict with the plain numbers.  Also, since OP_FALSE and
+			// OP_TRUE are aliases for the OP_0, and OP_1, respectively, they
+			// have the same value, so detect those by name and allow them.
+			if (opcodeName == "OP_FALSE" || opcodeName == "OP_TRUE") ||
+				(opcodeValue != OP_0 && (opcodeValue < OP_1 ||
+					opcodeValue > OP_16)) {
+
+				ops[strings.TrimPrefix(opcodeName, "OP_")] = opcodeValue
+			}
+		}
+		shortFormOps = ops
+	}
+
+	builder := NewScriptBuilder()
+
+	var handleToken func(tok string) error
+	handleToken = func(tok string) error {
+		// Multiple repeated tokens.
+		if m := repTokenRE.FindStringSubmatch(tok); m != nil {
+			count, err := strconv.ParseInt(m[2], 10, 32)
+			if err != nil {
+				return fmt.Errorf("bad token %q", tok)
+			}
+			tokens := tokenRE.FindAllStringSubmatch(m[1], -1)
+			for i := 0; i < int(count); i++ {
+				for _, t := range tokens {
+					if err := handleToken(t[0]); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		}
+
+		// Plain number.
+		if num, err := strconv.ParseInt(tok, 10, 64); err == nil {
+			builder.AddInt64(num)
+			return nil
+		}
+
+		// Raw data.
+		if bts, err := parseHex(tok); err == nil {
+			// Use the unchecked variant since the test code intentionally
+			// creates scripts that are too large and would cause the builder to
+			// error otherwise.
+			builder.AddOpsUnchecked(bts)
+			return nil
+		}
+
+		// Repeated raw bytes.
+		if m := repRawRE.FindStringSubmatch(tok); m != nil {
+			bts, err := parseHex(m[1])
+			if err != nil {
+				return fmt.Errorf("bad token %q", tok)
+			}
+			count, err := strconv.ParseInt(m[2], 10, 32)
+			if err != nil {
+				return fmt.Errorf("bad token %q", tok)
+			}
+
+			// Use the unchecked variant since the test code intentionally
+			// creates scripts that are too large and would cause the builder to
+			// error otherwise.
+			bts = bytes.Repeat(bts, int(count))
+			builder.AddOpsUnchecked(bts)
+			return nil
+		}
+
+		// Quoted data.
+		if len(tok) >= 2 && tok[0] == '\'' && tok[len(tok)-1] == '\'' {
+			builder.AddDataUnchecked([]byte(tok[1 : len(tok)-1]))
+			return nil
+		}
+
+		// Repeated quoted data.
+		if m := repQuoteRE.FindStringSubmatch(tok); m != nil {
+			count, err := strconv.ParseInt(m[2], 10, 32)
+			if err != nil {
+				return fmt.Errorf("bad token %q", tok)
+			}
+			data := strings.Repeat(m[1], int(count))
+			builder.AddDataUnchecked([]byte(data))
+			return nil
+		}
+
+		// Named opcode.
+		if opcode, ok := shortFormOps[tok]; ok {
+			builder.AddOp(opcode)
+			return nil
+		}
+
+		return fmt.Errorf("bad token %q", tok)
+	}
+
+	for _, tokens := range tokenRE.FindAllStringSubmatch(script, -1) {
+		if err := handleToken(tokens[0]); err != nil {
+			return nil, err
+		}
+	}
+	return builder.Script()
+}
+
+// mustParseShortForm parses the passed short form script and returns the
+// resulting bytes.  It panics if an error occurs.  This is only used in the
+// tests as a helper since the only way it can fail is if there is an error in
+// the test source code.
+func mustParseShortForm(script string) []byte {
+	s, err := parseShortForm(script)
+	if err != nil {
+		panic("invalid short form script in test source: err " +
+			err.Error() + ", script: " + script)
+	}
+
+	return s
+}

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -764,30 +764,6 @@ func MultiSigScript(threshold int, pubKeys ...[]byte) ([]byte, error) {
 	return builder.Script()
 }
 
-// PushedData returns an array of byte slices containing any pushed data found
-// in the passed script.  This includes OP_0, but not OP_1 - OP_16.
-//
-// NOTE: This function is only valid for version 0 scripts.  Since the function
-// does not accept a script version, the results are undefined for other script
-// versions.
-func PushedData(script []byte) ([][]byte, error) {
-	const scriptVersion = 0
-
-	var data [][]byte
-	tokenizer := MakeScriptTokenizer(scriptVersion, script)
-	for tokenizer.Next() {
-		if tokenizer.Data() != nil {
-			data = append(data, tokenizer.Data())
-		} else if tokenizer.Opcode() == OP_0 {
-			data = append(data, nil)
-		}
-	}
-	if err := tokenizer.Err(); err != nil {
-		return nil, err
-	}
-	return data, nil
-}
-
 // pubKeyHashToAddrs is a convenience function to attempt to convert the
 // passed hash to a pay-to-pubkey-hash address housed within an address
 // slice.  It is used to consolidate common code.

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -6,7 +6,6 @@
 package txscript
 
 import (
-	"encoding/binary"
 	"fmt"
 
 	"github.com/decred/dcrd/dcrec"
@@ -717,15 +716,6 @@ func MultisigRedeemScriptFromScriptSig(script []byte) []byte {
 	// The redeemScript is always the last item on the stack of the script sig.
 	const scriptVersion = 0
 	return finalOpcodeData(scriptVersion, script)
-}
-
-// GenerateSSGenVotes generates an OP_RETURN push for the vote bits in an SSGen tx.
-func GenerateSSGenVotes(votebits uint16) ([]byte, error) {
-	// Serialize the votebits
-	vbBytes := make([]byte, 2)
-	binary.LittleEndian.PutUint16(vbBytes, votebits)
-
-	return NewScriptBuilder().AddOp(OP_RETURN).AddData(vbBytes).Script()
 }
 
 // GenerateProvablyPruneableOut creates a provably-prunable script containing

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -686,24 +686,6 @@ func GetStakeOutSubclass(pkScript []byte, isTreasuryEnabled bool) (ScriptClass, 
 	return subClass, nil
 }
 
-// ContainsStakeOpCodes returns whether or not a pkScript contains stake tagging
-// OP codes.
-//
-// NOTE: This function is only valid for version 0 scripts.  Since the function
-// does not accept a script version, the results are undefined for other script
-// versions.
-func ContainsStakeOpCodes(pkScript []byte, isTreasuryEnabled bool) (bool, error) {
-	const scriptVersion = 0
-	tokenizer := MakeScriptTokenizer(scriptVersion, pkScript)
-	for tokenizer.Next() {
-		if isStakeOpcode(tokenizer.Opcode(), isTreasuryEnabled) {
-			return true, nil
-		}
-	}
-
-	return false, tokenizer.Err()
-}
-
 // CalcMultiSigStats returns the number of public keys and signatures from
 // a multi-signature transaction script.  The passed script MUST already be
 // known to be a multi-signature script.

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -9,7 +9,6 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrec"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/txscript/v4/stdaddr"
@@ -718,17 +717,6 @@ func MultisigRedeemScriptFromScriptSig(script []byte) []byte {
 	// The redeemScript is always the last item on the stack of the script sig.
 	const scriptVersion = 0
 	return finalOpcodeData(scriptVersion, script)
-}
-
-// GenerateSSGenBlockRef generates an OP_RETURN push for the block header hash and
-// height which the block votes on.
-func GenerateSSGenBlockRef(blockHash chainhash.Hash, height uint32) ([]byte, error) {
-	// Serialize the block hash and height
-	brBytes := make([]byte, 32+4)
-	copy(brBytes[0:32], blockHash[:])
-	binary.LittleEndian.PutUint32(brBytes[32:36], height)
-
-	return NewScriptBuilder().AddOp(OP_RETURN).AddData(brBytes).Script()
 }
 
 // GenerateSSGenVotes generates an OP_RETURN push for the vote bits in an SSGen tx.

--- a/txscript/standard_test.go
+++ b/txscript/standard_test.go
@@ -12,7 +12,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/txscript/v4/stdaddr"
@@ -910,44 +909,6 @@ func TestGenerateProvablyPruneableOut(t *testing.T) {
 				"got: %v, want: %v", i, test.name, scriptType,
 				test.class)
 			continue
-		}
-	}
-}
-
-// TestGenerateSSGenBlockRef ensures an expected OP_RETURN push is generated.
-func TestGenerateSSGenBlockRef(t *testing.T) {
-	var tests = []struct {
-		blockHash string
-		height    uint32
-		expected  []byte
-	}{
-		{
-			"0000000000004740ad140c86753f9295e09f9cc81b1bb75d7f5552aeeedb7012",
-			1000,
-			hexToBytes("6a241270dbeeae52557f5db71b1bc89c9fe095923" +
-				"f75860c14ad4047000000000000e8030000"),
-		},
-		{
-			"000000000000000033eafc268a67c8d1f02343d7a96cf3fe2a4915ef779b52f9",
-			290000,
-			hexToBytes("6a24f9529b77ef15492afef36ca9d74323f0d1c86" +
-				"78a26fcea330000000000000000d06c0400"),
-		},
-	}
-	for _, test := range tests {
-		h, err := chainhash.NewHashFromStr(test.blockHash)
-		if err != nil {
-			t.Errorf("NewHashFromStr failed: %v", err)
-			continue
-		}
-		s, err := GenerateSSGenBlockRef(*h, test.height)
-		if err != nil {
-			t.Errorf("GenerateSSGenBlockRef failed: %v", err)
-			continue
-		}
-		if !bytes.Equal(s, test.expected) {
-			t.Errorf("GenerateSSGenBlockRef: unexpected script:\n"+
-				" got %x\nwant %x", s, test.expected)
 		}
 	}
 }

--- a/txscript/standard_test.go
+++ b/txscript/standard_test.go
@@ -21,20 +21,6 @@ import (
 // throughout the tests.
 var mainNetParams = chaincfg.MainNetParams()
 
-// mustParseShortForm parses the passed short form script and returns the
-// resulting bytes.  It panics if an error occurs.  This is only used in the
-// tests as a helper since the only way it can fail is if there is an error in
-// the test source code.
-func mustParseShortForm(script string) []byte {
-	s, err := parseShortForm(script)
-	if err != nil {
-		panic("invalid short form script in test source: err " +
-			err.Error() + ", script: " + script)
-	}
-
-	return s
-}
-
 // newAddressPubKey returns a new pubkey address from the provided serialized
 // public key.  It panics if an error occurs.  This is only used in the tests as
 // a helper since the only way it can fail is if there is an error in the test

--- a/txscript/standard_test.go
+++ b/txscript/standard_test.go
@@ -913,30 +913,6 @@ func TestGenerateProvablyPruneableOut(t *testing.T) {
 	}
 }
 
-// TestGenerateSSGenVotes ensures an expected OP_RETURN push is generated.
-func TestGenerateSSGenVotes(t *testing.T) {
-	var tests = []struct {
-		votebits uint16
-		expected []byte
-	}{
-		{65535, hexToBytes("6a02ffff")},
-		{256, hexToBytes("6a020001")},
-		{127, hexToBytes("6a027f00")},
-		{0, hexToBytes("6a020000")},
-	}
-	for _, test := range tests {
-		s, err := GenerateSSGenVotes(test.votebits)
-		if err != nil {
-			t.Errorf("GenerateSSGenVotes failed: %v", err)
-			continue
-		}
-		if !bytes.Equal(s, test.expected) {
-			t.Errorf("GenerateSSGenVotes: unexpected script:\n "+
-				"got %x\nwant %x", s, test.expected)
-		}
-	}
-}
-
 // mustExpectedAtomicSwapData is a convenience function that converts the passed
 // parameters into an expected atomic swap data pushes structure and will panic
 // if there is an error.  This is only provided for the hard-coded constants so


### PR DESCRIPTION
This further separates and cleans up the consensus vs standard demarcation in `txscript` in preparation for ultimately removing all code related to standardness from `txscript`.  See each commit message for details regarding each change.

The following is an overview of the changes:

- Moves the following funcs from `standard.go` to `script.go` since they are used in consensus code:
  - `ContainsStakeOpCodes`
  - `GenerateSSGenBlockRef`
  - `GenerateSSGenVotes`
- Separates test code related to parsing scripts using the human-readable short form used throughout the tests into a separate file
- Removes the following unused funcs:
  - `IsPubKeyHashScript`
  - `IsStakeChangeScript`
  - `PushedData`
- Converts tests for `IsPayToScriptHash` and `Engine.isAnyKindOfScriptHash` to use explicit tests instead of using the script
    class tests which are only intended for use by standardness code
