### PR TITLE
mempool: Update fraud proof data.

### DIFF
--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -1572,8 +1572,7 @@ func (mp *TxPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit,
 	// Perform several checks on the transaction inputs using the invariant
 	// rules in blockchain for what transactions are allowed into blocks.
 	// Also returns the fees associated with the transaction which will be
-	// used later.  The fraud proof is not checked because it will be
-	// filled in by the miner.
+	// used later.
 
 	bestHash := mp.cfg.BestHash()
 	bestHeader, err := mp.cfg.HeaderByHash(bestHash)
@@ -1581,7 +1580,7 @@ func (mp *TxPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit,
 		return nil, err
 	}
 	txFee, err := blockchain.CheckTransactionInputs(mp.cfg.SubsidyCache,
-		tx, nextBlockHeight, utxoView, false, mp.cfg.ChainParams,
+		tx, nextBlockHeight, utxoView, true, mp.cfg.ChainParams,
 		&bestHeader, isTreasuryEnabled, isAutoRevocationsEnabled)
 	if err != nil {
 		var cerr blockchain.RuleError

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -2250,7 +2250,7 @@ func TestFetchTransaction(t *testing.T) {
 		t.Fatalf("FetchTransaction: failed to retrieve tx: %v", err)
 	}
 
-	if ticket.Hash() != foundTx.Hash() {
+	if *ticket.Hash() != *foundTx.Hash() {
 		t.Fatalf("FetchTransaction: expected ticket %v "+
 			"but got %v", ticket.Hash(), foundTx.Hash())
 	}


### PR DESCRIPTION
~~**This is rebased on https://github.com/decred/dcrd/pull/2802.**~~

This updates the fraud proof data on transaction inputs as necessary when entering the mempool.  The fraud proof data will ultimately get filled in properly when miners create a block template.  However, ensuring that it is filled in properly when entering the mempool is beneficial so that it is correct when relaying the transaction or returning it from an RPC API.

Additionally, this updates mempool to now set the check fraud proof flag to true for `blockchain.CheckTransactionInputs` since mempool now ensures that the fraud proof is correct for all transaction inputs prior to this check.

Finally, this adds tests to validate that the fraud proof of transaction inputs is corrected as necessary when entering the mempool under a variety of conditions.
