### PR TITLE
config: conditionally generate rpc credentials.

### DIFF
--- a/sampleconfig/sampleconfig.go
+++ b/sampleconfig/sampleconfig.go
@@ -182,8 +182,9 @@ const fileContents = `[Application Options]
 ; specified.
 ; ------------------------------------------------------------------------------
 
-; Secure the RPC API by specifying the username and password.  You must specify
-; both or the RPC server will be disabled.
+; Secure the RPC API by specifying the username and password if the 
+; authorization type is basic. You must specify both if so or the RPC 
+; server will be disabled.
 ; rpcuser=whatever_username_you_want
 ; rpcpass=
 


### PR DESCRIPTION
This updates the config to only generate random rpc credentials when the authorization type is basic.

resolves #2739.