### PR TITLE
mempool: Explicitly reject standalone treasurybase.

### DIFF
--- a/internal/mempool/error.go
+++ b/internal/mempool/error.go
@@ -38,6 +38,10 @@ const (
 	// ErrCoinbase indicates a transaction is a standalone coinbase transaction.
 	ErrCoinbase = ErrorKind("ErrCoinbase")
 
+	// ErrTreasurybase indicates a transaction is a standalone treasurybase
+	// transaction.
+	ErrTreasurybase = ErrorKind("ErrTreasurybase")
+
 	// ErrExpired indicates a transaction will be expired as of the next block.
 	ErrExpired = ErrorKind("ErrExpired")
 

--- a/internal/mempool/error_test.go
+++ b/internal/mempool/error_test.go
@@ -22,6 +22,7 @@ func TestErrorKindStringer(t *testing.T) {
 		{ErrAlreadyVoted, "ErrorAlreadyVoted"},
 		{ErrDuplicate, "ErrDuplicate"},
 		{ErrCoinbase, "ErrCoinbase"},
+		{ErrTreasurybase, "ErrTreasurybase"},
 		{ErrExpired, "ErrExpired"},
 		{ErrNonStandard, "ErrNonStandard"},
 		{ErrDustOutput, "ErrDustOutput"},


### PR DESCRIPTION
This updates the `mempool` to explicitly reject standalone `treasurybase`s and adds a test to ensure proper functionality.

Note that `treasurybase`s are already rejected because `IsCoinBaseTx` currently detects a `treasurybase` as a `coinbase` as well, but it is safer to be explicit in case the `coinbase` detection function is updated in the future to exclude `treasurybase`s.

Also since `treasurybase`s are rejected early, remove the code that deals with special casing them later given there is no way the transaction is one.