### PR TITLE
multi: DCP0009 Prep auto revocations.

### DIFF
--- a/blockchain/agendas_test.go
+++ b/blockchain/agendas_test.go
@@ -812,3 +812,127 @@ func TestExplictVerUpgradesDeployment(t *testing.T) {
 	testExplicitVerUpgradesDeployment(t, chaincfg.MainNetParams())
 	testExplicitVerUpgradesDeployment(t, chaincfg.RegNetParams())
 }
+
+// testAutoRevocationsDeployment ensures the deployment of the automatic ticket
+// revocations agenda activates for the provided network parameters.
+func testAutoRevocationsDeployment(t *testing.T, params *chaincfg.Params) {
+	// Clone the parameters so they can be mutated, find the correct deployment
+	// for the automatic ticket revocations agenda as well as the yes vote choice
+	// within it, and, finally, ensure it is always available to vote by removing
+	// the time constraints to prevent test failures when the real expiration time
+	// passes.
+	params = cloneParams(params)
+	deploymentVer, deployment, err := findDeployment(params,
+		chaincfg.VoteIDAutoRevocations)
+	if err != nil {
+		t.Fatal(err)
+	}
+	yesChoice, err := findDeploymentChoice(deployment, "yes")
+	if err != nil {
+		t.Fatal(err)
+	}
+	removeDeploymentTimeConstraints(deployment)
+
+	// Shorter versions of params for convenience.
+	stakeValidationHeight := uint32(params.StakeValidationHeight)
+	ruleChangeActivationInterval := params.RuleChangeActivationInterval
+
+	tests := []struct {
+		name       string
+		numNodes   uint32 // num fake nodes to create
+		curActive  bool   // whether agenda active for current block
+		nextActive bool   // whether agenda active for NEXT block
+	}{
+		{
+			name:       "stake validation height",
+			numNodes:   stakeValidationHeight,
+			curActive:  false,
+			nextActive: false,
+		},
+		{
+			name:       "started",
+			numNodes:   ruleChangeActivationInterval,
+			curActive:  false,
+			nextActive: false,
+		},
+		{
+			name:       "lockedin",
+			numNodes:   ruleChangeActivationInterval,
+			curActive:  false,
+			nextActive: false,
+		},
+		{
+			name:       "one before active",
+			numNodes:   ruleChangeActivationInterval - 1,
+			curActive:  false,
+			nextActive: true,
+		},
+		{
+			name:       "exactly active",
+			numNodes:   1,
+			curActive:  true,
+			nextActive: true,
+		},
+		{
+			name:       "one after active",
+			numNodes:   1,
+			curActive:  true,
+			nextActive: true,
+		},
+	}
+
+	curTimestamp := time.Now()
+	bc := newFakeChain(params)
+	node := bc.bestChain.Tip()
+	for _, test := range tests {
+		for i := uint32(0); i < test.numNodes; i++ {
+			node = newFakeNode(node, int32(deploymentVer), deploymentVer, 0,
+				curTimestamp)
+
+			// Create fake votes that vote yes on the agenda to ensure it is
+			// activated.
+			for j := uint16(0); j < params.TicketsPerBlock; j++ {
+				node.votes = append(node.votes, stake.VoteVersionTuple{
+					Version: deploymentVer,
+					Bits:    yesChoice.Bits | 0x01,
+				})
+			}
+			bc.index.AddNode(node)
+			bc.bestChain.SetTip(node)
+			curTimestamp = curTimestamp.Add(time.Second)
+		}
+
+		// Ensure the agenda reports the expected activation status for the
+		// current block.
+		gotActive, err := bc.isAutoRevocationsAgendaActive(node.parent)
+		if err != nil {
+			t.Errorf("%s: unexpected err: %v", test.name, err)
+			continue
+		}
+		if gotActive != test.curActive {
+			t.Errorf("%s: mismatched current active status - got: %v, want: %v",
+				test.name, gotActive, test.curActive)
+			continue
+		}
+
+		// Ensure the agenda reports the expected activation status for the NEXT
+		// block
+		gotActive, err = bc.IsAutoRevocationsAgendaActive(&node.hash)
+		if err != nil {
+			t.Errorf("%s: unexpected err: %v", test.name, err)
+			continue
+		}
+		if gotActive != test.nextActive {
+			t.Errorf("%s: mismatched next active status - got: %v, want: %v",
+				test.name, gotActive, test.nextActive)
+			continue
+		}
+	}
+}
+
+// TestAutoRevocationsDeployment ensures the deployment of the automatic ticket
+// revocations agenda activates as expected.
+func TestAutoRevocationsDeployment(t *testing.T) {
+	testAutoRevocationsDeployment(t, chaincfg.MainNetParams())
+	testAutoRevocationsDeployment(t, chaincfg.RegNetParams())
+}

