### PR TITLE
rpcserver: Handle getwork nil err during reorg.

### DIFF
--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -3686,9 +3686,13 @@ func handleGetWorkRequest(s *Server) (interface{}, error) {
 	if template == nil {
 		var err error
 		template, err = bt.CurrentTemplate()
-		if err != nil || template == nil {
+		if err != nil {
 			context := "Unable to retrieve work due to invalid template"
 			return nil, rpcInternalError(err.Error(), context)
+		}
+		if template == nil {
+			return nil, rpcMiscError("no work is available during a chain " +
+				"reorganization")
 		}
 	}
 

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -6160,6 +6160,25 @@ func TestHandleGetWork(t *testing.T) {
 		wantErr: true,
 		errCode: dcrjson.ErrRPCInternal.Code,
 	}, {
+		name:    "handleGetWork: no work during chain reorg",
+		handler: handleGetWork,
+		cmd:     &types.GetWorkCmd{},
+		mockMiningState: func() *testMiningState {
+			mockChain := defaultMockRPCChain()
+			ms := defaultMockMiningState()
+			ms.miningAddrs = []stdaddr.Address{miningaddr}
+			ms.workState.prevHash = &mockChain.bestSnapshot.Hash
+			return ms
+		}(),
+		mockBlockTemplater: func() *testBlockTemplater {
+			templater := defaultMockBlockTemplater()
+			templater.currTemplate = nil
+			templater.currTemplateErr = nil
+			return templater
+		}(),
+		wantErr: true,
+		errCode: dcrjson.ErrRPCMisc,
+	}, {
 		name:            "handleGetWork: unable to update block time",
 		handler:         handleGetWork,
 		cmd:             &types.GetWorkCmd{},


### PR DESCRIPTION
This modifies the `getwork` RPC to properly handle the case when both the template and the error are nil which happens if the caller makes a request during a chain reorganization.

It also adds a test for the condition to prevent regressions.

Fixes #2699.