### PR TITLE
main: Use pseudo-versions in bumped mods.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/base58 v1.0.3
-	github.com/decred/dcrd/addrmgr/v2 v2.0.0
+	github.com/decred/dcrd/addrmgr/v2 v2.0.0-20210802141345-893802fc06b0
 	github.com/decred/dcrd/bech32 v1.1.1
 	github.com/decred/dcrd/blockchain/stake/v4 v4.0.0-20210409183916-7f402345f0a6
 	github.com/decred/dcrd/blockchain/standalone/v2 v2.0.0
@@ -24,7 +24,7 @@ require (
 	github.com/decred/dcrd/gcs/v3 v3.0.0-20210129195202-a4265d63b619
 	github.com/decred/dcrd/hdkeychain/v3 v3.0.1-0.20210129190127-4ebd135a82f1
 	github.com/decred/dcrd/lru v1.1.0
-	github.com/decred/dcrd/peer/v3 v3.0.0
+	github.com/decred/dcrd/peer/v3 v3.0.0-20210802141345-893802fc06b0
 	github.com/decred/dcrd/rpc/jsonrpc/types/v3 v3.0.0-20210129200153-14fd1a785bf2
 	github.com/decred/dcrd/rpcclient/v7 v7.0.0-20210129214723-fc227a05904d
 	github.com/decred/dcrd/txscript/v4 v4.0.0-20210415215133-96b98390a9a9


### PR DESCRIPTION
This updates the addrmgr and peer dependencies to list the
pseudo-versions of their next major versions as dependencies instead of
the as-of-yet unreleased tagged versions.

This is needed to allow clients of the main dcrd module to correctly
import it while those dependencies are still under development.