### PR TITLE
main: Update .gitignore for Go1.18.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,15 @@ vendor
 playground
 notes
 
+# Testing, profiling, and benchmarking artifacts
+cov.out
+*cpu.out
+*mem.out
+
+# Go 1.18 workspace
+go.work
+go.work.sum
+
 # Architecture specific extensions/prefixes
 *.[568vq]
 [568vq].out
@@ -39,7 +48,6 @@ _testmain.go
 *.exe
 dcrd
 cmd/addblock/addblock
-cmd/checkdevpremine/checkdevpremine
 cmd/findcheckpoint/findcheckpoint
 cmd/gencerts/gencerts
 cmd/promptsecret/promptsecret


### PR DESCRIPTION
This adds entries to ignore the new local workspace related files being introduced with Go1.18 and also adds some entries for testing, profiling, and benchmarking artifacts and removes a binary that no longer exists while here.
