### PR TITLE
version: Include VCS build info in version string.

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -138,6 +138,16 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+	if BuildMetadata == "" {
+		BuildMetadata = vcsCommitID()
+		if BuildMetadata != "" {
+			Version = fmt.Sprintf("%d.%d.%d", Major, Minor, Patch)
+			if PreRelease != "" {
+				Version += "-" + PreRelease
+			}
+			Version += "+" + BuildMetadata
+		}
+	}
 }
 
 // String returns the application version as a properly formed string per the

--- a/internal/version/version_buildinfo.go
+++ b/internal/version/version_buildinfo.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+//go:build go1.18
+// +build go1.18
+
+package version
+
+import "runtime/debug"
+
+func vcsCommitID() string {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	var vcs, revision string
+	for _, bs := range bi.Settings {
+		switch bs.Key {
+		case "vcs":
+			vcs = bs.Value
+		case "vcs.revision":
+			revision = bs.Value
+		}
+	}
+	if vcs == "" {
+		return ""
+	}
+	if vcs == "git" && len(revision) > 9 {
+		revision = revision[:9]
+	}
+	return revision
+}

--- a/internal/version/version_nobuildinfo.go
+++ b/internal/version/version_nobuildinfo.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+//go:build !go1.18
+// +build !go1.18
+
+package version
+
+func vcsCommitID() string {
+	return ""
+}


### PR DESCRIPTION
VCS build info is only available when built from a VCS checkout using
Go 1.18 or later.

Example versions before and after this change:

```
$ go build && ./dcrd -V
dcrd version 1.7.0-pre (Go version go1.17.4 openbsd/amd64)
$ gotip build && ./dcrd -V
dcrd version 1.7.0-pre+3ab07abf1 (Go version devel go1.18-4300f1051 Tue Dec 7 18:58:57 2021 +0000 openbsd/amd64)
```