### PR TITLE
blockchain: Use short keys for block index.

### DIFF
--- a/blockchain/blockindex.go
+++ b/blockchain/blockindex.go
@@ -592,7 +592,7 @@ func newBlockIndex(db database.DB) *blockIndex {
 // This function is safe for concurrent access.
 func (bi *blockIndex) HaveBlock(hash *chainhash.Hash) bool {
 	bi.RLock()
-	node := bi.index[*hash]
+	node := bi.lookupNode(hash)
 	hasBlock := node != nil && node.status.HaveData()
 	bi.RUnlock()
 	return hasBlock

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -355,11 +355,7 @@ func (b *BlockChain) DisableVerify(disable bool) {
 //
 // This function is safe for concurrent access.
 func (b *BlockChain) HaveHeader(hash *chainhash.Hash) bool {
-	b.index.RLock()
-	node := b.index.index[*hash]
-	headerKnown := node != nil
-	b.index.RUnlock()
-	return headerKnown
+	return b.index.LookupNode(hash) != nil
 }
 
 // HaveBlock returns whether or not the chain instance has the block represented

--- a/blockchain/common_test.go
+++ b/blockchain/common_test.go
@@ -232,7 +232,7 @@ func newFakeChain(params *chaincfg.Params) *BlockChain {
 }
 
 // testNoncePrng provides a deterministic prng for the nonce in generated fake
-// nodes.  The ensures that the nodes have unique hashes.
+// nodes.  This ensures that the nodes have unique hashes.
 var testNoncePrng = mrand.New(mrand.NewSource(0))
 
 // newFakeNode creates a block node connected to the passed parent with the


### PR DESCRIPTION
This modifies the block index hash -> node mapping to use shortened keys with fallback to the full 32-byte key in the event of a collision in the shortened key.  This saves a significant amount of memory because there are hundreds of thousands of nodes in the index and Go maps duplicate keys.  As an added bonus, due to the implementation choices, it also results in slightly faster overall lookups on average.  This is because even though lookups of colliding keys are slightly slower, lookups of non-colliding keys are slightly faster and non-colliding keys are by far the most common case (typically > 99.5%).

It accomplishes this by taking advantage of the fact the full hash is part of the node itself and therefore can be used to disambiguate any collisions in the shortened key and splitting the non-colliding entries from the colliding entries across two maps where one is keyed by the shorter key and the other by the full key.

The shortened key is chosen to be the big-endian `uint32` formed by the first 4 bytes of the full hash.  The primary reasons for this choice are:

- The hash function used to produce the block hashes is a uniformly-random distribution, so the number of collisions will coincide with the expected value of a uniform distribution
- The bits zeroed by the mining process start at the end of the array, so there would need to be effectively impossible to achieve hash rates exceeding ~2^215.77 hashes/sec (aka ~89.8 peta yotta yotta hashes/sec) in order to start zeroing out the chosen bits
- Using 4 bytes per node results in a savings of 28 bytes per node minus a small amount of amortized overhead for the collision handling
- 4-byte keys produce a relatively small expected number of collisions
- The cutoff point where the overhead of the collisions is expected to reach just 10% of the savings gained is around 5800 years given the average `mainnet` block production rate
- Conversion of the bytes to a `uint32` is basically free in terms of processing overhead

Profiling of the implemented code as well as simulations show that both the actual number of observed collisions and observed memory savings match the expected theoretical values.  Specifically, as of block height 575166 on `mainnet`, there are 35 collisions in the shortened keys and the memory savings is around 30 MiB.

