### PR TITLE
indexers: update indexer error types.

### DIFF
--- a/blockchain/indexers/error.go
+++ b/blockchain/indexers/error.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package indexers
+
+// ErrorKind identifies a kind of error.  It has full support for errors.Is and
+// errors.As, so the caller can directly check against an error kind when
+// determining the reason for an error.
+type ErrorKind string
+
+// These constants are used to identify a specific IndexerError.
+const (
+	// ErrUnsupportedAddressType indicates an unsupported address type.
+	ErrUnsupportedAddressType = ErrorKind("ErrUnsupportedAddressType")
+
+	// ErrInvalidSpendConsumerType indicates an invalid spend consumer type.
+	ErrInvalidSpendConsumerType = ErrorKind("ErrInvalidSpendConsumerType")
+
+	// ErrConnectBlock indicates an error indexing a connected block.
+	ErrConnectBlock = ErrorKind("ErrConnectBlock")
+
+	// ErrDisconnectBlock indicates an error indexing a disconnected block.
+	ErrDisconnectBlock = ErrorKind("ErrDisconnectBlock")
+
+	// ErrRemoveSpendDependency indicates a spend dependency removal error.
+	ErrRemoveSpendDependency = ErrorKind("ErrRemoveSpendDependency")
+
+	// ErrInvalidNotificationType indicates an invalid indexer notification type.
+	ErrInvalidNotificationType = ErrorKind("ErrInvalidNotificationType")
+
+	// ErrInterruptRequested indicates an operation was cancelled due to
+	// a user-requested interrupt.
+	ErrInterruptRequested = ErrorKind("ErrInterruptRequested")
+
+	// ErrFetchSubscription indicates an error fetching an index subscription.
+	ErrFetchSubscription = ErrorKind("ErrFetchSubscription")
+
+	// ErrFetchTip indicates an error fetching an index tip.
+	ErrFetchTip = ErrorKind("ErrFetchTip")
+
+	// ErrMissingNotification indicates a missing index notification.
+	ErrMissingNotification = ErrorKind("ErrMissingNotification")
+
+	// ErrBlockNotOnMainChain indicates the provided block is not on the
+	// main chain.
+	ErrBlockNotOnMainChain = ErrorKind("ErrBlockNotOnMainChain")
+)
+
+// Error satisfies the error interface and prints human-readable errors.
+func (e ErrorKind) Error() string {
+	return string(e)
+}
+
+// IndexerError identifies an indexer error. It has full support for
+// errors.Is and errors.As, so the caller can ascertain the specific reason
+// for the error by checking the underlying error.
+type IndexerError struct {
+	Description string
+	Err         error
+}
+
+// Error satisfies the error interface and prints human-readable errors.
+func (e IndexerError) Error() string {
+	return e.Description
+}
+
+// Unwrap returns the underlying wrapped error.
+func (e IndexerError) Unwrap() error {
+	return e.Err
+}
+
+// indexerError creates a IndexerError given a set of arguments.
+func indexerError(kind ErrorKind, desc string) IndexerError {
+	return IndexerError{Err: kind, Description: desc}
+}

