### PR TITLE
secp256k1: Implement direct key generation.

### DIFF
--- a/dcrec/secp256k1/modnscalar.go
+++ b/dcrec/secp256k1/modnscalar.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Decred developers
+// Copyright (c) 2020-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -100,7 +100,7 @@ var (
 // arithmetic over the secp256k1 group order. This means all arithmetic is
 // performed modulo:
 //
-//   0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141
+//	0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141
 //
 // It only implements the arithmetic needed for elliptic curve operations,
 // however, the operations that are not implemented can typically be worked
@@ -172,6 +172,19 @@ func (s *ModNScalar) Zero() {
 	s.n[5] = 0
 	s.n[6] = 0
 	s.n[7] = 0
+}
+
+// IsZeroBit returns 1 when the scalar is equal to zero or 0 otherwise in
+// constant time.
+//
+// Note that a bool is not used here because it is not possible in Go to convert
+// from a bool to numeric value in constant time and many constant-time
+// operations require a numeric value.  See IsZero for the version that returns
+// a bool.
+func (s *ModNScalar) IsZeroBit() uint32 {
+	// The scalar can only be zero if no bits are set in any of the words.
+	bits := s.n[0] | s.n[1] | s.n[2] | s.n[3] | s.n[4] | s.n[5] | s.n[6] | s.n[7]
+	return constantTimeEq(bits, 0)
 }
 
 // IsZero returns whether or not the scalar is equal to zero in constant time.

--- a/dcrec/secp256k1/modnscalar_test.go
+++ b/dcrec/secp256k1/modnscalar_test.go
@@ -80,11 +80,14 @@ func TestModNScalarZero(t *testing.T) {
 	}
 }
 
-// TestModNScalarIsZero ensures that checking if a scalar is zero works as
-// expected.
+// TestModNScalarIsZero ensures that checking if a scalar is zero via IsZero and
+// IsZeroBit works as expected.
 func TestModNScalarIsZero(t *testing.T) {
 	var s ModNScalar
 	if !s.IsZero() {
+		t.Errorf("new scalar is not zero - got %v (rawints %x)", s, s.n)
+	}
+	if s.IsZeroBit() != 1 {
 		t.Errorf("new scalar is not zero - got %v (rawints %x)", s, s.n)
 	}
 
@@ -92,16 +95,25 @@ func TestModNScalarIsZero(t *testing.T) {
 	if s.IsZero() {
 		t.Errorf("claims zero for nonzero scalar - got %v (rawints %x)", s, s.n)
 	}
+	if s.IsZeroBit() == 1 {
+		t.Errorf("claims zero for nonzero scalar - got %v (rawints %x)", s, s.n)
+	}
 
 	s.SetInt(0)
 	if !s.IsZero() {
+		t.Errorf("claims nonzero for zero scalar - got %v (rawints %x)", s, s.n)
+	}
+	if s.IsZeroBit() != 1 {
 		t.Errorf("claims nonzero for zero scalar - got %v (rawints %x)", s, s.n)
 	}
 
 	s.SetInt(1)
 	s.Zero()
 	if !s.IsZero() {
-		t.Errorf("claims zero for nonzero scalar - got %v (rawints %x)", s, s.n)
+		t.Errorf("claims nonzero for zero scalar - got %v (rawints %x)", s, s.n)
+	}
+	if s.IsZeroBit() != 1 {
+		t.Errorf("claims nonzero for zero scalar - got %v (rawints %x)", s, s.n)
 	}
 }
 

--- a/dcrec/secp256k1/privkey_bench_test.go
+++ b/dcrec/secp256k1/privkey_bench_test.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2022 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package secp256k1
+
+import (
+	"testing"
+)
+
+// BenchmarkPrivateKeyGenerate benchmarks generating new cryptographically
+// secure private keys.
+func BenchmarkPrivateKeyGenerate(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := GeneratePrivateKey()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
This implements private key generation directly for the secp256k1 curve instead of calling the generic version in the standard library that requires the adaptor code and thus all of the extra allocations and big integer conversions involved with it.

Not only is this implementation significantly more efficient, both in terms of execution speed and memory allocations, it also is theoretically more secure since it does not have the modulo bias the implementation in the standard lib does.

The following is a before and after comparison of generating a private key:

```
name                 old time/op     new time/op     delta
-----------------------------------------------------------------------------
PrivateKeyGenerate   38.6µs ± 4%     0.4µs ± 5%      -99.01%  (p=0.008 n=5+5)

name                 old allocs/op   new allocs/op   delta
-----------------------------------------------------------------------------
PrivateKeyGenerate   14.0 ± 0%       3.0 ± 0%        -78.57%  (p=0.008 n=5+5)
```