--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -607,6 +607,9 @@ const (
 	// block which is not allowed.
 	ErrInvalidateGenesisBlock = ErrorKind("ErrInvalidateGenesisBlock")
 
+	// ErrSerializeHeader indicates an attempt to serialize a block header failed.
+	ErrSerializeHeader = ErrorKind("ErrSerializeHeader")
+
 	// ------------------------------------------
 	// Errors related to the UTXO backend.
 	// ------------------------------------------
@@ -627,6 +630,22 @@ const (
 	// a UTXO backend transaction that has already had one of those operations
 	// performed.
 	ErrUtxoBackendTxClosed = ErrorKind("ErrUtxoBackendTxClosed")
+
+	// -----------------------------------------------------------------
+	// Errors related to the automatic ticket revocations agenda.
+	// -----------------------------------------------------------------
+
+	// ErrInvalidRevocationTxVersion indicates that the revocation is the wrong
+	// transaction version.
+	ErrInvalidRevocationTxVersion = ErrorKind("ErrInvalidRevocationTxVersion")
+
+	// ErrNoExpiredTicketRevocation indicates that the block does not contain a
+	// revocation for a ticket that is becoming expired as of that block.
+	ErrNoExpiredTicketRevocation = ErrorKind("ErrNoExpiredTicketRevocation")
+
+	// ErrNoMissedTicketRevocation indicates that the block does not contain a
+	// revocation for a ticket that is becoming missed as of that block.
+	ErrNoMissedTicketRevocation = ErrorKind("ErrNoMissedTicketRevocation")
 )
 
 // Error satisfies the error interface and prints human-readable errors.

--- a/blockchain/error_test.go
+++ b/blockchain/error_test.go
@@ -157,10 +157,14 @@ func TestErrorKindStringer(t *testing.T) {
 		{ErrNoFilter, "ErrNoFilter"},
 		{ErrNoTreasuryBalance, "ErrNoTreasuryBalance"},
 		{ErrInvalidateGenesisBlock, "ErrInvalidateGenesisBlock"},
+		{ErrSerializeHeader, "ErrSerializeHeader"},
 		{ErrUtxoBackend, "ErrUtxoBackend"},
 		{ErrUtxoBackendCorruption, "ErrUtxoBackendCorruption"},
 		{ErrUtxoBackendNotOpen, "ErrUtxoBackendNotOpen"},
 		{ErrUtxoBackendTxClosed, "ErrUtxoBackendTxClosed"},
+		{ErrInvalidRevocationTxVersion, "ErrInvalidRevocationTxVersion"},
+		{ErrNoExpiredTicketRevocation, "ErrNoExpiredTicketRevocation"},
+		{ErrNoMissedTicketRevocation, "ErrNoMissedTicketRevocation"},
 	}
 
 	t.Logf("Running %d tests", len(tests))

--- a/blockchain/fullblocktests/params.go
+++ b/blockchain/fullblocktests/params.go
@@ -365,6 +365,33 @@ var regNetParams = &chaincfg.Params{
 			},
 			StartTime:  0,             // Always available for vote
 			ExpireTime: math.MaxInt64, // Never expires
+		}, {
+			Vote: chaincfg.Vote{
+				Id:          chaincfg.VoteIDAutoRevocations,
+				Description: "Enable automatic ticket revocations as defined in DCP0009",
+				Mask:        0x0060, // Bits 5 and 6
+				Choices: []chaincfg.Choice{{
+					Id:          "abstain",
+					Description: "abstain voting for change",
+					Bits:        0x0000,
+					IsAbstain:   true,
+					IsNo:        false,
+				}, {
+					Id:          "no",
+					Description: "keep the existing consensus rules",
+					Bits:        0x0020, // Bit 5
+					IsAbstain:   false,
+					IsNo:        true,
+				}, {
+					Id:          "yes",
+					Description: "change to the new consensus rules",
+					Bits:        0x0040, // Bit 6
+					IsAbstain:   false,
+					IsNo:        false,
+				}},
+			},
+			StartTime:  0,             // Always available for vote
+			ExpireTime: math.MaxInt64, // Never expires
 		}},
 	},
 

