### PR TITLE
indexers: fix indexer wait for sync.

### DIFF
--- a/blockchain/indexers/addrindex.go
+++ b/blockchain/indexers/addrindex.go
@@ -643,7 +643,7 @@ func (idx *AddrIndex) Init(ctx context.Context, chainParams *chaincfg.Params) er
 	}
 
 	// Recover the address index and its dependents to the main chain if needed.
-	if err := recover(ctx, idx); err != nil {
+	if err := recoverIndex(ctx, idx); err != nil {
 		return err
 	}
 
@@ -702,10 +702,20 @@ func (idx *AddrIndex) IndexSubscription() *IndexSubscription {
 // Subscribers returns all client channels waiting for the next index update.
 //
 // This is part of the Indexer interface.
+// Deprecated: This will be removed in the next major version bump.
 func (idx *AddrIndex) Subscribers() map[chan bool]struct{} {
 	idx.mtx.Lock()
 	defer idx.mtx.Unlock()
 	return idx.subscribers
+}
+
+// NotifySyncSubscribers signals subscribers of an index sync update.
+//
+// This is part of the Indexer interface.
+func (idx *AddrIndex) NotifySyncSubscribers() {
+	idx.mtx.Lock()
+	notifySyncSubscribers(idx.subscribers)
+	idx.mtx.Unlock()
 }
 
 // WaitForSync subscribes clients for the next index sync update.

--- a/blockchain/indexers/addrindex_test.go
+++ b/blockchain/indexers/addrindex_test.go
@@ -456,12 +456,16 @@ func TestAddrIndexAsync(t *testing.T) {
 	bk5a := addBlock(t, chain, &g, "bk5a")
 
 	// Resubscribe the indexes.
+	subber.mtx.Lock()
 	err = addrIdx.sub.stop()
+	subber.mtx.Unlock()
 	if err != nil {
 		t.Fatal(err)
 	}
 
+	subber.mtx.Lock()
 	err = txIdx.sub.stop()
+	subber.mtx.Unlock()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -619,7 +623,9 @@ func TestAddrIndexAsync(t *testing.T) {
 	}
 
 	// Drop the address index and resubscribe.
+	subber.mtx.Lock()
 	err = addrIdx.sub.stop()
+	subber.mtx.Unlock()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/blockchain/indexers/existsaddrindex.go
+++ b/blockchain/indexers/existsaddrindex.go
@@ -129,7 +129,7 @@ func (idx *ExistsAddrIndex) Init(ctx context.Context, chainParams *chaincfg.Para
 
 	// Recover the exists address index and its dependents to the main
 	// chain if needed.
-	if err := recover(ctx, idx); err != nil {
+	if err := recoverIndex(ctx, idx); err != nil {
 		return err
 	}
 
@@ -197,10 +197,20 @@ func (idx *ExistsAddrIndex) IndexSubscription() *IndexSubscription {
 // Subscribers returns all client channels waiting for the next index update.
 //
 // This is part of the Indexer interface.
+// Deprecated: This will be removed in the next major version bump.
 func (idx *ExistsAddrIndex) Subscribers() map[chan bool]struct{} {
 	idx.mtx.Lock()
 	defer idx.mtx.Unlock()
 	return idx.subscribers
+}
+
+// NotifySyncSubscribers signals subscribers of an index sync update.
+//
+// This is part of the Indexer interface.
+func (idx *ExistsAddrIndex) NotifySyncSubscribers() {
+	idx.mtx.Lock()
+	notifySyncSubscribers(idx.subscribers)
+	idx.mtx.Unlock()
 }
 
 // WaitForSync subscribes clients for the next index sync update.

--- a/blockchain/indexers/existsaddrindex_test.go
+++ b/blockchain/indexers/existsaddrindex_test.go
@@ -128,7 +128,9 @@ func TestExistsAddrIndexAsync(t *testing.T) {
 	bk5a := addBlock(t, chain, &g, "bk5a")
 
 	// Resubscribe the index.
+	subber.mtx.Lock()
 	err = idx.sub.stop()
+	subber.mtx.Unlock()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +225,9 @@ func TestExistsAddrIndexAsync(t *testing.T) {
 	}
 
 	// Resubscribe the index.
+	subber.mtx.Lock()
 	err = idx.sub.stop()
+	subber.mtx.Unlock()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/blockchain/indexers/txindex.go
+++ b/blockchain/indexers/txindex.go
@@ -369,7 +369,7 @@ func (idx *TxIndex) Init(ctx context.Context, chainParams *chaincfg.Params) erro
 	}
 
 	// Recover the tx index and its dependents to the main chain if needed.
-	if err := recover(ctx, idx); err != nil {
+	if err := recoverIndex(ctx, idx); err != nil {
 		return err
 	}
 
@@ -482,10 +482,20 @@ func (idx *TxIndex) IndexSubscription() *IndexSubscription {
 // Subscribers returns all client channels waiting for the next index update.
 //
 // This is part of the Indexer interface.
+// Deprecated: This will be removed in the next major version bump.
 func (idx *TxIndex) Subscribers() map[chan bool]struct{} {
 	idx.mtx.Lock()
 	defer idx.mtx.Unlock()
 	return idx.subscribers
+}
+
+// NotifySyncSubscribers signals subscribers of an index sync update.
+//
+// This is part of the Indexer interface.
+func (idx *TxIndex) NotifySyncSubscribers() {
+	idx.mtx.Lock()
+	notifySyncSubscribers(idx.subscribers)
+	idx.mtx.Unlock()
 }
 
 // WaitForSync subscribes clients for the next index sync update.

--- a/blockchain/indexers/txindex_test.go
+++ b/blockchain/indexers/txindex_test.go
@@ -434,7 +434,9 @@ func TestTxIndexAsync(t *testing.T) {
 	bk5a := addBlock(t, chain, &g, "bk5a")
 
 	// Resubscribe the index.
+	subber.mtx.Lock()
 	err = idx.sub.stop()
+	subber.mtx.Unlock()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -528,7 +530,9 @@ func TestTxIndexAsync(t *testing.T) {
 	}
 
 	// Resubscribe the index.
+	subber.mtx.Lock()
 	err = idx.sub.stop()
+	subber.mtx.Unlock()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This fixes an issue with indexers wait for sync where the indexer gets synced before a sync subscriber is created. The sync subscriber is left idling, waiting for the next update which blocks the caller. The index subscriber has been
updated to periodically update sync subscribers of all subscribed indexers to it as a result.