### PR TITLE
netsync: Request init state immediately upon sync.

### DIFF
--- a/internal/netsync/manager.go
+++ b/internal/netsync/manager.go
@@ -502,6 +502,14 @@ func (m *SyncManager) startSync() {
 	}
 }
 
+// onInitialChainSyncDone is invoked when the initial chain sync process
+// completes.
+func (m *SyncManager) onInitialChainSyncDone() {
+	best := m.cfg.Chain.BestSnapshot()
+	log.Infof("Initial chain sync complete (hash %s, height %d)",
+		best.Hash, best.Height)
+}
+
 // isSyncCandidate returns whether or not the peer is a candidate to consider
 // syncing from.
 func (m *SyncManager) isSyncCandidate(peer *peerpkg.Peer) bool {
@@ -791,9 +799,7 @@ func (m *SyncManager) handleBlockMsg(bmsg *blockMsg) {
 		forceLog := int64(header.Height) >= m.SyncHeight()
 		m.progressLogger.LogProgress(msgBlock, forceLog, chain.VerifyProgress)
 		if chain.IsCurrent() {
-			best := chain.BestSnapshot()
-			log.Infof("Initial chain sync complete (hash %s, height %d)",
-				best.Hash, best.Height)
+			m.onInitialChainSyncDone()
 		}
 	} else {
 		var interval string
@@ -1103,9 +1109,7 @@ func (m *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 			chain.MaybeUpdateIsCurrent()
 			isChainCurrent = chain.IsCurrent()
 			if isChainCurrent {
-				best := chain.BestSnapshot()
-				log.Infof("Initial chain sync complete (hash %s, height %d)",
-					best.Hash, best.Height)
+				m.onInitialChainSyncDone()
 			}
 		}
 	}


### PR DESCRIPTION
This modifies the logic that requests the initial state to happen immediately when the initial chain sync process is complete as opposed to the existing approach that uses a separate goroutine with polling on a 3 second interval.

This approach is more efficient since it avoids extra goroutines and it also allows obtaining initial data, most notably pending treasury spend transactions and votes for the current best block, more quickly.
