### PR TITLE
multi: Use dcrutil Tx in NewTxDeepTxIns.

### DIFF
--- a/dcrutil/tx.go
+++ b/dcrutil/tx.go
@@ -159,11 +159,12 @@ func NewTxDeep(msgTx *wire.MsgTx) *Tx {
 // pointers to the TxOuts while replacing the old pointers to the TxIns with
 // deep copies. This is to prevent races when the fraud proofs for the
 // transactions are set by the miner.
-func NewTxDeepTxIns(msgTx *wire.MsgTx) *Tx {
-	if msgTx == nil {
+func NewTxDeepTxIns(tx *Tx) *Tx {
+	if tx == nil {
 		return nil
 	}
 
+	msgTx := tx.msgTx
 	txIns := make([]*wire.TxIn, len(msgTx.TxIn))
 	txOuts := make([]*wire.TxOut, len(msgTx.TxOut))
 
@@ -201,8 +202,8 @@ func NewTxDeepTxIns(msgTx *wire.MsgTx) *Tx {
 	return &Tx{
 		hash:    newTxMsg.TxHash(),
 		msgTx:   newTxMsg,
-		txTree:  wire.TxTreeUnknown,
-		txIndex: TxIndexUnknown,
+		txTree:  tx.txTree,
+		txIndex: tx.txIndex,
 	}
 }
 

--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -1935,7 +1935,7 @@ nextPriorityQueueItem:
 			msgTx := tx.MsgTx()
 
 			if stake.IsSSGen(msgTx, isTreasuryEnabled) {
-				txCopy := dcrutil.NewTxDeepTxIns(msgTx)
+				txCopy := dcrutil.NewTxDeepTxIns(tx)
 				if g.maybeInsertStakeTx(txCopy, !knownDisapproved,
 					isTreasuryEnabled) {
 
@@ -2010,7 +2010,7 @@ nextPriorityQueueItem:
 
 			// Quick check for difficulty here.
 			if msgTx.TxOut[0].Value >= best.NextStakeDiff {
-				txCopy := dcrutil.NewTxDeepTxIns(msgTx)
+				txCopy := dcrutil.NewTxDeepTxIns(tx)
 				if g.maybeInsertStakeTx(txCopy, !knownDisapproved,
 					isTreasuryEnabled) {
 
@@ -2046,7 +2046,7 @@ nextPriorityQueueItem:
 		if tx.Tree() == wire.TxTreeStake && stake.IsSSRtx(msgTx,
 			isAutoRevocationsEnabled) {
 
-			txCopy := dcrutil.NewTxDeepTxIns(msgTx)
+			txCopy := dcrutil.NewTxDeepTxIns(tx)
 			if g.maybeInsertStakeTx(txCopy, !knownDisapproved,
 				isTreasuryEnabled) {
 
@@ -2066,7 +2066,7 @@ nextPriorityQueueItem:
 		for _, tx := range blockTxns {
 			msgTx := tx.MsgTx()
 			if tx.Tree() == wire.TxTreeStake && stake.IsTAdd(msgTx) {
-				txCopy := dcrutil.NewTxDeepTxIns(msgTx)
+				txCopy := dcrutil.NewTxDeepTxIns(tx)
 				if g.maybeInsertStakeTx(txCopy, !knownDisapproved,
 					isTreasuryEnabled) {
 
@@ -2074,7 +2074,7 @@ nextPriorityQueueItem:
 					log.Tracef("maybeInsertStakeTx TADD %v ", tx.Hash())
 				}
 			} else if tx.Tree() == wire.TxTreeStake && stake.IsTSpend(msgTx) {
-				txCopy := dcrutil.NewTxDeepTxIns(msgTx)
+				txCopy := dcrutil.NewTxDeepTxIns(tx)
 				if g.maybeInsertStakeTx(txCopy, !knownDisapproved,
 					isTreasuryEnabled) {
 
@@ -2221,7 +2221,7 @@ nextPriorityQueueItem:
 		}
 
 		// Copy the transaction and swap the pointer.
-		txCopy := dcrutil.NewTxDeepTxIns(tx.MsgTx())
+		txCopy := dcrutil.NewTxDeepTxIns(tx)
 		blockTxnsRegular[i] = txCopy
 		tx = txCopy
 


### PR DESCRIPTION
This updates `dcrutil.NewTxDeepTxIns` to take a `dcrutil.Tx` as a parameter rather than a `wire.MsgTx`, which allows for the tree and index set on the input `dcrutil.Tx` to be copied to the new `dcrutil.Tx`.

This is less error prone for callers since the existing implementation is often used to replace an existing `dcrutil.Tx` with the deep copy that this function creates, but a side effect that is easy to miss is that the new `dcrutil.Tx` would have reset the tree and index fields which can lead to unintended behavior.