### PR TITLE
multi: Enforce testnet difficulty throttling.

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -245,12 +245,16 @@ type Params struct {
 	// minimum required difficulty after a long enough period of time has
 	// passed without finding a block.  This is really only useful for test
 	// networks and should not be set on a main network.
+	//
+	// Deprecated: This will be removed in the next major version bump.
 	ReduceMinDifficulty bool
 
 	// MinDiffReductionTime is the amount of time after which the minimum
 	// required difficulty should be reduced when a block hasn't been found.
 	//
 	// NOTE: This only applies if ReduceMinDifficulty is true.
+	//
+	// Deprecated: This will be removed in the next major version bump.
 	MinDiffReductionTime time.Duration
 
 	// GenerateSupported specifies whether or not CPU mining is allowed.

--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -78,7 +78,10 @@ func TestNet3Params() *Params {
 			{"testnet-seed.decred.org", true},
 		},
 
-		// Chain parameters
+		// Chain parameters.
+		//
+		// Note that the minimum difficulty reduction parameter only applies up
+		// to and including block height 962927.
 		GenesisBlock:             &genesisBlock,
 		GenesisHash:              genesisBlock.BlockHash(),
 		PowLimit:                 testNetPowLimit,

--- a/internal/blockchain/chain.go
+++ b/internal/blockchain/chain.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 	"sync"
 	"time"
 
@@ -143,6 +144,7 @@ type BlockChain struct {
 	expectedBlocksInTwoWeeks int64
 	deploymentVers           map[string]uint32
 	minKnownWork             *uint256.Uint256
+	minTestNetTarget         *big.Int
 	db                       database.DB
 	dbInfo                   *databaseInfo
 	chainParams              *chaincfg.Params
@@ -2203,6 +2205,12 @@ func (b *BlockChain) RemoveSpendEntry(hash *chainhash.Hash) error {
 	return err
 }
 
+// isTestNet3 returns whether or not the chain instance is for version 3 of the
+// test network.
+func (b *BlockChain) isTestNet3() bool {
+	return b.chainParams.Net == wire.TestNet3
+}
+
 // ChainParams returns the network parameters of the chain.
 //
 // This is part of the indexers.ChainQueryer interface.
@@ -2333,6 +2341,16 @@ func New(ctx context.Context, config *Config) (*BlockChain, error) {
 		minKnownWork = new(uint256.Uint256).SetBig(params.MinKnownChainWork)
 	}
 
+	// Impose a maximum difficulty target on the test network to prevent runaway
+	// difficulty on testnet by ASICs and GPUs since it's not reasonable to
+	// require high-powered hardware to keep the test network running smoothly.
+	var minTestNetTarget *big.Int
+	if params.Net == wire.TestNet3 {
+		// This equates to a maximum difficulty of 2^6 = 64.
+		const maxTestDiffShift = 6
+		minTestNetTarget = new(big.Int).Rsh(params.PowLimit, maxTestDiffShift)
+	}
+
 	// Either use the subsidy cache provided by the caller or create a new
 	// one when one was not provided.
 	subsidyCache := config.SubsidyCache
@@ -2359,6 +2377,7 @@ func New(ctx context.Context, config *Config) (*BlockChain, error) {
 		expectedBlocksInTwoWeeks:      expectedBlksInTwoWeeks,
 		deploymentVers:                deploymentVers,
 		minKnownWork:                  minKnownWork,
+		minTestNetTarget:              minTestNetTarget,
 		db:                            config.DB,
 		chainParams:                   params,
 		timeSource:                    config.TimeSource,
@@ -2410,6 +2429,38 @@ func New(ctx context.Context, config *Config) (*BlockChain, error) {
 	}
 	log.Infof("UTXO database version info: version: %d, compression: %d, utxo "+
 		"set: %d", utxoDbInfo.version, utxoDbInfo.compVer, utxoDbInfo.utxoVer)
+
+	// Manually invalidate any chains on version 3 of the test network that were
+	// created prior to enforcement of the maximum difficulty rules.
+	if b.isTestNet3() {
+		// Discover any existing nodes at the max diff activation height that do
+		// not have the expected hash and have not already been invalidated.
+		invalidateNodes := make([]*blockNode, 0, 1)
+		b.index.Lock()
+		b.index.forEachChainTip(func(tip *blockNode) error {
+			node := tip.Ancestor(testNet3MaxDiffActivationHeight)
+			if node != nil && node.hash != *block962928Hash &&
+				!node.status.KnownInvalid() {
+
+				invalidateNodes = append(invalidateNodes, node)
+			}
+			return nil
+		})
+		b.index.Unlock()
+
+		// Invalidate the blocks without notification callbacks as the calling
+		// code will not be fully initialized yet at this point and this is
+		// being done as a part of chain initialization.
+		curNtfnCallback := b.notifications
+		b.notifications = nil
+		for _, node := range invalidateNodes {
+			if err := b.InvalidateBlock(&node.hash); err != nil {
+				b.notifications = curNtfnCallback
+				return nil, err
+			}
+		}
+		b.notifications = curNtfnCallback
+	}
 
 	bestHdr := b.index.BestHeader()
 	log.Infof("Best known header: height %d, hash %v", bestHdr.height,

--- a/internal/blockchain/error.go
+++ b/internal/blockchain/error.go
@@ -76,9 +76,9 @@ const (
 	// timestamps to have a maximum precision of one second.
 	ErrInvalidTime = ErrorKind("ErrInvalidTime")
 
-	// ErrTimeTooOld indicates the time is either before the median time of
-	// the last several blocks per the chain consensus rules or prior to the
-	// most recent checkpoint.
+	// ErrTimeTooOld indicates the time is either before the median time of the
+	// last several blocks per the chain consensus rules or prior to the time
+	// that is required by max difficulty limitations on the test network.
 	ErrTimeTooOld = ErrorKind("ErrTimeTooOld")
 
 	// ErrTimeTooNew indicates the time is too far in the future as compared
@@ -106,6 +106,11 @@ const (
 	// ErrForkTooOld indicates a block is attempting to fork the block chain
 	// before the fork rejection checkpoint.
 	ErrForkTooOld = ErrorKind("ErrForkTooOld")
+
+	// ErrBadMaxDiffCheckpoint indicates a block on the version 3 test network
+	// at the height used to activate maximum difficulty semantics does not
+	// match the expected one.
+	ErrBadMaxDiffCheckpoint = ErrorKind("ErrBadMaxDiffCheckpoint")
 
 	// ErrNoTransactions indicates the block does not have at least one
 	// transaction.  A valid block must have at least the coinbase transaction.

--- a/internal/blockchain/error_test.go
+++ b/internal/blockchain/error_test.go
@@ -32,6 +32,7 @@ func TestErrorKindStringer(t *testing.T) {
 		{ErrBadMerkleRoot, "ErrBadMerkleRoot"},
 		{ErrBadCommitmentRoot, "ErrBadCommitmentRoot"},
 		{ErrForkTooOld, "ErrForkTooOld"},
+		{ErrBadMaxDiffCheckpoint, "ErrBadMaxDiffCheckpoint"},
 		{ErrNoTransactions, "ErrNoTransactions"},
 		{ErrNoTxInputs, "ErrNoTxInputs"},
 		{ErrNoTxOutputs, "ErrNoTxOutputs"},

--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -855,6 +855,15 @@ func (g *BlkTmplGenerator) handleTooFewVoters(nextHeight int64,
 			block.AddSTransaction(treasuryBase.MsgTx())
 		}
 
+		// Copy all of the regular transactions over.
+		for i, tx := range topBlock.Transactions() {
+			if i == 0 {
+				// Skip copying coinbase.
+				continue
+			}
+			block.AddTransaction(tx.MsgTx())
+		}
+
 		// Copy all of the stake transactions over.
 		for i, stx := range topBlock.STransactions() {
 			if i == 0 && isTreasuryEnabled {
@@ -2371,8 +2380,7 @@ nextPriorityQueueItem:
 	err = g.cfg.CheckConnectBlockTemplate(block)
 	if err != nil {
 		str := fmt.Sprintf("failed to do final check for check connect "+
-			"block when making new block template: %v",
-			err.Error())
+			"block when making new block template: %v", err)
 		return nil, makeError(ErrCheckConnectBlock, str)
 	}
 

--- a/internal/netsync/manager.go
+++ b/internal/netsync/manager.go
@@ -763,6 +763,19 @@ func (m *SyncManager) processBlock(block *dcrutil.Block) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
+
+	// Update the sync height when the block is higher than the currently best
+	// known value and it extends the main chain.
+	onMainChain := forkLen == 0
+	if onMainChain {
+		m.syncHeightMtx.Lock()
+		blockHeight := int64(block.MsgBlock().Header.Height)
+		if blockHeight > m.syncHeight {
+			m.syncHeight = blockHeight
+		}
+		m.syncHeightMtx.Unlock()
+	}
+
 	m.isCurrentMtx.Lock()
 	m.maybeUpdateIsCurrent()
 	m.isCurrentMtx.Unlock()
@@ -1052,6 +1065,18 @@ func (m *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 	for _, header := range headers {
 		err := chain.ProcessBlockHeader(header)
 		if err != nil {
+			// Update the sync height when the sync peer fails to process any
+			// headers since that chain is invalid from the local point of view
+			// and thus whatever the best known good header is becomes the new
+			// sync height unless a better one is discovered from the new sync
+			// peer.
+			if peer == m.syncPeer && !headersSynced {
+				_, newBestHeaderHeight := chain.BestHeader()
+				m.syncHeightMtx.Lock()
+				m.syncHeight = newBestHeaderHeight
+				m.syncHeightMtx.Unlock()
+			}
+
 			// Note that there is no need to check for an orphan header here
 			// because they were already verified to connect above.
 

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -3660,11 +3660,20 @@ func getWorkTemplateKey(header *wire.BlockHeader) [merkleRootPairSize]byte {
 //
 // This function MUST be called with the RPC workstate locked.
 func handleGetWorkRequest(s *Server) (interface{}, error) {
+	// Return an error immediately in the case of a failed background template.
+	//
+	// The only time this is expected is due to imposition of certain additional
+	// time-based rules such as when the maximum allowed difficulty on testnet
+	// is reached and not enough time has passed since the last block.
+	bt := s.cfg.BlockTemplater
+	if _, err := bt.CurrentTemplate(); err != nil {
+		return nil, rpcMiscError(fmt.Sprintf("no work is available: %v", err))
+	}
+
 	// Prune old templates and wait for updated templates when the current best
 	// chain changes.
 	state := s.workState
 	best := s.cfg.Chain.BestSnapshot()
-	bt := s.cfg.BlockTemplater
 	var template *mining.BlockTemplate
 	if state.prevHash == nil || *state.prevHash != best.Hash {
 		// Prune old templates from the pool when the best block changes.
@@ -3726,10 +3735,10 @@ func handleGetWorkRequest(s *Server) (interface{}, error) {
 	// retuned as part of the data below.
 	//
 	// For reference (0-index based, end value is exclusive):
-	// data[115:119] --> Bits
-	// data[135:139] --> Timestamp
-	// data[139:143] --> Nonce
-	// data[143:151] --> ExtraNonce
+	// data[116:120] --> Bits
+	// data[136:140] --> Timestamp
+	// data[140:144] --> Nonce
+	// data[144:152] --> ExtraNonce
 	data := make([]byte, 0, getworkDataLen)
 	buf := bytes.NewBuffer(data)
 	err = headerCopy.Serialize(buf)

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -5756,7 +5756,7 @@ func TestHandleGetWork(t *testing.T) {
 			return templater
 		}(),
 		wantErr: true,
-		errCode: dcrjson.ErrRPCInternal.Code,
+		errCode: dcrjson.ErrRPCMisc,
 	}, {
 		name:    "handleGetWork: no work during chain reorg",
 		handler: handleGetWork,

--- a/server.go
+++ b/server.go
@@ -2519,9 +2519,10 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 	// possibly notify RPC clients with the winning tickets.
 	case blockchain.NTBlockAccepted:
 		// Don't relay or notify RPC clients with winning tickets if we are not
-		// current. Other peers that are current should already know about it
-		// and clients, such as wallets, shouldn't be voting on old blocks.
-		if !s.syncManager.IsCurrent() {
+		// current and unsynced mining is not allowed.  Other peers that are
+		// current should already know about it and clients, such as wallets,
+		// shouldn't be voting on old blocks.
+		if !cfg.AllowUnsyncedMining && !s.syncManager.IsCurrent() {
 			return
 		}
 


### PR DESCRIPTION
Currently, version 3 of the test network implements a minimum difficulty reduction rule that was inherited from btcsuite which intends to act as mechanism to deal with major difficulty spikes due to ASICs which are typically not running testnet and since it's not reasonable to require high-powered hardware to keep the test network running smoothly.

Unfortunately, this existing rule is not a particularly good solution in general as it is not very deterministic and introduces additional complications around difficulty selection.  It is an even worse solution in the the case of Decred due to its hybrid model.

Rather than the aforementioned reactive approach, this introduces more deterministic proactive testnet rules in order limit the type of games that ASICs can play on testnet.

In particular, two new rules are introduced that are only imposed starting with block height 962928:

- A maximum allowed difficulty is now imposed on testnet such that CPU mining will still be feasible without resorting to any type of reactive and more complicated difficulty dropping
- Once the maximum allowed difficulty is reached on testnet, blocks must be at least 1 minute apart

The combination of these rules will prevent the difficulty on testnet from ever rising to levels that are out of reach for CPUs to continue mining blocks and throttle production in the case of higher-powered hardware such as GPUs and ASICs.

It should be noted that this solution is only suitable on a test network where no real monetary value is in play and thus the typical game theory mechanics do not apply.

Code to invalidate the existing extremely high work testnet chain which has stalled testnet after that point is added to allow the test network to be recovered without needing to fire up a bunch of ASICs.

Finally, this includes several other commits which improve the handling of mining and syncing when the new rules are enforced.
