### PR TITLE
indexers: Fix subscribers race.

### DIFF
--- a/blockchain/indexers/addrindex_test.go
+++ b/blockchain/indexers/addrindex_test.go
@@ -682,7 +682,14 @@ func TestAddrIndexAsync(t *testing.T) {
 	// Wait for the index to sync with the main chain.
 	select {
 	case <-addrIdx.WaitForSync():
-		// Nothing to do.
+		// Ensure there are no subscribers for the indexer.
+		addrIdx.mtx.Lock()
+		subs := len(addrIdx.subscribers)
+		addrIdx.mtx.Unlock()
+		if subs != 0 {
+			t.Fatalf("expected no indexer subscribers, got %d", subs)
+		}
+
 	case <-time.After(time.Second):
 		panic("timeout waiting for index to synchronize")
 	}
@@ -716,5 +723,25 @@ func TestAddrIndexAsync(t *testing.T) {
 	if *addrIdxTipHash != *bk4a.Hash() {
 		t.Fatalf("expected tip hash to be %s, got %s",
 			bk4a.Hash().String(), addrIdxTipHash.String())
+	}
+
+	// Ensure indexer subscribers are cleaned up after waiting for an update
+	// beyond the indexer sync wait threshold.
+	_ = addrIdx.WaitForSync()
+
+	addrIdx.mtx.Lock()
+	subs := len(addrIdx.subscribers)
+	addrIdx.mtx.Unlock()
+	if subs != 1 {
+		t.Fatalf("expected one indexer subscriber, got %d", subs)
+	}
+
+	time.Sleep(syncWait + (syncWait / 2))
+
+	addrIdx.mtx.Lock()
+	subs = len(addrIdx.subscribers)
+	addrIdx.mtx.Unlock()
+	if subs != 0 {
+		t.Fatalf("expected no indexer subscribers, got %d", subs)
 	}
 }

--- a/blockchain/indexers/existsaddrindex_test.go
+++ b/blockchain/indexers/existsaddrindex_test.go
@@ -284,7 +284,13 @@ func TestExistsAddrIndexAsync(t *testing.T) {
 	// Wait for the index to sync with the main chain before terminating.
 	select {
 	case <-idx.WaitForSync():
-		// Nothing to do.
+		// Ensure there are no subscribers for the indexer.
+		idx.mtx.Lock()
+		subs := len(idx.subscribers)
+		idx.mtx.Unlock()
+		if subs != 0 {
+			t.Fatalf("expected no indexer subscribers, got %d", subs)
+		}
 	case <-time.After(time.Second):
 		panic("timeout waiting for index to synchronize")
 	}
@@ -318,5 +324,25 @@ func TestExistsAddrIndexAsync(t *testing.T) {
 	if *tipHash != *bk4a.Hash() {
 		t.Fatalf("expected tip hash to be %s, got %s",
 			bk4a.Hash().String(), tipHash.String())
+	}
+
+	// Ensure indexer subscribers are cleaned up after waiting for an update
+	// beyond the indexer sync wait threshold.
+	_ = idx.WaitForSync()
+
+	idx.mtx.Lock()
+	subs := len(idx.subscribers)
+	idx.mtx.Unlock()
+	if subs != 1 {
+		t.Fatalf("expected one indexer subscriber, got %d", subs)
+	}
+
+	time.Sleep(syncWait + (syncWait / 2))
+
+	idx.mtx.Lock()
+	subs = len(idx.subscribers)
+	idx.mtx.Unlock()
+	if subs != 0 {
+		t.Fatalf("expected no indexer subscribers, got %d", subs)
 	}
 }

--- a/blockchain/indexers/txindex.go
+++ b/blockchain/indexers/txindex.go
@@ -485,7 +485,7 @@ func (idx *TxIndex) IndexSubscription() *IndexSubscription {
 func (idx *TxIndex) Subscribers() map[chan bool]struct{} {
 	idx.mtx.Lock()
 	defer idx.mtx.Unlock()
-	return idx.subscribers
+	return fetchIndexerSubscribers(idx.subscribers)
 }
 
 // WaitForSync subscribes clients for the next index sync update.
@@ -493,6 +493,14 @@ func (idx *TxIndex) Subscribers() map[chan bool]struct{} {
 // This is part of the Indexer interface.
 func (idx *TxIndex) WaitForSync() chan bool {
 	c := make(chan bool)
+
+	removeIndexerSub := func() {
+		idx.mtx.Lock()
+		delete(idx.subscribers, c)
+		idx.mtx.Unlock()
+	}
+
+	go purgeIndexerSubscription(c, removeIndexerSub)
 
 	idx.mtx.Lock()
 	idx.subscribers[c] = struct{}{}


### PR DESCRIPTION
This fixes a race accessing an indexer's subscribers waiting on index updates.

fixes  #2913