### PR TITLE
[release-v1.7] release: Bump for 1.7.4.

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -56,7 +56,7 @@ var (
 	// the package will panic at runtime.  Of particular note is the pre-release
 	// and build metadata portions MUST only contain characters from
 	// semanticAlphabet.
-	Version = "1.7.2+release.local"
+	Version = "1.7.4+release.local"
 
 	// NOTE: The following values are set via init by parsing the above Version
 	// string.


### PR DESCRIPTION
**This requires #2985.**