### PR TITLE
chaincfg: Update min known chain work for release.

### DIFF
--- a/chaincfg/mainnetparams.go
+++ b/chaincfg/mainnetparams.go
@@ -120,9 +120,9 @@ func MainNetParams() *Params {
 		// chain at a given point in time.  This is intended to be updated
 		// periodically with new releases.
 		//
-		// Block 00000000000000000b639b99ec8b3097ed3dac076c455d30139db0d5958d4c4a
-		// Height: 487720
-		MinKnownChainWork: hexToBigInt("00000000000000000000000000000000000000000013e6909b5a73128d52fc6f"),
+		// Block 00000000000000001251efb83ad1a5c71351b50fe9195f009cf0bf5a7cd99d52
+		// Height: 606000
+		MinKnownChainWork: hexToBigInt("0000000000000000000000000000000000000000001d987ec2c7f4bc1199489e"),
 
 		// The miner confirmation window is defined as:
 		//   target proof of work timespan / target proof of work spacing

--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -115,9 +115,9 @@ func TestNet3Params() *Params {
 		// chain at a given point in time.  This is intended to be updated
 		// periodically with new releases.
 		//
-		// Block 000000097a93845014d7865997154cc186be0435742e0d3c37c019ff118493fa
-		// Height: 519845
-		MinKnownChainWork: hexToBigInt("000000000000000000000000000000000000000000000000e41955f181d00f59"),
+		// Block 00000000d64ceb1a686315ed56235e9a6838e3a22e9ec9bd92c2e04c09e0778b
+		// Height: 807905
+		MinKnownChainWork: hexToBigInt("000000000000000000000000000000000000000000000000e419ae4d750d4484"),
 
 		// Consensus rule change deployments.
 		//


### PR DESCRIPTION
This updates the minimum known chain work values for the main and test networks as follows:

> mainnet: 0x0000000000000000000000000000000000000000001d987ec2c7f4bc1199489e
> testnet: 0x000000000000000000000000000000000000000000000000e419ae4d750d4484
