### PR TITLE
multi: Add bulk import mode.

### DIFF
--- a/blockchain/process.go
+++ b/blockchain/process.go
@@ -436,7 +436,9 @@ func (b *BlockChain) ProcessBlock(block *dcrutil.Block, flags BehaviorFlags) (in
 	// this package and then the ability to specify the fast add flag should be
 	// removed along with the fast add portion of this check here so that it is
 	// solely determined internally.
-	if flags&BFFastAdd == BFFastAdd || b.isKnownCheckpointAncestor(node) {
+	if flags&BFFastAdd == BFFastAdd || b.bulkImportMode ||
+		b.isKnownCheckpointAncestor(node) {
+
 		b.index.SetStatusFlags(node, statusValidated)
 		flags |= BFFastAdd
 	}

--- a/cmd/addblock/import.go
+++ b/cmd/addblock/import.go
@@ -133,7 +133,7 @@ func (bi *blockImporter) processBlock(serializedBlock []byte) (bool, error) {
 
 	// Ensure the blocks follows all of the chain rules and match up to the
 	// known checkpoints.
-	forkLen, err := bi.chain.ProcessBlock(block, blockchain.BFFastAdd)
+	forkLen, err := bi.chain.ProcessBlock(block, blockchain.BFNone)
 	if err != nil {
 		if errors.Is(err, blockchain.ErrMissingParent) {
 			return false, fmt.Errorf("import file contains an orphan block: %v",
@@ -342,6 +342,10 @@ func newBlockImporter(ctx context.Context, db database.DB, utxoDb *leveldb.DB, r
 	if err != nil {
 		return nil, err
 	}
+
+	// Enable bulk import mode to allow several validation checks to be skipped
+	// when importing blocks.
+	chain.EnableBulkImportMode(true)
 
 	queryer := &blockchain.ChainQueryerAdapter{BlockChain: chain}
 


### PR DESCRIPTION
This adds a bulk import mode that provides a mechanism to indicate that several validation checks can be avoided when bulk importing blocks already known to be valid.

This provides an alternative mechanism to the current solution of passing a `BehaviorFlags` parameter around, which is inconvenient and makes it harder to determine where flags are being set. 

The second commit updates the block importer to enable bulk import mode on the chain rather than passing in the `blockchain.BFFastAdd` parameter when processing each block.