### PR TITLE
blockchain: Return uint256 from chain work method.

### DIFF
--- a/internal/blockchain/chain.go
+++ b/internal/blockchain/chain.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/big"
 	"sync"
 	"time"
 
@@ -463,13 +462,13 @@ func (b *BlockChain) HaveBlock(hash *chainhash.Hash) bool {
 
 // ChainWork returns the total work up to and including the block of the
 // provided block hash.
-func (b *BlockChain) ChainWork(hash *chainhash.Hash) (*big.Int, error) {
+func (b *BlockChain) ChainWork(hash *chainhash.Hash) (uint256.Uint256, error) {
 	node := b.index.LookupNode(hash)
 	if node == nil {
-		return nil, unknownBlockError(hash)
+		return uint256.Uint256{}, unknownBlockError(hash)
 	}
 
-	return node.workSum.ToBig(), nil
+	return node.workSum, nil
 }
 
 // TipGeneration returns the entire generation of blocks stemming from the

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -6,7 +6,6 @@ package rpcserver
 
 import (
 	"context"
-	"math/big"
 	"net"
 	"time"
 
@@ -19,6 +18,7 @@ import (
 	"github.com/decred/dcrd/internal/blockchain/indexers"
 	"github.com/decred/dcrd/internal/mempool"
 	"github.com/decred/dcrd/internal/mining"
+	"github.com/decred/dcrd/math/uint256"
 	"github.com/decred/dcrd/peer/v3"
 	"github.com/decred/dcrd/rpc/jsonrpc/types/v4"
 	"github.com/decred/dcrd/txscript/v4/stdaddr"
@@ -246,7 +246,7 @@ type Chain interface {
 
 	// ChainWork returns the total work up to and including the block of the
 	// provided block hash.
-	ChainWork(hash *chainhash.Hash) (*big.Int, error)
+	ChainWork(hash *chainhash.Hash) (uint256.Uint256, error)
 
 	// CheckLiveTicket returns whether or not a ticket exists in the live ticket
 	// treap of the best node.


### PR DESCRIPTION
This modifies the method that returns the total cumulative work for a given block to return a more efficient uint256 instead of a big integer and updates all consumers accordingly.