### PR TITLE
multi: Update module requirements to go1.13.

### DIFF
--- a/bech32/go.mod
+++ b/bech32/go.mod
@@ -1,3 +1,3 @@
 module github.com/decred/dcrd/bech32
 
-go 1.11
+go 1.13

--- a/blockchain/standalone/go.mod
+++ b/blockchain/standalone/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrd/blockchain/standalone/v2
 
-go 1.11
+go 1.13
 
 require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2

--- a/chaincfg/go.mod
+++ b/chaincfg/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrd/chaincfg/v3
 
-go 1.11
+go 1.13
 
 require (
 	github.com/davecgh/go-spew v1.1.1

--- a/crypto/blake256/go.mod
+++ b/crypto/blake256/go.mod
@@ -1,3 +1,3 @@
 module github.com/decred/dcrd/crypto/blake256
 
-go 1.11
+go 1.13

--- a/crypto/ripemd160/go.mod
+++ b/crypto/ripemd160/go.mod
@@ -1,3 +1,3 @@
 module github.com/decred/dcrd/crypto/ripemd160
 
-go 1.11
+go 1.13

--- a/dcrec/edwards/go.mod
+++ b/dcrec/edwards/go.mod
@@ -1,5 +1,5 @@
 module github.com/decred/dcrd/dcrec/edwards/v2
 
-go 1.11
+go 1.13
 
 require github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412

--- a/dcrjson/go.mod
+++ b/dcrjson/go.mod
@@ -1,5 +1,5 @@
 module github.com/decred/dcrd/dcrjson/v4
 
-go 1.11
+go 1.13
 
 require github.com/decred/dcrd/chaincfg/chainhash v1.0.3


### PR DESCRIPTION
This updates various modules to require `go1.13` since they make use of shifts on integers (technically signed shifts although they are only ever used with positive values) and the upcoming version of `go1.18` along with the latest version of `gopls` complains about not requiring `go1.13`.