### PR TITLE
multi: Consolidate header proof logic.

### DIFF
--- a/blockchain/treasury_test.go
+++ b/blockchain/treasury_test.go
@@ -1466,7 +1466,7 @@ func TestSpendableTreasuryTxs(t *testing.T) {
 
 	// Ensure the CFilter committed to the outputs of the TSpend and TAdds.
 	tipHash = &g.chain.BestSnapshot().Hash
-	bcf, err := g.chain.FilterByBlockHash(tipHash)
+	bcf, _, err := g.chain.FilterByBlockHash(tipHash)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -539,12 +539,13 @@ type BlockTemplater interface {
 // concurrent access.
 type FiltererV2 interface {
 	// FilterByBlockHash returns the version 2 GCS filter for the given block
-	// hash when it exists.  This function returns the filters regardless of
-	// whether or not their associated block is part of the main chain.
+	// hash along with a header commitment inclusion proof when they exist.
+	// This function returns the filters regardless of whether or not their
+	// associated block is part of the main chain.
 	//
 	// An error of type blockchain.ErrNoFilter must be returned when the filter
 	// for the given block hash does not exist.
-	FilterByBlockHash(hash *chainhash.Hash) (*gcs.FilterV2, error)
+	FilterByBlockHash(hash *chainhash.Hash) (*gcs.FilterV2, *blockchain.HeaderProof, error)
 }
 
 // ExistsAddresser represents a source of exists address methods for the RPC

--- a/server.go
+++ b/server.go
@@ -1332,20 +1332,14 @@ func (sp *serverPeer) OnGetCFilterV2(_ *peer.Peer, msg *wire.MsgGetCFilterV2) {
 	//
 	// Ignore request for unknown block or otherwise missing filters.
 	chain := sp.server.chain
-	filter, err := chain.FilterByBlockHash(&msg.BlockHash)
+	filter, proof, err := chain.FilterByBlockHash(&msg.BlockHash)
 	if err != nil {
 		return
 	}
 
-	// NOTE: When more header commitments are added, this will need to load the
-	// inclusion proof for the filter from the database.  However, since there
-	// is only currently a single commitment, there is only a single leaf in the
-	// commitment merkle tree, and hence the proof hashes will always be empty
-	// given there are no siblings.  Adding an additional header commitment will
-	// require a consensus vote anyway and this can be updated at that time.
-	cfilterMsg := wire.NewMsgCFilterV2(&msg.BlockHash, filter.Bytes(),
-		blockchain.HeaderCmtFilterIndex, nil)
-	sp.QueueMessage(cfilterMsg, nil)
+	filterMsg := wire.NewMsgCFilterV2(&msg.BlockHash, filter.Bytes(),
+		proof.ProofIndex, proof.ProofHashes)
+	sp.QueueMessage(filterMsg, nil)
 }
 
 // OnGetCFHeaders is invoked when a peer receives a getcfheader wire message.


### PR DESCRIPTION
Currently, the p2p and rpcserver handlers that deal with compact filters essentially duplicate the logic for dealing with the associated header proof and are also required to understand the structure of the proof in the form of knowing the associated index.  This is not ideal since there is no guarantee that a given index will always be the same through consensus changes.

With those points in mind, this reworks the header proof logic slightly to consolidate it by introducing a new `HeaderProof` struct to `blockchain` that houses a header commitment inclusion proof and associated proof index and updating the `FilterByBlockHash` method to return the header proof along with the filter and updates the p2p and rpcserver handlers and associated interfaces and tests accordingly.

The result is that the aforementioned p2p and rpcserver handlers for obtaining compact filters no longer need to understand anything about the proofs.  It is also useful for any future header commitments too since the same logic will hold true for those instances as well.