### PR TITLE
fullblocktests: Decouple from blockchain.

### DIFF
--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -76,10 +76,6 @@ const (
 	// the current time.
 	ErrTimeTooNew = ErrorKind("ErrTimeTooNew")
 
-	// ErrDifficultyTooLow indicates the difficulty for the block is lower
-	// than the difficulty required by the most recent checkpoint.
-	ErrDifficultyTooLow = ErrorKind("ErrDifficultyTooLow")
-
 	// ErrUnexpectedDifficulty indicates specified bits do not align with
 	// the expected value either because it doesn't match the calculated
 	// value based on difficulty regarding the rules or it is out of the

--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -57,7 +57,7 @@ const (
 	// to a newer version.
 	ErrBlockVersionTooOld = ErrorKind("ErrBlockVersionTooOld")
 
-	// ErrBadStakeVersionindicates the block version is too old and is no
+	// ErrBadStakeVersion indicates the block version is too old and is no
 	// longer accepted since the majority of the network has upgraded to a
 	// newer version.
 	ErrBadStakeVersion = ErrorKind("ErrBadStakeVersion")
@@ -102,9 +102,8 @@ const (
 	// before the fork rejection checkpoint.
 	ErrForkTooOld = ErrorKind("ErrForkTooOld")
 
-	// ErrNoTransactions indicates the block does not have a least one
-	// transaction.  A valid block must have at least the coinbase
-	// transaction.
+	// ErrNoTransactions indicates the block does not have at least one
+	// transaction.  A valid block must have at least the coinbase transaction.
 	ErrNoTransactions = ErrorKind("ErrNoTransactions")
 
 	// ErrNoTxInputs indicates a transaction does not have any inputs.  A
@@ -231,10 +230,10 @@ const (
 	// length or fail to parse.
 	ErrScriptMalformed = ErrorKind("ErrScriptMalformed")
 
-	// ErrScriptValidation indicates the result of executing transaction
+	// ErrScriptValidation indicates the result of executing a transaction
 	// script failed.  The error covers any failure when executing scripts
-	// such signature verification failures and execution past the end of
-	// the stack.
+	// such as signature verification failures and execution past the end
+	// of the stack.
 	ErrScriptValidation = ErrorKind("ErrScriptValidation")
 
 	// ErrNotEnoughStake indicates that there was for some SStx in a given block,
@@ -274,8 +273,8 @@ const (
 	// that could not be found.
 	ErrTicketUnavailable = ErrorKind("ErrTicketUnavailable")
 
-	// ErrVotesOnWrongBlock indicates that an SSGen voted on a block not the
-	// block's parent, and so was ineligible for inclusion into that block.
+	// ErrVotesOnWrongBlock indicates that an SSGen voted on a block that is not
+	// the block's parent, and so was ineligible for inclusion into that block.
 	ErrVotesOnWrongBlock = ErrorKind("ErrVotesOnWrongBlock")
 
 	// ErrVotesMismatch indicates that the number of SSGen in the block was not
@@ -392,12 +391,12 @@ const (
 	// was different from where it was actually embedded in the block chain.
 	ErrBadBlockHeight = ErrorKind("ErrBadBlockHeight")
 
-	// ErrBlockOneTx indicates that block height 1 failed to correct generate
+	// ErrBlockOneTx indicates that block height 1 failed to correctly generate
 	// the block one initial payout transaction.
 	ErrBlockOneTx = ErrorKind("ErrBlockOneTx")
 
-	// ErrBlockOneTx indicates that block height 1 coinbase transaction in
-	// zero was incorrect in some way.
+	// ErrBlockOneInputs indicates that block height 1 coinbase transaction
+	// input zero was incorrect in some way.
 	ErrBlockOneInputs = ErrorKind("ErrBlockOneInputs")
 
 	// ErrBlockOneOutputs indicates that block height 1 failed to incorporate

--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -399,9 +399,10 @@ const (
 	// the ledger addresses correctly into the transaction's outputs.
 	ErrBlockOneOutputs = ErrorKind("ErrBlockOneOutputs")
 
-	// ErrNoTax indicates that there was no tax present in the coinbase of a
-	// block after height 1.
-	ErrNoTax = ErrorKind("ErrNoTax")
+	// ErrNoTreasury indicates that there was no treasury payout present in the
+	// coinbase of a block after height 1 and prior to the activation of the
+	// decentralized treasury.
+	ErrNoTreasury = ErrorKind("ErrNoTreasury")
 
 	// ErrExpiredTx indicates that the transaction is currently expired.
 	ErrExpiredTx = ErrorKind("ErrExpiredTx")

--- a/blockchain/error_test.go
+++ b/blockchain/error_test.go
@@ -104,7 +104,7 @@ func TestErrorKindStringer(t *testing.T) {
 		{ErrBlockOneTx, "ErrBlockOneTx"},
 		{ErrBlockOneInputs, "ErrBlockOneInputs"},
 		{ErrBlockOneOutputs, "ErrBlockOneOutputs"},
-		{ErrNoTax, "ErrNoTax"},
+		{ErrNoTreasury, "ErrNoTreasury"},
 		{ErrExpiredTx, "ErrExpiredTx"},
 		{ErrExpiryTxSpentEarly, "ErrExpiryTxSpentEarly"},
 		{ErrFraudAmountIn, "ErrFraudAmountIn"},

--- a/blockchain/error_test.go
+++ b/blockchain/error_test.go
@@ -27,7 +27,6 @@ func TestErrorKindStringer(t *testing.T) {
 		{ErrInvalidTime, "ErrInvalidTime"},
 		{ErrTimeTooOld, "ErrTimeTooOld"},
 		{ErrTimeTooNew, "ErrTimeTooNew"},
-		{ErrDifficultyTooLow, "ErrDifficultyTooLow"},
 		{ErrUnexpectedDifficulty, "ErrUnexpectedDifficulty"},
 		{ErrHighHash, "ErrHighHash"},
 		{ErrBadMerkleRoot, "ErrBadMerkleRoot"},

--- a/blockchain/fullblocktests/README.md
+++ b/blockchain/fullblocktests/README.md
@@ -3,7 +3,7 @@ fullblocktests
 
 [![Build Status](https://github.com/decred/dcrd/workflows/Build%20and%20Test/badge.svg)](https://github.com/decred/dcrd/actions)
 [![ISC License](https://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![Doc](https://img.shields.io/badge/doc-reference-blue.svg)](https://pkg.go.dev/github.com/decred/dcrd/blockchain/v3/fullblocktests)
+[![Doc](https://img.shields.io/badge/doc-reference-blue.svg)](https://pkg.go.dev/github.com/decred/dcrd/blockchain/v4/fullblocktests)
 
 Package fullblocktests provides a set of full block tests to be used for testing
 the consensus validation rules.  The tests are intended to be flexible enough to
@@ -19,7 +19,7 @@ of blocks that exercise the consensus validation rules.
 
 ## Installation and Updating
 
-This package is part of the `github.com/decred/dcrd/blockchain/v3` module.  Use
+This package is part of the `github.com/decred/dcrd/blockchain/v4` module.  Use
 the standard go tooling for working with modules to incorporate it.
 
 ## License

--- a/blockchain/fullblocktests/error.go
+++ b/blockchain/fullblocktests/error.go
@@ -1,0 +1,309 @@
+// Copyright (c) 2022 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package fullblocktests
+
+// ErrorKind identifies a kind of error.  It has full support for errors.Is and
+// errors.As, so the caller can directly check against an error kind when
+// determining the reason for an error.
+type ErrorKind string
+
+// These constants are used to identify a specific ErrorKind.
+const (
+	// ErrDuplicateBlock indicates a block with the same hash already exists.
+	ErrDuplicateBlock = ErrorKind("ErrDuplicateBlock")
+
+	// ErrBlockTooBig indicates the serialized block size exceeds the maximum
+	// allowed size.
+	ErrBlockTooBig = ErrorKind("ErrBlockTooBig")
+
+	// ErrWrongBlockSize indicates that the block size in the header is not the
+	// actual serialized size of the block.
+	ErrWrongBlockSize = ErrorKind("ErrWrongBlockSize")
+
+	// ErrInvalidTime indicates the time in the passed block has a precision
+	// that is more than one second.  The chain consensus rules require
+	// timestamps to have a maximum precision of one second.
+	ErrInvalidTime = ErrorKind("ErrInvalidTime")
+
+	// ErrTimeTooOld indicates the time is either before the median time of the
+	// last several blocks per the chain consensus rules or prior to the most
+	// recent checkpoint.
+	ErrTimeTooOld = ErrorKind("ErrTimeTooOld")
+
+	// ErrTimeTooNew indicates the time is too far in the future as compared the
+	// current time.
+	ErrTimeTooNew = ErrorKind("ErrTimeTooNew")
+
+	// ErrUnexpectedDifficulty indicates specified bits do not align with the
+	// expected value either because it doesn't match the calculated value based
+	// on difficulty regarding the rules or it is out of the valid range.
+	ErrUnexpectedDifficulty = ErrorKind("ErrUnexpectedDifficulty")
+
+	// ErrHighHash indicates the block does not hash to a value which is lower
+	// than the required target difficultly.
+	ErrHighHash = ErrorKind("ErrHighHash")
+
+	// ErrBadMerkleRoot indicates the calculated merkle root does not match the
+	// expected value.
+	ErrBadMerkleRoot = ErrorKind("ErrBadMerkleRoot")
+
+	// ErrNoTransactions indicates the block does not have at least one
+	// transaction.  A valid block must have at least the coinbase transaction.
+	ErrNoTransactions = ErrorKind("ErrNoTransactions")
+
+	// ErrNoTxInputs indicates a transaction does not have any inputs.  A valid
+	// transaction must have at least one input.
+	ErrNoTxInputs = ErrorKind("ErrNoTxInputs")
+
+	// ErrNoTxOutputs indicates a transaction does not have any outputs.  A
+	// valid transaction must have at least one output.
+	ErrNoTxOutputs = ErrorKind("ErrNoTxOutputs")
+
+	// ErrBadTxOutValue indicates an output value for a transaction is invalid
+	// in some way such as being out of range.
+	ErrBadTxOutValue = ErrorKind("ErrBadTxOutValue")
+
+	// ErrDuplicateTxInputs indicates a transaction references the same input
+	// more than once.
+	ErrDuplicateTxInputs = ErrorKind("ErrDuplicateTxInputs")
+
+	// ErrBadTxInput indicates a transaction input is invalid in some way such
+	// as referencing a previous transaction outpoint which is out of range or
+	// not referencing one at all.
+	ErrBadTxInput = ErrorKind("ErrBadTxInput")
+
+	// ErrMissingTxOut indicates a transaction output referenced by an input
+	// either does not exist or has already been spent.
+	ErrMissingTxOut = ErrorKind("ErrMissingTxOut")
+
+	// ErrUnfinalizedTx indicates a transaction has not been finalized.  A valid
+	// block may only contain finalized transactions.
+	ErrUnfinalizedTx = ErrorKind("ErrUnfinalizedTx")
+
+	// ErrDuplicateTx indicates a block contains an identical transaction (or at
+	// least two transactions which hash to the same value).  A valid block may
+	// only contain unique transactions.
+	ErrDuplicateTx = ErrorKind("ErrDuplicateTx")
+
+	// ErrImmatureSpend indicates a transaction is attempting to spend a
+	// coinbase that has not yet reached the required maturity.
+	ErrImmatureSpend = ErrorKind("ErrImmatureSpend")
+
+	// ErrSpendTooHigh indicates a transaction is attempting to spend more value
+	// than the sum of all of its inputs.
+	ErrSpendTooHigh = ErrorKind("ErrSpendTooHigh")
+
+	// ErrTooManySigOps indicates the total number of signature operations for a
+	// transaction or block exceed the maximum allowed limits.
+	ErrTooManySigOps = ErrorKind("ErrTooManySigOps")
+
+	// ErrFirstTxNotCoinbase indicates the first transaction in a block is not a
+	// coinbase transaction.
+	ErrFirstTxNotCoinbase = ErrorKind("ErrFirstTxNotCoinbase")
+
+	// ErrCoinbaseHeight indicates that the encoded height in the coinbase is
+	// incorrect.
+	ErrCoinbaseHeight = ErrorKind("ErrCoinbaseHeight")
+
+	// ErrMultipleCoinbases indicates a block contains more than one coinbase
+	// transaction.
+	ErrMultipleCoinbases = ErrorKind("ErrMultipleCoinbases")
+
+	// ErrStakeTxInRegularTree indicates a stake transaction was found in the
+	// regular transaction tree.
+	ErrStakeTxInRegularTree = ErrorKind("ErrStakeTxInRegularTree")
+
+	// ErrRegTxInStakeTree indicates that a regular transaction was found in the
+	// stake transaction tree.
+	ErrRegTxInStakeTree = ErrorKind("ErrRegTxInStakeTree")
+
+	// ErrBadCoinbaseScriptLen indicates the length of the signature script for
+	// a coinbase transaction is not within the valid range.
+	ErrBadCoinbaseScriptLen = ErrorKind("ErrBadCoinbaseScriptLen")
+
+	// ErrBadCoinbaseValue indicates the amount of a coinbase value does not
+	// match the expected value of the subsidy plus the sum of all fees.
+	ErrBadCoinbaseValue = ErrorKind("ErrBadCoinbaseValue")
+
+	// ErrBadCoinbaseFraudProof indicates that the fraud proof for a coinbase
+	// input was non-null.
+	ErrBadCoinbaseFraudProof = ErrorKind("ErrBadCoinbaseFraudProof")
+
+	// ErrBadCoinbaseAmountIn indicates that the AmountIn (=subsidy) for a
+	// coinbase input was incorrect.
+	ErrBadCoinbaseAmountIn = ErrorKind("ErrBadCoinbaseAmountIn")
+
+	// ErrBadStakebaseAmountIn indicates that the AmountIn (=subsidy) for a
+	// stakebase input was incorrect.
+	ErrBadStakebaseAmountIn = ErrorKind("ErrBadStakebaseAmountIn")
+
+	// ErrBadStakebaseScriptLen indicates the length of the signature script for
+	// a stakebase transaction is not within the valid range.
+	ErrBadStakebaseScriptLen = ErrorKind("ErrBadStakebaseScriptLen")
+
+	// ErrBadStakebaseScrVal indicates the signature script for a stakebase
+	// transaction was not set to the network consensus value.
+	ErrBadStakebaseScrVal = ErrorKind("ErrBadStakebaseScrVal")
+
+	// ErrScriptMalformed indicates a transaction script is malformed in some
+	// way.  For example, it might be longer than the maximum allowed length or
+	// fail to parse.
+	ErrScriptMalformed = ErrorKind("ErrScriptMalformed")
+
+	// ErrScriptValidation indicates the result of executing a transaction
+	// script failed.  The error covers any failure when executing scripts such
+	// as signature verification failures and execution past the end of the
+	// stack.
+	ErrScriptValidation = ErrorKind("ErrScriptValidation")
+
+	// ErrNotEnoughStake indicates that there was for some SStx in a given
+	// block, the given SStx did not have enough stake to meet the network
+	// target.
+	ErrNotEnoughStake = ErrorKind("ErrNotEnoughStake")
+
+	// ErrStakeBelowMinimum indicates that for some SStx in a given block, the
+	// given SStx had an amount of stake below the minimum network target.
+	ErrStakeBelowMinimum = ErrorKind("ErrStakeBelowMinimum")
+
+	// ErrNotEnoughVotes indicates that a block contained less than a majority
+	// of voters.
+	ErrNotEnoughVotes = ErrorKind("ErrNotEnoughVotes")
+
+	// ErrTooManyVotes indicates that a block contained more than the maximum
+	// allowable number of votes.
+	ErrTooManyVotes = ErrorKind("ErrTooManyVotes")
+
+	// ErrFreshStakeMismatch indicates that a block's header contained a
+	// different number of SStx as compared to what was found in the block.
+	ErrFreshStakeMismatch = ErrorKind("ErrFreshStakeMismatch")
+
+	// ErrInvalidEarlyStakeTx indicates that a tx type other than SStx was found
+	// in the stake tx tree before the period when stake validation begins, or
+	// before the stake tx type could possibly be included in the block.
+	ErrInvalidEarlyStakeTx = ErrorKind("ErrInvalidEarlyStakeTx")
+
+	// ErrTicketUnavailable indicates that a vote in the block spent a ticket
+	// that could not be found.
+	ErrTicketUnavailable = ErrorKind("ErrTicketUnavailable")
+
+	// ErrVotesOnWrongBlock indicates that an SSGen voted on a block that is not
+	// the block's parent, and so was ineligible for inclusion into that block.
+	ErrVotesOnWrongBlock = ErrorKind("ErrVotesOnWrongBlock")
+
+	// ErrVotesMismatch indicates that the number of SSGen in the block was not
+	// equivalent to the number of votes provided in the block header.
+	ErrVotesMismatch = ErrorKind("ErrVotesMismatch")
+
+	// ErrIncongruentVotebit indicates that the first votebit in votebits was
+	// not the same as that determined by the majority of voters in the SSGen tx
+	// included in the block.
+	ErrIncongruentVotebit = ErrorKind("ErrIncongruentVotebit")
+
+	// ErrInvalidSSRtx indicates than an SSRtx in a block could not be found to
+	// have a valid missed sstx input as per the stake ticket database.
+	ErrInvalidSSRtx = ErrorKind("ErrInvalidSSRtx")
+
+	// ErrInvalidRevNum indicates that the number of revocations from the header
+	// was not the same as the number of SSRtx included in the block.
+	ErrRevocationsMismatch = ErrorKind("ErrRevocationsMismatch")
+
+	// ErrTicketCommitment indicates that a ticket commitment contains an amount
+	// that does not coincide with the associated ticket input amount.
+	ErrTicketCommitment = ErrorKind("ErrTicketCommitment")
+
+	// ErrBadNumPayees indicates that either a vote or revocation transaction
+	// does not make the correct number of payments per the associated ticket
+	// commitments.
+	ErrBadNumPayees = ErrorKind("ErrBadNumPayees")
+
+	// ErrBadPayeeScriptType indicates that either a vote or revocation
+	// transaction output that corresponds to a ticket commitment does not pay
+	// to the hash required by the commitment.
+	ErrMismatchedPayeeHash = ErrorKind("ErrMismatchedPayeeHash")
+
+	// ErrBadPayeeValue indicates that either a vote or revocation transaction
+	// output that corresponds to a ticket commitment does not pay the expected
+	// amount required by the commitment.
+	ErrBadPayeeValue = ErrorKind("ErrBadPayeeValue")
+
+	// ErrTxSStxOutSpend indicates that a non SSGen or SSRtx tx attempted to
+	// spend an OP_SSTX tagged output from an SStx.
+	ErrTxSStxOutSpend = ErrorKind("ErrTxSStxOutSpend")
+
+	// ErrRegTxCreateStakeOut indicates that a regular tx attempted to create a
+	// stake tagged output.
+	ErrRegTxCreateStakeOut = ErrorKind("ErrRegTxCreateStakeOut")
+
+	// ErrInvalidFinalState indicates that the final state of the PRNG included
+	// in the block differed from the calculated final state.
+	ErrInvalidFinalState = ErrorKind("ErrInvalidFinalState")
+
+	// ErrPoolSize indicates an error in the ticket pool size for this block.
+	ErrPoolSize = ErrorKind("ErrPoolSize")
+
+	// ErrBadBlockHeight indicates that a block header's embedded block height
+	// was different from where it was actually embedded in the block chain.
+	ErrBadBlockHeight = ErrorKind("ErrBadBlockHeight")
+
+	// ErrBlockOneOutputs indicates that block height 1 failed to incorporate
+	// the ledger addresses correctly into the transaction's outputs.
+	ErrBlockOneOutputs = ErrorKind("ErrBlockOneOutputs")
+
+	// ErrNoTreasury indicates that there was no treasury payout present in the
+	// coinbase of a block after height 1 and prior to the activation of the
+	// decentralized treasury.
+	ErrNoTreasury = ErrorKind("ErrNoTreasury")
+
+	// ErrExpiredTx indicates that the transaction is currently expired.
+	ErrExpiredTx = ErrorKind("ErrExpiredTx")
+
+	// ErrFraudAmountIn indicates the witness amount given was fraudulent.
+	ErrFraudAmountIn = ErrorKind("ErrFraudAmountIn")
+
+	// ErrFraudBlockHeight indicates the witness block height given was
+	// fraudulent.
+	ErrFraudBlockHeight = ErrorKind("ErrFraudBlockHeight")
+
+	// ErrFraudBlockIndex indicates the witness block index given was
+	// fraudulent.
+	ErrFraudBlockIndex = ErrorKind("ErrFraudBlockIndex")
+
+	// ErrInvalidEarlyVoteBits indicates that a block before stake validation
+	// height had an unallowed vote bits value.
+	ErrInvalidEarlyVoteBits = ErrorKind("ErrInvalidEarlyVoteBits")
+
+	// ErrInvalidEarlyFinalState indicates that a block before stake validation
+	// height had a non-zero final state.
+	ErrInvalidEarlyFinalState = ErrorKind("ErrInvalidEarlyFinalState")
+)
+
+// Error satisfies the error interface and prints human-readable errors.
+func (e ErrorKind) Error() string {
+	return string(e)
+}
+
+// RuleError identifies a rule violation.  It is used to indicate that
+// processing of a block or transaction failed due to one of the many validation
+// rules.  It has full support for errors.Is and errors.As, so the caller can
+// ascertain the specific reason for the rule violation.
+type RuleError struct {
+	Err         error
+	Description string
+}
+
+// Error satisfies the error interface and prints human-readable errors.
+func (e RuleError) Error() string {
+	return e.Description
+}
+
+// Unwrap returns the underlying wrapped error.
+func (e RuleError) Unwrap() error {
+	return e.Err
+}
+
+// ruleError creates a RuleError given a set of arguments.
+func ruleError(kind ErrorKind, desc string) RuleError {
+	return RuleError{Err: kind, Description: desc}
+}

--- a/blockchain/fullblocktests/error_test.go
+++ b/blockchain/fullblocktests/error_test.go
@@ -1,0 +1,197 @@
+// Copyright (c) 2022 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package fullblocktests
+
+import (
+	"errors"
+	"io"
+	"testing"
+)
+
+// TestErrorKindStringer tests the stringized output for the ErrorKind type.
+func TestErrorKindStringer(t *testing.T) {
+	tests := []struct {
+		in   ErrorKind
+		want string
+	}{
+		{ErrDuplicateBlock, "ErrDuplicateBlock"},
+		{ErrBlockTooBig, "ErrBlockTooBig"},
+		{ErrWrongBlockSize, "ErrWrongBlockSize"},
+		{ErrInvalidTime, "ErrInvalidTime"},
+		{ErrTimeTooOld, "ErrTimeTooOld"},
+		{ErrTimeTooNew, "ErrTimeTooNew"},
+		{ErrUnexpectedDifficulty, "ErrUnexpectedDifficulty"},
+		{ErrHighHash, "ErrHighHash"},
+		{ErrBadMerkleRoot, "ErrBadMerkleRoot"},
+		{ErrNoTransactions, "ErrNoTransactions"},
+		{ErrNoTxInputs, "ErrNoTxInputs"},
+		{ErrNoTxOutputs, "ErrNoTxOutputs"},
+		{ErrBadTxOutValue, "ErrBadTxOutValue"},
+		{ErrDuplicateTxInputs, "ErrDuplicateTxInputs"},
+		{ErrBadTxInput, "ErrBadTxInput"},
+		{ErrMissingTxOut, "ErrMissingTxOut"},
+		{ErrUnfinalizedTx, "ErrUnfinalizedTx"},
+		{ErrDuplicateTx, "ErrDuplicateTx"},
+		{ErrImmatureSpend, "ErrImmatureSpend"},
+		{ErrSpendTooHigh, "ErrSpendTooHigh"},
+		{ErrTooManySigOps, "ErrTooManySigOps"},
+		{ErrFirstTxNotCoinbase, "ErrFirstTxNotCoinbase"},
+		{ErrCoinbaseHeight, "ErrCoinbaseHeight"},
+		{ErrMultipleCoinbases, "ErrMultipleCoinbases"},
+		{ErrStakeTxInRegularTree, "ErrStakeTxInRegularTree"},
+		{ErrRegTxInStakeTree, "ErrRegTxInStakeTree"},
+		{ErrBadCoinbaseScriptLen, "ErrBadCoinbaseScriptLen"},
+		{ErrBadCoinbaseValue, "ErrBadCoinbaseValue"},
+		{ErrBadCoinbaseFraudProof, "ErrBadCoinbaseFraudProof"},
+		{ErrBadCoinbaseAmountIn, "ErrBadCoinbaseAmountIn"},
+		{ErrBadStakebaseAmountIn, "ErrBadStakebaseAmountIn"},
+		{ErrBadStakebaseScriptLen, "ErrBadStakebaseScriptLen"},
+		{ErrBadStakebaseScrVal, "ErrBadStakebaseScrVal"},
+		{ErrScriptMalformed, "ErrScriptMalformed"},
+		{ErrScriptValidation, "ErrScriptValidation"},
+		{ErrNotEnoughStake, "ErrNotEnoughStake"},
+		{ErrStakeBelowMinimum, "ErrStakeBelowMinimum"},
+		{ErrNotEnoughVotes, "ErrNotEnoughVotes"},
+		{ErrTooManyVotes, "ErrTooManyVotes"},
+		{ErrFreshStakeMismatch, "ErrFreshStakeMismatch"},
+		{ErrInvalidEarlyStakeTx, "ErrInvalidEarlyStakeTx"},
+		{ErrTicketUnavailable, "ErrTicketUnavailable"},
+		{ErrVotesOnWrongBlock, "ErrVotesOnWrongBlock"},
+		{ErrVotesMismatch, "ErrVotesMismatch"},
+		{ErrIncongruentVotebit, "ErrIncongruentVotebit"},
+		{ErrInvalidSSRtx, "ErrInvalidSSRtx"},
+		{ErrRevocationsMismatch, "ErrRevocationsMismatch"},
+		{ErrTicketCommitment, "ErrTicketCommitment"},
+		{ErrBadNumPayees, "ErrBadNumPayees"},
+		{ErrMismatchedPayeeHash, "ErrMismatchedPayeeHash"},
+		{ErrBadPayeeValue, "ErrBadPayeeValue"},
+		{ErrTxSStxOutSpend, "ErrTxSStxOutSpend"},
+		{ErrRegTxCreateStakeOut, "ErrRegTxCreateStakeOut"},
+		{ErrInvalidFinalState, "ErrInvalidFinalState"},
+		{ErrPoolSize, "ErrPoolSize"},
+		{ErrBadBlockHeight, "ErrBadBlockHeight"},
+		{ErrBlockOneOutputs, "ErrBlockOneOutputs"},
+		{ErrNoTreasury, "ErrNoTreasury"},
+		{ErrExpiredTx, "ErrExpiredTx"},
+		{ErrFraudAmountIn, "ErrFraudAmountIn"},
+		{ErrFraudBlockHeight, "ErrFraudBlockHeight"},
+		{ErrFraudBlockIndex, "ErrFraudBlockIndex"},
+		{ErrInvalidEarlyVoteBits, "ErrInvalidEarlyVoteBits"},
+		{ErrInvalidEarlyFinalState, "ErrInvalidEarlyFinalState"},
+	}
+
+	for i, test := range tests {
+		result := test.in.Error()
+		if result != test.want {
+			t.Errorf("#%d: got: %s want: %s", i, result, test.want)
+			continue
+		}
+	}
+}
+
+// TestRuleError tests the error output for the RuleError type.
+func TestRuleError(t *testing.T) {
+	tests := []struct {
+		in   RuleError
+		want string
+	}{{
+		RuleError{Description: "duplicate block"},
+		"duplicate block",
+	}, {
+		RuleError{Description: "human-readable error"},
+		"human-readable error",
+	}}
+
+	for i, test := range tests {
+		result := test.in.Error()
+		if result != test.want {
+			t.Errorf("#%d: got: %s want: %s", i, result, test.want)
+			continue
+		}
+	}
+}
+
+// TestErrorKindIsAs ensures both ErrorKind and Error can be identified as being
+// a specific error kind via errors.Is and unwrapped via errors.As.
+func TestErrorKindIsAs(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		target    error
+		wantMatch bool
+		wantAs    ErrorKind
+	}{{
+		name:      "ErrBlockTooBig == ErrBlockTooBig",
+		err:       ErrBlockTooBig,
+		target:    ErrBlockTooBig,
+		wantMatch: true,
+		wantAs:    ErrBlockTooBig,
+	}, {
+		name:      "RuleError.ErrBlockTooBig == ErrBlockTooBig",
+		err:       ruleError(ErrBlockTooBig, ""),
+		target:    ErrBlockTooBig,
+		wantMatch: true,
+		wantAs:    ErrBlockTooBig,
+	}, {
+		name:      "RuleError.ErrBlockTooBig == RuleError.ErrBlockTooBig",
+		err:       ruleError(ErrBlockTooBig, ""),
+		target:    ruleError(ErrBlockTooBig, ""),
+		wantMatch: true,
+		wantAs:    ErrBlockTooBig,
+	}, {
+		name:      "ErrBlockTooBig != ErrWrongBlockSize",
+		err:       ErrBlockTooBig,
+		target:    ErrWrongBlockSize,
+		wantMatch: false,
+		wantAs:    ErrBlockTooBig,
+	}, {
+		name:      "RuleError.ErrBlockTooBig != ErrWrongBlockSize",
+		err:       ruleError(ErrBlockTooBig, ""),
+		target:    ErrWrongBlockSize,
+		wantMatch: false,
+		wantAs:    ErrBlockTooBig,
+	}, {
+		name:      "ErrBlockTooBig != RuleError.ErrWrongBlockSize",
+		err:       ErrBlockTooBig,
+		target:    ruleError(ErrWrongBlockSize, ""),
+		wantMatch: false,
+		wantAs:    ErrBlockTooBig,
+	}, {
+		name:      "RuleError.ErrBlockTooBig != RuleError.ErrWrongBlockSize",
+		err:       ruleError(ErrBlockTooBig, ""),
+		target:    ruleError(ErrWrongBlockSize, ""),
+		wantMatch: false,
+		wantAs:    ErrBlockTooBig,
+	}, {
+		name:      "RuleError.ErrBlockTooBig != io.EOF",
+		err:       ruleError(ErrBlockTooBig, ""),
+		target:    io.EOF,
+		wantMatch: false,
+		wantAs:    ErrBlockTooBig,
+	}}
+
+	for _, test := range tests {
+		// Ensure the error matches or not depending on the expected result.
+		result := errors.Is(test.err, test.target)
+		if result != test.wantMatch {
+			t.Errorf("%s: incorrect error identification -- got %v, want %v",
+				test.name, result, test.wantMatch)
+			continue
+		}
+
+		// Ensure the underlying error kind can be unwrapped and is the expected
+		// kind.
+		var kind ErrorKind
+		if !errors.As(test.err, &kind) {
+			t.Errorf("%s: unable to unwrap to error kind", test.name)
+			continue
+		}
+		if kind != test.wantAs {
+			t.Errorf("%s: unexpected unwrapped error kind -- got %v, want %v",
+				test.name, kind, test.wantAs)
+			continue
+		}
+	}
+}

--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -833,7 +833,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 			taxOutput.Version = p2pkhScriptVer
 			taxOutput.PkScript = p2pkhScript
 		})
-	rejected(blockchain.ErrNoTax)
+	rejected(blockchain.ErrNoTreasury)
 
 	// Create a block that uses a newer output script version than is
 	// supported for the dev-org tax output.
@@ -846,7 +846,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 		func(b *wire.MsgBlock) {
 			b.Transactions[0].TxOut[0].Version = 1
 		})
-	rejected(blockchain.ErrNoTax)
+	rejected(blockchain.ErrNoTreasury)
 
 	// ---------------------------------------------------------------------
 	// Too much dev-org coinbase tests.
@@ -859,7 +859,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	//    \-> bf3(1) -> bf4(2)
 	g.SetTip("bf6")
 	g.NextBlock("bdc1", outs[4], ticketOuts[4], additionalCoinbaseDev(1))
-	rejected(blockchain.ErrNoTax)
+	rejected(blockchain.ErrNoTreasury)
 
 	// Create a fork that ends with block that generates too much dev-org
 	// coinbase.
@@ -872,7 +872,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	acceptedToSideChainWithExpectedTip("bf6")
 
 	g.NextBlock("bdc3", outs[4], ticketOuts[4], additionalCoinbaseDev(1))
-	rejected(blockchain.ErrNoTax)
+	rejected(blockchain.ErrNoTreasury)
 
 	// There was originally some processing order related tests here which
 	// extended the chain, but they have since been separated into tests
@@ -2013,7 +2013,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	g.NextBlock("bmf29", outs[15], ticketOuts[15], func(b *wire.MsgBlock) {
 		b.Transactions[0].TxOut[0] = b.Transactions[0].TxOut[1]
 	})
-	rejected(blockchain.ErrNoTax)
+	rejected(blockchain.ErrNoTreasury)
 
 	// Create block with an incorrect dev subsidy output amount.
 	//
@@ -2023,7 +2023,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	g.NextBlock("bmf30", outs[15], ticketOuts[15], func(b *wire.MsgBlock) {
 		b.Transactions[0].TxOut[0].Value--
 	})
-	rejected(blockchain.ErrNoTax)
+	rejected(blockchain.ErrNoTreasury)
 
 	// Create block that tries to buy a ticket with the block's coinbase
 	// transaction.

--- a/blockchain/process_test.go
+++ b/blockchain/process_test.go
@@ -155,7 +155,7 @@ func TestProcessOrder(t *testing.T) {
 	g.AcceptHeader("bdc1")
 	g.AcceptBlockData("bdc2")
 	g.AcceptBlockData("bdc3")
-	g.RejectBlock("bdc1", ErrNoTax)
+	g.RejectBlock("bdc1", ErrNoTreasury)
 	g.ExpectTip("bdc2")
 }
 

--- a/blockchain/subsidy.go
+++ b/blockchain/subsidy.go
@@ -102,12 +102,12 @@ func coinbasePaysTreasuryAddress(subsidyCache *standalone.SubsidyCache, tx *dcru
 	if treasuryOutput.Version != params.OrganizationPkScriptVersion {
 		str := fmt.Sprintf("treasury output version %d is instead of %d",
 			treasuryOutput.Version, params.OrganizationPkScriptVersion)
-		return ruleError(ErrNoTax, str)
+		return ruleError(ErrNoTreasury, str)
 	}
 	if !bytes.Equal(treasuryOutput.PkScript, params.OrganizationPkScript) {
 		str := fmt.Sprintf("treasury output script is %x instead of %x",
 			treasuryOutput.PkScript, params.OrganizationPkScript)
-		return ruleError(ErrNoTax, str)
+		return ruleError(ErrNoTreasury, str)
 	}
 
 	// Calculate the amount of subsidy that should have been paid out to the
@@ -117,7 +117,7 @@ func coinbasePaysTreasuryAddress(subsidyCache *standalone.SubsidyCache, tx *dcru
 	if orgSubsidy != treasuryOutput.Value {
 		str := fmt.Sprintf("treasury output amount is %s instead of %s",
 			dcrutil.Amount(treasuryOutput.Value), dcrutil.Amount(orgSubsidy))
-		return ruleError(ErrNoTax, str)
+		return ruleError(ErrNoTreasury, str)
 	}
 
 	return nil


### PR DESCRIPTION
The `blockchain/fullblocktests` package currently has a cyclic dependency on `blockchain` since the tests directly return the error codes in `blockchain` that are expected to be violated while `blockchain` itself needs to import the package in order to run the tests.

This resolves that cyclic dependency by defining all of the errors the `fullblocktests` produce in the package itself and then converting them to the associated error in blockchain when running the tests and checking for the expected error.

It also moves the code that runs the `fullblocktests` into the `blockchain` package itself instead of a separate `blockchain_test` package to match all other tests now that there is no longer a cyclic dependency that forced it to be be separated.

While duplication of the errors in question is a little less convenient, this approach ensures the `blockchain` package can be made internal in the future while still providing the publicly-available `fullblocktests` package for use both in testing the internal `blockchain` implementation as well as integration tests with other implementations.

Finally, this also has a few other commits with some minor cleanup.