### PR TITLE
blockchain: Remove flags maybeAcceptBlockHeader. 

### DIFF
--- a/blockchain/common_test.go
+++ b/blockchain/common_test.go
@@ -692,7 +692,7 @@ func (g *chaingenHarness) AcceptHeader(blockName string) {
 	// Determine if the header is already known before attempting to process it.
 	alreadyHaveHeader := g.chain.index.LookupNode(&blockHash) != nil
 
-	err := g.chain.ProcessBlockHeader(header, BFNone)
+	err := g.chain.ProcessBlockHeader(header)
 	if err != nil {
 		g.t.Fatalf("block header %q (hash %s, height %d) should have been "+
 			"accepted: %v", blockName, blockHash, blockHeight, err)
@@ -814,7 +814,7 @@ func (g *chaingenHarness) RejectHeader(blockName string, kind ErrorKind) {
 	// Determine if the header is already known before attempting to process it.
 	alreadyHaveHeader := g.chain.index.LookupNode(&blockHash) != nil
 
-	err := g.chain.ProcessBlockHeader(header, BFNone)
+	err := g.chain.ProcessBlockHeader(header)
 	if err == nil {
 		g.t.Fatalf("block header %q (hash %s, height %d) should not have been "+
 			"accepted", blockName, blockHash, blockHeight)

--- a/blockchain/process.go
+++ b/blockchain/process.go
@@ -159,7 +159,7 @@ func (b *BlockChain) maybeAcceptBlockHeader(header *wire.BlockHeader, flags Beha
 // be processed in order.
 //
 // This function is safe for concurrent access.
-func (b *BlockChain) ProcessBlockHeader(header *wire.BlockHeader, flags BehaviorFlags) error {
+func (b *BlockChain) ProcessBlockHeader(header *wire.BlockHeader) error {
 	b.processLock.Lock()
 	defer b.processLock.Unlock()
 
@@ -172,7 +172,7 @@ func (b *BlockChain) ProcessBlockHeader(header *wire.BlockHeader, flags Behavior
 	// positional checks, and create a block index entry for it.
 	b.chainLock.Lock()
 	const checkHeaderSanity = true
-	_, err := b.maybeAcceptBlockHeader(header, flags, checkHeaderSanity)
+	_, err := b.maybeAcceptBlockHeader(header, BFNone, checkHeaderSanity)
 	if err != nil {
 		b.chainLock.Unlock()
 		return err

--- a/internal/netsync/manager.go
+++ b/internal/netsync/manager.go
@@ -1007,7 +1007,7 @@ func (m *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 
 	// Process all of the received headers.
 	for _, header := range headers {
-		err := chain.ProcessBlockHeader(header, blockchain.BFNone)
+		err := chain.ProcessBlockHeader(header)
 		if err != nil {
 			// Note that there is no need to check for an orphan header here
 			// because they were already verified to connect above.


### PR DESCRIPTION
**This is rebased on https://github.com/decred/dcrd/pull/2784.**

This removes the flags param from the `maybeAcceptBlockHeader` function in `blockchain` since it is now passed in as `BFNone` in all instances.  The appropriate flags will now be determined internally within `blockchain`.