### PR TITLE
blockchain: Optimize stake node pruning.

### DIFF
--- a/blockchain/blockindex.go
+++ b/blockchain/blockindex.go
@@ -1069,6 +1069,23 @@ func (bi *blockIndex) maybeUpdateBestHeaderForTip(tip *blockNode) {
 	}
 }
 
+// BestHeader returns the header with the most cumulative work that is NOT known
+// to be invalid.  This is not necessarily the same as the active best chain,
+// especially when block data is not yet known.  However, since block nodes are
+// only added to the index for block headers that pass all sanity and positional
+// checks, which include checking proof of work, it does represent the tip of
+// the header chain with the highest known work that has a reasonably high
+// chance of becoming the best chain tip and is useful for things such as
+// reporting progress and discovering the most suitable blocks to download.
+//
+// This function is safe for concurrent access.
+func (bi *blockIndex) BestHeader() *blockNode {
+	bi.RLock()
+	bestHeader := bi.bestHeader
+	bi.RUnlock()
+	return bestHeader
+}
+
 // MarkBlockFailedValidation marks the passed node as having failed validation
 // and then marks all of its descendants (if any) as having a failed ancestor.
 //

--- a/blockchain/blockindex.go
+++ b/blockchain/blockindex.go
@@ -1362,9 +1362,11 @@ func (bi *blockIndex) FindBestChainCandidate() *blockNode {
 	return bestCandidate
 }
 
-// flush writes all of the modified block nodes to the database and clears the
+// Flush writes all of the modified block nodes to the database and clears the
 // set of modified nodes if it succeeds.
-func (bi *blockIndex) flush() error {
+//
+// This function is safe for concurrent access.
+func (bi *blockIndex) Flush() error {
 	// Nothing to flush if there are no modified nodes.
 	bi.Lock()
 	if len(bi.modified) == 0 {

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1531,7 +1531,7 @@ func (b *BlockChain) flushBlockIndex() error {
 			return err
 		}
 	}
-	return b.index.flush()
+	return b.index.Flush()
 }
 
 // flushBlockIndexWarnOnly attempts to flush any modified block index nodes to

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1578,9 +1578,7 @@ func (b *BlockChain) maybeUpdateIsCurrent(curBest *blockNode) {
 
 		// Not current if the best block is not synced to the header with the
 		// most cumulative work that is not known to be invalid.
-		b.index.RLock()
-		bestHeader := b.index.bestHeader
-		b.index.RUnlock()
+		bestHeader := b.index.BestHeader()
 		syncedToBestHeader := curBest.height == bestHeader.height ||
 			bestHeader.IsAncestorOf(curBest)
 		if !syncedToBestHeader {
@@ -2412,9 +2410,7 @@ func New(ctx context.Context, config *Config) (*BlockChain, error) {
 	log.Infof("UTXO database version info: version: %d, compression: %d, utxo "+
 		"set: %d", utxoDbInfo.version, utxoDbInfo.compVer, utxoDbInfo.utxoVer)
 
-	b.index.RLock()
-	bestHdr := b.index.bestHeader
-	b.index.RUnlock()
+	bestHdr := b.index.BestHeader()
 	log.Infof("Best known header: height %d, hash %v", bestHdr.height,
 		bestHdr.hash)
 

--- a/blockchain/chainquery.go
+++ b/blockchain/chainquery.go
@@ -141,9 +141,7 @@ func (b *BlockChain) ChainTips() []ChainTipInfo {
 //
 // This function is safe for concurrent access.
 func (b *BlockChain) BestHeader() (chainhash.Hash, int64) {
-	b.index.RLock()
-	header := b.index.bestHeader
-	b.index.RUnlock()
+	header := b.index.BestHeader()
 	return header.hash, header.height
 }
 
@@ -244,9 +242,7 @@ func (b *BlockChain) PutNextNeededBlocks(out []chainhash.Hash) []chainhash.Hash 
 //
 // This function is safe for concurrent access.
 func (b *BlockChain) VerifyProgress() float64 {
-	b.index.RLock()
-	bestHdr := b.index.bestHeader
-	b.index.RUnlock()
+	bestHdr := b.index.BestHeader()
 	if bestHdr.height == 0 {
 		return 0.0
 	}

--- a/blockchain/process.go
+++ b/blockchain/process.go
@@ -89,9 +89,7 @@ func (b *BlockChain) isAssumeValidAncestor(node *blockNode) bool {
 	}
 
 	// Return false if the node is not an ancestor of the best header.
-	b.index.RLock()
-	bestHeader := b.index.bestHeader
-	b.index.RUnlock()
+	bestHeader := b.index.BestHeader()
 	if !node.IsAncestorOf(bestHeader) {
 		return false
 	}


### PR DESCRIPTION
This optimizes the logic that prunes stake nodes when connecting blocks to make use of the best known header instead of the latest known checkpoint.

While here, it also adds an exported method to the block index to retrieve the best header node under the block index mutex and updates the various call sites that do it manually to use the newly exported function instead as well as exports the block index flush function to make it more consistent with the other funcs that are safe for concurrent access.
