### PR TITLE
docker: Update image to golang:1.18.0-alpine3.15.

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -7,8 +7,13 @@
 ###############
 
 # Basic Go environment with git, SSL CA certs, and upx.
-# golang:1.17.1-alpine (linux/amd64)
-FROM golang@sha256:13919fb9091f6667cb375d5fdf016ecd6d3a5d5995603000d422b04583de4ef9 AS builder
+# The image below is golang:1.18.0-alpine3.15 (linux/amd64)
+# It's pulled by the digest (immutable id) to avoid supply-chain attacks.
+# Maintainer Note:
+#    To update to a new digest, you must first manually pull the new image:
+#    `docker pull golang:<new version>`
+#    Docker will print the digest of the new image after the pull has finished.
+FROM golang@sha256:6fd04df1b7ba6253a09b4bd3f37cc1fb69903a60209ef959485328b1c2902327 AS builder
 RUN apk add --no-cache git ca-certificates upx
 
 # Empty directory to be copied into place in the production image since it will


### PR DESCRIPTION
This updates the docker image to golang:1.18.0-alpine3.15.
To find the new digest:
`docker pull golang:1.18.0-alpine3.15`
yields:
```
1.18.0-alpine3.15: Pulling from library/golang
3aa4d0bbde19: Pull complete
48ae170c2a8c: Pull complete
cb35b180f419: Pull complete
4b7aa5465d48: Pull complete
e21951e06724: Pull complete
Digest: sha256:6fd04df1b7ba6253a09b4bd3f37cc1fb69903a60209ef959485328b1c2902327
Status: Downloaded newer image for golang:1.18.0-alpine3.15
docker.io/library/golang:1.18.0-alpine3.15
```