### PR TITLE
multi: Implement reject new script and tx vers.

### DIFF
--- a/blockchain/agendas_test.go
+++ b/blockchain/agendas_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 The Decred developers
+// Copyright (c) 2017-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -694,4 +694,121 @@ func TestTreasuryFeaturesDeployment(t *testing.T) {
 	testTreasuryFeaturesDeployment(t, chaincfg.MainNetParams())
 	testTreasuryFeaturesDeployment(t, chaincfg.TestNet3Params())
 	testTreasuryFeaturesDeployment(t, chaincfg.RegNetParams())
+}
+
+// testExplicitVerUpgradesDeployment ensures the deployment of the explcit
+// version upgrades agenda activates for the provided network parameters.
+func testExplicitVerUpgradesDeployment(t *testing.T, params *chaincfg.Params) {
+	// Clone the parameters so they can be mutated, find the correct deployment
+	// for the header commitments agenda as well as the yes vote choice within
+	// it, and, finally, ensure it is always available to vote by removing the
+	// time constraints to prevent test failures when the real expiration time
+	// passes.
+	params = cloneParams(params)
+	deploymentVer, deployment, err := findDeployment(params,
+		chaincfg.VoteIDExplicitVersionUpgrades)
+	if err != nil {
+		t.Fatal(err)
+	}
+	yesChoice, err := findDeploymentChoice(deployment, "yes")
+	if err != nil {
+		t.Fatal(err)
+	}
+	removeDeploymentTimeConstraints(deployment)
+
+	// Shorter versions of params for convenience.
+	stakeValidationHeight := uint32(params.StakeValidationHeight)
+	ruleChangeActivationInterval := params.RuleChangeActivationInterval
+
+	tests := []struct {
+		name       string
+		numNodes   uint32 // num fake nodes to create
+		curActive  bool   // whether agenda active for current block
+		nextActive bool   // whether agenda active for NEXT block
+	}{{
+		name:       "stake validation height",
+		numNodes:   stakeValidationHeight,
+		curActive:  false,
+		nextActive: false,
+	}, {
+		name:       "started",
+		numNodes:   ruleChangeActivationInterval,
+		curActive:  false,
+		nextActive: false,
+	}, {
+		name:       "lockedin",
+		numNodes:   ruleChangeActivationInterval,
+		curActive:  false,
+		nextActive: false,
+	}, {
+		name:       "one before active",
+		numNodes:   ruleChangeActivationInterval - 1,
+		curActive:  false,
+		nextActive: true,
+	}, {
+		name:       "exactly active",
+		numNodes:   1,
+		curActive:  true,
+		nextActive: true,
+	}, {
+		name:       "one after active",
+		numNodes:   1,
+		curActive:  true,
+		nextActive: true,
+	}}
+
+	curTimestamp := time.Now()
+	bc := newFakeChain(params)
+	node := bc.bestChain.Tip()
+	for _, test := range tests {
+		for i := uint32(0); i < test.numNodes; i++ {
+			node = newFakeNode(node, int32(deploymentVer), deploymentVer, 0,
+				curTimestamp)
+
+			// Create fake votes that vote yes on the agenda to ensure it is
+			// activated.
+			for j := uint16(0); j < params.TicketsPerBlock; j++ {
+				node.votes = append(node.votes, stake.VoteVersionTuple{
+					Version: deploymentVer,
+					Bits:    yesChoice.Bits | 0x01,
+				})
+			}
+			bc.index.AddNode(node)
+			bc.bestChain.SetTip(node)
+			curTimestamp = curTimestamp.Add(time.Second)
+		}
+
+		// Ensure the agenda reports the expected activation status for the
+		// current block.
+		gotActive, err := bc.isExplicitVerUpgradesAgendaActive(node.parent)
+		if err != nil {
+			t.Errorf("%s: unexpected err: %v", test.name, err)
+			continue
+		}
+		if gotActive != test.curActive {
+			t.Errorf("%s: mismatched current active status - got: %v, want: %v",
+				test.name, gotActive, test.curActive)
+			continue
+		}
+
+		// Ensure the agenda reports the expected activation status for the NEXT
+		// block
+		gotActive, err = bc.IsExplicitVerUpgradesAgendaActive(&node.hash)
+		if err != nil {
+			t.Errorf("%s: unexpected err: %v", test.name, err)
+			continue
+		}
+		if gotActive != test.nextActive {
+			t.Errorf("%s: mismatched next active status - got: %v, want: %v",
+				test.name, gotActive, test.nextActive)
+			continue
+		}
+	}
+}
+
+// TestExplictVerUpgradesDeployment ensures the deployment of the explicit
+// version upgrades agenda activates as expected.
+func TestExplictVerUpgradesDeployment(t *testing.T) {
+	testExplicitVerUpgradesDeployment(t, chaincfg.MainNetParams())
+	testExplicitVerUpgradesDeployment(t, chaincfg.RegNetParams())
 }

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -553,17 +553,13 @@ func (b *BlockChain) connectBlock(node *blockNode, block, parent *dcrutil.Block,
 			node.height, prevHash, tip.hash, tip.height)
 	}
 
