### PR TITLE
multi: Use single latest checkpoint.

### DIFF
--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1471,13 +1471,12 @@ func (b *BlockChain) initChainState(ctx context.Context,
 		}
 
 		// Find the most recent checkpoint.
-		for i := len(b.checkpoints) - 1; i >= 0; i-- {
-			node := b.index.lookupNode(b.checkpoints[i].Hash)
+		if b.latestCheckpoint != nil {
+			node := b.index.lookupNode(b.latestCheckpoint.Hash)
 			if node != nil {
 				log.Debugf("Most recent checkpoint is %s (height %d)",
 					node.hash, node.height)
 				b.checkpointNode = node
-				break
 			}
 		}
 

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -329,6 +329,10 @@ type Params struct {
 	BlockTaxProportion uint16
 
 	// Checkpoints ordered from oldest to newest.
+	//
+	// Note: Only the most recent checkpoint is used and all others are ignored.
+	// This is left as a slice to avoid a major version bump for the module and
+	// will likely be changed to only allow a single checkpoint in the future.
 	Checkpoints []Checkpoint
 
 	// MinKnownChainWork is the minimum amount of known total work for the chain
@@ -339,7 +343,7 @@ type Params struct {
 	// These fields are related to voting on consensus rule changes as
 	// defined by BIP0009.
 	//
-	// RuleChangeActivationQurom is the number of votes required for a vote
+	// RuleChangeActivationQuorum is the number of votes required for a vote
 	// to take effect.
 	//
 	// RuleChangeActivationInterval is the number of blocks in each threshold

--- a/cmd/addblock/import.go
+++ b/cmd/addblock/import.go
@@ -17,6 +17,7 @@ import (
 	"github.com/decred/dcrd/blockchain/v4"
 	"github.com/decred/dcrd/blockchain/v4/indexers"
 	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/database/v3"
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/wire"
@@ -320,15 +321,23 @@ func newBlockImporter(ctx context.Context, db database.DB, utxoDb *leveldb.DB, r
 		MaxSize:      100 * 1024 * 1024, // 100 MiB
 	})
 
+	var latestCheckpoint *chaincfg.Checkpoint
+	numCheckpoints := len(activeNetParams.Checkpoints)
+	if numCheckpoints != 0 {
+		// Only use the most recent checkpoint, which is the last entry in the
+		// slice.
+		latestCheckpoint = &activeNetParams.Checkpoints[numCheckpoints-1]
+	}
+
 	chain, err := blockchain.New(context.Background(),
 		&blockchain.Config{
-			DB:              db,
-			ChainParams:     activeNetParams,
-			Checkpoints:     activeNetParams.Checkpoints,
-			TimeSource:      blockchain.NewMedianTime(),
-			IndexSubscriber: subber,
-			UtxoBackend:     blockchain.NewLevelDbUtxoBackend(utxoDb),
-			UtxoCache:       utxoCache,
+			DB:               db,
+			ChainParams:      activeNetParams,
+			LatestCheckpoint: latestCheckpoint,
+			TimeSource:       blockchain.NewMedianTime(),
+			IndexSubscriber:  subber,
+			UtxoBackend:      blockchain.NewLevelDbUtxoBackend(utxoDb),
+			UtxoCache:        utxoCache,
 		})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
~~**Rebased on https://github.com/decred/dcrd/pull/2762.**~~

This updates the `blockchain` checkpoints logic to use a single latest checkpoint rather than multiple checkpoints.  The intermediate checkpoints are no longer necessary because headers first syncing was introduced, which discovers the most recent checkpoint before block syncing even starts.