### PR TITLE
mining: Update to latest block vers for HFV.

### DIFF
--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -258,11 +258,11 @@ const (
 	// will require changes to the generated block.  Using the wire constant
 	// for generated block version could allow creation of invalid blocks
 	// for the updated version.
-	generatedBlockVersion = 8
+	generatedBlockVersion = 9
 
 	// generatedBlockVersionTest is the version of the block being generated
 	// for networks other than the main and simulation networks.
-	generatedBlockVersionTest = 9
+	generatedBlockVersionTest = 10
 
 	// blockHeaderOverhead is the max number of bytes it takes to serialize
 	// a block header and max possible transaction count.


### PR DESCRIPTION
This updates the block versions created by the mining code to produce the latest versions needed to trigger the hard fork vote for DCP0007, DCP0008, and DCP0009.