### PR TITLE
multi: Introduce AssumeValid.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -135,6 +135,7 @@ type BlockChain struct {
 	// The following fields are set when the instance is created and can't
 	// be changed afterwards, so there is no need to protect them with a
 	// separate mutex.
+	assumeValid      chainhash.Hash
 	latestCheckpoint *chaincfg.Checkpoint
 	deploymentVers   map[string]uint32
 	db               database.DB
@@ -2292,6 +2293,14 @@ type Config struct {
 	// This field is required.
 	ChainParams *chaincfg.Params
 
+	// AssumeValid is the hash of a block that has been externally verified to
+	// be valid.  It allows several validation checks to be skipped for blocks
+	// that are both an ancestor of the assumed valid block and an ancestor of
+	// the best header.
+	//
+	// This field may not be set for networks that do not require it.
+	AssumeValid chainhash.Hash
+
 	// LatestCheckpoint specifies the most recent known checkpoint that is
 	// typically the default checkpoint in ChainParams.
 	//
@@ -2371,6 +2380,7 @@ func New(ctx context.Context, config *Config) (*BlockChain, error) {
 	}
 
 	b := BlockChain{
+		assumeValid:                   config.AssumeValid,
 		latestCheckpoint:              config.LatestCheckpoint,
 		deploymentVers:                deploymentVers,
 		db:                            config.DB,

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -204,6 +204,11 @@ type BlockChain struct {
 	disapprovedViewLock sync.Mutex
 	disapprovedView     *UtxoViewpoint
 
+	// assumeValidNode tracks the assumed valid block.  It will be nil when a
+	// block header with the assumed valid block hash has not been discovered or
+	// when assume valid is disabled.  It is protected by the chain lock.
+	assumeValidNode *blockNode
+
 	// checkpointNode tracks the most recently known checkpoint.  It will be nil
 	// when no checkpoints are known or are disabled.  It is protected by the
 	// chain lock.

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1479,6 +1479,16 @@ func (b *BlockChain) initChainState(ctx context.Context,
 			}
 		}
 
+		// Find the assumed valid node.
+		if b.assumeValid != *zeroHash {
+			node := b.index.lookupNode(&b.assumeValid)
+			if node != nil {
+				log.Debugf("Assumed valid node is %s (height %d)", node.hash,
+					node.height)
+				b.assumeValidNode = node
+			}
+		}
+
 		b.stateSnapshot = newBestState(tip, blockSize, numTxns,
 			state.totalTxns, tip.CalcPastMedianTime(),
 			state.totalSubsidy, uint32(tip.stakeNode.PoolSize()),

--- a/blockchain/checkpoints.go
+++ b/blockchain/checkpoints.go
@@ -80,18 +80,6 @@ func (b *BlockChain) maybeUpdateMostRecentCheckpoint(node *blockNode) {
 	}
 }
 
-// isKnownCheckpointAncestor determines whether the provided node is an ancestor
-// of the most recently-known checkpoint.  False is returned when no checkpoint
-// is known or checkpoints are disabled.
-//
-// This function MUST be called with the chain lock held (for reads).
-func (b *BlockChain) isKnownCheckpointAncestor(node *blockNode) bool {
-	if b.checkpointNode == nil {
-		return false
-	}
-	return node.IsAncestorOf(b.checkpointNode)
-}
-
 // isNonstandardTransaction determines whether a transaction contains any
 // scripts which are not one of the standard types.
 func isNonstandardTransaction(tx *dcrutil.Tx) bool {

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -3807,15 +3807,14 @@ func (b *BlockChain) checkConnectBlock(node *blockNode, block, parent *dcrutil.B
 		}
 	}
 
-	// Don't run scripts if this node is before the latest known good
-	// checkpoint since the validity is verified via the checkpoints (all
-	// transactions are included in the merkle root hash and any changes
-	// will therefore be detected by the next checkpoint).  This is a huge
-	// optimization because running the scripts is the most time consuming
-	// portion of block handling.
-	checkpoint := b.LatestCheckpoint()
+	// Don't run scripts if this node is both an ancestor of the assumed valid
+	// block and an ancestor of the best header since the validity is verified
+	// via the assumed valid node (all transactions are included in the merkle
+	// root hash and any changes will therefore be detected by the assumed valid
+	// node).  This is a huge optimization because running the scripts is the
+	// most time consuming portion of block handling.
 	runScripts := !b.noVerify
-	if checkpoint != nil && node.height <= checkpoint.Height {
+	if b.isAssumeValidAncestor(node) {
 		runScripts = false
 	}
 	var scriptFlags txscript.ScriptFlags

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -962,7 +962,7 @@ func CheckBlockSanity(block *dcrutil.Block, timeSource MedianTimeSource, chainPa
 //
 // The blocks that violated DCP0005 due to specifying the old version were
 // otherwise valid and are whitelisted by this function so that they will be
-// accepted when fully syncing the chain without checkpoints.
+// accepted when fully syncing the chain with assume valid disabled.
 func isDCP0005Violation(network wire.CurrencyNet, header *wire.BlockHeader, blockHash *chainhash.Hash) bool {
 	switch network {
 	case wire.MainNet:

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -3814,7 +3814,7 @@ func (b *BlockChain) checkConnectBlock(node *blockNode, block, parent *dcrutil.B
 	// node).  This is a huge optimization because running the scripts is the
 	// most time consuming portion of block handling.
 	runScripts := !b.noVerify
-	if b.isAssumeValidAncestor(node) {
+	if b.bulkImportMode || b.isAssumeValidAncestor(node) {
 		runScripts = false
 	}
 	var scriptFlags txscript.ScriptFlags

--- a/chaincfg/mainnetparams.go
+++ b/chaincfg/mainnetparams.go
@@ -116,6 +116,16 @@ func MainNetParams() *Params {
 			{601900, newHashFromStr("00000000000000001c1865a45a038bb680fc076d70cd88c1843e3e669cb54942")},
 		},
 
+		// AssumeValid is the hash of a block that has been externally verified
+		// to be valid.  It allows several validation checks to be skipped for
+		// blocks that are both an ancestor of the assumed valid block and an
+		// ancestor of the best header.  This is intended to be updated
+		// periodically with new releases.
+		//
+		// Block 00000000000000001251efb83ad1a5c71351b50fe9195f009cf0bf5a7cd99d52
+		// Height: 606000
+		AssumeValid: *newHashFromStr("00000000000000001251efb83ad1a5c71351b50fe9195f009cf0bf5a7cd99d52"),
+
 		// MinKnownChainWork is the minimum amount of known total work for the
 		// chain at a given point in time.  This is intended to be updated
 		// periodically with new releases.

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -335,6 +335,13 @@ type Params struct {
 	// will likely be changed to only allow a single checkpoint in the future.
 	Checkpoints []Checkpoint
 
+	// AssumeValid is the hash of a block that has been externally verified to
+	// be valid.  It allows several validation checks to be skipped for blocks
+	// that are both an ancestor of the assumed valid block and an ancestor of
+	// the best header.  This is intended to be updated periodically with new
+	// releases.  It may not be set for networks that do not require it.
+	AssumeValid chainhash.Hash
+
 	// MinKnownChainWork is the minimum amount of known total work for the chain
 	// at a given point in time.  This is intended to be updated periodically
 	// with new releases.  It may be nil for networks that do not require it.

--- a/chaincfg/regnetparams.go
+++ b/chaincfg/regnetparams.go
@@ -112,6 +112,12 @@ func RegNetParams() *Params {
 		// Checkpoints ordered from oldest to newest.
 		Checkpoints: nil,
 
+		// AssumeValid is the hash of a block that has been externally verified
+		// to be valid.
+		//
+		// Not set for regression test network since its chain is dynamic.
+		AssumeValid: chainhash.Hash{},
+
 		// MinKnownChainWork is the minimum amount of known total work for the
 		// chain at a given point in time.
 		//

--- a/chaincfg/simnetparams.go
+++ b/chaincfg/simnetparams.go
@@ -111,6 +111,12 @@ func SimNetParams() *Params {
 		// Checkpoints ordered from oldest to newest.
 		Checkpoints: nil,
 
+		// AssumeValid is the hash of a block that has been externally verified
+		// to be valid.
+		//
+		// Not set for simnet test network since its chain is dynamic.
+		AssumeValid: chainhash.Hash{},
+
 		// MinKnownChainWork is the minimum amount of known total work for the
 		// chain at a given point in time.
 		//

--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -111,6 +111,16 @@ func TestNet3Params() *Params {
 			{803810, newHashFromStr("000000016e841f4d94c3b253bc7bdf3a13217c7f28a5935bbaec37c7752678e9")},
 		},
 
+		// AssumeValid is the hash of a block that has been externally verified
+		// to be valid.  It allows several validation checks to be skipped for
+		// blocks that are both an ancestor of the assumed valid block and an
+		// ancestor of the best header.  This is intended to be updated
+		// periodically with new releases.
+		//
+		// Block 00000000d64ceb1a686315ed56235e9a6838e3a22e9ec9bd92c2e04c09e0778b
+		// Height: 807905
+		AssumeValid: *newHashFromStr("00000000d64ceb1a686315ed56235e9a6838e3a22e9ec9bd92c2e04c09e0778b"),
+
 		// MinKnownChainWork is the minimum amount of known total work for the
 		// chain at a given point in time.  This is intended to be updated
 		// periodically with new releases.

--- a/config.go
+++ b/config.go
@@ -195,6 +195,7 @@ type config struct {
 	// Chain related options.
 	DisableCheckpoints bool   `long:"nocheckpoints" description:"Disable built-in checkpoints.  Don't do this unless you know what you're doing"`
 	DumpBlockchain     string `long:"dumpblockchain" description:"Write blockchain as a flat file of blocks for use with addblock, to the specified filename"`
+	AssumeValid        string `long:"assumevalid" description:"Hash of an assumed valid block.  Defaults to the hard-coded assumed valid block that is updated periodically with new releases.  Don't use a different hash unless you understand the implications.  Set to 0 to disable"`
 
 	// Relay and mempool policy.
 	MinRelayTxFee    float64 `long:"minrelaytxfee" description:"The minimum transaction fee in DCR/kB to be considered a non-zero fee"`

--- a/doc.go
+++ b/doc.go
@@ -121,6 +121,11 @@ Application Options:
                                unless you know what you're doing
       --dumpblockchain=        Write blockchain as a flat file of blocks for use
                                with addblock, to the specified filename
+      --assumevalid=           Hash of an assumed valid block. Defaults to the
+                               hard-coded assumed valid block that is updated
+                               periodically with new releases. Don't use a
+                               different hash unless you understand the
+                               implications. Set to 0 to disable
       --minrelaytxfee=         The minimum transaction fee in DCR/kB to be
                                considered a non-zero fee (default: 0.0001)
       --limitfreerelay=        Limit relay of transactions with no transaction

--- a/server.go
+++ b/server.go
@@ -3470,6 +3470,14 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB,
 	}
 	s.feeEstimator = fe
 
+	// Only set the assumed valid block when checkpoints are enabled.  A new
+	// config option to disable assume valid will be introduced in a future
+	// commit and will be used instead of the disable checkpoints option.
+	var assumeValid chainhash.Hash
+	if !cfg.DisableCheckpoints {
+		assumeValid = s.chainParams.AssumeValid
+	}
+
 	// Only configure checkpoints when enabled.
 	var latestCheckpoint *chaincfg.Checkpoint
 	numCheckpoints := len(s.chainParams.Checkpoints)
@@ -3491,6 +3499,7 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB,
 			DB:               s.db,
 			UtxoBackend:      utxoBackend,
 			ChainParams:      s.chainParams,
+			AssumeValid:      assumeValid,
 			LatestCheckpoint: latestCheckpoint,
 			TimeSource:       s.timeSource,
 			Notifications:    s.handleBlockchainNotification,


### PR DESCRIPTION
This introduces an `AssumeValid` parameter and configuration option.  It is broken down into several commits to ease the review process.

---

**Motivation: Checkpoints vs AssumeValid**

Prior to this PR, `Checkpoints` were being used for two distinct purposes:
- Reject blocks that fork the main chain before the most recently known checkpoint
- Allow several validation checks to be skipped for blocks that are an ancestor of the most recently known checkpoint

This PR introduces a new parameter, `AssumeValid`, to control when validation checks can be skipped rather than continuing to use `Checkpoints` for this purpose.

The separation of `Checkpoints` and `AssumeValid` provides a few benefits:
- It allows for node operators to configure each capability independently
- It allows for testing the distinct sync options independently
- It allows for specifying an `AssumeValid` hash that is closer to tip
  - This is safe since when bypassing some validation checks with assume valid for a given block, the block is still validated to be part of the chain with the most proof of work and additionally must be an ancestor of the assumed valid block, meaning that changes in any transaction data would be detected as it would necessarily change the merkle root of the assumed valid block
  - This would not be safe with `Checkpoints` since rejecting forks before a certain point affects consensus 
  
---

**The `--assumevalid` config option**

Since the `AssumeValid` hash can be closer to tip, this PR adds the ability to set it without a code change via an `--assumevalid` option.  It can be specified as follows:
- (flag not specified):  defaults to the hard-coded value in source
- `--assumevalid=0`: disable `AssumeValid`
- `--assumevalid=[blockhash]`: set `AssumeValid` to the specified block hash

Specifying an `AssumeValid` hash closer to tip allows for faster syncing.  This is useful since the hard-coded `AssumeValid` block becomes deeper in the chain (and therefore more validation needs to be done post the `AssumeValid` block) the longer a particular release build is out. 

As noted in the implementation, `AssumeValid` is clamped back as needed to ensure that it is at least 2 weeks worth of blocks behind the best header.  This protects against malicious actors trying to play games by tricking users into using an assumed valid hash near the tip.
