### PR TITLE
stdscript: Add consolidated stake extracts.

### DIFF
--- a/txscript/stdscript/scriptv0.go
+++ b/txscript/stdscript/scriptv0.go
@@ -700,6 +700,29 @@ func IsTreasuryGenScriptHashScriptV0(script []byte) bool {
 	return ExtractTreasuryGenScriptHashV0(script) != nil
 }
 
+// ExtractStakeScriptHashV0 extracts the script hash from the passed script if
+// it is any one of the supported standard version 0 stake-tagged
+// pay-to-script-hash scripts.  It will return nil otherwise.
+func ExtractStakeScriptHashV0(script []byte) []byte {
+	if h := ExtractStakeSubmissionScriptHashV0(script); h != nil {
+		return h
+	}
+	if h := ExtractStakeGenScriptHashV0(script); h != nil {
+		return h
+	}
+	if h := ExtractStakeRevocationScriptHashV0(script); h != nil {
+		return h
+	}
+	if h := ExtractStakeChangeScriptHashV0(script); h != nil {
+		return h
+	}
+	if h := ExtractTreasuryGenScriptHashV0(script); h != nil {
+		return h
+	}
+
+	return nil
+}
+
 // DetermineScriptTypeV0 returns the type of the passed version 0 script for
 // the known standard types.  This includes both types that are required by
 // consensus as well as those which are not.

--- a/txscript/stdscript/scriptv0.go
+++ b/txscript/stdscript/scriptv0.go
@@ -494,8 +494,8 @@ func extractStakePubKeyHashV0(script []byte, stakeOpcode byte) []byte {
 	return ExtractPubKeyHashV0(script[1:])
 }
 
-// ExtractStakeSubmissionPubKeyHashV0 extracts the public key hash from
-// the passed script if it is a standard version 0 stake submission
+// ExtractStakeSubmissionPubKeyHashV0 extracts the public key hash from the
+// passed script if it is a standard version 0 stake submission
 // pay-to-pubkey-hash script.  It will return nil otherwise.
 func ExtractStakeSubmissionPubKeyHashV0(script []byte) []byte {
 	// A stake submission pay-to-pubkey-hash script is of the form:
@@ -508,6 +508,29 @@ func ExtractStakeSubmissionPubKeyHashV0(script []byte) []byte {
 // is a standard version 0 stake submission pay-to-pubkey-hash script.
 func IsStakeSubmissionPubKeyHashScriptV0(script []byte) bool {
 	return ExtractStakeSubmissionPubKeyHashV0(script) != nil
+}
+
+// ExtractStakePubKeyHashV0 extracts the public key hash from the passed script
+// if it is any one of the supported standard version 0 stake-tagged
+// pay-to-pubkey-hash scripts.  It will return nil otherwise.
+func ExtractStakePubKeyHashV0(script []byte) []byte {
+	if h := ExtractStakeSubmissionPubKeyHashV0(script); h != nil {
+		return h
+	}
+	if h := ExtractStakeGenPubKeyHashV0(script); h != nil {
+		return h
+	}
+	if h := ExtractStakeRevocationPubKeyHashV0(script); h != nil {
+		return h
+	}
+	if h := ExtractStakeChangePubKeyHashV0(script); h != nil {
+		return h
+	}
+	if h := ExtractTreasuryGenPubKeyHashV0(script); h != nil {
+		return h
+	}
+
+	return nil
 }
 
 // extractStakeScriptHashV0 extracts the script hash from the passed script if

--- a/txscript/stdscript/scriptv0_bench_test.go
+++ b/txscript/stdscript/scriptv0_bench_test.go
@@ -34,3 +34,29 @@ func BenchmarkExtractStakePubKeyHashV0(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkExtractStakeScriptHashV0 benchmarks the performance of attempting to
+// extract script hashes from various version 0 stake-tagged public key scripts.
+func BenchmarkExtractStakeScriptHashV0(b *testing.B) {
+	counts := make(map[ScriptType]int)
+	benches := makeBenchmarks(func(test scriptTest) bool {
+		// Limit to one of each script type.
+		counts[test.wantType]++
+		return counts[test.wantType] == 1 &&
+			(test.wantType == STStakeSubmissionScriptHash ||
+				test.wantType == STStakeGenScriptHash ||
+				test.wantType == STStakeRevocationScriptHash ||
+				test.wantType == STStakeChangeScriptHash ||
+				test.wantType == STTreasuryGenScriptHash)
+	})
+
+	for _, bench := range benches {
+		b.Run(bench.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				ExtractStakeScriptHashV0(bench.script)
+			}
+		})
+	}
+}

--- a/txscript/stdscript/scriptv0_bench_test.go
+++ b/txscript/stdscript/scriptv0_bench_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package stdscript
+
+import (
+	"testing"
+)
+
+// BenchmarkExtractStakePubKeyHashV0 benchmarks the performance of attempting to
+// extract public key hashes from various version 0 stake-tagged public key
+// scripts.
+func BenchmarkExtractStakePubKeyHashV0(b *testing.B) {
+	counts := make(map[ScriptType]int)
+	benches := makeBenchmarks(func(test scriptTest) bool {
+		// Limit to one of each script type.
+		counts[test.wantType]++
+		return counts[test.wantType] == 1 &&
+			(test.wantType == STStakeSubmissionPubKeyHash ||
+				test.wantType == STStakeGenPubKeyHash ||
+				test.wantType == STStakeRevocationPubKeyHash ||
+				test.wantType == STStakeChangePubKeyHash ||
+				test.wantType == STTreasuryGenPubKeyHash)
+	})
+
+	for _, bench := range benches {
+		b.Run(bench.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				ExtractStakePubKeyHashV0(bench.script)
+			}
+		})
+	}
+}