--- a/blockchain/indexers/error_test.go
+++ b/blockchain/indexers/error_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package indexers
+
+import (
+	"errors"
+	"io"
+	"testing"
+)
+
+// TestErrorKindStringer tests the stringized output for the ErrorKind type.
+func TestErrorKindStringer(t *testing.T) {
+	tests := []struct {
+		in   ErrorKind
+		want string
+	}{
+		{ErrUnsupportedAddressType, "ErrUnsupportedAddressType"},
+		{ErrInvalidSpendConsumerType, "ErrInvalidSpendConsumerType"},
+		{ErrConnectBlock, "ErrConnectBlock"},
+		{ErrDisconnectBlock, "ErrDisconnectBlock"},
+		{ErrRemoveSpendDependency, "ErrRemoveSpendDependency"},
+		{ErrInvalidNotificationType, "ErrInvalidNotificationType"},
+		{ErrInterruptRequested, "ErrInterruptRequested"},
+		{ErrFetchSubscription, "ErrFetchSubscription"},
+		{ErrFetchTip, "ErrFetchTip"},
+		{ErrMissingNotification, "ErrMissingNotification"},
+		{ErrBlockNotOnMainChain, "ErrBlockNotOnMainChain"},
+	}
+
+	for i, test := range tests {
+		result := test.in.Error()
+		if result != test.want {
+			t.Errorf("%d: got: %s want: %s", i, result, test.want)
+			continue
+		}
+	}
+}
+
+// TestIndexerError tests the error output for the IndexerError type.
+func TestIndexerError(t *testing.T) {
+	tests := []struct {
+		in   IndexerError
+		want string
+	}{{
+		IndexerError{Description: "duplicate block"},
+		"duplicate block",
+	}, {
+		IndexerError{Description: "human-readable error"},
+		"human-readable error",
+	}}
+
+	for i, test := range tests {
+		result := test.in.Error()
+		if result != test.want {
+			t.Errorf("#%d: got: %s want: %s", i, result, test.want)
+			continue
+		}
+	}
+}
+
+// TestIndexerErrorKindIsAs ensures both ErrorKind and IndexerError can be
+// identified as being a specific error kind via errors.Is and unwrapped
+// via errors.As.
+func TestIndexerErrorKindIsAs(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		target    error
+		wantMatch bool
+		wantAs    ErrorKind
+	}{{
+		name:      "ErrUnsupportedAddressType == ErrUnsupportedAddressType",
+		err:       ErrUnsupportedAddressType,
+		target:    ErrUnsupportedAddressType,
+		wantMatch: true,
+		wantAs:    ErrUnsupportedAddressType,
+	}, {
+		name:      "IndexerError.ErrUnsupportedAddressType == ErrUnsupportedAddressType",
+		err:       indexerError(ErrUnsupportedAddressType, ""),
+		target:    ErrUnsupportedAddressType,
+		wantMatch: true,
+		wantAs:    ErrUnsupportedAddressType,
+	}, {
+		name:      "IndexerError.ErrUnsupportedAddressType == IndexerError.ErrUnsupportedAddressType",
+		err:       indexerError(ErrUnsupportedAddressType, ""),
+		target:    indexerError(ErrUnsupportedAddressType, ""),
+		wantMatch: true,
+		wantAs:    ErrUnsupportedAddressType,
+	}, {
+		name:      "ErrUnsupportedAddressType != ErrConnectBlock",
+		err:       ErrUnsupportedAddressType,
+		target:    ErrConnectBlock,
+		wantMatch: false,
+		wantAs:    ErrUnsupportedAddressType,
+	}, {
+		name:      "IndexerError.ErrUnsupportedAddressType != ErrConnectBlock",
+		err:       indexerError(ErrUnsupportedAddressType, ""),
+		target:    ErrConnectBlock,
+		wantMatch: false,
+		wantAs:    ErrUnsupportedAddressType,
+	}, {
+		name:      "ErrUnsupportedAddressType != IndexerError.ErrConnectBlock",
+		err:       ErrUnsupportedAddressType,
+		target:    indexerError(ErrConnectBlock, ""),
+		wantMatch: false,
+		wantAs:    ErrUnsupportedAddressType,
+	}, {
+		name:      "IndexerError.ErrUnsupportedAddressType != IndexerError.ErrConnectBlock",
+		err:       indexerError(ErrUnsupportedAddressType, ""),
+		target:    indexerError(ErrConnectBlock, ""),
+		wantMatch: false,
+		wantAs:    ErrUnsupportedAddressType,
+	}, {
+		name:      "IndexerError.ErrUnsupportedAddressType != io.EOF",
+		err:       indexerError(ErrUnsupportedAddressType, ""),
+		target:    io.EOF,
+		wantMatch: false,
+		wantAs:    ErrUnsupportedAddressType,
+	}}
+
+	for _, test := range tests {
+		// Ensure the error matches or not depending on the expected result.
+		result := errors.Is(test.err, test.target)
+		if result != test.wantMatch {
+			t.Errorf("%s: incorrect error identification -- got %v, want %v",
+				test.name, result, test.wantMatch)
+			continue
+		}
+
+		// Ensure the underlying error kind can be unwrapped and is the
+		// expected kind.
+		var kind ErrorKind
+		if !errors.As(test.err, &kind) {
+			t.Errorf("%s: unable to unwrap to error kind", test.name)
+			continue
+		}
+		if kind != test.wantAs {
+			t.Errorf("%s: unexpected unwrapped error kind -- got %v, want %v",
+				test.name, kind, test.wantAs)
+			continue
+		}
+	}
+}

