### PR TITLE
stdscript: Add num required sigs support.

### DIFF
--- a/internal/staging/stdscript/script.go
+++ b/internal/staging/stdscript/script.go
@@ -525,3 +525,20 @@ func DetermineScriptType(scriptVersion uint16, script []byte) ScriptType {
 	// All scripts with newer versions are considered non standard.
 	return STNonStandard
 }
+
+// DetermineRequiredSigs attempts to identify the number of signatures required
+// by the passed script for the known standard types.
+//
+// NOTE: Version 0 scripts are the only currently supported version.  It will
+// always return 0 for other script versions.
+//
+// Similarly, 0 is returned when the script does not parse or is not one of the
+// known standard types.
+func DetermineRequiredSigs(scriptVersion uint16, script []byte) uint16 {
+	switch scriptVersion {
+	case 0:
+		return DetermineRequiredSigsV0(script)
+	}
+
+	return 0
+}

--- a/internal/staging/stdscript/script_bench_test.go
+++ b/internal/staging/stdscript/script_bench_test.go
@@ -333,6 +333,31 @@ func BenchmarkDetermineScriptType(b *testing.B) {
 	}
 }
 
+// BenchmarkDetermineRequiredSigs benchmarks the performance of determining the
+// required number of signatures for various public key scripts.
+func BenchmarkDetermineRequiredSigs(b *testing.B) {
+	counts := make(map[ScriptType]int)
+	benches := makeBenchmarks(func(test scriptTest) bool {
+		// Limit to one of each script type.
+		counts[test.wantType]++
+		return counts[test.wantType] == 1
+	})
+
+	for _, bench := range benches {
+		b.Run(bench.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				got := DetermineRequiredSigs(bench.version, bench.script)
+				if got != bench.wantSigs {
+					b.Fatalf("%q: unexpected result -- got %v, want %v",
+						bench.name, got, bench.wantSigs)
+				}
+			}
+		})
+	}
+}
+
 // BenchmarkExtractAtomicSwapDataPushes benchmarks the performance of
 // attempting to extract the atomic swap data pushes from various version 0
 // public key scripts.

--- a/internal/staging/stdscript/script_test.go
+++ b/internal/staging/stdscript/script_test.go
@@ -65,6 +65,7 @@ type scriptTest struct {
 	isSig    bool        // treat as a signature script instead
 	wantType ScriptType  // expected script type
 	wantData interface{} // expected extracted data when applicable
+	wantSigs uint16      // expected number of required signatures
 }
 
 // TestDetermineScriptType ensures a wide variety of scripts for various script
@@ -170,5 +171,52 @@ func TestDetermineScriptType(t *testing.T) {
 		// to be a signature script which consists of a pay-to-script-hash
 		// multi-signature redeem script.
 		testIsSigX(IsMultiSigSigScript, STMultiSig)
+	}
+}
+
+// TestDetermineRequiredSigs ensures a wide variety of scripts for various
+// script versions return the expected number of required signatures.
+func TestDetermineRequiredSigs(t *testing.T) {
+	t.Parallel()
+
+	// Specify the per-version tests to include in the overall tests here.
+	// This is done to make it easy to add independent tests for new script
+	// versions while still testing them all through the API that accepts a
+	// specific version versus the exported variant that is specific to a given
+	// version per its exported name.
+	//
+	// NOTE: Maintainers should add tests for new script versions following the
+	// way scriptV0Tests is handled and add the resulting per-version tests
+	// here.
+	perVersionTests := [][]scriptTest{
+		scriptV0Tests,
+	}
+
+	// Flatten all of the per-version tests into a single set of tests.
+	var tests []scriptTest
+	for _, bundle := range perVersionTests {
+		tests = append(tests, bundle...)
+	}
+
+	for _, test := range tests {
+		// Ensure that no signatures are required for unsupported script
+		// versions regardless.
+		const unsupportedScriptVer = 9999
+		gotReqSigs := DetermineRequiredSigs(unsupportedScriptVer, test.script)
+		if gotReqSigs != 0 {
+			t.Errorf("%q -- unsupported script version: mismatched required "+
+				"sigs -- got %d, want %d (script %x)", test.name, gotReqSigs,
+				0, test.script)
+			continue
+		}
+
+		// Ensure that the calculated required number of signatures matches the
+		// expected result.
+		gotReqSigs = DetermineRequiredSigs(test.version, test.script)
+		if !test.isSig && gotReqSigs != test.wantSigs {
+			t.Errorf("%q: mismatched required sigs -- got %d, want %d "+
+				"(script %x)", test.name, gotReqSigs, test.wantSigs, test.script)
+			continue
+		}
 	}
 }

