### PR TITLE
blockchain: Harden and optimize utxo cache.

### DIFF
--- a/internal/blockchain/chain.go
+++ b/internal/blockchain/chain.go
@@ -2212,7 +2212,7 @@ func New(ctx context.Context, config *Config) (*BlockChain, error) {
 
 	// Initialize the UTXO state.  This entails running any database migrations
 	// as necessary as well as initializing the UTXO cache.
-	if err := b.utxoCache.Initialize(ctx, &b, b.bestChain.tip()); err != nil {
+	if err := b.utxoCache.Initialize(ctx, &b); err != nil {
 		return nil, err
 	}
 

--- a/internal/blockchain/chain.go
+++ b/internal/blockchain/chain.go
@@ -940,7 +940,8 @@ func countSpentStakeOutputs(block *dcrutil.Block) int {
 			continue
 		}
 
-		// Exclude TreasuryBase and TSpend.
+		// Exclude treasurybase and treasury spends since neither have any
+		// inputs.
 		if stake.IsTreasuryBase(stx) || stake.IsTSpend(stx) {
 			continue
 		}

--- a/internal/blockchain/common_test.go
+++ b/internal/blockchain/common_test.go
@@ -902,8 +902,10 @@ func (g *chaingenHarness) ExpectUtxoSetState(blockName string) {
 		lastFlushHash:   block.BlockHash(),
 	}
 	if !reflect.DeepEqual(gotState, wantState) {
-		g.t.Fatalf("mismatched utxo set state:\nwant: %+v\n got: %+v\n", wantState,
-			gotState)
+		g.t.Fatalf("mismatched utxo set state:\nwant: hash %s, height %d\n "+
+			"got: hash %s, height %d\n", wantState.lastFlushHash,
+			wantState.lastFlushHeight, gotState.lastFlushHash,
+			gotState.lastFlushHeight)
 	}
 }
 

--- a/internal/blockchain/indexers/indexsubscriber.go
+++ b/internal/blockchain/indexers/indexsubscriber.go
@@ -243,8 +243,8 @@ func (s *IndexSubscriber) findLowestIndexTipHeight(queryer ChainQueryer) (int64,
 	return lowestHeight, bestHeight, nil
 }
 
-// CatchUp syncs all subscribed indexes to the the main chain by connecting
-// blocks from after the lowest index tip to the current main chain tip.
+// CatchUp syncs all subscribed indexes to the main chain by connecting blocks
+// from after the lowest index tip to the current main chain tip.
 //
 // This should be called after all indexes have subscribed for updates.
 func (s *IndexSubscriber) CatchUp(ctx context.Context, db database.DB, queryer ChainQueryer) error {

--- a/internal/blockchain/indexers/txindex_test.go
+++ b/internal/blockchain/indexers/txindex_test.go
@@ -104,8 +104,7 @@ func (tc *testChain) MainChainHasBlock(hash *chainhash.Hash) bool {
 	return ok
 }
 
-// Best returns the height and block hash of the the current
-// chain tip.
+// Best returns the height and block hash of the current chain tip.
 func (tc *testChain) Best() (int64, *chainhash.Hash) {
 	tc.mtx.Lock()
 	defer tc.mtx.Unlock()

--- a/internal/blockchain/utxocache.go
+++ b/internal/blockchain/utxocache.go
@@ -265,7 +265,7 @@ func (c *UtxoCache) hitRatio() float64 {
 // it to the cache.
 //
 // This function MUST be called with the cache lock held.
-func (c *UtxoCache) addEntry(outpoint wire.OutPoint, entry *UtxoEntry) error {
+func (c *UtxoCache) addEntry(outpoint wire.OutPoint, entry *UtxoEntry) {
 	// Attempt to get an existing entry from the cache.
 	cachedEntry := c.entries[outpoint]
 
@@ -287,8 +287,6 @@ func (c *UtxoCache) addEntry(outpoint wire.OutPoint, entry *UtxoEntry) error {
 		c.totalEntrySize -= cachedEntry.size()
 	}
 	c.totalEntrySize += entry.size()
-
-	return nil
 }
 
 // spendEntry marks the specified output as spent.
@@ -464,11 +462,7 @@ func (c *UtxoCache) Commit(view *UtxoViewpoint) error {
 
 		// If we passed all of the conditions above, the entry is modified or
 		// fresh, but not spent, and should be added to the cache.
-		err := c.addEntry(outpoint, entry)
-		if err != nil {
-			c.cacheLock.Unlock()
-			return err
-		}
+		c.addEntry(outpoint, entry)
 
 		// All entries that are added to the cache should be removed from the
 		// provided view.  This is an optimization to allow the cache to take

--- a/internal/blockchain/utxocache.go
+++ b/internal/blockchain/utxocache.go
@@ -102,7 +102,7 @@ type UtxoCacher interface {
 	// Initialize initializes the utxo cache and underlying utxo backend.  This
 	// entails running any database migrations as well as ensuring that the utxo
 	// set is caught up to the tip of the best chain.
-	Initialize(ctx context.Context, b *BlockChain, tip *blockNode) error
+	Initialize(ctx context.Context, b *BlockChain) error
 
 	// MaybeFlush conditionally flushes the cache to the backend.  A flush can
 	// be forced by setting the force flush parameter.
@@ -668,7 +668,7 @@ func (c *UtxoCache) MaybeFlush(bestHash *chainhash.Hash, bestHeight uint32,
 // last flushed to the tip block through the cache.
 //
 // This function should only be called during initialization.
-func (c *UtxoCache) Initialize(ctx context.Context, b *BlockChain, tip *blockNode) error {
+func (c *UtxoCache) Initialize(ctx context.Context, b *BlockChain) error {
 	log.Infof("UTXO cache initializing (max size: %d MiB)...",
 		c.maxSize/1024/1024)
 
@@ -687,6 +687,7 @@ func (c *UtxoCache) Initialize(ctx context.Context, b *BlockChain, tip *blockNod
 	// If the state is nil, update the state to the tip.  This should only be
 	// the case when starting from a fresh backend or a backend that has not
 	// been run with the utxo cache yet.
+	tip := b.bestChain.Tip()
 	if state == nil {
 		state = &UtxoSetState{
 			lastFlushHeight: uint32(tip.height),

--- a/internal/blockchain/utxocache.go
+++ b/internal/blockchain/utxocache.go
@@ -291,21 +291,6 @@ func (c *UtxoCache) addEntry(outpoint wire.OutPoint, entry *UtxoEntry) error {
 	return nil
 }
 
-// AddEntry adds the specified output to the cache.  The entry being added MUST
-// NOT be mutated by the caller after being passed to this function.
-//
-// Note that this function does not check if the entry is unspendable and
-// therefore the caller should ensure that the entry is spendable before adding
-// it to the cache.
-//
-// This function is safe for concurrent access.
-func (c *UtxoCache) AddEntry(outpoint wire.OutPoint, entry *UtxoEntry) error {
-	c.cacheLock.Lock()
-	err := c.addEntry(outpoint, entry)
-	c.cacheLock.Unlock()
-	return err
-}
-
 // spendEntry marks the specified output as spent.
 //
 // This function MUST be called with the cache lock held.

--- a/internal/blockchain/utxocache.go
+++ b/internal/blockchain/utxocache.go
@@ -274,26 +274,41 @@ func (c *UtxoCache) hitRatio() float64 {
 //
 // This function MUST be called with the cache lock held.
 func (c *UtxoCache) addEntry(outpoint wire.OutPoint, entry *UtxoEntry) {
+	// The entry will either be added to the cache when there is not already
+	// an existing entry for the specified outpoint or will overwrite the
+	// existing one when there is, but in either case the resulting cache
+	// entry is modified and thus needs to be marked as such.
+	entry.state |= utxoStateModified
+
 	// Attempt to get an existing entry from the cache.
 	cachedEntry := c.entries[outpoint]
 
-	// If an existing entry does not exist, the added entry should be marked as
-	// modified and fresh.
+	// Mark the entry as fresh, add it to the cache, and update the total
+	// cache size when there is not already an existing cache entry.
 	if cachedEntry == nil {
-		entry.state |= utxoStateModified | utxoStateFresh
+		entry.state |= utxoStateFresh
+		c.entries[outpoint] = entry
+		c.totalEntrySize += entry.size()
+		return
 	}
 
-	// Add the entry to the cache.  In the case that an entry already exists,
-	// the existing entry is overwritten.  All fields are overwritten because
-	// it's possible (although extremely unlikely) that the existing entry is
-	// being replaced by a different transaction with the same hash.  This is
-	// allowed so long as the previous transaction is fully spent.
+	// There is an existing entry in the cache at this point.
+	//
+	// Ensure the state of whether or not the existing entry is fresh is
+	// maintained, overwrite the existing entry, and update the total cache size
+	// accordingly.
+	//
+	// All fields are overwritten because it's possible (although extremely
+	// unlikely) that the existing entry is being replaced by a different
+	// transaction with the same hash.  This is allowed so long as the previous
+	// transaction is fully spent.
+	if cachedEntry.isFresh() {
+		entry.state |= utxoStateFresh
+	} else {
+		entry.state &^= utxoStateFresh
+	}
 	c.entries[outpoint] = entry
-
-	// Update the total entry size of the cache.
-	if cachedEntry != nil {
-		c.totalEntrySize -= cachedEntry.size()
-	}
+	c.totalEntrySize -= cachedEntry.size()
 	c.totalEntrySize += entry.size()
 }
 
@@ -329,20 +344,30 @@ func (c *UtxoCache) spendEntry(outpoint wire.OutPoint) {
 // the output exists in the cache, it is returned immediately.  Otherwise, it
 // fetches the output from the backend, caches it, and returns it to the
 // caller.  A cloned copy of the entry is returned so it can safely be mutated
-// by the caller without invalidating the cache.
+// by the caller without invalidating the cache.  The returned entry will not
+// have the modified or fresh flags set to ensure the cache state is separate
+// from the caller state.
 //
 // When there is no entry for the provided output, nil will be returned for both
 // the entry and the error.
 //
 // This function MUST be called with the cache lock held.
 func (c *UtxoCache) fetchEntry(outpoint wire.OutPoint) (*UtxoEntry, error) {
-	// If the cache already has the entry, return it immediately.  A cloned copy
-	// of the entry is returned so it can safely be mutated by the caller
-	// without invalidating the cache.
+	// Return a cloned copy of the cache entry when one exists for the provided
+	// output.  A cloned copy of the entry is returned so it can safely be
+	// mutated by the caller without invalidating the cache.
+	//
+	// Also clear the modified and fresh flags for the returned entry to ensure
+	// the cache state is separate from the view state.
 	var entry *UtxoEntry
 	if entry, found := c.entries[outpoint]; found {
 		c.hits++
-		return entry.Clone(), nil
+
+		clonedEntry := entry.Clone()
+		if clonedEntry != nil {
+			clonedEntry.state &^= utxoStateModified | utxoStateFresh
+		}
+		return clonedEntry, nil
 	}
 
 	// Increment cache misses.
@@ -367,6 +392,9 @@ func (c *UtxoCache) fetchEntry(outpoint wire.OutPoint) (*UtxoEntry, error) {
 	// Add the entry to the cache and return it.  A cloned copy of the entry is
 	// returned so it can safely be mutated by the caller without invalidating
 	// the cache.
+	//
+	// Also note that all entries loaded from the backend will not have any
+	// state flags set since they are memory only flags.
 	c.entries[outpoint] = entry
 	return entry.Clone(), nil
 }

--- a/internal/blockchain/utxocache.go
+++ b/internal/blockchain/utxocache.go
@@ -816,7 +816,8 @@ func (c *UtxoCache) Initialize(ctx context.Context, b *BlockChain) error {
 		// succession when initializing.
 		const forceFlush = false
 		const logFlush = true
-		err = c.maybeFlushFn(&n.hash, uint32(n.height), forceFlush, logFlush)
+		err = c.maybeFlushFn(&n.parent.hash, uint32(n.parent.height),
+			forceFlush, logFlush)
 		if err != nil {
 			return err
 		}

--- a/internal/blockchain/utxocache.go
+++ b/internal/blockchain/utxocache.go
@@ -334,15 +334,6 @@ func (c *UtxoCache) spendEntry(outpoint wire.OutPoint) {
 	cachedEntry.Spend()
 }
 
-// SpendEntry marks the specified output as spent.
-//
-// This function is safe for concurrent access.
-func (c *UtxoCache) SpendEntry(outpoint wire.OutPoint) {
-	c.cacheLock.Lock()
-	c.spendEntry(outpoint)
-	c.cacheLock.Unlock()
-}
-
 // fetchEntry returns the specified transaction output from the utxo set.  If
 // the output exists in the cache, it is returned immediately.  Otherwise, it
 // fetches the output from the backend, caches it, and returns it to the

--- a/internal/blockchain/utxocache.go
+++ b/internal/blockchain/utxocache.go
@@ -451,15 +451,15 @@ func (c *UtxoCache) Commit(view *UtxoViewpoint) error {
 			continue
 		}
 
-		// If the entry is not modified and not fresh, continue as there is
-		// nothing to do.
-		if !entry.isModified() && !entry.isFresh() {
+		// There is nothing to update in the cache nor the view when the view
+		// entry was not modified.
+		if !entry.isModified() {
 			continue
 		}
 
 		// If the entry is modified and spent, mark it as spent in the cache and
 		// then delete it from the view.
-		if entry.isModified() && entry.IsSpent() {
+		if entry.IsSpent() {
 			// Mark the entry as spent in the cache.
 			c.spendEntry(outpoint)
 

--- a/internal/blockchain/utxocache.go
+++ b/internal/blockchain/utxocache.go
@@ -578,6 +578,28 @@ func (c *UtxoCache) Commit(view *UtxoViewpoint) error {
 		// connected block, so this optimizes for the much more common case.
 		// ---------------------------------------------------------------------
 
+		// There is nothing to update in the cache when the output is spent by a
+		// transaction later in the regular transaction tree of the same block
+		// since such outputs never exist beyond the scope of the view and
+		// therefore do not have any cache entries.
+		//
+		// Further, it is no longer needed in the view either since it's already
+		// spent and thus nothing else in future blocks could possibly spend it.
+		//
+		// Thus, remove the entry from the view and continue to the next one.
+		if entry.isSpentByZeroConf() {
+			// Sanity check zero confirmation spends are also marked as spent.
+			if !entry.IsSpent() {
+				return AssertError(fmt.Sprintf("output %v from view@%s is "+
+					"simultaneously marked as spent by a transaction later in "+
+					"the same block and not spent", outpoint,
+					view.BestHash()))
+			}
+
+			delete(view.entries, outpoint)
+			continue
+		}
+
 		// Mark the spent view entry as modified and spent in the cache and
 		// remove it from the view.
 		//

--- a/internal/blockchain/utxocache_test.go
+++ b/internal/blockchain/utxocache_test.go
@@ -193,10 +193,7 @@ func createTestUtxoCache(t *testing.T, entries map[wire.OutPoint]*UtxoEntry) *Ut
 		// Add the entry to the cache.  The entry is cloned before being added
 		// so that any modifications that the cache makes to the entry are not
 		// reflected in the provided test entry.
-		err := utxoCache.addEntry(outpoint, entry.Clone())
-		if err != nil {
-			t.Fatalf("unexpected error when adding entry: %v", err)
-		}
+		utxoCache.addEntry(outpoint, entry.Clone())
 
 		// Set the state of the cached entries based on the provided entries.
 		// This is allowed for tests to easily simulate entries in the cache
@@ -343,11 +340,7 @@ func TestAddEntry(t *testing.T) {
 		}
 
 		// Add the entry specified by the test.
-		err := utxoCache.addEntry(test.outpoint, test.entry)
-		if err != nil {
-			t.Fatalf("%q: unexpected error when adding entry: %v", test.name,
-				err)
-		}
+		utxoCache.addEntry(test.outpoint, test.entry)
 		wantTotalEntrySize += test.entry.size()
 
 		// Attempt to get the added entry from the cache.

--- a/internal/blockchain/utxocache_test.go
+++ b/internal/blockchain/utxocache_test.go
@@ -1075,8 +1075,7 @@ func TestInitialize(t *testing.T) {
 			MaxSize:      100 * 1024 * 1024, // 100 MiB
 		})
 		g.chain.utxoCache = testUtxoCache
-		err := testUtxoCache.Initialize(context.Background(), g.chain,
-			g.chain.bestChain.Tip())
+		err := testUtxoCache.Initialize(context.Background(), g.chain)
 		if err != nil {
 			t.Fatalf("error initializing test cache: %v", err)
 		}
@@ -1225,8 +1224,7 @@ func TestShutdownUtxoCache(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error initializing backend info: %v", err)
 	}
-	err = testUtxoCache.Initialize(context.Background(), g.chain,
-		g.chain.bestChain.Tip())
+	err = testUtxoCache.Initialize(context.Background(), g.chain)
 	if err != nil {
 		t.Fatalf("error initializing test cache: %v", err)
 	}

--- a/internal/blockchain/utxocache_test.go
+++ b/internal/blockchain/utxocache_test.go
@@ -152,7 +152,8 @@ func entry85314() *UtxoEntry {
 // simulate various scenarios.
 type testUtxoCache struct {
 	*UtxoCache
-	disableFlush bool
+	disableFlush bool // disable flushing unconditionally (even if forced)
+	forceFlush   bool // force flushing even when not requested by caller
 }
 
 // MaybeFlush conditionally flushes the cache to the backend.  If the disable
@@ -166,6 +167,9 @@ func (c *testUtxoCache) MaybeFlush(bestHash *chainhash.Hash, bestHeight uint32,
 		return nil
 	}
 
+	// Force a flush if either the flag provided by the caller is true or the
+	// test cache overrides it.
+	forceFlush = forceFlush || c.forceFlush
 	return c.UtxoCache.MaybeFlush(bestHash, bestHeight, forceFlush, logFlush)
 }
 
@@ -1071,12 +1075,13 @@ func TestInitialize(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error initializing backend info: %v", err)
 	}
-	resetTestUtxoCache := func() *testUtxoCache {
+	resetTestUtxoCache := func(forceFlush bool) *testUtxoCache {
 		testUtxoCache := newTestUtxoCache(&UtxoCacheConfig{
 			Backend:      backend,
 			FlushBlockDB: g.chain.db.Flush,
 			MaxSize:      100 * 1024 * 1024, // 100 MiB
 		})
+		testUtxoCache.forceFlush = forceFlush
 		g.chain.utxoCache = testUtxoCache
 		err := testUtxoCache.Initialize(context.Background(), g.chain)
 		if err != nil {
@@ -1101,7 +1106,7 @@ func TestInitialize(t *testing.T) {
 
 	// Replace the utxo cache in the test chain with a test utxo cache so that
 	// flushing can be toggled on and off for testing.
-	testUtxoCache := resetTestUtxoCache()
+	testUtxoCache := resetTestUtxoCache(false)
 
 	// Validate that the tip and utxo set state are currently at the genesis
 	// block.
@@ -1118,8 +1123,7 @@ func TestInitialize(t *testing.T) {
 	g.ExpectUtxoSetState("genesis")
 
 	// Reset the cache and force a flush.
-	testUtxoCache = resetTestUtxoCache()
-	forceFlush(testUtxoCache)
+	testUtxoCache = resetTestUtxoCache(true)
 
 	// Validate that the utxo cache is now caught up to the tip.
 	g.ExpectUtxoSetState(g.TipName())
@@ -1201,8 +1205,7 @@ func TestInitialize(t *testing.T) {
 	g.ExpectUtxoSetState("b1")
 
 	// Reset the cache and force a flush.
-	testUtxoCache = resetTestUtxoCache()
-	forceFlush(testUtxoCache)
+	testUtxoCache = resetTestUtxoCache(true)
 
 	// Validate that the cache recovered and is now caught up to b1a.
 	g.ExpectUtxoSetState("b1a")

--- a/internal/blockchain/utxocache_test.go
+++ b/internal/blockchain/utxocache_test.go
@@ -193,7 +193,7 @@ func createTestUtxoCache(t *testing.T, entries map[wire.OutPoint]*UtxoEntry) *Ut
 		// Add the entry to the cache.  The entry is cloned before being added
 		// so that any modifications that the cache makes to the entry are not
 		// reflected in the provided test entry.
-		err := utxoCache.AddEntry(outpoint, entry.Clone())
+		err := utxoCache.addEntry(outpoint, entry.Clone())
 		if err != nil {
 			t.Fatalf("unexpected error when adding entry: %v", err)
 		}
@@ -343,7 +343,7 @@ func TestAddEntry(t *testing.T) {
 		}
 
 		// Add the entry specified by the test.
-		err := utxoCache.AddEntry(test.outpoint, test.entry)
+		err := utxoCache.addEntry(test.outpoint, test.entry)
 		if err != nil {
 			t.Fatalf("%q: unexpected error when adding entry: %v", test.name,
 				err)

--- a/internal/blockchain/utxocache_test.go
+++ b/internal/blockchain/utxocache_test.go
@@ -172,9 +172,12 @@ func (c *testUtxoCache) MaybeFlush(bestHash *chainhash.Hash, bestHeight uint32,
 // newTestUtxoCache returns a testUtxoCache instance using the provided
 // configuration details.
 func newTestUtxoCache(config *UtxoCacheConfig) *testUtxoCache {
-	return &testUtxoCache{
-		UtxoCache: NewUtxoCache(config),
+	utxoCache := NewUtxoCache(config)
+	c := &testUtxoCache{
+		UtxoCache: utxoCache,
 	}
+	utxoCache.maybeFlushFn = c.MaybeFlush
+	return c
 }
 
 // Ensure testUtxoCache implements the UtxoCacher interface.

--- a/internal/blockchain/utxocache_test.go
+++ b/internal/blockchain/utxocache_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/database/v3"
+	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -1136,10 +1137,12 @@ func TestInitialize(t *testing.T) {
 
 	outs := g.OldestCoinbaseOuts()
 	g.NextBlock("b0", &outs[0], outs[1:])
+	g.SaveTipCoinbaseOuts()
 	g.AcceptTipBlock()
 
 	outs = g.OldestCoinbaseOuts()
 	b1 := g.NextBlock("b1", &outs[0], outs[1:])
+	g.SaveTipCoinbaseOuts()
 	g.AcceptTipBlock()
 
 	// Force a cache flush and validate that the cache is caught up to block b1.
@@ -1209,6 +1212,71 @@ func TestInitialize(t *testing.T) {
 
 	// Validate that the cache recovered and is now caught up to b1a.
 	g.ExpectUtxoSetState("b1a")
+
+	// -------------------------------------------------------------------------
+	// Simulate an unclean shutdown such that the utxocache was last flushed at
+	// the tip block which is later invalidated and ensure the cache and backend
+	// recover back to the parent block as expected.
+	//
+	// This is accomplished by creating a new block that becomes the new best
+	// chain tip, disabling flushing, and invalidating that new block to ensure
+	// that the flushed utxo cache state is the invalidated block.  Then the
+	// cache is reset while forcing flushing during initialization.
+	//
+	//   ... -> b0 -> b1
+	//            |      \-> b2bad
+	//            \-> b1a    -----
+	//                       ^ (marked invalid with no flush to cache backend)
+	// -------------------------------------------------------------------------
+
+	outs = g.OldestCoinbaseOuts()
+	g.SetTip("b1")
+	b2bad := g.NextBlock("b2bad", &outs[0], outs[1:])
+	g.AcceptTipBlock()
+	forceFlush(testUtxoCache)
+	g.ExpectUtxoSetState("b2bad")
+
+	// Disable flushing to ensure the block that is about to be invalidated is
+	// not flushed to the backend.
+	//
+	// Ordinarily, the spend journal entry for disconnected blocks is not
+	// removed when there is an error in flushing, however, since this bypasses
+	// the error, the entry needs to be saved and restored after the block is
+	// invalidated.
+	testUtxoCache.disableFlush = true
+	var b2badStxos []spentTxOut
+	err = g.chain.db.View(func(dbTx database.Tx) error {
+		prevHash := b2bad.Header.PrevBlock
+		isTrsyEnabled, err := g.chain.IsTreasuryAgendaActive(&prevHash)
+		if err != nil {
+			return err
+		}
+		block := dcrutil.NewBlock(b2bad)
+		b2badStxos, err = dbFetchSpendJournalEntry(dbTx, block, isTrsyEnabled)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("unexpected error getting spend journal entry: %v", err)
+	}
+
+	// Invalidate the previously connected block so that it is disconnected and
+	// ensure the flushed utxo cache state is still at the invalidated block.
+	g.InvalidateBlockAndExpectTip("b2bad", nil, "b1")
+	g.ExpectUtxoSetState("b2bad")
+
+	// Restore the spend journal entry for the invalidated block per the above.
+	err = g.chain.db.Update(func(dbTx database.Tx) error {
+		b2badHash := b2bad.BlockHash()
+		return dbPutSpendJournalEntry(dbTx, &b2badHash, b2badStxos)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error restoring spend journal entry: %v", err)
+	}
+
+	// Reset the cache while forcing flushing during the initialization and
+	// ensure the cache and backend recover back to b1 as expected.
+	resetTestUtxoCache(true)
+	g.ExpectUtxoSetState("b1")
 }
 
 // TestShutdownUtxoCache validates that a cache flush is forced when shutting

--- a/internal/blockchain/utxocache_test.go
+++ b/internal/blockchain/utxocache_test.go
@@ -437,7 +437,7 @@ func TestSpendEntry(t *testing.T) {
 		}
 
 		// Spend the entry specified by the test.
-		utxoCache.SpendEntry(test.outpoint)
+		utxoCache.spendEntry(test.outpoint)
 
 		// If the existing entry was nil or spent, continue as there is nothing
 		// else to validate.

--- a/internal/blockchain/utxoviewpoint.go
+++ b/internal/blockchain/utxoviewpoint.go
@@ -670,8 +670,8 @@ func (view *UtxoViewpoint) addRegularInputUtxos(block *dcrutil.Block,
 	// Build a map of in-flight transactions because some of the inputs in the
 	// regular transaction tree of this block could be referencing other
 	// transactions earlier in the block which are not yet in the chain.
-	txInFlight := map[chainhash.Hash]int{}
 	regularTxns := block.Transactions()
+	txInFlight := make(map[chainhash.Hash]int, len(regularTxns))
 	for i, tx := range regularTxns {
 		txInFlight[*tx.Hash()] = i
 	}

--- a/internal/blockchain/utxoviewpoint.go
+++ b/internal/blockchain/utxoviewpoint.go
@@ -90,7 +90,7 @@ func (view *UtxoViewpoint) addTxOut(outpoint wire.OutPoint, txOut *wire.TxOut,
 
 	// The referenced transaction output should always be marked as unspent and
 	// modified when being added to the view.
-	entry.state &^= utxoStateSpent
+	entry.state &^= utxoStateSpent | utxoStateSpentByZeroConf
 	entry.state |= utxoStateModified
 
 	// Deep copy the script when the script in the entry differs from the one in
@@ -318,19 +318,26 @@ func (view *UtxoViewpoint) connectStakeTransactions(block *dcrutil.Block,
 
 // connectRegularTransaction updates the view by adding all new utxos created by
 // the passed transaction from the regular transaction tree and marking all
-// utxos that the transaction spends as spent.  In addition, when the 'stxos'
-// argument is not nil, it will be updated to append an entry for each spent
-// txout.  An error will be returned if the view does not contain the required
-// utxos.
+// utxos that the transaction spends as spent.  The transaction is added to the
+// provided in-flight tx map which is used to detect and mark utxos earlier in
+// the same regular transaction tree as zero conf spends.
+//
+// When the 'stxos' argument is not nil, it will be updated to append an entry
+// for each spent txout.  An error will be returned if the view does not contain
+// the required utxos.
 func (view *UtxoViewpoint) connectRegularTransaction(tx *dcrutil.Tx,
-	blockHeight int64, blockIndex uint32, stxos *[]spentTxOut,
-	isTreasuryEnabled bool) error {
+	blockHeight int64, blockIndex uint32, inFlightTx map[chainhash.Hash]uint32,
+	stxos *[]spentTxOut, isTreasuryEnabled bool) error {
 
 	// Coinbase transactions don't have any inputs to spend.
 	msgTx := tx.MsgTx()
 	if standalone.IsCoinBaseTx(msgTx, isTreasuryEnabled) {
 		// Add the transaction's outputs as available utxos.
 		view.AddTxOuts(tx, blockHeight, blockIndex, isTreasuryEnabled)
+
+		// Keep track of in-flight transactions in order detect spends of
+		// earlier outputs by transactions later in the same block.
+		inFlightTx[*tx.Hash()] = blockIndex
 		return nil
 	}
 
@@ -355,27 +362,42 @@ func (view *UtxoViewpoint) connectRegularTransaction(tx *dcrutil.Tx,
 		// details have been accessed since spending it might clear the fields
 		// from memory in the future.
 		entry.Spend()
+
+		// Mark txouts that are spent by transaction inputs later in the regular
+		// transaction tree of the same block as zero conf spends.
+		if inFlightIdx, ok := inFlightTx[prevOut.Hash]; ok && blockIndex >
+			inFlightIdx {
+
+			entry.state |= utxoStateSpentByZeroConf
+		}
 	}
 
 	// Add the transaction's outputs as available utxos.
 	view.AddTxOuts(tx, blockHeight, blockIndex, isTreasuryEnabled)
 
+	// Keep track of in-flight transactions in order detect spends of earlier
+	// outputs by transactions later in the same block.
+	inFlightTx[*tx.Hash()] = blockIndex
 	return nil
 }
 
 // connectRegularTransactions updates the view by adding all new utxos created
 // by the transactions in the regular transaction tree of the block and marking
-// all utxos those same transactions spend as spent.  In addition, when the
-// 'stxos' argument is not nil, it will be updated to append an entry for each
-// spent txout.  An error will be returned if the view does not contain the
-// required utxos.
+// all utxos those same transactions spend as spent.  It also marks all earlier
+// utxos spent by transactions later in the tree as zero confirmation spends.
+//
+// When the 'stxos' argument is not nil, it will be updated to append an entry
+// for each spent txout.  An error will be returned if the view does not contain
+// the required utxos.
 func (view *UtxoViewpoint) connectRegularTransactions(block *dcrutil.Block,
 	stxos *[]spentTxOut, isTreasuryEnabled bool) error {
 
 	// Connect all of the transactions in the regular transaction tree.
-	for i, tx := range block.Transactions() {
+	regularTxns := block.Transactions()
+	inFlightTx := make(map[chainhash.Hash]uint32, len(regularTxns))
+	for i, tx := range regularTxns {
 		err := view.connectRegularTransaction(tx, block.Height(), uint32(i),
-			stxos, isTreasuryEnabled)
+			inFlightTx, stxos, isTreasuryEnabled)
 		if err != nil {
 			return err
 		}
@@ -398,9 +420,18 @@ func (view *UtxoViewpoint) disconnectTransactions(block *dcrutil.Block,
 	// disconnecting stake transactions.
 	stxoIdx := len(stxos) - 1
 	transactions := block.Transactions()
+	numSpentRegularOutputs := countSpentRegularOutputs(block)
 	if stakeTree {
-		stxoIdx = len(stxos) - countSpentRegularOutputs(block) - 1
+		stxoIdx = len(stxos) - numSpentRegularOutputs - 1
 		transactions = block.STransactions()
+	}
+
+	// Create a map to keep track of all in-flight spends by the regular
+	// transaction tree in order detect spends of earlier outputs by
+	// transactions later in the same block.
+	var spendsInFlight map[wire.OutPoint]int
+	if !stakeTree {
+		spendsInFlight = make(map[wire.OutPoint]int, numSpentRegularOutputs)
 	}
 
 	for txIdx := len(transactions) - 1; txIdx > -1; txIdx-- {
@@ -481,6 +512,14 @@ func (view *UtxoViewpoint) disconnectTransactions(block *dcrutil.Block,
 			}
 
 			entry.Spend()
+
+			// Mark txouts that are spent by transaction inputs later in the
+			// same block as zero conf spends.
+			if inFlightIdx, ok := spendsInFlight[outpoint]; ok &&
+				txIdx < inFlightIdx {
+
+				entry.state |= utxoStateSpentByZeroConf
+			}
 		}
 
 		// Loop backwards through all of the transaction inputs (except for the
@@ -524,8 +563,15 @@ func (view *UtxoViewpoint) disconnectTransactions(block *dcrutil.Block,
 
 			// Mark the existing referenced transaction output as unspent and
 			// modified.
-			entry.state &^= utxoStateSpent
+			entry.state &^= utxoStateSpent | utxoStateSpentByZeroConf
 			entry.state |= utxoStateModified
+
+			// Keep track of all in-flight spends by the regular transaction
+			// tree in order detect spends of earlier outputs by transactions
+			// later in the same block.
+			if !stakeTree {
+				spendsInFlight[txIn.PreviousOutPoint] = txIdx
+			}
 		}
 	}
 

--- a/internal/blockchain/utxoviewpoint.go
+++ b/internal/blockchain/utxoviewpoint.go
@@ -748,9 +748,20 @@ func (view *UtxoViewpoint) fetchInputUtxos(block *dcrutil.Block,
 	// stake tree are not allowed to access outputs of transactions earlier in
 	// the block.  This applies to both transactions earlier in the stake tree
 	// as well as those in the regular tree.
-	for _, stx := range block.STransactions() {
-		isVote := stake.IsSSGen(stx.MsgTx())
-		for txInIdx, txIn := range stx.MsgTx().TxIn {
+	for txIdx, stx := range block.STransactions() {
+		// Ignore treasurybases and treasury spends since they have no inputs.
+		msgTx := stx.MsgTx()
+		shouldBeTreasuryBase := isTreasuryEnabled && txIdx == 0
+		if shouldBeTreasuryBase && stake.IsTreasuryBase(msgTx) {
+			continue
+		}
+		isTreasurySpend := isTreasuryEnabled && stake.IsTSpend(msgTx)
+		if isTreasurySpend {
+			continue
+		}
+
+		isVote := stake.IsSSGen(msgTx)
+		for txInIdx, txIn := range msgTx.TxIn {
 			// Ignore stakebase since it has no input.
 			if isVote && txInIdx == 0 {
 				continue
@@ -866,8 +877,13 @@ func (b *BlockChain) FetchUtxoView(tx *dcrutil.Tx, includeRegularTxns bool) (*Ut
 		outpoint.Index = uint32(txOutIdx)
 		filteredSet.add(view, &outpoint)
 	}
-	if !standalone.IsCoinBaseTx(msgTx, isTreasuryEnabled) {
-		isVote := stake.IsSSGen(msgTx)
+	// Ignore coinbases, treasurybases, and treasury spends since none of them
+	// have any inputs.
+	isCoinBase := standalone.IsCoinBaseTx(msgTx, isTreasuryEnabled)
+	isTreasuryBase := txType == stake.TxTypeTreasuryBase
+	isTreasurySpend := txType == stake.TxTypeTSpend
+	if !isCoinBase && !isTreasuryBase && !isTreasurySpend {
+		isVote := txType == stake.TxTypeSSGen
 		for txInIdx, txIn := range msgTx.TxIn {
 			// Ignore stakebase since it has no input.
 			if isVote && txInIdx == 0 {

--- a/internal/blockchain/utxoviewpoint.go
+++ b/internal/blockchain/utxoviewpoint.go
@@ -224,16 +224,20 @@ func (view *UtxoViewpoint) PriorityInput(prevOut *wire.OutPoint) (int64, int64, 
 func (view *UtxoViewpoint) connectTransaction(tx *dcrutil.Tx, blockHeight int64,
 	blockIndex uint32, stxos *[]spentTxOut, isTreasuryEnabled bool) error {
 
-	// Coinbase transactions don't have any inputs to spend.
+	// Treasurybase transactions don't have any inputs to spend.
+	//
+	// NOTE: This check MUST come before the coinbase check because a
+	// treasurybase is identified as a coinbase as of the time this comment is
+	// being written.
 	msgTx := tx.MsgTx()
-	if standalone.IsCoinBaseTx(msgTx, isTreasuryEnabled) {
-		// Add the transaction's outputs as available utxos.
-		view.AddTxOuts(tx, blockHeight, blockIndex, isTreasuryEnabled)
+	if isTreasuryEnabled && standalone.IsTreasuryBase(msgTx) {
 		return nil
 	}
 
-	// Treasurybase transactions don't have any inputs to spend.
-	if isTreasuryEnabled && standalone.IsTreasuryBase(msgTx) {
+	// Coinbase transactions don't have any inputs to spend.
+	if standalone.IsCoinBaseTx(msgTx, isTreasuryEnabled) {
+		// Add the transaction's outputs as available utxos.
+		view.AddTxOuts(tx, blockHeight, blockIndex, isTreasuryEnabled)
 		return nil
 	}
 

--- a/internal/blockchain/utxoviewpoint.go
+++ b/internal/blockchain/utxoviewpoint.go
@@ -51,6 +51,13 @@ func (view *UtxoViewpoint) LookupEntry(outpoint wire.OutPoint) *UtxoEntry {
 	return view.entries[outpoint]
 }
 
+// RemoveEntry removes the given transaction output from the current state of
+// the view.  It will have no effect if the passed output does not exist in the
+// view.
+func (view *UtxoViewpoint) RemoveEntry(outpoint wire.OutPoint) {
+	delete(view.entries, outpoint)
+}
+
 // addTxOut adds the specified output to the view if it is not provably
 // unspendable.  When the view already has an entry for the output, it will be
 // marked unspent.  All fields will be updated for existing entries since it's
@@ -149,9 +156,8 @@ func (view *UtxoViewpoint) AddTxOut(tx *dcrutil.Tx, txOutIdx uint32,
 func (view *UtxoViewpoint) AddTxOuts(tx *dcrutil.Tx, blockHeight int64,
 	blockIndex uint32, isTreasuryEnabled bool) {
 
-	msgTx := tx.MsgTx()
-
 	// Set encoded flags for the transaction.
+	msgTx := tx.MsgTx()
 	isCoinBase := standalone.IsCoinBaseTx(msgTx, isTreasuryEnabled)
 	hasExpiry := msgTx.Expiry != wire.NoExpiryValue
 	txType := stake.DetermineTxType(msgTx)
@@ -234,18 +240,15 @@ func (view *UtxoViewpoint) connectTransaction(tx *dcrutil.Tx, blockHeight int64,
 	// Spend the referenced utxos by marking them spent in the view and, if a
 	// slice was provided for the spent txout details, append an entry to it.
 	isVote := stake.IsSSGen(msgTx)
-	var isTSpend bool
-	if isTreasuryEnabled {
-		isTSpend = stake.IsTSpend(msgTx)
-	}
+	isTreasurySpend := isTreasuryEnabled && stake.IsTSpend(msgTx)
 	for txInIdx, txIn := range msgTx.TxIn {
 		// Ignore stakebase since it has no input.
 		if isVote && txInIdx == 0 {
 			continue
 		}
 
-		// Ignore TSpend since it has no input.
-		if isTSpend {
+		// Ignore treasury spends since they have no inputs.
+		if isTreasurySpend {
 			continue
 		}
 
@@ -315,12 +318,11 @@ func (view *UtxoViewpoint) disconnectTransactions(block *dcrutil.Block,
 		}
 		isVote := txType == stake.TxTypeSSGen
 
-		var isTreasuryBase, isTSpend bool
-
+		var isTreasuryBase, isTreasurySpend bool
 		if isTreasuryEnabled {
-			isTSpend = txType == stake.TxTypeTSpend && stakeTree
-			isTreasuryBase = txType == stake.TxTypeTreasuryBase &&
-				stakeTree && txIdx == 0
+			isTreasurySpend = txType == stake.TxTypeTSpend && stakeTree
+			isTreasuryBase = txType == stake.TxTypeTreasuryBase && stakeTree &&
+				txIdx == 0
 		}
 
 		tree := wire.TxTreeRegular
@@ -387,10 +389,10 @@ func (view *UtxoViewpoint) disconnectTransactions(block *dcrutil.Block,
 		}
 
 		// Loop backwards through all of the transaction inputs (except for the
-		// coinbase and treasurybase which have no inputs) and unspend the
-		// referenced txos.  This is necessary to match the order of the spent
-		// txout entries.
-		if isCoinBase || isTreasuryBase || isTSpend {
+		// coinbase, treasurybase, and treasury spends which have no inputs) and
+		// unspend the referenced txos.  This is necessary to match the order of
+		// the spent txout entries.
+		if isCoinBase || isTreasuryBase || isTreasurySpend {
 			continue
 		}
 		for txInIdx := len(msgTx.TxIn) - 1; txInIdx > -1; txInIdx-- {
@@ -433,13 +435,6 @@ func (view *UtxoViewpoint) disconnectTransactions(block *dcrutil.Block,
 	}
 
 	return nil
-}
-
-// RemoveEntry removes the given transaction output from the current state of
-// the view.  It will have no effect if the passed output does not exist in the
-// view.
-func (view *UtxoViewpoint) RemoveEntry(outpoint wire.OutPoint) {
-	delete(view.entries, outpoint)
 }
 
 // disconnectRegularTransactions updates the view by removing all utxos created
@@ -520,8 +515,7 @@ func (view *UtxoViewpoint) connectBlock(db database.DB, block, parent *dcrutil.B
 	// Disconnect the transactions in the regular tree of the parent block if
 	// the passed block disapproves it.
 	if !headerApprovesParent(&block.MsgBlock().Header) {
-		err := view.disconnectDisapprovedBlock(db, parent,
-			isTreasuryEnabled)
+		err := view.disconnectDisapprovedBlock(db, parent, isTreasuryEnabled)
 		if err != nil {
 			return err
 		}
@@ -637,8 +631,8 @@ func (view *UtxoViewpoint) Entries() map[wire.OutPoint]*UtxoEntry {
 	return view.entries
 }
 
-// ViewFilteredSet represents a set of utxos to fetch from the database that are
-// not already in a view.
+// ViewFilteredSet represents a set of utxos to fetch from the cache/backend
+// that are not already in a view.
 type ViewFilteredSet map[wire.OutPoint]struct{}
 
 // add conditionally adds the provided outpoint to the set if it does not
@@ -703,8 +697,8 @@ func (view *UtxoViewpoint) addRegularInputUtxos(block *dcrutil.Block,
 				i >= inFlightIndex {
 
 				originTx := regularTxns[inFlightIndex]
-				view.AddTxOuts(originTx, block.Height(),
-					uint32(inFlightIndex), isTreasuryEnabled)
+				view.AddTxOuts(originTx, block.Height(), uint32(inFlightIndex),
+					isTreasuryEnabled)
 				continue
 			}
 

--- a/internal/blockchain/utxoviewpoint.go
+++ b/internal/blockchain/utxoviewpoint.go
@@ -216,26 +216,45 @@ func (view *UtxoViewpoint) PriorityInput(prevOut *wire.OutPoint) (int64, int64, 
 	return 0, 0, false
 }
 
-// connectTransaction updates the view by adding all new utxos created by the
-// passed transaction and marking all utxos that the transaction spends as
-// spent.  In addition, when the 'stxos' argument is not nil, it will be updated
-// to append an entry for each spent txout.  An error will be returned if the
-// view does not contain the required utxos.
-func (view *UtxoViewpoint) connectTransaction(tx *dcrutil.Tx, blockHeight int64,
-	blockIndex uint32, stxos *[]spentTxOut, isTreasuryEnabled bool) error {
+// utxoEntryToSpentTxOut converts the provided utxo entry to a spent txout for
+// use in tracking all spent txouts for the spend journal.
+func utxoEntryToSpentTxOut(entry *UtxoEntry) spentTxOut {
+	// Populate the stxo details using the utxo entry.
+	return spentTxOut{
+		amount:        entry.Amount(),
+		pkScript:      entry.PkScript(),
+		ticketMinOuts: entry.ticketMinOuts,
+		blockHeight:   uint32(entry.BlockHeight()),
+		blockIndex:    entry.BlockIndex(),
+		scriptVersion: entry.ScriptVersion(),
+		packedFlags: encodeFlags(entry.IsCoinBase(), entry.HasExpiry(),
+			entry.TransactionType()),
+	}
+}
 
-	// Treasurybase transactions don't have any inputs to spend.
+// connectStakeTransaction updates the view by adding all new utxos created by
+// the passed transaction from the stake transaction tree and marking all utxos
+// that the transaction spends as spent.  In addition, when the 'stxos' argument
+// is not nil, it will be updated to append an entry for each spent txout.  An
+// error will be returned if the view does not contain the required utxos.
+func (view *UtxoViewpoint) connectStakeTransaction(tx *dcrutil.Tx,
+	blockHeight int64, blockIndex uint32, stxos *[]spentTxOut,
+	isTreasuryEnabled bool) error {
+
+	// Treasurybase transactions don't have any inputs to spend or outputs to
+	// add.
 	//
-	// NOTE: This check MUST come before the coinbase check because a
-	// treasurybase is identified as a coinbase as of the time this comment is
-	// being written.
+	// NOTE: This check relies on the code already having validated that the
+	// first transaction, and only the first transaction, in the stake tree is
+	// the required treasurybase when the treasury agenda is active.
 	msgTx := tx.MsgTx()
-	if isTreasuryEnabled && standalone.IsTreasuryBase(msgTx) {
+	if isTreasuryEnabled && blockIndex == 0 {
 		return nil
 	}
 
-	// Coinbase transactions don't have any inputs to spend.
-	if standalone.IsCoinBaseTx(msgTx, isTreasuryEnabled) {
+	// Treasury spends don't have any inputs to spend.
+	isTreasurySpend := isTreasuryEnabled && stake.IsTSpend(msgTx)
+	if isTreasurySpend {
 		// Add the transaction's outputs as available utxos.
 		view.AddTxOuts(tx, blockHeight, blockIndex, isTreasuryEnabled)
 		return nil
@@ -244,41 +263,24 @@ func (view *UtxoViewpoint) connectTransaction(tx *dcrutil.Tx, blockHeight int64,
 	// Spend the referenced utxos by marking them spent in the view and, if a
 	// slice was provided for the spent txout details, append an entry to it.
 	isVote := stake.IsSSGen(msgTx)
-	isTreasurySpend := isTreasuryEnabled && stake.IsTSpend(msgTx)
 	for txInIdx, txIn := range msgTx.TxIn {
 		// Ignore stakebase since it has no input.
 		if isVote && txInIdx == 0 {
 			continue
 		}
 
-		// Ignore treasury spends since they have no inputs.
-		if isTreasurySpend {
-			continue
-		}
-
 		// Ensure the referenced utxo exists in the view.  This should never
-		// happen unless there is a bug is introduced in the code.
-		entry := view.entries[txIn.PreviousOutPoint]
+		// happen unless a bug is introduced in the code.
+		prevOut := &txIn.PreviousOutPoint
+		entry := view.entries[*prevOut]
 		if entry == nil {
-			return AssertError(fmt.Sprintf("view missing input %v",
-				txIn.PreviousOutPoint))
+			return AssertError(fmt.Sprintf("view missing input %v", *prevOut))
 		}
 
 		// Only create the stxo details if requested.
 		if stxos != nil {
 			// Populate the stxo details using the utxo entry.
-			var stxo = spentTxOut{
-				amount:        entry.Amount(),
-				pkScript:      entry.PkScript(),
-				ticketMinOuts: entry.ticketMinOuts,
-				blockHeight:   uint32(entry.BlockHeight()),
-				blockIndex:    entry.BlockIndex(),
-				scriptVersion: entry.ScriptVersion(),
-				packedFlags: encodeFlags(entry.IsCoinBase(), entry.HasExpiry(),
-					entry.TransactionType()),
-			}
-
-			*stxos = append(*stxos, stxo)
+			*stxos = append(*stxos, utxoEntryToSpentTxOut(entry))
 		}
 
 		// Mark the entry as spent.  This is not done until after the relevant
@@ -289,6 +291,95 @@ func (view *UtxoViewpoint) connectTransaction(tx *dcrutil.Tx, blockHeight int64,
 
 	// Add the transaction's outputs as available utxos.
 	view.AddTxOuts(tx, blockHeight, blockIndex, isTreasuryEnabled)
+
+	return nil
+}
+
+// connectStakeTransactions updates the view by adding all new utxos created by
+// the transactions in the stake transaction tree of the block and marking all
+// utxos those same transactions spend as spent.  In addition, when the 'stxos'
+// argument is not nil, it will be updated to append an entry for each spent
+// txout.  An error will be returned if the view does not contain the required
+// utxos.
+func (view *UtxoViewpoint) connectStakeTransactions(block *dcrutil.Block,
+	stxos *[]spentTxOut, isTreasuryEnabled bool) error {
+
+	// Connect all of the transactions in the stake transaction tree.
+	for i, tx := range block.STransactions() {
+		err := view.connectStakeTransaction(tx, block.Height(), uint32(i),
+			stxos, isTreasuryEnabled)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// connectRegularTransaction updates the view by adding all new utxos created by
+// the passed transaction from the regular transaction tree and marking all
+// utxos that the transaction spends as spent.  In addition, when the 'stxos'
+// argument is not nil, it will be updated to append an entry for each spent
+// txout.  An error will be returned if the view does not contain the required
+// utxos.
+func (view *UtxoViewpoint) connectRegularTransaction(tx *dcrutil.Tx,
+	blockHeight int64, blockIndex uint32, stxos *[]spentTxOut,
+	isTreasuryEnabled bool) error {
+
+	// Coinbase transactions don't have any inputs to spend.
+	msgTx := tx.MsgTx()
+	if standalone.IsCoinBaseTx(msgTx, isTreasuryEnabled) {
+		// Add the transaction's outputs as available utxos.
+		view.AddTxOuts(tx, blockHeight, blockIndex, isTreasuryEnabled)
+		return nil
+	}
+
+	// Spend the referenced utxos by marking them spent in the view and, if a
+	// slice was provided for the spent txout details, append an entry to it.
+	for _, txIn := range msgTx.TxIn {
+		// Ensure the referenced utxo exists in the view.  This should never
+		// happen unless a bug is introduced in the code.
+		prevOut := &txIn.PreviousOutPoint
+		entry := view.entries[*prevOut]
+		if entry == nil {
+			return AssertError(fmt.Sprintf("view missing input %v", *prevOut))
+		}
+
+		// Only create the stxo details if requested.
+		if stxos != nil {
+			// Populate the stxo details using the utxo entry.
+			*stxos = append(*stxos, utxoEntryToSpentTxOut(entry))
+		}
+
+		// Mark the entry as spent.  This is not done until after the relevant
+		// details have been accessed since spending it might clear the fields
+		// from memory in the future.
+		entry.Spend()
+	}
+
+	// Add the transaction's outputs as available utxos.
+	view.AddTxOuts(tx, blockHeight, blockIndex, isTreasuryEnabled)
+
+	return nil
+}
+
+// connectRegularTransactions updates the view by adding all new utxos created
+// by the transactions in the regular transaction tree of the block and marking
+// all utxos those same transactions spend as spent.  In addition, when the
+// 'stxos' argument is not nil, it will be updated to append an entry for each
+// spent txout.  An error will be returned if the view does not contain the
+// required utxos.
+func (view *UtxoViewpoint) connectRegularTransactions(block *dcrutil.Block,
+	stxos *[]spentTxOut, isTreasuryEnabled bool) error {
+
+	// Connect all of the transactions in the regular transaction tree.
+	for i, tx := range block.Transactions() {
+		err := view.connectRegularTransaction(tx, block.Height(), uint32(i),
+			stxos, isTreasuryEnabled)
+		if err != nil {
+			return err
+		}
+	}
 
 	return nil
 }
@@ -538,19 +629,13 @@ func (view *UtxoViewpoint) connectBlock(db database.DB, block, parent *dcrutil.B
 	// of transactions created in the regular tree of the same block, which is
 	// important since the regular tree may be disapproved by the subsequent
 	// block while the stake tree must remain valid.
-	for i, stx := range block.STransactions() {
-		err := view.connectTransaction(stx, block.Height(), uint32(i),
-			stxos, isTreasuryEnabled)
-		if err != nil {
-			return err
-		}
+	err = view.connectStakeTransactions(block, stxos, isTreasuryEnabled)
+	if err != nil {
+		return err
 	}
-	for i, tx := range block.Transactions() {
-		err := view.connectTransaction(tx, block.Height(), uint32(i),
-			stxos, isTreasuryEnabled)
-		if err != nil {
-			return err
-		}
+	err = view.connectRegularTransactions(block, stxos, isTreasuryEnabled)
+	if err != nil {
+		return err
 	}
 
 	// Update the best hash for view to include this block since all of its
@@ -615,12 +700,9 @@ func (view *UtxoViewpoint) disconnectBlock(block, parent *dcrutil.Block,
 			return err
 		}
 
-		for i, tx := range parent.Transactions() {
-			err := view.connectTransaction(tx, parent.Height(),
-				uint32(i), nil, isTreasuryEnabled)
-			if err != nil {
-				return err
-			}
+		err = view.connectRegularTransactions(parent, nil, isTreasuryEnabled)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/internal/blockchain/validate.go
+++ b/internal/blockchain/validate.go
@@ -3517,7 +3517,11 @@ func (b *BlockChain) checkTransactionsAndConnect(inputFees dcrutil.Amount, node 
 		//
 		// Also, update the passed spent txos slice to contain an entry for each
 		// output the transaction spends.
-		err = view.connectTransaction(tx, node.height, uint32(idx), stxos,
+		connectTransaction := view.connectRegularTransaction
+		if stakeTree {
+			connectTransaction = view.connectStakeTransaction
+		}
+		err = connectTransaction(tx, node.height, uint32(idx), stxos,
 			isTreasuryEnabled)
 		if err != nil {
 			return err

--- a/internal/blockchain/validate_test.go
+++ b/internal/blockchain/validate_test.go
@@ -1972,7 +1972,7 @@ func TestModifiedSubsidySplitSemantics(t *testing.T) {
 		trsySubsidy := cache.CalcTreasurySubsidy(height, numVotes, noTreasury)
 		powSubsidy := cache.CalcWorkSubsidyV2(height, numVotes, withDCP0010)
 
-		// Update the input value to the the new expected subsidy sum.
+		// Update the input value to the new expected subsidy sum.
 		coinbaseTx := b.Transactions[0]
 		coinbaseTx.TxIn[0].ValueIn = trsySubsidy + powSubsidy
 


### PR DESCRIPTION
~**This requires #2994**.~

This reworks several portions of the utxo cache to improve its robustness, optimize it, and correct some hard to hit corner cases that involve a mix of manual block invalidation, conditional flushing, and successive unclean shutdowns along with reworking several of the tests and significantly increasing the associated scenarios covered by the tests.

Note that since **this is consensus critical code**, significant effort has been put into making these changes easier to reason about and review by carefully crafting a series of individual commits such that every commit message thoroughly describes its purpose, maintains consensus, and therefore passes all tests.

The following is a high-level overview of the changes:
- Miscellaneous consistency cleanup
- Pre-allocates the map used to track in-flight transactions in utxo views
- Removes exported utxo cache `SpendEntry` method
- Remove exported utxo cache `AddEntry` method
- Removes unused utxo cache add entry error
- Removes the unnecessary `tip` parameter from the utxo cache `Initialize` method
- Modifies the utxo cache tests to allow overriding cache flushing
- Improves utxo cache initialize tests to ensure initialize code itself flushes the expected data to the backend
- Corrects an extremely hard to hit corner case involving a mix of manual block invalidation, conditional flushing, and successive unclean shutdowns
  - Adds tests for this condition to ensure proper behavior
- Modifies the code that deals with fetching input utxos to avoid needlessly looking up inputs for `treasurybase` and `treasury spend` transactions 
- Updates the code when connecting transactions in a utxo view to avoid adding `treasurybase` utxos since they are never directly spendable
- Simplifies the various utxo cache tests and improves their legibility 
- Reworks utxo cache spend entry tests to simplify them and make them more flexible
- Reworks utxo cache commit tests to simplify them, make them more flexible, and test a lot more conditions
- Improves the robustness of `Commit` in regards to unmodified spent and unspent fresh view entries to help defend against code changes that could easily inadvertently violate the non-obvious, and heretofore undocumented, assumptions
- Reworks the utxo cache add entry tests to simplify them and make them more flexible
- Separates utxo cache and view state by updating the `addEntry` and `fetchEntry` methods to ensure the modified and spent flags are cleared on cloned entries loaded from the cache and and always set correctly when adding entries to the cache
- Modifies the utxo cache commit logic to ensure more robust handling of spent outputs including checking the backend for entries not currently in the cache and conditionally loading them if needed
  - Includes the addition of a double spend assertion
  - Adds tests to ensure the new behavior works as intended
- Splits the logic for handling the connection of transactions from the regular tree and stake tree to a utxo view to provide a clean path for optimizing zero confirmation spends
- Updates the utxo view and cache handling to detect zero confirmation spends in the regular transaction tree and bypass the cache when committing the view to avoid cache misses given they are guaranteed to never have any cache entries since they never exist beyond the scope of the view