### PR TITLE
tests: Remove hardcoded CC=gcc from run_tests.sh.

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -22,7 +22,7 @@ ROOTPATHPATTERN=$(echo $ROOTPATH | sed 's/\\/\\\\/g' | sed 's/\//\\\//g')
 MODPATHS=$(go list -m all | grep "^$ROOTPATHPATTERN" | cut -d' ' -f1)
 for module in $MODPATHS; do
   echo "==> ${module}"
-  env CC=gcc go test -short -tags rpctest ${module}/...
+  go test -short -tags rpctest ${module}/...
 
   # check linters
   MODNAME=$(echo $module | sed -E -e "s/^$ROOTPATHPATTERN//" \


### PR DESCRIPTION
This environment variable was preventing the script from running
properly on OpenBSD. GCC is no longer provided in base on several
architectures, and GCC installed from packages is named 'egcc' to not
conflict with base GCC provided by the other architectures which still
require that toolchain.