### PR TITLE
blockchain: Move diff retarget log to connect.

### DIFF
--- a/blockchain/difficulty.go
+++ b/blockchain/difficulty.go
@@ -185,21 +185,8 @@ func (b *BlockChain) calcNextRequiredDifficulty(curNode *blockNode, newBlockTime
 		nextDiffBig.Set(b.chainParams.PowLimit)
 	}
 
-	// Convert the difficulty to the compact representation.
+	// Convert the difficulty to the compact representation and return it.
 	nextDiffBits := standalone.BigToCompact(nextDiffBig)
-
-	// Conditionally log the new target difficulty.  Only log if the chain
-	// believes it is current since it is very noisy during syncing.
-	//
-	// The new target logging is intentionally converting the bits back to a
-	// number since conversion to the compact representation loses precision.
-	if b.isCurrent(b.bestChain.Tip()) {
-		log.Debugf("Difficulty retarget at block height %d", curNode.height+1)
-		log.Debugf("Old target %08x (%064x)", curNode.bits, oldDiffBig)
-		log.Debugf("New target %08x (%064x)", nextDiffBits, standalone.CompactToBig(
-			nextDiffBits))
-	}
-
 	return nextDiffBits
 }
 


### PR DESCRIPTION
~**This is rebased on #2761**.~

The method that calculates the next required difficulty currently logs difficulty retargets which means it has side effects when it really should free from them given its purpose.

This can be evidenced by the fact the logging is actually slightly incorrect in a couple of ways due to those side effects.  Namely, it can potentially log when checking block templates when it shouldn't and it is also currently logging when the headers are connected as opposed to when the blocks themselves are actually connected which was the original intention prior to the new headers-first logic.

Thus, this moves the debug logging for difficulty retargets from the required difficulty calculation function to the block connection function and also takes the opportunity to impose a new condition to only log when the difficulty actually changes as opposed to the current behavior of always logging on a retarget interval regardless.
