### PR TITLE
rpcclient: Shutdown breaks reconnect sleep.

### DIFF
--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -716,9 +716,13 @@ out:
 				if scaledDuration > time.Minute {
 					scaledDuration = time.Minute
 				}
-				log.Infof("Retrying connection to %s in "+
-					"%s", c.config.Host, scaledDuration)
-				time.Sleep(scaledDuration)
+				log.Infof("Retrying connection to %s in %s",
+					c.config.Host, scaledDuration)
+				select {
+				case <-c.shutdown:
+					break out
+				case <-time.After(scaledDuration):
+				}
 				continue reconnect
 			}
 


### PR DESCRIPTION
When a shutdown is requested, the sleep should not continue in
`(*Client).wsReconnectHandler`.  Instead, use a `select` with the `shutdown`
channel and a `time.After`.