### PR TITLE
stake: Rename func to identify stake cmtmnt output.

### DIFF
--- a/blockchain/stake/staketx.go
+++ b/blockchain/stake/staketx.go
@@ -1284,13 +1284,13 @@ func DetermineTxType(tx *wire.MsgTx, isTreasuryEnabled,
 	return TxTypeRegular
 }
 
-// IsStakeSubmissionTxOut indicates whether the txOut identified by the
-// given index is a stake submission output. Stake Submission outputs are
-// the odd-numbered outputs of an SStx transaction.
+// IsStakeCommitmentTxOut indicates whether the transaction output identified by
+// the given index is a stake commitment output of a stake submission (aka
+// ticket) transaction.  Stake commitment outputs are the odd-numbered outputs.
 //
-// This function is only safe to be called on a transaction that
-// has passed IsSStx.
-func IsStakeSubmissionTxOut(index int) bool {
+// This function is only safe to be called on a transaction that has passed
+// IsSStx.
+func IsStakeCommitmentTxOut(index int) bool {
 	return (index % 2) != 0
 }
 


### PR DESCRIPTION
This renames `IsStakeSubmissionTxOut` to `IsStakeCommitmentTxOut` to help avoid ambiguity with the actual "stakesubmission" output which is only the 0th output of a stake submission transaction.

See #2824 for further context.