### PR TITLE
mining: Prevent unnecessary reorg with equal votes.

### DIFF
--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -367,7 +367,10 @@ func SortParentsByVotes(txSource TxSource, currentTopBlock chainhash.Hash, block
 	// point, all blocks listed in sortedUsefulBlocks definitely also have the
 	// minimum number of votes required.
 	curVoteMetadata := txSource.VotesForBlocks([]chainhash.Hash{currentTopBlock})
-	numTopBlockVotes := uint16(len(curVoteMetadata))
+	var numTopBlockVotes uint16
+	if len(curVoteMetadata) > 0 {
+		numTopBlockVotes = uint16(len(curVoteMetadata[0]))
+	}
 	if filtered[0].NumVotes == numTopBlockVotes && filtered[0].Hash !=
 		currentTopBlock {
 


### PR DESCRIPTION
This corrects the logic related to preventing unnecessary reorgs in the function that sorts parents based the number of votes available for them and the current tip block and adds tests to ensure proper functionality.

Closes #2823.