### PR TITLE
chaincfg: Update checkpoint for upcoming release.

### DIFF
--- a/chaincfg/mainnetparams.go
+++ b/chaincfg/mainnetparams.go
@@ -113,7 +113,7 @@ func MainNetParams() *Params {
 		// checkpoint is provided since with headers first syncing the most recent
 		// checkpoint will be discovered before block syncing even starts.
 		Checkpoints: []Checkpoint{
-			{483600, newHashFromStr("000000000000000010f98f7354b501b5747011c82d53b989dbcb368e5059ff9e")},
+			{601900, newHashFromStr("00000000000000001c1865a45a038bb680fc076d70cd88c1843e3e669cb54942")},
 		},
 
 		// MinKnownChainWork is the minimum amount of known total work for the

--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -108,7 +108,7 @@ func TestNet3Params() *Params {
 		// checkpoint is provided since with headers first syncing the most recent
 		// checkpoint will be discovered before block syncing even starts.
 		Checkpoints: []Checkpoint{
-			{515730, newHashFromStr("00000010ecddf8da5d91f7020f69130db8a163906d460cbbed2a91568701f0ac")},
+			{803810, newHashFromStr("000000016e841f4d94c3b253bc7bdf3a13217c7f28a5935bbaec37c7752678e9")},
 		},
 
 		// MinKnownChainWork is the minimum amount of known total work for the


### PR DESCRIPTION
This updates the checkpoints to the blocks at the heights as follows:

> mainnet: 601900
> testnet: 803810