-	isTreasuryEnabled, err := b.isTreasuryAgendaActive(node.parent)
+	// Create agenda flags for checking transactions based on which ones are
+	// active as of the block being connected.
+	checkTxFlags, err := b.determineCheckTxFlags(node.parent)
 	if err != nil {
 		return err
 	}
-
-	// Create agenda flags for checking transactions based on which ones are
-	// active as of the block being connected.
-	checkTxFlags := AFNone
-	if isTreasuryEnabled {
-		checkTxFlags |= AFTreasuryEnabled
-	}
+	isTreasuryEnabled := checkTxFlags.IsTreasuryEnabled()
 
 	// Sanity check the correct number of stxos are provided.
 	if len(stxos) != countSpentOutputs(block, isTreasuryEnabled) {
@@ -781,17 +777,13 @@ func (b *BlockChain) disconnectBlock(node *blockNode, block, parent *dcrutil.Blo
 			tip.height)
 	}
 
-	isTreasuryEnabled, err := b.isTreasuryAgendaActive(node.parent)
+	// Create agenda flags for checking transactions based on which ones were
+	// active as of the block being disconnected.
+	checkTxFlags, err := b.determineCheckTxFlags(node.parent)
 	if err != nil {
 		return err
 	}
-
-	// Create agenda flags for checking transactions based on which ones were
-	// active as of the block being disconnected.
-	checkTxFlags := AFNone
-	if isTreasuryEnabled {
-		checkTxFlags |= AFTreasuryEnabled
-	}
+	isTreasuryEnabled := checkTxFlags.IsTreasuryEnabled()
 
 	// Write any modified block index entries to the database before
 	// updating the best state.

