### PR TITLE
multi: Remove deprecated missed and expired tickets RPCs.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -818,25 +818,12 @@ func (b *BlockChain) connectBlock(node *blockNode, block, parent *dcrutil.Block,
 			return err
 		}
 
-		// Notify of spent and missed tickets.
-		b.sendNotification(NTSpentAndMissedTickets,
-			&TicketNotificationsData{
-				Hash:            node.hash,
-				Height:          node.height,
-				StakeDifficulty: nextStakeDiff,
-				TicketsSpent:    node.stakeNode.SpentByBlock(),
-				TicketsMissed:   node.stakeNode.MissedByBlock(),
-				TicketsNew:      nil,
-			})
-
 		// Notify of new tickets.
 		b.sendNotification(NTNewTickets,
 			&TicketNotificationsData{
 				Hash:            node.hash,
 				Height:          node.height,
 				StakeDifficulty: nextStakeDiff,
-				TicketsSpent:    nil,
-				TicketsMissed:   nil,
 				TicketsNew:      node.stakeNode.NewTickets(),
 			})
 	}

--- a/blockchain/notifications.go
+++ b/blockchain/notifications.go
@@ -66,10 +66,6 @@ const (
 	// place.
 	NTReorganization
 
-	// NTSpentAndMissedTickets indicates spent or missed tickets from a newly
-	// accepted block.
-	NTSpentAndMissedTickets
-
 	// NTNewTickets indicates newly maturing tickets from a newly accepted
 	// block.
 	NTNewTickets
@@ -78,15 +74,14 @@ const (
 // notificationTypeStrings is a map of notification types back to their constant
 // names for pretty printing.
 var notificationTypeStrings = map[NotificationType]string{
-	NTNewTipBlockChecked:    "NTNewTipBlockChecked",
-	NTBlockAccepted:         "NTBlockAccepted",
-	NTBlockConnected:        "NTBlockConnected",
-	NTBlockDisconnected:     "NTBlockDisconnected",
-	NTChainReorgStarted:     "NTChainReorgStarted",
-	NTChainReorgDone:        "NTChainReorgDone",
-	NTReorganization:        "NTReorganization",
-	NTSpentAndMissedTickets: "NTSpentAndMissedTickets",
-	NTNewTickets:            "NTNewTickets",
+	NTNewTipBlockChecked: "NTNewTipBlockChecked",
+	NTBlockAccepted:      "NTBlockAccepted",
+	NTBlockConnected:     "NTBlockConnected",
+	NTBlockDisconnected:  "NTBlockDisconnected",
+	NTChainReorgStarted:  "NTChainReorgStarted",
+	NTChainReorgDone:     "NTChainReorgDone",
+	NTReorganization:     "NTReorganization",
+	NTNewTickets:         "NTNewTickets",
 }
 
 // String returns the NotificationType in human-readable form.
@@ -166,14 +161,12 @@ type ReorganizationNtfnsData struct {
 	NewHeight int64
 }
 
-// TicketNotificationsData is the structure for new/spent/missed ticket
-// notifications at blockchain HEAD that are outgoing from chain.
+// TicketNotificationsData is the structure for data indicating information
+// about new tickets in a connected block.
 type TicketNotificationsData struct {
 	Hash            chainhash.Hash
 	Height          int64
 	StakeDifficulty int64
-	TicketsSpent    []chainhash.Hash
-	TicketsMissed   []chainhash.Hash
 	TicketsNew      []chainhash.Hash
 }
 
@@ -187,7 +180,6 @@ type TicketNotificationsData struct {
 // 	- NTChainReorgStarted:     nil
 // 	- NTChainReorgDone:        nil
 //  - NTReorganization:        *ReorganizationNtfnsData
-//  - NTSpentAndMissedTickets: *TicketNotificationsData
 //  - NTNewTickets:            *TicketNotificationsData
 type Notification struct {
 	Type NotificationType

--- a/blockchain/stakeext.go
+++ b/blockchain/stakeext.go
@@ -131,23 +131,6 @@ func (b *BlockChain) CheckLiveTickets(hashes []chainhash.Hash) []bool {
 	return existsSlice
 }
 
-// CheckMissedTickets returns a slice of bools representing whether each ticket
-// hash has been missed in the live ticket treap of the best node.
-//
-// This function is safe for concurrent access.
-func (b *BlockChain) CheckMissedTickets(hashes []chainhash.Hash) []bool {
-	b.chainLock.RLock()
-	sn := b.bestChain.Tip().stakeNode
-	b.chainLock.RUnlock()
-
-	existsSlice := make([]bool, len(hashes))
-	for i := range hashes {
-		existsSlice[i] = sn.ExistsMissedTicket(hashes[i])
-	}
-
-	return existsSlice
-}
-
 // CheckExpiredTicket returns whether or not a ticket was ever expired.
 //
 // This function is safe for concurrent access.

--- a/blockchain/stakeext.go
+++ b/blockchain/stakeext.go
@@ -131,34 +131,6 @@ func (b *BlockChain) CheckLiveTickets(hashes []chainhash.Hash) []bool {
 	return existsSlice
 }
 
-// CheckExpiredTicket returns whether or not a ticket was ever expired.
-//
-// This function is safe for concurrent access.
-func (b *BlockChain) CheckExpiredTicket(hash chainhash.Hash) bool {
-	b.chainLock.RLock()
-	sn := b.bestChain.Tip().stakeNode
-	b.chainLock.RUnlock()
-
-	return sn.ExistsExpiredTicket(hash)
-}
-
-// CheckExpiredTickets returns whether or not a ticket in a slice of
-// tickets was ever expired.
-//
-// This function is safe for concurrent access.
-func (b *BlockChain) CheckExpiredTickets(hashes []chainhash.Hash) []bool {
-	b.chainLock.RLock()
-	sn := b.bestChain.Tip().stakeNode
-	b.chainLock.RUnlock()
-
-	existsSlice := make([]bool, len(hashes))
-	for i := range hashes {
-		existsSlice[i] = sn.ExistsExpiredTicket(hashes[i])
-	}
-
-	return existsSlice
-}
-
 // TicketPoolValue returns the current value of all the locked funds in the
 // ticket pool.
 //

--- a/blockchain/stakeext.go
+++ b/blockchain/stakeext.go
@@ -73,17 +73,6 @@ func (b *BlockChain) LiveTickets() ([]chainhash.Hash, error) {
 	return sn.LiveTickets(), nil
 }
 
-// MissedTickets returns all currently missed tickets from the stake database.
-//
-// This function is safe for concurrent access.
-func (b *BlockChain) MissedTickets() ([]chainhash.Hash, error) {
-	b.chainLock.RLock()
-	sn := b.bestChain.Tip().stakeNode
-	b.chainLock.RUnlock()
-
-	return sn.MissedTickets(), nil
-}
-
 // TicketsWithAddress returns a slice of ticket hashes that are currently live
 // corresponding to the given address.
 //

--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -2656,10 +2656,6 @@ user.  Click the method name for further details such as parameter and return in
 |Send notifications for all tickets that are chosen to vote.
 |[[#winningtickets|winningtickets]]
 |-
-|[[#notifyspentandmissedtickets|notifyspentandmissedtickets]]
-|Send notifications for all tickets that are spent or missed.
-|[[#spentandmissedtickets|spentandmissedtickets]]
-|-
 |[[#notifynewtickets|notifynewtickets]]
 |Send notifications for all new tickets that have matured.
 |[[#newtickets|newtickets]]
@@ -3042,26 +3038,6 @@ NOTE: This is only required if an HTTP Authorization header is not being used.
 
 ----
 
-====notifyspentandmissedtickets====
-{|
-!Method
-|notifyspentandmissedtickets
-|-
-!Notifications
-|[[#spentandmissedtickets|spentandmissedtickets]]
-|-
-!Parameters
-|None
-|-
-!Description
-|Send a spentandmissedtickets notification when tickets are spent or missed.
-|-
-!Returns
-|Nothing
-|}
-
-----
-
 ====notifynewtickets====
 {|
 !Method
@@ -3155,10 +3131,6 @@ The following is an overview of the JSON-RPC notifications used for Websocket co
 |[[#winningtickets|winningtickets]]
 |Tickets were chosen to vote.
 |[[#notifywinningtickets|notifywinningtickets]]
-|-
-|[[#spentandmissedtickets|spentandmissedtickets]]
-|Tickets were spent or missed.
-|[[#notifyspentandmissedtickets|notifyspentandmissedtickets]]
 |-
 |[[#newtickets|newtickets]]
 |New tickets matured.
@@ -3403,30 +3375,6 @@ The redeemingtx notification for the same txout, after the spending transaction 
 !Example
 |Example notifywinningtickets notification for block 479903 on testnet:
 : <code>{"jsonrpc": "1.0", "method": "winningtickets", "params": ["00000044a6c0e2fb8f4feae2ac1133443859407abcf27d5d3a29d7d16eda8bc4", 479903, {"0": "37bb1218876ed8d11497130e253e98f7fd75546744aa9d209e40b97dd5ac735f", "1": "05ad6ce380d97f254c9c60669e9a33d044fccb5589789128abf7ca8c113159d3", "2": "0c43fa8b907acff3d35d81655b3c0a6ae41904ddd939f81b48e5df8d89c6283c", "3": "f2e544178e9e2a4473114b7bf0c383808eadf81f454fc11b835cd5083b0fae7e", "4": "c982fd8c7350df4781c0826c059e7675e6fb568cecee33d19f3a1b03aa41b1ce"}], "id": null}</code>
-|}
-----
-
-====spentandmissedtickets====
-{|
-!Method
-|spentandmissedtickets
-|-
-!Request
-|[[#notifyspentandmissedtickets|notifyspentandmissedtickets]]
-|-
-!Parameters
-|
-# <code>Hash</code>: <code>(string)</code> the hash of the block.
-# <code>Height</code>: <code>(numeric)</code> the height of the block.
-# <code>StakeDiff</code>: <code>(numeric)</code> the stake difficulty of the block.
-# <code>Tickets</code>: <code>(object)</code> the tickets that have been spent or missed.
-|-
-!Description
-|Notifies a client when tickets have been spent or missed.
-|-
-!Example
-|Example spentandmissedtickets notification for block 479903 on testnet:
-: <code>{"jsonrpc": "1.0", "method": "spentandmissedtickets", "params": ["00000044a6c0e2fb8f4feae2ac1133443859407abcf27d5d3a29d7d16eda8bc4", 479903, 9003800525, {"2911dbd36f0bf09e9e84d223b076413d34c39dea7a060c32e5271d0dbb64b332": "spent", "5edc39e2e5f2fccac6d3a10ae7b0cb51031472cc606d450bbf1d5680083f20a1": "spent", "67ec8b66c5bfc1277cc6c6fc00d1b9e9b1c4d61baed7774843ca86200876fe91": "spent", "c2ca81646dc7afb2165354bbe9fcbf8f3d1e97e4a8361934d43db8cdc7ffcdc0": "spent", "da5b300e1a05b9aad2323916cc4ec6eff98962fcb87787dbe24d25b8ea5b102c": "spent"}], "id": null}</code>
 |}
 ----
 

--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -352,10 +352,6 @@ the method name for further details such as parameter and return information.
 |Y
 |Returns live ticket hashes from the ticket database.
 |-
-|[[#missedtickets|missedtickets]]
-|Y
-|Returns missed ticket hashes from the ticket database.
-|-
 |[[#node|node]]
 |N
 |Attempts to add or remove a peer.
@@ -2219,27 +2215,6 @@ of the best block.
 |-
 !Example Return
 |<code>{"tickets": ["12ce6a03ce0d449cd88f2c0b6796d746be2f2902aedcc2829b9279ce27020ef4","325742e8037cfa2f76e32ed337978cc845001c9a0aeccb387186a6119ea510f4",...]}</code>
-|}
-
-----
-
-====missedtickets====
-{|
-!Method
-|missedtickets
-|-
-!Parameters
-|None
-|-
-!Description
-| Returns missed ticket hashes from the ticket database.
-|-
-!Returns
-|<code>(json object)</code>
-: <code>tickets</code>: <code>(json array)</code> List of missed tickets.
-|-
-!Example Return
-|<code>{"tickets": ["f56cd8250ac399773bd0a5461587fd1512193476278c4e4b05efc3eca35ca3fe","071c140969f6d74b90e98df5713e07f83f246a92b4f13f365952b83e3922c6fe",...]}</code>
 |}
 
 ----

--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -168,10 +168,6 @@ the method name for further details such as parameter and return information.
 |Y
 |Returns the existence of the provided addresses.
 |-
-|[[#existsexpiredtickets|existsexpiredtickets]]
-|Y
-|Returns the existence of the provided tickets in the expired ticket map.
-|-
 |[[#existsliveticket|existsliveticket]]
 |Y
 |Returns the existence of the provided ticket.
@@ -814,28 +810,6 @@ the method name for further details such as parameter and return information.
 |}
 
 ----
-
-====existsexpiredtickets====
-{|
-!Method
-|existsexpiredtickets
-|-
-!Parameters
-|
-# <code>txhashes</code>: <code>(json array, required)</code> The array of tx hashes to check.
-|-
-!Description
-|Returns the existence of the provided tickets in the expired ticket map.
-|-
-!Returns
-|<code>bitset</code> Bitset of bools showing if tx hashes exist or not as expired tickets.
-|-
-!Example Return
-|<code>00</code>
-|}
-
-----
-
 
 ====existsliveticket====
 {|

--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -184,10 +184,6 @@ the method name for further details such as parameter and return information.
 |Y
 |Returns the existence of the provided txs in the mempool.
 |-
-|[[#existsmissedtickets|existsmissedtickets]]
-|Y
-|Returns the existence of the provided tickets in the missed ticket map.
-|-
 |[[#generate|generate]]
 |N
 |When in simnet or regtest mode, generate a set number of blocks.
@@ -897,27 +893,6 @@ the method name for further details such as parameter and return information.
 |-
 !Returns
 |<code>bitset</code> Bitset of bools showing if tx hashes exist or not in the mempool.
-|-
-!Example Return
-|<code>00</code>
-|}
-
-----
-
-====existsmissedtickets====
-{|
-!Method
-|existsmissedtickets
-|-
-!Parameters
-|
-# <code>txhashes</code>: <code>(json array, required)</code> The array of tx hashes to check.
-|-
-!Description
-|Returns the existence of the provided tickets in the missed ticket map.
-|-
-!Returns
-|<code>bitset</code> Bitset of bools showing if tx hashes exist or not as missed tickets.
 |-
 !Example Return
 |<code>00</code>

--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -2687,10 +2687,6 @@ user.  Click the method name for further details such as parameter and return in
 |Load, add to, or reload a websocket client's transaction filter for mempool transactions, new blocks and rescanblocks.
 |[[#relevanttxaccepted|relevanttxaccepted]]
 |-
-|[[#rebroadcastmissed|rebroadcastmissed]]
-|Asks the daemon to rebroadcast missed votes.
-|[[#spentandmissedtickets|spentandmissedtickets]]
-|-
 |[[#rebroadcastwinners|rebroadcastwinners]]
 |Asks the daemon to rebroadcast the winners of the voting lottery.
 |[[#winningtickets|winningtickets]]
@@ -2984,24 +2980,6 @@ NOTE: This is only required if an HTTP Authorization header is not being used.
 |-
 !Returns
 |Nothing
-|}
-
-----
-
-====rebroadcastmissed====
-{|
-!Method
-|rebroadcastmissed
-|-
-!Parameters
-|None
-|-
-!Description
-|Asks the daemon to rebroadcast missed votes via a [[#spentandmissedtickets|spentandmissedtickets]] notification.
-|-
-!Returns
-|Nothing
-|-
 |}
 
 ----

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -690,10 +690,6 @@ type NtfnManager interface {
 	// processing.
 	NotifyWinningTickets(wtnd *WinningTicketsNtfnData)
 
-	// NotifySpentAndMissedTickets passes ticket spend and missing data for an
-	// incoming block to the manager for processing.
-	NotifySpentAndMissedTickets(tnd *blockchain.TicketNotificationsData)
-
 	// NotifyNewTickets passes a new ticket data for an incoming block to the
 	// manager for processing.
 	NotifyNewTickets(tnd *blockchain.TicketNotificationsData)
@@ -736,14 +732,6 @@ type NtfnManager interface {
 	// UnregisterWinningTickets removes winning ticket notifications for
 	// the passed websocket client.
 	UnregisterWinningTickets(wsc *wsClient)
-
-	// RegisterSpentAndMissedTickets requests spent/missed tickets update notifications
-	// to the passed websocket client.
-	RegisterSpentAndMissedTickets(wsc *wsClient)
-
-	// UnregisterSpentAndMissedTickets removes spent/missed ticket notifications for
-	// the passed websocket client.
-	UnregisterSpentAndMissedTickets(wsc *wsClient)
 
 	// RegisterNewTickets requests spent/missed tickets update notifications
 	// to the passed websocket client.

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -249,9 +249,6 @@ type Chain interface {
 	// provided block hash.
 	ChainWork(hash *chainhash.Hash) (*big.Int, error)
 
-	// CheckExpiredTicket returns whether or not a ticket was ever expired.
-	CheckExpiredTickets(hashes []chainhash.Hash) []bool
-
 	// CheckLiveTicket returns whether or not a ticket exists in the live ticket
 	// treap of the best node.
 	CheckLiveTicket(hash chainhash.Hash) bool

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -359,9 +359,6 @@ type Chain interface {
 	// or an error if it doesn't exist.
 	MedianTimeByHash(hash *chainhash.Hash) (time.Time, error)
 
-	// MissedTickets returns all currently missed tickets.
-	MissedTickets() ([]chainhash.Hash, error)
-
 	// NextThresholdState returns the current rule change threshold state of the
 	// given deployment ID for the block AFTER the provided block hash.
 	NextThresholdState(hash *chainhash.Hash, version uint32, deploymentID string) (blockchain.ThresholdStateTuple, error)

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -260,10 +260,6 @@ type Chain interface {
 	// exists in the live ticket treap of the best node.
 	CheckLiveTickets(hashes []chainhash.Hash) []bool
 
-	// CheckMissedTickets returns a slice of bools representing whether each ticket
-	// hash has been missed in the live ticket treap of the best node.
-	CheckMissedTickets(hashes []chainhash.Hash) []bool
-
 	// CountVoteVersion returns the total number of version votes for the current
 	// rule change activation interval.
 	CountVoteVersion(version uint32) (uint32, error)

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -330,7 +330,6 @@ var rpcLimited = map[string]struct{}{
 	"notifyspent":           {},
 	"rescan":                {},
 	"session":               {},
-	"rebroadcastmissed":     {},
 	"rebroadcastwinners":    {},
 
 	// Websockets AND HTTP/S commands

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -171,7 +171,6 @@ var rpcHandlersBeforeInit = map[types.Method]commandHandler{
 	"existsliveticket":      handleExistsLiveTicket,
 	"existslivetickets":     handleExistsLiveTickets,
 	"existsmempooltxs":      handleExistsMempoolTxs,
-	"existsmissedtickets":   handleExistsMissedTickets,
 	"generate":              handleGenerate,
 	"getaddednodeinfo":      handleGetAddedNodeInfo,
 	"getbestblock":          handleGetBestBlock,
@@ -350,7 +349,6 @@ var rpcLimited = map[string]struct{}{
 	"existsliveticket":      {},
 	"existslivetickets":     {},
 	"existsmempooltxs":      {},
-	"existsmissedtickets":   {},
 	"getbestblock":          {},
 	"getbestblockhash":      {},
 	"getblock":              {},
@@ -1652,35 +1650,6 @@ func decodeHashPointers(strs []string) ([]*chainhash.Hash, error) {
 		hashes[i] = h
 	}
 	return hashes, nil
-}
-
-// handleExistsMissedTickets implements the existsmissedtickets command.
-//
-// TODO: Add an upper bound to the number of hashes that can be checked. This
-// will come with a major RPC version bump.
-func handleExistsMissedTickets(_ context.Context, s *Server, cmd interface{}) (interface{}, error) {
-	c := cmd.(*types.ExistsMissedTicketsCmd)
-
-	hashes, err := decodeHashes(c.TxHashes)
-	if err != nil {
-		return nil, err
-	}
-
-	exists := s.cfg.Chain.CheckMissedTickets(hashes)
-	if len(exists) != len(hashes) {
-		return nil, rpcInvalidError("Invalid missed ticket count "+
-			"got %v, want %v", len(exists), len(hashes))
-	}
-
-	// Convert the slice of bools into a compacted set of bit flags.
-	set := bitset.NewBytes(len(hashes))
-	for i := range exists {
-		if exists[i] {
-			set.Set(i)
-		}
-	}
-
-	return hex.EncodeToString([]byte(set)), nil
 }
 
 // handleExistsExpiredTickets implements the existsexpiredtickets command.

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -167,7 +167,6 @@ var rpcHandlersBeforeInit = map[types.Method]commandHandler{
 	"estimatestakediff":     handleEstimateStakeDiff,
 	"existsaddress":         handleExistsAddress,
 	"existsaddresses":       handleExistsAddresses,
-	"existsexpiredtickets":  handleExistsExpiredTickets,
 	"existsliveticket":      handleExistsLiveTicket,
 	"existslivetickets":     handleExistsLiveTickets,
 	"existsmempooltxs":      handleExistsMempoolTxs,
@@ -345,7 +344,6 @@ var rpcLimited = map[string]struct{}{
 	"estimatestakediff":     {},
 	"existsaddress":         {},
 	"existsaddresses":       {},
-	"existsexpiredtickets":  {},
 	"existsliveticket":      {},
 	"existslivetickets":     {},
 	"existsmempooltxs":      {},
@@ -1650,35 +1648,6 @@ func decodeHashPointers(strs []string) ([]*chainhash.Hash, error) {
 		hashes[i] = h
 	}
 	return hashes, nil
-}
-
-// handleExistsExpiredTickets implements the existsexpiredtickets command.
-//
-// TODO: Add an upper bound to the number of hashes that can be checked. This
-// will come with a major RPC version bump.
-func handleExistsExpiredTickets(_ context.Context, s *Server, cmd interface{}) (interface{}, error) {
-	c := cmd.(*types.ExistsExpiredTicketsCmd)
-
-	hashes, err := decodeHashes(c.TxHashes)
-	if err != nil {
-		return nil, err
-	}
-
-	exists := s.cfg.Chain.CheckExpiredTickets(hashes)
-	if len(exists) != len(hashes) {
-		return nil, rpcInvalidError("Invalid expired ticket count "+
-			"got %v, want %v", len(exists), len(hashes))
-	}
-
-	// Convert the slice of bools into a compacted set of bit flags.
-	set := bitset.NewBytes(len(hashes))
-	for i := range exists {
-		if exists[i] {
-			set.Set(i)
-		}
-	}
-
-	return hex.EncodeToString([]byte(set)), nil
 }
 
 // handleExistsLiveTicket implements the existsliveticket command.

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -5698,12 +5698,6 @@ func (s *Server) NotifyBlockConnected(block *dcrutil.Block) {
 	s.ntfnMgr.NotifyBlockConnected(block)
 }
 
-// NotifySpentAndMissedTickets notifies websocket clients that have registered
-// for spent and missed ticket updates.
-func (s *Server) NotifySpentAndMissedTickets(tnd *blockchain.TicketNotificationsData) {
-	s.ntfnMgr.NotifySpentAndMissedTickets(tnd)
-}
-
 // NotifyBlockDisconnected notifies websocket clients that have registered for
 // block updates when a block is disconnected from the main chain.
 func (s *Server) NotifyBlockDisconnected(block *dcrutil.Block) {

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -213,7 +213,6 @@ var rpcHandlersBeforeInit = map[types.Method]commandHandler{
 	"help":                  handleHelp,
 	"invalidateblock":       handleInvalidateBlock,
 	"livetickets":           handleLiveTickets,
-	"missedtickets":         handleMissedTickets,
 	"node":                  handleNode,
 	"ping":                  handlePing,
 	"reconsiderblock":       handleReconsiderBlock,
@@ -380,7 +379,6 @@ var rpcLimited = map[string]struct{}{
 	"gettxout":              {},
 	"getvoteinfo":           {},
 	"livetickets":           {},
-	"missedtickets":         {},
 	"regentemplate":         {},
 	"searchrawtransactions": {},
 	"sendrawtransaction":    {},
@@ -4057,22 +4055,6 @@ func handleLiveTickets(_ context.Context, s *Server, cmd interface{}) (interface
 	}
 
 	return types.LiveTicketsResult{Tickets: ltString}, nil
-}
-
-// handleMissedTickets implements the missedtickets command.
-func handleMissedTickets(_ context.Context, s *Server, cmd interface{}) (interface{}, error) {
-	mt, err := s.cfg.Chain.MissedTickets()
-	if err != nil {
-		return nil, rpcInternalError("Could not get missed tickets "+
-			err.Error(), "")
-	}
-
-	mtString := make([]string, len(mt))
-	for i, hash := range mt {
-		mtString[i] = hash.String()
-	}
-
-	return types.MissedTicketsResult{Tickets: mtString}, nil
 }
 
 // handlePing implements the ping command.

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -59,7 +59,7 @@ import (
 
 // API version constants
 const (
-	jsonrpcSemverMajor = 7
+	jsonrpcSemverMajor = 8
 	jsonrpcSemverMinor = 0
 	jsonrpcSemverPatch = 0
 )

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -154,7 +154,6 @@ type testRPCChain struct {
 	checkExpiredTickets           []bool
 	checkLiveTicket               bool
 	checkLiveTickets              []bool
-	checkMissedTickets            []bool
 	countVoteVersion              uint32
 	countVoteVersionErr           error
 	estimateNextStakeDifficultyFn func(hash *chainhash.Hash, newTickets int64, useMaxTickets bool) (diff int64, err error)
@@ -268,12 +267,6 @@ func (c *testRPCChain) CheckLiveTicket(hash chainhash.Hash) bool {
 // whether each ticket exists in the live ticket treap of the best node.
 func (c *testRPCChain) CheckLiveTickets(hashes []chainhash.Hash) []bool {
 	return c.checkLiveTickets
-}
-
-// CheckMissedTickets returns a mocked slice of bools representing
-// whether each ticket hash has been missed.
-func (c *testRPCChain) CheckMissedTickets(hashes []chainhash.Hash) []bool {
-	return c.checkMissedTickets
 }
 
 // CountVoteVersion returns a mocked total number of version votes for the current
@@ -3547,89 +3540,6 @@ func TestHandleExistsMempoolTxs(t *testing.T) {
 		}(),
 		wantErr: true,
 		errCode: dcrjson.ErrRPCInternal.Code,
-	}})
-}
-
-func TestHandleExistsMissedTickets(t *testing.T) {
-	t.Parallel()
-
-	defaultCmdTxHashes := []string{
-		"1189cbe656c2ef1e0fcb91f107624d9aa8f0db7b28e6a86f694a4cf49abc5e39",
-		"2189cbe656c2ef1e0fcb91f107624d9aa8f0db7b28e6a86f694a4cf49abc5e39",
-	}
-	testRPCServerHandler(t, []rpcTest{{
-		name:    "handleExistsMissedTickets: both tickets exist",
-		handler: handleExistsMissedTickets,
-		cmd: &types.ExistsMissedTicketsCmd{
-			TxHashes: defaultCmdTxHashes,
-		},
-		mockChain: func() *testRPCChain {
-			chain := defaultMockRPCChain()
-			chain.checkMissedTickets = []bool{true, true}
-			return chain
-		}(),
-		result: "03",
-	}, {
-		name:    "handleExistsMissedTickets: only first ticket exists",
-		handler: handleExistsMissedTickets,
-		cmd: &types.ExistsMissedTicketsCmd{
-			TxHashes: defaultCmdTxHashes,
-		},
-		mockChain: func() *testRPCChain {
-			chain := defaultMockRPCChain()
-			chain.checkMissedTickets = []bool{true, false}
-			return chain
-		}(),
-		result: "01",
-	}, {
-		name:    "handleExistsMissedTickets: only second ticket exists",
-		handler: handleExistsMissedTickets,
-		cmd: &types.ExistsMissedTicketsCmd{
-			TxHashes: defaultCmdTxHashes,
-		},
-		mockChain: func() *testRPCChain {
-			chain := defaultMockRPCChain()
-			chain.checkMissedTickets = []bool{false, true}
-			return chain
-		}(),
-		result: "02",
-	}, {
-		name:    "handleExistsMissedTickets: none of the tickets exist",
-		handler: handleExistsMissedTickets,
-		cmd: &types.ExistsMissedTicketsCmd{
-			TxHashes: defaultCmdTxHashes,
-		},
-		mockChain: func() *testRPCChain {
-			chain := defaultMockRPCChain()
-			chain.checkMissedTickets = []bool{false, false}
-			return chain
-		}(),
-		result: "00",
-	}, {
-		name:    "handleExistsMissedTickets: invalid hash",
-		handler: handleExistsMissedTickets,
-		cmd: &types.ExistsMissedTicketsCmd{
-			TxHashes: []string{
-				"g189cbe656c2ef1e0fcb91f107624d9aa8f0db7b28e6a86f694a4cf49abc5e39",
-			},
-		},
-		wantErr: true,
-		errCode: dcrjson.ErrRPCDecodeHexString,
-	}, {
-		name:    "handleExistsMissedTickets: invalid missed ticket count",
-		handler: handleExistsMissedTickets,
-		cmd: &types.ExistsMissedTicketsCmd{
-			TxHashes: []string{
-				"1189cbe656c2ef1e0fcb91f107624d9aa8f0db7b28e6a86f694a4cf49abc5e39",
-			},
-		},
-		mockChain: func() *testRPCChain {
-			chain := defaultMockRPCChain()
-			chain.checkMissedTickets = []bool{true, true}
-			return chain
-		}(),
-		wantErr: true,
-		errCode: dcrjson.ErrRPCInvalidParameter,
 	}})
 }
 

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -1195,10 +1195,6 @@ func (mgr *testNtfnManager) NotifyReorganization(rd *blockchain.ReorganizationNt
 // processing.
 func (mgr *testNtfnManager) NotifyWinningTickets(wtnd *WinningTicketsNtfnData) {}
 
-// NotifySpentAndMissedTickets passes ticket spend and missing data for an
-// incoming block to the manager for processing.
-func (mgr *testNtfnManager) NotifySpentAndMissedTickets(tnd *blockchain.TicketNotificationsData) {}
-
 // NotifyNewTickets passes new ticket data for an incoming block to the
 // manager for processing.
 func (mgr *testNtfnManager) NotifyNewTickets(tnd *blockchain.TicketNotificationsData) {}
@@ -1243,14 +1239,6 @@ func (mgr *testNtfnManager) RegisterWinningTickets(wsc *wsClient) {}
 // UnregisterWinningTickets removes winning ticket notifications for
 // the passed websocket client.
 func (mgr *testNtfnManager) UnregisterWinningTickets(wsc *wsClient) {}
-
-// RegisterSpentAndMissedTickets requests spent/missed tickets update notifications
-// to the passed websocket client.
-func (mgr *testNtfnManager) RegisterSpentAndMissedTickets(wsc *wsClient) {}
-
-// UnregisterSpentAndMissedTickets removes spent/missed ticket notifications for
-// the passed websocket client.
-func (mgr *testNtfnManager) UnregisterSpentAndMissedTickets(wsc *wsClient) {}
 
 // RegisterNewTickets requests spent/missed tickets update notifications
 // to the passed websocket client.

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -5521,45 +5521,6 @@ func TestHandleLiveTickets(t *testing.T) {
 	}})
 }
 
-func TestHandleMissedTickets(t *testing.T) {
-	t.Parallel()
-
-	tkt1 := mustParseHash("1f6631957b4060d81ba7e760ec9c8150ba028eb051ddadf2b9749a5ccda1a955")
-	tkt2 := mustParseHash("eca7e802590df60f7d300b6170f63dfab213b26421ed2e70de3ec2224cb9e460")
-
-	testRPCServerHandler(t, []rpcTest{{
-		name:    "handleMissedTickets: no missed tickets",
-		handler: handleMissedTickets,
-		cmd:     &types.MissedTicketsCmd{},
-		result: types.MissedTicketsResult{
-			Tickets: []string{},
-		},
-	}, {
-		name:    "handleMissedTickets: two missed tickets",
-		handler: handleMissedTickets,
-		cmd:     &types.MissedTicketsCmd{},
-		mockChain: func() *testRPCChain {
-			chain := defaultMockRPCChain()
-			chain.missedTickets = []chainhash.Hash{*tkt1, *tkt2}
-			return chain
-		}(),
-		result: types.MissedTicketsResult{
-			Tickets: []string{tkt1.String(), tkt2.String()},
-		},
-	}, {
-		name:    "handleMissedTickets: unable to fetch missed tickets",
-		handler: handleMissedTickets,
-		cmd:     &types.MissedTicketsCmd{},
-		mockChain: func() *testRPCChain {
-			chain := defaultMockRPCChain()
-			chain.missedTicketsErr = errors.New("unable to fetch missed tickets")
-			return chain
-		}(),
-		wantErr: true,
-		errCode: dcrjson.ErrRPCInternal.Code,
-	}})
-}
-
 func TestHandleNode(t *testing.T) {
 	t.Parallel()
 

--- a/internal/rpcserver/rpcserverhelp.go
+++ b/internal/rpcserver/rpcserverhelp.go
@@ -174,11 +174,6 @@ var helpDescsEnUS = map[string]string{
 	"existsaddresses-addresses": "The addresses to check",
 	"existsaddresses--result0":  "Bitset of bools showing if addresses exist or not",
 
-	// ExistsExpiredTicketsCmd help.
-	"existsexpiredtickets--synopsis": "Test for the existence of the provided tickets in the expired ticket map",
-	"existsexpiredtickets-txhashes":  "Array of hashes to check",
-	"existsexpiredtickets--result0":  "Bool blob showing if ticket exists in the expired ticket database or not",
-
 	// ExistsLiveTicketCmd help.
 	"existsliveticket--synopsis": "Test for the existence of the provided ticket",
 	"existsliveticket-txhash":    "The ticket hash to check",
@@ -989,7 +984,6 @@ var rpcResultTypes = map[types.Method][]interface{}{
 	"estimatestakediff":     {(*types.EstimateStakeDiffResult)(nil)},
 	"existsaddress":         {(*bool)(nil)},
 	"existsaddresses":       {(*string)(nil)},
-	"existsexpiredtickets":  {(*string)(nil)},
 	"existsliveticket":      {(*bool)(nil)},
 	"existslivetickets":     {(*string)(nil)},
 	"existsmempooltxs":      {(*string)(nil)},

--- a/internal/rpcserver/rpcserverhelp.go
+++ b/internal/rpcserver/rpcserverhelp.go
@@ -174,11 +174,6 @@ var helpDescsEnUS = map[string]string{
 	"existsaddresses-addresses": "The addresses to check",
 	"existsaddresses--result0":  "Bitset of bools showing if addresses exist or not",
 
-	// ExitsMissedTicketsCmd help.
-	"existsmissedtickets--synopsis": "Test for the existence of the provided tickets in the missed ticket map",
-	"existsmissedtickets-txhashes":  "Array of hashes to check",
-	"existsmissedtickets--result0":  "Bool blob showing if the ticket exists in the missed ticket database or not",
-
 	// ExistsExpiredTicketsCmd help.
 	"existsexpiredtickets--synopsis": "Test for the existence of the provided tickets in the expired ticket map",
 	"existsexpiredtickets-txhashes":  "Array of hashes to check",
@@ -994,7 +989,6 @@ var rpcResultTypes = map[types.Method][]interface{}{
 	"estimatestakediff":     {(*types.EstimateStakeDiffResult)(nil)},
 	"existsaddress":         {(*bool)(nil)},
 	"existsaddresses":       {(*string)(nil)},
-	"existsmissedtickets":   {(*string)(nil)},
 	"existsexpiredtickets":  {(*string)(nil)},
 	"existsliveticket":      {(*bool)(nil)},
 	"existslivetickets":     {(*string)(nil)},

--- a/internal/rpcserver/rpcserverhelp.go
+++ b/internal/rpcserver/rpcserverhelp.go
@@ -735,9 +735,6 @@ var helpDescsEnUS = map[string]string{
 	"ping--synopsis": "Queues a ping to be sent to each connected peer.\n" +
 		"Ping times are provided by getpeerinfo via the pingtime and pingwait fields.",
 
-	// RebroadcastMissed help.
-	"rebroadcastmissed--synopsis": "Asks the daemon to rebroadcast missed votes.",
-
 	// RebroadcastWinnersCmd help.
 	"rebroadcastwinners--synopsis": "Asks the daemon to rebroadcast the winners of the voting lottery.",
 
@@ -1072,7 +1069,6 @@ var rpcResultTypes = map[types.Method][]interface{}{
 	"notifynewtransactions":       nil,
 	"notifyreceived":              nil,
 	"notifyspent":                 nil,
-	"rebroadcastmissed":           nil,
 	"rebroadcastwinners":          nil,
 	"rescan":                      nil,
 	"session":                     {(*types.SessionResult)(nil)},

--- a/internal/rpcserver/rpcserverhelp.go
+++ b/internal/rpcserver/rpcserverhelp.go
@@ -900,10 +900,6 @@ var helpDescsEnUS = map[string]string{
 	"livetickets--synopsis":     "Returns live ticket hashes from the ticket database",
 	"liveticketsresult-tickets": "List of live tickets",
 
-	// MissedTickets help.
-	"missedtickets--synopsis":     "Returns missed ticket hashes from the ticket database",
-	"missedticketsresult-tickets": "List of missed tickets",
-
 	// TicketBuckets help.
 	"ticketbuckets--synopsis": "Request for the number of tickets currently in each bucket of the ticket database.",
 	"ticketbucket-tickets":    "Number of tickets in bucket.",
@@ -1047,7 +1043,6 @@ var rpcResultTypes = map[types.Method][]interface{}{
 	"help":                  {(*string)(nil), (*string)(nil)},
 	"invalidateblock":       nil,
 	"livetickets":           {(*types.LiveTicketsResult)(nil)},
-	"missedtickets":         {(*types.MissedTicketsResult)(nil)},
 	"node":                  nil,
 	"ping":                  nil,
 	"reconsiderblock":       nil,

--- a/internal/rpcserver/rpcserverhelp.go
+++ b/internal/rpcserver/rpcserverhelp.go
@@ -807,9 +807,6 @@ var helpDescsEnUS = map[string]string{
 	"session--synopsis":       "Return details regarding a websocket client's current connection session.",
 	"sessionresult-sessionid": "The unique session ID for a client's websocket connection.",
 
-	// NotifySpentAndMissedTicketsCmd help
-	"notifyspentandmissedtickets--synopsis": "Request notifications for whenever tickets are spent or missed.",
-
 	// NotifyNewTicketsCmd help
 	"notifynewtickets--synopsis": "Request notifications for whenever new tickets are found.",
 
@@ -1047,25 +1044,24 @@ var rpcResultTypes = map[types.Method][]interface{}{
 	"version":               {(*map[string]types.VersionResult)(nil)},
 
 	// Websocket commands.
-	"loadtxfilter":                nil,
-	"notifywinningtickets":        nil,
-	"notifyspentandmissedtickets": nil,
-	"notifynewtickets":            nil,
-	"notifyblocks":                nil,
-	"notifywork":                  nil,
-	"notifytspend":                nil,
-	"notifynewtransactions":       nil,
-	"notifyreceived":              nil,
-	"notifyspent":                 nil,
-	"rebroadcastwinners":          nil,
-	"rescan":                      nil,
-	"session":                     {(*types.SessionResult)(nil)},
-	"stopnotifyblocks":            nil,
-	"stopnotifywork":              nil,
-	"stopnotifytspend":            nil,
-	"stopnotifynewtransactions":   nil,
-	"stopnotifyreceived":          nil,
-	"stopnotifyspent":             nil,
+	"loadtxfilter":              nil,
+	"notifywinningtickets":      nil,
+	"notifynewtickets":          nil,
+	"notifyblocks":              nil,
+	"notifywork":                nil,
+	"notifytspend":              nil,
+	"notifynewtransactions":     nil,
+	"notifyreceived":            nil,
+	"notifyspent":               nil,
+	"rebroadcastwinners":        nil,
+	"rescan":                    nil,
+	"session":                   {(*types.SessionResult)(nil)},
+	"stopnotifyblocks":          nil,
+	"stopnotifywork":            nil,
+	"stopnotifytspend":          nil,
+	"stopnotifynewtransactions": nil,
+	"stopnotifyreceived":        nil,
+	"stopnotifyspent":           nil,
 }
 
 // helpCacher provides a concurrent safe type that provides help and usage for

--- a/internal/rpcserver/rpcwebsocket.go
+++ b/internal/rpcserver/rpcwebsocket.go
@@ -86,7 +86,6 @@ var wsHandlersBeforeInit = map[types.Method]wsCommandHandler{
 	"notifyspentandmissedtickets": handleSpentAndMissedTickets,
 	"notifynewtickets":            handleNewTickets,
 	"notifynewtransactions":       handleNotifyNewTransactions,
-	"rebroadcastmissed":           handleRebroadcastMissed,
 	"rebroadcastwinners":          handleRebroadcastWinners,
 	"rescan":                      handleRescan,
 	"session":                     handleSession,
@@ -2134,30 +2133,6 @@ func handleLoadTxFilter(wsc *wsClient, icmd interface{}) (interface{}, error) {
 // websocket connections.
 func handleNotifyBlocks(wsc *wsClient, icmd interface{}) (interface{}, error) {
 	wsc.rpcServer.ntfnMgr.RegisterBlockUpdates(wsc)
-	return nil, nil
-}
-
-// handleRebroadcastMissed implements the rebroadcastmissed command.
-func handleRebroadcastMissed(wsc *wsClient, icmd interface{}) (interface{}, error) {
-	cfg := wsc.rpcServer.cfg
-	best := cfg.Chain.BestSnapshot()
-	mt, err := cfg.Chain.MissedTickets()
-	if err != nil {
-		return nil, rpcInternalError("Could not get missed tickets "+
-			err.Error(), "")
-	}
-
-	missedTicketsNtfn := &blockchain.TicketNotificationsData{
-		Hash:            best.Hash,
-		Height:          best.Height,
-		StakeDifficulty: best.NextStakeDiff,
-		TicketsSpent:    []chainhash.Hash{},
-		TicketsMissed:   mt,
-		TicketsNew:      []chainhash.Hash{},
-	}
-
-	wsc.rpcServer.ntfnMgr.NotifySpentAndMissedTickets(missedTicketsNtfn)
-
 	return nil, nil
 }
 

--- a/rpc/jsonrpc/types/chainsvrcmds.go
+++ b/rpc/jsonrpc/types/chainsvrcmds.go
@@ -265,19 +265,6 @@ func NewExistsAddressesCmd(addresses []string) *ExistsAddressesCmd {
 	}
 }
 
-// ExistsMissedTicketsCmd defines the existsmissedtickets JSON-RPC command.
-type ExistsMissedTicketsCmd struct {
-	TxHashes []string
-}
-
-// NewExistsMissedTicketsCmd returns a new instance which can be used to issue an
-// existsmissedtickets JSON-RPC command.
-func NewExistsMissedTicketsCmd(txHashes []string) *ExistsMissedTicketsCmd {
-	return &ExistsMissedTicketsCmd{
-		TxHashes: txHashes,
-	}
-}
-
 // ExistsExpiredTicketsCmd defines the existsexpiredtickets JSON-RPC command.
 type ExistsExpiredTicketsCmd struct {
 	TxHashes []string
@@ -1151,7 +1138,6 @@ func init() {
 	dcrjson.MustRegister(Method("estimatestakediff"), (*EstimateStakeDiffCmd)(nil), flags)
 	dcrjson.MustRegister(Method("existsaddress"), (*ExistsAddressCmd)(nil), flags)
 	dcrjson.MustRegister(Method("existsaddresses"), (*ExistsAddressesCmd)(nil), flags)
-	dcrjson.MustRegister(Method("existsmissedtickets"), (*ExistsMissedTicketsCmd)(nil), flags)
 	dcrjson.MustRegister(Method("existsexpiredtickets"), (*ExistsExpiredTicketsCmd)(nil), flags)
 	dcrjson.MustRegister(Method("existsliveticket"), (*ExistsLiveTicketCmd)(nil), flags)
 	dcrjson.MustRegister(Method("existslivetickets"), (*ExistsLiveTicketsCmd)(nil), flags)

--- a/rpc/jsonrpc/types/chainsvrcmds.go
+++ b/rpc/jsonrpc/types/chainsvrcmds.go
@@ -882,16 +882,6 @@ func NewLiveTicketsCmd() *LiveTicketsCmd {
 	return &LiveTicketsCmd{}
 }
 
-// MissedTicketsCmd is a type handling custom marshaling and
-// unmarshaling of missedtickets JSON RPC commands.
-type MissedTicketsCmd struct{}
-
-// NewMissedTicketsCmd returns a new instance which can be used to issue a JSON-RPC
-// missedtickets command.
-func NewMissedTicketsCmd() *MissedTicketsCmd {
-	return &MissedTicketsCmd{}
-}
-
 // NodeCmd defines the dropnode JSON-RPC command.
 type NodeCmd struct {
 	SubCmd        NodeSubCmd `jsonrpcusage:"\"connect|remove|disconnect\""`
@@ -1207,7 +1197,6 @@ func init() {
 	dcrjson.MustRegister(Method("help"), (*HelpCmd)(nil), flags)
 	dcrjson.MustRegister(Method("invalidateblock"), (*InvalidateBlockCmd)(nil), flags)
 	dcrjson.MustRegister(Method("livetickets"), (*LiveTicketsCmd)(nil), flags)
-	dcrjson.MustRegister(Method("missedtickets"), (*MissedTicketsCmd)(nil), flags)
 	dcrjson.MustRegister(Method("node"), (*NodeCmd)(nil), flags)
 	dcrjson.MustRegister(Method("ping"), (*PingCmd)(nil), flags)
 	dcrjson.MustRegister(Method("reconsiderblock"), (*ReconsiderBlockCmd)(nil), flags)

--- a/rpc/jsonrpc/types/chainsvrcmds.go
+++ b/rpc/jsonrpc/types/chainsvrcmds.go
@@ -265,19 +265,6 @@ func NewExistsAddressesCmd(addresses []string) *ExistsAddressesCmd {
 	}
 }
 
-// ExistsExpiredTicketsCmd defines the existsexpiredtickets JSON-RPC command.
-type ExistsExpiredTicketsCmd struct {
-	TxHashes []string
-}
-
-// NewExistsExpiredTicketsCmd returns a new instance which can be used to issue an
-// existsexpiredtickets JSON-RPC command.
-func NewExistsExpiredTicketsCmd(txHashes []string) *ExistsExpiredTicketsCmd {
-	return &ExistsExpiredTicketsCmd{
-		TxHashes: txHashes,
-	}
-}
-
 // ExistsLiveTicketCmd defines the existsliveticket JSON-RPC command.
 type ExistsLiveTicketCmd struct {
 	TxHash string
@@ -1138,7 +1125,6 @@ func init() {
 	dcrjson.MustRegister(Method("estimatestakediff"), (*EstimateStakeDiffCmd)(nil), flags)
 	dcrjson.MustRegister(Method("existsaddress"), (*ExistsAddressCmd)(nil), flags)
 	dcrjson.MustRegister(Method("existsaddresses"), (*ExistsAddressesCmd)(nil), flags)
-	dcrjson.MustRegister(Method("existsexpiredtickets"), (*ExistsExpiredTicketsCmd)(nil), flags)
 	dcrjson.MustRegister(Method("existsliveticket"), (*ExistsLiveTicketCmd)(nil), flags)
 	dcrjson.MustRegister(Method("existslivetickets"), (*ExistsLiveTicketsCmd)(nil), flags)
 	dcrjson.MustRegister(Method("existsmempooltxs"), (*ExistsMempoolTxsCmd)(nil), flags)

--- a/rpc/jsonrpc/types/chainsvrresults.go
+++ b/rpc/jsonrpc/types/chainsvrresults.go
@@ -466,12 +466,6 @@ type LiveTicketsResult struct {
 	Tickets []string `json:"tickets"`
 }
 
-// MissedTicketsResult models the data returned from the missedtickets
-// command.
-type MissedTicketsResult struct {
-	Tickets []string `json:"tickets"`
-}
-
 // FeeInfoBlock is ticket fee information about a block.
 type FeeInfoBlock struct {
 	Height uint32  `json:"height"`

--- a/rpc/jsonrpc/types/chainsvrwscmds.go
+++ b/rpc/jsonrpc/types/chainsvrwscmds.go
@@ -111,16 +111,6 @@ func NewNotifyNewTicketsCmd() *NotifyNewTicketsCmd {
 	return &NotifyNewTicketsCmd{}
 }
 
-// RebroadcastMissedCmd is a type handling custom marshaling and
-// unmarshaling of rebroadcastmissed JSON RPC commands.
-type RebroadcastMissedCmd struct{}
-
-// NewRebroadcastMissedCmd returns a new instance which can be used to
-// issue a JSON-RPC rebroadcastmissed command.
-func NewRebroadcastMissedCmd() *RebroadcastMissedCmd {
-	return &RebroadcastMissedCmd{}
-}
-
 // RebroadcastWinnersCmd is a type handling custom marshaling and
 // unmarshaling of rebroadcastwinners JSON RPC commands.
 type RebroadcastWinnersCmd struct{}
@@ -219,7 +209,6 @@ func init() {
 	dcrjson.MustRegister(Method("notifynewtickets"), (*NotifyNewTicketsCmd)(nil), flags)
 	dcrjson.MustRegister(Method("notifyspentandmissedtickets"), (*NotifySpentAndMissedTicketsCmd)(nil), flags)
 	dcrjson.MustRegister(Method("notifywinningtickets"), (*NotifyWinningTicketsCmd)(nil), flags)
-	dcrjson.MustRegister(Method("rebroadcastmissed"), (*RebroadcastMissedCmd)(nil), flags)
 	dcrjson.MustRegister(Method("rebroadcastwinners"), (*RebroadcastWinnersCmd)(nil), flags)
 	dcrjson.MustRegister(Method("session"), (*SessionCmd)(nil), flags)
 	dcrjson.MustRegister(Method("stopnotifyblocks"), (*StopNotifyBlocksCmd)(nil), flags)

--- a/rpc/jsonrpc/types/chainsvrwscmds.go
+++ b/rpc/jsonrpc/types/chainsvrwscmds.go
@@ -89,17 +89,6 @@ func NewNotifyWinningTicketsCmd() *NotifyWinningTicketsCmd {
 	return &NotifyWinningTicketsCmd{}
 }
 
-// NotifySpentAndMissedTicketsCmd is a type handling custom marshaling and
-// unmarshaling of notifyspentandmissedtickets JSON websocket extension
-// commands.
-type NotifySpentAndMissedTicketsCmd struct {
-}
-
-// NewNotifySpentAndMissedTicketsCmd creates a new NotifySpentAndMissedTicketsCmd.
-func NewNotifySpentAndMissedTicketsCmd() *NotifySpentAndMissedTicketsCmd {
-	return &NotifySpentAndMissedTicketsCmd{}
-}
-
 // NotifyNewTicketsCmd is a type handling custom marshaling and
 // unmarshaling of notifynewtickets JSON websocket extension
 // commands.
@@ -207,7 +196,6 @@ func init() {
 	dcrjson.MustRegister(Method("notifytspend"), (*NotifyTSpendCmd)(nil), flags)
 	dcrjson.MustRegister(Method("notifynewtransactions"), (*NotifyNewTransactionsCmd)(nil), flags)
 	dcrjson.MustRegister(Method("notifynewtickets"), (*NotifyNewTicketsCmd)(nil), flags)
-	dcrjson.MustRegister(Method("notifyspentandmissedtickets"), (*NotifySpentAndMissedTicketsCmd)(nil), flags)
 	dcrjson.MustRegister(Method("notifywinningtickets"), (*NotifyWinningTicketsCmd)(nil), flags)
 	dcrjson.MustRegister(Method("rebroadcastwinners"), (*RebroadcastWinnersCmd)(nil), flags)
 	dcrjson.MustRegister(Method("session"), (*SessionCmd)(nil), flags)

--- a/rpc/jsonrpc/types/chainsvrwscmds_test.go
+++ b/rpc/jsonrpc/types/chainsvrwscmds_test.go
@@ -53,17 +53,6 @@ func TestChainSvrWsCmds(t *testing.T) {
 			unmarshalled: &NotifyWinningTicketsCmd{},
 		},
 		{
-			name: "notifyspentandmissedtickets",
-			newCmd: func() (interface{}, error) {
-				return dcrjson.NewCmd(Method("notifyspentandmissedtickets"))
-			},
-			staticCmd: func() interface{} {
-				return NewNotifySpentAndMissedTicketsCmd()
-			},
-			marshalled:   `{"jsonrpc":"1.0","method":"notifyspentandmissedtickets","params":[],"id":1}`,
-			unmarshalled: &NotifySpentAndMissedTicketsCmd{},
-		},
-		{
 			name: "notifynewtickets",
 			newCmd: func() (interface{}, error) {
 				return dcrjson.NewCmd(Method("notifynewtickets"))

--- a/rpc/jsonrpc/types/chainsvrwsntfns.go
+++ b/rpc/jsonrpc/types/chainsvrwsntfns.go
@@ -49,10 +49,6 @@ const (
 	// transaction was accepted by the mempool.
 	RelevantTxAcceptedNtfnMethod Method = "relevanttxaccepted"
 
-	// SpentAndMissedTicketsNtfnMethod is the method of the daemon
-	// spentandmissedtickets notification.
-	SpentAndMissedTicketsNtfnMethod Method = "spentandmissedtickets"
-
 	// WinningTicketsNtfnMethod is the method of the daemon winningtickets
 	// notification.
 	WinningTicketsNtfnMethod Method = "winningtickets"
@@ -154,25 +150,6 @@ func NewReorganizationNtfn(oldHash string, oldHeight int32, newHash string,
 	}
 }
 
-// SpentAndMissedTicketsNtfn is a type handling custom marshaling and
-// unmarshaling of spentandmissedtickets JSON websocket notifications.
-type SpentAndMissedTicketsNtfn struct {
-	Hash      string
-	Height    int32
-	StakeDiff int64
-	Tickets   map[string]string
-}
-
-// NewSpentAndMissedTicketsNtfn creates a new SpentAndMissedTicketsNtfn.
-func NewSpentAndMissedTicketsNtfn(hash string, height int32, stakeDiff int64, tickets map[string]string) *SpentAndMissedTicketsNtfn {
-	return &SpentAndMissedTicketsNtfn{
-		Hash:      hash,
-		Height:    height,
-		StakeDiff: stakeDiff,
-		Tickets:   tickets,
-	}
-}
-
 // TxAcceptedNtfn defines the txaccepted JSON-RPC notification.
 type TxAcceptedNtfn struct {
 	TxID   string  `json:"txid"`
@@ -244,6 +221,5 @@ func init() {
 	dcrjson.MustRegister(TxAcceptedNtfnMethod, (*TxAcceptedNtfn)(nil), flags)
 	dcrjson.MustRegister(TxAcceptedVerboseNtfnMethod, (*TxAcceptedVerboseNtfn)(nil), flags)
 	dcrjson.MustRegister(RelevantTxAcceptedNtfnMethod, (*RelevantTxAcceptedNtfn)(nil), flags)
-	dcrjson.MustRegister(SpentAndMissedTicketsNtfnMethod, (*SpentAndMissedTicketsNtfn)(nil), flags)
 	dcrjson.MustRegister(WinningTicketsNtfnMethod, (*WinningTicketsNtfn)(nil), flags)
 }

--- a/rpc/jsonrpc/types/chainsvrwsntfns_test.go
+++ b/rpc/jsonrpc/types/chainsvrwsntfns_test.go
@@ -86,22 +86,6 @@ func TestChainSvrWsNtfns(t *testing.T) {
 			},
 		},
 		{
-			name: "spentandmissedtickets",
-			newNtfn: func() (interface{}, error) {
-				return dcrjson.NewCmd(Method("spentandmissedtickets"), "123", 100, 3, map[string]string{"a": "b"})
-			},
-			staticNtfn: func() interface{} {
-				return NewSpentAndMissedTicketsNtfn("123", 100, 3, map[string]string{"a": "b"})
-			},
-			marshalled: `{"jsonrpc":"1.0","method":"spentandmissedtickets","params":["123",100,3,{"a":"b"}],"id":null}`,
-			unmarshalled: &SpentAndMissedTicketsNtfn{
-				Hash:      "123",
-				Height:    100,
-				StakeDiff: 3,
-				Tickets:   map[string]string{"a": "b"},
-			},
-		},
-		{
 			name: "txaccepted",
 			newNtfn: func() (interface{}, error) {
 				return dcrjson.NewCmd(Method("txaccepted"), "123", 1.5)

--- a/rpcclient/extensions.go
+++ b/rpcclient/extensions.go
@@ -790,53 +790,6 @@ func (c *Client) LiveTickets(ctx context.Context) ([]*chainhash.Hash, error) {
 	return c.LiveTicketsAsync(ctx).Receive()
 }
 
-// FutureMissedTicketsResult is a future promise to deliver the result
-// of a FutureMissedTicketsResultAsync RPC invocation (or an applicable error).
-type FutureMissedTicketsResult cmdRes
-
-// Receive waits for the response promised by the future and returns all
-// currently missed tickets from the missed ticket database.
-func (r *FutureMissedTicketsResult) Receive() ([]*chainhash.Hash, error) {
-	res, err := receiveFuture(r.ctx, r.c)
-	if err != nil {
-		return nil, err
-	}
-
-	// Unmarshal result as a missed tickets result object.
-	var container chainjson.MissedTicketsResult
-	err = json.Unmarshal(res, &container)
-	if err != nil {
-		return nil, err
-	}
-
-	missedTickets := make([]*chainhash.Hash, 0, len(container.Tickets))
-	for _, ticketStr := range container.Tickets {
-		h, err := chainhash.NewHashFromStr(ticketStr)
-		if err != nil {
-			return nil, err
-		}
-		missedTickets = append(missedTickets, h)
-	}
-
-	return missedTickets, nil
-}
-
-// MissedTicketsAsync returns an instance of a type that can be used to get the
-// result of the RPC at some future time by invoking the Receive function on the
-// returned instance.
-func (c *Client) MissedTicketsAsync(ctx context.Context) *FutureMissedTicketsResult {
-	cmd := chainjson.NewMissedTicketsCmd()
-	return (*FutureMissedTicketsResult)(c.sendCmd(ctx, cmd))
-}
-
-// MissedTickets returns all currently missed tickets from the missed
-// ticket database in the daemon.
-//
-// NOTE: This is a dcrd extension.
-func (c *Client) MissedTickets(ctx context.Context) ([]*chainhash.Hash, error) {
-	return c.MissedTicketsAsync(ctx).Receive()
-}
-
 // FutureSessionResult is a future promise to deliver the result of a
 // SessionAsync RPC invocation (or an applicable error).
 type FutureSessionResult cmdRes

--- a/rpcclient/extensions.go
+++ b/rpcclient/extensions.go
@@ -191,45 +191,6 @@ func (c *Client) ExistsAddresses(ctx context.Context, addresses []stdaddr.Addres
 	return c.ExistsAddressesAsync(ctx, addresses).Receive()
 }
 
-// FutureExistsMissedTicketsResult is a future promise to deliver the result of
-// an ExistsMissedTicketsAsync RPC invocation (or an applicable error).
-type FutureExistsMissedTicketsResult cmdRes
-
-// Receive waits for the response promised by the future and returns whether
-// or not the tickets exist in the missed ticket database.
-func (r *FutureExistsMissedTicketsResult) Receive() (string, error) {
-	res, err := receiveFuture(r.ctx, r.c)
-	if err != nil {
-		return "", err
-	}
-
-	// Unmarshal the result as a string.
-	var exists string
-	err = json.Unmarshal(res, &exists)
-	if err != nil {
-		return "", err
-	}
-	return exists, nil
-}
-
-// ExistsMissedTicketsAsync returns an instance of a type that can be used to
-// get the result of the RPC at some future time by invoking the Receive
-// function on the returned instance.
-func (c *Client) ExistsMissedTicketsAsync(ctx context.Context, hashes []*chainhash.Hash) *FutureExistsMissedTicketsResult {
-	strHashes := make([]string, len(hashes))
-	for i := range hashes {
-		strHashes[i] = hashes[i].String()
-	}
-	cmd := chainjson.NewExistsMissedTicketsCmd(strHashes)
-	return (*FutureExistsMissedTicketsResult)(c.sendCmd(ctx, cmd))
-}
-
-// ExistsMissedTickets returns a hex-encoded bitset describing whether or not
-// ticket hashes exists in the missed ticket database.
-func (c *Client) ExistsMissedTickets(ctx context.Context, hashes []*chainhash.Hash) (string, error) {
-	return c.ExistsMissedTicketsAsync(ctx, hashes).Receive()
-}
-
 // FutureExistsExpiredTicketsResult is a future promise to deliver the result
 // of a FutureExistsExpiredTicketsResultAsync RPC invocation (or an
 // applicable error).

--- a/rpcclient/extensions.go
+++ b/rpcclient/extensions.go
@@ -191,48 +191,6 @@ func (c *Client) ExistsAddresses(ctx context.Context, addresses []stdaddr.Addres
 	return c.ExistsAddressesAsync(ctx, addresses).Receive()
 }
 
-// FutureExistsExpiredTicketsResult is a future promise to deliver the result
-// of a FutureExistsExpiredTicketsResultAsync RPC invocation (or an
-// applicable error).
-type FutureExistsExpiredTicketsResult cmdRes
-
-// Receive waits for the response promised by the future and returns whether
-// or not the tickets exist in the expired ticket database.
-func (r *FutureExistsExpiredTicketsResult) Receive() (string, error) {
-	res, err := receiveFuture(r.ctx, r.c)
-	if err != nil {
-		return "", err
-	}
-
-	// Unmarshal the result as a string.
-	var exists string
-	err = json.Unmarshal(res, &exists)
-	if err != nil {
-		return "", err
-	}
-	return exists, nil
-}
-
-// ExistsExpiredTicketsAsync returns an instance of a type that can be used to get the
-// result of the RPC at some future time by invoking the Receive function on the
-// returned instance.
-func (c *Client) ExistsExpiredTicketsAsync(ctx context.Context, hashes []*chainhash.Hash) *FutureExistsExpiredTicketsResult {
-	strHashes := make([]string, len(hashes))
-	for i := range hashes {
-		strHashes[i] = hashes[i].String()
-	}
-	cmd := chainjson.NewExistsExpiredTicketsCmd(strHashes)
-	return (*FutureExistsExpiredTicketsResult)(c.sendCmd(ctx, cmd))
-}
-
-// ExistsExpiredTickets returns information about whether or not a ticket hash exists
-// in the expired ticket database.
-//
-// NOTE: This is a dcrd extension.
-func (c *Client) ExistsExpiredTickets(ctx context.Context, hashes []*chainhash.Hash) (string, error) {
-	return c.ExistsExpiredTicketsAsync(ctx, hashes).Receive()
-}
-
 // FutureExistsLiveTicketResult is a future promise to deliver the result
 // of a FutureExistsLiveTicketResultAsync RPC invocation (or an
 // applicable error).

--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -279,9 +279,6 @@ func (c *Client) trackRegisteredNtfns(cmd interface{}) {
 	case *chainjson.NotifyWinningTicketsCmd:
 		c.ntfnState.notifyWinningTickets = true
 
-	case *chainjson.NotifySpentAndMissedTicketsCmd:
-		c.ntfnState.notifySpentAndMissedTickets = true
-
 	case *chainjson.NotifyNewTicketsCmd:
 		c.ntfnState.notifyNewTickets = true
 
@@ -582,14 +579,6 @@ func (c *Client) reregisterNtfns(ctx context.Context) error {
 	if stateCopy.notifyWinningTickets {
 		log.Debugf("Reregistering [notifywinningtickets]")
 		if err := c.NotifyWinningTickets(ctx); err != nil {
-			return err
-		}
-	}
-
-	// Reregister notifyspendandmissedtickets if needed.
-	if stateCopy.notifySpentAndMissedTickets {
-		log.Debugf("Reregistering [notifyspentandmissedtickets]")
-		if err := c.NotifySpentAndMissedTickets(ctx); err != nil {
 			return err
 		}
 	}

--- a/server.go
+++ b/server.go
@@ -2787,22 +2787,6 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 		// guaranteed to no longer be useful.
 		s.proactivelyEvictSigCacheEntries(block.Height())
 
-	// Stake tickets are spent or missed from the most recently connected block.
-	case blockchain.NTSpentAndMissedTickets:
-		// WARNING: The chain lock is not released before sending this
-		// notification, so care must be taken to avoid calling chain functions
-		// which could result in a deadlock.
-		tnd, ok := notification.Data.(*blockchain.TicketNotificationsData)
-		if !ok {
-			syncLog.Warnf("Tickets connected notification is not " +
-				"TicketNotificationsData")
-			break
-		}
-
-		if r := s.rpcServer; r != nil {
-			r.NotifySpentAndMissedTickets(tnd)
-		}
-
 	// Stake tickets are matured from the most recently connected block.
 	case blockchain.NTNewTickets:
 		// WARNING: The chain lock is not released before sending this


### PR DESCRIPTION
~**This requires #2909 and #2910**.~

Per the second phase of #2774, this removes all RPCs and associated code related to missed and expired tickets.

As stated in the original proposal, the only known way these RPCs are used is to support wallet staking statistics, but due to the automatic revocations consensus change, wallets will not really need the RPCs to calculate the vast majority of the information anymore since they can detect missed and expired tickets through a combination of seeing the revocation and comparing the number of confirmations against the ticket purchase height.

Further, these RPCs are really not something that dcrd should be maintaining by default anyway because they have some fairly significant downsides:

* The set of missed tickets and revoked tickets are both unbounded which means they take up more and more resources over time
* With the automatic revocations consensus change, the entire notion of a missed category effectively no longer exists
* The sets are already large enough that they take a non-trivial amount of RAM and I/O and will only become more burdensome over time
* Even though the missed category will effectively no longer exist, continued support of these RPCs requires the current ticket database and related consensus code to continue to be able to track and manipulate these unbounded sets

That final point is perhaps one of the most important ones, because the ticket database design can be significantly optimized due to the introduction of the automatic revocations consensus change so long as the RPCs in question are no longer supported.

The removals have been split into multiple commits to ease the review process and also ensure everything continues to work properly each step of the way.

The following is a high level overview of the changes:

- Bumps the RPC server major version to 8.0.0
- Removes the entries for the following RPCs and notifications from the JSON-RPC API docs:
  - `missedtickets`
  - `rebroadcastmissed`
  - `existsmissedtickets`
  - `existsexpiredtickets`
  - ` notifyspentandmissedtickets`
  - ` spentandmissedtickets`
- Removes all code for the following methods and notification tracking from the `rpcclient`:
  - `MissedTicketsAsync`
  - `MissedTickets`
  - `ExistsMissedTicketsAsync`
  - `ExistsMissedTickets`
  - `ExistsExpiredTicketsAsync`
  - `ExistsExpiredTickets`
  - `NotifySpentAndMissedTicketsAsync`
  - `NotifySpentAndMissedTickets`
  - `OnSpentAndMissedTickets`
- Removes all code from the RPC server for handling the following RPCs and notifications:
  - `missedtickets`
  - `rebroadcastmissed`
  - `existsmissedtickets`
  - `existsexpiredtickets`
  - `notifyspentandmissedtickets`
  - `spentandmissedtickets`
- Removes the following methods from `blockchain` that are no longer used as they only existed to support the RPCs:
  - `MissedTickets`
  - `CheckMissedTickets`
  - `CheckExpiredTicket`
  - `CheckExpiredTickets`
- Removes the `NTSpentAndMissedTickets` and associated code to send the notification from `blockchain`
- Updates the `blockchain.TicketNotificationsData` struct to remove the `TicketsSpent` and `TicketsMissed` fields
- Removes the following types, constants, and registrations along with associated tests from `rpc/jsonrpc/types`:
  - `MissedTicketsCmd`
  - `MissedTicketsResult`
  - `RebroadcastMissedCmd`
  - `ExistsMissedTicketsCmd`
  - `ExistsExpiredTicketsCmd`
  - `NotifySpentAndMissedTicketsCmd`
  - `SpentAndMissedTicketsNtfnMethod`
  - `SpentAndMissedTicketsNtfn`

---

This closes #2774.