--- a/blockchain/stake/error.go
+++ b/blockchain/stake/error.go
@@ -146,6 +146,14 @@ const (
 	// ErrSSRtxInvalidFee indicates that a given SSRtx contains an invalid fee.
 	ErrSSRtxInvalidFee = ErrorKind("ErrSSRtxInvalidFee")
 
+	// ErrSSRtxInputHasSigScript indicates that a given SSRtx input has a
+	// non-empty signature script.
+	ErrSSRtxInputHasSigScript = ErrorKind("ErrSSRtxInputHasSigScript")
+
+	// ErrSSRtxInvalidTxVersion indicates that a given SSRtx has an invalid
+	// transaction version.
+	ErrSSRtxInvalidTxVersion = ErrorKind("ErrSSRtxInvalidTxVersion")
+
 	// ErrVerSStxAmts indicates there was an error verifying the calculated
 	// SStx out amounts and the actual SStx out amounts.
 	ErrVerSStxAmts = ErrorKind("ErrVerSStxAmts")

--- a/blockchain/stake/error_test.go
+++ b/blockchain/stake/error_test.go
@@ -50,6 +50,8 @@ func TestErrorKindStringer(t *testing.T) {
 		{ErrSSRtxWrongTxTree, "ErrSSRtxWrongTxTree"},
 		{ErrSSRtxBadOuts, "ErrSSRtxBadOuts"},
 		{ErrSSRtxInvalidFee, "ErrSSRtxInvalidFee"},
+		{ErrSSRtxInputHasSigScript, "ErrSSRtxInputHasSigScript"},
+		{ErrSSRtxInvalidTxVersion, "ErrSSRtxInvalidTxVersion"},
 		{ErrVerSStxAmts, "ErrVerSStxAmts"},
 		{ErrVerifyInput, "ErrVerifyInput"},
 		{ErrVerifyOutType, "ErrVerifyOutType"},

--- a/blockchain/stake/lottery.go
+++ b/blockchain/stake/lottery.go
@@ -112,12 +112,12 @@ func (hp *Hash256PRNG) Hash256Rand() uint32 {
 	return r
 }
 
-// uniformRandom returns a random in the range [0 ... upperBound) while avoiding
+// UniformRandom returns a random in the range [0 ... upperBound) while avoiding
 // modulo bias, thus giving a normal distribution within the specified range.
 //
 // Ported from
 // https://github.com/conformal/clens/blob/master/src/arc4random_uniform.c
-func (hp *Hash256PRNG) uniformRandom(upperBound uint32) uint32 {
+func (hp *Hash256PRNG) UniformRandom(upperBound uint32) uint32 {
 	var r, min uint32
 	if upperBound < 2 {
 		return 0
@@ -170,7 +170,7 @@ func findTicketIdxs(size int, n uint16, prng *Hash256PRNG) ([]int, error) {
 	list := make([]int, 0, n)
 	var listLen uint16
 	for listLen < n {
-		r := int(prng.uniformRandom(sz))
+		r := int(prng.UniformRandom(sz))
 		if !intInSlice(r, list) {
 			list = append(list, r)
 			listLen++

--- a/chaincfg/mainnetparams.go
+++ b/chaincfg/mainnetparams.go
@@ -379,6 +379,33 @@ func MainNetParams() *Params {
 				},
 				StartTime:  1631750400, // Sep 16th, 2021
 				ExpireTime: 1694822400, // Sep 16th, 2023
+			}, {
+				Vote: Vote{
+					Id:          VoteIDAutoRevocations,
+					Description: "Enable automatic ticket revocations as defined in DCP0009",
+					Mask:        0x0060, // Bits 5 and 6
+					Choices: []Choice{{
+						Id:          "abstain",
+						Description: "abstain voting for change",
+						Bits:        0x0000,
+						IsAbstain:   true,
+						IsNo:        false,
+					}, {
+						Id:          "no",
+						Description: "keep the existing consensus rules",
+						Bits:        0x0020, // Bit 5
+						IsAbstain:   false,
+						IsNo:        true,
+					}, {
+						Id:          "yes",
+						Description: "change to the new consensus rules",
+						Bits:        0x0040, // Bit 6
+						IsAbstain:   false,
+						IsNo:        false,
+					}},
+				},
+				StartTime:  1631750400, // Sep 16th, 2021
+				ExpireTime: 1694822400, // Sep 16th, 2023
 			}},
 		},
 

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -155,6 +155,10 @@ const (
 	// rejection of new transaction and script versions until they are
 	// explicitly enabled via a consensus vote as defined by DCP0008.
 	VoteIDExplicitVersionUpgrades = "explicitverupgrades"
+
+	// VoteIDAutoRevocations is the vote ID for the agenda that enables automatic
+	// ticket revocations as defined in DCP0009.
+	VoteIDAutoRevocations = "autorevocations"
 )
 
 // ConsensusDeployment defines details related to a specific consensus rule

--- a/chaincfg/regnetparams.go
+++ b/chaincfg/regnetparams.go
@@ -349,6 +349,33 @@ func RegNetParams() *Params {
 				},
 				StartTime:  0,             // Always available for vote
 				ExpireTime: math.MaxInt64, // Never expires
+			}, {
+				Vote: Vote{
+					Id:          VoteIDAutoRevocations,
+					Description: "Enable automatic ticket revocations as defined in DCP0009",
+					Mask:        0x0060, // Bits 5 and 6
+					Choices: []Choice{{
+						Id:          "abstain",
+						Description: "abstain voting for change",
+						Bits:        0x0000,
+						IsAbstain:   true,
+						IsNo:        false,
+					}, {
+						Id:          "no",
+						Description: "keep the existing consensus rules",
+						Bits:        0x0020, // Bit 5
+						IsAbstain:   false,
+						IsNo:        true,
+					}, {
+						Id:          "yes",
+						Description: "change to the new consensus rules",
+						Bits:        0x0040, // Bit 6
+						IsAbstain:   false,
+						IsNo:        false,
+					}},
+				},
+				StartTime:  0,             // Always available for vote
+				ExpireTime: math.MaxInt64, // Never expires
 			}},
 		},
 

--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -271,6 +271,33 @@ func TestNet3Params() *Params {
 				},
 				StartTime:  1631750400, // Sep 16th, 2021
 				ExpireTime: 1694822400, // Sep 16th, 2023
+			}, {
+				Vote: Vote{
+					Id:          VoteIDAutoRevocations,
+					Description: "Enable automatic ticket revocations as defined in DCP0009",
+					Mask:        0x0060, // Bits 5 and 6
+					Choices: []Choice{{
+						Id:          "abstain",
+						Description: "abstain voting for change",
+						Bits:        0x0000,
+						IsAbstain:   true,
+						IsNo:        false,
+					}, {
+						Id:          "no",
+						Description: "keep the existing consensus rules",
+						Bits:        0x0020, // Bit 5
+						IsAbstain:   false,
+						IsNo:        true,
+					}, {
+						Id:          "yes",
+						Description: "change to the new consensus rules",
+						Bits:        0x0040, // Bit 6
+						IsAbstain:   false,
+						IsNo:        false,
+					}},
+				},
+				StartTime:  1631750400, // Sep 16th, 2021
+				ExpireTime: 1694822400, // Sep 16th, 2023
 			}},
 		},
 

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -149,6 +149,10 @@ type Config struct {
 	// IsTreasuryAgendaActive returns if the treasury agenda is active or
 	// not.
 	IsTreasuryAgendaActive func() (bool, error)
+
+	// IsAutoRevocationsAgendaActive returns if the automatic ticket revocations
+	// agenda is active or not.
+	IsAutoRevocationsAgendaActive func() (bool, error)
 
 	// OnTSpendReceived defines the function used to signal receiving a new
 	// tspend in the mempool.

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -1795,6 +1795,11 @@ func (mp *TxPool) MaybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit bool) 
 		return nil, err
 	}
 
