### PR TITLE
netsync/rpcserver: Submit transactions directly.

### DIFF
--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -2237,10 +2237,10 @@ func TestHandleCreateRawSStx(t *testing.T) {
 func TestHandleCreateRawSSRtx(t *testing.T) {
 	t.Parallel()
 
-	defaultTxId := "1189cbe656c2ef1e0fcb91f107624d9aa8f0db7b28e6a86f694a4cf49abc5e39"
+	defaultTxID := "1189cbe656c2ef1e0fcb91f107624d9aa8f0db7b28e6a86f694a4cf49abc5e39"
 	defaultCmdInputs := []types.TransactionInput{{
 		Amount: 1,
-		Txid:   defaultTxId,
+		Txid:   defaultTxID,
 		Vout:   0,
 		Tree:   1,
 	}}
@@ -2378,7 +2378,7 @@ func TestHandleCreateRawSSRtx(t *testing.T) {
 		cmd: &types.CreateRawSSRtxCmd{
 			Inputs: []types.TransactionInput{{
 				Amount: 1,
-				Txid:   defaultTxId,
+				Txid:   defaultTxID,
 				Vout:   1,
 				Tree:   1,
 			}},
@@ -2393,7 +2393,7 @@ func TestHandleCreateRawSSRtx(t *testing.T) {
 		cmd: &types.CreateRawSSRtxCmd{
 			Inputs: []types.TransactionInput{{
 				Amount: 100,
-				Txid:   defaultTxId,
+				Txid:   defaultTxID,
 				Vout:   0,
 				Tree:   1,
 			}},
@@ -2464,7 +2464,7 @@ func TestHandleCreateRawSSRtx(t *testing.T) {
 		cmd: &types.CreateRawSSRtxCmd{
 			Inputs: []types.TransactionInput{{
 				Amount: 100,
-				Txid:   defaultTxId,
+				Txid:   defaultTxID,
 				Vout:   0,
 				Tree:   0,
 			}},
@@ -2478,7 +2478,7 @@ func TestHandleCreateRawSSRtx(t *testing.T) {
 		cmd: &types.CreateRawSSRtxCmd{
 			Inputs: []types.TransactionInput{{
 				Amount: math.Inf(1),
-				Txid:   defaultTxId,
+				Txid:   defaultTxID,
 				Vout:   0,
 				Tree:   1,
 			}},

--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -351,7 +351,8 @@ func (b *rpcSyncMgr) SyncHeight() int64 {
 // into the memory pool.
 func (b *rpcSyncMgr) ProcessTransaction(tx *dcrutil.Tx, allowOrphans bool,
 	rateLimit bool, allowHighFees bool, tag mempool.Tag) ([]*dcrutil.Tx, error) {
-	return b.syncMgr.ProcessTransaction(tx, allowOrphans,
+
+	return b.server.txMemPool.ProcessTransaction(tx, allowOrphans,
 		rateLimit, allowHighFees, tag)
 }
 


### PR DESCRIPTION
This modifies the adaptor that the RPC server uses for transaction submission to process the transaction directly instead of piping through the `netsync` package.  There is no longer any reason to incur the extra overhead since the `mempool` is concurrent safe the initial reasons for piping it through `netsync` no longer apply.  This can be seen by noting that the net sync manager doesn't do anything except call the `mempool` method.

It also address a lint complaint and removes the code related to submitting transactions through the network sync manager since it is no longer used.
