### PR TITLE
txscript: Add versioned short form parsing.

### DIFF
--- a/txscript/bench_test.go
+++ b/txscript/bench_test.go
@@ -158,7 +158,7 @@ func BenchmarkIsMultisigScript(b *testing.B) {
 		"DATA_33 " +
 		"0x0284f4d078b236a9ff91661f8ffbe012737cd3507566f30fd97d25f2b23539f3cd " +
 		"2 CHECKMULTISIG"
-	pkScript := mustParseShortForm(multisigShortForm)
+	pkScript := mustParseShortFormV0(multisigShortForm)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -195,12 +195,12 @@ func BenchmarkIsMultisigSigScript(b *testing.B) {
 		"DATA_33 " +
 		"0x0284f4d078b236a9ff91661f8ffbe012737cd3507566f30fd97d25f2b23539f3cd " +
 		"2 CHECKMULTISIG"
-	pkScript := mustParseShortForm(multisigShortForm)
+	pkScript := mustParseShortFormV0(multisigShortForm)
 
 	sigHex := "0x304402205795c3ab6ba11331eeac757bf1fc9c34bef0c7e1a9c8bd5eebb8" +
 		"82f3b79c5838022001e0ab7b4c7662e4522dc5fa479e4b4133fa88c6a53d895dc1d5" +
 		"2eddc7bbcf2801 "
-	sigScript := mustParseShortForm("DATA_71 " + sigHex + "DATA_71 " +
+	sigScript := mustParseShortFormV0("DATA_71 " + sigHex + "DATA_71 " +
 		multisigShortForm)
 
 	b.ResetTimer()
@@ -255,7 +255,7 @@ func BenchmarkGetPreciseSigOpCount(b *testing.B) {
 	// the signature script accordingly by pushing the generated "redeem" script
 	// as the final data push so the benchmark will cover the p2sh path.
 	scriptHash := "0x0000000000000000000000000000000000000001"
-	pkScript := mustParseShortForm("HASH160 DATA_20 " + scriptHash + " EQUAL")
+	pkScript := mustParseShortFormV0("HASH160 DATA_20 " + scriptHash + " EQUAL")
 	sigScript, err := NewScriptBuilder().AddData(redeemScript).Script()
 	if err != nil {
 		b.Fatalf("failed to create signature script: %v", err)
@@ -280,7 +280,7 @@ func BenchmarkGetPreciseSigOpCountTreasury(b *testing.B) {
 	// the signature script accordingly by pushing the generated "redeem" script
 	// as the final data push so the benchmark will cover the p2sh path.
 	scriptHash := "0x0000000000000000000000000000000000000001"
-	pkScript := mustParseShortForm("HASH160 DATA_20 " + scriptHash + " EQUAL")
+	pkScript := mustParseShortFormV0("HASH160 DATA_20 " + scriptHash + " EQUAL")
 	sigScript, err := NewScriptBuilder().AddDataUnchecked(redeemScript).Script()
 	if err != nil {
 		b.Fatalf("failed to create signature script: %v", err)
@@ -520,7 +520,7 @@ func BenchmarkContainsStakeOpCodesTreasury(b *testing.B) {
 // BenchmarkCalcMultiSigStats benchmarks how long it takes CalcMultiSigStats to
 // analyze a typical multisig script.
 func BenchmarkCalcMultiSigStats(b *testing.B) {
-	script := mustParseShortForm("1 " +
+	script := mustParseShortFormV0("1 " +
 		"DATA_33 " +
 		"0x030478aaaa2be30772f1e69e581610f1840b3cf2fe7228ee0281cd599e5746f81e " +
 		"DATA_33 " +
@@ -591,7 +591,7 @@ func BenchmarkExtractAtomicSwapDataPushes(b *testing.B) {
 	secret := "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
 	recipient := "0000000000000000000000000000000000000001"
 	refund := "0000000000000000000000000000000000000002"
-	script := mustParseShortForm(fmt.Sprintf("IF SIZE 32 EQUALVERIFY SHA256 "+
+	script := mustParseShortFormV0(fmt.Sprintf("IF SIZE 32 EQUALVERIFY SHA256 "+
 		"DATA_32 0x%s EQUALVERIFY DUP HASH160 DATA_20 0x%s ELSE 300000 "+
 		"CHECKLOCKTIMEVERIFY DROP DUP HASH160 DATA_20 0x%s ENDIF "+
 		"EQUALVERIFY CHECKSIG", secret, recipient, refund))
@@ -629,7 +629,7 @@ func BenchmarkExtractPkScriptAddrsLarge(b *testing.B) {
 // BenchmarkExtractPkScriptAddrs benchmarks how long it takes to analyze and
 // potentially extract addresses from a typical script.
 func BenchmarkExtractPkScriptAddrs(b *testing.B) {
-	script := mustParseShortForm("OP_SSTX HASH160 " +
+	script := mustParseShortFormV0("OP_SSTX HASH160 " +
 		"DATA_20 0x0102030405060708090a0b0c0d0e0f1011121314 " +
 		"EQUAL")
 
@@ -648,7 +648,7 @@ func BenchmarkExtractPkScriptAddrs(b *testing.B) {
 // BenchmarkExtractAltSigType benchmarks how long it takes to analyze and
 // potentially extract the signature type from a typical script.
 func BenchmarkExtractAltSigType(b *testing.B) {
-	script := mustParseShortForm("DUP HASH160 " +
+	script := mustParseShortFormV0("DUP HASH160 " +
 		"DATA_20 0x0102030405060708090a0b0c0d0e0f1011121314 " +
 		"EQUALVERIFY OP_1 CHECKSIGALT")
 

--- a/txscript/consensus_test.go
+++ b/txscript/consensus_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020 The Decred developers
+// Copyright (c) 2018-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -320,135 +320,135 @@ func TestIsStrictNullData(t *testing.T) {
 	}{{
 		name:        "empty (bare OP_RETURN), req len 0",
 		scriptVer:   0,
-		script:      mustParseShortForm("RETURN"),
+		script:      mustParseShortFormV0("RETURN"),
 		requiredLen: 0,
 		want:        true,
 	}, {
 		name:        "empty (bare OP_RETURN), req len 0, unsupported script ver",
 		scriptVer:   65535,
-		script:      mustParseShortForm("RETURN"),
+		script:      mustParseShortFormV0("RETURN"),
 		requiredLen: 0,
 		want:        false,
 	}, {
 		name:        "small int push 0, req len 1",
 		scriptVer:   0,
-		script:      mustParseShortForm("RETURN 0"),
+		script:      mustParseShortFormV0("RETURN 0"),
 		requiredLen: 1,
 		want:        true,
 	}, {
 		name:        "small int push 0, req len 1, unsupported script ver",
 		scriptVer:   65535,
-		script:      mustParseShortForm("RETURN 0"),
+		script:      mustParseShortFormV0("RETURN 0"),
 		requiredLen: 1,
 		want:        false,
 	}, {
 		name:        "non-canonical small int push 0, req len 1",
 		scriptVer:   0,
-		script:      mustParseShortForm("RETURN DATA_1 0x00"),
+		script:      mustParseShortFormV0("RETURN DATA_1 0x00"),
 		requiredLen: 1,
 		want:        false,
 	}, {
 		name:        "small int push 1, req len 1",
 		scriptVer:   0,
-		script:      mustParseShortForm("RETURN 1"),
+		script:      mustParseShortFormV0("RETURN 1"),
 		requiredLen: 1,
 		want:        true,
 	}, {
 		name:        "small int push 1, req len 1, unsupported script ver",
 		scriptVer:   65535,
-		script:      mustParseShortForm("RETURN 1"),
+		script:      mustParseShortFormV0("RETURN 1"),
 		requiredLen: 1,
 		want:        false,
 	}, {
 		name:        "small int push 16, req len 1",
 		scriptVer:   0,
-		script:      mustParseShortForm("RETURN 16"),
+		script:      mustParseShortFormV0("RETURN 16"),
 		requiredLen: 1,
 		want:        true,
 	}, {
 		name:        "small int push 16, req len 1, unsupported script ver",
 		scriptVer:   65535,
-		script:      mustParseShortForm("RETURN 16"),
+		script:      mustParseShortFormV0("RETURN 16"),
 		requiredLen: 1,
 		want:        false,
 	}, {
 		name:        "small int push 0, req len 2",
 		scriptVer:   0,
-		script:      mustParseShortForm("RETURN 0"),
+		script:      mustParseShortFormV0("RETURN 0"),
 		requiredLen: 2,
 		want:        false,
 	}, {
 		name:        "small int push 1, req len 2",
 		scriptVer:   0,
-		script:      mustParseShortForm("RETURN 1"),
+		script:      mustParseShortFormV0("RETURN 1"),
 		requiredLen: 2,
 		want:        false,
 	}, {
 		name:        "small int push 16, req len 2",
 		scriptVer:   0,
-		script:      mustParseShortForm("RETURN 16"),
+		script:      mustParseShortFormV0("RETURN 16"),
 		requiredLen: 2,
 		want:        false,
 	}, {
 		name:      "32-byte push, req len 32",
 		scriptVer: 0,
-		script: mustParseShortForm("RETURN DATA_32 0x0102030405060708090a0b0c" +
+		script: mustParseShortFormV0("RETURN DATA_32 0x0102030405060708090a0b0c" +
 			"0d0e0f101112131415161718191a1b1c1d1e1f20"),
 		requiredLen: 32,
 		want:        true,
 	}, {
 		name:      "32-byte push, req len 32, unsupported script ver",
 		scriptVer: 65535,
-		script: mustParseShortForm("RETURN DATA_32 0x0102030405060708090a0b0c" +
+		script: mustParseShortFormV0("RETURN DATA_32 0x0102030405060708090a0b0c" +
 			"0d0e0f101112131415161718191a1b1c1d1e1f20"),
 		requiredLen: 32,
 		want:        false,
 	}, {
 		name:      "32-byte push, req len 31",
 		scriptVer: 0,
-		script: mustParseShortForm("RETURN DATA_32 0x0102030405060708090a0b0c" +
+		script: mustParseShortFormV0("RETURN DATA_32 0x0102030405060708090a0b0c" +
 			"0d0e0f101112131415161718191a1b1c1d1e1f20"),
 		requiredLen: 31,
 		want:        false,
 	}, {
 		name:      "32-byte push, req len 33",
 		scriptVer: 0,
-		script: mustParseShortForm("RETURN DATA_32 0x0102030405060708090a0b0c" +
+		script: mustParseShortFormV0("RETURN DATA_32 0x0102030405060708090a0b0c" +
 			"0d0e0f101112131415161718191a1b1c1d1e1f20"),
 		requiredLen: 33,
 		want:        false,
 	}, {
 		name:      "32-byte push, req len 32, no leading OP_RETURN",
 		scriptVer: 0,
-		script: mustParseShortForm("DATA_32 0x0102030405060708090a0b0c0d0e0f" +
+		script: mustParseShortFormV0("DATA_32 0x0102030405060708090a0b0c0d0e0f" +
 			"101112131415161718191a1b1c1d1e1f20"),
 		requiredLen: 32,
 		want:        false,
 	}, {
 		name:      "non-canonical 32-byte push via PUSHDATA1, req len 32",
 		scriptVer: 0,
-		script: mustParseShortForm("RETURN PUSHDATA1 0x20 0x0102030405060708" +
+		script: mustParseShortFormV0("RETURN PUSHDATA1 0x20 0x0102030405060708" +
 			"090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"),
 		requiredLen: 32,
 		want:        false,
 	}, {
 		name:      "non-canonical 32-byte push via PUSHDATA2, req len 32",
 		scriptVer: 0,
-		script: mustParseShortForm("RETURN PUSHDATA2 0x2000 0x01020304050607" +
+		script: mustParseShortFormV0("RETURN PUSHDATA2 0x2000 0x01020304050607" +
 			"08090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"),
 		requiredLen: 32,
 		want:        false,
 	}, {
 		name:      "non-canonical 32-byte push via PUSHDATA4, req len 32",
 		scriptVer: 0,
-		script: mustParseShortForm("RETURN PUSHDATA4 0x20000000 0x0102030405" +
+		script: mustParseShortFormV0("RETURN PUSHDATA4 0x20000000 0x0102030405" +
 			"060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"),
 		requiredLen: 32,
 		want:        false,
 	}, {
 		name:      "76-byte push, req len 76",
 		scriptVer: 0,
-		script: mustParseShortForm("RETURN PUSHDATA1 0x4c 0x0102030405060708" +
+		script: mustParseShortFormV0("RETURN PUSHDATA1 0x4c 0x0102030405060708" +
 			"090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728" +
 			"292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748" +
 			"494a4b4c"),

--- a/txscript/engine_test.go
+++ b/txscript/engine_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2017 The btcsuite developers
-// Copyright (c) 2015-2019 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -42,7 +42,7 @@ func TestBadPC(t *testing.T) {
 				}),
 				Index: 0,
 			},
-			SignatureScript: mustParseShortForm("NOP"),
+			SignatureScript: mustParseShortFormV0("NOP"),
 			Sequence:        4294967295,
 		}},
 		TxOut: []*wire.TxOut{{
@@ -51,7 +51,7 @@ func TestBadPC(t *testing.T) {
 		}},
 		LockTime: 0,
 	}
-	pkScript := mustParseShortForm("NOP")
+	pkScript := mustParseShortFormV0("NOP")
 
 	for _, test := range tests {
 		vm, err := NewEngine(pkScript, tx, 0, 0, 0, nil)
@@ -113,7 +113,7 @@ func TestCheckErrorCondition(t *testing.T) {
 		},
 		LockTime: 0,
 	}
-	pkScript := mustParseShortForm("NOP NOP NOP NOP NOP NOP NOP NOP NOP" +
+	pkScript := mustParseShortFormV0("NOP NOP NOP NOP NOP NOP NOP NOP NOP" +
 		" NOP TRUE")
 
 	vm, err := NewEngine(pkScript, tx, 0, 0, 0, nil)

--- a/txscript/reference_test.go
+++ b/txscript/reference_test.go
@@ -240,14 +240,14 @@ func testScripts(t *testing.T, tests [][]string, useSigCache bool) {
 		}
 
 		// Extract and parse the signature script from the test fields.
-		scriptSig, err := parseShortForm(test[0])
+		scriptSig, err := parseShortFormV0(test[0])
 		if err != nil {
 			t.Errorf("%s: can't parse scriptSig; %v", name, err)
 			continue
 		}
 
 		// Extract and parse the public key script from the test fields.
-		scriptPubKey, err := parseShortForm(test[1])
+		scriptPubKey, err := parseShortFormV0(test[1])
 		if err != nil {
 			t.Errorf("%s: can't parse scriptPubkey; %v", name, err)
 			continue
@@ -450,7 +450,7 @@ testloop:
 				continue testloop
 			}
 
-			script, err := parseShortForm(oscript)
+			script, err := parseShortFormV0(oscript)
 			if err != nil {
 				t.Errorf("bad test (%dth input script doesn't "+
 					"parse %v) %d: %v", j, err, i, test)
@@ -590,7 +590,7 @@ testloop:
 				continue
 			}
 
-			script, err := parseShortForm(oscript)
+			script, err := parseShortFormV0(oscript)
 			if err != nil {
 				t.Errorf("bad test (%dth input script doesn't "+
 					"parse %v) %d: %v", j, err, i, test)

--- a/txscript/script_test.go
+++ b/txscript/script_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2017 The btcsuite developers
-// Copyright (c) 2015-2019 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -149,7 +149,7 @@ func TestGetSigOpCount(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			script := mustParseShortForm(tc.script)
+			script := mustParseShortFormV0(tc.script)
 			gotCount := GetSigOpCount(script, false)
 			if gotCount != tc.wantCount {
 				t.Fatalf("unexpected sigOpCount with treasury=false. "+
@@ -178,11 +178,11 @@ func TestGetPreciseSigOps(t *testing.T) {
 	}{
 		{
 			name:      "scriptSig doesn't parse",
-			scriptSig: mustParseShortForm("PUSHDATA1 0x02"),
+			scriptSig: mustParseShortFormV0("PUSHDATA1 0x02"),
 		},
 		{
 			name:      "scriptSig isn't push only",
-			scriptSig: mustParseShortForm("1 DUP"),
+			scriptSig: mustParseShortFormV0("1 DUP"),
 			nSigOps:   0,
 		},
 		{
@@ -193,19 +193,19 @@ func TestGetPreciseSigOps(t *testing.T) {
 		{
 			name: "No script at the end",
 			// No script at end but still push only.
-			scriptSig: mustParseShortForm("1 1"),
+			scriptSig: mustParseShortFormV0("1 1"),
 			nSigOps:   0,
 		},
 		{
 			name:      "pushed script doesn't parse",
-			scriptSig: mustParseShortForm("DATA_2 PUSHDATA1 0x02"),
+			scriptSig: mustParseShortFormV0("DATA_2 PUSHDATA1 0x02"),
 		},
 	}
 
 	// The signature in the p2sh script is nonsensical for the tests since
 	// this script will never be executed.  What matters is that it matches
 	// the right pattern. Without treasury enabled.
-	pkScript := mustParseShortForm("HASH160 DATA_20 0x433ec2ac1ffa1b7b7d0" +
+	pkScript := mustParseShortFormV0("HASH160 DATA_20 0x433ec2ac1ffa1b7b7d0" +
 		"27f564529c57197f9ae88 EQUAL")
 	for _, test := range tests {
 		count := GetPreciseSigOpCount(test.scriptSig, pkScript,
@@ -219,7 +219,7 @@ func TestGetPreciseSigOps(t *testing.T) {
 	// The signature in the p2sh script is nonsensical for the tests since
 	// this script will never be executed.  What matters is that it matches
 	// the right pattern. With treasury enabled.
-	pkScript = mustParseShortForm("HASH160 DATA_20 0x433ec2ac1ffa1b7b7d0" +
+	pkScript = mustParseShortFormV0("HASH160 DATA_20 0x433ec2ac1ffa1b7b7d0" +
 		"27f564529c57197f9ae88 EQUAL")
 	for _, test := range tests {
 		count := GetPreciseSigOpCount(test.scriptSig, pkScript,
@@ -245,170 +245,170 @@ func TestRemoveOpcodeByData(t *testing.T) {
 	}{
 		{
 			name:   "nothing to do",
-			before: mustParseShortForm("NOP"),
+			before: mustParseShortFormV0("NOP"),
 			remove: []byte{1, 2, 3, 4},
-			after:  mustParseShortForm("NOP"),
+			after:  mustParseShortFormV0("NOP"),
 		},
 		{
 			name:   "simple case",
-			before: mustParseShortForm("DATA_4 0x01020304"),
+			before: mustParseShortFormV0("DATA_4 0x01020304"),
 			remove: []byte{1, 2, 3, 4},
 			after:  nil,
 		},
 		{
 			name:   "simple case (miss)",
-			before: mustParseShortForm("DATA_4 0x01020304"),
+			before: mustParseShortFormV0("DATA_4 0x01020304"),
 			remove: []byte{1, 2, 3, 5},
-			after:  mustParseShortForm("DATA_4 0x01020304"),
+			after:  mustParseShortFormV0("DATA_4 0x01020304"),
 		},
 		{
 			name: "stakesubmission simple case p2pkh",
-			before: mustParseShortForm("SSTX DUP HASH160 DATA_20 0x00{16} " +
+			before: mustParseShortFormV0("SSTX DUP HASH160 DATA_20 0x00{16} " +
 				"0x01020304 EQUALVERIFY CHECKSIG"),
 			remove: []byte{1, 2, 3, 4},
-			after:  mustParseShortForm("SSTX DUP HASH160 EQUALVERIFY CHECKSIG"),
+			after:  mustParseShortFormV0("SSTX DUP HASH160 EQUALVERIFY CHECKSIG"),
 		},
 		{
 			name: "stakesubmission simple case p2pkh (miss)",
-			before: mustParseShortForm("SSTX DUP HASH160 DATA_20 0x00{16} " +
+			before: mustParseShortFormV0("SSTX DUP HASH160 DATA_20 0x00{16} " +
 				"0x01020304 EQUALVERIFY CHECKSIG"),
 			remove: []byte{1, 2, 3, 4, 5},
-			after: mustParseShortForm("SSTX DUP HASH160 DATA_20 0x00{16} " +
+			after: mustParseShortFormV0("SSTX DUP HASH160 DATA_20 0x00{16} " +
 				"0x01020304 EQUALVERIFY CHECKSIG"),
 		},
 		{
 			name: "stakesubmission simple case p2sh",
-			before: mustParseShortForm("SSTX HASH160 DATA_20 0x00{16} " +
+			before: mustParseShortFormV0("SSTX HASH160 DATA_20 0x00{16} " +
 				"0x01020304 EQUAL"),
 			remove: []byte{1, 2, 3, 4},
-			after:  mustParseShortForm("SSTX HASH160 EQUAL"),
+			after:  mustParseShortFormV0("SSTX HASH160 EQUAL"),
 		},
 		{
 			name: "stakesubmission simple case p2sh (miss)",
-			before: mustParseShortForm("SSTX HASH160 DATA_20 0x00{16} " +
+			before: mustParseShortFormV0("SSTX HASH160 DATA_20 0x00{16} " +
 				"0x01020304 EQUAL"),
 			remove: []byte{1, 2, 3, 4, 5},
-			after: mustParseShortForm("SSTX HASH160 DATA_20 0x00{16} " +
+			after: mustParseShortFormV0("SSTX HASH160 DATA_20 0x00{16} " +
 				"0x01020304 EQUAL"),
 		},
 		{
 			name: "stakegen simple case p2pkh",
-			before: mustParseShortForm("SSGEN DUP HASH160 DATA_20 0x00{16} " +
+			before: mustParseShortFormV0("SSGEN DUP HASH160 DATA_20 0x00{16} " +
 				"0x01020304 EQUALVERIFY CHECKSIG"),
 			remove: []byte{1, 2, 3, 4},
-			after:  mustParseShortForm("SSGEN DUP HASH160 EQUALVERIFY CHECKSIG"),
+			after:  mustParseShortFormV0("SSGEN DUP HASH160 EQUALVERIFY CHECKSIG"),
 		},
 		{
 			name: "stakegen simple case p2pkh (miss)",
-			before: mustParseShortForm("SSGEN DUP HASH160 DATA_20 0x00{16} " +
+			before: mustParseShortFormV0("SSGEN DUP HASH160 DATA_20 0x00{16} " +
 				"0x01020304 EQUALVERIFY CHECKSIG"),
 			remove: []byte{1, 2, 3, 4, 5},
-			after: mustParseShortForm("SSGEN DUP HASH160 DATA_20 0x00{16} " +
+			after: mustParseShortFormV0("SSGEN DUP HASH160 DATA_20 0x00{16} " +
 				"0x01020304 EQUALVERIFY CHECKSIG"),
 		},
 		{
 			name: "stakegen simple case p2sh",
-			before: mustParseShortForm("SSGEN HASH160 DATA_20 0x00{16} " +
+			before: mustParseShortFormV0("SSGEN HASH160 DATA_20 0x00{16} " +
 				"0x01020304 EQUAL"),
 			remove: []byte{1, 2, 3, 4},
-			after:  mustParseShortForm("SSGEN HASH160 EQUAL"),
+			after:  mustParseShortFormV0("SSGEN HASH160 EQUAL"),
 		},
 		{
 			name: "stakegen simple case p2sh (miss)",
-			before: mustParseShortForm("SSGEN HASH160 DATA_20 0x00{16} " +
+			before: mustParseShortFormV0("SSGEN HASH160 DATA_20 0x00{16} " +
 				"0x01020304 EQUAL"),
 			remove: []byte{1, 2, 3, 4, 5},
-			after: mustParseShortForm("SSGEN HASH160 DATA_20 0x00{16} " +
+			after: mustParseShortFormV0("SSGEN HASH160 DATA_20 0x00{16} " +
 				"0x01020304 EQUAL"),
 		},
 		{
 			name: "stakerevoke simple case p2pkh",
-			before: mustParseShortForm("SSRTX DUP HASH160 DATA_20 0x00{16} " +
+			before: mustParseShortFormV0("SSRTX DUP HASH160 DATA_20 0x00{16} " +
 				"0x01020304 EQUALVERIFY CHECKSIG"),
 			remove: []byte{1, 2, 3, 4},
 			after:  []byte{OP_SSRTX, OP_DUP, OP_HASH160, OP_EQUALVERIFY, OP_CHECKSIG},
 		},
 		{
 			name: "stakerevoke simple case p2pkh (miss)",
-			before: mustParseShortForm("SSRTX DUP HASH160 DATA_20 0x00{20} " +
+			before: mustParseShortFormV0("SSRTX DUP HASH160 DATA_20 0x00{20} " +
 				"EQUALVERIFY CHECKSIG"),
 			remove: bytes.Repeat([]byte{0}, 21),
-			after: mustParseShortForm("SSRTX DUP HASH160 DATA_20 0x00{20} " +
+			after: mustParseShortFormV0("SSRTX DUP HASH160 DATA_20 0x00{20} " +
 				"EQUALVERIFY CHECKSIG"),
 		},
 		{
 			name: "stakerevoke simple case p2sh",
-			before: mustParseShortForm("SSRTX HASH160 DATA_20 0x00{16} " +
+			before: mustParseShortFormV0("SSRTX HASH160 DATA_20 0x00{16} " +
 				"0x01020304 EQUAL"),
 			remove: []byte{1, 2, 3, 4},
-			after:  mustParseShortForm("SSRTX HASH160 EQUAL"),
+			after:  mustParseShortFormV0("SSRTX HASH160 EQUAL"),
 		},
 		{
 			name: "stakerevoke simple case p2sh (miss)",
-			before: mustParseShortForm("SSRTX HASH160 DATA_20 0x00{16} " +
+			before: mustParseShortFormV0("SSRTX HASH160 DATA_20 0x00{16} " +
 				"0x01020304 EQUAL"),
 			remove: []byte{1, 2, 3, 4, 5},
-			after: mustParseShortForm("SSRTX HASH160 DATA_20 0x00{16} " +
+			after: mustParseShortFormV0("SSRTX HASH160 DATA_20 0x00{16} " +
 				"0x01020304 EQUAL"),
 		},
 		{
 			// padded to keep it canonical.
 			name:   "simple case (pushdata1)",
-			before: mustParseShortForm("PUSHDATA1 0x4c 0x00{72} 0x01020304"),
+			before: mustParseShortFormV0("PUSHDATA1 0x4c 0x00{72} 0x01020304"),
 			remove: []byte{1, 2, 3, 4},
 			after:  nil,
 		},
 		{
 			name:   "simple case (pushdata1 miss)",
-			before: mustParseShortForm("PUSHDATA1 0x4c 0x00{72} 0x01020304"),
+			before: mustParseShortFormV0("PUSHDATA1 0x4c 0x00{72} 0x01020304"),
 			remove: []byte{1, 2, 3, 5},
-			after:  mustParseShortForm("PUSHDATA1 0x4c 0x00{72} 0x01020304"),
+			after:  mustParseShortFormV0("PUSHDATA1 0x4c 0x00{72} 0x01020304"),
 		},
 		{
 			name:   "simple case (pushdata1 miss noncanonical)",
-			before: mustParseShortForm("PUSHDATA1 0x04 0x01020304"),
+			before: mustParseShortFormV0("PUSHDATA1 0x04 0x01020304"),
 			remove: []byte{1, 2, 3, 4},
-			after:  mustParseShortForm("PUSHDATA1 0x04 0x01020304"),
+			after:  mustParseShortFormV0("PUSHDATA1 0x04 0x01020304"),
 		},
 		{
 			name:   "simple case (pushdata2)",
-			before: mustParseShortForm("PUSHDATA2 0x0001 0x00{252} 0x01020304"),
+			before: mustParseShortFormV0("PUSHDATA2 0x0001 0x00{252} 0x01020304"),
 			remove: []byte{1, 2, 3, 4},
 			after:  nil,
 		},
 		{
 			name:   "simple case (pushdata2 miss)",
-			before: mustParseShortForm("PUSHDATA2 0x0001 0x00{252} 0x01020304"),
+			before: mustParseShortFormV0("PUSHDATA2 0x0001 0x00{252} 0x01020304"),
 			remove: []byte{1, 2, 3, 4, 5},
-			after:  mustParseShortForm("PUSHDATA2 0x0001 0x00{252} 0x01020304"),
+			after:  mustParseShortFormV0("PUSHDATA2 0x0001 0x00{252} 0x01020304"),
 		},
 		{
 			name:   "simple case (pushdata2 miss noncanonical)",
-			before: mustParseShortForm("PUSHDATA2 0x0400 0x01020304"),
+			before: mustParseShortFormV0("PUSHDATA2 0x0400 0x01020304"),
 			remove: []byte{1, 2, 3, 4},
-			after:  mustParseShortForm("PUSHDATA2 0x0400 0x01020304"),
+			after:  mustParseShortFormV0("PUSHDATA2 0x0400 0x01020304"),
 		},
 		{
 			// This is padded to make the push canonical.
 			name: "simple case (pushdata4)",
-			before: mustParseShortForm("PUSHDATA4 0x00000100 0x00{65532} " +
+			before: mustParseShortFormV0("PUSHDATA4 0x00000100 0x00{65532} " +
 				"0x01020304"),
 			remove: []byte{1, 2, 3, 4},
 			after:  nil,
 		},
 		{
 			name:   "simple case (pushdata4 miss noncanonical)",
-			before: mustParseShortForm("PUSHDATA4 0x04000000 0x01020304"),
+			before: mustParseShortFormV0("PUSHDATA4 0x04000000 0x01020304"),
 			remove: []byte{1, 2, 3, 4},
-			after:  mustParseShortForm("PUSHDATA4 0x04000000 0x01020304"),
+			after:  mustParseShortFormV0("PUSHDATA4 0x04000000 0x01020304"),
 		},
 		{
 			// This is padded to make the push canonical.
 			name: "simple case (pushdata4 miss)",
-			before: mustParseShortForm("PUSHDATA4 0x00000100 0x00{65532} " +
+			before: mustParseShortFormV0("PUSHDATA4 0x00000100 0x00{65532} " +
 				"0x01020304"),
 			remove: []byte{1, 2, 3, 4, 5},
-			after: mustParseShortForm("PUSHDATA4 0x00000100 0x00{65532} " +
+			after: mustParseShortFormV0("PUSHDATA4 0x00000100 0x00{65532} " +
 				"0x01020304"),
 		},
 		{
@@ -462,10 +462,10 @@ func TestRemoveOpcodeByData(t *testing.T) {
 func TestIsPayToScriptHash(t *testing.T) {
 	t.Parallel()
 
-	// Convience function that combines fmt.Sprintf with mustParseShortForm
+	// Convience function that combines fmt.Sprintf with mustParseShortFormV0
 	// to create more compact tests.
 	p := func(format string, a ...interface{}) []byte {
-		return mustParseShortForm(fmt.Sprintf(format, a...))
+		return mustParseShortFormV0(fmt.Sprintf(format, a...))
 	}
 
 	// Script hash for a 2-of-3 multisig composed of the following public keys:
@@ -506,10 +506,10 @@ func TestIsPayToScriptHash(t *testing.T) {
 func TestIsAnyKindOfScriptHash(t *testing.T) {
 	t.Parallel()
 
-	// Convience function that combines fmt.Sprintf with mustParseShortForm
+	// Convience function that combines fmt.Sprintf with mustParseShortFormV0
 	// to create more compact tests.
 	p := func(format string, a ...interface{}) []byte {
-		return mustParseShortForm(fmt.Sprintf(format, a...))
+		return mustParseShortFormV0(fmt.Sprintf(format, a...))
 	}
 
 	// Script hash for a 2-of-3 multisig composed of the following public keys:
@@ -640,7 +640,7 @@ func TestHasCanonicalPushes(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		script := mustParseShortForm(test.script)
+		script := mustParseShortForm(scriptVersion, test.script)
 		if err := checkScriptParses(scriptVersion, script); err != nil {
 			if test.expected {
 				t.Errorf("%q: script parse failed: %v", test.name, err)
@@ -670,7 +670,7 @@ func TestIsPushOnlyScript(t *testing.T) {
 		expected bool
 	}{
 		name: "does not parse",
-		script: mustParseShortForm("0x046708afdb0fe5548271967f1a67130" +
+		script: mustParseShortFormV0("0x046708afdb0fe5548271967f1a67130" +
 			"b7105cd6a828e03909a67962e0ea1f61d"),
 		expected: false,
 	}

--- a/txscript/sigcache_test.go
+++ b/txscript/sigcache_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2015-2016 The btcsuite developers
-// Copyright (c) 2016-2020 The Decred developers
+// Copyright (c) 2016-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -57,7 +57,7 @@ func msgTx113875_1() *wire.MsgTx {
 	txOut := wire.TxOut{
 		Value:   5000000000,
 		Version: 0xf0f0,
-		PkScript: mustParseShortForm("DATA_65 0x04d64bdfd09eb1c5fe295abdeb1dca4281b" +
+		PkScript: mustParseShortFormV0("DATA_65 0x04d64bdfd09eb1c5fe295abdeb1dca4281b" +
 			"e988e2da0b6c1c6a59dc226c28624e18175e851c96b973d81b01cc31f047834bc06d6d6e" +
 			"df620d184241a6aed8b63a6 CHECKSIG"),
 	}

--- a/txscript/standard_test.go
+++ b/txscript/standard_test.go
@@ -440,7 +440,7 @@ func TestMultiSigScript(t *testing.T) {
 			continue
 		}
 
-		expected := mustParseShortForm(test.expected)
+		expected := mustParseShortFormV0(test.expected)
 		if !bytes.Equal(script, expected) {
 			t.Errorf("%q: unexpected result -- got: %x\nwant: %x", test.name,
 				script, expected)
@@ -481,7 +481,7 @@ func TestCalcMultiSigStats(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		script := mustParseShortForm(test.script)
+		script := mustParseShortFormV0(test.script)
 		_, _, err := CalcMultiSigStats(script)
 		if !errors.Is(err, test.err) {
 			t.Errorf("%s: unexpected error - got %v, want %v", test.name, err,
@@ -698,7 +698,7 @@ func TestScriptClass(t *testing.T) {
 
 	const scriptVersion = 0
 	for _, test := range scriptClassTests {
-		script := mustParseShortForm(test.script)
+		script := mustParseShortFormV0(test.script)
 		class := GetScriptClass(scriptVersion, script, noTreasury)
 		if class != test.class {
 			t.Errorf("%s: expected %s got %s (script %x)", test.name,
@@ -709,7 +709,7 @@ func TestScriptClass(t *testing.T) {
 
 	// Repeat tests with treasury.
 	for _, test := range scriptClassTests {
-		script := mustParseShortForm(test.script)
+		script := mustParseShortFormV0(test.script)
 		class := GetScriptClass(scriptVersion, script, withTreasury)
 		if class != test.class {
 			t.Errorf("%s: expected %s got %s (script %x)", test.name,
@@ -798,14 +798,14 @@ func TestGenerateProvablyPruneableOut(t *testing.T) {
 		{
 			name:     "small int",
 			data:     hexToBytes("01"),
-			expected: mustParseShortForm("RETURN 1"),
+			expected: mustParseShortFormV0("RETURN 1"),
 			err:      nil,
 			class:    NullDataTy,
 		},
 		{
 			name:     "max small int",
 			data:     hexToBytes("10"),
-			expected: mustParseShortForm("RETURN 16"),
+			expected: mustParseShortFormV0("RETURN 16"),
 			err:      nil,
 			class:    NullDataTy,
 		},
@@ -813,7 +813,7 @@ func TestGenerateProvablyPruneableOut(t *testing.T) {
 			name: "data of size before OP_PUSHDATA1 is needed",
 			data: hexToBytes("0102030405060708090a0b0c0d0e0f10111" +
 				"2131415161718"),
-			expected: mustParseShortForm("RETURN 0x18 0x01020304" +
+			expected: mustParseShortFormV0("RETURN 0x18 0x01020304" +
 				"05060708090a0b0c0d0e0f101112131415161718"),
 			err:   nil,
 			class: NullDataTy,
@@ -830,7 +830,7 @@ func TestGenerateProvablyPruneableOut(t *testing.T) {
 				"132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4" +
 				"e4f202122232425262728292a2b2c2d2e2f303132333435363738393a3" +
 				"b3c3d3e"),
-			expected: mustParseShortForm("RETURN PUSHDATA1 0xFF " +
+			expected: mustParseShortFormV0("RETURN PUSHDATA1 0xFF " +
 				"0x000102030405060708090a0b0c0d0e0f101112131415161" +
 				"718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f" +
 				"303132333435363738393a3b3c3d3e3f40414243444546474" +
@@ -1035,7 +1035,7 @@ func TestExtractAtomicSwapDataPushes(t *testing.T) {
 	}}
 
 	for _, test := range tests {
-		script := mustParseShortForm(test.script)
+		script := mustParseShortFormV0(test.script)
 
 		// Attempt to extract the atomic swap data from the script and ensure
 		// the error is as expected.

--- a/txscript/tokenizer_test.go
+++ b/txscript/tokenizer_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 The Decred developers
+// Copyright (c) 2019-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -52,58 +52,58 @@ func TestScriptTokenizer(t *testing.T) {
 	}
 
 	// Add both positive and negative tests for OP_PUSHDATA{1,2,4}.
-	data := mustParseShortForm("0x01{76}")
+	data := mustParseShortFormV0("0x01{76}")
 	tests = append(tests, []tokenizerTest{{
 		name:     "OP_PUSHDATA1",
-		script:   mustParseShortForm("OP_PUSHDATA1 0x4c 0x01{76}"),
+		script:   mustParseShortFormV0("OP_PUSHDATA1 0x4c 0x01{76}"),
 		expected: []expectedResult{{OP_PUSHDATA1, data, 2 + int32(len(data))}},
 		finalIdx: 2 + int32(len(data)),
 		err:      nil,
 	}, {
 		name:     "OP_PUSHDATA1 no data length",
-		script:   mustParseShortForm("OP_PUSHDATA1"),
+		script:   mustParseShortFormV0("OP_PUSHDATA1"),
 		expected: nil,
 		finalIdx: 0,
 		err:      ErrMalformedPush,
 	}, {
 		name:     "OP_PUSHDATA1 short data by 1 byte",
-		script:   mustParseShortForm("OP_PUSHDATA1 0x4c 0x01{75}"),
+		script:   mustParseShortFormV0("OP_PUSHDATA1 0x4c 0x01{75}"),
 		expected: nil,
 		finalIdx: 0,
 		err:      ErrMalformedPush,
 	}, {
 		name:     "OP_PUSHDATA2",
-		script:   mustParseShortForm("OP_PUSHDATA2 0x4c00 0x01{76}"),
+		script:   mustParseShortFormV0("OP_PUSHDATA2 0x4c00 0x01{76}"),
 		expected: []expectedResult{{OP_PUSHDATA2, data, 3 + int32(len(data))}},
 		finalIdx: 3 + int32(len(data)),
 		err:      nil,
 	}, {
 		name:     "OP_PUSHDATA2 no data length",
-		script:   mustParseShortForm("OP_PUSHDATA2"),
+		script:   mustParseShortFormV0("OP_PUSHDATA2"),
 		expected: nil,
 		finalIdx: 0,
 		err:      ErrMalformedPush,
 	}, {
 		name:     "OP_PUSHDATA2 short data by 1 byte",
-		script:   mustParseShortForm("OP_PUSHDATA2 0x4c00 0x01{75}"),
+		script:   mustParseShortFormV0("OP_PUSHDATA2 0x4c00 0x01{75}"),
 		expected: nil,
 		finalIdx: 0,
 		err:      ErrMalformedPush,
 	}, {
 		name:     "OP_PUSHDATA4",
-		script:   mustParseShortForm("OP_PUSHDATA4 0x4c000000 0x01{76}"),
+		script:   mustParseShortFormV0("OP_PUSHDATA4 0x4c000000 0x01{76}"),
 		expected: []expectedResult{{OP_PUSHDATA4, data, 5 + int32(len(data))}},
 		finalIdx: 5 + int32(len(data)),
 		err:      nil,
 	}, {
 		name:     "OP_PUSHDATA4 no data length",
-		script:   mustParseShortForm("OP_PUSHDATA4"),
+		script:   mustParseShortFormV0("OP_PUSHDATA4"),
 		expected: nil,
 		finalIdx: 0,
 		err:      ErrMalformedPush,
 	}, {
 		name:     "OP_PUSHDATA4 short data by 1 byte",
-		script:   mustParseShortForm("OP_PUSHDATA4 0x4c000000 0x01{75}"),
+		script:   mustParseShortFormV0("OP_PUSHDATA4 0x4c000000 0x01{75}"),
 		expected: nil,
 		finalIdx: 0,
 		err:      ErrMalformedPush,
@@ -127,17 +127,17 @@ func TestScriptTokenizer(t *testing.T) {
 	// Add various positive and negative tests for multi-opcode scripts.
 	tests = append(tests, []tokenizerTest{{
 		name:   "pay-to-pubkey-hash",
-		script: mustParseShortForm("DUP HASH160 DATA_20 0x01{20} EQUAL CHECKSIG"),
+		script: mustParseShortFormV0("DUP HASH160 DATA_20 0x01{20} EQUAL CHECKSIG"),
 		expected: []expectedResult{
 			{OP_DUP, nil, 1}, {OP_HASH160, nil, 2},
-			{OP_DATA_20, mustParseShortForm("0x01{20}"), 23},
+			{OP_DATA_20, mustParseShortFormV0("0x01{20}"), 23},
 			{OP_EQUAL, nil, 24}, {OP_CHECKSIG, nil, 25},
 		},
 		finalIdx: 25,
 		err:      nil,
 	}, {
 		name:   "almost pay-to-pubkey-hash (short data)",
-		script: mustParseShortForm("DUP HASH160 DATA_20 0x01{17} EQUAL CHECKSIG"),
+		script: mustParseShortFormV0("DUP HASH160 DATA_20 0x01{17} EQUAL CHECKSIG"),
 		expected: []expectedResult{
 			{OP_DUP, nil, 1}, {OP_HASH160, nil, 2},
 		},
@@ -145,27 +145,27 @@ func TestScriptTokenizer(t *testing.T) {
 		err:      ErrMalformedPush,
 	}, {
 		name:   "almost pay-to-pubkey-hash (overlapped data)",
-		script: mustParseShortForm("DUP HASH160 DATA_20 0x01{19} EQUAL CHECKSIG"),
+		script: mustParseShortFormV0("DUP HASH160 DATA_20 0x01{19} EQUAL CHECKSIG"),
 		expected: []expectedResult{
 			{OP_DUP, nil, 1}, {OP_HASH160, nil, 2},
-			{OP_DATA_20, mustParseShortForm("0x01{19} EQUAL"), 23},
+			{OP_DATA_20, mustParseShortFormV0("0x01{19} EQUAL"), 23},
 			{OP_CHECKSIG, nil, 24},
 		},
 		finalIdx: 24,
 		err:      nil,
 	}, {
 		name:   "pay-to-script-hash",
-		script: mustParseShortForm("HASH160 DATA_20 0x01{20} EQUAL"),
+		script: mustParseShortFormV0("HASH160 DATA_20 0x01{20} EQUAL"),
 		expected: []expectedResult{
 			{OP_HASH160, nil, 1},
-			{OP_DATA_20, mustParseShortForm("0x01{20}"), 22},
+			{OP_DATA_20, mustParseShortFormV0("0x01{20}"), 22},
 			{OP_EQUAL, nil, 23},
 		},
 		finalIdx: 23,
 		err:      nil,
 	}, {
 		name:   "almost pay-to-script-hash (short data)",
-		script: mustParseShortForm("HASH160 DATA_20 0x01{18} EQUAL"),
+		script: mustParseShortFormV0("HASH160 DATA_20 0x01{18} EQUAL"),
 		expected: []expectedResult{
 			{OP_HASH160, nil, 1},
 		},
@@ -173,10 +173,10 @@ func TestScriptTokenizer(t *testing.T) {
 		err:      ErrMalformedPush,
 	}, {
 		name:   "almost pay-to-script-hash (overlapped data)",
-		script: mustParseShortForm("HASH160 DATA_20 0x01{19} EQUAL"),
+		script: mustParseShortFormV0("HASH160 DATA_20 0x01{19} EQUAL"),
 		expected: []expectedResult{
 			{OP_HASH160, nil, 1},
-			{OP_DATA_20, mustParseShortForm("0x01{19} EQUAL"), 22},
+			{OP_DATA_20, mustParseShortFormV0("0x01{19} EQUAL"), 22},
 		},
 		finalIdx: 22,
 		err:      nil,
@@ -231,7 +231,6 @@ func TestScriptTokenizer(t *testing.T) {
 		if !errors.Is(tokenizer.Err(), test.err) {
 			t.Fatalf("%q: unexpected tokenizer err -- got %v, want %v",
 				test.name, tokenizer.Err(), test.err)
-
 		}
 
 		// Ensure the final index is the expected value.


### PR DESCRIPTION
This adds the ability for the short form script parsing to handle different script versions and updates all of the tests to use the
version 0 function appropriately.