+	isAutoRevocationsEnabled, err := mp.cfg.IsAutoRevocationsAgendaActive()
+	if err != nil {
+		return nil, err
+	}
+
 	// Create agenda flags for checking transactions based on which ones are
 	// active or should otherwise always be enforced.
 	//
@@ -1802,6 +1807,9 @@ func (mp *TxPool) MaybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit bool) 
 	checkTxFlags := blockchain.AFExplicitVerUpgrades
 	if isTreasuryEnabled {
 		checkTxFlags |= blockchain.AFTreasuryEnabled
+	}
+	if isAutoRevocationsEnabled {
+		checkTxFlags |= blockchain.AFAutoRevocationsEnabled
 	}
 
 	// Protect concurrent access.
@@ -2041,6 +2049,11 @@ func (mp *TxPool) ProcessTransaction(tx *dcrutil.Tx, allowOrphan, rateLimit, all
 		return nil, err
 	}
 
+	isAutoRevocationsEnabled, err := mp.cfg.IsAutoRevocationsAgendaActive()
+	if err != nil {
+		return nil, err
+	}
+
 	// Create agenda flags for checking transactions based on which ones are
 	// active or should otherwise always be enforced.
 	//
@@ -2048,6 +2061,9 @@ func (mp *TxPool) ProcessTransaction(tx *dcrutil.Tx, allowOrphan, rateLimit, all
 	checkTxFlags := blockchain.AFExplicitVerUpgrades
 	if isTreasuryEnabled {
 		checkTxFlags |= blockchain.AFTreasuryEnabled
+	}
+	if isAutoRevocationsEnabled {
+		checkTxFlags |= blockchain.AFAutoRevocationsEnabled
 	}
 
 	// Protect concurrent access.

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -1244,6 +1244,7 @@ func (mp *TxPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit,
 
 	// Determine active agendas based on flags.
 	isTreasuryEnabled := checkTxFlags.IsTreasuryEnabled()
+	isAutoRevocationsEnabled := checkTxFlags.IsAutoRevocationsEnabled()
 
 	// A standalone transaction must not be a coinbase transaction.
 	if standalone.IsCoinBaseTx(msgTx, isTreasuryEnabled) {
@@ -1490,7 +1491,7 @@ func (mp *TxPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit,
 	// filled in by the miner.
 	txFee, err := blockchain.CheckTransactionInputs(mp.cfg.SubsidyCache,
 		tx, nextBlockHeight, utxoView, false, mp.cfg.ChainParams,
-		isTreasuryEnabled)
+		isTreasuryEnabled, isAutoRevocationsEnabled)
 	if err != nil {
 		var cerr blockchain.RuleError
 		if errors.As(err, &cerr) {

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -345,13 +345,14 @@ type poolHarness struct {
 	//
 	// payScriptVer and payScript are the script version and script to pay the
 	// aforementioned payAddr.
-	signKey        []byte
-	sigType        dcrec.SignatureType
-	payAddr        stdaddr.StakeAddress
-	payScriptVer   uint16
-	payScript      []byte
-	chainParams    *chaincfg.Params
-	treasuryActive bool
+	signKey               []byte
+	sigType               dcrec.SignatureType
+	payAddr               stdaddr.StakeAddress
+	payScriptVer          uint16
+	payScript             []byte
+	chainParams           *chaincfg.Params
+	treasuryActive        bool
+	autoRevocationsActive bool
 
 	chain  *fakeChain
 	txPool *TxPool
@@ -826,6 +827,9 @@ func newPoolHarness(chainParams *chaincfg.Params) (*poolHarness, []spendableOutp
 			OnVoteReceived:        nil,
 			IsTreasuryAgendaActive: func() (bool, error) {
 				return harness.treasuryActive, nil
+			},
+			IsAutoRevocationsAgendaActive: func() (bool, error) {
+				return harness.autoRevocationsActive, nil
 			},
 		}),
 	}

--- a/internal/mining/error.go
+++ b/internal/mining/error.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -51,6 +51,13 @@ const (
 	// calculating the associated commitment root for a newly created block
 	// template failed.
 	ErrCalcCommitmentRoot = ErrorKind("ErrCalcCommitmentRoot")
+
+	// ErrGetTicketInfo indicates that ticket information could not be retreived
+	// in order to connect a transaction.
+	ErrGetTicketInfo = ErrorKind("ErrGetTicketInfo")
+
+	// ErrSerializeHeader indicates an attempt to serialize a block header failed.
+	ErrSerializeHeader = ErrorKind("ErrSerializeHeader")
 )
 
 // Error satisfies the error interface and prints human-readable errors.

--- a/internal/mining/error_test.go
+++ b/internal/mining/error_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Decred developers
+// Copyright (c) 2020-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -26,6 +26,8 @@ func TestErrorKindStringer(t *testing.T) {
 		{ErrFraudProofIndex, "ErrFraudProofIndex"},
 		{ErrFetchTxStore, "ErrFetchTxStore"},
 		{ErrCalcCommitmentRoot, "ErrCalcCommitmentRoot"},
+		{ErrGetTicketInfo, "ErrGetTicketInfo"},
+		{ErrSerializeHeader, "ErrSerializeHeader"},
 	}
 
 	for i, test := range tests {

--- a/internal/mining/txpriorityqueue_test.go
+++ b/internal/mining/txpriorityqueue_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -34,6 +34,7 @@ func TestStakeTxFeePrioHeap(t *testing.T) {
 		{feePerKB: 1234, txType: stake.TxTypeRegular, priority: 2},
 		{feePerKB: 10000, txType: stake.TxTypeRegular, priority: 0}, // Higher fee, lower prio
 		{feePerKB: 0, txType: stake.TxTypeRegular, priority: 10000}, // Higher prio, lower fee
+		{txType: stake.TxTypeSSRtx, autoRevocation: true},
 	}
 
 	// Add random data in addition to the edge conditions already manually
@@ -92,8 +93,8 @@ func TestStakeTxFeePrioHeap(t *testing.T) {
 		txpi, ok := prioItem.(*txPrioItem)
 		if ok {
 			bothAreLowStakePriority :=
-				txStakePriority(txpi.txType) == regOrRevocPriority &&
-					txStakePriority(last.txType) == regOrRevocPriority
+				txStakePriority(txpi.txType, txpi.autoRevocation) == regOrRevocPriority &&
+					txStakePriority(last.txType, last.autoRevocation) == regOrRevocPriority
 			if !bothAreLowStakePriority {
 				if txpi.feePerKB > last.feePerKB &&
 					compareStakePriority(txpi, last) >= 0 {

--- a/server.go
+++ b/server.go
@@ -3560,11 +3560,12 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB,
 			CheckConnectBlockTemplate:  s.chain.CheckConnectBlockTemplate,
 			CheckTicketExhaustion:      s.chain.CheckTicketExhaustion,
 			CheckTransactionInputs: func(tx *dcrutil.Tx, txHeight int64,
-				view *blockchain.UtxoViewpoint, checkFraudProof bool,
-				isTreasuryEnabled bool) (int64, error) {
+				view *blockchain.UtxoViewpoint, checkFraudProof, isTreasuryEnabled,
+				isAutoRevocationsEnabled bool) (int64, error) {
 
 				return blockchain.CheckTransactionInputs(s.subsidyCache, tx, txHeight,
-					view, checkFraudProof, s.chainParams, isTreasuryEnabled)
+					view, checkFraudProof, s.chainParams, isTreasuryEnabled,
+					isAutoRevocationsEnabled)
 			},
 			CheckTSpendHasVotes:             s.chain.CheckTSpendHasVotes,
 			CountSigOps:                     blockchain.CountSigOps,
@@ -3575,6 +3576,7 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB,
 			IsFinalizedTransaction:          blockchain.IsFinalizedTransaction,
 			IsHeaderCommitmentsAgendaActive: s.chain.IsHeaderCommitmentsAgendaActive,
 			IsTreasuryAgendaActive:          s.chain.IsTreasuryAgendaActive,
+			IsAutoRevocationsAgendaActive:   s.chain.IsAutoRevocationsAgendaActive,
 			MaxTreasuryExpenditure:          s.chain.MaxTreasuryExpenditure,
 			NewUtxoViewpoint: func() *blockchain.UtxoViewpoint {
 				return blockchain.NewUtxoViewpoint(utxoCache)

--- a/server.go
+++ b/server.go
@@ -3488,6 +3488,10 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB,
 			tipHash := &s.chain.BestSnapshot().Hash
 			return s.chain.IsTreasuryAgendaActive(tipHash)
 		},
+		IsAutoRevocationsAgendaActive: func() (bool, error) {
+			tipHash := &s.chain.BestSnapshot().Hash
+			return s.chain.IsAutoRevocationsAgendaActive(tipHash)
+		},
 		TSpendMinedOnAncestor: func(tspend chainhash.Hash) error {
 			tipHash := s.chain.BestSnapshot().Hash
 			return s.chain.CheckTSpendExists(tipHash, tspend)


### PR DESCRIPTION
~~**Requires https://github.com/decred/dcrd/pull/2702, https://github.com/decred/dcrd/pull/2707, https://github.com/decred/dcrd/pull/2708, https://github.com/decred/dcrd/pull/2709.**~~

~~**Also, DCP0008 PRs are expected to go in first and this will be rebased on top.**~~

**Requires https://github.com/decred/dcrd/pull/2716.**

---

This introduces changes in preparation for the automatic ticket revocations consensus change as defined in [DCP0009](https://github.com/decred/dcps/pull/21).

This does not contain any consensus rule changes.  The consensus rule changes for DCP0009 will come in a separate pull request that is dependent on this one.

An overview of the changes is as follows:

- Add `CalculateRewards` tests  to ensure that ticket output amounts are calculated correctly under a variety of conditions
  - Additionally, clean up the code, naming, and documentation to be more consistent with the consensus code that defines the rules that this is following
- Add full test coverage for `CheckSSRtx` and update the existing tests to follow the newer standard
- Export `Hash256PRNG` `UniformRandom` so that it can be used outside of the `stake` package
- Add a new definition for the upcoming agenda vote to enable automatic ticket revocations as defined in DCP0009
- Add functionality to check whether or not the automatic ticket revocations agenda vote is active
- Add tests to ensure the deployment of the automatic ticket revocations agenda activates as expected
- Add an `IsAutoRevocationsAgendaActive` function to `mempool.Config`, which returns whether the automatic ticket revocations agenda is active or not
- Add `AFAutoRevocationsEnabled` to `blockchain.AgendaFlags`, which may be set to indicate that the automatic ticket revocations agenda should be considered as active when checking a transaction so that any additional checks which depend on the agenda being active are applied
  - Update all references of `blockchain.AgendaFlags` to set `AFAutoRevocationsEnabled` if the automatic ticket revocations agenda is active
- Add an `isAutoRevocationsEnabled` boolean to `checkTicketRedeemerCommitments` and updates all callers accordingly
- Add two new revocation chain generator mungers:
  - `ReplaceRevocationVersions` returns a function that itself takes a block and modifies it by replacing the transaction version of all revocations contained in the block
  - `CreateRevocationsForMissedTickets` returns a function that itself takes a block and modifies it by creating revocations for all tickets that would otherwise become missed as of that block
- Add additional `blockchain` error kinds that will be used by the automatic ticket revocations agenda implementation
- Add additional `stake` error kinds that will be used by the automatic ticket revocations agenda implementation
- Add additional `mining` error kinds that will be used by the automatic ticket revocations agenda implementation
- Add a new priority for automatic revocations to the tx priority queue
  - With the automatic ticket revocations agenda, revocations are required for all tickets that are becoming missed or expired as of the block being created
  - Ensure that those revocations are treated as the second-highest priority after votes in the priority queue, ahead of other non-mandatory transactions
- Move the revocation checks from `checkBlockSanity` to `checkBlockContext` since they will require context due to the automatic ticket revocations agenda