### PR TITLE
blockchain: Add convenience ancestor of func.

### DIFF
--- a/blockchain/blockindex.go
+++ b/blockchain/blockindex.go
@@ -1132,7 +1132,7 @@ func (bi *blockIndex) MarkBlockFailedValidation(node *blockNode) {
 	// need to be marked invalid.
 	markDescendantsInvalid := func(node, tip *blockNode) {
 		// Nothing to do if the node is not an ancestor of the given chain tip.
-		if tip.Ancestor(node.height) != node {
+		if !node.IsAncestorOf(tip) {
 			return
 		}
 
@@ -1191,7 +1191,7 @@ func (bi *blockIndex) MarkBlockFailedValidation(node *blockNode) {
 			// Skip chain tips that are descendants of the failed block since
 			// none of the intermediate headers are eligible to become the best
 			// header given they all have an invalid ancestor.
-			if tip.Ancestor(node.height) == node {
+			if node.IsAncestorOf(tip) {
 				return nil
 			}
 

--- a/blockchain/blockindex.go
+++ b/blockchain/blockindex.go
@@ -365,6 +365,14 @@ func (node *blockNode) RelativeAncestor(distance int64) *blockNode {
 	return node.Ancestor(node.height - distance)
 }
 
+// IsAncestorOf returns whether or not this node is an ancestor of the provided
+// target node.
+//
+// NOTE: Nodes are considered ancestors of themselves.
+func (node *blockNode) IsAncestorOf(target *blockNode) bool {
+	return target.Ancestor(node.height) == node
+}
+
 // CalcPastMedianTime calculates the median time of the previous few blocks
 // prior to, and including, the block node.
 //

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1334,7 +1334,7 @@ func (b *BlockChain) reorganizeChain(target *blockNode) error {
 		// Determine if the chain is being reorganized to a competing branch.
 		// This is the case when the current tip is not an ancestor of the
 		// target tip.
-		if !sentReorgingNtfn && target.Ancestor(tip.height) != tip {
+		if !sentReorgingNtfn && !tip.IsAncestorOf(target) {
 			// Send a notification announcing the start of the chain
 			// reorganization.
 			//
@@ -1587,7 +1587,7 @@ func (b *BlockChain) maybeUpdateIsCurrent(curBest *blockNode) {
 		bestHeader := b.index.bestHeader
 		b.index.RUnlock()
 		syncedToBestHeader := curBest.height == bestHeader.height ||
-			curBest.Ancestor(bestHeader.height) == bestHeader
+			bestHeader.IsAncestorOf(curBest)
 		if !syncedToBestHeader {
 			return
 		}

--- a/blockchain/checkpoints.go
+++ b/blockchain/checkpoints.go
@@ -89,7 +89,7 @@ func (b *BlockChain) isKnownCheckpointAncestor(node *blockNode) bool {
 	if b.checkpointNode == nil {
 		return false
 	}
-	return b.checkpointNode.Ancestor(node.height) == node
+	return node.IsAncestorOf(b.checkpointNode)
 }
 
 // isNonstandardTransaction determines whether a transaction contains any

--- a/blockchain/process.go
+++ b/blockchain/process.go
@@ -499,10 +499,10 @@ func (b *BlockChain) ProcessBlock(block *dcrutil.Block, flags BehaviorFlags) (in
 	//    of the new target tip
 	target := b.index.FindBestChainCandidate()
 	if b.index.CanValidate(node) {
-		triggersReorg := target.Ancestor(currentTip.height) != currentTip
+		triggersReorg := !currentTip.IsAncestorOf(target)
 		if triggersReorg {
 			log.Infof("REORGANIZE: Block %v is causing a reorganize", node.hash)
-		} else if target.Ancestor(node.height) != node {
+		} else if !node.IsAncestorOf(target) {
 			fork := b.bestChain.FindFork(node)
 			if fork == node.parent {
 				log.Infof("FORK: Block %v (height %v) forks the chain at "+
@@ -778,7 +778,7 @@ func (b *BlockChain) ReconsiderBlock(hash *chainhash.Hash) error {
 	b.index.forEachChainTipAfterHeight(vfNode, func(tip *blockNode) error {
 		// Nothing to do if the earliest failed block to be reconsidered is not
 		// an ancestor of this chain tip.
-		if tip.Ancestor(vfNode.height) != vfNode {
+		if !vfNode.IsAncestorOf(tip) {
 			return nil
 		}
 

--- a/blockchain/treasury.go
+++ b/blockchain/treasury.go
@@ -893,7 +893,7 @@ func (b *BlockChain) checkTSpendExists(prevNode *blockNode, tspend chainhash.Has
 			continue
 		}
 
-		if prevNode.Ancestor(node.height) != node {
+		if !node.IsAncestorOf(prevNode) {
 			trsyLog.Errorf("  checkTSpendExists: not ancestor "+
 				"block %v tspend %v", v, tspend)
 			continue

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -1051,7 +1051,7 @@ func (b *BlockChain) checkBlockHeaderPositional(header *wire.BlockHeader, prevNo
 	checkpoint := b.checkpointNode
 	blockHash := header.BlockHash()
 	if checkpoint != nil && blockHeight < checkpoint.height &&
-		(checkpoint.Ancestor(prevNode.height) != prevNode ||
+		(!prevNode.IsAncestorOf(checkpoint) ||
 			b.index.LookupNode(&blockHash) == nil) {
 
 		str := fmt.Sprintf("block at height %d forks the main chain before "+


### PR DESCRIPTION
This adds a convenience func to block nodes named `IsAncestorOf` for determining whether or not a node is an ancestor of a given target node along with tests to ensure proper functionality.

It also updates the various `blockchain` call sites that deal with determining if a node is an ancestor (or descendant) to make use of the new func in a separate commit.


