### PR TITLE
build: Set token permissions for go.yml.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,8 @@
 name: Build and Test
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Go CI


### PR DESCRIPTION
GitHub asks users to define workflow permissions, see https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/ and https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token for securing GitHub workflows against supply-chain attacks.

StepSecurity is working on securing GitHub workflows and [OSSF Scorecards](https://github.com/ossf/scorecard) recommends using StepSecurity's secure-workflows online tool [app.stepsecurity.io](https://github.com/cosmos/cosmos-sdk/pull/app.stepsecurity.io) to improve the security of GitHub workflows.

This repository has a Scorecards score in the `Token-Permissions` category of 0/10.

We have fixed one of the repo's workflows for you by adding permissions for the involved jobs. You can secure the rest of the workflows for improved security by using the StepSecurity online tool at [app.stepsecurity.io](https://app.stepsecurity.io/).