### PR TITLE
contrib: Use bash builtins instead of seq

### DIFF
--- a/contrib/dcr_tmux_simnet_setup.sh
+++ b/contrib/dcr_tmux_simnet_setup.sh
@@ -111,7 +111,7 @@ case \$1 in
   *) NUM=\$1 ;;
 esac
 
-for i in \$(seq \$NUM) ; do
+while [ \$((NUM--)) != 0 ]; do
   ./ctl generate 1
   sleep 1
 done


### PR DESCRIPTION
seq is not portable (for example, the command is not provided by
OpenBSD and would need to be installed as a package).

Since the script already assumes bash, use the numeric builtins to
iterate NUM times instead of using seq.