### PR TITLE
blockchain: Reject old block vers for HFV.

### DIFF
--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -1073,7 +1073,7 @@ func (b *BlockChain) checkBlockHeaderPositional(header *wire.BlockHeader, prevNo
 		//
 		// Note that the latest block version for all networks other than the
 		// main network is one higher.
-		latestBlockVersion := int32(8)
+		latestBlockVersion := int32(9)
 		dcp0005Version := int32(7)
 		if b.chainParams.Net != wire.MainNet {
 			latestBlockVersion++


### PR DESCRIPTION
This updates the latest block version for the upcoming hard fork vote for DCP0007, DCP0008, and DCP0009 in order to reject old block versions once a super majority of the network has upgraded.