### PR TITLE
server: Correct tx not found ban reason.

### DIFF
--- a/server.go
+++ b/server.go
@@ -1446,7 +1446,7 @@ func (sp *serverPeer) OnNotFound(p *peer.Peer, msg *wire.MsgNotFound) {
 	}
 	if numTxns > 0 {
 		txStr := pickNoun(uint64(numTxns), "transaction", "transactions")
-		reason := fmt.Sprintf("%d %v not found", numBlocks, txStr)
+		reason := fmt.Sprintf("%d %v not found", numTxns, txStr)
 		if sp.addBanScore(0, 10*numTxns, reason) {
 			return
 		}


### PR DESCRIPTION
This corrects the ban reason string when too many transactions are advertised and then claimed as not found to display the number of transactions as intended.