### PR TITLE
multi: Flush cache before fetching UTXO stats.

### DIFF
--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -288,11 +288,6 @@ type Chain interface {
 	FetchUtxoEntry(outpoint wire.OutPoint) (UtxoEntry, error)
 
 	// FetchUtxoStats returns statistics on the current utxo set.
-	//
-	// NOTE: During initial block download the utxo stats will lag behind the best
-	// block that is currently synced since the utxo cache is only flushed to the
-	// database periodically.  After initial block download the utxo stats will
-	// always be in sync with the best block.
 	FetchUtxoStats() (*blockchain.UtxoStats, error)
 
 	// GetStakeVersions returns a cooked array of StakeVersions.  We do this in


### PR DESCRIPTION
This updates the UTXO cache to flush all entries to the backend before UTXO stats are fetched.  This ensures that the UTXO stats are always in sync with the current best block.

This also does not impact the effectiveness of the UTXO cache since entries are still only evicted if necessary.