### PR TITLE
server: Remove unnecessary vote ntfn check.

### DIFF
--- a/server.go
+++ b/server.go
@@ -2578,7 +2578,6 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 		//   voting begins
 		// - The block that would build on this one would not cause a reorg
 		//   larger than the max reorg notify depth
-		// - This block is after the final checkpoint height
 		// - A notification for this block has not already been sent
 		//
 		// To help visualize the math here, consider the following two competing
@@ -2610,7 +2609,6 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 		if s.rpcServer != nil &&
 			blockHeight >= s.chainParams.StakeValidationHeight-1 &&
 			reorgDepth < maxReorgDepthNotify &&
-			blockHeight > s.chainParams.LatestCheckpointHeight() &&
 			!isOldMainnetBlock &&
 			!s.notifiedWinningTickets(blockHash) {
 


### PR DESCRIPTION
This removes the check for whether or not the block height is after the height of the final checkpoint when deciding whether to send a vote notification since it is no longer necessary or has any effect.

The reason it no longer has any effect is because there is a check prior to it that ensures the the chain is considered current and the more recent headers-first syncing means the chain will not be considered current until the block associated with the best known header is reached which is always ahead of any checkpoint.