### PR TITLE
mempool: Remove unused agenda flags.

### DIFF
--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -2065,9 +2065,7 @@ func (mp *TxPool) PruneStakeTx(requiredStakeDifficulty, height int64) {
 // longer able to be included into a block.
 //
 // This function MUST be called with the mempool lock held (for writes).
-func (mp *TxPool) pruneExpiredTx(isTreasuryEnabled,
-	isAutoRevocationsEnabled bool) {
-
+func (mp *TxPool) pruneExpiredTx() {
 	nextBlockHeight := mp.cfg.BestHeight() + 1
 
 	for _, txDesc := range mp.pool {
@@ -2094,19 +2092,9 @@ func (mp *TxPool) pruneExpiredTx(isTreasuryEnabled,
 //
 // This function is safe for concurrent access.
 func (mp *TxPool) PruneExpiredTx() {
-	isTreasuryEnabled, err := mp.cfg.IsTreasuryAgendaActive()
-	if err != nil {
-		return
-	}
-
-	isAutoRevocationsEnabled, err := mp.cfg.IsAutoRevocationsAgendaActive()
-	if err != nil {
-		return
-	}
-
 	// Protect concurrent access.
 	mp.mtx.Lock()
-	mp.pruneExpiredTx(isTreasuryEnabled, isAutoRevocationsEnabled)
+	mp.pruneExpiredTx()
 	mp.mtx.Unlock()
 }
 

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -922,9 +922,7 @@ func (mp *TxPool) findTx(txHash *chainhash.Hash) *mining.TxDesc {
 // helper for maybeAcceptTransaction and maybeUnstageTransaction.
 //
 // This function MUST be called with the mempool lock held (for writes).
-func (mp *TxPool) addTransaction(utxoView *blockchain.UtxoViewpoint,
-	txDesc *TxDesc, isTreasuryEnabled bool) {
-
+func (mp *TxPool) addTransaction(utxoView *blockchain.UtxoViewpoint, txDesc *TxDesc) {
 	tx := txDesc.Tx
 	txHash := tx.Hash()
 	txType := txDesc.Type
@@ -1170,7 +1168,7 @@ func (mp *TxPool) maybeUnstageTransaction(txDesc *TxDesc, isTreasuryEnabled bool
 		if err != nil {
 			return err
 		}
-		mp.addTransaction(utxoView, txDesc, isTreasuryEnabled)
+		mp.addTransaction(utxoView, txDesc)
 	}
 	return nil
 }
@@ -1802,7 +1800,7 @@ func (mp *TxPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit,
 	}
 
 	// Add to transaction pool.
-	mp.addTransaction(utxoView, txDesc, isTreasuryEnabled)
+	mp.addTransaction(utxoView, txDesc)
 
 	// A regular transaction entering the mempool causes
 	// mempool tickets that redeem it to move to the stage pool.

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -554,9 +554,7 @@ func (mp *TxPool) addOrphan(tx *dcrutil.Tx, tag Tag) {
 // maybeAddOrphan potentially adds an orphan to the orphan pool.
 //
 // This function MUST be called with the mempool lock held (for writes).
-func (mp *TxPool) maybeAddOrphan(tx *dcrutil.Tx, tag Tag,
-	isTreasuryEnabled, isAutoRevocationsEnabled bool) error {
-
+func (mp *TxPool) maybeAddOrphan(tx *dcrutil.Tx, tag Tag) error {
 	// Ignore orphan transactions that are too large.  This helps avoid
 	// a memory exhaustion attack based on sending a lot of really large
 	// orphans.  In the case there is a valid transaction larger than this,
@@ -2175,8 +2173,6 @@ func (mp *TxPool) ProcessTransaction(tx *dcrutil.Tx, allowOrphan, rateLimit, all
 	if err != nil {
 		return nil, err
 	}
-	isTreasuryEnabled := checkTxFlags.IsTreasuryEnabled()
-	isAutoRevocationsEnabled := checkTxFlags.IsAutoRevocationsEnabled()
 
 	// Protect concurrent access.
 	mp.mtx.Lock()
@@ -2231,7 +2227,7 @@ func (mp *TxPool) ProcessTransaction(tx *dcrutil.Tx, allowOrphan, rateLimit, all
 	}
 
 	// Potentially add the orphan transaction to the orphan pool.
-	err = mp.maybeAddOrphan(tx, tag, isTreasuryEnabled, isAutoRevocationsEnabled)
+	err = mp.maybeAddOrphan(tx, tag)
 	return nil, err
 }
 

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -586,9 +586,7 @@ func (mp *TxPool) maybeAddOrphan(tx *dcrutil.Tx, tag Tag) error {
 // that orphans also spend.
 //
 // This function MUST be called with the mempool lock held (for writes).
-func (mp *TxPool) removeOrphanDoubleSpends(tx *dcrutil.Tx, isTreasuryEnabled,
-	isAutoRevocationsEnabled bool) {
-
+func (mp *TxPool) removeOrphanDoubleSpends(tx *dcrutil.Tx) {
 	msgTx := tx.MsgTx()
 	for _, txIn := range msgTx.TxIn {
 		for _, orphan := range mp.orphansByPrev[txIn.PreviousOutPoint] {
@@ -1909,10 +1907,6 @@ func (mp *TxPool) MaybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit bool) 
 func (mp *TxPool) processOrphans(acceptedTx *dcrutil.Tx, checkTxFlags blockchain.AgendaFlags) []*dcrutil.Tx {
 	var acceptedTxns []*dcrutil.Tx
 
-	// Determine active agendas based on flags.
-	isTreasuryEnabled := checkTxFlags.IsTreasuryEnabled()
-	isAutoRevocationsEnabled := checkTxFlags.IsAutoRevocationsEnabled()
-
 	// Start with processing at least the passed transaction.
 	processList := []*dcrutil.Tx{acceptedTx}
 	for len(processList) > 0 {
@@ -1988,10 +1982,9 @@ func (mp *TxPool) processOrphans(acceptedTx *dcrutil.Tx, checkTxFlags blockchain
 	// Recursively remove any orphans that also redeem any outputs redeemed
 	// by the accepted transactions since those are now definitive double
 	// spends.
-	mp.removeOrphanDoubleSpends(acceptedTx, isTreasuryEnabled,
-		isAutoRevocationsEnabled)
+	mp.removeOrphanDoubleSpends(acceptedTx)
 	for _, tx := range acceptedTxns {
-		mp.removeOrphanDoubleSpends(tx, isTreasuryEnabled, isAutoRevocationsEnabled)
+		mp.removeOrphanDoubleSpends(tx)
 	}
 
 	return acceptedTxns

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -879,9 +879,7 @@ func (mp *TxPool) RemoveTransaction(tx *dcrutil.Tx, removeRedeemers bool) {
 // contain transactions which were previously unknown to the memory pool.
 //
 // This function is safe for concurrent access.
-func (mp *TxPool) RemoveDoubleSpends(tx *dcrutil.Tx, isTreasuryEnabled,
-	isAutoRevocationsEnabled bool) {
-
+func (mp *TxPool) RemoveDoubleSpends(tx *dcrutil.Tx) {
 	// Protect concurrent access.
 	mp.mtx.Lock()
 	for _, txIn := range tx.MsgTx().TxIn {

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -523,9 +523,7 @@ func (mp *TxPool) limitNumOrphans() {
 // addOrphan adds an orphan transaction to the orphan pool.
 //
 // This function MUST be called with the mempool lock held (for writes).
-func (mp *TxPool) addOrphan(tx *dcrutil.Tx, tag Tag, isTreasuryEnabled,
-	isAutoRevocationsEnabled bool) {
-
+func (mp *TxPool) addOrphan(tx *dcrutil.Tx, tag Tag) {
 	// Nothing to do if no orphans are allowed.
 	if mp.cfg.Policy.MaxOrphanTxs <= 0 {
 		return
@@ -578,7 +576,7 @@ func (mp *TxPool) maybeAddOrphan(tx *dcrutil.Tx, tag Tag,
 	}
 
 	// Add the orphan if the none of the above disqualified it.
-	mp.addOrphan(tx, tag, isTreasuryEnabled, isAutoRevocationsEnabled)
+	mp.addOrphan(tx, tag)
 
 	return nil
 }

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -475,7 +475,7 @@ func (mp *TxPool) RemoveOrphansByTag(tag Tag, isTreasuryEnabled,
 // orphan if adding a new one would cause it to overflow the max allowed.
 //
 // This function MUST be called with the mempool lock held (for writes).
-func (mp *TxPool) limitNumOrphans(isTreasuryEnabled, isAutoRevocationsEnabled bool) {
+func (mp *TxPool) limitNumOrphans() {
 	// Scan through the orphan pool and remove any expired orphans when it's
 	// time.  This is done for efficiency so the scan only happens periodically
 	// instead of on every orphan added to the pool.
@@ -534,7 +534,7 @@ func (mp *TxPool) addOrphan(tx *dcrutil.Tx, tag Tag, isTreasuryEnabled,
 	// Limit the number orphan transactions to prevent memory exhaustion.
 	// This will periodically remove any expired orphans and evict a random
 	// orphan if space is still needed.
-	mp.limitNumOrphans(isTreasuryEnabled, isAutoRevocationsEnabled)
+	mp.limitNumOrphans()
 
 	mp.orphans[*tx.Hash()] = &orphanTx{
 		tx:         tx,

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -1987,9 +1987,7 @@ func (mp *TxPool) processOrphans(acceptedTx *dcrutil.Tx, checkTxFlags blockchain
 // PruneStakeTx.  See the comment for PruneStakeTx for more details.
 //
 // This function MUST be called with the mempool lock held (for writes).
-func (mp *TxPool) pruneStakeTx(requiredStakeDifficulty, height int64,
-	isTreasuryEnabled, isAutoRevocationsEnabled bool) {
-
+func (mp *TxPool) pruneStakeTx(requiredStakeDifficulty, height int64, isAutoRevocationsEnabled bool) {
 	for _, txDesc := range mp.pool {
 		txType := txDesc.Type
 		if txType == stake.TxTypeSStx &&
@@ -2052,11 +2050,6 @@ func (mp *TxPool) pruneStakeTx(requiredStakeDifficulty, height int64,
 // pruned from mempool since they will never be mined.  The same idea stands
 // for SSGen and SSRtx
 func (mp *TxPool) PruneStakeTx(requiredStakeDifficulty, height int64) {
-	isTreasuryEnabled, err := mp.cfg.IsTreasuryAgendaActive()
-	if err != nil {
-		return
-	}
-
 	isAutoRevocationsEnabled, err := mp.cfg.IsAutoRevocationsAgendaActive()
 	if err != nil {
 		return
@@ -2064,8 +2057,7 @@ func (mp *TxPool) PruneStakeTx(requiredStakeDifficulty, height int64) {
 
 	// Protect concurrent access.
 	mp.mtx.Lock()
-	mp.pruneStakeTx(requiredStakeDifficulty, height, isTreasuryEnabled,
-		isAutoRevocationsEnabled)
+	mp.pruneStakeTx(requiredStakeDifficulty, height, isAutoRevocationsEnabled)
 	mp.mtx.Unlock()
 }
 

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -454,8 +454,7 @@ func (mp *TxPool) RemoveOrphan(tx *dcrutil.Tx) {
 // identifier.
 //
 // This function is safe for concurrent access.
-func (mp *TxPool) RemoveOrphansByTag(tag Tag, isTreasuryEnabled,
-	isAutoRevocationsEnabled bool) uint64 {
+func (mp *TxPool) RemoveOrphansByTag(tag Tag) uint64 {
 
 	var numEvicted uint64
 	mp.mtx.Lock()

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -444,9 +444,7 @@ func (mp *TxPool) removeOrphan(tx *dcrutil.Tx, removeRedeemers bool) {
 // previous orphan index.
 //
 // This function is safe for concurrent access.
-func (mp *TxPool) RemoveOrphan(tx *dcrutil.Tx, isTreasuryEnabled,
-	isAutoRevocationsEnabled bool) {
-
+func (mp *TxPool) RemoveOrphan(tx *dcrutil.Tx) {
 	mp.mtx.Lock()
 	mp.removeOrphan(tx, false)
 	mp.mtx.Unlock()
@@ -1555,8 +1553,7 @@ func (mp *TxPool) maybeAcceptTransaction(tx *dcrutil.Tx, isNew, rateLimit,
 	// Don't allow transactions with non-standard inputs if the mempool config
 	// forbids their acceptance and relaying.
 	if !mp.cfg.Policy.AcceptNonStd {
-		err := checkInputsStandard(tx, txType, utxoView,
-			isTreasuryEnabled)
+		err := checkInputsStandard(tx, txType, utxoView, isTreasuryEnabled)
 		if err != nil {
 			str := fmt.Sprintf("transaction %v has a non-standard "+
 				"input: %v", txHash, err)

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -865,9 +865,7 @@ func (mp *TxPool) removeTransaction(tx *dcrutil.Tx, removeRedeemers bool) {
 // they would otherwise become orphans.
 //
 // This function is safe for concurrent access.
-func (mp *TxPool) RemoveTransaction(tx *dcrutil.Tx, removeRedeemers,
-	isTreasuryEnabled, isAutoRevocationsEnabled bool) {
-
+func (mp *TxPool) RemoveTransaction(tx *dcrutil.Tx, removeRedeemers bool) {
 	// Protect concurrent access.
 	mp.mtx.Lock()
 	mp.removeTransaction(tx, removeRedeemers)

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -1046,7 +1046,7 @@ func TestTicketPurchaseOrphan(t *testing.T) {
 	// in the stage pool to enter the mempool.
 	harness.AddFakeUTXO(tx, int64(ticket.MsgTx().TxIn[0].BlockHeight),
 		wire.NullBlockIndex)
-	harness.txPool.RemoveTransaction(tx, false, noTreasury, noAutoRevocations)
+	harness.txPool.RemoveTransaction(tx, false)
 	harness.txPool.MaybeAcceptDependents(tx, noTreasury)
 
 	testPoolMembership(tc, tx, false, false)
@@ -1987,7 +1987,7 @@ func TestMaxVoteDoubleSpendRejection(t *testing.T) {
 	// Remove one of the votes from the pool and ensure it is not in the orphan
 	// pool, not in the transaction pool, and not reported as available.
 	vote := votes[2]
-	harness.txPool.RemoveTransaction(vote, true, noTreasury, noAutoRevocations)
+	harness.txPool.RemoveTransaction(vote, true)
 	testPoolMembership(tc, vote, false, false)
 
 	// Add one of the votes that was rejected above due to the pool being at the
@@ -2089,7 +2089,7 @@ func TestDuplicateVoteRejection(t *testing.T) {
 
 	// Remove the original vote from the pool and ensure it is not in the orphan
 	// pool, not in the transaction pool, and not reported as available.
-	harness.txPool.RemoveTransaction(vote, true, noTreasury, noAutoRevocations)
+	harness.txPool.RemoveTransaction(vote, true)
 	testPoolMembership(tc, vote, false, false)
 
 	// Add the duplicate vote which should now be accepted.  Also, ensure it is
@@ -2489,7 +2489,7 @@ func TestHandlesTSpends(t *testing.T) {
 
 	// Remove the first tspend from the mempool and assert TSpendHashes()
 	// is working as intended.
-	harness.txPool.RemoveTransaction(tspends[0], true, true, noAutoRevocations)
+	harness.txPool.RemoveTransaction(tspends[0], true)
 	testPoolMembership(tc, tspends[0], false, false)
 	assertTSpendHashes(tspends[1:maxTSpends])
 
@@ -2500,7 +2500,7 @@ func TestHandlesTSpends(t *testing.T) {
 	// Remove all tspends from the mempool and ensure TSpendHashes() is
 	// empty again.
 	for _, tx := range tspends[1 : maxTSpends+1] {
-		harness.txPool.RemoveTransaction(tx, true, true, noAutoRevocations)
+		harness.txPool.RemoveTransaction(tx, true)
 		testPoolMembership(tc, tx, false, false)
 	}
 	assertTSpendHashes(nil)
@@ -2688,7 +2688,7 @@ func TestHandlesTAdds(t *testing.T) {
 			t.Fatalf("ProcessTransaction: failed to accept valid tadd %v", err)
 		}
 		testPoolMembership(tc, tx, false, true)
-		harness.txPool.RemoveTransaction(tx, true, true, noAutoRevocations)
+		harness.txPool.RemoveTransaction(tx, true)
 	}
 
 	// Create a few valid tadds that can enter the mempool. Generate a TAdd
@@ -2764,7 +2764,7 @@ func TestStagedTransactionHeight(t *testing.T) {
 	newBlockHeight := initialBlockHeight + 1
 	harness.AddFakeUTXO(txA, newBlockHeight, wire.NullBlockIndex)
 	harness.chain.SetHeight(newBlockHeight)
-	harness.txPool.RemoveTransaction(txA, false, noTreasury, noAutoRevocations)
+	harness.txPool.RemoveTransaction(txA, false)
 	harness.txPool.MaybeAcceptDependents(txA, noTreasury)
 
 	poolTxDescs = harness.txPool.TxDescs()
@@ -3229,8 +3229,7 @@ func TestSubsidySplitSemantics(t *testing.T) {
 
 	// Remove the vote from the pool and ensure it is not in the orphan pool,
 	// not in the transaction pool, and not reported as available.
-	harness.txPool.RemoveTransaction(preDCP0010Vote, true, noTreasury,
-		noAutoRevocations)
+	harness.txPool.RemoveTransaction(preDCP0010Vote, true)
 	testPoolMembership(tc, preDCP0010Vote, false, false)
 
 	// Attempt to add the vote with the original subsidy when the agenda is

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -2318,8 +2318,7 @@ func TestRemoveDoubleSpends(t *testing.T) {
 
 	// If a staged transaction double-spends an input due to a reorg,
 	// it should be removed from the stage pool.
-	tc.harness.txPool.RemoveDoubleSpends(doubleSpendTx, noTreasury,
-		noAutoRevocations)
+	tc.harness.txPool.RemoveDoubleSpends(doubleSpendTx)
 
 	// FetchTransaction should not be able to retrieve the ticket anymore.
 	_, err = harness.txPool.FetchTransaction(ticket.Hash())

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -1524,8 +1524,7 @@ func TestOrphanChainRemoval(t *testing.T) {
 	// remove redeemer flag set and ensure that only the first orphan was
 	// removed.
 	harness.txPool.mtx.Lock()
-	harness.txPool.removeOrphan(chainedTxns[1], false, noTreasury,
-		noAutoRevocations)
+	harness.txPool.removeOrphan(chainedTxns[1], false)
 	harness.txPool.mtx.Unlock()
 	testPoolMembership(tc, chainedTxns[1], false, false)
 	for _, tx := range chainedTxns[2 : maxOrphans+1] {
@@ -1535,8 +1534,7 @@ func TestOrphanChainRemoval(t *testing.T) {
 	// Remove the first remaining orphan that starts the orphan chain with
 	// the remove redeemer flag set and ensure they are all removed.
 	harness.txPool.mtx.Lock()
-	harness.txPool.removeOrphan(chainedTxns[2], true, noTreasury,
-		noAutoRevocations)
+	harness.txPool.removeOrphan(chainedTxns[2], true)
 	harness.txPool.mtx.Unlock()
 	for _, tx := range chainedTxns[2 : maxOrphans+1] {
 		testPoolMembership(tc, tx, false, false)

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -1455,7 +1455,7 @@ func TestBasicOrphanRemoval(t *testing.T) {
 		t.Fatalf("unable to create signed tx: %v", err)
 	}
 
-	harness.txPool.RemoveOrphan(nonChainedOrphanTx, noTreasury, noAutoRevocations)
+	harness.txPool.RemoveOrphan(nonChainedOrphanTx)
 	testPoolMembership(tc, nonChainedOrphanTx, false, false)
 	for _, tx := range chainedTxns[1 : maxOrphans+1] {
 		testPoolMembership(tc, tx, true, false)
@@ -1464,7 +1464,7 @@ func TestBasicOrphanRemoval(t *testing.T) {
 	// Attempt to remove an orphan that has an existing redeemer but itself
 	// is not present and ensure the state of all other orphans (including
 	// the one that redeems it) are unaffected.
-	harness.txPool.RemoveOrphan(chainedTxns[0], noTreasury, noAutoRevocations)
+	harness.txPool.RemoveOrphan(chainedTxns[0])
 	testPoolMembership(tc, chainedTxns[0], false, false)
 	for _, tx := range chainedTxns[1 : maxOrphans+1] {
 		testPoolMembership(tc, tx, true, false)
@@ -1473,7 +1473,7 @@ func TestBasicOrphanRemoval(t *testing.T) {
 	// Remove each orphan one-by-one and ensure they are removed as
 	// expected.
 	for _, tx := range chainedTxns[1 : maxOrphans+1] {
-		harness.txPool.RemoveOrphan(tx, noTreasury, noAutoRevocations)
+		harness.txPool.RemoveOrphan(tx)
 		testPoolMembership(tc, tx, false, false)
 	}
 }

--- a/internal/mempool/policy_test.go
+++ b/internal/mempool/policy_test.go
@@ -26,11 +26,6 @@ const (
 	// noTreasury signifies the treasury agenda should be treated as though it
 	// is inactive.  It is used to increase the readability of the tests.
 	noTreasury = false
-
-	// noAutoRevocations signifies the automatic ticket revocations agenda should
-	// be treated as though it is inactive.  It is used to increase the
-	// readability of the tests.
-	noAutoRevocations = false
 )
 
 // TestCalcMinRequiredTxRelayFee tests the calcMinRequiredTxRelayFee API.

--- a/server.go
+++ b/server.go
@@ -2644,7 +2644,6 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 
 		// Determine active agendas based on flags.
 		isTreasuryEnabled := ntfn.CheckTxFlags.IsTreasuryEnabled()
-		isAutoRevocationsEnabled := ntfn.CheckTxFlags.IsAutoRevocationsEnabled()
 
 		// Account for transactions mined in the newly connected block for fee
 		// estimation. This must be done before attempting to remove
@@ -2681,8 +2680,7 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 			for _, tx := range txns {
 				txMemPool.RemoveTransaction(tx, false)
 				txMemPool.MaybeAcceptDependents(tx, isTreasuryEnabled)
-				txMemPool.RemoveDoubleSpends(tx, isTreasuryEnabled,
-					isAutoRevocationsEnabled)
+				txMemPool.RemoveDoubleSpends(tx)
 				txMemPool.RemoveOrphan(tx)
 				acceptedTxs := txMemPool.ProcessOrphans(tx, ntfn.CheckTxFlags)
 				s.AnnounceNewTransactions(acceptedTxs)
@@ -2790,7 +2788,6 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 
 		// Determine active agendas based on flags.
 		isTreasuryEnabled := ntfn.CheckTxFlags.IsTreasuryEnabled()
-		isAutoRevocationsEnabled := ntfn.CheckTxFlags.IsAutoRevocationsEnabled()
 
 		// In the case the regular tree of the previous block was disapproved,
 		// disconnecting the current block makes all of those transactions valid
@@ -2803,8 +2800,7 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 			for _, tx := range parentBlock.Transactions()[1:] {
 				txMemPool.RemoveTransaction(tx, false)
 				txMemPool.MaybeAcceptDependents(tx, isTreasuryEnabled)
-				txMemPool.RemoveDoubleSpends(tx, isTreasuryEnabled,
-					isAutoRevocationsEnabled)
+				txMemPool.RemoveDoubleSpends(tx)
 				txMemPool.RemoveOrphan(tx)
 				txMemPool.ProcessOrphans(tx, ntfn.CheckTxFlags)
 			}

--- a/server.go
+++ b/server.go
@@ -2679,8 +2679,7 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 		txMemPool := s.txMemPool
 		handleConnectedBlockTxns := func(txns []*dcrutil.Tx) {
 			for _, tx := range txns {
-				txMemPool.RemoveTransaction(tx, false, isTreasuryEnabled,
-					isAutoRevocationsEnabled)
+				txMemPool.RemoveTransaction(tx, false)
 				txMemPool.MaybeAcceptDependents(tx, isTreasuryEnabled)
 				txMemPool.RemoveDoubleSpends(tx, isTreasuryEnabled,
 					isAutoRevocationsEnabled)
@@ -2730,8 +2729,7 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 			for _, tx := range parentBlock.Transactions()[1:] {
 				_, err := txMemPool.MaybeAcceptTransaction(tx, false, true)
 				if err != nil && !isDoubleSpendOrDuplicateError(err) {
-					txMemPool.RemoveTransaction(tx, true, isTreasuryEnabled,
-						isAutoRevocationsEnabled)
+					txMemPool.RemoveTransaction(tx, true)
 				}
 			}
 		}
@@ -2803,8 +2801,7 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 		txMemPool := s.txMemPool
 		if !headerApprovesParent(&block.MsgBlock().Header) {
 			for _, tx := range parentBlock.Transactions()[1:] {
-				txMemPool.RemoveTransaction(tx, false, isTreasuryEnabled,
-					isAutoRevocationsEnabled)
+				txMemPool.RemoveTransaction(tx, false)
 				txMemPool.MaybeAcceptDependents(tx, isTreasuryEnabled)
 				txMemPool.RemoveDoubleSpends(tx, isTreasuryEnabled,
 					isAutoRevocationsEnabled)
@@ -2839,8 +2836,7 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 			for _, tx := range txns {
 				_, err := txMemPool.MaybeAcceptTransaction(tx, false, true)
 				if err != nil && !isDoubleSpendOrDuplicateError(err) {
-					txMemPool.RemoveTransaction(tx, true, isTreasuryEnabled,
-						isAutoRevocationsEnabled)
+					txMemPool.RemoveTransaction(tx, true)
 				}
 			}
 		}

--- a/server.go
+++ b/server.go
@@ -2252,22 +2252,8 @@ func (s *server) peerDoneHandler(sp *serverPeer) {
 	}
 
 	if sp.VersionKnown() {
-		tipHash := &s.chain.BestSnapshot().Hash
-		isTreasuryEnabled, err := s.chain.IsTreasuryAgendaActive(tipHash)
-		if err != nil {
-			srvrLog.Errorf("Could not obtain treasury agenda status: %v", err)
-		}
-
-		isAutoRevocationsEnabled, err :=
-			s.chain.IsAutoRevocationsAgendaActive(tipHash)
-		if err != nil {
-			srvrLog.Errorf("Could not obtain automatic ticket revocations agenda "+
-				"status: %v", err)
-		}
-
 		// Evict any remaining orphans that were sent by the peer.
-		numEvicted := s.txMemPool.RemoveOrphansByTag(mempool.Tag(sp.ID()),
-			isTreasuryEnabled, isAutoRevocationsEnabled)
+		numEvicted := s.txMemPool.RemoveOrphansByTag(mempool.Tag(sp.ID()))
 		if numEvicted > 0 {
 			srvrLog.Debugf("Evicted %d %s from peer %v (id %d)", numEvicted,
 				pickNoun(numEvicted, "orphan", "orphans"), sp, sp.ID())

--- a/server.go
+++ b/server.go
@@ -2698,7 +2698,7 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 				txMemPool.MaybeAcceptDependents(tx, isTreasuryEnabled)
 				txMemPool.RemoveDoubleSpends(tx, isTreasuryEnabled,
 					isAutoRevocationsEnabled)
-				txMemPool.RemoveOrphan(tx, isTreasuryEnabled, isAutoRevocationsEnabled)
+				txMemPool.RemoveOrphan(tx)
 				acceptedTxs := txMemPool.ProcessOrphans(tx, ntfn.CheckTxFlags)
 				s.AnnounceNewTransactions(acceptedTxs)
 
@@ -2822,7 +2822,7 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 				txMemPool.MaybeAcceptDependents(tx, isTreasuryEnabled)
 				txMemPool.RemoveDoubleSpends(tx, isTreasuryEnabled,
 					isAutoRevocationsEnabled)
-				txMemPool.RemoveOrphan(tx, isTreasuryEnabled, isAutoRevocationsEnabled)
+				txMemPool.RemoveOrphan(tx)
 				txMemPool.ProcessOrphans(tx, ntfn.CheckTxFlags)
 			}
 		}


### PR DESCRIPTION
This removes the treasury and auto revocations agenda flags from the several mempool functions since they are now unused and updates the callers accordingly.

The removals have been split into separate commits so that everything continues to compile and the tests continue to pass at each step to ease the review process.

The following is an overview of the functions the agenda flags have been removed from:

- `removeOrphan`
- `limitNumOrphan`
- `addOrphan`
- `maybeAddOrphan`
- `removeOrphanDoubleSpends`
- `removeTransaction`
- `addTransaction`
- `pruneStakeTx`
- `pruneExpiredTx`
- `RemoveOrphan`
- `RemoveOrphansByTag`
- `RemoveTransaction`
- `RemoveDoubleSpends`
