### PR TITLE
stdscript: Add provably pruneable script support.

### DIFF
--- a/internal/staging/stdscript/README.md
+++ b/internal/staging/stdscript/README.md
@@ -179,6 +179,22 @@ need to return interfaces that callers would have to type assert based on the
 version thereby defeating the original intention of using a version-agnostic
 method to begin with.
 
+### Provably Pruneable Scripts
+
+A provably pruneable script is a public key script that is of a specific form
+that is provably unspendable and therefore is safe to prune from the set of
+unspent transaction outputs.  They are primarily useful for anchoring
+commitments into the blockchain and are the preferred method to achieve that
+goal.
+
+This package provides the version-specific `ProvablyPruneableScriptV0` method
+for this purpose.
+
+Note that no version-agnostic variant of the method that accepts a dynamic
+version is provided since the exact details of what is considered standard is
+likely to change between scripting language versions, so callers will
+necessarily have to ensure appropriate data is provided based on the version.
+
 ### Additional Convenience Methods
 
 As mentioned in the overview, standardness only applies to public key scripts.

--- a/internal/staging/stdscript/error.go
+++ b/internal/staging/stdscript/error.go
@@ -20,6 +20,11 @@ const (
 
 	// ErrPubKeyType is returned when a script contains invalid public keys.
 	ErrPubKeyType = ErrorKind("ErrPubKeyType")
+
+	// ErrTooMuchNullData is returned when attempting to generate a
+	// provably-pruneable script with data that exceeds the maximum allowed
+	// length.
+	ErrTooMuchNullData = ErrorKind("ErrTooMuchNullData")
 )
 
 // Error satisfies the error interface and prints human-readable errors.

--- a/internal/staging/stdscript/error_test.go
+++ b/internal/staging/stdscript/error_test.go
@@ -19,6 +19,7 @@ func TestErrorKindStringer(t *testing.T) {
 		{ErrUnsupportedScriptVersion, "ErrUnsupportedScriptVersion"},
 		{ErrTooManyRequiredSigs, "ErrTooManyRequiredSigs"},
 		{ErrPubKeyType, "ErrPubKeyType"},
+		{ErrTooMuchNullData, "ErrTooMuchNullData"},
 	}
 
 	for i, test := range tests {

--- a/internal/staging/stdscript/scriptv0.go
+++ b/internal/staging/stdscript/scriptv0.go
@@ -11,6 +11,13 @@ import (
 	"github.com/decred/dcrd/txscript/v4"
 )
 
+const (
+	// MaxDataCarrierSizeV0 is the maximum number of bytes allowed in pushed
+	// data to be considered a standard version 0 provably pruneable nulldata
+	// script.
+	MaxDataCarrierSizeV0 = 256
+)
+
 // ExtractCompressedPubKeyV0 extracts a compressed public key from the passed
 // script if it is a standard version 0 pay-to-compressed-secp256k1-pubkey
 // script.  It will return nil otherwise.
@@ -408,7 +415,7 @@ func IsNullDataScriptV0(script []byte) bool {
 	//  OP_RETURN <optional data>
 	//
 	// Thus, it can either be a single OP_RETURN or an OP_RETURN followed by a
-	// canonical data push up to MaxDataCarrierSize bytes.
+	// canonical data push up to MaxDataCarrierSizeV0 bytes.
 
 	// The script can't possibly be a null data script if it doesn't start
 	// with OP_RETURN.  Fail fast to avoid more work below.
@@ -421,12 +428,12 @@ func IsNullDataScriptV0(script []byte) bool {
 		return true
 	}
 
-	// OP_RETURN followed by a canonical data push up to MaxDataCarrierSize
+	// OP_RETURN followed by a canonical data push up to MaxDataCarrierSizeV0
 	// bytes in length.
 	const scriptVersion = 0
 	tokenizer := txscript.MakeScriptTokenizer(scriptVersion, script[1:])
 	return tokenizer.Next() && tokenizer.Done() &&
-		len(tokenizer.Data()) <= txscript.MaxDataCarrierSize &&
+		len(tokenizer.Data()) <= MaxDataCarrierSizeV0 &&
 		isCanonicalPushV0(tokenizer.Opcode(), tokenizer.Data())
 }
 

--- a/internal/staging/stdscript/scriptv0.go
+++ b/internal/staging/stdscript/scriptv0.go
@@ -722,6 +722,21 @@ func MultiSigScriptV0(threshold int, pubKeys ...[]byte) ([]byte, error) {
 	return builder.Script()
 }
 
+// ProvablyPruneableScriptV0 returns a valid version 0 provably-pruneable script
+// which consists of an OP_RETURN followed by the passed data.  An Error with
+// kind ErrTooMuchNullData will be returned if the length of the passed data
+// exceeds MaxDataCarrierSizeV0.
+func ProvablyPruneableScriptV0(data []byte) ([]byte, error) {
+	if len(data) > MaxDataCarrierSizeV0 {
+		str := fmt.Sprintf("data size %d is larger than max allowed size %d",
+			len(data), MaxDataCarrierSizeV0)
+		return nil, makeError(ErrTooMuchNullData, str)
+	}
+
+	builder := txscript.NewScriptBuilder()
+	return builder.AddOp(txscript.OP_RETURN).AddData(data).Script()
+}
+
 // AtomicSwapDataPushesV0 houses the data pushes found in hash-based atomic swap
 // contracts using version 0 scripts.
 type AtomicSwapDataPushesV0 struct {


### PR DESCRIPTION
This adds support for generating a provably pruneable version 0 script that is considered standard `stdscript` since the equivalent variant of it is eventually going to be removed from `txscript` given it is a standardness construct as opposed to a consensus rule.

It also adds an exported constant for the maximum allowed size of version 0 nulldata scripts to be considered standard and makes use of it instead of the one from `txscript` since it will also be removed from `txscript` for the same reason.

Finally, it updates `stdscript/README.md` to describe provably pruneable scripts and document the new function.