### PR TITLE
standalone: Add transaction sanity check.

### DIFF
--- a/blockchain/standalone/README.md
+++ b/blockchain/standalone/README.md
@@ -34,6 +34,10 @@ The provided functions fall into the following categories:
   - Stake vote subsidy for a given height
   - Treasury subsidy for a given height and number of votes
 - Coinbase transaction identification
+ - Merkle tree inclusion proofs
+   - Generate an inclusion proof for a given tree and leaf index
+   - Verify a leaf is a member of the tree at a given index via the proof
+- Transaction sanity checking
 
 ## Installation and Updating
 

--- a/blockchain/standalone/doc.go
+++ b/blockchain/standalone/doc.go
@@ -35,6 +35,7 @@ The provided functions fall into the following categories:
  - Merkle tree inclusion proofs
    - Generate an inclusion proof for a given tree and leaf index
    - Verify a leaf is a member of the tree at a given index via the proof
+- Transaction sanity checking
 
 Errors
 

--- a/blockchain/standalone/error.go
+++ b/blockchain/standalone/error.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 The Decred developers
+// Copyright (c) 2019-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -23,6 +23,26 @@ const (
 	// ErrInvalidTSpendExpiry indicates that an invalid expiry was
 	// provided when calculating the treasury spend voting window.
 	ErrInvalidTSpendExpiry = ErrorKind("ErrInvalidTSpendExpiry")
+
+	// ErrNoTxInputs indicates a transaction does not have any inputs.  A valid
+	// transaction must have at least one input.
+	ErrNoTxInputs = ErrorKind("ErrNoTxInputs")
+
+	// ErrNoTxOutputs indicates a transaction does not have any outputs.  A
+	// valid transaction must have at least one output.
+	ErrNoTxOutputs = ErrorKind("ErrNoTxOutputs")
+
+	// ErrTxTooBig indicates a transaction exceeds the maximum allowed size when
+	// serialized.
+	ErrTxTooBig = ErrorKind("ErrTxTooBig")
+
+	// ErrBadTxOutValue indicates an output value for a transaction is
+	// invalid in some way such as being out of range.
+	ErrBadTxOutValue = ErrorKind("ErrBadTxOutValue")
+
+	// ErrDuplicateTxInputs indicates a transaction references the same
+	// input more than once.
+	ErrDuplicateTxInputs = ErrorKind("ErrDuplicateTxInputs")
 )
 
 // Error satisfies the error interface and prints human-readable errors.

--- a/blockchain/standalone/error_test.go
+++ b/blockchain/standalone/error_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021 The Decred developers
+// Copyright (c) 2019-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -19,6 +19,11 @@ func TestErrorKindStringer(t *testing.T) {
 		{ErrUnexpectedDifficulty, "ErrUnexpectedDifficulty"},
 		{ErrHighHash, "ErrHighHash"},
 		{ErrInvalidTSpendExpiry, "ErrInvalidTSpendExpiry"},
+		{ErrNoTxInputs, "ErrNoTxInputs"},
+		{ErrNoTxOutputs, "ErrNoTxOutputs"},
+		{ErrTxTooBig, "ErrTxTooBig"},
+		{ErrBadTxOutValue, "ErrBadTxOutValue"},
+		{ErrDuplicateTxInputs, "ErrDuplicateTxInputs"},
 	}
 
 	t.Logf("Running %d tests", len(tests))

