### PR TITLE
gcs: Prerel module release ver updates.

### DIFF
--- a/gcs/go.mod
+++ b/gcs/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/dchest/siphash v1.2.2
-	github.com/decred/dcrd/blockchain/stake/v4 v4.0.0-20210129192908-660d0518b4cf
+	github.com/decred/dcrd/blockchain/stake/v4 v4.0.0-20210906140327-598bf66f24a6
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/crypto/blake256 v1.0.0
 	github.com/decred/dcrd/txscript/v4 v4.0.0-20210415215133-96b98390a9a9


### PR DESCRIPTION
**Rebased on https://github.com/decred/dcrd/pull/2748.**

This modifies the recently-updated `gcs` module to use a valid prerelease version of the `blockchain/stake` module so it can be used in require statements in consumer code that is also under development.

The updated direct dependencies are as follows:

- github.com/decred/dcrd/blockchain/stake/v4 v4.0.0-20210906140327-598bf66f24a6