### PR TITLE
build: Use recommended golangci-lint installer.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f #v2.3.4
       - name: Install Linters
-        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.44.2"
+        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.44.2"
       - name: Build
         run: go build ./...
       - name: Test


### PR DESCRIPTION
The CI pipeline was previously downloading `golangci-lint` using the tool [goreleaser/godownloader](https://github.com/goreleaser/godownloader) which is now [deprecated](https://github.com/goreleaser/godownloader/issues/207). This PR changes the GitHub actions config file to use the latest [recommended installation method](https://golangci-lint.run/usage/install/#other-ci).