### PR TITLE
multi: Update README and CI for 1.18.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [1.16, 1.17]
+        go: [1.17, 1.18]
     steps:
       - name: Set up Go
         uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab #v3.0.0
@@ -18,7 +18,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 #v3.0.0
       - name: Install Linters
-        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.44.2"
+        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.45.2"
       - name: Build
         run: go build ./...
       - name: Test

--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ transactions.
 
 ## Minimum Recommended Specifications (dcrd only)
 
-* 12 GB disk space (as of April 2020, increases over time)
-* 2GB memory (RAM)
-* ~150MB/day download, ~1.5GB/day upload
+* 16 GB disk space (as of April 2022, increases over time, ~2 GB/yr)
+* 2 GB memory (RAM)
+* ~150 MB/day download, ~1.5 GB/day upload
   * Plus one-time initial download of the entire block chain
 * Windows 10 (server preferred), macOS, Linux
 * High uptime

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ https://decred.org/downloads/
 
 <details><summary><b>Install Dependencies</b></summary>
 
-- **Go 1.16 or 1.17**
+- **Go 1.17 or 1.18**
 
   Installation instructions can be found here: https://golang.org/doc/install.
   Ensure Go was installed properly and is a supported version:


### PR DESCRIPTION
Now that Go 1.18 has been released and Go 1.17 is the minimum supported version, this updates the README and `.github/workflows/go.yml` CI.

Also, regarding the README's Minimum Recommended Specifications:

- Updated the recommended disc space 12 GB -> 16 GB and added a rough estimate that it has been increasing ~2 GB/yr
- Followed The International System of Units (SI) guide: A space is always used to separate the unit from the number.