### PR TITLE
blockchain: Correct treasury spend vote data.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -2402,8 +2402,8 @@ func New(ctx context.Context, config *Config) (*BlockChain, error) {
 		return nil, err
 	}
 
-	// Initialize the UTXO state.  This entails running any database migrations as
-	// necessary as well as initializing the UTXO cache.
+	// Initialize the UTXO state.  This entails running any database migrations
+	// as necessary as well as initializing the UTXO cache.
 	if err := b.utxoCache.Initialize(ctx, &b, b.bestChain.tip()); err != nil {
 		return nil, err
 	}

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	// currentDatabaseVersion indicates the current database version.
-	currentDatabaseVersion = 11
+	currentDatabaseVersion = 12
 
 	// currentBlockIndexVersion indicates the current block index database
 	// version.
@@ -1433,9 +1433,8 @@ func (b *BlockChain) initChainState(ctx context.Context,
 
 		log.Debugf("Block index loaded in %v", time.Since(bidxStart))
 
-		// Exception for version 1 blockchains: skip loading the stake
-		// node, as the upgrade path handles ensuring this is correctly
-		// set.
+		// Exception for version 1 blockchains: skip loading the stake node, as
+		// the upgrade path handles ensuring this is correctly set.
 		if b.dbInfo.version >= 2 {
 			tip.stakeNode, err = stake.LoadBestNode(dbTx, uint32(tip.height),
 				tip.hash, tip.Header(), b.chainParams)


### PR DESCRIPTION
### Testing Notes

As of this PR, the expected behavior is that there is a single migration that takes around 15 to 20 minutes to complete after which it will no longer be possible to downgrade.

As the warning above notes, if you try to run an older software version after this migration has completed, you will get an error message similar to `Unable to start server: the current blockchain database is no longer compatible with this version of the software (12 > 11)`

---

This modifies `FindSpentTicketsInBlock` to also properly detect votes that include information to vote on treasury spends as intended and adds code to correct the ticket database and block index treasury spend vote data via a database migration.

It should be noted that the issue does not affect consensus in a way that could lead to an unintended fork.

However, the incorrect behavior does mean the stake ticket database and block index now have invalid entries in them that require the database migration.

More specifically, the behavior has resulted in the ticket database incorrectly marking the associated tickets as missed instead of voted, but that information is only used for serving RPC data, so the live ticket pool is still accurate and all votes and payouts are unaffected.

Further, the associated data in the block index is only used when tallying vote information and since an upgrade is required before a new vote can start anyway, it will necessarily be resolved prior to that point.

The migration involves unwinding all of the blocks from the current tip back to the known good point in the ticket database and replaying them to apply the the correct information to the various buckets in the ticket database as well as the relevant entries in the block index.  The process can be interrupted at any point and future invocations will resume from the point it was interrupted.

Also, since the next release of the software will include a vote to change the consensus rules, all of the blocks previously marked as having failed validation need to be unmarked so they are eligible for which ensures clients that did not update prior to new rules activating are able to automatically recover under the new rules without having to download the entire chain again.

Since both cases require a database version bump, this takes advantage of the database version bump to do both a single version bump.

Fixes #2668.