### PR TITLE
multi: Use AgendaFlags in mempool. 

### DIFF
--- a/blockchain/notifications.go
+++ b/blockchain/notifications.go
@@ -128,9 +128,9 @@ type BlockConnectedNtfnsData struct {
 	// chain.
 	ParentBlock *dcrutil.Block
 
-	// IsTreasuryActive indicates whether or not the treasury agenda is active
-	// for the block that was connected.
-	IsTreasuryActive bool
+	// CheckTxFlags represents the agendas to consider as active when checking
+	// transactions for the block that was connected.
+	CheckTxFlags AgendaFlags
 }
 
 // BlockDisconnectedNtfnsData is the structure for data indicating information
@@ -143,9 +143,9 @@ type BlockDisconnectedNtfnsData struct {
 	// main chain meaning this block is now the tip of the main chain.
 	ParentBlock *dcrutil.Block
 
-	// IsTreasuryActive indicates whether or not the treasury agenda was active
-	// for the block that was **disconnected**.
-	IsTreasuryActive bool
+	// CheckTxFlags represents the agendas to consider as active when checking
+	// transactions for the block that was **disconnected**.
+	CheckTxFlags AgendaFlags
 }
 
 // ReorganizationNtfnsData is the structure for data indicating information

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -328,6 +328,12 @@ const (
 	AFNone AgendaFlags = 0
 )
 
+// IsTreasuryEnabled returns whether the flags indicate that the treasury agenda
+// is enabled.
+func (flags AgendaFlags) IsTreasuryEnabled() bool {
+	return flags&AFTreasuryEnabled == AFTreasuryEnabled
+}
+
 // checkTransactionContext performs several validation checks on the transaction
 // which depend on having the full block data for all of its ancestors
 // available, most likely because the checks depend on whether or not an agenda
@@ -338,7 +344,7 @@ const (
 // in order to change how the validation rules are applied accordingly.
 func checkTransactionContext(tx *wire.MsgTx, params *chaincfg.Params, flags AgendaFlags) error {
 	// Determine active agendas based on flags.
-	isTreasuryEnabled := flags&AFTreasuryEnabled == AFTreasuryEnabled
+	isTreasuryEnabled := flags.IsTreasuryEnabled()
 
 	// Determine type.
 	var isCoinBase, isVote, isTicket, isRevocation bool

--- a/server.go
+++ b/server.go
@@ -2573,7 +2573,9 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 		}
 		block := ntfn.Block
 		parentBlock := ntfn.ParentBlock
-		isTreasuryEnabled := ntfn.IsTreasuryActive
+
+		// Determine active agendas based on flags.
+		isTreasuryEnabled := ntfn.CheckTxFlags.IsTreasuryEnabled()
 
 		// Account for transactions mined in the newly connected block for fee
 		// estimation. This must be done before attempting to remove
@@ -2720,7 +2722,9 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 		}
 		block := ntfn.Block
 		parentBlock := ntfn.ParentBlock
-		isTreasuryEnabled := ntfn.IsTreasuryActive
+
+		// Determine active agendas based on flags.
+		isTreasuryEnabled := ntfn.CheckTxFlags.IsTreasuryEnabled()
 
 		// In the case the regular tree of the previous block was disapproved,
 		// disconnecting the current block makes all of those transactions valid

--- a/server.go
+++ b/server.go
@@ -2614,7 +2614,7 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 				txMemPool.MaybeAcceptDependents(tx, isTreasuryEnabled)
 				txMemPool.RemoveDoubleSpends(tx, isTreasuryEnabled)
 				txMemPool.RemoveOrphan(tx, isTreasuryEnabled)
-				acceptedTxs := txMemPool.ProcessOrphans(tx, isTreasuryEnabled)
+				acceptedTxs := txMemPool.ProcessOrphans(tx, ntfn.CheckTxFlags)
 				s.AnnounceNewTransactions(acceptedTxs)
 
 				// Now that this block is in the blockchain, mark the
@@ -2739,7 +2739,7 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 				txMemPool.MaybeAcceptDependents(tx, isTreasuryEnabled)
 				txMemPool.RemoveDoubleSpends(tx, isTreasuryEnabled)
 				txMemPool.RemoveOrphan(tx, isTreasuryEnabled)
-				txMemPool.ProcessOrphans(tx, isTreasuryEnabled)
+				txMemPool.ProcessOrphans(tx, ntfn.CheckTxFlags)
 			}
 		}
 


### PR DESCRIPTION
This updates the `ProcessOrphans`, `processOrphans`, and `maybeAcceptTransaction` methods in `mempool` to accept an agenda flags parameter rather than just a boolean for whether the treasury agenda is active.  Additionally, it updates the `blockchain` `BlockConnectedNtfnsData` and `BlockDisconnectedNtfnsData` types to contain agenda flags rather than a boolean indicating if the treasury is active.

This is useful in particular since `maybeAcceptTransaction` makes use of the `blockchain.CheckTransaction` function to perform validation checks on transactions, which includes checks which depend on whether or not an agenda is active.  This allows future agendas to be included in the agenda flags parameter rather than introducing additional boolean params for each new agenda. 

