### PR TITLE
txscript: Support min int64 script num encoding.

### DIFF
--- a/txscript/scriptnum.go
+++ b/txscript/scriptnum.go
@@ -126,17 +126,18 @@ func (n ScriptNum) Bytes() []byte {
 
 	// Take the absolute value and keep track of whether it was originally
 	// negative.
+	nu64 := uint64(n)
 	isNegative := n < 0
 	if isNegative {
-		n = -n
+		nu64 = uint64(-n)
 	}
 
 	// Encode to little endian.  The maximum number of encoded bytes is 9
 	// (8 bytes for max int64 plus a potential byte for sign extension).
 	result := make([]byte, 0, 9)
-	for n > 0 {
-		result = append(result, byte(n&0xff))
-		n >>= 8
+	for nu64 > 0 {
+		result = append(result, byte(nu64&0xff))
+		nu64 >>= 8
 	}
 
 	// When the most significant byte already has the high bit set, an

--- a/txscript/scriptnum_test.go
+++ b/txscript/scriptnum_test.go
@@ -75,6 +75,7 @@ func TestScriptNumBytes(t *testing.T) {
 		{-72057594037927935, hexToBytes("ffffffffffffff80")},
 		{9223372036854775807, hexToBytes("ffffffffffffff7f")},
 		{-9223372036854775807, hexToBytes("ffffffffffffffff")},
+		{-9223372036854775808, hexToBytes("000000000000008080")},
 	}
 
 	for _, test := range tests {
@@ -133,6 +134,7 @@ func TestMakeScriptNum(t *testing.T) {
 		{hexToBytes("ffffffffff"), -549755813887, 5, nil},
 		{hexToBytes("ffffffffffffff7f"), 9223372036854775807, 8, nil},
 		{hexToBytes("ffffffffffffffff"), -9223372036854775807, 8, nil},
+		{hexToBytes("000000000000008080"), -9223372036854775808, 9, nil},
 		{hexToBytes("ffffffffffffffff7f"), -1, 9, nil},
 		{hexToBytes("ffffffffffffffffff"), 1, 9, nil},
 		{hexToBytes("ffffffffffffffffff7f"), -1, 10, nil},


### PR DESCRIPTION
This modifies the encoding logic for script numbers to support encoding min `int64`s.  This was previously not supported since the type was not public and it is not possible to achieve a min `int64` within the context of the script system itself due to the strict limits it imposes.

However, now that script numbers are exported for external use and callers are not bound by the aforementioned strictness, it should be possible to encode the entire range for completeness.

In practice, callers should never realistically need to encode the value since the purpose of the type is to create encoded numbers for scripts and the value in question will be rejected upon any attempt to use it as a number when verifying scripts given it is out of range.