### PR TITLE
secp256k1: Use blake256 directly in examples.

### DIFF
--- a/dcrec/secp256k1/ecdsa/example_test.go
+++ b/dcrec/secp256k1/ecdsa/example_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -9,7 +9,7 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/crypto/blake256"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
 )
@@ -28,15 +28,15 @@ func ExampleSign() {
 
 	// Sign a message using the private key.
 	message := "test message"
-	messageHash := chainhash.HashB([]byte(message))
-	signature := ecdsa.Sign(privKey, messageHash)
+	messageHash := blake256.Sum256([]byte(message))
+	signature := ecdsa.Sign(privKey, messageHash[:])
 
 	// Serialize and display the signature.
 	fmt.Printf("Serialized Signature: %x\n", signature.Serialize())
 
 	// Verify the signature for the message using the public key.
 	pubKey := privKey.PubKey()
-	verified := signature.Verify(messageHash, pubKey)
+	verified := signature.Verify(messageHash[:], pubKey)
 	fmt.Printf("Signature Verified? %v\n", verified)
 
 	// Output:
@@ -77,8 +77,8 @@ func ExampleSignature_Verify() {
 
 	// Verify the signature for the message using the public key.
 	message := "test message"
-	messageHash := chainhash.HashB([]byte(message))
-	verified := signature.Verify(messageHash, pubKey)
+	messageHash := blake256.Sum256([]byte(message))
+	verified := signature.Verify(messageHash[:], pubKey)
 	fmt.Println("Signature Verified?", verified)
 
 	// Output:

--- a/dcrec/secp256k1/go.mod
+++ b/dcrec/secp256k1/go.mod
@@ -2,7 +2,4 @@ module github.com/decred/dcrd/dcrec/secp256k1/v4
 
 go 1.13
 
-require (
-	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
-	github.com/decred/dcrd/crypto/blake256 v1.0.0
-)
+require github.com/decred/dcrd/crypto/blake256 v1.0.0

--- a/dcrec/secp256k1/go.sum
+++ b/dcrec/secp256k1/go.sum
@@ -1,4 +1,2 @@
-github.com/decred/dcrd/chaincfg/chainhash v1.0.2 h1:rt5Vlq/jM3ZawwiacWjPa+smINyLRN07EO0cNBV6DGU=
-github.com/decred/dcrd/chaincfg/chainhash v1.0.2/go.mod h1:BpbrGgrPTr3YJYRN3Bm+D9NuaFd+zGyNeIKgrhCXK60=
 github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=

--- a/dcrec/secp256k1/schnorr/example_test.go
+++ b/dcrec/secp256k1/schnorr/example_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Decred developers
+// Copyright (c) 2020-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -8,7 +8,7 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/crypto/blake256"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4/schnorr"
 )
@@ -28,8 +28,8 @@ func ExampleSign() {
 
 	// Sign a message using the private key.
 	message := "test message"
-	messageHash := chainhash.HashB([]byte(message))
-	signature, err := schnorr.Sign(privKey, messageHash)
+	messageHash := blake256.Sum256([]byte(message))
+	signature, err := schnorr.Sign(privKey, messageHash[:])
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -40,7 +40,7 @@ func ExampleSign() {
 
 	// Verify the signature for the message using the public key.
 	pubKey := privKey.PubKey()
-	verified := signature.Verify(messageHash, pubKey)
+	verified := signature.Verify(messageHash[:], pubKey)
 	fmt.Printf("Signature Verified? %v\n", verified)
 
 	// Output:
@@ -81,8 +81,8 @@ func ExampleSignature_Verify() {
 
 	// Verify the signature for the message using the public key.
 	message := "test message"
-	messageHash := chainhash.HashB([]byte(message))
-	verified := signature.Verify(messageHash, pubKey)
+	messageHash := blake256.Sum256([]byte(message))
+	verified := signature.Verify(messageHash[:], pubKey)
 	fmt.Println("Signature Verified?", verified)
 
 	// Output:


### PR DESCRIPTION
This modifies the `ecdsa` and `schnorr` examples to call `blake256` directly instead of indirecting through `chainhash` in order to avoid the `chainhash` dependency which is otherwise not needed.

The `go.mod` and `go.sum` files are updated accordingly to remove the no longer required dependency.