### PR TITLE
ffldb: Add dbErr to error description.

### DIFF
--- a/blockchain/upgrade.go
+++ b/blockchain/upgrade.go
@@ -5061,7 +5061,7 @@ func migrateUtxoDbBuckets(ctx context.Context, utxoBackend UtxoBackend) error {
 			numMigrated++
 		}
 		if iterErr := iter.Error(); iterErr != nil {
-			return false, convertLdbErr(iterErr, iterErr.Error())
+			return false, convertLdbErr(iterErr, "failed to run batch")
 		}
 		isFullyDone := err == nil
 		if (isFullyDone || logProgress) && numMigrated > 0 {
@@ -5202,7 +5202,7 @@ func moveUtxoDatabase(ctx context.Context, oldPath string, newPath string) error
 	// Open the database at the old path.
 	oldDb, err := leveldb.OpenFile(oldPath, &opts)
 	if err != nil {
-		str := fmt.Sprintf("failed to open UTXO database at old path: %v", err)
+		str := "failed to open UTXO database at old path"
 		return convertLdbErr(err, str)
 	}
 
@@ -5212,7 +5212,7 @@ func moveUtxoDatabase(ctx context.Context, oldPath string, newPath string) error
 		if err := oldDb.Close(); err != nil {
 			return convertLdbErr(err, "failed to close UTXO database at old path")
 		}
-		str := fmt.Sprintf("failed to open UTXO database at new path: %v", err)
+		str := "failed to open UTXO database at new path"
 		return convertLdbErr(err, str)
 	}
 
@@ -5265,7 +5265,7 @@ func moveUtxoDatabase(ctx context.Context, oldPath string, newPath string) error
 			numMigrated++
 		}
 		if iterErr := iter.Error(); iterErr != nil {
-			return false, convertLdbErr(iterErr, iterErr.Error())
+			return false, convertLdbErr(iterErr, "failed to run batch")
 		}
 		isFullyDone := err == nil
 		if (isFullyDone || logProgress) && numMigrated > 0 {

--- a/blockchain/utxobackend_test.go
+++ b/blockchain/utxobackend_test.go
@@ -6,6 +6,7 @@ package blockchain
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -47,7 +48,7 @@ func TestConvertLdbErr(t *testing.T) {
 		want:   ErrUtxoBackend,
 	}, {
 		name:   "Corruption error",
-		ldbErr: &ldberrors.ErrCorrupted{},
+		ldbErr: &ldberrors.ErrCorrupted{Err: errors.New("corrupted")},
 		desc:   "Some corruption error occurred",
 		want:   ErrUtxoBackendCorruption,
 	}, {
@@ -78,10 +79,11 @@ func TestConvertLdbErr(t *testing.T) {
 			continue
 		}
 
+		wantDesc := fmt.Sprintf("%s: %v", test.desc, test.ldbErr)
 		// Validate the error description.
-		if gotErr.Description != test.desc {
+		if gotErr.Description != wantDesc {
 			t.Errorf("%q: mismatched error description:\nwant: %v\n got: %v\n",
-				test.name, test.desc, gotErr.Description)
+				test.name, wantDesc, gotErr.Description)
 			continue
 		}
 

--- a/database/ffldb/dbcache.go
+++ b/database/ffldb/dbcache.go
@@ -443,7 +443,7 @@ func (c *dbCache) commitTreaps(pendingKeys, pendingRemove TreapForEacher) error 
 		var innerErr error
 		pendingKeys.ForEach(func(k, v []byte) bool {
 			if dbErr := ldbTx.Put(k, v, nil); dbErr != nil {
-				str := fmt.Sprintf("failed to put key %q to "+
+				str := fmt.Sprintf("failed to put key %x to "+
 					"ldb transaction", k)
 				innerErr = convertErr(str, dbErr)
 				return false
@@ -457,7 +457,7 @@ func (c *dbCache) commitTreaps(pendingKeys, pendingRemove TreapForEacher) error 
 		pendingRemove.ForEach(func(k, v []byte) bool {
 			if dbErr := ldbTx.Delete(k, nil); dbErr != nil {
 				str := fmt.Sprintf("failed to delete "+
-					"key %q from ldb transaction",
+					"key %x from ldb transaction",
 					k)
 				innerErr = convertErr(str, dbErr)
 				return false


### PR DESCRIPTION
    ffldb: Add dbErr to error description.

    Add the reason for bad inserts, updates, and deletes to the error
    description and display key as hex in order to give the user more
    information when the database errors. This is especially useful for
    upgrades which may fail for several reasons, such as low disc space,
    which the user will now be informed about.

    blockchain: Add ldbErr to error description.

    Add the reason for bad inserts, updates, and deletes to the error
    description.


I am sorry for not making an issue first. I believe displaying the key as hex was lightly discussed in matrix and the consensus was that it's ok.

Error for low disc space on master:
```
[ERR] DCRD: Unable to start server: failed to put key "\x00\x00\x00\x19\x1dn\xf1\x14()d\x17*\xa2\x91y\x9c\xcc\xf5Ic{(\xbaW\xbc\xe3\x92G\x00\x00\x00\x00\x00\x00\x00" to ldb transaction
```

With this diff:
```
[ERR] DCRD: Unable to start server: failed to put key 0000001620a9ba256242f74a82afe270bacaae88680e636b698cca830500000000000000 to ldb transaction: write /home/joe/.dcrd/data/mainnet/blocks_ffldb/metadata/069617.ldb: no space left on device
```

Tested with a real upgrade.