### PR TITLE
rpcserver: Use duplicate tx error for recently mined transactions

### DIFF
--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -161,6 +161,12 @@ type SyncManager interface {
 	// insertion into the memory pool.
 	ProcessTransaction(tx *dcrutil.Tx, allowOrphans bool, rateLimit bool,
 		allowHighFees bool, tag mempool.Tag) ([]*dcrutil.Tx, error)
+
+	// RecentlyConfirmedTxn returns with high degree of confidence whether a
+	// transaction has been recently confirmed in a block.
+	//
+	// This method may report a false positive, but never a false negative.
+	RecentlyConfirmedTxn(hash *chainhash.Hash) bool
 }
 
 // UtxoEntry represents a utxo entry for use with the RPC server.

--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -355,6 +355,14 @@ func (b *rpcSyncMgr) ProcessTransaction(tx *dcrutil.Tx, allowOrphans bool,
 		rateLimit, allowHighFees, tag)
 }
 
+// RecentlyConfirmedTxn returns with high degree of confidence whether a
+// transaction has been recently confirmed in a block.
+//
+// This method may report a false positive, but never a false negative.
+func (b *rpcSyncMgr) RecentlyConfirmedTxn(hash *chainhash.Hash) bool {
+	return b.server.recentlyConfirmedTxns.Contains(hash[:])
+}
+
 // rpcUtxoEntry represents a utxo entry for use with the RPC server and
 // implements the rpcserver.UtxoEntry interface.
 type rpcUtxoEntry struct {


### PR DESCRIPTION
Attempting to publish a recently-mined transaction using the
sendrawtransaction JSON-RPC method will now use the same error code as
for duplicate transactions currently present in the mempool, rather
than a generic error for double spending or spending unknown inputs.

There is a very small chance that this check results in a false
positive and that a transaction rejected for other reasons is reported
as a duplicate when it had never been mined at all.