### PR TITLE
chaincfg: Remove planetdecred seeders.

### DIFF
--- a/chaincfg/mainnetparams.go
+++ b/chaincfg/mainnetparams.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2016 The btcsuite developers
-// Copyright (c) 2015-2021 The Decred developers
+// Copyright (c) 2015-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -506,7 +506,6 @@ func MainNetParams() *Params {
 		seeders: []string{
 			"mainnet-seed-1.decred.org",
 			"mainnet-seed-2.decred.org",
-			"mainnet-seed.planetdecred.org",
 			"mainnet-seed.dcrdata.org",
 			"mainnet-seed.jholdstock.uk",
 		},

--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2016 The btcsuite developers
-// Copyright (c) 2015-2021 The Decred developers
+// Copyright (c) 2015-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -416,7 +416,6 @@ func TestNet3Params() *Params {
 		seeders: []string{
 			"testnet-seed-1.decred.org",
 			"testnet-seed-2.decred.org",
-			"testnet-seed.planetdecred.org",
 			"testnet-seed.dcrdata.org",
 			"testnet-seed.jholdstock.uk",
 		},


### PR DESCRIPTION
This removes the planetdecred seeders for both mainnet and testnet as requested by their maintainer.

Closes #2973.