### PR TITLE
blockchain: Don't use deprecated ioutil package.

### DIFF
--- a/blockchain/indexers/spendconsumer_test.go
+++ b/blockchain/indexers/spendconsumer_test.go
@@ -4,7 +4,6 @@
 package indexers
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -17,7 +16,7 @@ import (
 
 // TestSpendConsumer ensures the spend consumer behaves as expected.
 func TestSpendConsumer(t *testing.T) {
-	dbPath, err := ioutil.TempDir("", "test_spendconsumer")
+	dbPath, err := os.MkdirTemp("", "test_spendconsumer")
 	if err != nil {
 		t.Fatalf("unable to create test db path: %v", err)
 	}

--- a/blockchain/indexers/txindex_test.go
+++ b/blockchain/indexers/txindex_test.go
@@ -7,7 +7,6 @@ package indexers
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sync"
 	"testing"
@@ -326,7 +325,7 @@ func addBlock(t *testing.T, chain *testChain, gen *chaingen.Generator, name stri
 
 // setupDB initializes the test database.
 func setupDB(t *testing.T, dbName string) (database.DB, string) {
-	dbPath, err := ioutil.TempDir("", dbName)
+	dbPath, err := os.MkdirTemp("", dbName)
 	if err != nil {
 		t.Fatalf("unable to create test db path: %v", err)
 	}


### PR DESCRIPTION
Replace usage of `ioutil.TempDir` with `os.MkdirTemp` as suggested by go 1.16 release notes.