### PR TITLE
multi: Update gcs prerel version.

### DIFF
--- a/blockchain/go.mod
+++ b/blockchain/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/decred/dcrd/dcrec v1.0.0
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210127014238-b33b46cf1a24
 	github.com/decred/dcrd/dcrutil/v4 v4.0.0-20210129181600-6ae0142d3b28
-	github.com/decred/dcrd/gcs/v3 v3.0.0-20210129195202-a4265d63b619
+	github.com/decred/dcrd/gcs/v3 v3.0.0-20210916172859-ca03de05ecd0
 	github.com/decred/dcrd/lru v1.1.0
 	github.com/decred/dcrd/txscript/v4 v4.0.0-20210415215133-96b98390a9a9
 	github.com/decred/dcrd/wire v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210127014238-b33b46cf1a24
 	github.com/decred/dcrd/dcrjson/v4 v4.0.0
 	github.com/decred/dcrd/dcrutil/v4 v4.0.0-20210129181600-6ae0142d3b28
-	github.com/decred/dcrd/gcs/v3 v3.0.0-20210129195202-a4265d63b619
+	github.com/decred/dcrd/gcs/v3 v3.0.0-20210916172859-ca03de05ecd0
 	github.com/decred/dcrd/hdkeychain/v3 v3.0.1-0.20210129190127-4ebd135a82f1
 	github.com/decred/dcrd/lru v1.1.0
 	github.com/decred/dcrd/peer/v3 v3.0.0-20210802141345-893802fc06b0

--- a/rpcclient/go.mod
+++ b/rpcclient/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.3
 	github.com/decred/dcrd/dcrjson/v4 v4.0.0
 	github.com/decred/dcrd/dcrutil/v4 v4.0.0-20210129181600-6ae0142d3b28
-	github.com/decred/dcrd/gcs/v3 v3.0.0-20210129195202-a4265d63b619
+	github.com/decred/dcrd/gcs/v3 v3.0.0-20210916172859-ca03de05ecd0
 	github.com/decred/dcrd/rpc/jsonrpc/types/v3 v3.0.0-20210129200153-14fd1a785bf2
 	github.com/decred/dcrd/txscript/v4 v4.0.0-20210415215133-96b98390a9a9
 	github.com/decred/dcrd/wire v1.4.0


### PR DESCRIPTION
This modifies some recently-updated modules to use a valid `gcs` prerelease version so they can be used in require statements in consumer code that is also under development.

The updated direct dependencies are as follows:

- github.com/decred/dcrd/gcs/v3 v3.0.0-20210916172859-ca03de05ecd0