### PR TITLE
edwards: More strict pubkey parsing.

### DIFF
--- a/dcrec/edwards/ecdsa_test.go
+++ b/dcrec/edwards/ecdsa_test.go
@@ -286,6 +286,21 @@ func TestNonStandardSignatures(t *testing.T) {
 				t.Fatalf("expected %v, got %v", false, ok)
 			}
 		}
+
+		// Append an extra byte and make sure the parse fails.
+		pkBad2 := append(pub.Serialize(), 0x01)
+		_, err = ParsePubKey(pkBad2)
+		if err == nil {
+			t.Fatal("expected err, got nil")
+		}
+
+		// Remove a random byte and make sure the parse fails.
+		pkBad3 := pub.Serialize()
+		pkBad3 = append(pkBad3[:pos], pkBad3[pos+1:]...)
+		_, err = ParsePubKey(pkBad3)
+		if err == nil {
+			t.Fatal("expected err, got nil")
+		}
 	}
 }
 

--- a/dcrec/edwards/pubkey.go
+++ b/dcrec/edwards/pubkey.go
@@ -32,6 +32,10 @@ func ParsePubKey(pubKeyStr []byte) (key *PublicKey, err error) {
 	if len(pubKeyStr) == 0 {
 		return nil, errors.New("pubkey string is empty")
 	}
+	if len(pubKeyStr) != PubKeyBytesLen {
+		return nil, fmt.Errorf("malformed public key: invalid length: %d",
+			len(pubKeyStr))
+	}
 
 	curve := Edwards()
 	pubkey := PublicKey{}


### PR DESCRIPTION
This modifies the public key parsing method to make it more strict by rejecting public keys that are not exactly the required length as opposed to silently truncating or padding them and adds tests accordingly.

This helps prevent misuse by callers and makes it behave more consistently with the `secp256k1` public key parsing.

Note that this does not affect consensus code since the only place it is called is during the signature verification opcode where the consensus rules ensure the the key is the correct length before parsing it.

Closes #2857.