### PR TITLE
[release-v1.7] main: Use backported blockchain updates.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/decred/dcrd/bech32 v1.1.2
 	github.com/decred/dcrd/blockchain/stake/v4 v4.0.0
 	github.com/decred/dcrd/blockchain/standalone/v2 v2.1.0
-	github.com/decred/dcrd/blockchain/v4 v4.0.0
+	github.com/decred/dcrd/blockchain/v4 v4.0.1
 	github.com/decred/dcrd/certgen v1.1.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.3
 	github.com/decred/dcrd/chaincfg/v3 v3.1.1

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/decred/dcrd/blockchain/stake/v4 v4.0.0 h1:PwoCjCTbRvDUZKKs6N2Haus8Xcb
 github.com/decred/dcrd/blockchain/stake/v4 v4.0.0/go.mod h1:bOgG7YTbTOWQgtHLL2l1Y9gBHIuM86zwVcQtsoGlZlQ=
 github.com/decred/dcrd/blockchain/standalone/v2 v2.1.0 h1:aXh7a+86p+H65MGy0QKu4Juf3/j+Y5koVSyVYFMdqP0=
 github.com/decred/dcrd/blockchain/standalone/v2 v2.1.0/go.mod h1:t2qaZ3hNnxHZ5kzVJDgW5sp47/8T5hYJt7SR+/JtRhI=
-github.com/decred/dcrd/blockchain/v4 v4.0.0 h1:fCzGqW9aKd3/4x0z2+LM+GpSksYAyftPFVvHGeEDX38=
-github.com/decred/dcrd/blockchain/v4 v4.0.0/go.mod h1:i1FeTNN0LUEWBSMoI3riAFgfVE1X/7Seoz1aJ7YQGbk=
+github.com/decred/dcrd/blockchain/v4 v4.0.1 h1:TI7NRPijz0IpT6Cw+OQIJR8Afh2YP0APyI32Y/pCNHQ=
+github.com/decred/dcrd/blockchain/v4 v4.0.1/go.mod h1:i1FeTNN0LUEWBSMoI3riAFgfVE1X/7Seoz1aJ7YQGbk=
 github.com/decred/dcrd/certgen v1.1.1 h1:MYPG5jCysnbF4OiJ1++YumFEu2p/MsM/zxmmqC9mVFg=
 github.com/decred/dcrd/certgen v1.1.1/go.mod h1:ivkPLChfjdAgFh7ZQOtl6kJRqVkfrCq67dlq3AbZBQE=
 github.com/decred/dcrd/chaincfg/chainhash v1.0.2/go.mod h1:BpbrGgrPTr3YJYRN3Bm+D9NuaFd+zGyNeIKgrhCXK60=


### PR DESCRIPTION
This updates the 1.7 release to use the latest version of the `blockchain` module which includes a minor fix to optional indexing where a race condition could occur.

In particular, the following updated module version is used:

- github.com/decred/dcrd/blockchain/v4@v4.0.1