### PR TITLE
blockchain: Use new uint256 for work sums.

### DIFF
--- a/internal/blockchain/blockindex_test.go
+++ b/internal/blockchain/blockindex_test.go
@@ -6,13 +6,13 @@ package blockchain
 
 import (
 	"fmt"
-	"math/big"
 	"math/rand"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/decred/dcrd/chaincfg/v3"
+	"github.com/decred/dcrd/math/uint256"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -406,13 +406,13 @@ func TestBetterCandidate(t *testing.T) {
 		name: "exactly equal, both data",
 		nodeA: &blockNode{
 			hash:            *mustParseHash("0000000000000000000000000000000000000000000000000000000000000000"),
-			workSum:         big.NewInt(2),
+			workSum:         *new(uint256.Uint256).SetUint64(2),
 			status:          statusDataStored,
 			receivedOrderID: 0,
 		},
 		nodeB: &blockNode{
 			hash:            *mustParseHash("0000000000000000000000000000000000000000000000000000000000000000"),
-			workSum:         big.NewInt(2),
+			workSum:         *new(uint256.Uint256).SetUint64(2),
 			status:          statusDataStored,
 			receivedOrderID: 0,
 		},
@@ -422,12 +422,12 @@ func TestBetterCandidate(t *testing.T) {
 		name: "exactly equal, no data",
 		nodeA: &blockNode{
 			hash:            *mustParseHash("0000000000000000000000000000000000000000000000000000000000000000"),
-			workSum:         big.NewInt(2),
+			workSum:         *new(uint256.Uint256).SetUint64(2),
 			receivedOrderID: 0,
 		},
 		nodeB: &blockNode{
 			hash:            *mustParseHash("0000000000000000000000000000000000000000000000000000000000000000"),
-			workSum:         big.NewInt(2),
+			workSum:         *new(uint256.Uint256).SetUint64(2),
 			receivedOrderID: 0,
 		},
 		wantCmp:    0,
@@ -436,12 +436,12 @@ func TestBetterCandidate(t *testing.T) {
 		name: "a has more cumulative work, same order, higher hash, b has data",
 		nodeA: &blockNode{
 			hash:            *higherHash,
-			workSum:         big.NewInt(4),
+			workSum:         *new(uint256.Uint256).SetUint64(4),
 			receivedOrderID: 0,
 		},
 		nodeB: &blockNode{
 			hash:            *lowerHash,
-			workSum:         big.NewInt(2),
+			workSum:         *new(uint256.Uint256).SetUint64(2),
 			status:          statusDataStored,
 			receivedOrderID: 0,
 		},
@@ -451,13 +451,13 @@ func TestBetterCandidate(t *testing.T) {
 		name: "a has less cumulative work, same order, lower hash, a has data",
 		nodeA: &blockNode{
 			hash:            *lowerHash,
-			workSum:         big.NewInt(2),
+			workSum:         *new(uint256.Uint256).SetUint64(2),
 			status:          statusDataStored,
 			receivedOrderID: 0,
 		},
 		nodeB: &blockNode{
 			hash:            *higherHash,
-			workSum:         big.NewInt(4),
+			workSum:         *new(uint256.Uint256).SetUint64(4),
 			receivedOrderID: 0,
 		},
 		wantCmp:    -1,
@@ -466,12 +466,12 @@ func TestBetterCandidate(t *testing.T) {
 		name: "a has same cumulative work, same order, lower hash, b has data",
 		nodeA: &blockNode{
 			hash:            *lowerHash,
-			workSum:         big.NewInt(2),
+			workSum:         *new(uint256.Uint256).SetUint64(2),
 			receivedOrderID: 0,
 		},
 		nodeB: &blockNode{
 			hash:            *higherHash,
-			workSum:         big.NewInt(2),
+			workSum:         *new(uint256.Uint256).SetUint64(2),
 			status:          statusDataStored,
 			receivedOrderID: 0,
 		},
@@ -481,13 +481,13 @@ func TestBetterCandidate(t *testing.T) {
 		name: "a has same cumulative work, same order, higher hash, a has data",
 		nodeA: &blockNode{
 			hash:            *higherHash,
-			workSum:         big.NewInt(2),
+			workSum:         *new(uint256.Uint256).SetUint64(2),
 			status:          statusDataStored,
 			receivedOrderID: 0,
 		},
 		nodeB: &blockNode{
 			hash:            *lowerHash,
-			workSum:         big.NewInt(2),
+			workSum:         *new(uint256.Uint256).SetUint64(2),
 			receivedOrderID: 0,
 		},
 		wantCmp:    1,
@@ -496,13 +496,13 @@ func TestBetterCandidate(t *testing.T) {
 		name: "a has same cumulative work, higher order, lower hash, both data",
 		nodeA: &blockNode{
 			hash:            *lowerHash,
-			workSum:         big.NewInt(2),
+			workSum:         *new(uint256.Uint256).SetUint64(2),
 			status:          statusDataStored,
 			receivedOrderID: 1,
 		},
 		nodeB: &blockNode{
 			hash:            *higherHash,
-			workSum:         big.NewInt(2),
+			workSum:         *new(uint256.Uint256).SetUint64(2),
 			status:          statusDataStored,
 			receivedOrderID: 0,
 		},
@@ -512,13 +512,13 @@ func TestBetterCandidate(t *testing.T) {
 		name: "a has same cumulative work, lower order, lower hash, both data",
 		nodeA: &blockNode{
 			hash:            *lowerHash,
-			workSum:         big.NewInt(2),
+			workSum:         *new(uint256.Uint256).SetUint64(2),
 			status:          statusDataStored,
 			receivedOrderID: 1,
 		},
 		nodeB: &blockNode{
 			hash:            *higherHash,
-			workSum:         big.NewInt(2),
+			workSum:         *new(uint256.Uint256).SetUint64(2),
 			status:          statusDataStored,
 			receivedOrderID: 2,
 		},
@@ -528,12 +528,12 @@ func TestBetterCandidate(t *testing.T) {
 		name: "a has same cumulative work, same order, lower hash, no data",
 		nodeA: &blockNode{
 			hash:            *lowerHash,
-			workSum:         big.NewInt(2),
+			workSum:         *new(uint256.Uint256).SetUint64(2),
 			receivedOrderID: 0,
 		},
 		nodeB: &blockNode{
 			hash:            *higherHash,
-			workSum:         big.NewInt(2),
+			workSum:         *new(uint256.Uint256).SetUint64(2),
 			receivedOrderID: 0,
 		},
 		wantCmp:    -1,
@@ -542,13 +542,13 @@ func TestBetterCandidate(t *testing.T) {
 		name: "a has same cumulative work, same order, lower hash, both data",
 		nodeA: &blockNode{
 			hash:            *lowerHash,
-			workSum:         big.NewInt(2),
+			workSum:         *new(uint256.Uint256).SetUint64(2),
 			status:          statusDataStored,
 			receivedOrderID: 0,
 		},
 		nodeB: &blockNode{
 			hash:            *higherHash,
-			workSum:         big.NewInt(2),
+			workSum:         *new(uint256.Uint256).SetUint64(2),
 			status:          statusDataStored,
 			receivedOrderID: 0,
 		},
@@ -558,13 +558,13 @@ func TestBetterCandidate(t *testing.T) {
 		name: "a has same cumulative work, same order, higher hash, both data",
 		nodeA: &blockNode{
 			hash:            *higherHash,
-			workSum:         big.NewInt(2),
+			workSum:         *new(uint256.Uint256).SetUint64(2),
 			status:          statusDataStored,
 			receivedOrderID: 0,
 		},
 		nodeB: &blockNode{
 			hash:            *lowerHash,
-			workSum:         big.NewInt(2),
+			workSum:         *new(uint256.Uint256).SetUint64(2),
 			status:          statusDataStored,
 			receivedOrderID: 0,
 		},

--- a/internal/blockchain/chainio_test.go
+++ b/internal/blockchain/chainio_test.go
@@ -10,16 +10,16 @@ import (
 	"encoding/hex"
 	"errors"
 	"math"
-	"math/big"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/decred/dcrd/blockchain/stake/v5"
-	"github.com/decred/dcrd/blockchain/standalone/v2"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/database/v3"
+	"github.com/decred/dcrd/internal/staging/primitives"
+	"github.com/decred/dcrd/math/uint256"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -892,7 +892,7 @@ func TestHeaderCommitmentDeserializeErrors(t *testing.T) {
 func TestBestChainStateSerialization(t *testing.T) {
 	t.Parallel()
 
-	workSum := new(big.Int)
+	var workSum uint256.Uint256
 	tests := []struct {
 		name       string
 		state      bestChainState
@@ -905,9 +905,10 @@ func TestBestChainStateSerialization(t *testing.T) {
 				height:       0,
 				totalTxns:    1,
 				totalSubsidy: 0,
-				workSum: func() *big.Int {
-					workSum.Add(workSum, standalone.CalcWork(486604799))
-					return new(big.Int).Set(workSum)
+				workSum: func() uint256.Uint256 {
+					work := primitives.CalcWork(486604799)
+					workSum.Add(&work)
+					return workSum
 				}(), // 0x0100010001
 			},
 			serialized: hexToBytes("6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d61900000000000000000001000000000000000000000000000000050000000100010001"),
@@ -919,9 +920,10 @@ func TestBestChainStateSerialization(t *testing.T) {
 				height:       1,
 				totalTxns:    2,
 				totalSubsidy: 123456789,
-				workSum: func() *big.Int {
-					workSum.Add(workSum, standalone.CalcWork(486604799))
-					return new(big.Int).Set(workSum)
+				workSum: func() uint256.Uint256 {
+					work := primitives.CalcWork(486604799)
+					workSum.Add(&work)
+					return workSum
 				}(), // 0x0200020002,
 			},
 			serialized: hexToBytes("4860eb18bf1b1620e37e9490fc8a427514416fd75159ab86688e9a830000000001000000020000000000000015cd5b0700000000050000000200020002"),

--- a/internal/blockchain/process.go
+++ b/internal/blockchain/process.go
@@ -736,7 +736,7 @@ func (b *BlockChain) InvalidateBlock(hash *chainhash.Hash) error {
 		// Chain tips that have less work than the new tip are not best chain
 		// candidates nor are any of their ancestors since they have even less
 		// work.
-		if tip.workSum.Cmp(newTip.workSum) < 0 {
+		if tip.workSum.Lt(&newTip.workSum) {
 			return nil
 		}
 
@@ -748,7 +748,7 @@ func (b *BlockChain) InvalidateBlock(hash *chainhash.Hash) error {
 		for n != nil && (n.status.KnownInvalid() || !b.index.canValidate(n)) {
 			n = n.parent
 		}
-		if n != nil && n != newTip && n.workSum.Cmp(newTip.workSum) >= 0 {
+		if n != nil && n != newTip && n.workSum.GtEq(&newTip.workSum) {
 			b.index.addBestChainCandidate(n)
 		}
 
@@ -826,7 +826,7 @@ func (b *BlockChain) ReconsiderBlock(hash *chainhash.Hash) error {
 			b.recentContextChecks.Delete(n.hash)
 		}
 
-		if b.index.canValidate(n) && n.workSum.Cmp(curBestTip.workSum) >= 0 {
+		if b.index.canValidate(n) && n.workSum.GtEq(&curBestTip.workSum) {
 			b.index.addBestChainCandidate(n)
 		}
 
@@ -875,7 +875,7 @@ func (b *BlockChain) ReconsiderBlock(hash *chainhash.Hash) error {
 		for n := finalNotKnownInvalidDescendant; n != vfNode; n = n.parent {
 			b.index.unsetStatusFlags(n, statusInvalidAncestor)
 			b.recentContextChecks.Delete(n.hash)
-			if b.index.canValidate(n) && n.workSum.Cmp(curBestTip.workSum) >= 0 {
+			if b.index.canValidate(n) && n.workSum.GtEq(&curBestTip.workSum) {
 				b.index.addBestChainCandidate(n)
 			}
 


### PR DESCRIPTION
~**This requires PR #2952**~.

Live profiling data pulled from an instance of dcrd v1.8.0-pre on commit a4b20e9d performing an initial sync shows that roughly 36% of all in-use allocations are the result of the big integers used to store the cumulative work for each block. Further, around 12% of the entire CPU time is spent scaning the heap for garbage collection which is a direct result of the total number of inuse allocations.  Therefore, a reasonable expectation is that eliminating those heap objects should produce a speedup of around 4-5%.

CPU Profiling Data:

```
      flat  flat%   sum%        cum   cum%
  1456.78s 25.97% 25.97%   1459.30s 26.01%  runtime.cgocall
      668s 11.91% 37.87%   2176.40s 38.79%  runtime.scanobject
   609.77s 10.87% 48.74%    668.60s 11.92%  runtime.findObject
   231.85s  4.13% 52.88%    231.85s  4.13%  runtime.heapBits.bits
   226.34s  4.03% 56.91%    226.34s  4.03%  runtime.markBits.isMarked
   178.15s  3.18% 60.09%    178.15s  3.18%  cmpbody
   176.58s  3.15% 63.23%    510.10s  9.09%  runtime.greyobject
```

Memory Profiling Data:
```
      flat  flat%   sum%        cum   cum%
    720918 20.08% 20.08%    1308043 36.44%  github.com/decred/dcrd/blockchain/standalone/v2.CalcWork
    587125 16.36% 73.81%     587125 16.36%  math/big.nat.make (inline)
```

Consequently, this modifies the blockchain package to make use of the much more efficient zero-alloc uint256s and associated work calculation funcs in the new primitives package that is under development.

As can be seen in the following graphs, the result is about 100MiB less heap usage on average while the overall total number of used bytes is almost identical, which results in a reduction of about 5% to the initial sync time which is all in line with the expected results.

![dcrd_initial_sync_total_bytes_used_comparison_uint256_work_sums_vs_1_8_0_a4b20e9d](https://user-images.githubusercontent.com/2115102/170807885-02621a63-384d-4c21-bd34-339560027dfc.png)

![dcrd_initial_sync_mem_usage_comparison_uint256_work_sums_vs_1_8_0_a4b20e9d](https://user-images.githubusercontent.com/2115102/170807891-9f2f2017-8aa2-4dd8-a4fc-7d79879b49da.png)

