### PR TITLE
rpcserver: Avoid error in handleRebroadcastWinners.

### DIFF
--- a/internal/rpcserver/rpcwebsocket.go
+++ b/internal/rpcserver/rpcwebsocket.go
@@ -2071,8 +2071,11 @@ func handleRebroadcastWinners(wsc *wsClient, icmd interface{}) (interface{}, err
 	for i := range blocks {
 		winningTickets, _, _, err := cfg.Chain.LotteryDataForBlock(&blocks[i])
 		if err != nil {
-			return nil, rpcInternalError("Lottery data for block "+
-				"failed: "+err.Error(), "")
+			// This can legitimately happen if we have the block
+			// header but not the block data, so just log a warning
+			// and keep sending notifications.
+			log.Warnf("Lottery data for block failed: %v", err)
+			continue
 		}
 		ntfnData := &WinningTicketsNtfnData{
 			BlockHash:   blocks[i],


### PR DESCRIPTION
This downgrades an error when rebroadcasting the winning tickets to a
logged warning.

This is necessary because it is a legitimate state to have a chain tip
header returned by the Chain.TipGeneration() while the actual block data
is not yet available for the LotteryDataForBlock to complete.

Prior to this change, a voting wallet connecting to a dcrd instance with
multiple chain tip headers without the associated data would be unable
to re-start voting for blocks due to the associated RPC call failing.

