### PR TITLE
secp256k1: Correct 96-bit accum double overflow.

### DIFF
--- a/dcrec/secp256k1/modnscalar.go
+++ b/dcrec/secp256k1/modnscalar.go
@@ -491,7 +491,7 @@ func (a *accumulator96) Add(v uint64) {
 	low := uint32(v & uint32Mask)
 	hi := uint32(v >> 32)
 	a.n[0] += low
-	a.n[1] += constantTimeLess(a.n[0], low) // Carry if overflow in n[0].
+	hi += constantTimeLess(a.n[0], low) // Carry if overflow in n[0].
 	a.n[1] += hi
 	a.n[2] += constantTimeLess(a.n[1], hi) // Carry if overflow in n[1].
 }


### PR DESCRIPTION
This corrects the internal 96-bit accumulator used during modular reduction over the curve order (`ModNScalar`) to properly handle the case when both words of the multi-word addition overflow and adds accumulator tests for all potential overflow conditions to ensure correctness.

Fixes #2777.