### PR TITLE
blockchain: UTXO database migration fix.

### DIFF
--- a/blockchain/upgrade.go
+++ b/blockchain/upgrade.go
@@ -4933,6 +4933,12 @@ func migrateUtxoDbBuckets(ctx context.Context, utxoBackend UtxoBackend) error {
 		if err != nil {
 			return err
 		}
+
+		// Return immediately if the entry does not exist at the old location.
+		if serialized == nil {
+			return nil
+		}
+
 		err = tx.Put(newKey, serialized)
 		if err != nil {
 			return err

--- a/blockchain/utxobackend.go
+++ b/blockchain/utxobackend.go
@@ -512,7 +512,7 @@ func (l *levelDbUtxoBackend) FetchState() (*UtxoSetState, error) {
 	// Return nil if the utxo set state does not exist in the database.  This
 	// should only be the case when starting from a fresh database or a
 	// database that has not been run with the utxo cache yet.
-	if serialized == nil {
+	if len(serialized) == 0 {
 		return nil, nil
 	}
 


### PR DESCRIPTION
This fixes an edge case within the UTXO database migration logic.  In the upgrade that migrates the UTXO data to use simple key prefixes rather than buckets, old entries will still be copied to the new location even if they are nil, which incorrectly creates an empty entry in the new location.

The issue can be reproduced with the following steps:
- Start from a data directory created with `release-v1.6.2`
- Check out a commit from after the UTXO database was introduced but before it was moved to using `leveldb` directly (for example, `git checkout c88eb03e82a1476a4b2b2999996731feb1b2c5f8`)
- Build from the commit in the previous step and use the `release-v1.6.2` data directory
- Kill the node before it finishes the spend journal migration
- Check out `master`
- Run `dcrd` with that same data directory, and after finishing the migration, it will error out with `Unable to start server: unexpected end of data after height`

The second commit in this PR allows for recovery from a data directory that ends up in this state.

