### PR TITLE
rpcclient: Start v8 module dev cycle.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/decred/dcrd/math/uint256 v1.0.0
 	github.com/decred/dcrd/peer/v3 v3.0.0
 	github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.0.0
-	github.com/decred/dcrd/rpcclient/v7 v7.0.0
+	github.com/decred/dcrd/rpcclient/v8 v8.0.0
 	github.com/decred/dcrd/txscript/v4 v4.0.0
 	github.com/decred/dcrd/wire v1.5.0
 	github.com/decred/go-socks v1.1.0
@@ -74,7 +74,7 @@ replace (
 	github.com/decred/dcrd/math/uint256 => ./math/uint256
 	github.com/decred/dcrd/peer/v3 => ./peer
 	github.com/decred/dcrd/rpc/jsonrpc/types/v4 => ./rpc/jsonrpc/types
-	github.com/decred/dcrd/rpcclient/v7 => ./rpcclient
+	github.com/decred/dcrd/rpcclient/v8 => ./rpcclient
 	github.com/decred/dcrd/txscript/v4 => ./txscript
 	github.com/decred/dcrd/wire => ./wire
 )

--- a/internal/rpcserver/treasury_test.go
+++ b/internal/rpcserver/treasury_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 The Decred developers
+// Copyright (c) 2020-2022 The Decred developers
 
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
@@ -21,7 +21,7 @@ import (
 	"github.com/decred/dcrd/dcrec"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/dcrutil/v4"
-	"github.com/decred/dcrd/rpcclient/v7"
+	"github.com/decred/dcrd/rpcclient/v8"
 	"github.com/decred/dcrd/rpctest"
 	"github.com/decred/dcrd/txscript/v4"
 	"github.com/decred/dcrd/txscript/v4/sign"

--- a/rpcclient/examples/dcrdwebsockets/main.go
+++ b/rpcclient/examples/dcrdwebsockets/main.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2015 The btcsuite developers
-// Copyright (c) 2015-2021 The Decred developers
+// Copyright (c) 2015-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/decred/dcrd/dcrutil/v4"
-	"github.com/decred/dcrd/rpcclient/v7"
+	"github.com/decred/dcrd/rpcclient/v8"
 )
 
 func main() {

--- a/rpcclient/go.mod
+++ b/rpcclient/go.mod
@@ -1,4 +1,4 @@
-module github.com/decred/dcrd/rpcclient/v7
+module github.com/decred/dcrd/rpcclient/v8
 
 go 1.17
 

--- a/rpctest/memwallet.go
+++ b/rpctest/memwallet.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2016-2017 The btcsuite developers
-// Copyright (c) 2017-2021 The Decred developers
+// Copyright (c) 2017-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -20,7 +20,7 @@ import (
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/hdkeychain/v3"
-	"github.com/decred/dcrd/rpcclient/v7"
+	"github.com/decred/dcrd/rpcclient/v8"
 	"github.com/decred/dcrd/txscript/v4"
 	"github.com/decred/dcrd/txscript/v4/sign"
 	"github.com/decred/dcrd/txscript/v4/stdaddr"

--- a/rpctest/node.go
+++ b/rpctest/node.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2016 The btcsuite developers
-// Copyright (c) 2017-2020 The Decred developers
+// Copyright (c) 2017-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/decred/dcrd/certgen"
-	rpc "github.com/decred/dcrd/rpcclient/v7"
+	rpc "github.com/decred/dcrd/rpcclient/v8"
 )
 
 // nodeConfig contains all the args, and data required to launch a dcrd process

--- a/rpctest/rpc_harness.go
+++ b/rpctest/rpc_harness.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2016 The btcsuite developers
-// Copyright (c) 2017-2021 The Decred developers
+// Copyright (c) 2017-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -19,7 +19,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/dcrutil/v4"
-	"github.com/decred/dcrd/rpcclient/v7"
+	"github.com/decred/dcrd/rpcclient/v8"
 	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 )

--- a/rpctest/simnet_miner.go
+++ b/rpctest/simnet_miner.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Decred developers
+// Copyright (c) 2020-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -15,7 +15,7 @@ import (
 
 	"github.com/decred/dcrd/blockchain/standalone/v2"
 	"github.com/decred/dcrd/chaincfg/chainhash"
-	"github.com/decred/dcrd/rpcclient/v7"
+	"github.com/decred/dcrd/rpcclient/v8"
 	"github.com/decred/dcrd/wire"
 )
 

--- a/rpctest/utils.go
+++ b/rpctest/utils.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	dcrdtypes "github.com/decred/dcrd/rpc/jsonrpc/types/v4"
-	"github.com/decred/dcrd/rpcclient/v7"
+	"github.com/decred/dcrd/rpcclient/v8"
 )
 
 // JoinType is an enum representing a particular type of "node join". A node

--- a/rpctest/votingwallet.go
+++ b/rpctest/votingwallet.go
@@ -19,7 +19,7 @@ import (
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/dcrutil/v4"
 	dcrdtypes "github.com/decred/dcrd/rpc/jsonrpc/types/v4"
-	"github.com/decred/dcrd/rpcclient/v7"
+	"github.com/decred/dcrd/rpcclient/v8"
 	"github.com/decred/dcrd/txscript/v4"
 	"github.com/decred/dcrd/txscript/v4/sign"
 	"github.com/decred/dcrd/txscript/v4/stdaddr"

--- a/rpctest/votingwallet_test.go
+++ b/rpctest/votingwallet_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 The Decred developers
+// Copyright (c) 2019-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -14,7 +14,7 @@ import (
 	"testing"
 
 	"github.com/decred/dcrd/chaincfg/v3"
-	"github.com/decred/dcrd/rpcclient/v7"
+	"github.com/decred/dcrd/rpcclient/v8"
 )
 
 // testCanPassSVH tests whether the wallet can maintain the chain going past SVH


### PR DESCRIPTION
**This is rebased on #2910**.

Upcoming changes constitute breaking public API changes to the `rpcclient` module, therefore, this follows the process for introducing major API breaks which consists of:

- Bump the major version in the `go.mod` of the affected module if not already done since the last release tag
- Add a replacement to the `go.mod` in the main module if not already done since the last release tag
- Update all imports in the repo to use the new major version as necessary
- Make necessary modifications to allow all other modules to use the new version in the same commit
- Repeat the process for any other modules the require a new major as a result of consuming the new major(s)