### PR TITLE
multi: Build and doco updates for Go 1.19.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,11 +12,11 @@ jobs:
         go: [1.17, 1.18]
     steps:
       - name: Set up Go
-        uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab #v3.0.0
+        uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a #v3.2.1
         with:
           go-version: ${{ matrix.go }}
       - name: Check out source
-        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 #v3.0.0
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
       - name: Install Linters
         run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.45.2"
       - name: Build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [1.17, 1.18]
+        go: [1.18, 1.19]
     steps:
       - name: Set up Go
         uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a #v3.2.1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
       - name: Install Linters
-        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.45.2"
+        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.48.0"
       - name: Build
         run: go build ./...
       - name: Test

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ https://decred.org/downloads/
 
 <details><summary><b>Install Dependencies</b></summary>
 
-- **Go 1.17 or 1.18**
+- **Go 1.18 or 1.19**
 
   Installation instructions can be found here: https://golang.org/doc/install.
   Ensure Go was installed properly and is a supported version:

--- a/dcrec/secp256k1/schnorr/doc.go
+++ b/dcrec/secp256k1/schnorr/doc.go
@@ -27,23 +27,23 @@ time of this writing.
 
 Some of the advantages over ECDSA include:
 
- * They are linear which makes them easier to aggregate and use in protocols that
-   build on them such as multi-party signatures, threshold signatures, adaptor
-   signatures, and blind signatures
- * They are provably secure with weaker assumptions than the best known security
-   proofs for ECDSA
-   *  Specifically Schnorr signatures are provably secure under SUF-CMA (Strong
-      Existential Unforgeability under Chosen Message Attack) in the ROM (Random
-      Oracle Model) which guarantees that as long as the hash function behaves
-      ideally, the only way to break Schnorr signatures is by solving the ECDLP
-      (Elliptic Curve Discrete Logarithm Problem).
- * Their relatively straightforward and efficient aggregation properties make
-   them excellent for scalability and allow them to provide some nice privacy
-   characteristics
- * They support faster batch verification unlike the standardized version of
-   ECDSA signatures
+  - They are linear which makes them easier to aggregate and use in protocols that
+    build on them such as multi-party signatures, threshold signatures, adaptor
+    signatures, and blind signatures
+  - They are provably secure with weaker assumptions than the best known security
+    proofs for ECDSA
+  - Specifically Schnorr signatures are provably secure under SUF-CMA (Strong
+    Existential Unforgeability under Chosen Message Attack) in the ROM (Random
+    Oracle Model) which guarantees that as long as the hash function behaves
+    ideally, the only way to break Schnorr signatures is by solving the ECDLP
+    (Elliptic Curve Discrete Logarithm Problem).
+  - Their relatively straightforward and efficient aggregation properties make
+    them excellent for scalability and allow them to provide some nice privacy
+    characteristics
+  - They support faster batch verification unlike the standardized version of
+    ECDSA signatures
 
-Custom Schnorr-based Signature Scheme
+# Custom Schnorr-based Signature Scheme
 
 As mentioned in the overview, the primary downside of Schnorr signatures for
 elliptic curves is that they are not standardized as well as ECDSA signatures


### PR DESCRIPTION
This consists of several commit to update the CI and documentation for Go 1.19.  It also takes the opportunity to bump to the latest linter and action versions.

In particular:

- docs: Update README.md to required Go 1.18/1.19.
- build: Test against Go 1.19 and remove Go 1.17 accordingly.
- build: Update golangci-lint to v1.48.0.
- build: Update to latest action versions.
  - `actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a #v3.2.1`
  - `actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2`