--- a/blockchain/standalone/tx.go
+++ b/blockchain/standalone/tx.go
@@ -1,11 +1,12 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package standalone
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
@@ -21,6 +22,16 @@ const (
 	opTAdd   = 0xc1
 	opTSpend = 0xc2
 	opTGen   = 0xc3
+
+	// These constants are defined here to avoid a dependency on dcrutil.  They
+	// are used in consensus code which can't be changed without a vote anyway,
+	// so not referring to them directly via dcrutil is safe.
+	//
+	// atomsPerCoin is the number of atoms in one coin.
+	//
+	// maxAtoms is the maximum transaction amount allowed in atoms.
+	atomsPerCoin = 1e8
+	maxAtoms     = 21e6 * atomsPerCoin
 )
 
 var (
@@ -129,4 +140,74 @@ func IsTreasuryBase(tx *wire.MsgTx) bool {
 	}
 
 	return isNullOutpoint(tx)
+}
+
+// CheckTransactionSanity performs some preliminary checks on a transaction to
+// ensure it is sane.  These checks are context free.
+func CheckTransactionSanity(tx *wire.MsgTx, maxTxSize uint64) error {
+	// A transaction must have at least one input.
+	if len(tx.TxIn) == 0 {
+		return ruleError(ErrNoTxInputs, "transaction has no inputs")
+	}
+
+	// A transaction must have at least one output.
+	if len(tx.TxOut) == 0 {
+		return ruleError(ErrNoTxOutputs, "transaction has no outputs")
+	}
+
+	// A transaction must not exceed the maximum allowed size when serialized.
+	serializedTxSize := uint64(tx.SerializeSize())
+	if serializedTxSize > maxTxSize {
+		str := fmt.Sprintf("serialized transaction is too big - got %d, max %d",
+			serializedTxSize, maxTxSize)
+		return ruleError(ErrTxTooBig, str)
+	}
+
+	// Ensure the transaction amounts are in range.  Each transaction output
+	// must not be negative or more than the max allowed per transaction.  Also,
+	// the total of all outputs must abide by the same restrictions.  All
+	// amounts in a transaction are in a unit value known as an atom.  One
+	// Decred is a quantity of atoms as defined by the AtomsPerCoin constant.
+	var totalAtoms int64
+	for _, txOut := range tx.TxOut {
+		atoms := txOut.Value
+		if atoms < 0 {
+			str := fmt.Sprintf("transaction output has negative value of %v",
+				atoms)
+			return ruleError(ErrBadTxOutValue, str)
+		}
+		if atoms > maxAtoms {
+			str := fmt.Sprintf("transaction output value of %v is higher than "+
+				"max allowed value of %v", atoms, maxAtoms)
+			return ruleError(ErrBadTxOutValue, str)
+		}
+
+		// Two's complement int64 overflow guarantees that any overflow is
+		// detected and reported.  This is impossible for Decred, but perhaps
+		// possible if an alt increases the total money supply.
+		totalAtoms += atoms
+		if totalAtoms < 0 {
+			str := fmt.Sprintf("total value of all transaction outputs "+
+				"exceeds max allowed value of %v", maxAtoms)
+			return ruleError(ErrBadTxOutValue, str)
+		}
+		if totalAtoms > maxAtoms {
+			str := fmt.Sprintf("total value of all transaction outputs is %v "+
+				"which is higher than max allowed value of %v", totalAtoms,
+				maxAtoms)
+			return ruleError(ErrBadTxOutValue, str)
+		}
+	}
+
+	// Check for duplicate transaction inputs.
+	existingTxOut := make(map[wire.OutPoint]struct{})
+	for _, txIn := range tx.TxIn {
+		if _, exists := existingTxOut[txIn.PreviousOutPoint]; exists {
+			str := "transaction contains duplicate inputs"
+			return ruleError(ErrDuplicateTxInputs, str)
+		}
+		existingTxOut[txIn.PreviousOutPoint] = struct{}{}
+	}
+
+	return nil
 }


### PR DESCRIPTION
This adds a new exported function to the `blockchain/standalone` module named `CheckTransactionSanity` which can be used to perform basic transaction sanity checks.

It also updates the documentation and includes comprehensive tests.

The primary motivation for this change is that there are several consumers that currently make use of this functionality and it lives in the `blockchain` package which is slated to made internal and therefore would otherwise become inaccessible to external consumers.

Another nice benefit of making this logic available via the `blockchain/standalone` module is that it intentionally requires way less
dependencies which is ideal for consumers.