### PR TITLE
secp256k1: Optimize NAF conversion.

### DIFF
--- a/dcrec/secp256k1/bench_test.go
+++ b/dcrec/secp256k1/bench_test.go
@@ -93,11 +93,16 @@ func BenchmarkScalarMult(b *testing.B) {
 	}
 }
 
-// BenchmarkNAF benchmarks the NAF function.
+// BenchmarkNAF benchmarks conversion of a positive integer into its
+// non-adjacent form representation.
 func BenchmarkNAF(b *testing.B) {
 	k := fromHex("d74bf844b0862475103d96a611cf2d898447e288d34b360bc885cb8ce7c00575")
+	kBytes := k.Bytes()
+
+	b.ReportAllocs()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		naf(k.Bytes())
+		naf(kBytes)
 	}
 }
 

--- a/dcrec/secp256k1/curve.go
+++ b/dcrec/secp256k1/curve.go
@@ -778,6 +778,11 @@ func ScalarBaseMultNonConst(k *ModNScalar, result *JacobianPoint) {
 // Essentially, this makes it possible to minimize the number of operations
 // since the resulting ints returned will be at least 50% 0s.
 func naf(k []byte) ([]byte, []byte) {
+	// Strip leading zero bytes.
+	for len(k) > 0 && k[0] == 0x00 {
+		k = k[1:]
+	}
+
 	// The essence of this algorithm is that whenever we have consecutive 1s
 	// in the binary, we want to put a -1 in the lowest bit and get a bunch
 	// of 0s up to the highest bit of consecutive 1s.  This is due to this

--- a/dcrec/secp256k1/curve_test.go
+++ b/dcrec/secp256k1/curve_test.go
@@ -611,7 +611,8 @@ func TestNAF(t *testing.T) {
 		// Ensure the resulting positive and negative portions of the overall
 		// NAF representation adhere to the requirements of NAF encoding and
 		// they sum back to the original value.
-		pos, neg := naf(hexToBytes(test.in))
+		result := naf(hexToBytes(test.in))
+		pos, neg := result.Pos(), result.Neg()
 		if err := checkNAFEncoding(pos, neg, fromHex(test.in)); err != nil {
 			t.Errorf("%q: %v", test.name, err)
 		}
@@ -636,7 +637,8 @@ func TestNAFRandom(t *testing.T) {
 		// they sum back to the original value.
 		bigIntVal, modNVal := randIntAndModNScalar(t, rng)
 		valBytes := modNVal.Bytes()
-		pos, neg := naf(valBytes[:])
+		result := naf(valBytes[:])
+		pos, neg := result.Pos(), result.Neg()
 		if err := checkNAFEncoding(pos, neg, bigIntVal); err != nil {
 			t.Fatalf("encoding err: %v\nin: %x\npos: %x\nneg: %x", err,
 				bigIntVal, pos, neg)

--- a/dcrec/secp256k1/ellipticadaptor.go
+++ b/dcrec/secp256k1/ellipticadaptor.go
@@ -225,6 +225,9 @@ func (p *PrivateKey) ToECDSA() *ecdsa.PrivateKey {
 // constants so errors in the source code can bet detected. It will only (and
 // must only) be called for initialization purposes.
 func fromHex(s string) *big.Int {
+	if s == "" {
+		return big.NewInt(0)
+	}
 	r, ok := new(big.Int).SetString(s, 16)
 	if !ok {
 		panic("invalid hex in source file: " + s)


### PR DESCRIPTION
**This is rebased on #2690**.

This significantly optimizes the NAF conversion code by rewriting it to avoid all heap allocations as well as switch to an O(1) algorithm.

It also reworks the NAF tests to actually test the produced encoding adheres to the requires of NAF encoding as well as to make them more consistent with modern practices in the code.

Specifically, the following properties are asserted:

- There must not be a leading zero byte and the number of bytes used to encode the negative portion must not exceed the positive portion
- There must not be any adjacent non-zero digits
- The negative and positive portions must sum back to the original value

The existing tests only ensure the positive and negative portions sum back up to the original value.

The updated tests also revealed that the existing naf function doesn't strip leading zeroes, so that logic has been added.  That behavior is not a problem in terms of correctness given how it is used in the code since extra leading zeroes don't change the resulting value, but it could potentially cause more work to be done than necessary and having leading zeroes technically doesn't conform to NAF encoding.

Finally, it slightly reworks the scalar multiplication logic to improve its readability by making use of zero values and a single mask instead of shifting every individual byte of the positive and negative portions of k1 and k2.

The following benchmark shows a before and after comparison of the NAF conversion as well as how that translates to scalar multiplication and signature verification:

```
name        old time/op      new time/op     delta
----------------------------------------------------------------------
NAF          1.16µs ± 1%     0.08µs ± 1%     -93.02%  (p=0.008 n=5+5)
ScalarMult    138µs ± 1%      135µs ± 0%      -1.77%  (p=0.016 n=5+4)
SigVerify     164µs ± 0%      162µs ± 0%      -0.98%  (p=0.008 n=5+5)

name         old alloc/op    new alloc/op    delta
----------------------------------------------------------------------
NAF           96.0B ± 0%       0.0B          -100.00%  (p=0.008 n=5+5)
ScalarMult     816B ± 0%       720B ± 0%      -11.76%  (p=0.008 n=5+5)
SigVerify    1.54kB ± 0%     1.44kB ± 0%      -6.25%   (p=0.008 n=5+5)

name         old allocs/op   new allocs/op   delta
----------------------------------------------------------------------
NAF          2.00 ± 0%       0.00            -100.00%  (p=0.008 n=5+5)
ScalarMult   15.0 ± 0%       11.0 ± 0%        -26.67%  (p=0.008 n=5+5)
SigVerify    32.0 ± 0%       28.0 ± 0%        -12.50%  (p=0.008 n=5+5)
```