### PR TITLE
multi: Add isAutoRevocationsEnabled to CheckSSRtx.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1061,6 +1061,12 @@ func (b *BlockChain) reorganizeChainInternal(target *blockNode) error {
 			return err
 		}
 
+		// Determine if the automatic ticket revocations agenda is active.
+		isAutoRevocationsEnabled, err := b.isAutoRevocationsAgendaActive(n.parent)
+		if err != nil {
+			return err
+		}
+
 		// Load all of the spent txos for the block from the spend journal.
 		var stxos []spentTxOut
 		err = b.db.View(func(dbTx database.Tx) error {
@@ -1074,7 +1080,8 @@ func (b *BlockChain) reorganizeChainInternal(target *blockNode) error {
 		// Update the view to unspend all of the spent txos and remove the utxos
 		// created by the block.  Also, if the block votes against its parent,
 		// reconnect all of the regular transactions.
-		err = view.disconnectBlock(block, parent, stxos, isTreasuryEnabled)
+		err = view.disconnectBlock(block, parent, stxos, isTreasuryEnabled,
+			isAutoRevocationsEnabled)
 		if err != nil {
 			return err
 		}
@@ -1150,6 +1157,12 @@ func (b *BlockChain) reorganizeChainInternal(target *blockNode) error {
 			return err
 		}
 
+		// Determine if the automatic ticket revocations agenda is active.
+		isAutoRevocationsEnabled, err := b.isAutoRevocationsAgendaActive(n.parent)
+		if err != nil {
+			return err
+		}
+
 		// Skip validation if the block has already been validated.  However,
 		// the utxo view still needs to be updated and the stxos and header
 		// commitment data are still needed.
@@ -1163,7 +1176,7 @@ func (b *BlockChain) reorganizeChainInternal(target *blockNode) error {
 			// all of the regular transactions in the parent block.  Finally,
 			// provide an stxo slice so the spent txout details are generated.
 			err := view.connectBlock(b.db, block, parent, &stxos,
-				isTreasuryEnabled)
+				isTreasuryEnabled, isAutoRevocationsEnabled)
 			if err != nil {
 				return err
 			}

--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -30,6 +30,11 @@ const (
 	// it is inactive.  It is used to increase the readability of the
 	// tests.
 	noTreasury = false
+
+	// noAutoRevocations signifies the automatic ticket revocations agenda should
+	// be treated as though it is inactive.  It is used to increase the
+	// readability of the tests.
+	noAutoRevocations = false
 )
 
 // cloneParams returns a deep copy of the provided parameters so the caller is

--- a/blockchain/headercmt.go
+++ b/blockchain/headercmt.go
@@ -85,7 +85,14 @@ func (b *BlockChain) FetchUtxoViewParentTemplate(block *wire.MsgBlock) (*UtxoVie
 		return nil, err
 	}
 
+	// Determine if treasury agenda is active.
 	isTreasuryEnabled, err := b.isTreasuryAgendaActive(tip.parent)
+	if err != nil {
+		return nil, err
+	}
+
+	// Determine if the automatic ticket revocations agenda is active.
+	isAutoRevocationsEnabled, err := b.isAutoRevocationsAgendaActive(tip.parent)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +110,8 @@ func (b *BlockChain) FetchUtxoViewParentTemplate(block *wire.MsgBlock) (*UtxoVie
 	// Update the view to unspend all of the spent txos and remove the utxos
 	// created by the tip block.  Also, if the block votes against its parent,
 	// reconnect all of the regular transactions.
-	err = view.disconnectBlock(tipBlock, parent, stxos, isTreasuryEnabled)
+	err = view.disconnectBlock(tipBlock, parent, stxos, isTreasuryEnabled,
+		isAutoRevocationsEnabled)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +124,8 @@ func (b *BlockChain) FetchUtxoViewParentTemplate(block *wire.MsgBlock) (*UtxoVie
 	// the parent, also disconnect all of the regular transactions in the parent
 	// block.
 	utilBlock := dcrutil.NewBlock(block)
-	err = view.connectBlock(b.db, utilBlock, parent, nil, isTreasuryEnabled)
+	err = view.connectBlock(b.db, utilBlock, parent, nil, isTreasuryEnabled,
+		isAutoRevocationsEnabled)
 	if err != nil {
 		return nil, err
 	}

--- a/blockchain/sequencelock_test.go
+++ b/blockchain/sequencelock_test.go
@@ -56,7 +56,7 @@ func TestCalcSequenceLock(t *testing.T) {
 		}},
 	})
 	view := NewUtxoViewpoint(nil)
-	view.AddTxOuts(targetTx, int64(numBlocks)-4, 0, noTreasury)
+	view.AddTxOuts(targetTx, int64(numBlocks)-4, 0, noTreasury, noAutoRevocations)
 	view.SetBestHash(&node.hash)
 
 	// Create a utxo that spends the fake utxo created above for use in the
@@ -101,7 +101,7 @@ func TestCalcSequenceLock(t *testing.T) {
 	// Adding a utxo with a height of 0x7fffffff indicates that the output
 	// is currently unmined.
 	view.AddTxOuts(dcrutil.NewTx(unConfTx), 0x7fffffff, wire.NullBlockIndex,
-		noTreasury)
+		noTreasury, noAutoRevocations)
 
 	tests := []struct {
 		name      string

--- a/blockchain/stake/tickets_test.go
+++ b/blockchain/stake/tickets_test.go
@@ -126,7 +126,7 @@ func copyNode(n *Node) *Node {
 func ticketsInBlock(bl *dcrutil.Block) []chainhash.Hash {
 	tickets := make([]chainhash.Hash, 0)
 	for _, stx := range bl.STransactions() {
-		if DetermineTxType(stx.MsgTx(), noTreasury) == TxTypeSStx {
+		if IsSStx(stx.MsgTx()) {
 			h := stx.Hash()
 			tickets = append(tickets, *h)
 		}
@@ -139,7 +139,7 @@ func ticketsInBlock(bl *dcrutil.Block) []chainhash.Hash {
 func ticketsSpentInBlock(bl *dcrutil.Block) []chainhash.Hash {
 	tickets := make([]chainhash.Hash, 0, bl.MsgBlock().Header.Voters)
 	for _, stx := range bl.STransactions() {
-		if DetermineTxType(stx.MsgTx(), noTreasury) == TxTypeSSGen {
+		if IsSSGen(stx.MsgTx(), noTreasury) {
 			tickets = append(tickets, stx.MsgTx().TxIn[1].PreviousOutPoint.Hash)
 		}
 	}
@@ -151,7 +151,7 @@ func ticketsSpentInBlock(bl *dcrutil.Block) []chainhash.Hash {
 func revokedTicketsInBlock(bl *dcrutil.Block) []chainhash.Hash {
 	tickets := make([]chainhash.Hash, 0, bl.MsgBlock().Header.Revocations)
 	for _, stx := range bl.STransactions() {
-		if DetermineTxType(stx.MsgTx(), noTreasury) == TxTypeSSRtx {
+		if IsSSRtx(stx.MsgTx(), noAutoRevocations) {
 			tickets = append(tickets, stx.MsgTx().TxIn[0].PreviousOutPoint.Hash)
 		}
 	}

--- a/gcs/blockcf2/blockcf.go
+++ b/gcs/blockcf2/blockcf.go
@@ -334,7 +334,13 @@ func Regular(block *wire.MsgBlock, prevScripts PrevScripter) (*gcs.FilterV2, err
 		// on consensus to make sure treasury opcodes never make it
 		// here. Setting it to true also will automatically enable the
 		// opcodes once the treasury agenda is voted in.
-		switch stake.DetermineTxType(tx, true) {
+		//
+		// Pass false for whether the automatic ticket revocations agenda is active.
+		// This is okay since the auto revocations flag just adds additional rules
+		// that revocations must have an empty signature script for its input and
+		// must have zero fee.  Revocations that don't follow those rules will still
+		// be rejected by consensus.
+		switch stake.DetermineTxType(tx, true, false) {
 		case stake.TxTypeSStx:
 			for txInIdx, txIn := range tx.TxIn {
 				prevOut := &txIn.PreviousOutPoint

--- a/internal/mempool/policy_test.go
+++ b/internal/mempool/policy_test.go
@@ -25,6 +25,11 @@ const (
 	// noTreasury signifies the treasury agenda should be treated as though it
 	// is inactive.  It is used to increase the readability of the tests.
 	noTreasury = false
+
+	// noAutoRevocations signifies the automatic ticket revocations agenda should
+	// be treated as though it is inactive.  It is used to increase the
+	// readability of the tests.
+	noAutoRevocations = false
 )
 
 // TestCalcMinRequiredTxRelayFee tests the calcMinRequiredTxRelayFee API.
@@ -516,7 +521,7 @@ func TestCheckTransactionStandard(t *testing.T) {
 	medianTime := time.Now()
 	for _, test := range tests {
 		// Ensure standardness is as expected.
-		txType := stake.DetermineTxType(&test.tx, noTreasury)
+		txType := stake.DetermineTxType(&test.tx, noTreasury, noAutoRevocations)
 		tx := dcrutil.NewTx(&test.tx)
 		err := checkTransactionStandard(tx, txType, test.height, medianTime,
 			DefaultMinRelayTxFee, noTreasury)

--- a/internal/mining/mining_view_test.go
+++ b/internal/mining/mining_view_test.go
@@ -488,7 +488,8 @@ func TestAncestorTrackingLimits(t *testing.T) {
 
 		harness.RemoveTransactionFromTxSource(tx, false)
 		harness.txSource.MaybeAcceptDependents(tx,
-			harness.chain.isTreasuryAgendaActive)
+			harness.chain.isTreasuryAgendaActive,
+			harness.chain.isAutoRevocationsAgendaActive)
 	}
 
 	// Add all transactions back to the tx source in reverse order to demonstrate

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -397,6 +397,11 @@ type Chain interface {
 	// given block.
 	IsTreasuryAgendaActive(*chainhash.Hash) (bool, error)
 
+	// IsAutoRevocationsAgendaActive returns whether or not the automatic ticket
+	// revocations agenda vote, as defined in DCP0009, has passed and is now
+	// active for the block AFTER the given block.
+	IsAutoRevocationsAgendaActive(*chainhash.Hash) (bool, error)
+
 	// FetchTSpend returns all blocks where the treasury spend tx
 	// identified by the specified hash can be found.
 	FetchTSpend(chainhash.Hash) ([]chainhash.Hash, error)


### PR DESCRIPTION
**Requires https://github.com/decred/dcrd/pull/2718.**

---

**Note:** This modifies the following exported functions from the `stake` package:

- `func CheckSSRtx(tx *wire.MsgTx, isAutoRevocationsEnabled bool) error`
- `func IsSSRtx(tx *wire.MsgTx, isAutoRevocationsEnabled bool) bool`
- `func DetermineTxType(tx *wire.MsgTx, isTreasuryEnabled bool, isAutoRevocationsEnabled bool) TxType`
---

This adds the `isAutoRevocationsEnabled` flag to `stake.CheckSSRtx`, which in turn requires it to be added to `stake.DetermineTxType` and updating all callers.

This is required for `stake.CheckSSRtx` since it will be updated to return errors if revocation transactions are not valid when the automatic ticket revocations agenda is enabled.

This is not ideal since it requires passing around the context-based `isAutoRevocationsEnabled` flag in many places.

If the automatic ticket revocations agenda activates and there are no existing version 2 revocation transactions in blocks, then this could retroactively be removed and the updated checks can be based on the transaction version instead.

This does not contain any consensus rule changes.  The consensus rule changes for DCP0009 will come in a separate pull request that is dependent on this one.