### PR TITLE
mining: Remove unnecessary tx copy.

### DIFF
--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -2246,14 +2246,10 @@ nextPriorityQueueItem:
 			continue
 		}
 
-		// Copy the transaction and swap the pointer.
-		txCopy := dcrutil.NewTxDeepTxIns(tx.MsgTx())
-		blockTxnsRegular[i] = txCopy
-		tx = txCopy
-
 		for _, txIn := range tx.MsgTx().TxIn {
-			// This tx was at some point 0-conf and now requires the
-			// correct block height and index. Set it here.
+			// This tx was at some point 0-conf and now requires the correct block
+			// height and index.  Set it here.  It is safe to modify the transaction
+			// directly since it has already been copied above.
 			if txIn.BlockIndex == wire.NullBlockIndex {
 				idx := txIndexFromTxList(txIn.PreviousOutPoint.Hash,
 					blockTxnsRegular)


### PR DESCRIPTION
This removes an unnecessary transaction copy in the `mining` code.  It is not needed since all of the regular transactions have already been copied prior to this point.  Specifically, all regular transactions in the block are already copied [here](https://github.com/rstaudt2/dcrd/blob/6a448c0331098dba2de580120b87f65722fddd17/internal/mining/mining.go#L2223-L2226) in the loop that proceeds the code modified in this PR.
