### PR TITLE
stdscript: Reject multisig neg thresholds.

### DIFF
--- a/txscript/stdscript/error.go
+++ b/txscript/stdscript/error.go
@@ -13,6 +13,10 @@ const (
 	// supported.
 	ErrUnsupportedScriptVersion = ErrorKind("ErrUnsupportedScriptVersion")
 
+	// ErrNegativeRequiredSigs is returned from MultiSigScript when the
+	// specified number of required signatures is negative.
+	ErrNegativeRequiredSigs = ErrorKind("ErrNegativeRequiredSigs")
+
 	// ErrTooManyRequiredSigs is returned from MultiSigScript when the
 	// specified number of required signatures is larger than the number of
 	// provided public keys.

--- a/txscript/stdscript/error_test.go
+++ b/txscript/stdscript/error_test.go
@@ -17,6 +17,7 @@ func TestErrorKindStringer(t *testing.T) {
 		want string
 	}{
 		{ErrUnsupportedScriptVersion, "ErrUnsupportedScriptVersion"},
+		{ErrNegativeRequiredSigs, "ErrNegativeRequiredSigs"},
 		{ErrTooManyRequiredSigs, "ErrTooManyRequiredSigs"},
 		{ErrPubKeyType, "ErrPubKeyType"},
 		{ErrTooMuchNullData, "ErrTooMuchNullData"},

--- a/txscript/stdscript/scriptv0.go
+++ b/txscript/stdscript/scriptv0.go
@@ -818,6 +818,11 @@ func DetermineRequiredSigsV0(script []byte) uint16 {
 // An Error with kind ErrTooManyRequiredSigs will be returned if the threshold
 // is larger than the number of keys provided.
 func MultiSigScriptV0(threshold int, pubKeys ...[]byte) ([]byte, error) {
+	if threshold < 0 {
+		str := fmt.Sprintf("unable to generate multisig script with %d "+
+			"required signatures", threshold)
+		return nil, makeError(ErrNegativeRequiredSigs, str)
+	}
 	if len(pubKeys) < threshold {
 		str := fmt.Sprintf("unable to generate multisig script with %d "+
 			"required signatures when there are only %d public keys available",

--- a/txscript/stdscript/scriptv0_test.go
+++ b/txscript/stdscript/scriptv0_test.go
@@ -1113,6 +1113,12 @@ func TestMultiSigScriptV0(t *testing.T) {
 		threshold: 1,
 		expected:  "",
 		err:       ErrPubKeyType,
+	}, {
+		name:      "reject negative threshold",
+		pubKeys:   [][]byte{p2pkUncompressedMain},
+		threshold: -1,
+		expected:  "",
+		err:       ErrNegativeRequiredSigs,
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
This modifies the `MultiSigScriptV0` convenience func for creating a multisig script to return an error if the caller improperly calls it with a negative threshold.