### PR TITLE
multi: Remove flags from blockchain ProcessBlock.

### DIFF
--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -115,7 +115,7 @@ func TestBlockchainFunctions(t *testing.T) {
 			t.Errorf("NewBlockFromBytes error: %v", err.Error())
 		}
 
-		_, err = chain.ProcessBlock(bl, BFNone)
+		_, err = chain.ProcessBlock(bl)
 		if err != nil {
 			t.Fatalf("ProcessBlock error at height %v: %v", i, err.Error())
 		}

--- a/blockchain/common_test.go
+++ b/blockchain/common_test.go
@@ -746,7 +746,7 @@ func (g *chaingenHarness) AcceptBlockData(blockName string) {
 	g.t.Logf("Testing block %q (hash %s, height %d)", blockName, blockHash,
 		blockHeight)
 
-	_, err := g.chain.ProcessBlock(block, BFNone)
+	_, err := g.chain.ProcessBlock(block)
 	if err != nil {
 		g.t.Fatalf("block %q (hash %s, height %d) should have been accepted: %v",
 			blockName, blockHash, blockHeight, err)
@@ -775,7 +775,7 @@ func (g *chaingenHarness) AcceptBlock(blockName string) {
 	g.t.Logf("Testing block %q (hash %s, height %d)", blockName, block.Hash(),
 		blockHeight)
 
-	forkLen, err := g.chain.ProcessBlock(block, BFNone)
+	forkLen, err := g.chain.ProcessBlock(block)
 	if err != nil {
 		g.t.Fatalf("block %q (hash %s, height %d) should have been accepted: %v",
 			blockName, block.Hash(), blockHeight, err)
@@ -869,7 +869,7 @@ func (g *chaingenHarness) RejectBlock(blockName string, kind ErrorKind) {
 	g.t.Logf("Testing reject block %q (hash %s, height %d, reason %v)",
 		blockName, block.Hash(), blockHeight, kind)
 
-	_, err := g.chain.ProcessBlock(block, BFNone)
+	_, err := g.chain.ProcessBlock(block)
 	if err == nil {
 		g.t.Fatalf("block %q (hash %s, height %d) should not have been accepted",
 			blockName, block.Hash(), blockHeight)
@@ -943,7 +943,7 @@ func (g *chaingenHarness) AcceptedToSideChainWithExpectedTip(tipName string) {
 	g.t.Logf("Testing block %q (hash %s, height %d)", g.TipName(), block.Hash(),
 		blockHeight)
 
-	forkLen, err := g.chain.ProcessBlock(block, BFNone)
+	forkLen, err := g.chain.ProcessBlock(block)
 	if err != nil {
 		g.t.Fatalf("block %q (hash %s, height %d) should have been accepted: %v",
 			g.TipName(), block.Hash(), blockHeight, err)

--- a/blockchain/example_test.go
+++ b/blockchain/example_test.go
@@ -87,8 +87,7 @@ func ExampleBlockChain_ProcessBlock() {
 	// Process a block.  For this example, intentionally cause an error by
 	// trying to process the genesis block which already exists.
 	genesisBlock := dcrutil.NewBlock(mainNetParams.GenesisBlock)
-	forkLen, err := chain.ProcessBlock(genesisBlock,
-		blockchain.BFNone)
+	forkLen, err := chain.ProcessBlock(genesisBlock)
 	if err != nil {
 		fmt.Printf("Failed to create chain instance: %v\n", err)
 		return

--- a/blockchain/fullblocks_test.go
+++ b/blockchain/fullblocks_test.go
@@ -213,7 +213,7 @@ func TestFullBlocks(t *testing.T) {
 			item.Name, block.Hash(), blockHeight)
 
 		var isOrphan bool
-		forkLen, err := chain.ProcessBlock(block, blockchain.BFNone)
+		forkLen, err := chain.ProcessBlock(block)
 		if errors.Is(err, blockchain.ErrMissingParent) {
 			isOrphan = true
 			err = nil
@@ -250,7 +250,7 @@ func TestFullBlocks(t *testing.T) {
 		t.Logf("Testing block %s (hash %s, height %d)",
 			item.Name, block.Hash(), blockHeight)
 
-		_, err := chain.ProcessBlock(block, blockchain.BFNone)
+		_, err := chain.ProcessBlock(block)
 		if err == nil {
 			t.Fatalf("block %q (hash %s, height %d) should not "+
 				"have been accepted", item.Name, block.Hash(),
@@ -300,7 +300,7 @@ func TestFullBlocks(t *testing.T) {
 		t.Logf("Testing block %s (hash %s, height %d)",
 			item.Name, block.Hash(), blockHeight)
 
-		_, err := chain.ProcessBlock(block, blockchain.BFNone)
+		_, err := chain.ProcessBlock(block)
 		if err != nil {
 			// Ensure the error is of the expected type.  Note that orphans are
 			// rejected with ErrMissingParent, so this check covers both

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -95,7 +95,7 @@ func TestBlockchainSpendJournal(t *testing.T) {
 			t.Fatalf("NewBlockFromBytes error: %v", err.Error())
 		}
 
-		forkLen, err := chain.ProcessBlock(bl, BFNone)
+		forkLen, err := chain.ProcessBlock(bl)
 		if err != nil {
 			t.Fatalf("ProcessBlock error at height %v: %v", i, err.Error())
 		}

--- a/cmd/addblock/import.go
+++ b/cmd/addblock/import.go
@@ -133,7 +133,7 @@ func (bi *blockImporter) processBlock(serializedBlock []byte) (bool, error) {
 
 	// Ensure the blocks follows all of the chain rules and match up to the
 	// known checkpoints.
-	forkLen, err := bi.chain.ProcessBlock(block, blockchain.BFNone)
+	forkLen, err := bi.chain.ProcessBlock(block)
 	if err != nil {
 		if errors.Is(err, blockchain.ErrMissingParent) {
 			return false, fmt.Errorf("import file contains an orphan block: %v",

--- a/internal/mining/cpuminer/cpuminer.go
+++ b/internal/mining/cpuminer/cpuminer.go
@@ -92,7 +92,7 @@ type Config struct {
 	// ProcessBlock defines the function to call with any solved blocks.
 	// It typically must run the provided block through the same set of
 	// rules and handling as any other block coming from the network.
-	ProcessBlock func(*dcrutil.Block, blockchain.BehaviorFlags) error
+	ProcessBlock func(*dcrutil.Block) error
 
 	// ConnectedCount defines the function to use to obtain how many other
 	// peers the server is connected to.  This is used by the automatic
@@ -196,7 +196,7 @@ func (m *CPUMiner) submitBlock(block *dcrutil.Block) bool {
 
 	// Process this block using the same rules as blocks coming from other
 	// nodes. This will in turn relay it to the network like normal.
-	err := m.cfg.ProcessBlock(block, blockchain.BFNone)
+	err := m.cfg.ProcessBlock(block)
 	if err != nil {
 		if errors.Is(err, blockchain.ErrMissingParent) {
 			log.Errorf("Block submitted via CPU miner is an orphan building "+

--- a/internal/netsync/manager.go
+++ b/internal/netsync/manager.go
@@ -714,7 +714,7 @@ func (m *SyncManager) maybeUpdateIsCurrent() {
 // detected by checking if the error is blockchain.ErrMissingParent.
 func (m *SyncManager) processBlock(block *dcrutil.Block) (int64, error) {
 	// Process the block to include validation, best chain selection, etc.
-	forkLen, err := m.cfg.Chain.ProcessBlock(block, blockchain.BFNone)
+	forkLen, err := m.cfg.Chain.ProcessBlock(block)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/netsync/manager.go
+++ b/internal/netsync/manager.go
@@ -1653,10 +1653,11 @@ func (m *SyncManager) requestFromPeer(p *peerpkg.Peer, blocks, voteHashes,
 // ProcessBlock makes use of ProcessBlock on an internal instance of a block
 // chain.  It is funneled through the sync manager since blockchain is not safe
 // for concurrent access.
-func (m *SyncManager) ProcessBlock(block *dcrutil.Block, flags blockchain.BehaviorFlags) error {
+func (m *SyncManager) ProcessBlock(block *dcrutil.Block) error {
 	reply := make(chan processBlockResponse, 1)
 	select {
-	case m.msgChan <- processBlockMsg{block: block, flags: flags, reply: reply}:
+	case m.msgChan <- processBlockMsg{block: block, flags: blockchain.BFNone,
+		reply: reply}:
 	case <-m.quit:
 	}
 

--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -331,7 +331,7 @@ func (b *rpcSyncMgr) IsCurrent() bool {
 // This function is safe for concurrent access and is part of the
 // rpcserver.SyncManager interface implementation.
 func (b *rpcSyncMgr) SubmitBlock(block *dcrutil.Block) error {
-	return b.syncMgr.ProcessBlock(block, blockchain.BFNone)
+	return b.syncMgr.ProcessBlock(block)
 }
 
 // SyncPeer returns the id of the current peer being synced with.


### PR DESCRIPTION
~~**This is rebased on https://github.com/decred/dcrd/pull/2782.**~~

This removes the flags param from the `ProcessBlock` functions in `blockchain` and `netsync` since it is now passed in as `BFNone` in all instances.  The appropriate flags will now be determined internally within `blockchain`.
