### PR TITLE
netsync: Remove unused RpcServer.

### DIFF
--- a/internal/netsync/manager.go
+++ b/internal/netsync/manager.go
@@ -23,7 +23,6 @@ import (
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/internal/mempool"
 	"github.com/decred/dcrd/internal/progresslog"
-	"github.com/decred/dcrd/internal/rpcserver"
 	peerpkg "github.com/decred/dcrd/peer/v3"
 	"github.com/decred/dcrd/wire"
 )
@@ -1742,10 +1741,6 @@ type Config struct {
 
 	// TxMemPool specifies the mempool to use for processing transactions.
 	TxMemPool *mempool.TxPool
-
-	// RpcServer returns an instance of an RPC server to use for notifications.
-	// It may return nil if there is no active RPC server.
-	RpcServer func() *rpcserver.Server
 
 	// NoMiningStateSync indicates whether or not the sync manager should
 	// perform an initial mining state synchronization with peers once they are

--- a/server.go
+++ b/server.go
@@ -3637,14 +3637,11 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB,
 		srvrLog.Info("Checkpoints are disabled")
 	}
 	s.syncManager = netsync.New(&netsync.Config{
-		PeerNotifier: &s,
-		Chain:        s.chain,
-		ChainParams:  s.chainParams,
-		TimeSource:   s.timeSource,
-		TxMemPool:    s.txMemPool,
-		RpcServer: func() *rpcserver.Server {
-			return s.rpcServer
-		},
+		PeerNotifier:          &s,
+		Chain:                 s.chain,
+		ChainParams:           s.chainParams,
+		TimeSource:            s.timeSource,
+		TxMemPool:             s.txMemPool,
 		NoMiningStateSync:     cfg.NoMiningStateSync,
 		MaxPeers:              cfg.MaxPeers,
 		MaxOrphanTxs:          cfg.MaxOrphanTxs,


### PR DESCRIPTION
This removes the `RpcServer` config option from the `internal/netsync` package since it is no longer used.
