### PR TITLE
rpcserver: Update websocket ping timeout handling.

### DIFF
--- a/internal/rpcserver/rpcwebsocket.go
+++ b/internal/rpcserver/rpcwebsocket.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2021 The Decred developers
+// Copyright (c) 2015-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -52,6 +52,10 @@ const (
 	// websocketReadLimitAuthenticated is the maximum number of bytes allowed
 	// for an authenticated JSON-RPC message read from a websocket client.
 	websocketReadLimitAuthenticated = 1 << 24 // 16 MiB
+
+	// websocketPongTimeout is the maximum amount of time attempts to respond to
+	// websocket ping messages with a pong will wait before giving up.
+	websocketPongTimeout = time.Second * 5
 )
 
 type semaphore chan struct{}


### PR DESCRIPTION
Currently, timeouts when responding to a websocket ping control message with a pong message cause the websocket client to be disconnected, but these types of failures are nearly always temporary network errors due to things such as congestion and thus should not result in disconnection.

In order to make that the case, this modifies the websocket ping handler to ignore timeout network errors when attempting to respond with a pong and also takes this opportunity to increase the timeout to 5 seconds from 1 second to support multi-continent communication.