--- a/internal/staging/stdscript/scriptv0_test.go
+++ b/internal/staging/stdscript/scriptv0_test.go
@@ -109,16 +109,19 @@ var scriptV0Tests = func() []scriptTest {
 		script:   p("DATA_65 0x%s CHECKSIG", pkUE),
 		wantType: STPubKeyEcdsaSecp256k1,
 		wantData: hexToBytes(pkUE),
+		wantSigs: 1,
 	}, {
 		name:     "v0 p2pk-ecdsa-secp256k1 compressed even",
 		script:   p("DATA_33 0x%s CHECKSIG", pkCE),
 		wantType: STPubKeyEcdsaSecp256k1,
 		wantData: hexToBytes(pkCE),
+		wantSigs: 1,
 	}, {
 		name:     "v0 p2pk-ecdsa-secp256k1 compressed odd",
 		script:   p("DATA_33 0x%s CHECKSIG", pkCO),
 		wantType: STPubKeyEcdsaSecp256k1,
 		wantData: hexToBytes(pkCO),
+		wantSigs: 1,
 	}, {
 		// ---------------------------------------------------------------------
 		// Negative P2PK Alt tests.
@@ -164,6 +167,7 @@ var scriptV0Tests = func() []scriptTest {
 		script:   p("DATA_32 0x%s 1 CHECKSIGALT", pkEd),
 		wantType: STPubKeyEd25519,
 		wantData: hexToBytes(pkEd),
+		wantSigs: 1,
 	}, {
 		// ---------------------------------------------------------------------
 		// Negative P2PK Schnorr secp256k1 tests.
@@ -201,11 +205,13 @@ var scriptV0Tests = func() []scriptTest {
 		script:   p("DATA_33 0x%s 2 CHECKSIGALT", pkCE),
 		wantType: STPubKeySchnorrSecp256k1,
 		wantData: hexToBytes(pkCE),
+		wantSigs: 1,
 	}, {
 		name:     "v0 p2pk-schnorr-secp256k1 compressed odd",
 		script:   p("DATA_33 0x%s 2 CHECKSIGALT", pkCO),
 		wantType: STPubKeySchnorrSecp256k1,
 		wantData: hexToBytes(pkCO),
+		wantSigs: 1,
 	}, {
 		// ---------------------------------------------------------------------
 		// Negative P2PKH ECDSA secp256k1 tests.
@@ -223,6 +229,7 @@ var scriptV0Tests = func() []scriptTest {
 		script:   p("DUP HASH160 DATA_20 0x%s EQUALVERIFY CHECKSIG", h160CE),
 		wantType: STPubKeyHashEcdsaSecp256k1,
 		wantData: hexToBytes(h160CE),
+		wantSigs: 1,
 	}, {
 		// ---------------------------------------------------------------------
 		// Negative P2PKH Alt tests.
@@ -266,6 +273,7 @@ var scriptV0Tests = func() []scriptTest {
 			h160Ed),
 		wantType: STPubKeyHashEd25519,
 		wantData: hexToBytes(h160Ed),
+		wantSigs: 1,
 	}, {
 		// ---------------------------------------------------------------------
 		// Negative P2PKH Schnorr secp256k1 tests.
@@ -285,12 +293,14 @@ var scriptV0Tests = func() []scriptTest {
 			h160CE),
 		wantType: STPubKeyHashSchnorrSecp256k1,
 		wantData: hexToBytes(h160CE),
+		wantSigs: 1,
 	}, {
 		name: "v0 p2pkh-schnorr-secp256k1 2",
 		script: p("DUP HASH160 DATA_20 0x%s EQUALVERIFY 2 CHECKSIGALT",
 			h160CE2),
 		wantType: STPubKeyHashSchnorrSecp256k1,
 		wantData: hexToBytes(h160CE2),
+		wantSigs: 1,
 	}, {
 		// ---------------------------------------------------------------------
 		// Negative P2SH tests.
@@ -312,6 +322,7 @@ var scriptV0Tests = func() []scriptTest {
 		script:   p("HASH160 DATA_20 0x%s EQUAL", p2sh),
 		wantType: STScriptHash,
 		wantData: hexToBytes(p2sh),
+		wantSigs: 1,
 	}, {
 		// ---------------------------------------------------------------------
 		// Negative ECDSA multisig secp256k1 tests.
@@ -390,6 +401,7 @@ var scriptV0Tests = func() []scriptTest {
 			PubKeys:      [][]byte{hexToBytes(pkCE)},
 			Valid:        true,
 		},
+		wantSigs: 1,
 	}, {
 		name:     "v0 multisig 1-of-2 compressed pubkeys",
 		script:   p("1 DATA_33 0x%s DATA_33 0x%s 2 CHECKMULTISIG", pkCE, pkCE2),
@@ -400,6 +412,7 @@ var scriptV0Tests = func() []scriptTest {
 			PubKeys:      [][]byte{hexToBytes(pkCE), hexToBytes(pkCE2)},
 			Valid:        true,
 		},
+		wantSigs: 1,
 	}, {
 		name: "v0 multisig 2-of-3 compressed pubkeys",
 		script: p("2 DATA_33 0x%s DATA_33 0x%s DATA_33 0x%s 3 CHECKMULTISIG",
@@ -413,6 +426,7 @@ var scriptV0Tests = func() []scriptTest {
 			},
 			Valid: true,
 		},
+		wantSigs: 2,
 	}, {
 		// ---------------------------------------------------------------------
 		// Negative ECDSA multisig secp256k1 redeem script tests.
@@ -539,6 +553,7 @@ var scriptV0Tests = func() []scriptTest {
 		script:   p("SSTX DUP HASH160 DATA_20 0x%s EQUALVERIFY CHECKSIG", h160CE),
 		wantType: STStakeSubmissionPubKeyHash,
 		wantData: hexToBytes(h160CE),
+		wantSigs: 1,
 	}, {
 		// ---------------------------------------------------------------------
 		// Negative stake submission P2SH tests.
@@ -556,6 +571,7 @@ var scriptV0Tests = func() []scriptTest {
 		script:   p("SSTX HASH160 DATA_20 0x%s EQUAL", p2sh),
 		wantType: STStakeSubmissionScriptHash,
 		wantData: hexToBytes(p2sh),
+		wantSigs: 1,
 	}, {
 		// ---------------------------------------------------------------------
 		// Negative stake submission generation P2PKH tests.
@@ -575,6 +591,7 @@ var scriptV0Tests = func() []scriptTest {
 			h160CE),
 		wantType: STStakeGenPubKeyHash,
 		wantData: hexToBytes(h160CE),
+		wantSigs: 1,
 	}, {
 		// ---------------------------------------------------------------------
 		// Negative stake submission generation P2SH tests.
@@ -592,6 +609,7 @@ var scriptV0Tests = func() []scriptTest {
 		script:   p("SSGEN HASH160 DATA_20 0x%s EQUAL", p2sh),
 		wantType: STStakeGenScriptHash,
 		wantData: hexToBytes(p2sh),
+		wantSigs: 1,
 	}, {
 		// ---------------------------------------------------------------------
 		// Negative stake submission revocation P2PKH tests.
@@ -611,6 +629,7 @@ var scriptV0Tests = func() []scriptTest {
 			h160CE),
 		wantType: STStakeRevocationPubKeyHash,
 		wantData: hexToBytes(h160CE),
+		wantSigs: 1,
 	}, {
 		// ---------------------------------------------------------------------
 		// Negative stake submission revocation P2SH tests.
@@ -628,6 +647,7 @@ var scriptV0Tests = func() []scriptTest {
 		script:   p("SSRTX HASH160 DATA_20 0x%s EQUAL", p2sh),
 		wantType: STStakeRevocationScriptHash,
 		wantData: hexToBytes(p2sh),
+		wantSigs: 1,
 	}, {
 		// ---------------------------------------------------------------------
 		// Negative stake submission change P2PKH tests.
@@ -647,6 +667,7 @@ var scriptV0Tests = func() []scriptTest {
 			h160CE),
 		wantType: STStakeChangePubKeyHash,
 		wantData: hexToBytes(h160CE),
+		wantSigs: 1,
 	}, {
 		// ---------------------------------------------------------------------
 		// Negative stake submission change P2SH tests.
@@ -664,6 +685,7 @@ var scriptV0Tests = func() []scriptTest {
 		script:   p("SSTXCHANGE HASH160 DATA_20 0x%s EQUAL", p2sh),
 		wantType: STStakeChangeScriptHash,
 		wantData: hexToBytes(p2sh),
+		wantSigs: 1,
 	}, {
 		// ---------------------------------------------------------------------
 		// Negative treasury add tests.
@@ -703,6 +725,7 @@ var scriptV0Tests = func() []scriptTest {
 			h160CE),
 		wantType: STTreasuryGenPubKeyHash,
 		wantData: hexToBytes(h160CE),
+		wantSigs: 1,
 	}, {
 		// ---------------------------------------------------------------------
 		// Negative treasury generation P2SH tests.
@@ -720,6 +743,7 @@ var scriptV0Tests = func() []scriptTest {
 		script:   p("TGEN HASH160 DATA_20 0x%s EQUAL", p2sh),
 		wantType: STTreasuryGenScriptHash,
 		wantData: hexToBytes(p2sh),
+		wantSigs: 1,
 	}}
 }()
 

--- a/txscript/script.go
+++ b/txscript/script.go
@@ -293,7 +293,6 @@ func removeOpcodeByData(script []byte, dataToRemove []byte) []byte {
 // AsSmallInt returns the passed opcode, which MUST be true according to the
 // IsSmallInt function, as an integer.
 //
-//
 // NOTE: This function is only valid for version 0 opcodes.  Since the function
 // does not accept a script version, the results are undefined for other script
 // versions.


### PR DESCRIPTION
**This is rebased on #2803**.

This adds support to the `stdscript` package for determining the number of signatures required by a given script version and script for the known standard  types along with an implementation for version 0 scripts.

Full test coverage is included.

Note that this functionality is currently part of `txscript.ExtractPkScriptAddrs`, but that is going to be removed in favor of the new `stdscript` package in upcoming PRs so it needs to be made available prior to that.

Aside from that, the primary reasons for splitting it out from address extraction are:

- The number of required signatures is only used in a small number of cases, specifically for RPC results and signing, while all the other cases end up ignoring it
- Providing separate analysis methods results in an API that is better able to deal with multiple script versions without requiring major module version bumps

```
BenchmarkDetermineRequiredSigs
------------------------------
v0_complex_non_standard                        31580193    33.47 ns/op   0 B/op   0 allocs/op
malformed_v0_script_that_does_not_parse        35297439    33.45 ns/op   0 B/op   0 allocs/op
v0_p2pk-ecdsa-secp256k1_uncompressed          135813928     8.72 ns/op   0 B/op   0 allocs/op
v0_p2pk-ed25519                               100000000    11.17 ns/op   0 B/op   0 allocs/op
v0_p2pk-schnorr-secp256k1_compressed_even      68248903    17.14 ns/op   0 B/op   0 allocs/op
v0_p2pkh-ecdsa-secp256k1                       85467650    14.27 ns/op   0 B/op   0 allocs/op
v0_p2pkh-ed25519                               54437568    21.10 ns/op   0 B/op   0 allocs/op
v0_p2pkh-schnorr-secp256k1                     49283944    24.22 ns/op   0 B/op   0 allocs/op
v0_p2sh                                        58491218    19.14 ns/op   0 B/op   0 allocs/op
v0_multisig_1-of-1_compressed_pubkey           10233825   118.70 ns/op   0 B/op   0 allocs/op
v0_nulldata_no_data_push                       42779635    26.65 ns/op   0 B/op   0 allocs/op
v0_stake_submission_p2pkh-ecdsa-secp256k1      41388444    27.88 ns/op   0 B/op   0 allocs/op
v0_stake_submission_p2sh                       40624120    29.19 ns/op   0 B/op   0 allocs/op
v0_stake_gen_p2pkh-ecdsa-secp256k1             39675847    29.56 ns/op   0 B/op   0 allocs/op
v0_stake_gen_p2sh                              35297232    30.90 ns/op   0 B/op   0 allocs/op
v0_stake_revoke_p2pkh-ecdsa-secp256k1          38717295    30.44 ns/op   0 B/op   0 allocs/op
v0_stake_revoke_p2sh                           36837500    33.05 ns/op   0 B/op   0 allocs/op
v0_stake_change_p2pkh-ecdsa-secp256k1          36365949    32.56 ns/op   0 B/op   0 allocs/op
v0_stake_change_p2sh                           35291002    34.11 ns/op   0 B/op   0 allocs/op
v0_treasury_add                                37483249    32.74 ns/op   0 B/op   0 allocs/op
v0_treasury_generation_p2pkh-ecdsa-secp256k1   34267209    34.95 ns/op   0 B/op   0 allocs/op
v0_treasury_generation_p2sh                    33676647    35.41 ns/op   0 B/op   0 allocs/op
```
