### PR TITLE
blockchain: Implement header proof storage.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1248,6 +1248,7 @@ func (b *BlockChain) reorganizeChainInternal(target *blockNode) error {
 				return err
 			}
 			hdrCommitments.filter = filter
+			hdrCommitments.filterHash = filter.Hash()
 		} else {
 			// The block must pass all of the validation rules which depend on
 			// having the full block data for all of its ancestors available.

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -826,8 +826,7 @@ func dbRemoveSpendJournalEntry(dbTx database.Tx, blockHash *chainhash.Hash) erro
 //
 // -----------------------------------------------------------------------------
 
-// dbFetchGCSFilter fetches the GCS filter for the passed block and deserializes
-// it into a slice of spent txout entries.
+// dbFetchGCSFilter fetches the version 2 GCS filter for the passed block.
 //
 // When there is no entry for the provided hash, nil will be returned for both
 // the filter and the error.
@@ -847,8 +846,8 @@ func dbFetchGCSFilter(dbTx database.Tx, blockHash *chainhash.Hash) (*gcs.FilterV
 	return filter, nil
 }
 
-// dbPutGCSFilter uses an existing database transaction to update the GCS filter
-// for the given block hash using the provided filter.
+// dbPutGCSFilter uses an existing database transaction to update the version 2
+// GCS filter for the given block hash using the provided filter.
 func dbPutGCSFilter(dbTx database.Tx, blockHash *chainhash.Hash, filter *gcs.FilterV2) error {
 	filterBucket := dbTx.Metadata().Bucket(gcsFilterBucketName)
 	serialized := filter.Bytes()

--- a/blockchain/go.mod
+++ b/blockchain/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/decred/dcrd/blockchain/standalone/v2 v2.1.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.3
 	github.com/decred/dcrd/chaincfg/v3 v3.1.1
+	github.com/decred/dcrd/crypto/blake256 v1.0.0
 	github.com/decred/dcrd/database/v3 v3.0.0
 	github.com/decred/dcrd/dcrec v1.0.0
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1
@@ -23,7 +24,6 @@ require (
 	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 // indirect
 	github.com/dchest/siphash v1.2.2 // indirect
 	github.com/decred/base58 v1.0.3 // indirect
-	github.com/decred/dcrd/crypto/blake256 v1.0.0 // indirect
 	github.com/decred/dcrd/crypto/ripemd160 v1.0.1 // indirect
 	github.com/decred/dcrd/dcrec/edwards/v2 v2.0.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect

--- a/blockchain/headercmt.go
+++ b/blockchain/headercmt.go
@@ -22,7 +22,8 @@ const (
 // headerCommitmentData houses information the block header commits to via the
 // commitment root.
 type headerCommitmentData struct {
-	filter *gcs.FilterV2
+	filter     *gcs.FilterV2
+	filterHash chainhash.Hash
 }
 
 // CalcCommitmentRootV1 calculates and returns the required v1 block commitment

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -3960,8 +3960,10 @@ func (b *BlockChain) checkConnectBlock(node *blockNode, block, parent *dcrutil.B
 	if err != nil {
 		return ruleError(ErrMissingTxOut, err.Error())
 	}
+	filterHash := filter.Hash()
 	if hdrCommitments != nil {
 		hdrCommitments.filter = filter
+		hdrCommitments.filterHash = filterHash
 	}
 
 	// The calculated commitment root must match the associated entry in the
@@ -3975,7 +3977,7 @@ func (b *BlockChain) checkConnectBlock(node *blockNode, block, parent *dcrutil.B
 		return err
 	}
 	if hdrCommitmentsActive {
-		wantCommitmentRoot := CalcCommitmentRootV1(filter.Hash())
+		wantCommitmentRoot := CalcCommitmentRootV1(filterHash)
 		header := &block.MsgBlock().Header
 		if header.StakeRoot != wantCommitmentRoot {
 			str := fmt.Sprintf("block commitment root is invalid - block "+


### PR DESCRIPTION
~**This requires #2937**~.

### Testing Notes

As of this PR, the expected behavior is that there is a single migration that takes around 1 to 2 minutes to complete.  after which it will no longer be possible to downgrade.

As the warning above notes, if you try to run an older software version after this migration has completed, you will get an error message similar to `Unable to start server on [:9108]: the current blockchain database is no longer compatible with this version of the software (13 > 12).`

---

This modifies the chain logic to create and store the individual commitment hashes covered by the commitment root field of the header of each block, adds code to migrate the database to retroactively create and store entries for all applicable historical blocks, and updates the code that generates inclusion proofs to use the stored data instead so that it will continue to work properly when new header commitments are added without further modification.

The upgrade can be interrupted at any point and future invocations will resume from the point it was interrupted.

The following is a high level overview of the changes:
- Introduce a new database bucket to house the header commitments
- Add serialization code for use when storing and loading the individual header commitment hashes
  - Add full test coverage for new serialization code
- Store the commitment hashes in the db when connecting blocks
- Implement database migration code to retroactively store the commitment hashes for all applicable historical blocks
   - Bump the chain database version to 13
   - Support resuming from interrupted upgrades
- Update internal header commitment data  struct:
  - Add a field to store the hash of the filter along with the filter so that it can be reused without needing to recalculate the hash
  - Add a new func that returns the v1 header commitment hashes to consolidate the logic
- Modify `FilterByBlockHash` implementation:
  - Avoid hitting the database when a compact filter that can't possibly be available by first checking the block index to ensure the requested block is both available and its data is known
  - Load the header commitments from the db and generate the inclusion proof accordingly
