### PR TITLE
multi: Limit inputs to base58 decode.

### DIFF
--- a/dcrutil/wif_test.go
+++ b/dcrutil/wif_test.go
@@ -72,6 +72,12 @@ func TestWIF(t *testing.T) {
 		// Misc decoding error tests.
 		// ---------------------------------------------------------------------
 
+		name:      "encoded wif too long",
+		skipMake:  true,
+		net:       mainNetPrivKeyID,
+		wif:       "2jV1H5Abfm1gV6GxGxNAvVfuSJPApQ9mr5vNzqJctmzbA6Km9vsBDvW",
+		decodeErr: ErrMalformedPrivateKey,
+	}, {
 		name:      "bad checksum",
 		skipMake:  true,
 		net:       mainNetPrivKeyID,

--- a/dcrutil/wif_test.go
+++ b/dcrutil/wif_test.go
@@ -1,197 +1,273 @@
 // Copyright (c) 2013, 2014 The btcsuite developers
-// Copyright (c) 2015-2019 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package dcrutil
 
 import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
 	"testing"
 
 	"github.com/decred/dcrd/dcrec"
 )
 
-func TestEncodeDecodeWIF(t *testing.T) {
+// TestWIF ensures that WIF-related APIs work as intended including that they
+// are properly encoded and decoded, that they produce the expected private and
+// public keys as well as DSA, and that error paths fail as expected.
+func TestWIF(t *testing.T) {
+	t.Parallel()
+
 	mainNetPrivKeyID := [2]byte{0x22, 0xde} // starts with Pm
 	testNetPrivKeyID := [2]byte{0x23, 0x0e} // starts with Pt
 	simNetPrivKeyID := [2]byte{0x23, 0x07}  // starts with Ps
 	regNetPrivKeyID := [2]byte{0x22, 0xfe}  // starts with Pr
-	suites := []dcrec.SignatureType{
-		dcrec.STEcdsaSecp256k1,
-		dcrec.STEd25519,
-		dcrec.STSchnorrSecp256k1,
+	priv1 := "0c28fca386c7a227600b2fe50b7cae11ec86d3bf1fbe471be89827e19d72aa1d"
+	priv2 := "dda35a1488fb97b6eb3fe6e9ef2a25814e396fb5dc295fe994b96789b21a0398"
+	priv3 := "0ca35a1488fb97b6eb3fe6e9ef2a25814e396fb5dc295fe994b96789b21a0398"
+	pub1 := "02d0de0aaeaefad02b8bdc8a01a1b8b11c696bd3d66a2c5f10780d95b7df42645c"
+	pub2 := "02eec2540661b0c39d271570742413bd02932dd0093493fd0beced0b7f93addec4"
+	pub3 := "544e3399a8df7b99a0454bfd9691050c8bba58f8d685e98cb72277032a0cf3ac"
+
+	// isErr is a convenience func which acts as a limited version of errors.Is
+	// until the package is converted to support it at which point this can be
+	// removed.
+	isErr := func(err error, target error) bool {
+		if (err == nil) != (target == nil) {
+			return false
+		}
+		return err == target || (err != nil && err.Error() == target.Error())
 	}
-	for _, suite := range suites {
-		var priv1, priv2 []byte
-		switch suite {
-		case dcrec.STEcdsaSecp256k1:
-			priv1 = []byte{
-				0x0c, 0x28, 0xfc, 0xa3, 0x86, 0xc7, 0xa2, 0x27,
-				0x60, 0x0b, 0x2f, 0xe5, 0x0b, 0x7c, 0xae, 0x11,
-				0xec, 0x86, 0xd3, 0xbf, 0x1f, 0xbe, 0x47, 0x1b,
-				0xe8, 0x98, 0x27, 0xe1, 0x9d, 0x72, 0xaa, 0x1d,
-			}
-			priv2 = []byte{
-				0xdd, 0xa3, 0x5a, 0x14, 0x88, 0xfb, 0x97, 0xb6,
-				0xeb, 0x3f, 0xe6, 0xe9, 0xef, 0x2a, 0x25, 0x81,
-				0x4e, 0x39, 0x6f, 0xb5, 0xdc, 0x29, 0x5f, 0xe9,
-				0x94, 0xb9, 0x67, 0x89, 0xb2, 0x1a, 0x03, 0x98,
-			}
-		case dcrec.STEd25519:
-			priv1 = []byte{
-				0x0c, 0x28, 0xfc, 0xa3, 0x86, 0xc7, 0xa2, 0x27,
-				0x60, 0x0b, 0x2f, 0xe5, 0x0b, 0x7c, 0xae, 0x11,
-				0xec, 0x86, 0xd3, 0xbf, 0x1f, 0xbe, 0x47, 0x1b,
-				0xe8, 0x98, 0x27, 0xe1, 0x9d, 0x72, 0xaa, 0x1d,
-			}
-			priv2 = []byte{
-				0x0c, 0xa3, 0x5a, 0x14, 0x88, 0xfb, 0x97, 0xb6,
-				0xeb, 0x3f, 0xe6, 0xe9, 0xef, 0x2a, 0x25, 0x81,
-				0x4e, 0x39, 0x6f, 0xb5, 0xdc, 0x29, 0x5f, 0xe9,
-				0x94, 0xb9, 0x67, 0x89, 0xb2, 0x1a, 0x03, 0x98,
-			}
-		case dcrec.STSchnorrSecp256k1:
-			priv1 = []byte{
-				0x0c, 0x28, 0xfc, 0xa3, 0x86, 0xc7, 0xa2, 0x27,
-				0x60, 0x0b, 0x2f, 0xe5, 0x0b, 0x7c, 0xae, 0x11,
-				0xec, 0x86, 0xd3, 0xbf, 0x1f, 0xbe, 0x47, 0x1b,
-				0xe8, 0x98, 0x27, 0xe1, 0x9d, 0x72, 0xaa, 0x1d,
-			}
 
-			priv2 = []byte{
-				0xdd, 0xa3, 0x5a, 0x14, 0x88, 0xfb, 0x97, 0xb6,
-				0xeb, 0x3f, 0xe6, 0xe9, 0xef, 0x2a, 0x25, 0x81,
-				0x4e, 0x39, 0x6f, 0xb5, 0xdc, 0x29, 0x5f, 0xe9,
-				0x94, 0xb9, 0x67, 0x89, 0xb2, 0x1a, 0x03, 0x98,
-			}
-		}
+	tests := []struct {
+		name      string              // test description
+		privKey   string              // hex-encoded private key
+		net       [2]byte             // network for WIF
+		dsa       dcrec.SignatureType // DSA suite
+		skipMake  bool                // set to skip new WIF via API
+		makeErr   error               // expected error from new WIF func
+		wif       string              // WIF to decode and expected WIF
+		decodeErr error               // expected error from decode func
+		pubKey    string              // expected hex-encoded public key
+	}{{
+		// ---------------------------------------------------------------------
+		// Misc construction error tests.
+		// ---------------------------------------------------------------------
 
-		wif1, err := NewWIF(priv1, mainNetPrivKeyID, suite)
+		name:    "unsupported signature type",
+		privKey: priv1,
+		net:     mainNetPrivKeyID,
+		dsa:     99999,
+		makeErr: fmt.Errorf("unsupported signature type '99999'"),
+	}, {
+		name:    "invalid ed25519 privkey via constructor",
+		privKey: priv2,
+		net:     mainNetPrivKeyID,
+		dsa:     dcrec.STEd25519,
+		makeErr: fmt.Errorf("not on subgroup (>N)"),
+	}, {
+		// ---------------------------------------------------------------------
+		// Misc decoding error tests.
+		// ---------------------------------------------------------------------
+
+		name:      "bad checksum",
+		skipMake:  true,
+		net:       mainNetPrivKeyID,
+		wif:       "PmQdMn8xafwaQouk8ngs1CccRCB1ZmsqQxBaxNR4vhQi5a5QB5717",
+		decodeErr: ErrChecksumMismatch,
+	}, {
+		name:      "bad decoded data length",
+		skipMake:  true,
+		net:       mainNetPrivKeyID,
+		wif:       "6A9ymjvs2UDRijKt1s2qfC5i9cvQiZmBDbzmDukTfT3jZS4mStxo",
+		decodeErr: ErrMalformedPrivateKey,
+	}, {
+		name:      "wif for wrong network",
+		skipMake:  true,
+		net:       mainNetPrivKeyID,
+		wif:       "PtWVDUidYaiiNT5e2Sfb1Ah4evbaSopZJkkpFBuzkJYcYteugvdFg",
+		decodeErr: ErrWrongWIFNetwork(mainNetPrivKeyID),
+	}, {
+		name:      "invalid ed25519 privkey via decode",
+		skipMake:  true,
+		net:       mainNetPrivKeyID,
+		wif:       "PmQgtn9ZpDCASuNpjbwDkxHqskf3kTPFFpLZ4SMWtda6PmFyvM5aG",
+		decodeErr: fmt.Errorf("not on subgroup (>N)"),
+	}, {
+		// ---------------------------------------------------------------------
+		// Positive path tests.
+		// ---------------------------------------------------------------------
+
+		name:    "mainnet ecdsa secp256k1 priv1",
+		privKey: priv1,
+		net:     mainNetPrivKeyID,
+		dsa:     dcrec.STEcdsaSecp256k1,
+		wif:     "PmQdMn8xafwaQouk8ngs1CccRCB1ZmsqQxBaxNR4vhQi5a5QB5716",
+		pubKey:  pub1,
+	}, {
+		name:    "testnet ecdsa secp256k1 priv2",
+		privKey: priv2,
+		net:     testNetPrivKeyID,
+		dsa:     dcrec.STEcdsaSecp256k1,
+		wif:     "PtWVDUidYaiiNT5e2Sfb1Ah4evbaSopZJkkpFBuzkJYcYteugvdFg",
+		pubKey:  pub2,
+	}, {
+		name:    "simnet ecdsa secp256k1 priv2",
+		privKey: priv2,
+		net:     simNetPrivKeyID,
+		dsa:     dcrec.STEcdsaSecp256k1,
+		wif:     "PsURoUb7FMeJQdTYea8pkbUQFBZAsxtfDcfTLGja5sCLZvLZWRtjK",
+		pubKey:  pub2,
+	}, {
+		name:    "regnet ecdsa secp256k1 priv2",
+		privKey: priv2,
+		net:     regNetPrivKeyID,
+		dsa:     dcrec.STEcdsaSecp256k1,
+		wif:     "Pr9D8L8s9nG4AroRjbTGiRuYrweN1T8Dg9grAEeTEStZAPMnjxwCT",
+		pubKey:  pub2,
+	}, {
+		name:    "mainnet ed25519 priv1",
+		privKey: priv1,
+		net:     mainNetPrivKeyID,
+		dsa:     dcrec.STEd25519,
+		wif:     "PmQfJXKC2ho1633ZiVbSdCZw1y68BVXYFpyE2UfDcbQN5xa3DByDn",
+		pubKey:  "667c1c28ec2d59ceb33673a94165a5e51d5cbcef620aec663cd83638643bba3b",
+	}, {
+		name:    "testnet ed25519 priv3",
+		privKey: priv3,
+		net:     testNetPrivKeyID,
+		dsa:     dcrec.STEd25519,
+		wif:     "PtWVaBGeCfbFQfgqFew8YvdrSH5TH439K7rvpo3aWnSfDvyK8ijbK",
+		pubKey:  pub3,
+	}, {
+		name:    "simnet ed25519 priv3",
+		privKey: priv3,
+		net:     simNetPrivKeyID,
+		dsa:     dcrec.STEd25519,
+		wif:     "PsUSAB97uSWqSr4jsnQNJMRC2Y33iD7FDymZuss9rM6PExexSPyTQ",
+		pubKey:  pub3,
+	}, {
+		name:    "regnet ed25519 priv3",
+		privKey: priv3,
+		net:     regNetPrivKeyID,
+		dsa:     dcrec.STEd25519,
+		wif:     "Pr9DV2gsos8bD5QcxoipGBrLeJ8EqhLogWnxjqn2zvnbqRg9fZMHs",
+		pubKey:  pub3,
+	}, {
+		name:    "mainnet schnorr secp256k1 priv2",
+		privKey: priv1,
+		net:     mainNetPrivKeyID,
+		dsa:     dcrec.STSchnorrSecp256k1,
+		wif:     "PmQhFGVRUjeRmGBPJCW2FCXFck1EoDBF6hks6auNJVQ26M4h73W9W",
+		pubKey:  pub1,
+	}, {
+		name:    "testnet schnorr secp256k1 priv2",
+		privKey: priv2,
+		net:     testNetPrivKeyID,
+		dsa:     dcrec.STSchnorrSecp256k1,
+		wif:     "PtWZ6y56SeRZiuMHBrUkFAbhrURogF7xzWL6PQQJ86XvZfeE3jf1a",
+		pubKey:  pub2,
+	}, {
+		name:    "simnet schnorr secp256k1 priv2",
+		privKey: priv2,
+		net:     simNetPrivKeyID,
+		dsa:     dcrec.STSchnorrSecp256k1,
+		wif:     "PsUVgxwa9RM9m5jBoywyzbP3SjPQ7QC4uNEjUVDsTfBeahKkmETvQ",
+		pubKey:  pub2,
+	}, {
+		name:    "regnet schnorr secp256k1 priv2",
+		privKey: priv2,
+		net:     regNetPrivKeyID,
+		dsa:     dcrec.STSchnorrSecp256k1,
+		wif:     "Pr9H1pVL3qxuXK54u1GRxRpC4VUbEtRdMuG8JT8kcEssBALyTRM7v",
+		pubKey:  pub2,
+	}}
+
+	for _, test := range tests {
+		// Decode test data.
+		privKey, err := hex.DecodeString(test.privKey)
 		if err != nil {
-			t.Fatalf("NewWIF mainnet priv1 failed: %v", err)
+			t.Errorf("%q: invalid private key hex error: %v", test.name, err)
+			continue
 		}
-		wif2, err := NewWIF(priv2, testNetPrivKeyID, suite)
+		pubKey, err := hex.DecodeString(test.pubKey)
 		if err != nil {
-			t.Fatalf("NewWIF testnet priv2 failed: %v", err)
-		}
-		wif3, err := NewWIF(priv2, simNetPrivKeyID, suite)
-		if err != nil {
-			t.Fatalf("NewWIF simnet priv2 failed: %v", err)
-		}
-		wif4, err := NewWIF(priv2, regNetPrivKeyID, suite)
-		if err != nil {
-			t.Fatalf("NewWIF regnet priv2 failed: %v", err)
+			t.Errorf("%q: invalid public key hex error: %v", test.name, err)
+			continue
 		}
 
-		var tests []struct {
-			wif     *WIF
-			encoded string
-			net     [2]byte
+		// checkWIF ensures the various methods of the provided WIF return the
+		// expected results.
+		checkWIF := func(wif *WIF) bool {
+			t.Helper()
+
+			// Ensure the WIF encodes to the expected string.
+			gotEncoded := wif.String()
+			if gotEncoded != test.wif {
+				t.Errorf("%q: mismatched encoding -- got %s, want %s",
+					test.name, gotEncoded, test.wif)
+				return false
+			}
+
+			// Ensure the WIF returns the expected private key.
+			gotPriv := wif.PrivKey()
+			if !bytes.Equal(gotPriv, privKey) {
+				t.Errorf("%q: mismatched private key -- got %x, want %x",
+					test.name, gotPriv, privKey)
+				return false
+			}
+
+			// Ensure the WIF returns the expected public key.
+			gotPub := wif.PubKey()
+			if !bytes.Equal(gotPub, pubKey) {
+				t.Errorf("%q: mismatched public key -- got %x, want %x",
+					test.name, gotPub, pubKey)
+				return false
+			}
+
+			// Ensure the WIF returns the expected DSA.
+			gotDSA := wif.DSA()
+			if gotDSA != test.dsa {
+				t.Errorf("%q: mismatched DSA -- got %v, want %v", test.name,
+					gotDSA, test.dsa)
+				return false
+			}
+
+			return true
 		}
 
-		switch suite {
-		case dcrec.STEcdsaSecp256k1:
-			tests = []struct {
-				wif     *WIF
-				encoded string
-				net     [2]byte
-			}{
-				{
-					wif1,
-					"PmQdMn8xafwaQouk8ngs1CccRCB1ZmsqQxBaxNR4vhQi5a5QB5716",
-					mainNetPrivKeyID,
-				},
-				{
-					wif2,
-					"PtWVDUidYaiiNT5e2Sfb1Ah4evbaSopZJkkpFBuzkJYcYteugvdFg",
-					testNetPrivKeyID,
-				},
-				{
-					wif3,
-					"PsURoUb7FMeJQdTYea8pkbUQFBZAsxtfDcfTLGja5sCLZvLZWRtjK",
-					simNetPrivKeyID,
-				},
-				{
-					wif4,
-					"Pr9D8L8s9nG4AroRjbTGiRuYrweN1T8Dg9grAEeTEStZAPMnjxwCT",
-					regNetPrivKeyID,
-				},
-			}
-		case dcrec.STEd25519:
-			tests = []struct {
-				wif     *WIF
-				encoded string
-				net     [2]byte
-			}{
-				{
-					wif1,
-					"PmQfJXKC2ho1633ZiVbSdCZw1y68BVXYFpyE2UfDcbQN5xa3DByDn",
-					mainNetPrivKeyID,
-				},
-				{
-					wif2,
-					"PtWVaBGeCfbFQfgqFew8YvdrSH5TH439K7rvpo3aWnSfDvyK8ijbK",
-					testNetPrivKeyID,
-				},
-				{
-					wif3,
-					"PsUSAB97uSWqSr4jsnQNJMRC2Y33iD7FDymZuss9rM6PExexSPyTQ",
-					simNetPrivKeyID,
-				},
-				{
-					wif4,
-					"Pr9DV2gsos8bD5QcxoipGBrLeJ8EqhLogWnxjqn2zvnbqRg9fZMHs",
-					regNetPrivKeyID,
-				},
-			}
-		case dcrec.STSchnorrSecp256k1:
-			tests = []struct {
-				wif     *WIF
-				encoded string
-				net     [2]byte
-			}{
-				{
-					wif1,
-					"PmQhFGVRUjeRmGBPJCW2FCXFck1EoDBF6hks6auNJVQ26M4h73W9W",
-					mainNetPrivKeyID,
-				},
-				{
-					wif2,
-					"PtWZ6y56SeRZiuMHBrUkFAbhrURogF7xzWL6PQQJ86XvZfeE3jf1a",
-					testNetPrivKeyID,
-				},
-				{
-					wif3,
-					"PsUVgxwa9RM9m5jBoywyzbP3SjPQ7QC4uNEjUVDsTfBeahKkmETvQ",
-					simNetPrivKeyID,
-				},
-				{
-					wif4,
-					"Pr9H1pVL3qxuXK54u1GRxRpC4VUbEtRdMuG8JT8kcEssBALyTRM7v",
-					regNetPrivKeyID,
-				},
-			}
-		}
-
-		for _, test := range tests {
-			// Test that encoding the WIF structure matches the expected string.
-			s := test.wif.String()
-			if s != test.encoded {
-				t.Errorf("TestEncodeDecodePrivateKey failed: want '%s', got '%s'",
-					test.encoded, s)
+		// Create the WIF from the test data and ensure it returns all of the
+		// expected data.
+		if !test.skipMake {
+			wif, err := NewWIF(privKey, test.net, test.dsa)
+			if !isErr(err, test.makeErr) {
+				t.Errorf("%q: unexpected error -- got %v, want %v", test.name,
+					err, test.makeErr)
 				continue
 			}
-
-			// Test that decoding the expected string results in the original WIF
-			// structure.
-			w, err := DecodeWIF(test.encoded, test.net)
 			if err != nil {
-				t.Error(err)
 				continue
 			}
-			if got := w.String(); got != test.encoded {
-				t.Errorf("NewWIF failed: want '%v', got '%v'", test.wif, got)
+			if !checkWIF(wif) {
+				continue
 			}
+		}
+
+		// Ensure the WIF decodes as expected and that it returns all of the
+		// expected data.
+		wif2, err := DecodeWIF(test.wif, test.net)
+		if !isErr(err, test.decodeErr) {
+			t.Errorf("%q: unexpected error -- got %v, want %v", test.name, err,
+				test.decodeErr)
+			continue
+		}
+		if err != nil {
+			continue
+		}
+		if !checkWIF(wif2) {
+			continue
 		}
 	}
 }

--- a/hdkeychain/extendedkey_test.go
+++ b/hdkeychain/extendedkey_test.go
@@ -736,6 +736,11 @@ func TestErrors(t *testing.T) {
 		err  error
 	}{
 		{
+			name: "key length too long",
+			key:  "DNQvB3p9wsKRyaoxXrh2UyBby7RpMtvhe4uJszAE4Mc8qinPwdUkcpqoUZPFAtXf41ukuio6JsUTgKjPnCaAy99fSBHKJgeRmWCrcytLR1GZQqpnR5",
+			err:  ErrInvalidKeyLen,
+		},
+		{
 			name: "invalid key length",
 			key:  "dpub1234",
 			err:  ErrInvalidKeyLen,

--- a/txscript/stdaddr/address_test.go
+++ b/txscript/stdaddr/address_test.go
@@ -1301,6 +1301,11 @@ func TestDecodeAddressV0Corners(t *testing.T) {
 		net:       mainNetParams,
 		decodeErr: ErrMalformedAddress,
 	}, {
+		name:      "exceeds max version 0 address size",
+		addr:      "5HLcANeEU3u2pxrCZFmLoyY4bAH7sgEuiTGcionhA7tzHdecFmgg1LJk",
+		net:       mainNetParams,
+		decodeErr: ErrMalformedAddress,
+	}, {
 		// ---------------------------------------------------------------------
 		// Negative P2PK ECDSA secp256k1 tests.
 		// ---------------------------------------------------------------------
@@ -1308,7 +1313,7 @@ func TestDecodeAddressV0Corners(t *testing.T) {
 		name:      "mainnet p2pk-ecdsa-secp256k1 uncompressed (0x04) rejected via decode",
 		addr:      "HiQeNVx8PNYP8ysyunUoicyNdfRUrEu1kzPE6v5gECBHBYgDzXCg8BsDGjmaHCpV97ytaQGHz5XDMJgJVHjv9YeSXWkHfwmBJj",
 		net:       mainNetParams,
-		decodeErr: ErrMalformedAddressData,
+		decodeErr: ErrMalformedAddress,
 	}, {
 		name:      "p2pk-ecdsa-secp256k1 malformed pubkey via decode",
 		addr:      "3tWTcxjUnAKTzHh8pHPYpSsUKVbTvziNGHtbBFQkY12khQWuW83p",
@@ -1331,7 +1336,7 @@ func TestDecodeAddressV0Corners(t *testing.T) {
 		name:      "mainnet p2pk-schnorr-secp256k1 uncompressed (0x04) rejected via decode",
 		addr:      "HiQjU9uCJtiQD7osQuYHWJRFiBCTuqtaTw8QFMtMgAW2ny4nUENeXDiV5VxfVZrK6PZynKPDpL7bwc6XLFNpV8k7ePDJmkkVCh",
 		net:       mainNetParams,
-		decodeErr: ErrMalformedAddressData,
+		decodeErr: ErrMalformedAddress,
 	}, {
 		name:      "p2pk-schnorr-secp256k1 malformed pubkey via decode",
 		addr:      "3tWUW3oD87XtmFVGnLX4Z3Hdesm2qRvvN8H5kq3yXxJumCxbvCpo",


### PR DESCRIPTION
This modifies the following funcs that accept inputs which ultimately involve base58 decoding to reject any attempts to decode strings that are larger than the max possible size early since there is no reason to waste time and memory doing the base 58 decode when it is guaranteed to be invalid anyway:

- `stdaddr.DecodeAddressV0`
- `hdkeychain.NewKeyFromString`
- `dcrutil.DecodeWIF`

It also adds associated tests to ensure proper functionality and includes a rework of the WIF tests in `dcrutil` to provide full coverage for both positive and negative paths, to test for the explicit reason for the failure to ensure that each test is actually testing the intended condition, and to make them more consistent with modern practices in the code.