### PR TITLE
multi: update build tags to pref. go1.17 syntax.

### DIFF
--- a/certgen/certgen_ed25519.go
+++ b/certgen/certgen_ed25519.go
@@ -3,7 +3,8 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-//+build go1.13
+//go:build go1.13
+// +build go1.13
 
 package certgen
 

--- a/certgen/net.go
+++ b/certgen/net.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
+//go:build !appengine
 // +build !appengine
 
 package certgen

--- a/certgen/net_noop.go
+++ b/certgen/net_noop.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
+//go:build appengine
 // +build appengine
 
 package certgen

--- a/chaincfg/generatesubsidytables.go
+++ b/chaincfg/generatesubsidytables.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-//+build ignore
+//go:build ignore
+// +build ignore
 
 package main
 

--- a/chaincfg/subsidydefinitions.go
+++ b/chaincfg/subsidydefinitions.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-//+build subsidydefs
+//go:build subsidydefs
+// +build subsidydefs
 
 package chaincfg
 

--- a/container/apbf/generateapbftable.go
+++ b/container/apbf/generateapbftable.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-//+build ignore
+//go:build ignore
+// +build ignore
 
 package main
 

--- a/dcrec/secp256k1/genprecomps.go
+++ b/dcrec/secp256k1/genprecomps.go
@@ -6,6 +6,7 @@
 // This file is ignored during the regular build due to the following build tag.
 // It is called by go generate and used to automatically generate pre-computed
 // tables used to accelerate operations.
+//go:build ignore
 // +build ignore
 
 package main

--- a/dcrec/secp256k1/genstatics.go
+++ b/dcrec/secp256k1/genstatics.go
@@ -5,6 +5,7 @@
 
 // This file is ignored during the regular build due to the following build tag.
 // This build tag is set during go generate.
+//go:build gensecp256k1
 // +build gensecp256k1
 
 package secp256k1

--- a/gcs/fastreduce.go
+++ b/gcs/fastreduce.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-//+build go1.12
+//go:build go1.12
+// +build go1.12
 
 package gcs
 

--- a/gcs/fastreduce_old.go
+++ b/gcs/fastreduce_old.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-//+build !go1.12
+//go:build !go1.12
+// +build !go1.12
 
 package gcs
 

--- a/internal/limits/limits_unix.go
+++ b/internal/limits/limits_unix.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
+//go:build !windows && !plan9
 // +build !windows,!plan9
 
 package limits

--- a/internal/rpcserver/rpcserver_test.go
+++ b/internal/rpcserver/rpcserver_test.go
@@ -5,6 +5,7 @@
 // license that can be found in the LICENSE file.
 
 // This file is ignored during the regular tests due to the following build tag.
+//go:build rpctest
 // +build rpctest
 
 package rpcserver

--- a/rpctest/rpc_harness_test.go
+++ b/rpctest/rpc_harness_test.go
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 // This file is ignored during the regular tests due to the following build tag.
+//go:build rpctest
 // +build rpctest
 
 package rpctest

--- a/rpctest/votingwallet_test.go
+++ b/rpctest/votingwallet_test.go
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // This file is ignored during the regular tests due to the following build tag.
+//go:build rpctest
 // +build rpctest
 
 package rpctest

--- a/signal_unix.go
+++ b/signal_unix.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
 // +build darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package main


### PR DESCRIPTION
This updates build tags to the transitional preferred go1.17 syntax.