### PR TITLE
addrmgr: Remove deprecated code.

### DIFF
--- a/addrmgr/addrmanager.go
+++ b/addrmgr/addrmanager.go
@@ -1048,15 +1048,6 @@ func (a *AddrManager) LocalAddresses() []LocalAddr {
 	return addrs
 }
 
-// FetchLocalAddresses fetches a summary of local addresses information for
-// the getnetworkinfo rpc.
-//
-// Deprecated: This will be removed in the next major version bump.
-// Use LocalAddresses instead.
-func (a *AddrManager) FetchLocalAddresses() []LocalAddr {
-	return a.LocalAddresses()
-}
-
 const (
 	// Unreachable represents a publicly unreachable connection state
 	// between two addresses.
@@ -1199,16 +1190,6 @@ func (a *AddrManager) ValidatePeerNa(localAddr, remoteAddr *wire.NetAddress) (bo
 	valid := (net == IPv4Address && reach == Ipv4) || (net == IPv6Address &&
 		(reach == Ipv6Weak || reach == Ipv6Strong || reach == Teredo))
 	return valid, reach
-}
-
-// IsPeerNaValid asserts if the provided local address is routable
-// and reachabile from the peer that suggested it.
-//
-// Deprecated: This will be removed in the next major version bump.
-// Use ValidatePeerNa instead.
-func (a *AddrManager) IsPeerNaValid(localAddr, remoteAddr *wire.NetAddress) bool {
-	valid, _ := a.ValidatePeerNa(localAddr, remoteAddr)
-	return valid
 }
 
 // New returns a new Decred address manager.

--- a/addrmgr/log.go
+++ b/addrmgr/log.go
@@ -15,14 +15,6 @@ import (
 // The default amount of logging is none.
 var log = slog.Disabled
 
-// DisableLog disables all library log output.  Logging output is disabled
-// by default until UseLogger is called.
-//
-// Deprecated: Use UseLogger(slog.Disabled) instead.
-func DisableLog() {
-	log = slog.Disabled
-}
-
 // UseLogger uses a specified Logger to output package logging info.
 // This should be used in preference to SetLogWriter if the caller is also
 // using slog.


### PR DESCRIPTION
This removes the deprecated functions along with the additional code and tests which are no longer necessary as a result of removing the functions.

The following is a list of exported types and functions removed along with what they were replaced by:

- `DisableLog` -> `UseLogger(slog.Disabled)`
- `FetchLocalAddresses` -> `LocalAddresses`
- `IsPeerNaValid` -> `ValidatePeerNa`
