### PR TITLE
mining: Don't fetch inputs for coinbase.

### DIFF
--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -2236,6 +2236,11 @@ nextPriorityQueueItem:
 			break
 		}
 
+		// Skip coinbase.
+		if i == 0 {
+			continue
+		}
+
 		view, err := g.cfg.FetchUtxoView(tx, !knownDisapproved)
 		if err != nil {
 			str := fmt.Sprintf("failed to fetch utxo view for tx %v: %s",


### PR DESCRIPTION
This modifies the template generation code to avoid needlessly attempting to fetch the inputs for the coinbase when determining whether to update fraud proofs since the coinbase doesn't have any inputs.