### PR TITLE
chain: Revalidate blocks for new deployments. 

### DIFF
--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2015-2016 The btcsuite developers
-// Copyright (c) 2016-2021 The Decred developers
+// Copyright (c) 2016-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -77,6 +77,10 @@ var (
 	// chainStateKeyName is the name of the db key used to store the best chain
 	// state.
 	chainStateKeyName = []byte("chainstate")
+
+	// deploymentVerKeyName is the name of the db key used to store the
+	// deployment version.
+	deploymentVerKeyName = []byte("deploymentver")
 
 	// spendJournalBucketName is the name of the db bucket used to house
 	// transactions outputs that are spent in each block.
@@ -1105,6 +1109,25 @@ func dbFetchBestState(dbTx database.Tx) (bestChainState, error) {
 	serializedData := meta.Get(chainStateKeyName)
 	log.Tracef("Serialized chain state: %x", serializedData)
 	return deserializeBestChainState(serializedData)
+}
+
+// dbPutDeploymentVer uses an existing database transaction to update the
+// deployment version to the provided version.
+func dbPutDeploymentVer(dbTx database.Tx, version uint32) error {
+	serializedData := make([]byte, 4)
+	byteOrder.PutUint32(serializedData, version)
+	return dbTx.Metadata().Put(deploymentVerKeyName, serializedData)
+}
+
+// dbFetchDeploymentVer uses an existing database transaction to fetch the
+// deployment version.
+func dbFetchDeploymentVer(dbTx database.Tx) uint32 {
+	meta := dbTx.Metadata()
+	serializedData := meta.Get(deploymentVerKeyName)
+	if len(serializedData) == 0 {
+		return 0
+	}
+	return byteOrder.Uint32(serializedData)
 }
 
 // createChainState initializes both the database and the chain state to the

--- a/blockchain/thresholdstate.go
+++ b/blockchain/thresholdstate.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2016 The btcsuite developers
-// Copyright (c) 2017-2021 The Decred developers
+// Copyright (c) 2017-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -210,6 +210,19 @@ func newThresholdCaches(params *chaincfg.Params) map[uint32][]thresholdStateCach
 		}
 	}
 	return caches
+}
+
+// currentDeploymentVersion returns the highest deployment version that is
+// defined in the given network parameters.  Zero is returned if no deployments
+// are defined.
+func currentDeploymentVersion(params *chaincfg.Params) uint32 {
+	var currentVersion uint32
+	for version := range params.Deployments {
+		if version > currentVersion {
+			currentVersion = version
+		}
+	}
+	return currentVersion
 }
 
 // nextThresholdState returns the current rule change threshold state for the

--- a/blockchain/thresholdstate.go
+++ b/blockchain/thresholdstate.go
@@ -225,6 +225,28 @@ func currentDeploymentVersion(params *chaincfg.Params) uint32 {
 	return currentVersion
 }
 
+// nextDeploymentVersion returns the lowest deployment version defined in the
+// given network parameters that is higher than the provided version.  Zero is
+// returned if a deployment version higher than the provided version does not
+// exist.
+func nextDeploymentVersion(params *chaincfg.Params, version uint32) uint32 {
+	var nextVersion uint32
+	for deploymentVersion := range params.Deployments {
+		// Continue if the deployment version is not greater than the provided
+		// version.
+		if deploymentVersion <= version {
+			continue
+		}
+
+		// Set next version if it has not been set yet or if the deployment
+		// version is lower than the current next version.
+		if nextVersion == 0 || deploymentVersion < nextVersion {
+			nextVersion = deploymentVersion
+		}
+	}
+	return nextVersion
+}
+
 // nextThresholdState returns the current rule change threshold state for the
 // block AFTER the given node and deployment ID.  The cache is used to ensure
 // the threshold states for previous windows are only calculated once.

--- a/blockchain/thresholdstate_test.go
+++ b/blockchain/thresholdstate_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 The Decred developers
+// Copyright (c) 2017-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -108,6 +108,56 @@ var (
 		}},
 	}
 )
+
+// TestCurrentDeploymentVersion ensures that the highest deployment version is
+// returned based on given network parameters.
+func TestCurrentDeploymentVersion(t *testing.T) {
+	t.Parallel()
+
+	// Default parameters to use for tests.  Clone the parameters so they can be
+	// mutated.
+	params := cloneParams(chaincfg.RegNetParams())
+
+	tests := []struct {
+		name        string
+		deployments map[uint32][]chaincfg.ConsensusDeployment
+		wantVersion uint32
+	}{{
+		name:        "no deployments defined",
+		wantVersion: 0,
+	}, {
+		name: "single deployment defined",
+		deployments: map[uint32][]chaincfg.ConsensusDeployment{
+			7: {{
+				Vote: testDummy1,
+			}},
+		},
+		wantVersion: 7,
+	}, {
+		name: "multiple deployments defined",
+		deployments: map[uint32][]chaincfg.ConsensusDeployment{
+			7: {{
+				Vote: testDummy1,
+			}},
+			8: {{
+				Vote: testDummy2,
+			}},
+		},
+		wantVersion: 8,
+	}}
+
+	for _, test := range tests {
+		// Set deployments based on the test parameter.
+		params.Deployments = test.deployments
+
+		// Ensure that the returned version matches the expected version.
+		gotVersion := currentDeploymentVersion(params)
+		if gotVersion != test.wantVersion {
+			t.Errorf("%q: mismatched current deployment version:\nwant: %v\n "+
+				"got: %v\n", test.name, test.wantVersion, gotVersion)
+		}
+	}
+}
 
 // TestThresholdState ensures that the threshold state function progresses
 // through the states correctly.


### PR DESCRIPTION
This adds functionality to automatically unmark blocks that were previously marked as failed when new consensus rules are detected.  It is split into several commits to ease the review process.  An overview of the approach to do this is as follows:
- Track the current consensus deployment version in the database
  - The current deployment version is effectively the consensus ruleset version since new deployments are required to introduce new consensus rules
- During initialization, if a deployment version is detected that is newer than the deployment version previously saved in the database, unmark blocks that were previously marked failed if their median time is after the start time of the newly detected deployments
  - The deployment start time is used for this purpose rather than the actual activation height to simplify the logic and context that would otherwise be required during initialization 
---
**Closes https://github.com/decred/dcrd/issues/2766.**