### PR TITLE
netsync: Rework next block download logic.

### DIFF
--- a/blockchain/chainview.go
+++ b/blockchain/chainview.go
@@ -323,13 +323,13 @@ func (c *chainView) findFork(node *blockNode) *blockNode {
 }
 
 // FindFork returns the final common block between the provided node and the
-// the chain view.  It will return nil if there is no common block.
+// chain view.  It will return nil if there is no common block.
 //
 // For example, assume a block chain with a side chain as depicted below:
 //   genesis -> 1 -> 2 -> ... -> 5 -> 6  -> 7  -> 8
 //                                \-> 6a -> 7a
 //
-// Further, assume the view is for the longer chain depicted above.  That is to
+// Further, assume the view is for the longer branch depicted above.  That is to
 // say it consists of:
 //   genesis -> 1 -> 2 -> ... -> 5 -> 6 -> 7 -> 8.
 //


### PR DESCRIPTION
Currently, the next blocks that need to be downloaded are determined in blockchain and returned via a new slice by using a lookahead method along with allowing the caller to specify a map of blocks to exclude for the blocks that have already been requested.

While this method works fine for a single peer, it does not lend itself well to parallel block downloads.  Further, the lookahead mechanism imposes an artificial limit on the number of outstanding requests which is not something that it should be concerned with and it also is not particularly efficient since it results in new allocations every time it is queried.

Consequently, this reworks the logic such that the function in `blockchain` accepts a backing array from the caller that is populated via an allocation-free windowing mechanism and the sync manager now maintains that array along with additional logic to detect when to update it.  Not only is the new approach quite a bit more efficient, it removes the artificial limits on outstanding requests so they can be tuned as needed by the sync manager.