### PR TITLE
blockchain: Further decouple upgrade code.

### DIFF
--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -265,7 +265,7 @@ func readDeserializeSizeOfMinimalOutputs(serialized []byte) (int, error) {
 //
 // The serialized value format is:
 //
-//   <block header><status><num votes><votes info><num revoked><revoked tickets>
+//   <block header><status><num votes><votes info>
 //
 //   Field              Type                Size
 //   block header       wire.BlockHeader    180 bytes
@@ -1399,7 +1399,7 @@ func (b *BlockChain) initChainState(ctx context.Context,
 		return err
 	}
 
-	// Attempt to load the chain state from the database.
+	// Attempt to load the chain state and block index from the database.
 	var tip *blockNode
 	err = b.db.View(func(dbTx database.Tx) error {
 		// Fetch the stored best chain state from the database.


### PR DESCRIPTION
This modifies the upgrade code related to block index entries to further decouple it from the primary code base to help ensure legacy upgrade paths remain stable as the primary code evolves.

The addition of the separate version 3 block index bits will also be useful in future upgrade code as well.