### PR TITLE
dcrutil: Correct off-by-1 index check.

### DIFF
--- a/dcrutil/block.go
+++ b/dcrutil/block.go
@@ -115,7 +115,7 @@ func (b *Block) Hash() *chainhash.Hash {
 func (b *Block) Tx(txNum int) (*Tx, error) {
 	// Ensure the requested transaction is in range.
 	numTx := uint64(len(b.msgBlock.Transactions))
-	if txNum < 0 || uint64(txNum) > numTx {
+	if txNum < 0 || uint64(txNum) > numTx-1 {
 		str := fmt.Sprintf("transaction index %d is out of range - max %d",
 			txNum, numTx-1)
 		return nil, OutOfRangeError(str)
@@ -144,7 +144,7 @@ func (b *Block) Tx(txNum int) (*Tx, error) {
 func (b *Block) STx(txNum int) (*Tx, error) {
 	// Ensure the requested transaction is in range.
 	numTx := uint64(len(b.msgBlock.STransactions))
-	if txNum < 0 || uint64(txNum) > numTx {
+	if txNum < 0 || uint64(txNum) > numTx-1 {
 		str := fmt.Sprintf("transaction index %d is out of range - max %d",
 			txNum, numTx-1)
 		return nil, OutOfRangeError(str)

--- a/dcrutil/block_test.go
+++ b/dcrutil/block_test.go
@@ -297,7 +297,7 @@ func TestBlockErrors(t *testing.T) {
 		t.Errorf("TxHash: wrong error - got: %v <%T>, "+
 			"want: <%T>", err, err, OutOfRangeError(""))
 	}
-	_, err = b.TxHash(len(Block100000.Transactions) + 1)
+	_, err = b.TxHash(len(Block100000.Transactions))
 	if !errors.As(err, &oErr) {
 		t.Errorf("TxHash: wrong error - got: %v <%T>, "+
 			"want: <%T>", err, err, OutOfRangeError(""))
@@ -309,7 +309,7 @@ func TestBlockErrors(t *testing.T) {
 		t.Errorf("Tx: wrong error - got: %v <%T>, "+
 			"want: <%T>", err, err, OutOfRangeError(""))
 	}
-	_, err = b.Tx(len(Block100000.Transactions) + 1)
+	_, err = b.Tx(len(Block100000.Transactions))
 	if !errors.As(err, &oErr) {
 		t.Errorf("Tx: wrong error - got: %v <%T>, "+
 			"want: <%T>", err, err, OutOfRangeError(""))


### PR DESCRIPTION
Hi, I was reading through this section of the code when I noticed what seems to be a 1-off issue, 

even though I couldn't find the affected `funcs` being used in `dcrd` code-base (besides tests), I assume:
- they might be utilised in the future
- external packages might use these