### PR TITLE
config: Correct dir create failure error message.

### DIFF
--- a/config.go
+++ b/config.go
@@ -790,7 +790,7 @@ func loadConfig(appName string) (*config, []string, error) {
 			}
 		}
 
-		str := "%s: failed to create home directory: %w"
+		str := "%s: failed to create home directory: %s"
 		err := errSuppressUsage(fmt.Sprintf(str, funcName, err))
 		return nil, nil, err
 	}


### PR DESCRIPTION
This corrects the error message when the home directory fails to be created since the `%w` verb only works with `fmt.Errorf`.