### PR TITLE
rpcserver: Impose additional read limits.

### DIFF
--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -15,6 +15,9 @@ such as [https://github.com/decred/dcrwallet dcrwallet] for inter-process
 communication with dcrd.  The websocket connection endpoint for dcrd is
 <code>wss://your_ip_or_domain:9109/ws</code>.
 
+All requests are limited to a maximum size of 8 MiB when accessed via HTTP POST
+and 16 MiB when accessed via Websockets.
+
 In addition to the [[#5-standard-methods|standard API]], an [[#6-websocket-methods-websocket-specific|extension API]]
 has been developed that is exclusive to clients using Websockets. In its current
 state, this API attempts to cover features found missing in the standard API
@@ -96,7 +99,6 @@ The [[#authenticate|authenticate]] command must be the first command sent after
 connecting to the websocket.  Sending any other commands before authenticating,
 supplying invalid credentials, or attempting to authenticate again when already
 authenticated will cause the websocket to be closed immediately.
-
 
 ==4. Command-line Utility==
 

--- a/internal/rpcserver/rpcwebsocket.go
+++ b/internal/rpcserver/rpcwebsocket.go
@@ -44,6 +44,14 @@ const (
 	// handler since notifications have their own queuing mechanism
 	// independent of the send channel buffer.
 	websocketSendBufferSize = 50
+
+	// websocketReadLimitUnauthenticated is the maximum number of bytes allowed
+	// for an unauthenticated JSON-RPC message read from a websocket client.
+	websocketReadLimitUnauthenticated = 1 << 12 // 4 KiB
+
+	// websocketReadLimitAuthenticated is the maximum number of bytes allowed
+	// for an authenticated JSON-RPC message read from a websocket client.
+	websocketReadLimitAuthenticated = 1 << 24 // 16 MiB
 )
 
 type semaphore chan struct{}
@@ -1460,6 +1468,9 @@ out:
 				}
 				c.authenticated = true
 				c.isAdmin = cmp == 1
+
+				// Increase the read limits for authenticated connections.
+				c.conn.SetReadLimit(websocketReadLimitAuthenticated)
 
 				// Marshal and send response.
 				reply, err = createMarshalledReply(cmd.jsonrpc, cmd.id, nil, nil)


### PR DESCRIPTION
This imposes additional per-connection read limits on the RPC server to help further harden it against potential abuse in non-standard configurations on poorly-configured networks.

In practice, these changes will not have any noticeable effect for the vast majority of nodes since the RPC server is not publicly accessible by default and requires authentication.

Nevertheless, it can still be useful to apply additional read limits for scenarios such as authenticated fuzz testing and poorly-configured networks that have disabled all other security measures.

The following are the updated per-connection limits:

- 0 B / 8 MiB for pre and post auth HTTP connections
- 4 KiB / 16 MiB for pre and post auth websocket connections
