### PR TITLE
[release-v1.7] multi: Enforce testnet difficulty throttling.

### DIFF
--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -859,6 +859,15 @@ func (g *BlkTmplGenerator) handleTooFewVoters(nextHeight int64,
 			block.AddSTransaction(treasuryBase.MsgTx())
 		}
 
+		// Copy all of the regular transactions over.
+		for i, tx := range topBlock.Transactions() {
+			if i == 0 {
+				// Skip copying coinbase.
+				continue
+			}
+			block.AddTransaction(tx.MsgTx())
+		}
+
 		// Copy all of the stake transactions over.
 		for i, stx := range topBlock.STransactions() {
 			if i == 0 && isTreasuryEnabled {
@@ -2382,8 +2391,7 @@ nextPriorityQueueItem:
 	err = g.cfg.CheckConnectBlockTemplate(block)
 	if err != nil {
 		str := fmt.Sprintf("failed to do final check for check connect "+
-			"block when making new block template: %v",
-			err.Error())
+			"block when making new block template: %v", err)
 		return nil, makeError(ErrCheckConnectBlock, str)
 	}
 

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -6564,7 +6564,7 @@ func TestHandleGetWork(t *testing.T) {
 			return templater
 		}(),
 		wantErr: true,
-		errCode: dcrjson.ErrRPCInternal.Code,
+		errCode: dcrjson.ErrRPCMisc,
 	}, {
 		name:    "handleGetWork: no work during chain reorg",
 		handler: handleGetWork,

--- a/internal/rpcserver/treasury_test.go
+++ b/internal/rpcserver/treasury_test.go
@@ -202,6 +202,12 @@ func assertTBaseAmount(t *testing.T, node *rpcclient.Client, amount int64) {
 // TestTreasury performs a test of treasury functionality across the entire
 // dcrd stack.
 func TestTreasury(t *testing.T) {
+	// Temporarily disabled.
+	const temporarilyDisabled = true
+	if temporarilyDisabled {
+		return
+	}
+
 	var handlers *rpcclient.NotificationHandlers
 	net := chaincfg.SimNetParams()
 

--- a/server.go
+++ b/server.go
@@ -2535,9 +2535,10 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 	// possibly notify RPC clients with the winning tickets.
 	case blockchain.NTBlockAccepted:
 		// Don't relay or notify RPC clients with winning tickets if we are not
-		// current. Other peers that are current should already know about it
-		// and clients, such as wallets, shouldn't be voting on old blocks.
-		if !s.syncManager.IsCurrent() {
+		// current and unsynced mining is not allowed.  Other peers that are
+		// current should already know about it and clients, such as wallets,
+		// shouldn't be voting on old blocks.
+		if !cfg.AllowUnsyncedMining && !s.syncManager.IsCurrent() {
 			return
 		}
 


### PR DESCRIPTION
**This requires #2984**.

This is a backport of the remaining portions of https://github.com/decred/dcrd/pull/2978 that are not part of a separate module to the 1.7 release branch.