### PR TITLE
Testing: Add ClusterfuzzLite

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,4 @@
+FROM gcr.io/oss-fuzz-base/base-builder-go
+COPY . $SRC/
+WORKDIR dcrd
+COPY .clusterfuzzlite/build.sh $SRC/build.sh

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,1 @@
+compile_go_fuzzer github.com/decred/dcrd/crypto/blake256 FuzzSum256 fuzz_sum256

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: go

--- a/.github/workflows/cflite.yaml
+++ b/.github/workflows/cflite.yaml
@@ -1,0 +1,29 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '**'
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: go
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 400
+        mode: 'code-change'
+        sanitizer: ${{ matrix.sanitizer }}

--- a/crypto/blake256/fuzz.go
+++ b/crypto/blake256/fuzz.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2022 The Decred developers
+// Originally written in 2011-2012 by Dmitry Chestnykh.
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package blake256
+
+func FuzzSum256(data []byte) int {
+	if len(data) < 10 {
+		return 0
+	}
+	switch data[0] % 3 {
+	case 0:
+		_ = Sum224(data[1:])
+	case 1:
+		_ = Sum256(data[1:])
+	case 2:
+		if len(data) < 18 {
+			return 0
+		}
+		_ = New224Salt(data[1:17])
+	}
+	return 1
+}


### PR DESCRIPTION
Signed-off-by: AdamKorcz <Adam@adalogics.com>

This PR adds [ClusterfuzzLite](https://google.github.io/clusterfuzzlite/) and a simple fuzzer. 

ClusterfuzzLite will run fuzzers in the CI when PRs are made. It can be extended beyond this PR with code coverage and batch fuzzing: https://google.github.io/clusterfuzzlite/running-clusterfuzzlite/github-actions/