### PR TITLE
rpc/jsonrpc/types: Prepare v3.0.0.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -175,7 +175,7 @@ The following versioned modules are provided by dcrd repository:
   a robust and easy to use Websocket-enabled Decred JSON-RPC client
 * [dcrjson/v4](https://github.com/decred/dcrd/tree/master/dcrjson) - Provides
   infrastructure for working with Decred JSON-RPC APIs
-* [rpc/jsonrpc/types](https://github.com/decred/dcrd/tree/master/rpc/jsonrpc/types) -
+* [rpc/jsonrpc/types/v3](https://github.com/decred/dcrd/tree/master/rpc/jsonrpc/types) -
   Provides concrete types via dcrjson for the chain server JSON-RPC commands,
   return values, and notifications
 * [wire](https://github.com/decred/dcrd/tree/master/wire) - Implements the

--- a/docs/assets/module_hierarchy.gv
+++ b/docs/assets/module_hierarchy.gv
@@ -8,7 +8,7 @@ digraph {
 	bech32 [label="bech32" fillcolor=antiquewhite3]
 	chainhash [label="chaincfg/chainhash" fillcolor=aquamarine]
 	dcrjson [label="dcrjson/v4" fillcolor=indianred]
-	types [label="rpc/jsonrpc/types" fillcolor=tomato]
+	types [label="rpc/jsonrpc/types/v3" fillcolor=tomato]
 	wire [label="wire" fillcolor=coral]
 	addrmgr [label="addrmgr/v2" fillcolor=lightsalmon]
 	chaincfg [label="chaincfg/v3" fillcolor=cadetblue]

--- a/docs/assets/module_hierarchy.svg
+++ b/docs/assets/module_hierarchy.svg
@@ -87,13 +87,13 @@
 </g>
 <!-- types -->
 <g id="node7" class="node"><title>types</title>
-<path fill="tomato" stroke="black" d="M789,-252C789,-252 698,-252 698,-252 692,-252 686,-246 686,-240 686,-240 686,-228 686,-228 686,-222 692,-216 698,-216 698,-216 789,-216 789,-216 795,-216 801,-222 801,-228 801,-228 801,-240 801,-240 801,-246 795,-252 789,-252"/>
-<text text-anchor="middle" x="743.5" y="-230.3" font-family="Times New Roman,serif" font-size="14.00">rpc/jsonrpc/types</text>
+<path fill="tomato" stroke="black" d="M803.5,-252C803.5,-252 695.5,-252 695.5,-252 689.5,-252 683.5,-246 683.5,-240 683.5,-240 683.5,-228 683.5,-228 683.5,-222 689.5,-216 695.5,-216 695.5,-216 803.5,-216 803.5,-216 809.5,-216 815.5,-222 815.5,-228 815.5,-228 815.5,-240 815.5,-240 815.5,-246 809.5,-252 803.5,-252"/>
+<text text-anchor="middle" x="749.5" y="-230.3" font-family="Times New Roman,serif" font-size="14.00">rpc/jsonrpc/types/v3</text>
 </g>
 <!-- dcrjson&#45;&gt;types -->
 <g id="edge24" class="edge"><title>dcrjson&#45;&gt;types</title>
-<path fill="none" stroke="tomato" d="M781.25,-421.955C781.25,-421.955 781.25,-252.145 781.25,-252.145"/>
-<polygon fill="tomato" stroke="tomato" points="777.75,-421.955 781.25,-431.955 784.75,-421.956 777.75,-421.955"/>
+<path fill="none" stroke="tomato" d="M788.5,-421.955C788.5,-421.955 788.5,-252.145 788.5,-252.145"/>
+<polygon fill="tomato" stroke="tomato" points="785,-421.955 788.5,-431.955 792,-421.956 785,-421.955"/>
 </g>
 <!-- rpcclient -->
 <g id="node25" class="node"><title>rpcclient</title>
@@ -102,8 +102,8 @@
 </g>
 <!-- types&#45;&gt;rpcclient -->
 <g id="edge25" class="edge"><title>types&#45;&gt;rpcclient</title>
-<path fill="none" stroke="indianred" d="M711.75,-205.762C711.75,-205.762 711.75,-108.09 711.75,-108.09"/>
-<polygon fill="indianred" stroke="indianred" points="708.25,-205.762 711.75,-215.762 715.25,-205.762 708.25,-205.762"/>
+<path fill="none" stroke="indianred" d="M710.5,-205.762C710.5,-205.762 710.5,-108.09 710.5,-108.09"/>
+<polygon fill="indianred" stroke="indianred" points="707,-205.762 710.5,-215.762 714,-205.762 707,-205.762"/>
 </g>
 <!-- addrmgr -->
 <g id="node9" class="node"><title>addrmgr</title>

--- a/rpc/jsonrpc/types/chainsvrresults.go
+++ b/rpc/jsonrpc/types/chainsvrresults.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/rpc/jsonrpc/types/doc.go
+++ b/rpc/jsonrpc/types/doc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 The Decred developers
+// Copyright (c) 2019-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/rpc/jsonrpc/types/go.mod
+++ b/rpc/jsonrpc/types/go.mod
@@ -3,5 +3,3 @@ module github.com/decred/dcrd/rpc/jsonrpc/types/v3
 go 1.11
 
 require github.com/decred/dcrd/dcrjson/v4 v4.0.0
-
-replace github.com/decred/dcrd/dcrjson/v4 => ../../../dcrjson

--- a/rpc/jsonrpc/types/go.sum
+++ b/rpc/jsonrpc/types/go.sum
@@ -2,3 +2,5 @@ github.com/decred/dcrd/chaincfg/chainhash v1.0.3 h1:PF2czcYZGW3dz4i/35AUfVAgnqHl
 github.com/decred/dcrd/chaincfg/chainhash v1.0.3/go.mod h1:BpbrGgrPTr3YJYRN3Bm+D9NuaFd+zGyNeIKgrhCXK60=
 github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
+github.com/decred/dcrd/dcrjson/v4 v4.0.0 h1:KsaFhHAYO+vLYz7Qmx/fs1gOY5ouTEz8hRuDm8jmJtU=
+github.com/decred/dcrd/dcrjson/v4 v4.0.0/go.mod h1:DMnSpU8lsVh+Nt5kHl63tkrjBDA7UIs4+ov8Kwwgvjs=


### PR DESCRIPTION
This updates the `rpc/jsonrpc/types` module dependencies, the copyright year in the files modified since the previous release, and serves as a base for `rpc/jsonrpc/types/v3.0.0`.

The updated direct dependencies in this commit are as follows:

- github.com/decred/dcrd/dcrjson/v4@v4.0.0

The full list of updated direct dependencies since the previous `rpc/jsonrpc/types/v2.3.0` release are the same as above.