### PR TITLE
chaincfg: Introduce subsidy split change agenda.

### DIFF
--- a/blockchain/fullblocktests/params.go
+++ b/blockchain/fullblocktests/params.go
@@ -128,7 +128,9 @@ var regNetParams = &chaincfg.Params{
 	DivSubsidy:               101,
 	SubsidyReductionInterval: 128,
 	WorkRewardProportion:     6,
+	WorkRewardProportionV2:   1,
 	StakeRewardProportion:    3,
+	StakeRewardProportionV2:  8,
 	BlockTaxProportion:       1,
 
 	// Checkpoints ordered from oldest to newest.
@@ -386,6 +388,33 @@ var regNetParams = &chaincfg.Params{
 					Id:          "yes",
 					Description: "change to the new consensus rules",
 					Bits:        0x0040, // Bit 6
+					IsAbstain:   false,
+					IsNo:        false,
+				}},
+			},
+			StartTime:  0,             // Always available for vote
+			ExpireTime: math.MaxInt64, // Never expires
+		}, {
+			Vote: chaincfg.Vote{
+				Id:          chaincfg.VoteIDChangeSubsidySplit,
+				Description: "Change block reward subsidy split to 10/80/10 as defined in DCP0010",
+				Mask:        0x0180, // Bits 7 and 8
+				Choices: []chaincfg.Choice{{
+					Id:          "abstain",
+					Description: "abstain from voting",
+					Bits:        0x0000,
+					IsAbstain:   true,
+					IsNo:        false,
+				}, {
+					Id:          "no",
+					Description: "keep the existing consensus rules",
+					Bits:        0x0080, // Bit 7
+					IsAbstain:   false,
+					IsNo:        true,
+				}, {
+					Id:          "yes",
+					Description: "change to the new consensus rules",
+					Bits:        0x0100, // Bit 8
 					IsAbstain:   false,
 					IsNo:        false,
 				}},

--- a/blockchain/go.mod
+++ b/blockchain/go.mod
@@ -18,3 +18,7 @@ require (
 	github.com/decred/slog v1.2.0
 	github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca
 )
+
+replace (
+	github.com/decred/dcrd/chaincfg/v3 => ../chaincfg
+)

--- a/chaincfg/mainnetparams.go
+++ b/chaincfg/mainnetparams.go
@@ -106,7 +106,9 @@ func MainNetParams() *Params {
 		DivSubsidy:               101,
 		SubsidyReductionInterval: 6144,
 		WorkRewardProportion:     6,
+		WorkRewardProportionV2:   1,
 		StakeRewardProportion:    3,
+		StakeRewardProportionV2:  8,
 		BlockTaxProportion:       1,
 
 		// Checkpoints ordered from oldest to newest.  Note that only the latest
@@ -383,6 +385,33 @@ func MainNetParams() *Params {
 						Id:          "yes",
 						Description: "change to the new consensus rules",
 						Bits:        0x0040, // Bit 6
+						IsAbstain:   false,
+						IsNo:        false,
+					}},
+				},
+				StartTime:  1631750400, // Sep 16th, 2021
+				ExpireTime: 1694822400, // Sep 16th, 2023
+			}, {
+				Vote: Vote{
+					Id:          VoteIDChangeSubsidySplit,
+					Description: "Change block reward subsidy split to 10/80/10 as defined in DCP0010",
+					Mask:        0x0180, // Bits 7 and 8
+					Choices: []Choice{{
+						Id:          "abstain",
+						Description: "abstain from voting",
+						Bits:        0x0000,
+						IsAbstain:   true,
+						IsNo:        false,
+					}, {
+						Id:          "no",
+						Description: "keep the existing consensus rules",
+						Bits:        0x0080, // Bit 7
+						IsAbstain:   false,
+						IsNo:        true,
+					}, {
+						Id:          "yes",
+						Description: "change to the new consensus rules",
+						Bits:        0x0100, // Bit 8
 						IsAbstain:   false,
 						IsNo:        false,
 					}},

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -159,6 +159,11 @@ const (
 	// VoteIDAutoRevocations is the vote ID for the agenda that enables automatic
 	// ticket revocations as defined in DCP0009.
 	VoteIDAutoRevocations = "autorevocations"
+
+	// VoteIDChangeSubsidySplit is the vote ID for the agenda that changes the
+	// block reward subsidy split to 10% PoW, 80% PoS, and 10% Treasury as
+	// defined in DCP0010.
+	VoteIDChangeSubsidySplit = "changesubsidysplit"
 )
 
 // ConsensusDeployment defines details related to a specific consensus rule
@@ -315,12 +320,23 @@ type Params struct {
 	SubsidyReductionInterval int64
 
 	// WorkRewardProportion is the comparative amount of the subsidy given for
-	// creating a block.
+	// creating a block using the proportions prior to the modified values
+	// defined in DCP0010.
 	WorkRewardProportion uint16
 
+	// WorkRewardProportionV2 is the comparative amount of the subsidy given for
+	// creating a block using the proportions defined in DCP0010.
+	WorkRewardProportionV2 uint16
+
 	// StakeRewardProportion is the comparative amount of the subsidy given for
-	// casting stake votes (collectively, per block).
+	// casting stake votes (collectively, per block) using the proportions prior
+	// to the modified values defined in DCP0010.
 	StakeRewardProportion uint16
+
+	// StakeRewardProportionV2 is the comparative amount of the subsidy given
+	// for casting stake votes (collectively, per block) using the proportions
+	// defined in DCP0010.
+	StakeRewardProportionV2 uint16
 
 	// BlockTaxProportion is the inverse of the percentage of funds for each
 	// block to allocate to the developer organization.
@@ -607,7 +623,8 @@ func (p *Params) SubsidyReductionIntervalBlocks() int64 {
 }
 
 // WorkSubsidyProportion returns the comparative proportion of the subsidy
-// generated for creating a block (PoW).
+// generated for creating a block (PoW) using the proportions prior to the
+// modified values defined in DCP0010.
 //
 // The proportional split between PoW, PoS, and the Treasury is calculated
 // by treating each of the proportional parameters as a ratio to the sum of
@@ -623,9 +640,10 @@ func (p *Params) WorkSubsidyProportion() uint16 {
 }
 
 // StakeSubsidyProportion returns the comparative proportion of the subsidy
-// generated for casting stake votes (collectively, per block).  See the
-// documentation for WorkSubsidyProportion for more details on how the
-// parameter is used.
+// generated for casting stake votes (collectively, per block) using the
+// proportions prior to the modified values defined in DCP0010.  See the
+// documentation for WorkSubsidyProportion for more details on how the parameter
+// is used.
 func (p *Params) StakeSubsidyProportion() uint16 {
 	return p.StakeRewardProportion
 }

--- a/chaincfg/regnetparams.go
+++ b/chaincfg/regnetparams.go
@@ -106,7 +106,9 @@ func RegNetParams() *Params {
 		DivSubsidy:               101,
 		SubsidyReductionInterval: 128,
 		WorkRewardProportion:     6,
+		WorkRewardProportionV2:   1,
 		StakeRewardProportion:    3,
+		StakeRewardProportionV2:  8,
 		BlockTaxProportion:       1,
 
 		// Checkpoints ordered from oldest to newest.
@@ -376,6 +378,33 @@ func RegNetParams() *Params {
 						Id:          "yes",
 						Description: "change to the new consensus rules",
 						Bits:        0x0040, // Bit 6
+						IsAbstain:   false,
+						IsNo:        false,
+					}},
+				},
+				StartTime:  0,             // Always available for vote
+				ExpireTime: math.MaxInt64, // Never expires
+			}, {
+				Vote: Vote{
+					Id:          VoteIDChangeSubsidySplit,
+					Description: "Change block reward subsidy split to 10/80/10 as defined in DCP0010",
+					Mask:        0x0180, // Bits 7 and 8
+					Choices: []Choice{{
+						Id:          "abstain",
+						Description: "abstain from voting",
+						Bits:        0x0000,
+						IsAbstain:   true,
+						IsNo:        false,
+					}, {
+						Id:          "no",
+						Description: "keep the existing consensus rules",
+						Bits:        0x0080, // Bit 7
+						IsAbstain:   false,
+						IsNo:        true,
+					}, {
+						Id:          "yes",
+						Description: "change to the new consensus rules",
+						Bits:        0x0100, // Bit 8
 						IsAbstain:   false,
 						IsNo:        false,
 					}},

--- a/chaincfg/simnetparams.go
+++ b/chaincfg/simnetparams.go
@@ -105,7 +105,9 @@ func SimNetParams() *Params {
 		DivSubsidy:               101,
 		SubsidyReductionInterval: 128,
 		WorkRewardProportion:     6,
+		WorkRewardProportionV2:   1,
 		StakeRewardProportion:    3,
+		StakeRewardProportionV2:  8,
 		BlockTaxProportion:       1,
 
 		// Checkpoints ordered from oldest to newest.

--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -101,7 +101,9 @@ func TestNet3Params() *Params {
 		DivSubsidy:               101,
 		SubsidyReductionInterval: 2048,
 		WorkRewardProportion:     6,
+		WorkRewardProportionV2:   1,
 		StakeRewardProportion:    3,
+		StakeRewardProportionV2:  8,
 		BlockTaxProportion:       1,
 
 		// Checkpoints ordered from oldest to newest.  Note that only the latest
@@ -297,6 +299,33 @@ func TestNet3Params() *Params {
 						Id:          "yes",
 						Description: "change to the new consensus rules",
 						Bits:        0x0040, // Bit 6
+						IsAbstain:   false,
+						IsNo:        false,
+					}},
+				},
+				StartTime:  1631750400, // Sep 16th, 2021
+				ExpireTime: 1694822400, // Sep 16th, 2023
+			}, {
+				Vote: Vote{
+					Id:          VoteIDChangeSubsidySplit,
+					Description: "Change block reward subsidy split to 10/80/10 as defined in DCP0010",
+					Mask:        0x0180, // Bits 7 and 8
+					Choices: []Choice{{
+						Id:          "abstain",
+						Description: "abstain from voting",
+						Bits:        0x0000,
+						IsAbstain:   true,
+						IsNo:        false,
+					}, {
+						Id:          "no",
+						Description: "keep the existing consensus rules",
+						Bits:        0x0080, // Bit 7
+						IsAbstain:   false,
+						IsNo:        true,
+					}, {
+						Id:          "yes",
+						Description: "change to the new consensus rules",
+						Bits:        0x0100, // Bit 8
 						IsAbstain:   false,
 						IsNo:        false,
 					}},


### PR DESCRIPTION
**This is rebased on #2846**.

This adds a new definition for the upcoming agenda vote to change the subsidy split to 10% PoW, 80% PoS, and 10% Treasury defined in DCP0010 along with two new parameters for the modified values.

It does not include any code to make decisions based on the status of the agenda or bump block versions.  It only adds the definition for the agenda.
