### PR TITLE
multi: avoid sending spend nftns via goroutines.

### DIFF
--- a/internal/blockchain/agendas_test.go
+++ b/internal/blockchain/agendas_test.go
@@ -181,7 +181,8 @@ func TestFixedSequenceLocks(t *testing.T) {
 	params = cloneParams(params)
 
 	// Create a test harness initialized with the genesis block as the tip.
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// ---------------------------------------------------------------------
 	// Generate and accept enough blocks to reach stake validation height.

--- a/internal/blockchain/chain.go
+++ b/internal/blockchain/chain.go
@@ -2483,9 +2483,14 @@ func New(ctx context.Context, config *Config) (*BlockChain, error) {
 
 	best := b.BestSnapshot()
 	tipHeight := uint32(best.Height)
-	b.spendPruner, err = spendpruner.NewSpendJournalPruner(b.db,
-		b.BatchRemoveSpendEntry, tipHeight, spendpruner.BatchPruneInterval,
-		spendpruner.DependencyPruneInterval)
+	cfg := &spendpruner.SpendJournalPrunerConfig{
+		DB:                      b.db,
+		BatchRemoveSpendEntry:   b.BatchRemoveSpendEntry,
+		BatchPruneInterval:      spendpruner.BatchPruneInterval,
+		DependencyPruneInterval: spendpruner.DependencyPruneInterval,
+		BlockHeightByHash:       b.BlockHeightByHash,
+	}
+	b.spendPruner, err = spendpruner.NewSpendJournalPruner(cfg, tipHeight)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/blockchain/chain_test.go
+++ b/internal/blockchain/chain_test.go
@@ -74,11 +74,13 @@ func TestBlockchainFunctions(t *testing.T) {
 	params.GenesisHash = params.GenesisBlock.BlockHash()
 
 	// Create a new database and chain instance to run tests against.
-	chain, err := chainSetup(t, params)
+	chain, startupFunc, err := chainSetup(t, params)
 	if err != nil {
 		t.Errorf("Failed to setup chain instance: %v", err)
 		return
 	}
+
+	startupFunc()
 
 	// Load up the rest of the blocks up to HEAD~1.
 	filename := filepath.Join("testdata", "blocks0to168.bz2")
@@ -149,7 +151,8 @@ func TestBlockchainFunctions(t *testing.T) {
 func TestForceHeadReorg(t *testing.T) {
 	// Create a test harness initialized with the genesis block as the tip.
 	params := chaincfg.RegNetParams()
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// Define some additional convenience helper functions to process the
 	// current tip block associated with the generator.

--- a/internal/blockchain/fullblocks_test.go
+++ b/internal/blockchain/fullblocks_test.go
@@ -167,10 +167,12 @@ func TestFullBlocks(t *testing.T) {
 	}
 
 	// Create a new database and chain instance to run tests against.
-	chain, err := chainSetup(t, chaincfg.RegNetParams())
+	chain, startupFunc, err := chainSetup(t, chaincfg.RegNetParams())
 	if err != nil {
 		t.Fatalf("Failed to setup chain instance: %v", err)
 	}
+
+	startupFunc()
 
 	// testAcceptedBlock attempts to process the block in the provided test
 	// instance and ensures that it was accepted according to the flags

--- a/internal/blockchain/fullblocksstakeversion_test.go
+++ b/internal/blockchain/fullblocksstakeversion_test.go
@@ -17,7 +17,8 @@ import (
 func TestStakeVersion(t *testing.T) {
 	// Create a test harness initialized with the genesis block as the tip.
 	params := chaincfg.RegNetParams()
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// Shorter versions of useful params for convenience.
 	ticketsPerBlock := params.TicketsPerBlock

--- a/internal/blockchain/process.go
+++ b/internal/blockchain/process.go
@@ -679,6 +679,10 @@ func (b *BlockChain) InvalidateBlock(hash *chainhash.Hash) error {
 		return unknownBlockError(hash)
 	}
 
+	// Update the tip of the invalidate/reconsider spend journal consumer
+	// to ensure it requires all the blocks to be disconnected.
+	b.invalidateSpendConsumer.UpdateTip(&b.BestSnapshot().Hash)
+
 	// Disallow invalidation of the genesis block.
 	if node.height == 0 {
 		str := "invalidating the genesis block is not allowed"
@@ -923,5 +927,10 @@ func (b *BlockChain) ReconsiderBlock(hash *chainhash.Hash) error {
 	b.index.Lock()
 	b.index.pruneCachedTips(b.bestChain.Tip())
 	b.index.Unlock()
+
+	// Update the tip of the invalidate/reconsider spend journal consumer
+	// to ensure it no longer requires all the reconnected blocks.
+	b.invalidateSpendConsumer.UpdateTip(&b.BestSnapshot().Hash)
+
 	return err
 }

--- a/internal/blockchain/process_test.go
+++ b/internal/blockchain/process_test.go
@@ -29,7 +29,8 @@ var (
 func TestProcessOrder(t *testing.T) {
 	// Create a test harness initialized with the genesis block as the tip.
 	params := chaincfg.RegNetParams()
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// Shorter versions of useful params for convenience.
 	coinbaseMaturity := params.CoinbaseMaturity
@@ -218,7 +219,8 @@ func genSharedProcessTestBlocks(t *testing.T) *chaingen.Generator {
 	// Create a new database and chain instance needed to create the generator
 	// populated with the desired blocks.
 	params := chaincfg.RegNetParams()
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// Shorter versions of useful params for convenience.
 	coinbaseMaturity := params.CoinbaseMaturity
@@ -527,7 +529,8 @@ func TestProcessLogic(t *testing.T) {
 	sharedGen := genSharedProcessTestBlocks(t)
 
 	// Create a new database and chain instance to run tests against.
-	g := newChaingenHarnessWithGen(t, sharedGen)
+	g, startupFunc := newChaingenHarnessWithGen(t, sharedGen)
+	startupFunc()
 
 	// Shorter versions of useful params for convenience.
 	params := g.Params()
@@ -1179,7 +1182,8 @@ func TestInvalidateReconsider(t *testing.T) {
 	sharedGen := genSharedProcessTestBlocks(t)
 
 	// Create a new database and chain instance to run tests against.
-	g := newChaingenHarnessWithGen(t, sharedGen)
+	g, startupFunc := newChaingenHarnessWithGen(t, sharedGen)
+	startupFunc()
 
 	// Shorter versions of useful params for convenience.
 	params := g.Params()
@@ -1881,7 +1885,8 @@ func TestAssumeValid(t *testing.T) {
 	params.TargetTimePerBlock = time.Hour * 24
 
 	// Create a test harness initialized with the genesis block as the tip.
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// Calculate the expected number of blocks in 2 weeks.
 	const timeInTwoWeeks = time.Hour * 24 * 14

--- a/internal/blockchain/spendpruner/db.go
+++ b/internal/blockchain/spendpruner/db.go
@@ -6,6 +6,7 @@ package spendpruner
 
 import (
 	"bytes"
+	"encoding/binary"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/database/v3"
@@ -18,9 +19,9 @@ const (
 )
 
 var (
-	// spendConsumerDepsBucketName is the name of the bucket used in storing
-	// spend journal consumer dependencies.
-	spendConsumerDepsBucketName = []byte("spendconsumerdeps")
+	// spendJournalHeightsBucketName is the name of the bucket used in
+	// storing spend journal heights.
+	spendJournalHeightsBucketName = []byte("spendheights")
 )
 
 // initConsumerDepsBucket creates the spend consumer dependencies bucket if it
@@ -34,9 +35,17 @@ func initConsumerDepsBucket(db database.DB) error {
 	})
 }
 
-// serializeSpendConsumerDeps returns serialized bytes of the provided spend
-// journal consumer dependencies.
-func serializeSpendConsumerDeps(deps []string) []byte {
+// initSpendJournalHeightsBucket creates the spend journal heights bucket
+// if it does not exist.
+func initSpendJournalHeightsBucket(db database.DB) error {
+	// Create the spend journal heights bucket if it does not exist yet.
+	return db.Update(func(dbTx database.Tx) error {
+		meta := dbTx.Metadata()
+		_, err := meta.CreateBucketIfNotExists(spendJournalHeightsBucketName)
+		return err
+	})
+}
+
 	var buf bytes.Buffer
 	for idx := 0; idx < len(deps); idx++ {
 		buf.WriteString(deps[idx])
@@ -76,10 +85,77 @@ func dbUpdateSpendConsumerDeps(dbTx database.Tx, blockHash chainhash.Hash, consu
 	return depsBucket.Put(blockHash[:], serialized)
 }
 
-// dbFetchSpendConsumerDeps uses an existing database transaction to fetch all
-// spend consumer dependency entries in the database.
-func dbFetchSpendConsumerDeps(dbTx database.Tx) (map[chainhash.Hash][]string, error) {
-	depsBucket := dbTx.Metadata().Bucket(spendConsumerDepsBucketName)
+// dbPersistSpendHeights uses an existing database transaction to persist the
+// provided spend heights.
+func dbPersistSpendHeights(dbTx database.Tx, spendHeights map[chainhash.Hash]uint32) error {
+	heightsBucket := dbTx.Metadata().Bucket(spendJournalHeightsBucketName)
+
+	// return immediately if there are no spend heights to persist.
+	if len(spendHeights) == 0 {
+		return nil
+	}
+
+	// Persist all spend height map entries.
+	for blockHash, height := range spendHeights {
+		var b [8]byte
+		binary.LittleEndian.PutUint32(b[:], height)
+		err := heightsBucket.Put(blockHash[:], b[:])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// dbRemoveSpendHeight uses an existing database transaction to
+// remove the spend height entry for the provided block hash.
+func dbRemoveSpendHeight(dbTx database.Tx, blockHash chainhash.Hash) error {
+	heightsBucket := dbTx.Metadata().Bucket(spendJournalHeightsBucketName)
+	return heightsBucket.Delete(blockHash[:])
+}
+
+// dbPruneSpendDependencies uses an existing database transaction to prune the
+// spend dependencies associated with the provided keys.
+func dbPruneSpendDependencies(dbTx database.Tx, keys []chainhash.Hash) error {
+	depsBucket := dbTx.Metadata().Bucket(spendConsumerDependenciesBucketName)
+
+	// Return immediately if there are no spend dependencies to remove.
+	if len(keys) == 0 {
+		return nil
+	}
+
+	// Prune all spend dependency map entries.
+	for _, blockHash := range keys {
+		err := depsBucket.Delete(blockHash[:])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// dbPruneSpendHeights uses an existing database transaction to prune the
+// provided spend heights associated with the provided keys.
+func dbPruneSpendHeights(dbTx database.Tx, keys []chainhash.Hash) error {
+	heightsBucket := dbTx.Metadata().Bucket(spendJournalHeightsBucketName)
+
+	// Return immediately if there are no spend heights to remove.
+	if len(keys) == 0 {
+		return nil
+	}
+
+	// Persist all spend height map entries.
+	for _, blockHash := range keys {
+		err := heightsBucket.Delete(blockHash[:])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
 	consumerDeps := make(map[chainhash.Hash][]string)
 	cursor := depsBucket.Cursor()
 	for ok := cursor.First(); ok; ok = cursor.Next() {
@@ -93,4 +169,23 @@ func dbFetchSpendConsumerDeps(dbTx database.Tx) (map[chainhash.Hash][]string, er
 	}
 
 	return consumerDeps, nil
+}
+
+// dbFetchSpendHeights uses an existing database transaction to fetch all
+// spend journal height entries in the database.
+func dbFetchSpendHeights(dbTx database.Tx) (map[chainhash.Hash]uint32, error) {
+	heightsBucket := dbTx.Metadata().Bucket(spendJournalHeightsBucketName)
+	spendHeights := make(map[chainhash.Hash]uint32)
+	cursor := heightsBucket.Cursor()
+	for ok := cursor.First(); ok; ok = cursor.Next() {
+		hash, err := chainhash.NewHash(cursor.Key())
+		if err != nil {
+			return nil, err
+		}
+
+		height := binary.LittleEndian.Uint32(cursor.Value())
+		spendHeights[*hash] = height
+	}
+
+	return spendHeights, nil
 }

--- a/internal/blockchain/spendpruner/db_test.go
+++ b/internal/blockchain/spendpruner/db_test.go
@@ -15,9 +15,9 @@ import (
 	"github.com/decred/dcrd/wire"
 )
 
-// TestSerializeConsumerDeps ensures consumer dependencies serialize as
+// TestSerializeConsumerDependencies ensures consumer dependencies serialize as
 // intended.
-func TestSerializeConsumerDeps(t *testing.T) {
+func TestSerializeConsumerDependencies(t *testing.T) {
 	tests := []struct {
 		name     string
 		deps     []string
@@ -41,7 +41,7 @@ func TestSerializeConsumerDeps(t *testing.T) {
 	}}
 
 	for _, test := range tests {
-		serialized := serializeSpendConsumerDeps(test.deps)
+		serialized := serializeSpendConsumerDependencies(test.deps)
 		if !bytes.Equal(serialized, test.expected) {
 			t.Errorf("%q: unexpected serialized mismatch, "+
 				"expected %q, got %q", test.name, test.expected, serialized)
@@ -50,9 +50,9 @@ func TestSerializeConsumerDeps(t *testing.T) {
 	}
 }
 
-// TestDeserializeConsumerDeps ensures consumer dependencies deserialize as
-// intended.
-func TestDeserializeConsumerDeps(t *testing.T) {
+// TestDeserializeConsumerDependencies ensures consumer dependencies
+// deserialize as intended.
+func TestDeserializeConsumerDependencies(t *testing.T) {
 	tests := []struct {
 		name       string
 		serialized []byte
@@ -76,7 +76,7 @@ func TestDeserializeConsumerDeps(t *testing.T) {
 	}}
 
 	for _, test := range tests {
-		deserialized := deserializeSpendConsumerDeps(test.serialized)
+		deserialized := deserializeSpendConsumerDependencies(test.serialized)
 		for idx := range test.expected {
 			if deserialized[idx] != test.expected[idx] {
 				t.Errorf("%q: unexpected dependency mismatch at index %d, "+
@@ -104,7 +104,7 @@ func createDB() (database.DB, func(), error) {
 		return nil, nil, err
 	}
 
-	err = initConsumerDepsBucket(db)
+	err = initConsumerDependenciesBucket(db)
 	if err != nil {
 		os.RemoveAll(dbPath)
 		return nil, nil, err

--- a/internal/blockchain/spendpruner/db_test.go
+++ b/internal/blockchain/spendpruner/db_test.go
@@ -90,8 +90,8 @@ func TestDeserializeConsumerDependencies(t *testing.T) {
 
 // createdDB creates the test database. This is intended to be used for testing
 // purposes only.
-func createDB() (database.DB, func(), error) {
-	dbPath := filepath.Join(os.TempDir(), "spdb")
+func createDB(dir string) (database.DB, func(), error) {
+	dbPath := filepath.Join(dir, "spdb")
 
 	err := os.MkdirAll(dbPath, 0700)
 	if err != nil {
@@ -100,25 +100,21 @@ func createDB() (database.DB, func(), error) {
 
 	db, err := database.Create("ffldb", dbPath, wire.SimNet)
 	if err != nil {
-		os.RemoveAll(dbPath)
 		return nil, nil, err
 	}
 
 	err = initConsumerDependenciesBucket(db)
 	if err != nil {
-		os.RemoveAll(dbPath)
 		return nil, nil, err
 	}
 
 	err = initSpendJournalHeightsBucket(db)
 	if err != nil {
-		os.RemoveAll(dbPath)
 		return nil, nil, err
 	}
 
 	teardown := func() {
 		db.Close()
-		os.RemoveAll(dbPath)
 	}
 
 	return db, teardown, nil

--- a/internal/blockchain/spendpruner/db_test.go
+++ b/internal/blockchain/spendpruner/db_test.go
@@ -100,11 +100,19 @@ func createDB() (database.DB, func(), error) {
 
 	db, err := database.Create("ffldb", dbPath, wire.SimNet)
 	if err != nil {
+		os.RemoveAll(dbPath)
 		return nil, nil, err
 	}
 
 	err = initConsumerDepsBucket(db)
 	if err != nil {
+		os.RemoveAll(dbPath)
+		return nil, nil, err
+	}
+
+	err = initSpendJournalHeightsBucket(db)
+	if err != nil {
+		os.RemoveAll(dbPath)
 		return nil, nil, err
 	}
 

--- a/internal/blockchain/spendpruner/error.go
+++ b/internal/blockchain/spendpruner/error.go
@@ -24,6 +24,12 @@ const (
 	// ErrUpdateConsumerDeps indicates an error updating consumer spend
 	// dependencies.
 	ErrUpdateConsumerDependencies = ErrorKind("ErrUpdateConsumerDependencies")
+
+	// ErrLoadSpendHeights indicates an error loading spend heights.
+	ErrLoadSpendHeights = ErrorKind("ErrLoadSpendHeights")
+
+	// ErrRemoveSpendHeight indicates an error removing a spend height.
+	ErrRemoveSpendHeight = ErrorKind("ErrRemoveSpendHeight")
 )
 
 // Error satisfies the error interface and prints human-readable errors.

--- a/internal/blockchain/spendpruner/error.go
+++ b/internal/blockchain/spendpruner/error.go
@@ -14,16 +14,16 @@ const (
 	// ErrNoConsumer indicates a spend journal consumer hash does not exist.
 	ErrNoConsumer = ErrorKind("ErrNoConsumer")
 
-	// ErrLoadSpendDeps indicates an error loading consumer
+	// ErrLoadSpendDependencies indicates an error loading consumer
 	// spend dependencies.
-	ErrLoadSpendDeps = ErrorKind("ErrLoadSpendDeps")
+	ErrLoadSpendDependencies = ErrorKind("ErrLoadSpendDependencies")
 
 	// ErrNeedSpendData indicates an error asserting a spend data dependency.
 	ErrNeedSpendData = ErrorKind("ErrNeedSpendData")
 
 	// ErrUpdateConsumerDeps indicates an error updating consumer spend
 	// dependencies.
-	ErrUpdateConsumerDeps = ErrorKind("ErrUpdateConsumerDeps")
+	ErrUpdateConsumerDependencies = ErrorKind("ErrUpdateConsumerDependencies")
 )
 
 // Error satisfies the error interface and prints human-readable errors.

--- a/internal/blockchain/spendpruner/error_test.go
+++ b/internal/blockchain/spendpruner/error_test.go
@@ -20,6 +20,8 @@ func TestErrorKindStringer(t *testing.T) {
 		{ErrLoadSpendDependencies, "ErrLoadSpendDependencies"},
 		{ErrNeedSpendData, "ErrNeedSpendData"},
 		{ErrUpdateConsumerDependencies, "ErrUpdateConsumerDependencies"},
+		{ErrLoadSpendHeights, "ErrLoadSpendHeights"},
+		{ErrRemoveSpendHeight, "ErrRemoveSpendHeight"},
 	}
 
 	for i, test := range tests {

--- a/internal/blockchain/spendpruner/error_test.go
+++ b/internal/blockchain/spendpruner/error_test.go
@@ -17,9 +17,9 @@ func TestErrorKindStringer(t *testing.T) {
 		want string
 	}{
 		{ErrNoConsumer, "ErrNoConsumer"},
-		{ErrLoadSpendDeps, "ErrLoadSpendDeps"},
+		{ErrLoadSpendDependencies, "ErrLoadSpendDependencies"},
 		{ErrNeedSpendData, "ErrNeedSpendData"},
-		{ErrUpdateConsumerDeps, "ErrUpdateConsumerDeps"},
+		{ErrUpdateConsumerDependencies, "ErrUpdateConsumerDependencies"},
 	}
 
 	for i, test := range tests {

--- a/internal/blockchain/spendpruner/pruner.go
+++ b/internal/blockchain/spendpruner/pruner.go
@@ -8,67 +8,106 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/database/v3"
 )
 
-// spendPrunerEventType represents a spend pruner event message.
-type spendPrunerEventType int
-
 const (
-	// spBlockConnected indicates a new block was connected to the chain.
-	spBlockConnected spendPrunerEventType = iota
+	// batchSignalBufferSize is the buffer size for batch signals.
+	batchSignalBufferSize = 32
 
-	// spBlockDisconnected indicates there are no spend dependencies for the
-	// block disconnected from the chain.
-	spBlockDisconnected
+	// batchThreshold is the prune batch size that triggers a batch prune.
+	batchThreshold = 128
+
+	// BatchPruneInterval is the time elapsed before a batch prune is triggered.
+	BatchPruneInterval = time.Second * 10
+
+	// DependencyPruneInterval is the time elapsed before a dependency prune
+	// is triggered.
+	DependencyPruneInterval = time.Second * 30
+
+	// maxDependencyDifference is the maximum difference in height
+	// between a spend dependency and the chain tip which makes the
+	// dependency prunable.
+	maxDependencyDifference = 288
 )
-
-// SpendJournalNotification represents the notification received by the pruner
-// on block connections and disconnections.
-type SpendJournalNotification struct {
-	BlockHash *chainhash.Hash
-	Event     spendPrunerEventType
-	Done      chan bool
-}
 
 // SpendJournalPruner represents a spend journal pruner that ensures spend
 // journal entries needed by consumers are retained until no longer needed.
 type SpendJournalPruner struct {
-	// This removes the spend journal entry of the provided block hash if it
-	// is not part of the main chain.
-	removeSpendEntry func(hash *chainhash.Hash) error
+	// This field tracks the chain tip height based on block connections and
+	// disconnections.
+	currentTip uint32 // Update atomically.
 
-	// These fields track spend consumers and their spend journal dependencies.
-	dependents    map[chainhash.Hash][]string
-	dependentsMtx sync.RWMutex
-	consumers     map[string]SpendConsumer
-	consumersMtx  sync.RWMutex
+	// This removes the spend journal entries of the provided block hashes if
+	// they are not part of the main chain.
+	batchRemoveSpendEntry func(hash []chainhash.Hash) error
 
-	// This field relays block connection and disconnection signals for
-	// processing.
-	ch chan SpendJournalNotification
+	// These fields track spend consumers, their spend journal dependencies
+	// and block heights of the spend entries.
+	dependents      map[chainhash.Hash][]string
+	dependentsMtx   sync.Mutex
+	spendHeights    map[chainhash.Hash]uint32
+	spendHeightsMtx sync.Mutex
+	consumers       map[string]SpendConsumer
+	consumersMtx    sync.Mutex
+
+	// This field relays prune batch signals for processing.
+	ch chan struct{}
+
+	// These fields batches hashes associated with spend journal entries
+	// scheduled to be pruned.
+	pruneBatch    []chainhash.Hash
+	pruneBatchMtx sync.Mutex
+
+	// This is the maximum time between processing batched prunes.
+	batchPruneInterval time.Duration
+
+	// This is the maximum time between processing dependency prunes.
+	dependencyPruneInterval time.Duration
 
 	// This field provides access to the database.
 	db database.DB
+
+	// This field synchronizes channel sends and receives.
+	quit chan struct{}
 }
 
 // NewSpendJournalPruner initializes a spend journal pruner.
+func NewSpendJournalPruner(db database.DB, batchRemoveSpendEntry func(hash []chainhash.Hash) error, currentTip uint32, batchPruneInterval time.Duration, dependencyPruneInterval time.Duration) (*SpendJournalPruner, error) {
 	err := initConsumerDependenciesBucket(db)
 	if err != nil {
 		return nil, err
 	}
 
+	err = initSpendJournalHeightsBucket(db)
+	if err != nil {
+		return nil, err
+	}
+
 	spendPruner := &SpendJournalPruner{
-		db:               db,
-		removeSpendEntry: removeSpendEntry,
-		dependents:       make(map[chainhash.Hash][]string),
-		consumers:        make(map[string]SpendConsumer),
-		ch:               make(chan SpendJournalNotification),
+		db:                      db,
+		currentTip:              currentTip,
+		batchRemoveSpendEntry:   batchRemoveSpendEntry,
+		batchPruneInterval:      batchPruneInterval,
+		dependencyPruneInterval: dependencyPruneInterval,
+		dependents:              make(map[chainhash.Hash][]string),
+		spendHeights:            make(map[chainhash.Hash]uint32),
+		consumers:               make(map[string]SpendConsumer),
+		pruneBatch:              make([]chainhash.Hash, 0, batchThreshold),
+		ch:                      make(chan struct{}, batchSignalBufferSize),
+		quit:                    make(chan struct{}),
 	}
 
 	err = spendPruner.loadSpendConsumerDependencies()
+	if err != nil {
+		return nil, err
+	}
+
+	err = spendPruner.loadSpendJournalHeights()
 	if err != nil {
 		return nil, err
 	}
@@ -86,9 +125,9 @@ func (s *SpendJournalPruner) AddConsumer(consumer SpendConsumer) {
 // FetchConsumer returns the spend journal consumer associated with the
 // provided id.
 func (s *SpendJournalPruner) FetchConsumer(id string) (SpendConsumer, error) {
-	s.consumersMtx.RLock()
-	defer s.consumersMtx.RUnlock()
+	s.consumersMtx.Lock()
 	consumer, ok := s.consumers[id]
+	s.consumersMtx.Unlock()
 	if !ok {
 		msg := fmt.Sprintf("no spend consumer found with id %s", id)
 		return nil, pruneError(ErrNoConsumer, msg)
@@ -100,28 +139,104 @@ func (s *SpendJournalPruner) FetchConsumer(id string) (SpendConsumer, error) {
 // DependencyExists determines whether there are spend consumer dependencies
 // for the provided block hash.
 func (s *SpendJournalPruner) DependencyExists(blockHash *chainhash.Hash) bool {
-	s.dependentsMtx.RLock()
-	defer s.dependentsMtx.RUnlock()
-
+	s.dependentsMtx.Lock()
 	_, ok := s.dependents[*blockHash]
+	s.dependentsMtx.Unlock()
 	return ok
 }
 
-// NotifyConnectedBlock signals the spend pruner of the provided
-// connected block hash.
-func (s *SpendJournalPruner) NotifyConnectedBlock(blockHash *chainhash.Hash) {
-	s.ch <- SpendJournalNotification{
-		BlockHash: blockHash,
-		Event:     spBlockConnected,
+// filterDependentPrunes filters spend dependencies eligible for pruning.
+func (s *SpendJournalPruner) filterPrunableDependents() []chainhash.Hash {
+	var toPrune []chainhash.Hash
+	currentTip := atomic.LoadUint32(&s.currentTip)
+
+	s.spendHeightsMtx.Lock()
+	for blockHash, height := range s.spendHeights {
+		if currentTip-height >= maxDependencyDifference {
+			toPrune = append(toPrune, blockHash)
+		}
+	}
+	s.spendHeightsMtx.Unlock()
+
+	return toPrune
+}
+
+// pruneSpendDependencies purges spend journal dependency information of the
+// provided set of block hashes.
+func (s *SpendJournalPruner) pruneSpendDependencies(dependencies []chainhash.Hash) error {
+	for _, hash := range dependencies {
+		s.dependentsMtx.Lock()
+		delete(s.dependents, hash)
+		s.dependentsMtx.Unlock()
+
+		s.spendHeightsMtx.Lock()
+		delete(s.spendHeights, hash)
+		s.spendHeightsMtx.Unlock()
+	}
+
+	err := s.db.Update(func(tx database.Tx) error {
+		err := dbPruneSpendDependencies(tx, dependencies)
+		if err != nil {
+			return err
+		}
+
+		err = dbPruneSpendHeights(tx, dependencies)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	return err
+}
+
+// ConnectBlock updates the spend pruner of the provided connected block hash.
+func (s *SpendJournalPruner) ConnectBlock(blockHash *chainhash.Hash) error {
+	if !s.DependencyExists(blockHash) {
+		// Do nothing if there are no spend journal dependencies
+		// for the the connected block.
+		return nil
+	}
+
+	// Remove the key/value pair of persisted spend consumer dependencies and
+	// the provided connected block hash from the prune set as well as the
+	// spend height of the connected block.
+	err := s.removeSpendConsumerDependencies(blockHash)
+	if err != nil {
+		return err
+	}
+
+	atomic.AddUint32(&s.currentTip, uint32(1))
+
+	return nil
+}
+
+// DisconnectBlock signals the spend pruner of the provided
+// disconnected block hash.
+func (s *SpendJournalPruner) DisconnectBlock(blockHash *chainhash.Hash) {
+	s.pruneBatchMtx.Lock()
+	s.pruneBatch = append(s.pruneBatch, *blockHash)
+	length := len(s.pruneBatch)
+	s.pruneBatchMtx.Unlock()
+
+	atomic.AddUint32(&s.currentTip, ^uint32(0))
+
+	if length >= batchThreshold {
+		select {
+		case <-s.quit:
+		case s.ch <- struct{}{}:
+		default:
+			// Non-blocking send fallthrough.
+		}
 	}
 }
 
 // dependencyExistsInternal determines whether a spend consumer depends on
 // the spend data of the provided block hash.
 func (s *SpendJournalPruner) dependencyExistsInternal(blockHash *chainhash.Hash, consumerID string) bool {
-	s.dependentsMtx.RLock()
+	s.dependentsMtx.Lock()
 	dependents, ok := s.dependents[*blockHash]
-	s.dependentsMtx.RUnlock()
+	s.dependentsMtx.Unlock()
 	if !ok {
 		// The dependency does not exist if the block hash is not
 		// a key for dependents.
@@ -137,9 +252,21 @@ func (s *SpendJournalPruner) dependencyExistsInternal(blockHash *chainhash.Hash,
 	return false
 }
 
+// spendHeightExists determines if there is a spend height entry for the
+// provided block hash.
+func (s *SpendJournalPruner) spendHeightExists(hash *chainhash.Hash) bool {
+	s.spendHeightsMtx.Lock()
+	_, ok := s.spendHeights[*hash]
+	s.spendHeightsMtx.Unlock()
+
+	return ok
+}
+
 // addSpendConsumerDependencies adds an entry for each spend consumer dependent
 // on journal data for the provided block hash.
 func (s *SpendJournalPruner) addSpendConsumerDependencies(blockHash *chainhash.Hash, blockHeight uint32) error {
+	s.consumersMtx.Lock()
+	defer s.consumersMtx.Unlock()
 
 	for _, consumer := range s.consumers {
 		if s.dependencyExistsInternal(blockHash, consumer.ID()) {
@@ -177,11 +304,32 @@ func (s *SpendJournalPruner) addSpendConsumerDependencies(blockHash *chainhash.H
 	dependents := s.dependents[*blockHash]
 	s.dependentsMtx.Unlock()
 
-	// Update the persisted spend consumer deps entry for
-	// the provided block hash.
+	s.spendHeightsMtx.Lock()
+	var spendHeightUpdate bool
+	_, ok := s.spendHeights[*blockHash]
+	if !ok {
+		s.spendHeights[*blockHash] = blockHeight
+		spendHeightUpdate = true
+	}
+	s.spendHeightsMtx.Unlock()
+
+	// Update the persisted spend consumer deps entry for the provided block
+	// hash as well as the spend heights map if it was updated.
 	err := s.db.Update(func(tx database.Tx) error {
-		err := dbUpdateSpendConsumerDeps(tx, *blockHash, dependents)
-		return err
+		err := dbUpdateSpendConsumerDependencies(tx, *blockHash, dependents)
+		if err != nil {
+			return err
+		}
+
+		if spendHeightUpdate {
+			heightUpdate := map[chainhash.Hash]uint32{*blockHash: blockHeight}
+			err := dbPersistSpendHeights(tx, heightUpdate)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
 	})
 	if err != nil {
 		msg := fmt.Sprintf("unable to update persisted consumer "+
@@ -218,12 +366,18 @@ func (s *SpendJournalPruner) RemoveSpendConsumerDependency(dbTx database.Tx, blo
 		s.dependentsMtx.Lock()
 		delete(s.dependents, *blockHash)
 		s.dependentsMtx.Unlock()
-		go func() {
-			s.ch <- SpendJournalNotification{
-				BlockHash: blockHash,
-				Event:     spBlockDisconnected,
-			}
-		}()
+
+		s.DisconnectBlock(blockHash)
+
+		// Remove the associated spend height of the block hash since
+		// it has no dependencies now.
+		if s.spendHeightExists(blockHash) {
+			s.spendHeightsMtx.Lock()
+			delete(s.spendHeights, *blockHash)
+			s.spendHeightsMtx.Unlock()
+
+			dbRemoveSpendHeight(dbTx, *blockHash)
+		}
 	}
 
 	// Update the tracked spend journal entry for the provided
@@ -240,20 +394,35 @@ func (s *SpendJournalPruner) RemoveSpendConsumerDependency(dbTx database.Tx, blo
 
 // removeSpendConsumerDependencies removes the key/value pair of spend consumer
 // dependencies and the provided block hash from the the prune set as well
+// as the database. The associated spend height of the block is also removed.
 func (s *SpendJournalPruner) removeSpendConsumerDependencies(blockHash *chainhash.Hash) error {
 	s.dependentsMtx.Lock()
 	delete(s.dependents, *blockHash)
 	s.dependentsMtx.Unlock()
 
+	s.spendHeightsMtx.Lock()
+	delete(s.spendHeights, *blockHash)
+	s.spendHeightsMtx.Unlock()
+
 	// Remove the tracked spend journal entry for the provided
 	// block hash.
+	return s.db.Update(func(tx database.Tx) error {
 		err := dbUpdateSpendConsumerDependencies(tx, *blockHash, nil)
-		msg := fmt.Sprintf("unable to remove persisted consumer dependencies "+
-			"entry for block hash %v: %v", blockHash, err)
-		return pruneError(ErrUpdateConsumerDeps, msg)
-	}
+		if err != nil {
+			msg := fmt.Sprintf("unable to remove persisted consumer "+
+				"dependencies entry for block hash %v: %v", blockHash, err)
+			return pruneError(ErrUpdateConsumerDependencies, msg)
+		}
 
-	return nil
+		err = dbRemoveSpendHeight(tx, *blockHash)
+		if err != nil {
+			msg := fmt.Sprintf("unable to remove persisted spend journal "+
+				"height entry for block hash %v: %v", blockHash, err)
+			return pruneError(ErrRemoveSpendHeight, msg)
+		}
+
+		return nil
+	})
 }
 
 // loadSpendConsumerDependencies loads persisted consumer spend dependencies
@@ -268,73 +437,38 @@ func (s *SpendJournalPruner) loadSpendConsumerDependencies() error {
 		}
 
 		s.dependentsMtx.Lock()
-		for k, v := range consumerDeps {
-			s.dependents[k] = v
-		}
+		s.dependents = consumerDeps
 		s.dependentsMtx.Unlock()
 
 		return nil
 	})
 }
 
-// HandleSignals processes incoming signals to the spend pruner.
-func (s *SpendJournalPruner) HandleSignals(ctx context.Context) {
-	for {
-		select {
-		case <-ctx.Done():
-			return
-
-		case ntfn := <-s.ch:
-			signalDone := func() {
-				if ntfn.Done != nil {
-					close(ntfn.Done)
-				}
-			}
-
-			switch ntfn.Event {
-			case spBlockDisconnected:
-				err := s.removeSpendEntry(ntfn.BlockHash)
-				if err != nil {
-					log.Errorf("unable to prune spend data for "+
-						"block hash (%s): %v", ntfn.BlockHash, err)
-
-				}
-
-				signalDone()
-
-			case spBlockConnected:
-				if !s.DependencyExists(ntfn.BlockHash) {
-					// Do nothing if there are no spend journal dependencies
-					// for the the connected block.
-					signalDone()
-					continue
-				}
-
-				// Remove the key/value pair of persisted spend consumer
-				// dependencies and the provided connected block hash from
-				// the prune set.
-				err := s.removeSpendConsumerDeps(ntfn.BlockHash)
-				if err != nil {
-					log.Error(err)
-				}
-
-				signalDone()
-
-			default:
-				log.Errorf("unknown spend journal notification type: %d",
-					ntfn.Event)
-
-				signalDone()
-			}
+// loadSpendJournalHeights loads persisted spend journal heights
+// from the database.
+func (s *SpendJournalPruner) loadSpendJournalHeights() error {
+	return s.db.View(func(tx database.Tx) error {
+		spendHeights, err := dbFetchSpendHeights(tx)
+		if err != nil {
+			msg := fmt.Sprintf("unable to load spend journal "+
+				"heights: %v", err)
+			return pruneError(ErrLoadSpendHeights, msg)
 		}
-	}
+
+		s.spendHeightsMtx.Lock()
+		s.spendHeights = spendHeights
+		s.spendHeightsMtx.Unlock()
+
+		return nil
+	})
 }
 
-// MaybePruneSpendData firsts adds consumer spend dependencies for the provided
+// MaybePruneSpendData first adds consumer spend dependencies for the provided
 // blockhash if any. If there are no dependencies the spend journal entry
 // associated with the provided block hash is pruned.
-func (s *SpendJournalPruner) MaybePruneSpendData(blockHash *chainhash.Hash, done chan bool) error {
-	err := s.addSpendConsumerDeps(blockHash)
+func (s *SpendJournalPruner) MaybePruneSpendData(blockHash *chainhash.Hash) error {
+	blockHeight := atomic.LoadUint32(&s.currentTip)
+	err := s.addSpendConsumerDependencies(blockHash, blockHeight)
 	if err != nil {
 		return err
 	}
@@ -345,13 +479,75 @@ func (s *SpendJournalPruner) MaybePruneSpendData(blockHash *chainhash.Hash, done
 		return nil
 	}
 
-	go func() {
-		s.ch <- SpendJournalNotification{
-			BlockHash: blockHash,
-			Event:     spBlockDisconnected,
-			Done:      done,
-		}
-	}()
+	s.DisconnectBlock(blockHash)
 
 	return nil
+}
+
+// handleBatchPrunes purges batched spend journal data.
+//
+// This should be run as a goroutine.
+func (s *SpendJournalPruner) handleBatchPrunes(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case <-s.ch:
+			s.pruneBatchMtx.Lock()
+			batch := make([]chainhash.Hash, len(s.pruneBatch))
+			copy(batch, s.pruneBatch)
+			s.pruneBatch = s.pruneBatch[:0]
+			s.pruneBatchMtx.Unlock()
+
+			err := s.batchRemoveSpendEntry(batch)
+			if err != nil {
+				log.Errorf("unable to batch remove spend entries: %v", err)
+			}
+		}
+	}
+}
+
+// handleTicks processes ticker signals of the spend pruner.
+//
+// This should be run as a goroutine.
+func (s *SpendJournalPruner) handleTicks(ctx context.Context) {
+	batchTicker := time.NewTicker(s.batchPruneInterval)
+	dependencyTicker := time.NewTicker(s.dependencyPruneInterval)
+	for {
+		select {
+		case <-ctx.Done():
+			close(s.quit)
+			batchTicker.Stop()
+			dependencyTicker.Stop()
+			return
+
+		case <-batchTicker.C:
+			s.pruneBatchMtx.Lock()
+			length := len(s.pruneBatch)
+			s.pruneBatchMtx.Unlock()
+
+			if length >= 0 {
+				select {
+				case <-s.quit:
+				case s.ch <- struct{}{}:
+				default:
+					// Non-blocking send fallthrough.
+				}
+			}
+
+		case <-dependencyTicker.C:
+			toPrune := s.filterPrunableDependents()
+			err := s.pruneSpendDependencies(toPrune)
+			if err != nil {
+				log.Error("unable to prune spend dependencies: %w", err)
+			}
+		}
+	}
+}
+
+// Run handles the lifecycle process of the spend journal pruner.
+func (s *SpendJournalPruner) Run(ctx context.Context) {
+	go s.handleTicks(ctx)
+	go s.handleBatchPrunes(ctx)
 }

--- a/internal/blockchain/spendpruner/pruner_test.go
+++ b/internal/blockchain/spendpruner/pruner_test.go
@@ -110,7 +110,7 @@ func TestSpendPruner(t *testing.T) {
 	// Ensure adding dependents fails if a consumer errors checking if the
 	// data is needed.
 	hashA := &chainhash.Hash{'a'}
-	err = pruner.addSpendConsumerDeps(hashA)
+	err = pruner.addSpendConsumerDependencies(hashA, 0)
 	if !errors.Is(err, ErrNeedSpendData) {
 		t.Fatalf("expected a spend data error, got %v", err)
 	}
@@ -135,7 +135,7 @@ func TestSpendPruner(t *testing.T) {
 
 	// Ensure adding dependents creates entries for consumers that need
 	// the spend data of the provided block hash.
-	err = pruner.addSpendConsumerDeps(hashA)
+	err = pruner.addSpendConsumerDependencies(hashA, 0)
 	if err != nil {
 		t.Fatalf("unexpected error adding consumer dependencies: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestSpendPruner(t *testing.T) {
 		})
 	}
 
-	err = pruner.addSpendConsumerDeps(hashA)
+	err = pruner.addSpendConsumerDependencies(hashA, 0)
 	if err != nil {
 		t.Fatalf("unexpected error adding spend data dependents "+
 			"for hashA: %v", err)
@@ -244,7 +244,7 @@ func TestSpendPruner(t *testing.T) {
 
 	// Ensure the spend pruner does not remove the spend entries if
 	// there are existing dependencies for it.
-	err = pruner.MaybePruneSpendData(hashA, nil)
+	err = pruner.MaybePruneSpendData(hashA, 0)
 	if err != nil {
 		t.Fatalf("[MaybePruneSpendData] unexpected error: %v", err)
 	}
@@ -304,14 +304,14 @@ func TestSpendPruner(t *testing.T) {
 
 	// Create consumer dependencies for hashB and hashC.
 	hashB := &chainhash.Hash{'b'}
-	err = pruner.addSpendConsumerDeps(hashB)
+	err = pruner.addSpendConsumerDependencies(hashB, 1)
 	if err != nil {
 		t.Fatalf("unexpected error adding consumer dependencies "+
 			"for hashB: %v", err)
 	}
 
 	hashC := &chainhash.Hash{'c'}
-	err = pruner.addSpendConsumerDeps(hashC)
+	err = pruner.addSpendConsumerDependencies(hashC, 2)
 	if err != nil {
 		t.Fatalf("unexpected error adding consumer dependencies "+
 			"for hashC: %v", err)

--- a/internal/blockchain/thresholdstate_test.go
+++ b/internal/blockchain/thresholdstate_test.go
@@ -250,7 +250,8 @@ func TestThresholdState(t *testing.T) {
 		})
 
 	// Create a test harness initialized with the genesis block as the tip.
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// Shorter versions of useful params for convenience.
 	ticketsPerBlock := int64(params.TicketsPerBlock)

--- a/internal/blockchain/treasury_policy_test.go
+++ b/internal/blockchain/treasury_policy_test.go
@@ -72,7 +72,8 @@ func TestTSpendLegacyExpendituresPolicy(t *testing.T) {
 		params.TreasuryExpenditureBootstrap/2)
 
 	// Create a test harness initialized with the genesis block as the tip.
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// Helper to verify the tip balance.
 	assertTipTreasuryBalance := func(wantBalance int64) {
@@ -614,7 +615,8 @@ func TestTSpendExpendituresPolicyDCP0007(t *testing.T) {
 	}
 
 	// Create a test harness initialized with the genesis block as the tip.
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// Helper to verify the tip balance.
 	assertTipTreasuryBalance := func(wantBalance int64) {

--- a/internal/blockchain/treasury_test.go
+++ b/internal/blockchain/treasury_test.go
@@ -508,7 +508,8 @@ func TestTSpendVoteCount(t *testing.T) {
 	mul := params.TreasuryVoteIntervalMultiplier
 
 	// Create a test harness initialized with the genesis block as the tip.
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// replaceTreasuryVersions is a munge function which modifies the
 	// provided block by replacing the block, stake, and vote versions with
@@ -921,7 +922,8 @@ func TestTSpendEmptyTreasury(t *testing.T) {
 	mul := params.TreasuryVoteIntervalMultiplier
 
 	// Create a test harness initialized with the genesis block as the tip.
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// replaceTreasuryVersions is a munge function which modifies the
 	// provided block by replacing the block, stake, and vote versions with
@@ -1059,7 +1061,8 @@ func TestExpendituresReorg(t *testing.T) {
 	mul := params.TreasuryVoteIntervalMultiplier
 
 	// Create a test harness initialized with the genesis block as the tip.
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// Helper to check the treasury balance at tip.
 	assertTipTreasuryBalance := func(wantBalance int64) {
@@ -1309,7 +1312,8 @@ func TestSpendableTreasuryTxs(t *testing.T) {
 	mul := params.TreasuryVoteIntervalMultiplier
 
 	// Create a test harness initialized with the genesis block as the tip.
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// replaceTreasuryVersions is a munge function which modifies the
 	// provided block by replacing the block, stake, and vote versions with
@@ -1606,7 +1610,8 @@ func TestTSpendDupVote(t *testing.T) {
 	mul := params.TreasuryVoteIntervalMultiplier
 
 	// Create a test harness initialized with the genesis block as the tip.
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// replaceTreasuryVersions is a munge function which modifies the
 	// provided block by replacing the block, stake, and vote versions with
@@ -1752,7 +1757,8 @@ func TestTSpendTooManyTSpend(t *testing.T) {
 	mul := params.TreasuryVoteIntervalMultiplier
 
 	// Create a test harness initialized with the genesis block as the tip.
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// replaceTreasuryVersions is a munge function which modifies the
 	// provided block by replacing the block, stake, and vote versions with
@@ -1865,7 +1871,8 @@ func TestTSpendWindow(t *testing.T) {
 	mul := params.TreasuryVoteIntervalMultiplier
 
 	// Create a test harness initialized with the genesis block as the tip.
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// replaceTreasuryVersions is a munge function which modifies the
 	// provided block by replacing the block, stake, and vote versions with
@@ -1987,7 +1994,8 @@ func TestTSpendSignature(t *testing.T) {
 	mul := params.TreasuryVoteIntervalMultiplier
 
 	// Create a test harness initialized with the genesis block as the tip.
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// replaceTreasuryVersions is a munge function which modifies the
 	// provided block by replacing the block, stake, and vote versions with
@@ -2204,7 +2212,8 @@ func TestTSpendSignatureInvalid(t *testing.T) {
 	mul := params.TreasuryVoteIntervalMultiplier
 
 	// Create a test harness initialized with the genesis block as the tip.
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// replaceTreasuryVersions is a munge function which modifies the
 	// provided block by replacing the block, stake, and vote versions with
@@ -2351,7 +2360,8 @@ func TestTSpendExists(t *testing.T) {
 	mul := params.TreasuryVoteIntervalMultiplier
 
 	// Create a test harness initialized with the genesis block as the tip.
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// replaceTreasuryVersions is a munge function which modifies the
 	// provided block by replacing the block, stake, and vote versions with
@@ -2615,7 +2625,8 @@ func TestTreasuryBalance(t *testing.T) {
 	removeDeploymentTimeConstraints(deployment)
 
 	// Create a test harness initialized with the genesis block as the tip.
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// replaceTreasuryVersions is a munge function which modifies the
 	// provided block by replacing the block, stake, and vote versions with
@@ -2913,7 +2924,8 @@ func TestTAddCorners(t *testing.T) {
 	removeDeploymentTimeConstraints(deployment)
 
 	// Create a test harness initialized with the genesis block as the tip.
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// replaceTreasuryVersions is a munge function which modifies the
 	// provided block by replacing the block, stake, and vote versions with the
@@ -3106,7 +3118,8 @@ func TestTreasuryBaseCorners(t *testing.T) {
 	removeDeploymentTimeConstraints(deployment)
 
 	// Create a test harness initialized with the genesis block as the tip.
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// replaceTreasuryVersions is a munge function which modifies the provided
 	// block by replacing the block, stake, and vote versions with the treasury
@@ -3304,7 +3317,8 @@ func TestTSpendCorners(t *testing.T) {
 	removeDeploymentTimeConstraints(deployment)
 
 	// Create a test harness initialized with the genesis block as the tip.
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// replaceTreasuryVersions is a munge function which modifies the provided
 	// block by replacing the block, stake, and vote versions with the treasury
@@ -3419,7 +3433,8 @@ func TestTSpendFirstTVICorner(t *testing.T) {
 	t.Logf("svh: %v tvi %v mul %v", svh, tvi, mul)
 
 	// Create a test harness initialized with the genesis block as the tip.
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// With an SVH of 144 and a TVI of 11 and a MUL of 1 create a tspend
 	// that expires on block 156 (voting interval [143,154]). Start voting
@@ -3624,7 +3639,8 @@ func TestTreasuryInRegularTree(t *testing.T) {
 	removeDeploymentTimeConstraints(deployment)
 
 	// Create a test harness initialized with the genesis block as the tip.
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// replaceTreasuryVersions is a munge function which modifies the provided
 	// block by replacing the block, stake, and vote versions with the treasury
@@ -4195,7 +4211,8 @@ func TestTSpendTooManyTAdds(t *testing.T) {
 	removeDeploymentTimeConstraints(deployment)
 
 	// Create a test harness initialized with the genesis block as the tip.
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// replaceTreasuryVersions is a munge function which modifies the
 	// provided block by replacing the block, stake, and vote versions with

--- a/internal/blockchain/utxocache_test.go
+++ b/internal/blockchain/utxocache_test.go
@@ -1061,7 +1061,8 @@ func TestMaybeFlush(t *testing.T) {
 func TestInitialize(t *testing.T) {
 	// Create a test harness initialized with the genesis block as the tip.
 	params := chaincfg.RegNetParams()
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// -------------------------------------------------------------------------
 	// Create some convenience functions to improve test readability.
@@ -1218,7 +1219,8 @@ func TestInitialize(t *testing.T) {
 func TestShutdownUtxoCache(t *testing.T) {
 	// Create a test harness initialized with the genesis block as the tip.
 	params := chaincfg.RegNetParams()
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// Replace the chain utxo cache with a test cache so that flushing can be
 	// disabled.

--- a/internal/blockchain/utxoviewpoint_test.go
+++ b/internal/blockchain/utxoviewpoint_test.go
@@ -26,7 +26,8 @@ func TestFetchUtxoView(t *testing.T) {
 
 	// Create a test harness initialized with the genesis block as the tip.
 	params := chaincfg.RegNetParams()
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// ---------------------------------------------------------------------
 	// Create some convenience functions to improve test readability.

--- a/internal/blockchain/validate_test.go
+++ b/internal/blockchain/validate_test.go
@@ -58,11 +58,12 @@ func TestBlockchainSpendJournal(t *testing.T) {
 	params.GenesisHash = params.GenesisBlock.BlockHash()
 
 	// Create a new database and chain instance to run tests against.
-	chain, err := chainSetup(t, params)
+	chain, startupFunc, err := chainSetup(t, params)
 	if err != nil {
 		t.Errorf("Failed to setup chain instance: %v", err)
 		return
 	}
+	startupFunc()
 
 	// Load up the rest of the blocks up to HEAD.
 	filename := filepath.Join("testdata", "reorgto179.bz2")
@@ -357,7 +358,8 @@ var badBlock = wire.MsgBlock{
 func TestCheckConnectBlockTemplate(t *testing.T) {
 	// Create a test harness initialized with the genesis block as the tip.
 	params := chaincfg.RegNetParams()
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// Define some additional convenience helper functions to process the
 	// current tip block associated with the generator.
@@ -990,7 +992,8 @@ func TestExplicitVerUpgradesSemantics(t *testing.T) {
 	coinbaseMaturity := params.CoinbaseMaturity
 
 	// Create a test harness initialized with the genesis block as the tip.
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// The following funcs are convenience funcs for asserting the tests are
 	// actually testing what they intend to.
@@ -1757,7 +1760,8 @@ func TestAutoRevocations(t *testing.T) {
 	ruleChangeInterval := int64(params.RuleChangeActivationInterval)
 
 	// Create a test harness initialized with the genesis block as the tip.
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// replaceAutoRevocationsVersions is a munge function which modifies the
 	// provided block by replacing the block, stake, vote, and revocation
@@ -1948,7 +1952,8 @@ func TestModifiedSubsidySplitSemantics(t *testing.T) {
 	removeDeploymentTimeConstraints(deployment)
 
 	// Create a test harness initialized with the genesis block as the tip.
-	g := newChaingenHarness(t, params)
+	g, startupFunc := newChaingenHarness(t, params)
+	startupFunc()
 
 	// replaceCoinbaseSubsidy is a munge function which modifies the provided
 	// block by replacing the coinbase subsidy with the proportion required for


### PR DESCRIPTION
This updates call sites sending spend journal notifications to the spend journal pruner to avoid sending notifications via goroutines. This should preserve the message ordering and avoid possibly spinning up an unbounded number of goroutines.

The spend pruner has also been refactored to batch spend prunes instead of processing single notifications individually.