### PR TITLE
multi: Address some linter complaints.

### DIFF
--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -2508,7 +2508,7 @@ func TestHandlesTSpends(t *testing.T) {
 	// Attempt to add a tspend with an incorrect expiry (not tvi+2). This
 	// should fail.
 	tx := tspends[1].MsgTx()
-	tx.Expiry += 1
+	tx.Expiry++
 	tx.TxIn[0].SignatureScript, err = sign.TSpendSignatureScript(tx, piKey)
 	if err != nil {
 		t.Fatal(err)

--- a/rpctest/node.go
+++ b/rpctest/node.go
@@ -190,16 +190,6 @@ func (n *node) tracef(format string, args ...interface{}) {
 	tracef(n.t, pid+format, args...)
 }
 
-// debugf is identical to debug.go.debugf but it prepends the pid of this
-// node.
-func (n *node) debugf(format string, args ...interface{}) {
-	if !debug {
-		return
-	}
-	pid := strconv.Itoa(n.pid) + " "
-	debugf(n.t, pid+format, args...)
-}
-
 // buildNode creates a new temporary directory and node and saves the location
 // to a package level variable where it is used for all tests. pathToDCRDMtx
 // must be held for writes.

--- a/upnp.go
+++ b/upnp.go
@@ -114,7 +114,7 @@ func discover(ctx context.Context) (*upnpNAT, error) {
 		if err != nil {
 			return nil, err
 		}
-		var serviceIP string = getServiceIP(serviceURL)
+		serviceIP := getServiceIP(serviceURL)
 		var ourIP string
 		ourIP, err = getOurIP(serviceIP)
 		if err != nil {


### PR DESCRIPTION
This makes the following changes pointed out by linting:

- Uses ++ instead of += 1 for incrementing the expiry in `mempool` test  code
- Removes an unused function in the `rpctest` code
- No need to specify variable type since it is inferred