--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -142,6 +142,10 @@ const (
 	// ErrDuplicateTxInputs indicates a transaction references the same
 	// input more than once.
 	ErrDuplicateTxInputs = ErrorKind("ErrDuplicateTxInputs")
+
+	// ErrTxVersionTooHigh indicates a transaction version is higher than the
+	// maximum version allowed by the active consensus rules.
+	ErrTxVersionTooHigh = ErrorKind("ErrTxVersionTooHigh")
 
 	// ErrBadTxInput indicates a transaction input is invalid in some way
 	// such as referencing a previous transaction outpoint which is out of

--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -152,6 +152,10 @@ const (
 	// range or not referencing one at all.
 	ErrBadTxInput = ErrorKind("ErrBadTxInput")
 
+	// ErrScriptVersionTooHigh indicates a transaction script version is higher
+	// than the maximum version allowed by the active consensus rules.
+	ErrScriptVersionTooHigh = ErrorKind("ErrScriptVersionTooHigh")
+
 	// ErrMissingTxOut indicates a transaction output referenced by an input
 	// either does not exist or has already been spent.
 	ErrMissingTxOut = ErrorKind("ErrMissingTxOut")

--- a/blockchain/error_test.go
+++ b/blockchain/error_test.go
@@ -45,6 +45,7 @@ func TestErrorKindStringer(t *testing.T) {
 		{ErrDuplicateTxInputs, "ErrDuplicateTxInputs"},
 		{ErrTxVersionTooHigh, "ErrTxVersionTooHigh"},
 		{ErrBadTxInput, "ErrBadTxInput"},
+		{ErrScriptVersionTooHigh, "ErrScriptVersionTooHigh"},
 		{ErrMissingTxOut, "ErrMissingTxOut"},
 		{ErrUnfinalizedTx, "ErrUnfinalizedTx"},
 		{ErrDuplicateTx, "ErrDuplicateTx"},

--- a/blockchain/error_test.go
+++ b/blockchain/error_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -43,6 +43,7 @@ func TestErrorKindStringer(t *testing.T) {
 		{ErrTxTooBig, "ErrTxTooBig"},
 		{ErrBadTxOutValue, "ErrBadTxOutValue"},
 		{ErrDuplicateTxInputs, "ErrDuplicateTxInputs"},
+		{ErrTxVersionTooHigh, "ErrTxVersionTooHigh"},
 		{ErrBadTxInput, "ErrBadTxInput"},
 		{ErrMissingTxOut, "ErrMissingTxOut"},
 		{ErrUnfinalizedTx, "ErrUnfinalizedTx"},

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -1231,9 +1231,6 @@ func (mp *TxPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit,
 		return nil, txRuleError(ErrDuplicate, str)
 	}
 
-	// Determine active agendas based on flags.
-	isTreasuryEnabled := checkTxFlags.IsTreasuryEnabled()
-
 	// Perform preliminary validation checks on the transaction.  This makes use
 	// of blockchain which contains the invariant rules for what transactions
 	// are allowed into blocks.
@@ -1245,6 +1242,9 @@ func (mp *TxPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit,
 		}
 		return nil, err
 	}
+
+	// Determine active agendas based on flags.
+	isTreasuryEnabled := checkTxFlags.IsTreasuryEnabled()
 
 	// A standalone transaction must not be a coinbase transaction.
 	if standalone.IsCoinBaseTx(msgTx, isTreasuryEnabled) {
@@ -1798,8 +1798,10 @@ func (mp *TxPool) MaybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit bool) 
 	}
 
 	// Create agenda flags for checking transactions based on which ones are
-	// active.
-	checkTxFlags := blockchain.AFNone
+	// active or should otherwise always be enforced.
+	//
+	// Note that explicit version upgrades are always enforced by policy.
+	checkTxFlags := blockchain.AFExplicitVerUpgrades
 	if isTreasuryEnabled {
 		checkTxFlags |= blockchain.AFTreasuryEnabled
 	}
@@ -2042,8 +2044,10 @@ func (mp *TxPool) ProcessTransaction(tx *dcrutil.Tx, allowOrphan, rateLimit, all
 	}
 
 	// Create agenda flags for checking transactions based on which ones are
-	// active.
-	checkTxFlags := blockchain.AFNone
+	// active or should otherwise always be enforced.
+	//
+	// Note that explicit version upgrades are always enforced by policy.
+	checkTxFlags := blockchain.AFExplicitVerUpgrades
 	if isTreasuryEnabled {
 		checkTxFlags |= blockchain.AFTreasuryEnabled
 	}

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -162,11 +162,6 @@ type Config struct {
 // Policy houses the policy (configuration parameters) which is used to
 // control the mempool.
 type Policy struct {
-	// MaxTxVersion is the max transaction version that the mempool should
-	// accept.  All transactions above this version are rejected as
-	// non-standard.
-	MaxTxVersion uint16
-
 	// DisableRelayPriority defines whether to relay free or low-fee
 	// transactions that do not have enough priority to be relayed.
 	DisableRelayPriority bool
@@ -1311,8 +1306,7 @@ func (mp *TxPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit,
 	medianTime := mp.cfg.PastMedianTime()
 	if !mp.cfg.Policy.AcceptNonStd {
 		err := checkTransactionStandard(tx, txType, nextBlockHeight,
-			medianTime, mp.cfg.Policy.MinRelayTxFee,
-			mp.cfg.Policy.MaxTxVersion, isTreasuryEnabled)
+			medianTime, mp.cfg.Policy.MinRelayTxFee, isTreasuryEnabled)
 		if err != nil {
 			str := fmt.Sprintf("transaction %v is not standard: %v",
 				txHash, err)

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -790,7 +790,6 @@ func newPoolHarness(chainParams *chaincfg.Params) (*poolHarness, []spendableOutp
 		txPool: New(&Config{
 			Policy: Policy{
 				EnableAncestorTracking: true,
-				MaxTxVersion:           wire.TxVersionTreasury,
 				DisableRelayPriority:   true,
 				FreeTxRelayLimit:       15.0,
 				MaxOrphanTxs:           5,

--- a/internal/mempool/policy.go
+++ b/internal/mempool/policy.go
@@ -296,19 +296,15 @@ func isDust(txOut *wire.TxOut, minRelayTxFee dcrutil.Amount) bool {
 //
 // Note: all non-nil errors MUST be RuleError with an underlying TxRuleError
 // instance.
-func checkTransactionStandard(tx *dcrutil.Tx, txType stake.TxType, height int64, medianTime time.Time, minRelayTxFee dcrutil.Amount, maxTxVersion uint16, isTreasuryEnabled bool) error {
+func checkTransactionStandard(tx *dcrutil.Tx, txType stake.TxType, height int64,
+	medianTime time.Time, minRelayTxFee dcrutil.Amount,
+	isTreasuryEnabled bool) error {
 
-	// The transaction must be a currently supported version and serialize
-	// type.
+	// The transaction must be a currently supported serialize type.
 	msgTx := tx.MsgTx()
 	if msgTx.SerType != wire.TxSerializeFull {
 		str := fmt.Sprintf("transaction is not serialized with all "+
 			"required data -- type %v", msgTx.SerType)
-		return txRuleError(ErrNonStandard, str)
-	}
-	if msgTx.Version > maxTxVersion || msgTx.Version < 1 {
-		str := fmt.Sprintf("transaction version %d is not in the "+
-			"valid range of %d-%d", msgTx.Version, 1, maxTxVersion)
 		return txRuleError(ErrNonStandard, str)
 	}
 

--- a/internal/mempool/policy_test.go
+++ b/internal/mempool/policy_test.go
@@ -306,10 +306,6 @@ func TestDust(t *testing.T) {
 
 // TestCheckTransactionStandard tests the checkTransactionStandard API.
 func TestCheckTransactionStandard(t *testing.T) {
-	// maxTxVersion is used as the maximum support transaction version for
-	// the policy in these tests.
-	const maxTxVersion = 1
-
 	// Create some dummy, but otherwise standard, data for transactions.
 	prevOutHash, err := chainhash.NewHashFromStr("01")
 	if err != nil {
@@ -362,19 +358,6 @@ func TestCheckTransactionStandard(t *testing.T) {
 			tx: wire.MsgTx{
 				SerType:  wire.TxSerializeNoWitness,
 				Version:  1,
-				TxIn:     []*wire.TxIn{&dummyTxIn},
-				TxOut:    []*wire.TxOut{&dummyTxOut},
-				LockTime: 0,
-			},
-			height:     300000,
-			isStandard: false,
-			err:        ErrNonStandard,
-		},
-		{
-			name: "Transaction version too high",
-			tx: wire.MsgTx{
-				SerType:  wire.TxSerializeFull,
-				Version:  maxTxVersion + 1,
 				TxIn:     []*wire.TxIn{&dummyTxIn},
 				TxOut:    []*wire.TxOut{&dummyTxOut},
 				LockTime: 0,
@@ -536,7 +519,7 @@ func TestCheckTransactionStandard(t *testing.T) {
 		txType := stake.DetermineTxType(&test.tx, noTreasury)
 		tx := dcrutil.NewTx(&test.tx)
 		err := checkTransactionStandard(tx, txType, test.height, medianTime,
-			DefaultMinRelayTxFee, maxTxVersion, noTreasury)
+			DefaultMinRelayTxFee, noTreasury)
 		if err == nil && test.isStandard {
 			// Test passes since function returned standard for a
 			// transaction which is intended to be standard.

--- a/server.go
+++ b/server.go
@@ -3432,7 +3432,6 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB,
 	txC := mempool.Config{
 		Policy: mempool.Policy{
 			EnableAncestorTracking: len(cfg.miningAddrs) > 0,
-			MaxTxVersion:           wire.TxVersionTreasury,
 			DisableRelayPriority:   cfg.NoRelayPriority,
 			AcceptNonStd:           cfg.AcceptNonStd,
 			FreeTxRelayLimit:       cfg.FreeTxRelayLimit,


### PR DESCRIPTION
~**This requires #2713, #2715, and #2721**.~

This implements the agenda for voting on rejecting new transaction and script versions until they have explicitly been enabled by a consensus rule change as defined in [DCP0008](https://github.com/decred/dcps/blob/master/dcp-0008/dcp-0008.mediawiki) along with consensus tests.

In particular, once the vote has passed and is active, transaction versions greater than 3 and script versions greater than 0 will no longer be accepted by consensus.

This PR also updates the `mempool` policy when considering candidate transactions for acceptance to the mempool, relaying, and inclusion into block templates to enforce the new version behavior at a consensus level versus via the standardness policy.  In practice, this change means the following:

- For `mainnet`, there will be no externally observable difference since standardness rules are already enforced on `mainnet` and they already prevent transactions which violate the new rules
- For `testnet` (where non-standard transactions are allowed) the `mempool` policy will now match the existing `mainnet` policy in terms of version handling
  - Namely, any transaction versions greater than 3 and script versions greater than 0 will no longer be accepted

Note that this does not implement block version bumps in the mining and validation code that will ultimately be needed since another consensus vote is expected to land before voting begins.

The following is an overview of the changes:

- Introduce a convenience function for determining if the vote passed and is now active
- Modify block validation to enforce the rejection of newer transaction versions in accordance with the state of the vote
- Modify block validation to enforce the rejection of newer script versions in accordance with the state of the vote
- Add tests for determining if the agenda is active for both mainnet and testnet
- Add tests to ensure proper behavior for new transaction versions as follows:
  - New regular and stake transaction versions are rejected once the agenda is active
  - Existing regular and stake outputs created with newer tx versions are spendable before the agenda is active and remain spendable after it is active
- Add tests to ensure proper behavior for new script versions as follows:
  - Ensure stake transactions still require version 0 scripts regardless of the state of the agenda
  - Regular transactions with script versions newer than 0 are rejected once the agenda is active
  - Transaction outputs that have a non-zero output and script that would make the output unspendable if it were version 0 are spendable with a `nil` signature script both before the agenda is active and remain spendable after it is active
- Modify the `mempool` policy to enforce the explicit version upgrade requirements via the consensus rules versus via the standardness rules
- Remove the `mempool` `MaxTxVersion` field from the `Policy` struct
- Remove the `mempool` max tx version checking logic from `checkTransactionStandard`
- Remove the `mempool` max tx version param from `checkTransactionStandard`
- Update the `mempool` transaction standardness tests accordingly
- Update all callers to account for the aforementioned `mempool` changes accordingly