### PR TITLE
rpctest: Pass and use context versus channel.

### DIFF
--- a/internal/rpcserver/treasury_test.go
+++ b/internal/rpcserver/treasury_test.go
@@ -244,12 +244,15 @@ func TestTreasury(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	// Create the voting wallet.
-	vw, err := rpctest.NewVotingWallet(context.Background(), hn)
+	vw, err := rpctest.NewVotingWallet(ctx, hn)
 	if err != nil {
 		t.Fatalf("unable to create voting wallet for test: %v", err)
 	}
-	err = vw.Start()
+	err = vw.Start(ctx)
 	if err != nil {
 		t.Fatalf("unable to setup voting wallet: %v", err)
 	}

--- a/rpctest/votingwallet_test.go
+++ b/rpctest/votingwallet_test.go
@@ -106,7 +106,9 @@ func TestMinimalVotingWallet(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	for _, tc := range testCases {
 		var vw *VotingWallet
 		success := t.Run(tc.name, func(t1 *testing.T) {
@@ -115,7 +117,7 @@ func TestMinimalVotingWallet(t *testing.T) {
 				t1.Fatalf("unable to create voting wallet for test: %v", err)
 			}
 
-			err = vw.Start()
+			err = vw.Start(ctx)
 			if err != nil {
 				t1.Fatalf("unable to setup voting wallet: %v", err)
 			}
@@ -129,7 +131,7 @@ func TestMinimalVotingWallet(t *testing.T) {
 
 		if vw != nil {
 			vw.SetErrorReporting(nil)
-			vw.Stop()
+			cancel()
 		}
 
 		if !success {


### PR DESCRIPTION
This removes the Stop API.