--- a/txscript/stdscript/scriptv0_test.go
+++ b/txscript/stdscript/scriptv0_test.go
@@ -1368,6 +1368,31 @@ func TestExtractStakePubKeyHashV0(t *testing.T) {
 	}
 }
 
+// TestExtractStakeScriptHashV0 ensures that extracting a script hash from the
+// supported standard version 0 stake-tagged pay-to-script-hash scripts works as
+// intended for all of the version 0 test scripts.
+func TestExtractStakeScriptHashV0(t *testing.T) {
+	for _, test := range scriptV0Tests {
+		// Determine the expected data based on the expected script type and
+		// data specified in the test.
+		var want []byte
+		switch test.wantType {
+		case STStakeSubmissionScriptHash, STStakeGenScriptHash,
+			STStakeRevocationScriptHash, STStakeChangeScriptHash,
+			STTreasuryGenScriptHash:
+
+			want = asByteSlice(t, test)
+		}
+
+		got := ExtractStakeScriptHashV0(test.script)
+		if !bytes.Equal(got, want) {
+			t.Errorf("%q: unexpected script hash -- got %x, want %x", test.name,
+				got, want)
+			continue
+		}
+	}
+}
+
 // TestProvablyPruneableScriptV0 ensures generating a version 0
 // provably-pruneable nulldata script works as intended.
 func TestProvablyPruneableScriptV0(t *testing.T) {

--- a/txscript/stdscript/scriptv0_test.go
+++ b/txscript/stdscript/scriptv0_test.go
@@ -1343,6 +1343,31 @@ func TestExtractTreasuryGenScriptHashV0(t *testing.T) {
 	}
 }
 
+// TestExtractStakePubKeyHashV0 ensures that extracting a public key hash from
+// the supported standard version 0 stake-tagged pay-to-pubkey-hash scripts
+// works as intended for all of the version 0 test scripts.
+func TestExtractStakePubKeyHashV0(t *testing.T) {
+	for _, test := range scriptV0Tests {
+		// Determine the expected data based on the expected script type and
+		// data specified in the test.
+		var want []byte
+		switch test.wantType {
+		case STStakeSubmissionPubKeyHash, STStakeGenPubKeyHash,
+			STStakeRevocationPubKeyHash, STStakeChangePubKeyHash,
+			STTreasuryGenPubKeyHash:
+
+			want = asByteSlice(t, test)
+		}
+
+		got := ExtractStakePubKeyHashV0(test.script)
+		if !bytes.Equal(got, want) {
+			t.Errorf("%q: unexpected script hash -- got %x, want %x", test.name,
+				got, want)
+			continue
+		}
+	}
+}
+
 // TestProvablyPruneableScriptV0 ensures generating a version 0
 // provably-pruneable nulldata script works as intended.
 func TestProvablyPruneableScriptV0(t *testing.T) {


### PR DESCRIPTION
This adds support for extracting the public key and script hashes from version 0 scripts that are any of of the standard types usable in the staking system along with associated tests and benchmarks.

Namely, it adds

* `ExtractStakePubKeyHashV0`
* `ExtractStakeScriptHashV0`

While all of the data can be extracted from each individual type, it can be more convenient for callers who treat all types of script hashes and/or public key hashes as the same entity which is the case for many applications.

```
BenchmarkExtractStakeScriptHashV0
---------------------------------
v0_complex_non_standard       226793582   5.253 ns/op
v0_stake_submission_p2sh      372232682   3.233 ns/op
v0_stake_gen_p2sh             305602378   3.979 ns/op
v0_stake_revoke_p2sh          201691552   5.064 ns/op
v0_stake_change_p2sh          209401243   5.687 ns/op
v0_treasury_generation_p2sh   221794405   5.419 ns/op

BenchmarkExtractStakePubKeyHashV0
---------------------------------
v0_complex_non_standard-16                        229676676   5.139 ns/op
v0_stake_submission_p2pkh-ecdsa-secp256k1-16      335241789   3.531 ns/op
v0_stake_gen_p2pkh-ecdsa-secp256k1-16             268142942   4.517 ns/op
v0_stake_revoke_p2pkh-ecdsa-secp256k1-16          244045095   4.908 ns/op
v0_stake_change_p2pkh-ecdsa-secp256k1-16          220275314   5.441 ns/op
v0_treasury_generation_p2pkh-ecdsa-secp256k1-16   197104339   6.086 ns/op
```