### PR TITLE
multi: Max line length and wrapping guidelines.

### DIFF
--- a/blockchain/utxobackend.go
+++ b/blockchain/utxobackend.go
@@ -96,20 +96,20 @@ func prefixedKey(prefix []byte, key []byte) []byte {
 
 // These variables define keys that are part of the database info key set.
 var (
-	// utxoDbInfoVersionKeyName is the name of the database key used to house the
-	// database version.  It is itself under utxoPrefixDbInfo.
+	// utxoDbInfoVersionKeyName is the name of the database key used to house
+	// the database version.  It is itself under utxoPrefixDbInfo.
 	utxoDbInfoVersionKeyName = []byte("version")
 
-	// utxoDbInfoCompVerKeyName is the name of the database key used to house the
-	// database compression version.  It is itself under utxoPrefixDbInfo.
+	// utxoDbInfoCompVerKeyName is the name of the database key used to house
+	// the database compression version.  It is itself under utxoPrefixDbInfo.
 	utxoDbInfoCompVerKeyName = []byte("compver")
 
-	// utxoDbInfoUtxoVerKeyName is the name of the database key used to house the
-	// database UTXO set version.  It is itself under utxoPrefixDbInfo.
+	// utxoDbInfoUtxoVerKeyName is the name of the database key used to house
+	// the database UTXO set version.  It is itself under utxoPrefixDbInfo.
 	utxoDbInfoUtxoVerKeyName = []byte("utxover")
 
-	// utxoDbInfoCreatedKeyName is the name of the database key used to house the
-	// date the database was created.  It is itself under utxoPrefixDbInfo.
+	// utxoDbInfoCreatedKeyName is the name of the database key used to house
+	// the date the database was created.  It is itself under utxoPrefixDbInfo.
 	utxoDbInfoCreatedKeyName = []byte("created")
 
 	// utxoDbInfoVersionKey is the database key used to house the database
@@ -131,13 +131,13 @@ var (
 
 // These variables define keys that are part of the UTXO state key set.
 var (
-	// utxoSetStateKeyName is the name of the database key used to house the state
-	// of the unspent transaction output set.  It is itself under
+	// utxoSetStateKeyName is the name of the database key used to house the
+	// state of the unspent transaction output set.  It is itself under
 	// utxoPrefixUtxoState.
 	utxoSetStateKeyName = []byte("utxosetstate")
 
-	// utxoSetStateKey is the database key used to house the state of the unspent
-	// transaction output set.
+	// utxoSetStateKey is the database key used to house the state of the
+	// unspent transaction output set.
 	utxoSetStateKey = prefixedKey(utxoPrefixUtxoState, utxoSetStateKeyName)
 )
 
@@ -183,7 +183,8 @@ type UtxoBackend interface {
 	// both the entry and the error.
 	FetchEntry(outpoint wire.OutPoint) (*UtxoEntry, error)
 
-	// FetchInfo returns versioning and creation information for the UTXO backend.
+	// FetchInfo returns versioning and creation information for the UTXO
+	// backend.
 	FetchInfo() (*UtxoBackendInfo, error)
 
 	// FetchState returns the current state of the UTXO set.
@@ -217,11 +218,12 @@ type UtxoBackend interface {
 	// The iterator must be released after use, by calling the Release method.
 	NewIterator(prefix []byte) UtxoBackendIterator
 
-	// PutInfo sets the versioning and creation information for the UTXO backend.
+	// PutInfo sets the versioning and creation information for the UTXO
+	// backend.
 	PutInfo(info *UtxoBackendInfo) error
 
-	// PutUtxos atomically updates the UTXO set with the entries from the provided
-	// map along with the current state.
+	// PutUtxos atomically updates the UTXO set with the entries from the
+	// provided map along with the current state.
 	PutUtxos(utxos map[wire.OutPoint]*UtxoEntry, state *UtxoSetState) error
 
 	// Update invokes the passed function in the context of a UTXO Backend
@@ -239,8 +241,8 @@ type UtxoBackend interface {
 // levelDbUtxoBackend implements the UtxoBackend interface using an underlying
 // leveldb database instance.
 type levelDbUtxoBackend struct {
-	// db is the database that contains the UTXO set.  It is set when the instance
-	// is created and is not changed afterward.
+	// db is the database that contains the UTXO set.  It is set when the
+	// instance is created and is not changed afterward.
 	db *leveldb.DB
 }
 
@@ -344,10 +346,11 @@ func LoadUtxoDB(ctx context.Context, params *chaincfg.Params, dataDir string) (*
 		// fail if the directory couldn't be created.
 		//
 		// NOTE: It is important that os.MkdirAll is only called if the database
-		// does not exist.  The documentation states that os.MidirAll does nothing
-		// if the directory already exists.  However, this has proven not to be the
-		// case on some less supported OSes and can lead to creating new directories
-		// with the wrong permissions or otherwise lead to hard to diagnose issues.
+		// does not exist.  The documentation states that os.MidirAll does
+		// nothing if the directory already exists.  However, this has proven
+		// not to be the case on some less supported OSes and can lead to
+		// creating new directories with the wrong permissions or otherwise lead
+		// to hard to diagnose issues.
 		_ = os.MkdirAll(dataDir, 0700)
 	}
 
@@ -452,8 +455,8 @@ func (l *levelDbUtxoBackend) NewIterator(prefix []byte) UtxoBackendIterator {
 // When there is no entry for the provided output, nil will be returned for both
 // the entry and the error.
 func (l *levelDbUtxoBackend) dbFetchUtxoEntry(outpoint wire.OutPoint) (*UtxoEntry, error) {
-	// Fetch the unspent transaction output information for the passed transaction
-	// output.  Return now when there is no entry.
+	// Fetch the unspent transaction output information for the passed
+	// transaction output.  Return now when there is no entry.
 	key := outpointKey(outpoint)
 	serializedUtxo, err := l.Get(*key)
 	recycleOutpointKey(key)
@@ -467,15 +470,15 @@ func (l *levelDbUtxoBackend) dbFetchUtxoEntry(outpoint wire.OutPoint) (*UtxoEntr
 	// A non-nil zero-length entry means there is an entry in the database for a
 	// spent transaction output which should never be the case.
 	if len(serializedUtxo) == 0 {
-		return nil, AssertError(fmt.Sprintf("database contains entry for spent tx "+
-			"output %v", outpoint))
+		return nil, AssertError(fmt.Sprintf("database contains entry for "+
+			"spent tx output %v", outpoint))
 	}
 
 	// Deserialize the utxo entry and return it.
 	entry, err := deserializeUtxoEntry(serializedUtxo, outpoint.Index)
 	if err != nil {
-		// Ensure any deserialization errors are returned as UTXO backend corruption
-		// errors.
+		// Ensure any deserialization errors are returned as UTXO backend
+		// corruption errors.
 		if isDeserializeErr(err) {
 			str := fmt.Sprintf("corrupt utxo entry for %v: %v", outpoint, err)
 			return nil, contextError(ErrUtxoBackendCorruption, str)
@@ -540,11 +543,11 @@ func (l *levelDbUtxoBackend) FetchStats() (*UtxoStats, error) {
 		serializedUtxo := iter.Value()
 		entrySize := len(serializedUtxo)
 
-		// A non-nil zero-length entry means there is an entry in the database for a
-		// spent transaction output which should never be the case.
+		// A non-nil zero-length entry means there is an entry in the database
+		// for a spent transaction output which should never be the case.
 		if entrySize == 0 {
-			return nil, AssertError(fmt.Sprintf("database contains entry for spent "+
-				"tx output %v", outpoint))
+			return nil, AssertError(fmt.Sprintf("database contains entry for "+
+				"spent tx output %v", outpoint))
 		}
 
 		stats.Utxos++
@@ -559,7 +562,8 @@ func (l *levelDbUtxoBackend) FetchStats() (*UtxoStats, error) {
 			// Ensure any deserialization errors are returned as UTXO backend
 			// corruption errors.
 			if isDeserializeErr(err) {
-				str := fmt.Sprintf("corrupt utxo entry for %v: %v", outpoint, err)
+				str := fmt.Sprintf("corrupt utxo entry for %v: %v", outpoint,
+					err)
 				return nil, contextError(ErrUtxoBackendCorruption, str)
 			}
 

--- a/blockchain/utxobackend_test.go
+++ b/blockchain/utxobackend_test.go
@@ -73,8 +73,8 @@ func TestConvertLdbErr(t *testing.T) {
 
 		// Validate the error kind.
 		if gotErr.Err != test.want {
-			t.Errorf("%q: mismatched error kind:\nwant: %v\n got: %v\n", test.name,
-				test.want, gotErr.Err)
+			t.Errorf("%q: mismatched error kind:\nwant: %v\n got: %v\n",
+				test.name, test.want, gotErr.Err)
 			continue
 		}
 
@@ -87,8 +87,8 @@ func TestConvertLdbErr(t *testing.T) {
 
 		// Validate the raw error.
 		if gotErr.RawErr != test.ldbErr {
-			t.Errorf("%q: mismatched raw error:\nwant: %v\n got: %v\n", test.name,
-				test.ldbErr, gotErr.RawErr)
+			t.Errorf("%q: mismatched raw error:\nwant: %v\n got: %v\n",
+				test.name, test.ldbErr, gotErr.RawErr)
 			continue
 		}
 	}
@@ -118,8 +118,8 @@ func TestFetchEntryFromBackend(t *testing.T) {
 	}, {
 		name: "entry is in the backend",
 		backendEntries: map[wire.OutPoint][]byte{
-			outpoint: hexToBytes("812b010080fba8a41b0000454017705ab80470d089c7f644e" +
-				"39cc9e0fd308e"),
+			outpoint: hexToBytes("812b010080fba8a41b0000454017705ab80470d089c" +
+				"7f644e39cc9e0fd308e"),
 		},
 		outpoint:  outpoint,
 		wantEntry: entry,
@@ -182,10 +182,10 @@ func TestPutUtxos(t *testing.T) {
 	backend := createTestUtxoBackend(t)
 
 	// Create test hashes to be used throughout the tests.
-	block1000Hash := mustParseHash("0000000000004740ad140c86753f9295e09f9cc81b1" +
-		"bb75d7f5552aeeedb7012")
-	block2000Hash := mustParseHash("0000000000000c8a886e3f7c32b1bb08422066dcfd0" +
-		"08de596471f11a5aff475")
+	block1000Hash := mustParseHash("0000000000004740ad140c86753f9295e09f9cc81" +
+		"b1bb75d7f5552aeeedb7012")
+	block2000Hash := mustParseHash("0000000000000c8a886e3f7c32b1bb08422066dcf" +
+		"d008de596471f11a5aff475")
 
 	// entry299Fresh is from block height 299 and is modified and fresh.
 	outpoint299 := outpoint299()
@@ -267,8 +267,8 @@ func TestPutUtxos(t *testing.T) {
 		for outpoint := range test.utxos {
 			entry, err := backend.FetchEntry(outpoint)
 			if err != nil {
-				t.Fatalf("%q: unexpected error fetching entries from test backend: %v",
-					test.name, err)
+				t.Fatalf("%q: unexpected error fetching entries from test "+
+					"backend: %v", test.name, err)
 			}
 
 			if entry != nil {
@@ -310,8 +310,8 @@ func TestFetchState(t *testing.T) {
 		name: "last flush saved in backend",
 		state: &UtxoSetState{
 			lastFlushHeight: 432100,
-			lastFlushHash: *mustParseHash("000000000000000023455b4328635d8e014dbeea" +
-				"99c6140aa715836cc7e55981"),
+			lastFlushHash: *mustParseHash("000000000000000023455b4328635d8e01" +
+				"4dbeea99c6140aa715836cc7e55981"),
 		},
 	}}
 
@@ -370,7 +370,8 @@ func TestPutInfo(t *testing.T) {
 			// Update the UTXO backend info.
 			err := backend.PutInfo(test.backendInfo)
 			if err != nil {
-				t.Fatalf("%q: error putting UTXO backend info: %v", test.name, err)
+				t.Fatalf("%q: error putting UTXO backend info: %v", test.name,
+					err)
 			}
 		}
 

--- a/blockchain/utxobackenditerator.go
+++ b/blockchain/utxobackenditerator.go
@@ -17,9 +17,10 @@ package blockchain
 // The interface contract does NOT require that these methods are safe for
 // concurrent access.
 type UtxoBackendIterator interface {
-	// First moves the iterator to the first key/value pair.  If the iterator only
-	// contains one key/value pair then First and Last would move to the same
-	// key/value pair.  It returns whether the pair that is moved to exists.
+	// First moves the iterator to the first key/value pair.  If the iterator
+	// only contains one key/value pair then First and Last would move to the
+	// same key/value pair.  It returns whether the pair that is moved to
+	// exists.
 	First() bool
 
 	// Last moves the iterator to the last key/value pair.  If the iterator only
@@ -28,8 +29,8 @@ type UtxoBackendIterator interface {
 	Last() bool
 
 	// Seek moves the iterator to the first key/value pair whose key is greater
-	// than or equal to the given key.  It returns whether the pair that is moved
-	// to exists.
+	// than or equal to the given key.  It returns whether the pair that is
+	// moved to exists.
 	//
 	// It is safe to modify the contents of the argument after Seek returns.
 	Seek(key []byte) bool
@@ -42,8 +43,8 @@ type UtxoBackendIterator interface {
 	// if the iterator is exhausted.
 	Prev() bool
 
-	// Error returns any accumulated error.  Exhausting all of the key/value pairs
-	// is not considered to be an error.
+	// Error returns any accumulated error.  Exhausting all of the key/value
+	// pairs is not considered to be an error.
 	Error() error
 
 	// Key returns the key of the current key/value pair, or nil if done.  The
@@ -51,8 +52,8 @@ type UtxoBackendIterator interface {
 	// contents may change on the next call to any iteration method.
 	Key() []byte
 
-	// Value returns the value of the current key/value pair, or nil if done.  The
-	// caller should not modify the contents of the returned slice, and its
+	// Value returns the value of the current key/value pair, or nil if done.
+	// The caller should not modify the contents of the returned slice, and its
 	// contents may change on the next call to any iteration method.
 	Value() []byte
 

--- a/blockchain/utxobackendtx.go
+++ b/blockchain/utxobackendtx.go
@@ -35,20 +35,22 @@ type UtxoBackendTx interface {
 	// It is safe to modify the slice passed as an argument after Has returns.
 	Has(key []byte) (bool, error)
 
-	// Put sets the value for the given key.  It overwrites any previous value for
-	// that key.
+	// Put sets the value for the given key.  It overwrites any previous value
+	// for that key.
 	//
 	// It is safe to modify the slice passed as an argument after Put returns.
 	Put(key, value []byte) error
 
 	// Delete removes the given key.
 	//
-	// It is safe to modify the slice passed as an argument after Delete returns.
+	// It is safe to modify the slice passed as an argument after Delete
+	// returns.
 	Delete(key []byte) error
 
-	// NewIterator returns an iterator for the latest snapshot of the transaction.
-	// The returned iterator is NOT safe for concurrent use, but it is safe to use
-	// multiple iterators concurrently, with each in a dedicated goroutine.
+	// NewIterator returns an iterator for the latest snapshot of the
+	// transaction.  The returned iterator is NOT safe for concurrent use, but
+	// it is safe to use multiple iterators concurrently, with each in a
+	// dedicated goroutine.
 	//
 	// The prefix parameter allows for slicing the iterator to only contain keys
 	// with the given prefix.  A nil prefix is treated as a key BEFORE all keys.
@@ -59,8 +61,8 @@ type UtxoBackendTx interface {
 	// The iterator must be released after use, by calling the Release method.
 	NewIterator(prefix []byte) UtxoBackendIterator
 
-	// Commit commits the transaction.  If the returned error is not nil, then the
-	// transaction is not committed and can either be retried or discarded.
+	// Commit commits the transaction.  If the returned error is not nil, then
+	// the transaction is not committed and can either be retried or discarded.
 	//
 	// Other methods should not be called after the transaction has been
 	// committed.
@@ -121,8 +123,8 @@ func (tx *levelDbUtxoBackendTx) Has(key []byte) (bool, error) {
 func (tx *levelDbUtxoBackendTx) Put(key, value []byte) error {
 	err := tx.Transaction.Put(key, value, nil)
 	if err != nil {
-		str := fmt.Sprintf("failed to put key %x (value %x) to leveldb transaction",
-			key, value)
+		str := fmt.Sprintf("failed to put key %x (value %x) to leveldb "+
+			"transaction", key, value)
 		return convertLdbErr(err, str)
 	}
 	return nil
@@ -134,7 +136,8 @@ func (tx *levelDbUtxoBackendTx) Put(key, value []byte) error {
 func (tx *levelDbUtxoBackendTx) Delete(key []byte) error {
 	err := tx.Transaction.Delete(key, nil)
 	if err != nil {
-		str := fmt.Sprintf("failed to delete key %x from leveldb transaction", key)
+		str := fmt.Sprintf("failed to delete key %x from leveldb transaction",
+			key)
 		return convertLdbErr(err, str)
 	}
 	return nil

--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -27,35 +27,36 @@ const (
 	pointerSize = 8
 
 	// p2pkhScriptLen is the length of a standard pay-to-pubkey-hash script.  It
-	// is used in the calculation to approximate the average size of a utxo entry
-	// when setting the initial capacity of the cache.
+	// is used in the calculation to approximate the average size of a utxo
+	// entry when setting the initial capacity of the cache.
 	p2pkhScriptLen = 25
 
-	// mapOverhead is the number of bytes per entry to use when approximating the
-	// memory overhead of the entries map itself (i.e. the memory usage due to
-	// internals of the map, such as the underlying buckets that are allocated).
-	// This number was determined by inspecting the true size of the map with
-	// various numbers of entries and comparing it with the total size of all
-	// entries in the map.  The average overhead came out to 57 bytes per entry.
+	// mapOverhead is the number of bytes per entry to use when approximating
+	// the memory overhead of the entries map itself (i.e. the memory usage due
+	// to internals of the map, such as the underlying buckets that are
+	// allocated).  This number was determined by inspecting the true size of
+	// the map with various numbers of entries and comparing it with the total
+	// size of all entries in the map.  The average overhead came out to 57
+	// bytes per entry.
 	mapOverhead = 57
 
-	// evictionPercentage is the targeted percentage of entries to evict from the
-	// cache when its maximum size has been reached.
+	// evictionPercentage is the targeted percentage of entries to evict from
+	// the cache when its maximum size has been reached.
 	//
-	// A lower percentage will result in a higher overall hit ratio for the cache,
-	// and thus better performance, but will require eviction again sooner.  This
-	// value was selected to keep the hit ratio of the cache as high as possible
-	// while still evicting a significant portion of the cache when it reaches its
-	// maximum allowed size.
+	// A lower percentage will result in a higher overall hit ratio for the
+	// cache, and thus better performance, but will require eviction again
+	// sooner.  This value was selected to keep the hit ratio of the cache as
+	// high as possible while still evicting a significant portion of the cache
+	// when it reaches its maximum allowed size.
 	evictionPercentage = 0.15
 
-	// periodicFlushInterval is the amount of time to wait before a periodic flush
-	// is required.
+	// periodicFlushInterval is the amount of time to wait before a periodic
+	// flush is required.
 	//
 	// The cache is flushed periodically during initial block download to avoid
-	// requiring a flush that would take a significant amount of time on shutdown
-	// (or, in the case of an unclean shutdown, a significant amount of time to
-	// initialize the cache when restarted).
+	// requiring a flush that would take a significant amount of time on
+	// shutdown (or, in the case of an unclean shutdown, a significant amount of
+	// time to initialize the cache when restarted).
 	periodicFlushInterval = time.Minute * 2
 )
 
@@ -67,28 +68,29 @@ type UtxoCacher interface {
 	// Commit updates the cache based on the state of each entry in the provided
 	// view.
 	//
-	// All entries in the provided view that are marked as modified and spent are
-	// removed from the view.  Additionally, all entries that are added to the
-	// cache are removed from the provided view.
+	// All entries in the provided view that are marked as modified and spent
+	// are removed from the view.  Additionally, all entries that are added to
+	// the cache are removed from the provided view.
 	Commit(view *UtxoViewpoint) error
 
-	// FetchBackendState returns the current state of the UTXO set in the backend.
+	// FetchBackendState returns the current state of the UTXO set in the
+	// backend.
 	FetchBackendState() (*UtxoSetState, error)
 
 	// FetchEntries adds the requested transaction outputs to the provided view.
-	// It first checks the cache for each output, and if an output does not exist
-	// in the cache, it will fetch it from the backend.
+	// It first checks the cache for each output, and if an output does not
+	// exist in the cache, it will fetch it from the backend.
 	//
 	// Upon completion of this function, the view will contain an entry for each
 	// requested outpoint.  Spent outputs, or those which otherwise don't exist,
 	// will result in a nil entry in the view.
 	FetchEntries(filteredSet ViewFilteredSet, view *UtxoViewpoint) error
 
-	// FetchEntry returns the specified transaction output from the utxo set.  If
-	// the output exists in the cache, it is returned immediately.  Otherwise, it
-	// fetches the output from the backend, caches it, and returns it to the
-	// caller.  The entry that is returned can safely be mutated by the caller
-	// without invalidating the cache.
+	// FetchEntry returns the specified transaction output from the utxo set.
+	// If the output exists in the cache, it is returned immediately.
+	// Otherwise, it fetches the output from the backend, caches it, and returns
+	// it to the caller.  The entry that is returned can safely be mutated by
+	// the caller without invalidating the cache.
 	//
 	// When there is no entry for the provided output, nil will be returned for
 	// both the entry and the error.
@@ -102,8 +104,8 @@ type UtxoCacher interface {
 	// set is caught up to the tip of the best chain.
 	Initialize(ctx context.Context, b *BlockChain, tip *blockNode) error
 
-	// MaybeFlush conditionally flushes the cache to the backend.  A flush can be
-	// forced by setting the force flush parameter.
+	// MaybeFlush conditionally flushes the cache to the backend.  A flush can
+	// be forced by setting the force flush parameter.
 	MaybeFlush(bestHash *chainhash.Hash, bestHeight uint32, forceFlush bool,
 		logFlush bool) error
 }
@@ -134,19 +136,19 @@ type UtxoCache struct {
 
 	// flushBlockDB defines the function to use to flush the block database to
 	// disk.  The block database is always flushed to disk before the UTXO cache
-	// writes to disk in order to maintain a recoverable state in the event of an
-	// unclean shutdown.  It is set when the instance is created and is not
+	// writes to disk in order to maintain a recoverable state in the event of
+	// an unclean shutdown.  It is set when the instance is created and is not
 	// changed afterward.
 	flushBlockDB func() error
 
-	// maxSize is the maximum allowed size of the utxo cache, in bytes.  It is set
-	// when the instance is created and is not changed afterward.
+	// maxSize is the maximum allowed size of the utxo cache, in bytes.  It is
+	// set when the instance is created and is not changed afterward.
 	maxSize uint64
 
-	// cacheLock protects access to the fields in the struct below this point.  A
-	// standard mutex is used rather than a read-write mutex since the cache will
-	// often write when reads result in a cache miss, so it is generally not worth
-	// the additional overhead of using a read-write mutex.
+	// cacheLock protects access to the fields in the struct below this point.
+	// A standard mutex is used rather than a read-write mutex since the cache
+	// will often write when reads result in a cache miss, so it is generally
+	// not worth the additional overhead of using a read-write mutex.
 	cacheLock sync.Mutex
 
 	// entries holds the cached utxo entries.
@@ -154,8 +156,8 @@ type UtxoCache struct {
 
 	// lastFlushHash is the block hash of the last flush.  It is used to compare
 	// the state of the cache to the utxo set state in the backend so that the
-	// utxo set can properly be initialized in the case that the latest utxo data
-	// had not been flushed to the backend yet.
+	// utxo set can properly be initialized in the case that the latest utxo
+	// data had not been flushed to the backend yet.
 	lastFlushHash chainhash.Hash
 
 	// lastFlushTime is the last time that the cache was flushed to the backend.
@@ -166,12 +168,13 @@ type UtxoCache struct {
 
 	// lastEvictionHeight is the block height of the last eviction.  When the
 	// cache reaches the maximum allowed size, entries are evicted based on the
-	// height of the block that they are contained in, and last eviction height is
-	// updated to the current height.
+	// height of the block that they are contained in, and last eviction height
+	// is updated to the current height.
 	lastEvictionHeight uint32
 
 	// totalEntrySize is the total size of all utxo entries in the cache, in
-	// bytes.  It is updated whenever an entry is added or removed from the cache.
+	// bytes.  It is updated whenever an entry is added or removed from the
+	// cache.
 	totalEntrySize uint64
 
 	// The following fields track the total number of cache hits and misses and
@@ -198,8 +201,8 @@ type UtxoCacheConfig struct {
 
 	// FlushBlockDB defines the function to use to flush the block database to
 	// disk.  The block database is always flushed to disk before the UTXO cache
-	// writes to disk in order to maintain a recoverable state in the event of an
-	// unclean shutdown.
+	// writes to disk in order to maintain a recoverable state in the event of
+	// an unclean shutdown.
 	//
 	// This field is required.
 	FlushBlockDB func() error
@@ -272,11 +275,11 @@ func (c *UtxoCache) addEntry(outpoint wire.OutPoint, entry *UtxoEntry) error {
 		entry.state |= utxoStateModified | utxoStateFresh
 	}
 
-	// Add the entry to the cache.  In the case that an entry already exists, the
-	// existing entry is overwritten.  All fields are overwritten because it's
-	// possible (although extremely unlikely) that the existing entry is being
-	// replaced by a different transaction with the same hash.  This is allowed so
-	// long as the previous transaction is fully spent.
+	// Add the entry to the cache.  In the case that an entry already exists,
+	// the existing entry is overwritten.  All fields are overwritten because
+	// it's possible (although extremely unlikely) that the existing entry is
+	// being replaced by a different transaction with the same hash.  This is
+	// allowed so long as the previous transaction is fully spent.
 	c.entries[outpoint] = entry
 
 	// Update the total entry size of the cache.
@@ -320,8 +323,8 @@ func (c *UtxoCache) spendEntry(outpoint wire.OutPoint) {
 	// are added and spent in between flushes to the backend.
 	if cachedEntry.isFresh() {
 		// The entry in the map is marked as nil rather than deleting it so that
-		// subsequent lookups for the outpoint will still result in a cache hit and
-		// avoid querying the backend.
+		// subsequent lookups for the outpoint will still result in a cache hit
+		// and avoid querying the backend.
 		c.entries[outpoint] = nil
 		c.totalEntrySize -= cachedEntry.size()
 		return
@@ -352,8 +355,8 @@ func (c *UtxoCache) SpendEntry(outpoint wire.OutPoint) {
 // This function MUST be called with the cache lock held.
 func (c *UtxoCache) fetchEntry(outpoint wire.OutPoint) (*UtxoEntry, error) {
 	// If the cache already has the entry, return it immediately.  A cloned copy
-	// of the entry is returned so it can safely be mutated by the caller without
-	// invalidating the cache.
+	// of the entry is returned so it can safely be mutated by the caller
+	// without invalidating the cache.
 	var entry *UtxoEntry
 	if entry, found := c.entries[outpoint]; found {
 		c.hits++
@@ -380,8 +383,8 @@ func (c *UtxoCache) fetchEntry(outpoint wire.OutPoint) (*UtxoEntry, error) {
 	}
 
 	// Add the entry to the cache and return it.  A cloned copy of the entry is
-	// returned so it can safely be mutated by the caller without invalidating the
-	// cache.
+	// returned so it can safely be mutated by the caller without invalidating
+	// the cache.
 	c.entries[outpoint] = entry
 	return entry.Clone(), nil
 }
@@ -466,8 +469,8 @@ func (c *UtxoCache) Commit(view *UtxoViewpoint) error {
 			continue
 		}
 
-		// If the entry is not modified and not fresh, continue as there is nothing
-		// to do.
+		// If the entry is not modified and not fresh, continue as there is
+		// nothing to do.
 		if !entry.isModified() && !entry.isFresh() {
 			continue
 		}
@@ -483,8 +486,8 @@ func (c *UtxoCache) Commit(view *UtxoViewpoint) error {
 			continue
 		}
 
-		// If we passed all of the conditions above, the entry is modified or fresh,
-		// but not spent, and should be added to the cache.
+		// If we passed all of the conditions above, the entry is modified or
+		// fresh, but not spent, and should be added to the cache.
 		err := c.addEntry(outpoint, entry)
 		if err != nil {
 			c.cacheLock.Unlock()
@@ -493,14 +496,14 @@ func (c *UtxoCache) Commit(view *UtxoViewpoint) error {
 
 		// All entries that are added to the cache should be removed from the
 		// provided view.  This is an optimization to allow the cache to take
-		// ownership of the entry from the view and avoid an additional allocation.
-		// It is removed from the view to ensure that it is not mutated by the
-		// caller after being added to the cache.
+		// ownership of the entry from the view and avoid an additional
+		// allocation.  It is removed from the view to ensure that it is not
+		// mutated by the caller after being added to the cache.
 		//
-		// This does cause the view to refetch the entry if it is requested again
-		// after being removed.  However, this only really occurs during reorgs,
-		// whereas committing the view to the cache happens with every connected
-		// block, so this optimizes for the much more common case.
+		// This does cause the view to refetch the entry if it is requested
+		// again after being removed.  However, this only really occurs during
+		// reorgs, whereas committing the view to the cache happens with every
+		// connected block, so this optimizes for the much more common case.
 		delete(view.entries, outpoint)
 	}
 	c.cacheLock.Unlock()
@@ -590,9 +593,9 @@ func (c *UtxoCache) flush(bestHash *chainhash.Hash, bestHeight uint32, logFlush 
 
 	// Flush the block database to disk.  The block database MUST always be
 	// flushed to disk prior to flushing the UTXO cache to the UTXO database.
-	// This ensures that the block database is always at least as far along as the
-	// UTXO database which keeps the UTXO database in a recoverable state in the
-	// event of an unclean shutdown.
+	// This ensures that the block database is always at least as far along as
+	// the UTXO database which keeps the UTXO database in a recoverable state in
+	// the event of an unclean shutdown.
 	err := c.flushBlockDB()
 	if err != nil {
 		return err
@@ -614,9 +617,9 @@ func (c *UtxoCache) flush(bestHash *chainhash.Hash, bestHeight uint32, logFlush 
 	// inconsistent state.
 	for outpoint, entry := range c.entries {
 		// Conditionally evict entries from the cache.  Entries that are nil or
-		// spent are always evicted since they are unlikely to be accessed again.
-		// Additionally, entries that are contained in a block with a height less
-		// than the eviction height are evicted.
+		// spent are always evicted since they are unlikely to be accessed
+		// again.  Additionally, entries that are contained in a block with a
+		// height less than the eviction height are evicted.
 		if entry == nil || entry.IsSpent() ||
 			entry.BlockHeight() < int64(evictionHeight) {
 
@@ -648,17 +651,17 @@ func (c *UtxoCache) flush(bestHash *chainhash.Hash, bestHeight uint32, logFlush 
 		c.lastEvictionHeight = evictionHeight
 	}
 
-	// Log that the flush has been completed and indicate the updated memory usage
-	// as it will be reduced due to evicting entries above.
+	// Log that the flush has been completed and indicate the updated memory
+	// usage as it will be reduced due to evicting entries above.
 	if logFlush {
 		remainingEntries := len(c.entries)
 		flushedEntries := preFlushNumEntries - remainingEntries
 		memUsage = c.totalSize()
 		memUsageMiB := float64(memUsage) / 1024 / 1024
 		memUsagePercent := float64(memUsage) / float64(c.maxSize) * 100
-		log.Debugf("UTXO cache flush completed (%d entries flushed, %d entries "+
-			"remaining, %.2f MiB (%.2f%%))", flushedEntries, remainingEntries,
-			memUsageMiB, memUsagePercent)
+		log.Debugf("UTXO cache flush completed (%d entries flushed, %d "+
+			"entries remaining, %.2f MiB (%.2f%%))", flushedEntries,
+			remainingEntries, memUsageMiB, memUsagePercent)
 	}
 
 	return nil
@@ -711,9 +714,9 @@ func (c *UtxoCache) Initialize(ctx context.Context, b *BlockChain, tip *blockNod
 		return err
 	}
 
-	// If the state is nil, update the state to the tip.  This should only be the
-	// case when starting from a fresh backend or a backend that has not been run
-	// with the utxo cache yet.
+	// If the state is nil, update the state to the tip.  This should only be
+	// the case when starting from a fresh backend or a backend that has not
+	// been run with the utxo cache yet.
 	if state == nil {
 		state = &UtxoSetState{
 			lastFlushHeight: uint32(tip.height),
@@ -730,7 +733,8 @@ func (c *UtxoCache) Initialize(ctx context.Context, b *BlockChain, tip *blockNod
 	c.lastFlushHash = state.lastFlushHash
 	c.lastEvictionHeight = state.lastFlushHeight
 
-	// If state is already caught up to the tip, return as there is nothing to do.
+	// If state is already caught up to the tip, return as there is nothing to
+	// do.
 	if state.lastFlushHash == tip.hash {
 		log.Info("UTXO cache initialization completed")
 		return nil
@@ -739,8 +743,8 @@ func (c *UtxoCache) Initialize(ctx context.Context, b *BlockChain, tip *blockNod
 	// Find the fork point between the current tip and the last flushed block.
 	lastFlushedNode := b.index.LookupNode(&state.lastFlushHash)
 	if lastFlushedNode == nil {
-		// panic if the last flushed block node does not exist.  This should never
-		// happen unless the backend is corrupted.
+		// panic if the last flushed block node does not exist.  This should
+		// never happen unless the backend is corrupted.
 		panicf("last flushed block node hash %v (height %v) does not exist",
 			state.lastFlushHash, state.lastFlushHeight)
 	}
@@ -753,11 +757,11 @@ func (c *UtxoCache) Initialize(ctx context.Context, b *BlockChain, tip *blockNod
 	// parent, the regular transactions are reconnected.
 	//
 	// Note that blocks will only need to be disconnected during initialization
-	// if an unclean shutdown occurred between a block being disconnected and the
-	// cache being flushed.  Since the cache is always flushed immediately after
-	// disconnecting a block, this will occur very infrequently.  In the typical
-	// catchup case, the fork node will be the last flushed node itself and this
-	// loop will be skipped.
+	// if an unclean shutdown occurred between a block being disconnected and
+	// the cache being flushed.  Since the cache is always flushed immediately
+	// after disconnecting a block, this will occur very infrequently.  In the
+	// typical catchup case, the fork node will be the last flushed node itself
+	// and this loop will be skipped.
 	view := NewUtxoViewpoint(c)
 	view.SetBestHash(&tip.hash)
 	var nextBlockToDetach *dcrutil.Block
@@ -828,16 +832,16 @@ func (c *UtxoCache) Initialize(ctx context.Context, b *BlockChain, tip *blockNod
 
 		// Commit all entries in the view to the utxo cache.  All entries in the
 		// view that are marked as modified and spent are removed from the view.
-		// Additionally, all entries that are added to the cache are removed from
-		// the view.
+		// Additionally, all entries that are added to the cache are removed
+		// from the view.
 		err = c.Commit(view)
 		if err != nil {
 			return err
 		}
 
 		// Conditionally flush the utxo cache to the backend.  Don't force flush
-		// since many blocks may be disconnected and connected in quick succession
-		// when initializing.
+		// since many blocks may be disconnected and connected in quick
+		// succession when initializing.
 		err = c.MaybeFlush(&n.hash, uint32(n.height), false, true)
 		if err != nil {
 			return err
@@ -863,8 +867,8 @@ func (c *UtxoCache) Initialize(ctx context.Context, b *BlockChain, tip *blockNod
 		default:
 		}
 
-		// Grab the block to attach based on the node.  The parent of the block is
-		// the previous one that was attached except for the first node being
+		// Grab the block to attach based on the node.  The parent of the block
+		// is the previous one that was attached except for the first node being
 		// attached, which needs to be fetched.
 		block, err := b.fetchBlockByNode(n)
 		if err != nil {
@@ -910,15 +914,16 @@ func (c *UtxoCache) Initialize(ctx context.Context, b *BlockChain, tip *blockNod
 
 		// Commit all entries in the view to the utxo cache.  All entries in the
 		// view that are marked as modified and spent are removed from the view.
-		// Additionally, all entries that are added to the cache are removed from
-		// the view.
+		// Additionally, all entries that are added to the cache are removed
+		// from the view.
 		err = c.Commit(view)
 		if err != nil {
 			return err
 		}
 
 		// Conditionally flush the utxo cache to the backend.  Don't force flush
-		// since many blocks may be connected in quick succession when initializing.
+		// since many blocks may be connected in quick succession when
+		// initializing.
 		err = c.MaybeFlush(&n.hash, uint32(n.height), false, true)
 		if err != nil {
 			return err

--- a/blockchain/utxocache_test.go
+++ b/blockchain/utxocache_test.go
@@ -29,8 +29,8 @@ const (
 // throughout the tests.
 func outpoint299() wire.OutPoint {
 	return wire.OutPoint{
-		Hash: *mustParseHash("e299d2cc5deb5b39d230ad2a6046ff9cc164064f431a2893eb6" +
-			"28b467d018452"),
+		Hash: *mustParseHash("e299d2cc5deb5b39d230ad2a6046ff9cc164064f431a289" +
+			"3eb628b467d018452"),
 		Index: 0,
 		Tree:  wire.TxTreeRegular,
 	}
@@ -58,8 +58,8 @@ func entry299() *UtxoEntry {
 // throughout the tests.
 func outpoint1100() wire.OutPoint {
 	return wire.OutPoint{
-		Hash: *mustParseHash("ce1d0f74440c391d15516015224755a8661e56e796ac25490f3" +
-			"0ad1081c5d638"),
+		Hash: *mustParseHash("ce1d0f74440c391d15516015224755a8661e56e796ac254" +
+			"90f30ad1081c5d638"),
 		Index: 1,
 		Tree:  wire.TxTreeRegular,
 	}
@@ -87,8 +87,8 @@ func entry1100() *UtxoEntry {
 // throughout the tests.
 func outpoint1200() wire.OutPoint {
 	return wire.OutPoint{
-		Hash: *mustParseHash("72914cae2d4bc75f7777373b7c085c4b92d59f3e059fc7fd39d" +
-			"ef71c9fe188b5"),
+		Hash: *mustParseHash("72914cae2d4bc75f7777373b7c085c4b92d59f3e059fc7f" +
+			"d39def71c9fe188b5"),
 		Index: 2,
 		Tree:  wire.TxTreeRegular,
 	}
@@ -116,8 +116,8 @@ func entry1200() *UtxoEntry {
 // used throughout the tests.
 func outpoint85314() wire.OutPoint {
 	return wire.OutPoint{
-		Hash: *mustParseHash("d3bce77da2747baa85fb7ca4f6f8e123f31cd15ac691b2f8254" +
-			"3780158587d3a"),
+		Hash: *mustParseHash("d3bce77da2747baa85fb7ca4f6f8e123f31cd15ac691b2f" +
+			"82543780158587d3a"),
 		Index: 0,
 		Tree:  wire.TxTreeStake,
 	}
@@ -139,10 +139,10 @@ func entry85314() *UtxoEntry {
 			stake.TxTypeSStx,
 		),
 		ticketMinOuts: &ticketMinimalOutputs{
-			data: hexToBytes("03808efefade57001aba76a914a13afb81d54c9f8bb0c5e08" +
-				"2d56fd563ab9b359688ac0000206a1e9ac39159847e259c9162405b5f6c8135d" +
-				"2c7eaf1a375040001000000005800001abd76a91400000000000000000000000" +
-				"0000000000000000088ac"),
+			data: hexToBytes("03808efefade57001aba76a914a13afb81d54c9f8bb0c5e" +
+				"082d56fd563ab9b359688ac0000206a1e9ac39159847e259c9162405b5f6" +
+				"c8135d2c7eaf1a375040001000000005800001abd76a9140000000000000" +
+				"00000000000000000000000000088ac"),
 		},
 	}
 }
@@ -190,17 +190,17 @@ func createTestUtxoCache(t *testing.T, entries map[wire.OutPoint]*UtxoEntry) *Ut
 		},
 	})
 	for outpoint, entry := range entries {
-		// Add the entry to the cache.  The entry is cloned before being added so
-		// that any modifications that the cache makes to the entry are not
+		// Add the entry to the cache.  The entry is cloned before being added
+		// so that any modifications that the cache makes to the entry are not
 		// reflected in the provided test entry.
 		err := utxoCache.AddEntry(outpoint, entry.Clone())
 		if err != nil {
 			t.Fatalf("unexpected error when adding entry: %v", err)
 		}
 
-		// Set the state of the cached entries based on the provided entries.  This
-		// is allowed for tests to easily simulate entries in the cache that are not
-		// fresh without having to fetch them from the backend.
+		// Set the state of the cached entries based on the provided entries.
+		// This is allowed for tests to easily simulate entries in the cache
+		// that are not fresh without having to fetch them from the backend.
 		cachedEntry := utxoCache.entries[outpoint]
 		if cachedEntry != nil {
 			cachedEntry.state = entry.state
@@ -235,8 +235,9 @@ func TestTotalSize(t *testing.T) {
 			outpointTicket:  entryTicket,
 		},
 		// mapOverhead*numEntries + outpointSize*numEntries +
-		// pointerSize*numEntries + (first entry: base entry size + len(pkScript)) +
-		// (second entry: base entry size + len(pkScript) + len(ticketMinOuts.data))
+		// pointerSize*numEntries + (first entry: base entry size +
+		// len(pkScript)) + (second entry: base entry size + len(pkScript) +
+		// len(ticketMinOuts.data))
 		want: mapOverhead*2 + outpointSize*2 + pointerSize*2 +
 			(baseEntrySize + 25) + (baseEntrySize + 26 + 99),
 	}}
@@ -333,8 +334,9 @@ func TestAddEntry(t *testing.T) {
 		utxoCache := createTestUtxoCache(t, test.existingEntries)
 		wantTotalEntrySize := utxoCache.totalEntrySize
 
-		// Attempt to get an existing entry from the cache.  If it exists, subtract
-		// its size from the expected total entry size since it will be overwritten.
+		// Attempt to get an existing entry from the cache.  If it exists,
+		// subtract its size from the expected total entry size since it will be
+		// overwritten.
 		existingEntry := utxoCache.entries[test.outpoint]
 		if existingEntry != nil {
 			wantTotalEntrySize -= test.entry.size()
@@ -343,7 +345,8 @@ func TestAddEntry(t *testing.T) {
 		// Add the entry specified by the test.
 		err := utxoCache.AddEntry(test.outpoint, test.entry)
 		if err != nil {
-			t.Fatalf("%q: unexpected error when adding entry: %v", test.name, err)
+			t.Fatalf("%q: unexpected error when adding entry: %v", test.name,
+				err)
 		}
 		wantTotalEntrySize += test.entry.size()
 
@@ -370,8 +373,8 @@ func TestAddEntry(t *testing.T) {
 
 		// Validate that the total entry size was updated as expected.
 		if utxoCache.totalEntrySize != wantTotalEntrySize {
-			t.Fatalf("%q: unexpected total entry size -- got %v, want %v", test.name,
-				utxoCache.totalEntrySize, wantTotalEntrySize)
+			t.Fatalf("%q: unexpected total entry size -- got %v, want %v",
+				test.name, utxoCache.totalEntrySize, wantTotalEntrySize)
 		}
 	}
 }
@@ -442,29 +445,29 @@ func TestSpendEntry(t *testing.T) {
 			continue
 		}
 
-		// If the entry is fresh, validate that it was removed from the cache when
-		// spent.
+		// If the entry is fresh, validate that it was removed from the cache
+		// when spent.
 		if entry.isFresh() {
 			wantTotalEntrySize -= test.entry.size()
 			if utxoCache.entries[test.outpoint] != nil {
-				t.Fatalf("%q: entry for outpoint %v was not removed from the cache",
-					test.name, test.outpoint)
+				t.Fatalf("%q: entry for outpoint %v was not removed from the "+
+					"cache", test.name, test.outpoint)
 			}
 		}
 
 		// Validate that the total entry size was updated as expected.
 		if utxoCache.totalEntrySize != wantTotalEntrySize {
-			t.Fatalf("%q: unexpected total entry size -- got %v, want %v", test.name,
-				utxoCache.totalEntrySize, wantTotalEntrySize)
+			t.Fatalf("%q: unexpected total entry size -- got %v, want %v",
+				test.name, utxoCache.totalEntrySize, wantTotalEntrySize)
 		}
 
-		// If entry is not fresh, validate that it still exists in the cache and is
-		// now marked as spent.
+		// If entry is not fresh, validate that it still exists in the cache and
+		// is now marked as spent.
 		if !entry.isFresh() {
 			cachedEntry := utxoCache.entries[test.outpoint]
 			if cachedEntry == nil || !cachedEntry.IsSpent() {
-				t.Fatalf("%q: expected entry for outpoint %v to exist in the cache "+
-					"and be marked spent", test.name, test.outpoint)
+				t.Fatalf("%q: expected entry for outpoint %v to exist in the "+
+					"cache and be marked spent", test.name, test.outpoint)
 			}
 		}
 	}
@@ -558,8 +561,8 @@ func TestFetchEntry(t *testing.T) {
 			wantTotalEntrySize += cachedEntry.size()
 		}
 		if utxoCache.totalEntrySize != wantTotalEntrySize {
-			t.Fatalf("%q: unexpected total entry size -- got %v, want %v", test.name,
-				utxoCache.totalEntrySize, wantTotalEntrySize)
+			t.Fatalf("%q: unexpected total entry size -- got %v, want %v",
+				test.name, utxoCache.totalEntrySize, wantTotalEntrySize)
 		}
 	}
 }
@@ -623,14 +626,14 @@ func TestFetchEntries(t *testing.T) {
 		view := NewUtxoViewpoint(utxoCache)
 		err = utxoCache.FetchEntries(test.filteredSet, view)
 		if err != nil {
-			t.Fatalf("%q: unexpected error fetching entries for view: %v", test.name,
-				err)
+			t.Fatalf("%q: unexpected error fetching entries for view: %v",
+				test.name, err)
 		}
 
 		// Ensure that the fetched entries match the expected entries.
 		if !reflect.DeepEqual(view.entries, test.wantEntries) {
-			t.Fatalf("%q: mismatched entries:\nwant: %+v\n got: %+v\n", test.name,
-				test.wantEntries, view.entries)
+			t.Fatalf("%q: mismatched entries:\nwant: %+v\n got: %+v\n",
+				test.name, test.wantEntries, view.entries)
 		}
 	}
 }
@@ -763,10 +766,10 @@ func TestShouldFlush(t *testing.T) {
 	t.Parallel()
 
 	// Create test hashes to be used throughout the tests.
-	block1000Hash := mustParseHash("0000000000004740ad140c86753f9295e09f9cc81b1" +
-		"bb75d7f5552aeeedb7012")
-	block2000Hash := mustParseHash("0000000000000c8a886e3f7c32b1bb08422066dcfd0" +
-		"08de596471f11a5aff475")
+	block1000Hash := mustParseHash("0000000000004740ad140c86753f9295e09f9cc81" +
+		"b1bb75d7f5552aeeedb7012")
+	block2000Hash := mustParseHash("0000000000000c8a886e3f7c32b1bb08422066dcf" +
+		"d008de596471f11a5aff475")
 
 	tests := []struct {
 		name           string
@@ -819,7 +822,8 @@ func TestShouldFlush(t *testing.T) {
 	}}
 
 	for _, test := range tests {
-		// Create a utxo cache and set the field values as specified by the test.
+		// Create a utxo cache and set the field values as specified by the
+		// test.
 		utxoCache := NewUtxoCache(&UtxoCacheConfig{
 			MaxSize: test.maxSize,
 		})
@@ -845,10 +849,10 @@ func TestMaybeFlush(t *testing.T) {
 	backend := createTestUtxoBackend(t)
 
 	// Create test hashes to be used throughout the tests.
-	block1000Hash := mustParseHash("0000000000004740ad140c86753f9295e09f9cc81b1" +
-		"bb75d7f5552aeeedb7012")
-	block2000Hash := mustParseHash("0000000000000c8a886e3f7c32b1bb08422066dcfd0" +
-		"08de596471f11a5aff475")
+	block1000Hash := mustParseHash("0000000000004740ad140c86753f9295e09f9cc81" +
+		"b1bb75d7f5552aeeedb7012")
+	block2000Hash := mustParseHash("0000000000000c8a886e3f7c32b1bb08422066dcf" +
+		"d008de596471f11a5aff475")
 
 	// entry299Fresh is from block height 299 and is modified and fresh.
 	outpoint299 := outpoint299()
@@ -939,7 +943,8 @@ func TestMaybeFlush(t *testing.T) {
 		},
 		// entry299Fresh should be evicted from the cache due to its height.
 		// entry1100Spent should be evicted since it is spent.
-		// entry1200Fresh should remain in the cache but should now be unmodified.
+		// entry1200Fresh should remain in the cache but should now be
+		// unmodified.
 		wantCachedEntries: map[wire.OutPoint]*UtxoEntry{
 			outpoint1200: entry1200Unmodified,
 		},
@@ -964,9 +969,9 @@ func TestMaybeFlush(t *testing.T) {
 		utxoCache.lastEvictionHeight = test.lastEvictionHeight
 		utxoCache.lastFlushHash = *test.lastFlushHash
 
-		// Mock the current time as 1 minute after the last flush time.  This allows
-		// for validating that the last flush time is correctly updated to the
-		// current time when a flush occurs.
+		// Mock the current time as 1 minute after the last flush time.  This
+		// allows for validating that the last flush time is correctly updated
+		// to the current time when a flush occurs.
 		mockedCurrentTime := utxoCache.lastFlushTime.Add(time.Minute)
 		utxoCache.timeNow = func() time.Time {
 			return mockedCurrentTime
@@ -983,8 +988,8 @@ func TestMaybeFlush(t *testing.T) {
 		}
 
 		// Conditionally flush the cache based on the test parameters.
-		err = utxoCache.MaybeFlush(test.bestHash, test.bestHeight, test.forceFlush,
-			false)
+		err = utxoCache.MaybeFlush(test.bestHash, test.bestHeight,
+			test.forceFlush, false)
 		if err != nil {
 			t.Fatalf("%q: unexpected error flushing cache: %v", test.name, err)
 		}
@@ -1002,8 +1007,8 @@ func TestMaybeFlush(t *testing.T) {
 		for outpoint := range test.cachedEntries {
 			entry, err := backend.FetchEntry(outpoint)
 			if err != nil {
-				t.Fatalf("%q: unexpected error fetching entries from test backend: %v",
-					test.name, err)
+				t.Fatalf("%q: unexpected error fetching entries from test "+
+					"backend: %v", test.name, err)
 			}
 
 			if entry != nil {
@@ -1011,29 +1016,32 @@ func TestMaybeFlush(t *testing.T) {
 			}
 		}
 		if err != nil {
-			t.Fatalf("%q: unexpected error fetching entries from test backend: %v",
-				test.name, err)
+			t.Fatalf("%q: unexpected error fetching entries from test "+
+				"backend: %v", test.name, err)
 		}
 		if !reflect.DeepEqual(backendEntries, test.wantBackendEntries) {
 			t.Fatalf("%q: mismatched backend entries:\nwant: %+v\n got: %+v\n",
 				test.name, test.wantBackendEntries, backendEntries)
 		}
 
-		// Validate that the last flush hash and time have been updated as expected.
+		// Validate that the last flush hash and time have been updated as
+		// expected.
 		if utxoCache.lastFlushHash != *test.wantLastFlushHash {
-			t.Fatalf("%q: unexpected last flush hash -- got %x, want %x", test.name,
-				utxoCache.lastFlushHash, *test.wantLastFlushHash)
+			t.Fatalf("%q: unexpected last flush hash -- got %x, want %x",
+				test.name, utxoCache.lastFlushHash, *test.wantLastFlushHash)
 		}
 		updatedLastFlushTime := utxoCache.lastFlushTime == mockedCurrentTime
 		if updatedLastFlushTime != test.wantUpdatedLastFlushTime {
-			t.Fatalf("%q: unexpected updated last flush time -- got %v, want %v",
-				test.name, updatedLastFlushTime, test.wantUpdatedLastFlushTime)
+			t.Fatalf("%q: unexpected updated last flush time -- got %v, want "+
+				" %v", test.name, updatedLastFlushTime,
+				test.wantUpdatedLastFlushTime)
 		}
 
 		// Validate the updated last eviction height.
 		if utxoCache.lastEvictionHeight != test.wantLastEvictionHeight {
 			t.Fatalf("%q: unexpected last eviction height -- got %d, want %d",
-				test.name, utxoCache.lastEvictionHeight, test.wantLastEvictionHeight)
+				test.name, utxoCache.lastEvictionHeight,
+				test.wantLastEvictionHeight)
 		}
 
 		// Validate the updated total entry size of the cache.
@@ -1042,8 +1050,8 @@ func TestMaybeFlush(t *testing.T) {
 			wantTotalEntrySize += entry.size()
 		}
 		if utxoCache.totalEntrySize != wantTotalEntrySize {
-			t.Fatalf("%q: unexpected total entry size -- got %v, want %v", test.name,
-				utxoCache.totalEntrySize, wantTotalEntrySize)
+			t.Fatalf("%q: unexpected total entry size -- got %v, want %v",
+				test.name, utxoCache.totalEntrySize, wantTotalEntrySize)
 		}
 	}
 }
@@ -1056,13 +1064,13 @@ func TestInitialize(t *testing.T) {
 	g, teardownFunc := newChaingenHarness(t, params, "initializetest")
 	defer teardownFunc()
 
-	// ---------------------------------------------------------------------------
+	// -------------------------------------------------------------------------
 	// Create some convenience functions to improve test readability.
-	// ---------------------------------------------------------------------------
+	// -------------------------------------------------------------------------
 
 	// resetTestUtxoCache replaces the current utxo cache with a new test utxo
-	// cache and calls initialize on it.  This simulates an empty utxo cache that
-	// gets created and initialized at startup.
+	// cache and calls initialize on it.  This simulates an empty utxo cache
+	// that gets created and initialized at startup.
 	backend := createTestUtxoBackend(t)
 	err := backend.InitInfo(g.chain.dbInfo.version)
 	if err != nil {
@@ -1089,13 +1097,13 @@ func TestInitialize(t *testing.T) {
 		utxoCache.MaybeFlush(&tip.hash, uint32(tip.height), true, false)
 	}
 
-	// ---------------------------------------------------------------------------
+	// -------------------------------------------------------------------------
 	// Generate and accept enough blocks to reach stake validation height.
 	//
 	// Disable flushing of the cache while advancing the chain.  After reaching
-	// stake validation height, reset the cache and validate that it recovers and
-	// properly catches up to the tip.
-	// ---------------------------------------------------------------------------
+	// stake validation height, reset the cache and validate that it recovers
+	// and properly catches up to the tip.
+	// -------------------------------------------------------------------------
 
 	// Replace the utxo cache in the test chain with a test utxo cache so that
 	// flushing can be toggled on and off for testing.
@@ -1110,8 +1118,8 @@ func TestInitialize(t *testing.T) {
 	testUtxoCache.disableFlush = true
 	g.AdvanceToStakeValidationHeight()
 
-	// Validate that the tip is at stake validation height but the utxo set state
-	// is still at the genesis block.
+	// Validate that the tip is at stake validation height but the utxo set
+	// state is still at the genesis block.
 	g.AssertTipHeight(uint32(params.StakeValidationHeight))
 	g.ExpectUtxoSetState("genesis")
 
@@ -1122,11 +1130,11 @@ func TestInitialize(t *testing.T) {
 	// Validate that the utxo cache is now caught up to the tip.
 	g.ExpectUtxoSetState(g.TipName())
 
-	// ---------------------------------------------------------------------------
+	// -------------------------------------------------------------------------
 	// Create a few blocks to use as a base for the tests below.
 	//
 	//   ... -> b0 -> b1
-	// ---------------------------------------------------------------------------
+	// -------------------------------------------------------------------------
 
 	outs := g.OldestCoinbaseOuts()
 	g.NextBlock("b0", &outs[0], outs[1:])
@@ -1140,7 +1148,7 @@ func TestInitialize(t *testing.T) {
 	forceFlush(testUtxoCache)
 	g.ExpectUtxoSetState("b1")
 
-	// ---------------------------------------------------------------------------
+	// -------------------------------------------------------------------------
 	// Simulate the following scenario:
 	//   - The utxo cache was last flushed at the tip block
 	//   - A reorg to a side chain is triggered
@@ -1158,14 +1166,14 @@ func TestInitialize(t *testing.T) {
 	//            \-> b1a
 	//                ^^^
 	//              new tip
-	// ---------------------------------------------------------------------------
+	// -------------------------------------------------------------------------
 
 	// Disable flushing to simulate a failure resulting in the cache not being
 	// flushed after disconnecting a block.
 	testUtxoCache.disableFlush = true
 
-	// Save the spend journal entry for b1.  The spend journal entry for block b1
-	// needs to be restored after the reorg to properly simulate the failure
+	// Save the spend journal entry for b1.  The spend journal entry for block
+	// b1 needs to be restored after the reorg to properly simulate the failure
 	// scenario described above.
 	var serialized []byte
 	b1Hash := b1.BlockHash()
@@ -1233,13 +1241,13 @@ func TestShutdownUtxoCache(t *testing.T) {
 	}
 	g.chain.utxoCache = testUtxoCache
 
-	// ---------------------------------------------------------------------------
+	// -------------------------------------------------------------------------
 	// Generate and accept enough blocks to reach stake validation height.
 	//
 	// Disable flushing of the cache while advancing the chain.  After reaching
-	// stake validation height, call shutdown and validate that it forces a flush
-	// and properly catches up to the tip.
-	// ---------------------------------------------------------------------------
+	// stake validation height, call shutdown and validate that it forces a
+	// flush and properly catches up to the tip.
+	// -------------------------------------------------------------------------
 
 	// Validate that the tip and utxo set state are currently at the genesis
 	// block.
@@ -1250,8 +1258,8 @@ func TestShutdownUtxoCache(t *testing.T) {
 	testUtxoCache.disableFlush = true
 	g.AdvanceToStakeValidationHeight()
 
-	// Validate that the tip is at stake validation height but the utxo set state
-	// is still at the genesis block.
+	// Validate that the tip is at stake validation height but the utxo set
+	// state is still at the genesis block.
 	g.AssertTipHeight(uint32(params.StakeValidationHeight))
 	g.ExpectUtxoSetState("genesis")
 

--- a/blockchain/utxoentry.go
+++ b/blockchain/utxoentry.go
@@ -11,7 +11,8 @@ import (
 const (
 	// baseEntrySize is the base size of a utxo entry on a 64-bit platform,
 	// excluding the contents of the script and ticket minimal outputs.  It is
-	// equivalent to what unsafe.Sizeof(UtxoEntry{}) returns on a 64-bit platform.
+	// equivalent to what unsafe.Sizeof(UtxoEntry{}) returns on a 64-bit
+	// platform.
 	baseEntrySize = 56
 )
 
@@ -32,8 +33,8 @@ const (
 	// loaded.
 	utxoStateModified
 
-	// utxoStateFresh indicates that a txout is fresh, which means that it exists
-	// in the utxo cache but does not exist in the underlying database.
+	// utxoStateFresh indicates that a txout is fresh, which means that it
+	// exists in the utxo cache but does not exist in the underlying database.
 	utxoStateFresh
 )
 
@@ -120,9 +121,9 @@ type UtxoEntry struct {
 	// utxoState.
 	state utxoState
 
-	// packedFlags contains additional info for the containing transaction of the
-	// output as defined by utxoFlags.  This approach is used in order to reduce
-	// memory usage since there will be a lot of these in memory.
+	// packedFlags contains additional info for the containing transaction of
+	// the output as defined by utxoFlags.  This approach is used in order to
+	// reduce memory usage since there will be a lot of these in memory.
 	packedFlags utxoFlags
 }
 

--- a/blockchain/utxoentry_test.go
+++ b/blockchain/utxoentry_test.go
@@ -114,8 +114,8 @@ func TestUtxoEntry(t *testing.T) {
 		coinbase: true,
 		txType:   stake.TxTypeRegular,
 		amount:   9999,
-		pkScript: hexToBytes("76a9146edbc6c4d31bae9f1ccc38538a114bf42de65e8688a" +
-			"c"),
+		pkScript: hexToBytes("76a9146edbc6c4d31bae9f1ccc38538a114bf42de65e868" +
+			"8ac"),
 		blockHeight:   54321,
 		blockIndex:    0,
 		scriptVersion: 0,
@@ -127,30 +127,30 @@ func TestUtxoEntry(t *testing.T) {
 		expiry: true,
 		txType: stake.TxTypeSStx,
 		amount: 4294959555,
-		pkScript: hexToBytes("ba76a914a13afb81d54c9f8bb0c5e082d56fd563ab9b359688a" +
-			"c"),
+		pkScript: hexToBytes("ba76a914a13afb81d54c9f8bb0c5e082d56fd563ab9b359" +
+			"688ac"),
 		blockHeight:   55555,
 		blockIndex:    1,
 		scriptVersion: 0,
 		ticketMinOuts: &ticketMinimalOutputs{
-			data: hexToBytes("03808efefade57001aba76a914a13afb81d54c9f8bb0c5e082d56" +
-				"fd563ab9b359688ac0000206a1e9ac39159847e259c9162405b5f6c8135d2c7eaf1a" +
-				"375040001000000005800001abd76a91400000000000000000000000000000000000" +
-				"0000088ac"),
+			data: hexToBytes("03808efefade57001aba76a914a13afb81d54c9f8bb0c5e" +
+				"082d56fd563ab9b359688ac0000206a1e9ac39159847e259c9162405b5f6" +
+				"c8135d2c7eaf1a375040001000000005800001abd76a9140000000000000" +
+				"00000000000000000000000000088ac"),
 		},
 		deserializedTicketMinOuts: []*stake.MinimalOutput{{
-			PkScript: hexToBytes("ba76a914a13afb81d54c9f8bb0c5e082d56fd563ab9b35968" +
-				"8ac"),
+			PkScript: hexToBytes("ba76a914a13afb81d54c9f8bb0c5e082d56fd563ab9" +
+				"b359688ac"),
 			Value:   4294959555,
 			Version: 0,
 		}, {
-			PkScript: hexToBytes("6a1e9ac39159847e259c9162405b5f6c8135d2c7eaf1a3750" +
-				"400010000000058"),
+			PkScript: hexToBytes("6a1e9ac39159847e259c9162405b5f6c8135d2c7eaf" +
+				"1a3750400010000000058"),
 			Value:   0,
 			Version: 0,
 		}, {
-			PkScript: hexToBytes("bd76a91400000000000000000000000000000000000000008" +
-				"8ac"),
+			PkScript: hexToBytes("bd76a91400000000000000000000000000000000000" +
+				"0000088ac"),
 			Value:   0,
 			Version: 0,
 		}},
@@ -202,8 +202,8 @@ func TestUtxoEntry(t *testing.T) {
 		// Validate the modified flag.
 		isModified := entry.isModified()
 		if isModified != test.modified {
-			t.Fatalf("%q: unexpected modified flag -- got %v, want %v", test.name,
-				isModified, test.modified)
+			t.Fatalf("%q: unexpected modified flag -- got %v, want %v",
+				test.name, isModified, test.modified)
 		}
 
 		// Validate the fresh flag.
@@ -216,8 +216,8 @@ func TestUtxoEntry(t *testing.T) {
 		// Validate the coinbase flag.
 		isCoinBase := entry.IsCoinBase()
 		if isCoinBase != test.coinbase {
-			t.Fatalf("%q: unexpected coinbase flag -- got %v, want %v", test.name,
-				isCoinBase, test.coinbase)
+			t.Fatalf("%q: unexpected coinbase flag -- got %v, want %v",
+				test.name, isCoinBase, test.coinbase)
 		}
 
 		// Validate the expiry flag.
@@ -230,18 +230,19 @@ func TestUtxoEntry(t *testing.T) {
 		// Validate the type of the transaction that the output is contained in.
 		gotTxType := entry.TransactionType()
 		if gotTxType != test.txType {
-			t.Fatalf("%q: unexpected transaction type -- got %v, want %v", test.name,
-				gotTxType, test.txType)
+			t.Fatalf("%q: unexpected transaction type -- got %v, want %v",
+				test.name, gotTxType, test.txType)
 		}
 
 		// Validate the height of the block containing the output.
 		gotBlockHeight := entry.BlockHeight()
 		if gotBlockHeight != int64(test.blockHeight) {
-			t.Fatalf("%q: unexpected block height -- got %v, want %v", test.name,
-				gotBlockHeight, int64(test.blockHeight))
+			t.Fatalf("%q: unexpected block height -- got %v, want %v",
+				test.name, gotBlockHeight, int64(test.blockHeight))
 		}
 
-		// Validate the index of the transaction that the output is contained in.
+		// Validate the index of the transaction that the output is contained
+		// in.
 		gotBlockIndex := entry.BlockIndex()
 		if gotBlockIndex != test.blockIndex {
 			t.Fatalf("%q: unexpected block index -- got %v, want %v", test.name,
@@ -251,22 +252,22 @@ func TestUtxoEntry(t *testing.T) {
 		// Validate the amount of the output.
 		gotAmount := entry.Amount()
 		if gotAmount != test.amount {
-			t.Fatalf("%q: unexpected amount -- got %v, want %v", test.name, gotAmount,
-				test.amount)
+			t.Fatalf("%q: unexpected amount -- got %v, want %v", test.name,
+				gotAmount, test.amount)
 		}
 
 		// Validate the script of the output.
 		gotScript := entry.PkScript()
 		if !bytes.Equal(gotScript, test.pkScript) {
-			t.Fatalf("%q: unexpected script -- got %v, want %v", test.name, gotScript,
-				test.pkScript)
+			t.Fatalf("%q: unexpected script -- got %v, want %v", test.name,
+				gotScript, test.pkScript)
 		}
 
 		// Validate the script version of the output.
 		gotScriptVersion := entry.ScriptVersion()
 		if gotScriptVersion != test.scriptVersion {
-			t.Fatalf("%q: unexpected script version -- got %v, want %v", test.name,
-				gotScriptVersion, test.scriptVersion)
+			t.Fatalf("%q: unexpected script version -- got %v, want %v",
+				test.name, gotScriptVersion, test.scriptVersion)
 		}
 
 		// Spend the entry.  Validate that it is marked as spent and modified.
@@ -278,34 +279,39 @@ func TestUtxoEntry(t *testing.T) {
 			t.Fatalf("%q: expected entry to be modified", test.name)
 		}
 
-		// Validate that if spend is called again the entry is still marked as spent
-		// and modified.
+		// Validate that if spend is called again the entry is still marked as
+		// spent and modified.
 		entry.Spend()
 		if !entry.IsSpent() {
-			t.Fatalf("%q: expected entry to still be marked as spent", test.name)
+			t.Fatalf("%q: expected entry to still be marked as spent",
+				test.name)
 		}
 		if !entry.isModified() {
-			t.Fatalf("%q: expected entry to still be marked as modified", test.name)
+			t.Fatalf("%q: expected entry to still be marked as modified",
+				test.name)
 		}
 
 		// Validate the ticket minimal outputs.
 		ticketMinOutsResult := entry.TicketMinimalOutputs()
-		if !reflect.DeepEqual(ticketMinOutsResult, test.deserializedTicketMinOuts) {
-			t.Fatalf("%q: unexpected ticket min outs -- got %v, want %v", test.name,
-				ticketMinOutsResult, test.deserializedTicketMinOuts)
+		if !reflect.DeepEqual(ticketMinOutsResult,
+			test.deserializedTicketMinOuts) {
+
+			t.Fatalf("%q: unexpected ticket min outs -- got %v, want %v",
+				test.name, ticketMinOutsResult, test.deserializedTicketMinOuts)
 		}
 
 		// Clone the entry and validate that all values are deep equal.
 		clonedEntry := entry.Clone()
 		if !reflect.DeepEqual(clonedEntry, entry) {
-			t.Fatalf("%q: expected entry to be equal to cloned entry -- got %v, "+
-				"want %v", test.name, clonedEntry, entry)
+			t.Fatalf("%q: expected entry to be equal to cloned entry -- got "+
+				"%v, want %v", test.name, clonedEntry, entry)
 		}
 
 		// Validate that clone returns nil when called on a nil entry.
 		var nilEntry *UtxoEntry
 		if nilEntry.Clone() != nil {
-			t.Fatalf("%q: expected nil when calling clone on a nil entry", test.name)
+			t.Fatalf("%q: expected nil when calling clone on a nil entry",
+				test.name)
 		}
 	}
 }

--- a/blockchain/utxoio.go
+++ b/blockchain/utxoio.go
@@ -211,7 +211,8 @@ func deserializeUtxoEntry(serialized []byte, txOutIndex uint32) (*UtxoEntry, err
 	amount, scriptVersion, script, bytesRead, err :=
 		decodeCompressedTxOut(serialized[offset:], true)
 	if err != nil {
-		return nil, errDeserialize(fmt.Sprintf("unable to decode utxo: %v", err))
+		return nil, errDeserialize(fmt.Sprintf("unable to decode utxo: %v",
+			err))
 	}
 	offset += bytesRead
 

--- a/blockchain/utxoio_test.go
+++ b/blockchain/utxoio_test.go
@@ -38,9 +38,9 @@ func TestUtxoSerialization(t *testing.T) {
 			name: "Coinbase, even uncomp pubkey",
 			entry: &UtxoEntry{
 				amount: 5000000000,
-				pkScript: hexToBytes("410496b538e853519c726a2c91e61ec11600ae1390813a6" +
-					"27c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621" +
-					"e73a82cbf2342c858eeac"),
+				pkScript: hexToBytes("410496b538e853519c726a2c91e61ec11600ae1" +
+					"390813a627c66fb8be7947be63c52da7589379515d4e0a604f814178" +
+					"1e62294721166bf621e73a82cbf2342c858eeac"),
 				blockHeight:   12345,
 				blockIndex:    54321,
 				scriptVersion: 0,
@@ -50,16 +50,16 @@ func TestUtxoSerialization(t *testing.T) {
 					stake.TxTypeRegular,
 				),
 			},
-			serialized: hexToBytes("df3982a7310132000496b538e853519c726a2c91e61ec11" +
-				"600ae1390813a627c66fb8be7947be63c52"),
+			serialized: hexToBytes("df3982a7310132000496b538e853519c726a2c91e" +
+				"61ec11600ae1390813a627c66fb8be7947be63c52"),
 			txOutIndex: 0,
 		}, {
 			name: "Coinbase, odd uncomp pubkey",
 			entry: &UtxoEntry{
 				amount: 5000000000,
-				pkScript: hexToBytes("410496b538e853519c726a2c91e61ec11600ae1390813a6" +
-					"27c66fb8be7947be63c52258a76c86aea2b1f59fb07ebe87e19dd6b8dee99409de" +
-					"18c57d340dbbd37a341ac"),
+				pkScript: hexToBytes("410496b538e853519c726a2c91e61ec11600ae1" +
+					"390813a627c66fb8be7947be63c52258a76c86aea2b1f59fb07ebe87" +
+					"e19dd6b8dee99409de18c57d340dbbd37a341ac"),
 				blockHeight:   12345,
 				blockIndex:    54321,
 				scriptVersion: 0,
@@ -69,15 +69,15 @@ func TestUtxoSerialization(t *testing.T) {
 					stake.TxTypeRegular,
 				),
 			},
-			serialized: hexToBytes("df3982a7310132000596b538e853519c726a2c91e61ec11" +
-				"600ae1390813a627c66fb8be7947be63c52"),
+			serialized: hexToBytes("df3982a7310132000596b538e853519c726a2c91e" +
+				"61ec11600ae1390813a627c66fb8be7947be63c52"),
 			txOutIndex: 0,
 		}, {
 			name: "Non-coinbase regular tx",
 			entry: &UtxoEntry{
 				amount: 1000000,
-				pkScript: hexToBytes("76a914ee8bd501094a7d5ca318da2506de35e1cb025ddc8" +
-					"8ac"),
+				pkScript: hexToBytes("76a914ee8bd501094a7d5ca318da2506de35e1c" +
+					"b025ddc88ac"),
 				blockHeight:   55555,
 				blockIndex:    1,
 				scriptVersion: 0,
@@ -87,15 +87,15 @@ func TestUtxoSerialization(t *testing.T) {
 					stake.TxTypeRegular,
 				),
 			},
-			serialized: hexToBytes("82b1030100070000ee8bd501094a7d5ca318da2506de35e" +
-				"1cb025ddc"),
+			serialized: hexToBytes("82b1030100070000ee8bd501094a7d5ca318da250" +
+				"6de35e1cb025ddc"),
 			txOutIndex: 0,
 		}, {
 			name: "Ticket tx",
 			entry: &UtxoEntry{
 				amount: 1000000,
-				pkScript: hexToBytes("76a914ee8bd501094a7d5ca318da2506de35e1cb025ddc8" +
-					"8ac"),
+				pkScript: hexToBytes("76a914ee8bd501094a7d5ca318da2506de35e1c" +
+					"b025ddc88ac"),
 				blockHeight:   55555,
 				blockIndex:    1,
 				scriptVersion: 0,
@@ -105,23 +105,24 @@ func TestUtxoSerialization(t *testing.T) {
 					stake.TxTypeSStx,
 				),
 				ticketMinOuts: &ticketMinimalOutputs{
-					data: hexToBytes("030f001aba76a9140cdf9941c0c221243cb8672cd1ad2c4c0" +
-						"933850588ac0000206a1e1a221182c26bbae681e4d96d452794e1951e70a2085" +
-						"20000000000000054b5f466001abd76a9146c4f8b15918566534d134be7d7004" +
-						"b7f481bf36988ac"),
+					data: hexToBytes("030f001aba76a9140cdf9941c0c221243cb8672" +
+						"cd1ad2c4c0933850588ac0000206a1e1a221182c26bbae681e4d" +
+						"96d452794e1951e70a208520000000000000054b5f466001abd7" +
+						"6a9146c4f8b15918566534d134be7d7004b7f481bf36988ac"),
 				},
 			},
-			serialized: hexToBytes("82b1030106070000ee8bd501094a7d5ca318da2506de35e" +
-				"1cb025ddc030f001aba76a9140cdf9941c0c221243cb8672cd1ad2c4c0933850588a" +
-				"c0000206a1e1a221182c26bbae681e4d96d452794e1951e70a208520000000000000" +
-				"054b5f466001abd76a9146c4f8b15918566534d134be7d7004b7f481bf36988ac"),
+			serialized: hexToBytes("82b1030106070000ee8bd501094a7d5ca318da250" +
+				"6de35e1cb025ddc030f001aba76a9140cdf9941c0c221243cb8672cd1ad2" +
+				"c4c0933850588ac0000206a1e1a221182c26bbae681e4d96d452794e1951" +
+				"e70a208520000000000000054b5f466001abd76a9146c4f8b15918566534" +
+				"d134be7d7004b7f481bf36988ac"),
 			txOutIndex: 0,
 		}, {
 			name: "Output 2, coinbase, non-zero script version",
 			entry: &UtxoEntry{
 				amount: 100937281,
-				pkScript: hexToBytes("76a914da33f77cee27c2a975ed5124d7e4f7f9751351018" +
-					"8ac"),
+				pkScript: hexToBytes("76a914da33f77cee27c2a975ed5124d7e4f7f97" +
+					"513510188ac"),
 				blockHeight:   12345,
 				blockIndex:    1,
 				scriptVersion: 0xffff,
@@ -131,15 +132,15 @@ func TestUtxoSerialization(t *testing.T) {
 					stake.TxTypeRegular,
 				),
 			},
-			serialized: hexToBytes("df39010182b095bf4182fe7f00da33f77cee27c2a975ed5" +
-				"124d7e4f7f975135101"),
+			serialized: hexToBytes("df39010182b095bf4182fe7f00da33f77cee27c2a" +
+				"975ed5124d7e4f7f975135101"),
 			txOutIndex: 2,
 		}, {
 			name: "Has expiry",
 			entry: &UtxoEntry{
 				amount: 20000000,
-				pkScript: hexToBytes("76a914e2ccd6ec7c6e2e581349c77e067385fa8236bf8a8" +
-					"8ac"),
+				pkScript: hexToBytes("76a914e2ccd6ec7c6e2e581349c77e067385fa8" +
+					"236bf8a88ac"),
 				blockHeight:   99999,
 				blockIndex:    3,
 				scriptVersion: 0,
@@ -149,16 +150,16 @@ func TestUtxoSerialization(t *testing.T) {
 					stake.TxTypeRegular,
 				),
 			},
-			serialized: hexToBytes("858c1f0302120000e2ccd6ec7c6e2e581349c77e067385f" +
-				"a8236bf8a"),
+			serialized: hexToBytes("858c1f0302120000e2ccd6ec7c6e2e581349c77e0" +
+				"67385fa8236bf8a"),
 			txOutIndex: 0,
 		}, {
 			name: "Coinbase, spent",
 			entry: &UtxoEntry{
 				amount: 5000000000,
-				pkScript: hexToBytes("410496b538e853519c726a2c91e61ec11600ae1390813a6" +
-					"27c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621" +
-					"e73a82cbf2342c858eeac"),
+				pkScript: hexToBytes("410496b538e853519c726a2c91e61ec11600ae1" +
+					"390813a627c66fb8be7947be63c52da7589379515d4e0a604f814178" +
+					"1e62294721166bf621e73a82cbf2342c858eeac"),
 				blockHeight:   33333,
 				blockIndex:    3,
 				scriptVersion: 0,
@@ -178,18 +179,19 @@ func TestUtxoSerialization(t *testing.T) {
 		// Ensure the utxo entry serializes to the expected value.
 		gotBytes := serializeUtxoEntry(test.entry)
 		if !bytes.Equal(gotBytes, test.serialized) {
-			t.Errorf("%q: mismatched bytes - got %x, want %x", test.name, gotBytes,
-				test.serialized)
+			t.Errorf("%q: mismatched bytes - got %x, want %x", test.name,
+				gotBytes, test.serialized)
 			continue
 		}
 
-		// Don't try to deserialize if the test entry was spent since it will have a
-		// nil serialization.
+		// Don't try to deserialize if the test entry was spent since it will
+		// have a nil serialization.
 		if test.entry.IsSpent() {
 			continue
 		}
 
-		// Ensure that the serialized bytes are decoded back to the expected utxo.
+		// Ensure that the serialized bytes are decoded back to the expected
+		// utxo.
 		gotUtxo, err := deserializeUtxoEntry(test.serialized, test.txOutIndex)
 		if err != nil {
 			t.Errorf("%q: unexpected error: %v", test.name, err)
@@ -248,8 +250,8 @@ func TestUtxoEntryDeserializeErrors(t *testing.T) {
 		//  <script version 00> <compressed pk script 01 6e ...> EOF]
 		name: "no minimal output data after script for a ticket submission " +
 			"output",
-		serialized: hexToBytes("0101064900016edbc6c4d31bae9f1ccc38538a114bf42de65" +
-			"e86"),
+		serialized: hexToBytes("0101064900016edbc6c4d31bae9f1ccc38538a114bf42" +
+			"de65e86"),
 		txOutIndex: 0,
 		errType:    errDeserialize(""),
 	}, {
@@ -258,8 +260,8 @@ func TestUtxoEntryDeserializeErrors(t *testing.T) {
 		//  <ticket min outs {num outputs 01}> EOF]
 		name: "truncated minimal output data after script for a ticket " +
 			"submission output (num outputs only)",
-		serialized: hexToBytes("0101064900016edbc6c4d31bae9f1ccc38538a114bf42de65" +
-			"e8601"),
+		serialized: hexToBytes("0101064900016edbc6c4d31bae9f1ccc38538a114bf42" +
+			"de65e8601"),
 		txOutIndex: 0,
 		errType:    errDeserialize(""),
 	}, {
@@ -268,18 +270,19 @@ func TestUtxoEntryDeserializeErrors(t *testing.T) {
 		//  <ticket min outs {num outputs 01} {amount 0f}> EOF]
 		name: "truncated minimal output data after script for a ticket " +
 			"submission output (num outputs and amount only)",
-		serialized: hexToBytes("0101064900016edbc6c4d31bae9f1ccc38538a114bf42de65" +
-			"e86010f"),
+		serialized: hexToBytes("0101064900016edbc6c4d31bae9f1ccc38538a114bf42" +
+			"de65e86010f"),
 		txOutIndex: 0,
 		errType:    errDeserialize(""),
 	}, {
 		// [<block height 01> <block index 01> <flags 06> <compressed amount 49>
 		//  <script version 00> <compressed pk script 01 6e ...>
-		//  <ticket min outs {num outputs 01} {amount 0f} {script version 00}> EOF]
+		//  <ticket min outs {num outputs 01} {amount 0f} {script version 00}>
+		//  EOF]
 		name: "truncated minimal output data after script for a ticket " +
 			"submission output (num outputs, amount, and script version only)",
-		serialized: hexToBytes("0101064900016edbc6c4d31bae9f1ccc38538a114bf42de65" +
-			"e86010f00"),
+		serialized: hexToBytes("0101064900016edbc6c4d31bae9f1ccc38538a114bf42" +
+			"de65e86010f00"),
 		txOutIndex: 0,
 		errType:    errDeserialize(""),
 	}, {
@@ -288,10 +291,10 @@ func TestUtxoEntryDeserializeErrors(t *testing.T) {
 		//  <ticket min outs {num outputs 01} {amount 0f} {script version 00}
 		//  {script size 1a} {25 bytes of script instead of 26}> EOF]
 		name: "truncated minimal output data after script for a ticket " +
-			"submission output (script size specified as 0x1a, but only 0x19 bytes " +
-			"provided)",
-		serialized: hexToBytes("0101064900016edbc6c4d31bae9f1ccc38538a114bf42de65" +
-			"e86010f001aba76a9140cdf9941c0c221243cb8672cd1ad2c4c0933850588"),
+			"submission output (script size specified as 0x1a, but only 0x19 " +
+			"bytes provided)",
+		serialized: hexToBytes("0101064900016edbc6c4d31bae9f1ccc38538a114bf42" +
+			"de65e86010f001aba76a9140cdf9941c0c221243cb8672cd1ad2c4c0933850588"),
 		txOutIndex: 0,
 		errType:    errDeserialize(""),
 	}}
@@ -325,33 +328,33 @@ func TestUtxoSetStateSerialization(t *testing.T) {
 		name: "last flush height and hash updated",
 		state: &UtxoSetState{
 			lastFlushHeight: 432100,
-			lastFlushHash: *mustParseHash("000000000000000023455b4328635d8e014dbeea" +
-				"99c6140aa715836cc7e55981"),
+			lastFlushHash: *mustParseHash("000000000000000023455b4328635d8e01" +
+				"4dbeea99c6140aa715836cc7e55981"),
 		},
-		serialized: hexToBytes("99ae648159e5c76c8315a70a14c699eabe4d018e5d6328435" +
-			"b45230000000000000000"),
+		serialized: hexToBytes("99ae648159e5c76c8315a70a14c699eabe4d018e5d632" +
+			"8435b45230000000000000000"),
 	}, {
 		name: "last flush height and hash are the genesis block",
 		state: &UtxoSetState{
 			lastFlushHeight: 0,
-			lastFlushHash: *mustParseHash("298e5cc3d985bfe7f81dc135f360abe089edd439" +
-				"6b86d2de66b0cef42b21d980"),
+			lastFlushHash: *mustParseHash("298e5cc3d985bfe7f81dc135f360abe089" +
+				"edd4396b86d2de66b0cef42b21d980"),
 		},
-		serialized: hexToBytes("0080d9212bf4ceb066ded2866b39d4ed89e0ab60f335c11df" +
-			"8e7bf85d9c35c8e29"),
+		serialized: hexToBytes("0080d9212bf4ceb066ded2866b39d4ed89e0ab60f335c" +
+			"11df8e7bf85d9c35c8e29"),
 	}}
 
 	for _, test := range tests {
 		// Ensure the utxo set state serializes to the expected value.
 		gotBytes := serializeUtxoSetState(test.state)
 		if !bytes.Equal(gotBytes, test.serialized) {
-			t.Errorf("%q: mismatched bytes - got %x, want %x", test.name, gotBytes,
-				test.serialized)
+			t.Errorf("%q: mismatched bytes - got %x, want %x", test.name,
+				gotBytes, test.serialized)
 			continue
 		}
 
-		// Ensure that the serialized bytes are decoded back to the expected utxo
-		// set state.
+		// Ensure that the serialized bytes are decoded back to the expected
+		// utxo set state.
 		gotUtxoSetState, err := deserializeUtxoSetState(test.serialized)
 		if err != nil {
 			t.Errorf("%q: unexpected error: %v", test.name, err)
@@ -418,33 +421,33 @@ func TestOutpointKey(t *testing.T) {
 	}{{
 		name: "outpoint in regular tree at index 2",
 		outpoint: &wire.OutPoint{
-			Hash: *mustParseHash("72914cae2d4bc75f7777373b7c085c4b92d59f3e059fc7fd3" +
-				"9def71c9fe188b5"),
+			Hash: *mustParseHash("72914cae2d4bc75f7777373b7c085c4b92d59f3e059" +
+				"fc7fd39def71c9fe188b5"),
 			Index: 2,
 			Tree:  wire.TxTreeRegular,
 		},
 		// [<prefix 0303><hash b588...9172><tree 00><index 02>]
-		serialized: hexToBytes("0303b588e19f1cf7de39fdc79f053e9fd5924b5c087c3b377" +
-			"7775fc74b2dae4c91720002"),
+		serialized: hexToBytes("0303b588e19f1cf7de39fdc79f053e9fd5924b5c087c3" +
+			"b3777775fc74b2dae4c91720002"),
 	}, {
 		name: "outpoint in stake tree at index 0",
 		outpoint: &wire.OutPoint{
-			Hash: *mustParseHash("d3bce77da2747baa85fb7ca4f6f8e123f31cd15ac691b2f82" +
-				"543780158587d3a"),
+			Hash: *mustParseHash("d3bce77da2747baa85fb7ca4f6f8e123f31cd15ac69" +
+				"1b2f82543780158587d3a"),
 			Index: 0,
 			Tree:  wire.TxTreeStake,
 		},
 		// [<prefix 0303><hash 3a7d...bcd3><tree 01><index 00>]
-		serialized: hexToBytes("03033a7d585801784325f8b291c65ad11cf323e1f8f6a47cf" +
-			"b85aa7b74a27de7bcd30100"),
+		serialized: hexToBytes("03033a7d585801784325f8b291c65ad11cf323e1f8f6a" +
+			"47cfb85aa7b74a27de7bcd30100"),
 	}}
 
 	for _, test := range tests {
 		// Ensure that the outpoint serializes to the expected outpoint key.
 		gotBytes := outpointKey(*test.outpoint)
 		if !bytes.Equal(*gotBytes, test.serialized) {
-			t.Errorf("%q: mismatched bytes - got %x, want %x", test.name, *gotBytes,
-				test.serialized)
+			t.Errorf("%q: mismatched bytes - got %x, want %x", test.name,
+				*gotBytes, test.serialized)
 			continue
 		}
 
@@ -457,8 +460,8 @@ func TestOutpointKey(t *testing.T) {
 			continue
 		}
 		if !reflect.DeepEqual(gotOutpoint, *test.outpoint) {
-			t.Errorf("%q: mismatched outpoint:\nwant: %+v\n got: %+v\n", test.name,
-				*test.outpoint, gotOutpoint)
+			t.Errorf("%q: mismatched outpoint:\nwant: %+v\n got: %+v\n",
+				test.name, *test.outpoint, gotOutpoint)
 			continue
 		}
 	}
@@ -491,14 +494,14 @@ func TestDecodeOutpointKeyErrors(t *testing.T) {
 	}, {
 		// [<prefix 0303><hash b588...9172>]
 		name: "no data after hash",
-		serialized: hexToBytes("0303b588e19f1cf7de39fdc79f053e9fd5924b5c087c3b377" +
-			"7775fc74b2dae4c9172"),
+		serialized: hexToBytes("0303b588e19f1cf7de39fdc79f053e9fd5924b5c087c3" +
+			"b3777775fc74b2dae4c9172"),
 		errType: errDeserialize(""),
 	}, {
 		// [<prefix 0303><hash b588...9172><tree 00>]
 		name: "no data after tree",
-		serialized: hexToBytes("0303b588e19f1cf7de39fdc79f053e9fd5924b5c087c3b377" +
-			"7775fc74b2dae4c917200"),
+		serialized: hexToBytes("0303b588e19f1cf7de39fdc79f053e9fd5924b5c087c3" +
+			"b3777775fc74b2dae4c917200"),
 		errType: errDeserialize(""),
 	}}
 

--- a/blockchain/utxoviewpoint.go
+++ b/blockchain/utxoviewpoint.go
@@ -64,9 +64,9 @@ func (view *UtxoViewpoint) addTxOut(outpoint wire.OutPoint, txOut *wire.TxOut,
 	}
 
 	// Update existing entries.  All fields are updated because it's possible
-	// (although extremely unlikely) that the existing entry is being replaced by
-	// a different transaction with the same hash.  This is allowed so long as the
-	// previous transaction is fully spent.
+	// (although extremely unlikely) that the existing entry is being replaced
+	// by a different transaction with the same hash.  This is allowed so long
+	// as the previous transaction is fully spent.
 	entry := view.LookupEntry(outpoint)
 	if entry == nil {
 		entry = new(UtxoEntry)
@@ -88,8 +88,9 @@ func (view *UtxoViewpoint) addTxOut(outpoint wire.OutPoint, txOut *wire.TxOut,
 	// Deep copy the script.  This is required since the tx out script is a
 	// subslice of the overall contiguous buffer that the msg tx houses for all
 	// scripts within the tx.  It is deep copied here since this entry may be
-	// added to the utxo cache, and we don't want the utxo cache holding the entry
-	// to prevent all of the other tx scripts from getting garbage collected.
+	// added to the utxo cache, and we don't want the utxo cache holding the
+	// entry to prevent all of the other tx scripts from getting garbage
+	// collected.
 	scriptLen := len(txOut.PkScript)
 	if scriptLen != 0 {
 		entry.pkScript = make([]byte, scriptLen)
@@ -123,9 +124,9 @@ func (view *UtxoViewpoint) AddTxOut(tx *dcrutil.Tx, txOutIdx uint32,
 	flags := encodeUtxoFlags(isCoinBase, hasExpiry, txType)
 
 	// Update existing entries.  All fields are updated because it's possible
-	// (although extremely unlikely) that the existing entry is being replaced by
-	// a different transaction with the same hash.  This is allowed so long as the
-	// previous transaction is fully spent.
+	// (although extremely unlikely) that the existing entry is being replaced
+	// by a different transaction with the same hash.  This is allowed so long
+	// as the previous transaction is fully spent.
 	outpoint := wire.OutPoint{Hash: *tx.Hash(), Index: txOutIdx, Tree: tree}
 	txOut := msgTx.TxOut[txOutIdx]
 	var ticketMinOuts *ticketMinimalOutputs
@@ -135,7 +136,8 @@ func (view *UtxoViewpoint) AddTxOut(tx *dcrutil.Tx, txOutIdx uint32,
 		}
 		putTxToMinimalOutputs(ticketMinOuts.data, tx)
 	}
-	view.addTxOut(outpoint, txOut, flags, blockHeight, blockIndex, ticketMinOuts)
+	view.addTxOut(outpoint, txOut, flags, blockHeight, blockIndex,
+		ticketMinOuts)
 }
 
 // AddTxOuts adds all outputs in the passed transaction which are not provably
@@ -162,10 +164,10 @@ func (view *UtxoViewpoint) AddTxOuts(tx *dcrutil.Tx, blockHeight int64,
 	// provably unspendable.
 	outpoint := wire.OutPoint{Hash: *tx.Hash(), Tree: tree}
 	for txOutIdx, txOut := range msgTx.TxOut {
-		// Update existing entries.  All fields are updated because it's possible
-		// (although extremely unlikely) that the existing entry is being replaced
-		// by a different transaction with the same hash.  This is allowed so long
-		// as the previous transaction is fully spent.
+		// Update existing entries.  All fields are updated because it's
+		// possible (although extremely unlikely) that the existing entry is
+		// being replaced by a different transaction with the same hash.  This
+		// is allowed so long as the previous transaction is fully spent.
 		outpoint.Index = uint32(txOutIdx)
 		var ticketMinOuts *ticketMinimalOutputs
 		if isTicketSubmissionOutput(txType, uint32(txOutIdx)) {
@@ -248,8 +250,8 @@ func (view *UtxoViewpoint) connectTransaction(tx *dcrutil.Tx, blockHeight int64,
 			continue
 		}
 
-		// Ensure the referenced utxo exists in the view.  This should never happen
-		// unless there is a bug is introduced in the code.
+		// Ensure the referenced utxo exists in the view.  This should never
+		// happen unless there is a bug is introduced in the code.
 		entry := view.entries[txIn.PreviousOutPoint]
 		if entry == nil {
 			return AssertError(fmt.Sprintf("view missing input %v",
@@ -274,8 +276,8 @@ func (view *UtxoViewpoint) connectTransaction(tx *dcrutil.Tx, blockHeight int64,
 		}
 
 		// Mark the entry as spent.  This is not done until after the relevant
-		// details have been accessed since spending it might clear the fields from
-		// memory in the future.
+		// details have been accessed since spending it might clear the fields
+		// from memory in the future.
 		entry.Spend()
 	}
 
@@ -296,8 +298,8 @@ func (view *UtxoViewpoint) disconnectTransactions(block *dcrutil.Block,
 
 	// Choose which transaction tree to use and the appropriate offset into the
 	// spent transaction outputs that corresponds to them depending on the flag.
-	// Transactions in the stake tree are spent before transactions in the regular
-	// tree, thus skip all of the outputs spent by the regular tree when
+	// Transactions in the stake tree are spent before transactions in the
+	// regular tree, thus skip all of the outputs spent by the regular tree when
 	// disconnecting stake transactions.
 	stxoIdx := len(stxos) - 1
 	transactions := block.Transactions()
@@ -333,12 +335,12 @@ func (view *UtxoViewpoint) disconnectTransactions(block *dcrutil.Block,
 		isCoinBase := !stakeTree && txIdx == 0
 		hasExpiry := msgTx.Expiry != wire.NoExpiryValue
 
-		// It is instructive to note that there is no practical difference between
-		// a utxo that does not exist and one that has been spent with a pruned
-		// utxo set. So, even though the outputs here technically no longer exist,
-		// any missing entries are added to the view and marked spent because the
-		// code relies on their existence in the view in order to signal
-		// modifications have happened.
+		// It is instructive to note that there is no practical difference
+		// between a utxo that does not exist and one that has been spent with a
+		// pruned utxo set. So, even though the outputs here technically no
+		// longer exist, any missing entries are added to the view and marked
+		// spent because the code relies on their existence in the view in order
+		// to signal modifications have happened.
 		outpoint := wire.OutPoint{Hash: *txHash, Tree: tree}
 		for txOutIdx, txOut := range msgTx.TxOut {
 			// Don't add provably unspendable outputs.
@@ -355,15 +357,16 @@ func (view *UtxoViewpoint) disconnectTransactions(block *dcrutil.Block,
 					blockIndex:    uint32(txIdx),
 					scriptVersion: txOut.Version,
 					state:         utxoStateModified,
-					packedFlags:   encodeUtxoFlags(isCoinBase, hasExpiry, txType),
+					packedFlags: encodeUtxoFlags(isCoinBase, hasExpiry,
+						txType),
 				}
 
-				// Deep copy the script.  This is required since the tx out script is a
-				// subslice of the overall contiguous buffer that the msg tx houses for
-				// all scripts within the tx.  It is deep copied here since this entry
-				// may be added to the utxo cache, and we don't want the utxo cache
-				// holding the entry to prevent all of the other tx scripts from getting
-				// garbage collected.
+				// Deep copy the script.  This is required since the tx out
+				// script is a subslice of the overall contiguous buffer that
+				// the msg tx houses for all scripts within the tx.  It is deep
+				// copied here since this entry may be added to the utxo cache,
+				// and we don't want the utxo cache holding the entry to prevent
+				// all of the other tx scripts from getting garbage collected.
 				scriptLen := len(txOut.PkScript)
 				if scriptLen != 0 {
 					entry.pkScript = make([]byte, scriptLen)
@@ -385,8 +388,8 @@ func (view *UtxoViewpoint) disconnectTransactions(block *dcrutil.Block,
 
 		// Loop backwards through all of the transaction inputs (except for the
 		// coinbase and treasurybase which have no inputs) and unspend the
-		// referenced txos.  This is necessary to match the order of the spent txout
-		// entries.
+		// referenced txos.  This is necessary to match the order of the spent
+		// txout entries.
 		if isCoinBase || isTreasuryBase || isTSpend {
 			continue
 		}
@@ -396,14 +399,14 @@ func (view *UtxoViewpoint) disconnectTransactions(block *dcrutil.Block,
 				continue
 			}
 
-			// Ensure the spent txout index is decremented to stay in sync with the
-			// transaction input.
+			// Ensure the spent txout index is decremented to stay in sync with
+			// the transaction input.
 			stxo := &stxos[stxoIdx]
 			stxoIdx--
 
-			// When there is not already an entry for the referenced output in the
-			// view, it means it was previously spent, so create a new utxo entry in
-			// order to resurrect it.
+			// When there is not already an entry for the referenced output in
+			// the view, it means it was previously spent, so create a new utxo
+			// entry in order to resurrect it.
 			txIn := msgTx.TxIn[txInIdx]
 			entry := view.entries[txIn.PreviousOutPoint]
 			if entry == nil {
@@ -415,8 +418,8 @@ func (view *UtxoViewpoint) disconnectTransactions(block *dcrutil.Block,
 					blockIndex:    stxo.blockIndex,
 					scriptVersion: stxo.scriptVersion,
 					state:         utxoStateModified,
-					packedFlags: encodeUtxoFlags(stxo.IsCoinBase(), stxo.HasExpiry(),
-						stxo.TransactionType()),
+					packedFlags: encodeUtxoFlags(stxo.IsCoinBase(),
+						stxo.HasExpiry(), stxo.TransactionType()),
 				}
 
 				view.entries[txIn.PreviousOutPoint] = entry
@@ -871,8 +874,9 @@ func (b *BlockChain) FetchUtxoView(tx *dcrutil.Tx, includeRegularTxns bool) (*Ut
 	}
 
 	// Create a set of needed transactions based on those referenced by the
-	// inputs of the passed transaction.  Also, add the outputs of the transaction
-	// as a way for the caller to detect duplicates that are not fully spent.
+	// inputs of the passed transaction.  Also, add the outputs of the
+	// transaction as a way for the caller to detect duplicates that are not
+	// fully spent.
 	filteredSet := make(ViewFilteredSet)
 	msgTx := tx.MsgTx()
 	txType := stake.DetermineTxType(msgTx, isTreasuryEnabled,

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -332,8 +332,8 @@ const (
 
 	// AFAutoRevocationsEnabled may be set to indicate that the automatic ticket
 	// revocations agenda should be considered as active when checking a
-	// transaction so that any additional checks which depend on the agenda being
-	// active are applied.
+	// transaction so that any additional checks which depend on the agenda
+	// being active are applied.
 	AFAutoRevocationsEnabled
 
 	// AFNone is a convenience value to specifically indicate no flags.
@@ -485,8 +485,8 @@ func checkTransactionContext(tx *wire.MsgTx, params *chaincfg.Params, flags Agen
 		if isAutoRevocationsEnabled &&
 			tx.Version != stake.TxVersionAutoRevocations {
 
-			str := fmt.Sprintf("revocation transaction version is %d instead of %d",
-				tx.Version, stake.TxVersionAutoRevocations)
+			str := fmt.Sprintf("revocation transaction version is %d instead "+
+				"of %d", tx.Version, stake.TxVersionAutoRevocations)
 			return ruleError(ErrInvalidRevocationTxVersion, str)
 		}
 
@@ -1080,8 +1080,8 @@ func (b *BlockChain) checkBlockHeaderPositional(header *wire.BlockHeader, prevNo
 			dcp0005Version++
 		}
 		for version := latestBlockVersion; version > 1; version-- {
-			// Skip the version check for blocks that are known to violate DCP0005.
-			// See isDCP0005Violation for more details.
+			// Skip the version check for blocks that are known to violate
+			// DCP0005.  See isDCP0005Violation for more details.
 			if version == dcp0005Version &&
 				isDCP0005Violation(b.chainParams.Net, header, &blockHash) {
 
@@ -1450,10 +1450,11 @@ func checkTicketRedeemers(voteTicketHashes, revocationTicketHashes, winners,
 	}
 
 	// Iterate through all votes in the block, validate that they are spending
-	// tickets that are eligible to vote, and mark the corresponding winning hash
-	// as voted in the winning hashes map.
+	// tickets that are eligible to vote, and mark the corresponding winning
+	// hash as voted in the winning hashes map.
 	for _, voteTicketHash := range voteTicketHashes {
-		// Ensure the ticket being spent is actually eligible to vote in this block.
+		// Ensure the ticket being spent is actually eligible to vote in this
+		// block.
 		if _, ok := winningHashes[voteTicketHash]; !ok {
 			errStr := fmt.Sprintf("block contains vote for "+
 				"ineligible ticket %s (eligible tickets: %s)",
@@ -1465,7 +1466,8 @@ func checkTicketRedeemers(voteTicketHashes, revocationTicketHashes, winners,
 		winningHashes[voteTicketHash] = true
 	}
 
-	// Create a map of the ticket hashes that will become missed as of the block.
+	// Create a map of the ticket hashes that will become missed as of the
+	// block.
 	missedTicketHashes := make(map[chainhash.Hash]struct{}, len(winningHashes))
 	for ticketHash, hasVote := range winningHashes {
 		// If a winning ticket does not have a vote in this block, it will be
@@ -1476,7 +1478,8 @@ func checkTicketRedeemers(voteTicketHashes, revocationTicketHashes, winners,
 	}
 	numMissed := len(missedTicketHashes)
 
-	// Create a map of the ticket hashes that will become expired as of the block.
+	// Create a map of the ticket hashes that will become expired as of the
+	// block.
 	numExpiring := len(expiringNextBlock)
 	expiringTicketHashes := make(map[chainhash.Hash]struct{}, numExpiring)
 	for _, ticketHash := range expiringNextBlock {
@@ -1491,16 +1494,16 @@ func checkTicketRedeemers(voteTicketHashes, revocationTicketHashes, winners,
 	// spending tickets that are eligible to be revoked, and add the revocation
 	// to the revocations map.
 	for _, revocationTicketHash := range revocationTicketHashes {
-		// Determine if the ticket being revoked will become missed or expired as of
-		// this block.
+		// Determine if the ticket being revoked will become missed or expired
+		// as of this block.
 		_, missedInBlock := missedTicketHashes[revocationTicketHash]
 		_, expiringInBlock := expiringTicketHashes[revocationTicketHash]
 		missedOrExpiredInBlock := missedInBlock || expiringInBlock
 
-		// Ensure the ticket being spent is actually eligible to be revoked in this
-		// block.  If the automatic ticket revocations agenda is active, then
-		// revocations are allowed if the ticket will become missed or expired as of
-		// this block.
+		// Ensure the ticket being spent is actually eligible to be revoked in
+		// this block.  If the automatic ticket revocations agenda is active,
+		// then revocations are allowed if the ticket will become missed or
+		// expired as of this block.
 		eligible := (isAutoRevocationsEnabled && missedOrExpiredInBlock) ||
 			existsMissedTicket(revocationTicketHash)
 		if !eligible {
@@ -1514,8 +1517,8 @@ func checkTicketRedeemers(voteTicketHashes, revocationTicketHashes, winners,
 	}
 
 	// If the automatic ticket revocations agenda is active, then the block MUST
-	// contain revocation transactions for all tickets that will become missed or
-	// expired as of this block.
+	// contain revocation transactions for all tickets that will become missed
+	// or expired as of this block.
 	if isAutoRevocationsEnabled {
 		// Check that the block contains revocations for the tickets that will
 		// become missed as of this block.
@@ -1986,8 +1989,8 @@ func (b *BlockChain) checkBlockContext(block *dcrutil.Block, prevNode *blockNode
 				}
 			}
 
-			// Validate that all votes and revocations in the block are redeeming
-			// tickets according to consensus rules.
+			// Validate that all votes and revocations in the block are
+			// redeeming tickets according to consensus rules.
 			err = checkTicketRedeemers(voteTicketHashes, revocationTicketHashes,
 				parentStakeNode.Winners(), parentStakeNode.ExpiringNextBlock(),
 				parentStakeNode.ExistsMissedTicket, isTreasuryEnabled,
@@ -2317,8 +2320,8 @@ func calcTicketReturnAmounts(ticketOuts []*stake.MinimalOutput,
 		// return amount =  ------------------- * contribution amount
 		//                  total contributions
 		//
-		// However, in order to avoid floating point math, it uses 64.32 fixed point
-		// integer division to perform:
+		// However, in order to avoid floating point math, it uses 64.32 fixed
+		// point integer division to perform:
 		//
 		//                   --                                              --
 		//                  | total output amount * contribution amount * 2^32 |
@@ -2349,8 +2352,8 @@ func calcTicketReturnAmounts(ticketOuts []*stake.MinimalOutput,
 		return returnAmounts
 	}
 
-	// For revocations, if the automatic ticket revocations agenda is active, and
-	// there is a remainder after distributing the returns, then select a
+	// For revocations, if the automatic ticket revocations agenda is active,
+	// and there is a remainder after distributing the returns, then select a
 	// uniformly pseudorandom output index to receive each remaining atom.
 	if isAutoRevocationsEnabled && totalReturnAmount < totalOutputAmt {
 		remainder := totalOutputAmt - totalReturnAmount
@@ -2500,10 +2503,10 @@ func checkTicketRedeemerCommitments(ticketHash *chainhash.Hash,
 		}
 
 		// Determine the fee limit that is imposed.  If the transaction is a
-		// revocation, the version is greater than or equal to 2, and the automatic
-		// ticket revocation agenda is active, then the fee MUST be zero.
-		// Otherwise, the encoded fee limit from the ticket output commitment script
-		// should be used.
+		// revocation, the version is greater than or equal to 2, and the
+		// automatic ticket revocation agenda is active, then the fee MUST be
+		// zero.  Otherwise, the encoded fee limit from the ticket output
+		// commitment script should be used.
 		var feeLimitsEncoded uint16
 		var hasFeeLimit bool
 		if isVote || !isAutoRevocationsEnabled ||
@@ -2693,7 +2696,8 @@ func checkVoteInputs(subsidyCache *standalone.SubsidyCache, tx *dcrutil.Tx,
 
 	// Ensure the outputs adhere to the ticket commitments.
 	return checkTicketRedeemerCommitments(ticketHash, ticketOuts, msgTx,
-		true, voteSubsidy, prevHeader, isTreasuryEnabled, isAutoRevocationsEnabled)
+		true, voteSubsidy, prevHeader, isTreasuryEnabled,
+		isAutoRevocationsEnabled)
 }
 
 // checkRevocationInputs performs a series of checks on the inputs to a
@@ -2751,9 +2755,9 @@ func checkRevocationInputs(tx *dcrutil.Tx, txHeight int64, view *UtxoViewpoint,
 	// in the block AFTER the entire ticket maturity has passed, and, in order
 	// to be revoked, the ticket must have been missed which can't possibly
 	// happen for another block after that, hence the +2.  However, if the
-	// automatic ticket revocations agenda is active, +1 is used since revocations
-	// are allowed (and in fact, are required) in the block in which the ticket is
-	// missed or expired.
+	// automatic ticket revocations agenda is active, +1 is used since
+	// revocations are allowed (and in fact, are required) in the block in which
+	// the ticket is missed or expired.
 	originHeight := ticketUtxo.BlockHeight()
 	blocksSincePrev := txHeight - originHeight
 	revocationAdditionalMaturity := int64(2)
@@ -2851,7 +2855,8 @@ func CheckTransactionInputs(subsidyCache *standalone.SubsidyCache,
 	isVote := stake.IsSSGen(msgTx, isTreasuryEnabled)
 	if isVote {
 		err := checkVoteInputs(subsidyCache, tx, txHeight, view,
-			chainParams, prevHeader, isTreasuryEnabled, isAutoRevocationsEnabled)
+			chainParams, prevHeader, isTreasuryEnabled,
+			isAutoRevocationsEnabled)
 		if err != nil {
 			return 0, err
 		}
@@ -2865,8 +2870,8 @@ func CheckTransactionInputs(subsidyCache *standalone.SubsidyCache,
 	// need to be skipped later.
 	isRevocation := stake.IsSSRtx(msgTx, isAutoRevocationsEnabled)
 	if isRevocation {
-		err := checkRevocationInputs(tx, txHeight, view, chainParams, prevHeader,
-			isTreasuryEnabled, isAutoRevocationsEnabled)
+		err := checkRevocationInputs(tx, txHeight, view, chainParams,
+			prevHeader, isTreasuryEnabled, isAutoRevocationsEnabled)
 		if err != nil {
 			return 0, err
 		}
@@ -3473,7 +3478,8 @@ func (b *BlockChain) checkTransactionsAndConnect(inputFees dcrutil.Amount, node 
 		// spent, so be aware of this.
 		txFee, err := CheckTransactionInputs(b.subsidyCache, tx,
 			node.height, view, true, /* check fraud proofs */
-			b.chainParams, &prevHeader, isTreasuryEnabled, isAutoRevocationsEnabled)
+			b.chainParams, &prevHeader, isTreasuryEnabled,
+			isAutoRevocationsEnabled)
 		if err != nil {
 			log.Tracef("CheckTransactionInputs failed; error "+
 				"returned: %v", err)
@@ -3857,7 +3863,8 @@ func (b *BlockChain) checkConnectBlock(node *blockNode, block, parent *dcrutil.B
 	//
 	// These utxo entries are needed for verification of things such as
 	// transaction inputs, counting pay-to-script-hashes, and scripts.
-	err = view.fetchInputUtxos(block, isTreasuryEnabled, isAutoRevocationsEnabled)
+	err = view.fetchInputUtxos(block, isTreasuryEnabled,
+		isAutoRevocationsEnabled)
 	if err != nil {
 		return err
 	}

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -1362,12 +1362,12 @@ func TestCalcTicketReturnAmounts(t *testing.T) {
 	t.Parallel()
 
 	// Default header bytes for tests.
-	prevHeaderBytes, _ := hex.DecodeString("07000000dc02335daa073d293e1b150648f" +
-		"0444a60b9c97604abd01e00000000000000003c449b2321c4bd0d1fa76ed59f80ebaf46f" +
-		"16cfb2d17ba46948f09f21861095566482410a463ed49473c27278cd7a2a3712a3b19ff1" +
-		"f6225717d3eb71cc2b5590100012c7312a3c30500050095a100000cf42418f1820a87030" +
-		"0000020a10700091600005b32a55f5bcce31078832100007469943958002e00000000000" +
-		"0000000000000000000000000000007000000")
+	prevHeaderBytes, _ := hex.DecodeString("07000000dc02335daa073d293e1b15064" +
+		"8f0444a60b9c97604abd01e00000000000000003c449b2321c4bd0d1fa76ed59f80e" +
+		"baf46f16cfb2d17ba46948f09f21861095566482410a463ed49473c27278cd7a2a37" +
+		"12a3b19ff1f6225717d3eb71cc2b5590100012c7312a3c30500050095a100000cf42" +
+		"418f1820a870300000020a10700091600005b32a55f5bcce31078832100007469943" +
+		"958002e000000000000000000000000000000000000000007000000")
 
 	// Default ticket commitment script hex for tests.
 	p2pkhCommitScriptHex := "ba76a914097e847d49c6806f6933e806a350f43b97ac70d088ac"
@@ -1644,8 +1644,8 @@ func TestCheckTicketRedeemers(t *testing.T) {
 		winners:          testTicketHashes[1:6],
 		wantErr:          ErrTicketUnavailable,
 	}, {
-		name: "block contains revocation of ineligible ticket (auto revocations " +
-			"disabled)",
+		name: "block contains revocation of ineligible ticket (auto " +
+			"revocations disabled)",
 		voteTicketHashes:       testTicketHashes[:5],
 		revocationTicketHashes: testTicketHashes[5:6],
 		winners:                testTicketHashes[:5],
@@ -1691,8 +1691,8 @@ func TestCheckTicketRedeemers(t *testing.T) {
 		isAutoRevocationsEnabled: true,
 	}, {
 		name: "ok with revocations for previously missed tickets, tickets " +
-			"missed this block, and tickets expired this block (auto revocations " +
-			"enabled)",
+			"missed this block, and tickets expired this block (auto " +
+			"revocations enabled)",
 		voteTicketHashes:       testTicketHashes[:3],
 		revocationTicketHashes: testTicketHashes[3:9],
 		winners:                testTicketHashes[:5],
@@ -1717,15 +1717,15 @@ func TestCheckTicketRedeemers(t *testing.T) {
 		isAutoRevocationsEnabled: true,
 		wantErr:                  ErrInvalidSSRtx,
 	}, {
-		name: "block does not contain a revocation for ticket that is becoming " +
-			"missed as of this block (auto revocations enabled)",
+		name: "block does not contain a revocation for ticket that is " +
+			"becoming missed as of this block (auto revocations enabled)",
 		voteTicketHashes:         testTicketHashes[:4],
 		winners:                  testTicketHashes[:5],
 		isAutoRevocationsEnabled: true,
 		wantErr:                  ErrNoMissedTicketRevocation,
 	}, {
-		name: "block does not contain a revocation for ticket that is becoming " +
-			"expired as of this block (auto revocations enabled)",
+		name: "block does not contain a revocation for ticket that is " +
+			"becoming expired as of this block (auto revocations enabled)",
 		voteTicketHashes:         testTicketHashes[:5],
 		winners:                  testTicketHashes[:5],
 		expiringNextBlock:        testTicketHashes[5:6],
@@ -1734,8 +1734,8 @@ func TestCheckTicketRedeemers(t *testing.T) {
 	}}
 
 	for _, test := range tests {
-		// Use the default exists missed ticket function unless its overridden by
-		// the test.
+		// Use the default exists missed ticket function unless its overridden
+		// by the test.
 		existsMissedTicketFunc := defaultExistsMissedTicket
 		if test.existsMissedTicket != nil {
 			existsMissedTicketFunc = test.existsMissedTicket
@@ -1750,8 +1750,8 @@ func TestCheckTicketRedeemers(t *testing.T) {
 		// Validate that the expected error was returned for negative tests.
 		if test.wantErr != nil {
 			if !errors.Is(err, test.wantErr) {
-				t.Errorf("%q: mismatched error -- got %T, want %T", test.name, err,
-					test.wantErr)
+				t.Errorf("%q: mismatched error -- got %T, want %T", test.name,
+					err, test.wantErr)
 			}
 			continue
 		}
@@ -1766,8 +1766,8 @@ func TestCheckTicketRedeemers(t *testing.T) {
 // TestAutoRevocations ensures that all of the validation rules associated with
 // the automatic ticket revocations agenda work as expected.
 func TestAutoRevocations(t *testing.T) {
-	// Use a set of test chain parameters which allow for quicker vote activation
-	// as compared to various existing network params.
+	// Use a set of test chain parameters which allow for quicker vote
+	// activation as compared to various existing network params.
 	params := quickVoteActivationParams()
 
 	// Clone the parameters so they can be mutated, find the correct
@@ -1794,8 +1794,8 @@ func TestAutoRevocations(t *testing.T) {
 
 	// replaceAutoRevocationsVersions is a munge function which modifies the
 	// provided block by replacing the block, stake, vote, and revocation
-	// transaction versions with the versions associated with the automatic ticket
-	// revocations deployment.
+	// transaction versions with the versions associated with the automatic
+	// ticket revocations deployment.
 	replaceAutoRevocationsVersions := func(b *wire.MsgBlock) {
 		chaingen.ReplaceBlockVersion(int32(version))(b)
 		chaingen.ReplaceStakeVersion(version)(b)
@@ -1876,8 +1876,8 @@ func TestAutoRevocations(t *testing.T) {
 	g.AssertTipNumRevocations(1)
 	g.RejectTipBlock(ErrInvalidRevocationTxVersion)
 
-	// Create a block that misses a vote and contains a revocation with a non-zero
-	// fee.
+	// Create a block that misses a vote and contains a revocation with a
+	// non-zero fee.
 	//
 	//   ...
 	//      \-> b3(0)
@@ -1890,17 +1890,18 @@ func TestAutoRevocations(t *testing.T) {
 					continue
 				}
 
-				// Decrement the first output value to create a non-zero fee and return
-				// so that only a single revocation transaction is modified.
+				// Decrement the first output value to create a non-zero fee and
+				// return so that only a single revocation transaction is
+				// modified.
 				stx.TxOut[0].Value--
 				return
 			}
 		})
 	g.AssertTipNumRevocations(1)
 	// Note that this will fail with ErrRegTxCreateStakeOut rather than hitting
-	// the later error case of ErrBadPayeeValue since a revocation with a non-zero
-	// fee will not be identified as a revocation if the automatic ticket
-	// revocations agenda is active.
+	// the later error case of ErrBadPayeeValue since a revocation with a
+	// non-zero fee will not be identified as a revocation if the automatic
+	// ticket revocations agenda is active.
 	g.RejectTipBlock(ErrRegTxCreateStakeOut)
 
 	// Create a valid block that misses multiple votes and contains revocation
@@ -1913,8 +1914,8 @@ func TestAutoRevocations(t *testing.T) {
 	g.AssertTipNumRevocations(2)
 	g.AcceptTipBlock()
 
-	// Create a slice of the ticket hashes that revocations spent in the tip block
-	// that was just connected.
+	// Create a slice of the ticket hashes that revocations spent in the tip
+	// block that was just connected.
 	revocationTicketHashes := make([]chainhash.Hash, 0, params.TicketsPerBlock)
 	for _, stx := range g.Tip().STransactions {
 		// Append revocation ticket hashes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -204,7 +204,7 @@ The following versioned modules are provided by dcrd repository:
   Decred-specific convenience functions and types
 * [chaincfg/v3](https://github.com/decred/dcrd/tree/master/chaincfg) - Defines
   chain configuration parameters for the standard Decred networks and allows
-  callers to define their own custom Decred networks for testing puproses
+  callers to define their own custom Decred networks for testing purposes
   * [chainhash](https://github.com/decred/dcrd/tree/master/chaincfg/chainhash) -
     Provides a generic hash type and associated functions that allows the
     specific hash algorithm to be abstracted

--- a/docs/code_contribution_guidelines.md
+++ b/docs/code_contribution_guidelines.md
@@ -8,6 +8,7 @@
 4.3. [Code Documentation and Commenting](#CodeDocumentation)<br />
 4.4. [Model Git Commit Messages](#ModelGitCommitMessages)<br />
 4.5. [Handling Module Breaking Changes](#HandlingModuleBreakingChanges)<br />
+4.6. [Maximum Line Length and Wrapping](#MaximumLineLengthAndWrapping)<br />
 5. [Code Approval Process](#CodeApproval)<br />
 5.1 [Code Review](#CodeReview)<br />
 5.2 [Rework Code (if needed)](#CodeRework)<br />
@@ -305,6 +306,14 @@ new breaking change to a module's API is introduced:
   version in the same commit.
 - Repeat the process for any other modules the require a new major as a result
   of consuming the new major(s).
+
+<a name="MaximumLineLengthAndWrapping" />
+
+### 4.6 Maximum Line Length and Wrapping
+
+Lines are generally wrapped at 80 columns, with tabs counted as 4 columns,
+unless it makes sense to be longer for readability purposes.  This is a
+guideline for consistency among contributors and is not strictly enforced.
 
 <a name="CodeApproval" />
 

--- a/docs/code_contribution_guidelines.md
+++ b/docs/code_contribution_guidelines.md
@@ -285,25 +285,25 @@ other issues, PRs, or discussion threads.
 
 ### 4.5 Handling Module Breaking Changes
 
-Pull requests that introduce breaking changes to modules must ensure dependent 
-modules on the change are updated to referrence newly bumped module versions.  
-The purpose of this is to improve the release process by handling version 
-updates with the pull request that introduces it instead of waiting until 
-release.
+Pull requests that introduce breaking changes to modules must ensure that
+modules that depend on the change are updated to reference newly bumped module
+versions.  The purpose of this is to improve the release process by handling
+version updates with the pull request that introduces it instead of waiting
+until release.
 
-The request submitter should ensure the following steps are covered whenever a 
+The request submitter should ensure the following steps are covered whenever a
 new breaking change to a module's API is introduced:
 
-- Bump the major version in the `go.mod` of the affected module if not already 
-  done since the last release tag. Note that v1 modules are stablilized even 
-  without a release, breaking changes to such modules will require a major 
+- Bump the major version in the `go.mod` of the affected module if not already
+  done since the last release tag. Note that v1 modules are stabilized even
+  without a release, breaking changes to such modules will require a major
   version bump as well.
-- Add a replacement to the `go.mod` in the main module if not already done since 
+- Add a replacement to the `go.mod` in the main module if not already done since
   the last release tag.
 - Update all imports in the repo to use the new major version as necessary.
-  - Make necessary modifications to allow all other modules to use the new 
+  - Make necessary modifications to allow all other modules to use the new
   version in the same commit.
-- Repeat the process for any other modules the require a new major as a result 
+- Repeat the process for any other modules the require a new major as a result
   of consuming the new major(s).
 
 <a name="CodeApproval" />


### PR DESCRIPTION
This adds the following verbiage to the code contribution guidelines docs:

> 4.6 Maximum Line Length and Wrapping

> Lines are generally wrapped at 80 columns, with tabs counted as 4 columns, unless it makes sense to be longer for readability purposes. This is a guideline for consistency among contributors and is not strictly enforced.

This is very minor, but it is nice to have consistency between contributors, and it takes the guessing out of it for those trying to follow the code contribution guidelines closely.

The final commit updates some of the files where I had quite a few violations of this guideline due to initially using a tab size of 2 rather than 4. 