### PR TITLE
blockchain: Remove serializeUtxoEntry error.

### DIFF
--- a/blockchain/utxobackend.go
+++ b/blockchain/utxobackend.go
@@ -617,12 +617,9 @@ func (l *LevelDbUtxoBackend) dbPutUtxoEntry(dbTx database.Tx,
 	}
 
 	// Serialize and store the utxo entry.
-	serialized, err := serializeUtxoEntry(entry)
-	if err != nil {
-		return err
-	}
+	serialized := serializeUtxoEntry(entry)
 	key := outpointKey(outpoint)
-	err = utxoBucket.Put(*key, serialized)
+	err := utxoBucket.Put(*key, serialized)
 	// NOTE: The key is intentionally not recycled here since the database
 	// interface contract prohibits modifications.  It will be garbage collected
 	// normally when the database is done with it.

--- a/blockchain/utxoio.go
+++ b/blockchain/utxoio.go
@@ -137,10 +137,10 @@ func recycleOutpointKey(key *[]byte) {
 
 // serializeUtxoEntry returns the entry serialized to a format that is suitable
 // for long-term storage.  The format is described in detail above.
-func serializeUtxoEntry(entry *UtxoEntry) ([]byte, error) {
+func serializeUtxoEntry(entry *UtxoEntry) []byte {
 	// Spent entries have no serialization.
 	if entry.IsSpent() {
-		return nil, nil
+		return nil
 	}
 
 	// Calculate the size needed to serialize the entry.
@@ -169,7 +169,7 @@ func serializeUtxoEntry(entry *UtxoEntry) ([]byte, error) {
 		copy(serialized[offset:], entry.ticketMinOuts.data)
 	}
 
-	return serialized, nil
+	return serialized
 }
 
 // deserializeUtxoEntry decodes a utxo entry from the passed serialized byte

--- a/blockchain/utxoio_test.go
+++ b/blockchain/utxoio_test.go
@@ -175,11 +175,7 @@ func TestUtxoSerialization(t *testing.T) {
 
 	for _, test := range tests {
 		// Ensure the utxo entry serializes to the expected value.
-		gotBytes, err := serializeUtxoEntry(test.entry)
-		if err != nil {
-			t.Errorf("%q: unexpected error: %v", test.name, err)
-			continue
-		}
+		gotBytes := serializeUtxoEntry(test.entry)
 		if !bytes.Equal(gotBytes, test.serialized) {
 			t.Errorf("%q: mismatched bytes - got %x, want %x", test.name, gotBytes,
 				test.serialized)


### PR DESCRIPTION
This removes the error returned from serializeUtxoEntry since that function never actually returns an error.