### PR TITLE
multi: Decouple RPC agenda info status strings.

### DIFF
--- a/rpc/jsonrpc/types/chainsvrresults.go
+++ b/rpc/jsonrpc/types/chainsvrresults.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015-2021 The Decred developers
+// Copyright (c) 2015-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -90,6 +90,16 @@ type GetBlockVerboseResult struct {
 	PreviousHash  string        `json:"previousblockhash"`
 	NextHash      string        `json:"nextblockhash,omitempty"`
 }
+
+// The following constants specify the possible status strings for an agenda in
+// a consensus deployment of a getblockchaininfo result.
+const (
+	AgendaInfoStatusDefined  = "defined"
+	AgendaInfoStatusStarted  = "started"
+	AgendaInfoStatusLockedIn = "lockedin"
+	AgendaInfoStatusActive   = "active"
+	AgendaInfoStatusFailed   = "failed"
+)
 
 // AgendaInfo provides an overview of an agenda in a consensus deployment.
 type AgendaInfo struct {


### PR DESCRIPTION
Currently, the `getblockchainfo` RPC implementation directly returns the internal threshold state strings defined in `blockchain`.  This is not ideal since it means that any changes to the internal implementation could inadvertently change the RPC results without being noticed.

It also means that consumers of the RPC have to import the `blockchain` module solely to access those constants.  Not only does that mean an extremely heavy dependency is required just to access those constants, the module is eventually going to be removed in favor of making the `blockchain` package an internal package meaning clients will no longer have access to it.

Consequently, this makes the following changes to improve the situation:

- Adds constants for the possible status strings in the agenda info that is a part of the `getblockchaininfo` result to the `rpc/jsonrpc/types` module
- Updates the `getblockchaininfo` RPC implementation to decouple the agenda status strings by converting the internal `blockchain` threshold state to use the new agenda status string constants defined in the `rpc/jsonrpc/types` module
