### PR TITLE
build: Pin GitHub Actions to SHA.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,11 +9,11 @@ jobs:
         go: [1.16, 1.17]
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@331ce1d993939866bb63c32c6cbbfd48fa76fc57 #v2
         with:
           go-version: ${{ matrix.go }}
       - name: Check out source
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f #v2.3.4
       - name: Install Linters
         run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.0"
       - name: Build


### PR DESCRIPTION
* The actions tags can be moved. So pinned the actions based on SHA.
 https://julienrenaux.fr/2019/12/20/github-actions-security-risk/