### PR TITLE
blockchain: Fix revocation fee limit bug.

### DIFF
--- a/blockchain/stake/staketx.go
+++ b/blockchain/stake/staketx.go
@@ -126,6 +126,11 @@ const (
 	// is set.
 	SStxRevReturnFractionMask = 0x3f00
 
+	// SStxRevReturnFractionShift is the number of bits to shift to the right
+	// to yield the correct value after applying the SStxRevReturnFractionMask
+	// bitmask with AND.
+	SStxRevReturnFractionShift = 8
+
 	// SStxVoteFractionFlag is a bitflag mask specifying whether or not to
 	// apply a fractional limit to the amount used for fees in a vote.
 	// 00000000 00000000 = No fees allowed
@@ -384,7 +389,7 @@ func SStxStakeOutputInfo(outs []*MinimalOutput) ([]bool, [][]byte, []int64,
 			// This is the fraction to use out of 64.
 			spendLimits[0] = feeLimitUint16 & SStxVoteReturnFractionMask
 			spendLimits[1] = feeLimitUint16 & SStxRevReturnFractionMask
-			spendLimits[1] >>= 8
+			spendLimits[1] >>= SStxRevReturnFractionShift
 			allSpendLimits[idx/2] = spendLimits
 		}
 

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -2461,11 +2461,13 @@ func checkTicketRedeemerCommitments(ticketHash *chainhash.Hash,
 	reqStakeOpcode := byte(txscript.OP_SSGEN)
 	hasFeeLimitFlag := uint16(stake.SStxVoteFractionFlag)
 	feeLimitMask := uint16(stake.SStxVoteReturnFractionMask)
+	var feeLimitShift uint16
 	if !isVote {
 		startIdx = 0
 		reqStakeOpcode = txscript.OP_SSRTX
 		hasFeeLimitFlag = stake.SStxRevFractionFlag
 		feeLimitMask = stake.SStxRevReturnFractionMask
+		feeLimitShift = stake.SStxRevReturnFractionShift
 	}
 	ticketPaidAmt := ticketOuts[submissionOutputIdx].Value
 
@@ -2577,7 +2579,7 @@ func checkTicketRedeemerCommitments(ticketHash *chainhash.Hash,
 			// limit while preventing degenerate cases such as negative numbers
 			// for 63.
 			var amtLimitLow int64
-			feeLimitLog2 := feeLimitsEncoded & feeLimitMask
+			feeLimitLog2 := (feeLimitsEncoded & feeLimitMask) >> feeLimitShift
 			if feeLimitLog2 < 63 {
 				feeLimit := int64(1 << uint64(feeLimitLog2))
 				if feeLimit < expectedOutAmt {


### PR DESCRIPTION
This retroactively fixes a bug that resulted in the fee limit not being properly enforced for revocation transactions.  The exploitation risk of this was that in a split transaction, one party could intentionally increase the fee paid to miners for another party.

It is no longer possible to exploit this on `mainnet` since the automatic revocations agenda has activated, which enforces that the fee must be zero for revocation transactions.

The fee limit for revocation transactions was never violated on `mainnet`, so this logic can be safely corrected without impacting consensus.  This has been validated by running a full sync with checkpoints and assume valid disabled.