--- a/blockchain/indexers/existsaddrindex.go
+++ b/blockchain/indexers/existsaddrindex.go
@@ -109,7 +109,7 @@ var _ Indexer = (*ExistsAddrIndex)(nil)
 // This is part of the Indexer interface.
 func (idx *ExistsAddrIndex) Init(ctx context.Context, chainParams *chaincfg.Params) error {
 	if interruptRequested(ctx) {
-		return errInterruptRequested
+		return indexerError(ErrInterruptRequested, interruptMsg)
 	}
 
 	// Finish any drops that were previously interrupted.
@@ -550,19 +550,24 @@ func (idx *ExistsAddrIndex) ProcessNotification(dbTx database.Tx, ntfn *IndexNtf
 		err := idx.connectBlock(dbTx, ntfn.Block, ntfn.Parent,
 			ntfn.PrevScripts, ntfn.IsTreasuryEnabled)
 		if err != nil {
-			return fmt.Errorf("%s: unable to connect block: %v", idx.Name(), err)
+			msg := fmt.Sprintf("%s: unable to connect block: %v",
+				idx.Name(), err)
+			return indexerError(ErrConnectBlock, msg)
 		}
 
 	case DisconnectNtfn:
 		err := idx.disconnectBlock(dbTx, ntfn.Block, ntfn.Parent,
 			ntfn.PrevScripts, ntfn.IsTreasuryEnabled)
 		if err != nil {
-			log.Errorf("%s: unable to disconnect block: %v", idx.Name(), err)
+			msg := fmt.Sprintf("%s: unable to disconnect block: %v",
+				idx.Name(), err)
+			return indexerError(ErrDisconnectBlock, msg)
 		}
 
 	default:
-		return fmt.Errorf("%s: unknown notification type received: %d",
+		msg := fmt.Sprintf("%s: unknown notification type received: %d",
 			idx.Name(), ntfn.NtfnType)
+		return indexerError(ErrInvalidNotificationType, msg)
 	}
 
 	return nil

--- a/blockchain/indexers/indexsubscriber.go
+++ b/blockchain/indexers/indexsubscriber.go
@@ -259,7 +259,7 @@ func (s *IndexSubscriber) CatchUp(ctx context.Context, db database.DB, queryer C
 	var cachedParent *dcrutil.Block
 	for height := lowestHeight + 1; height <= bestHeight; height++ {
 		if interruptRequested(ctx) {
-			return errInterruptRequested
+			return indexerError(ErrInterruptRequested, interruptMsg)
 		}
 
 		hash, err := queryer.BlockHashByHeight(height)
@@ -269,8 +269,9 @@ func (s *IndexSubscriber) CatchUp(ctx context.Context, db database.DB, queryer C
 
 		// Ensure the next tip hash is on the main chain.
 		if !queryer.MainChainHasBlock(hash) {
-			return fmt.Errorf("the next block being synced to (%s) "+
-				"at height %d is "+"not on the main chain", hash, height)
+			msg := fmt.Sprintf("the next block being synced to (%s) "+
+				"at height %d is not on the main chain", hash, height)
+			return indexerError(ErrBlockNotOnMainChain, msg)
 		}
 
 		var parent *dcrutil.Block
@@ -296,7 +297,7 @@ func (s *IndexSubscriber) CatchUp(ctx context.Context, db database.DB, queryer C
 		var prevScripts PrevScripter
 		err = db.View(func(dbTx database.Tx) error {
 			if interruptRequested(ctx) {
-				return errInterruptRequested
+				return indexerError(ErrInterruptRequested, interruptMsg)
 			}
 
 			prevScripts, err = queryer.PrevScripts(dbTx, child)

--- a/blockchain/indexers/txindex.go
+++ b/blockchain/indexers/txindex.go
@@ -350,7 +350,7 @@ var _ Indexer = (*TxIndex)(nil)
 // This is part of the Indexer interface.
 func (idx *TxIndex) Init(ctx context.Context, chainParams *chaincfg.Params) error {
 	if interruptRequested(ctx) {
-		return errInterruptRequested
+		return indexerError(ErrInterruptRequested, interruptMsg)
 	}
 
 	// Finish any drops that were previously interrupted.
@@ -714,19 +714,24 @@ func (idx *TxIndex) ProcessNotification(dbTx database.Tx, ntfn *IndexNtfn) error
 		err := idx.connectBlock(dbTx, ntfn.Block, ntfn.Parent,
 			ntfn.PrevScripts, ntfn.IsTreasuryEnabled)
 		if err != nil {
-			return fmt.Errorf("%s: unable to connect block: %v", idx.Name(), err)
+			msg := fmt.Sprintf("%s: unable to connect block: %v",
+				idx.Name(), err)
+			return indexerError(ErrConnectBlock, msg)
 		}
 
 	case DisconnectNtfn:
 		err := idx.disconnectBlock(dbTx, ntfn.Block, ntfn.Parent,
 			ntfn.PrevScripts, ntfn.IsTreasuryEnabled)
 		if err != nil {
-			log.Errorf("%s: unable to disconnect block: %v", idx.Name(), err)
+			msg := fmt.Sprintf("%s: unable to disconnect block: %v",
+				idx.Name(), err)
+			return indexerError(ErrDisconnectBlock, msg)
 		}
 
 	default:
-		return fmt.Errorf("%s: unknown notification type received: %d",
+		msg := fmt.Sprintf("%s: unknown notification type received: %d",
 			idx.Name(), ntfn.NtfnType)
+		return indexerError(ErrInvalidNotificationType, msg)
 	}
 
 	return nil


### PR DESCRIPTION
This updates the wire error types to leverage go 1.13 errors.Is/As functionality as well as confirm to the error infrastructure best practices outlined in #2181.