### PR TITLE
blockchain: Remove unspendable utxo set entries.

### DIFF
--- a/internal/blockchain/utxobackend.go
+++ b/internal/blockchain/utxobackend.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	// currentUtxoDatabaseVersion indicates the current UTXO database version.
-	currentUtxoDatabaseVersion = 2
+	currentUtxoDatabaseVersion = 3
 
 	// utxoDbName is the name of the UTXO database.
 	utxoDbName = "utxodb"


### PR DESCRIPTION
**This requires #2995**.

---

### Testing Notes

As of this PR, the expected behavior is that there is a single database update that takes around 1 to 2 seconds to complete after which it will no longer be possible to downgrade.

As the warning above notes, if you try to run an older software version after this migration has completed, you will get an error message similar to `Unable to start server: the current UTXO database is no longer compatible with this version of the software (3 > 2)`

---

This adds code to update the utxo database to version 3 which removes outputs from the utxo set that are never directly spendable to avoid needlessly wasting space.