### PR TITLE
jsonrpc/types: Add missing Method type to vars.

### DIFF
--- a/rpc/jsonrpc/types/chainsvrwsntfns.go
+++ b/rpc/jsonrpc/types/chainsvrwsntfns.go
@@ -24,11 +24,11 @@ const (
 
 	// WorkNtfnMethod is the method used for notifications from
 	// the chain server that a new block template has been generated.
-	WorkNtfnMethod = "work"
+	WorkNtfnMethod Method = "work"
 
 	// TSpendNtfnMethod is the method used for notifications from the chain
 	// server that a new tspend has arrived in the mempool.
-	TSpendNtfnMethod = "tspend"
+	TSpendNtfnMethod Method = "tspend"
 
 	// ReorganizationNtfnMethod is the method used for notifications that the
 	// block chain is in the process of a reorganization.


### PR DESCRIPTION
This adds a missing Method type declaration to the "work" and "tspend"
notification method names.

This allows importing both v2 and v3 versions of this package without
running into RPC command registration errors.

