### PR TITLE
config: Deprecate min block size CLI option.

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -160,8 +160,9 @@ Application Options:
 	                             of addresses to use for generated blocks -- At
 	                             least one address is required if the generate
 	                             option is set
-	    --blockminsize=          Minimum block size in bytes to be used when
-	                             creating a block
+	    --blockminsize=          DEPRECATED: This behavior is no longer available
+	                             and this option will be removed in a future
+	                             version of the software
 	    --blockmaxsize=          Maximum block size in bytes to be used when
 	                             creating a block (default: 375000)
 	    --blockprioritysize=     Size in bytes for high-priority/low-fee

--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -1140,9 +1140,7 @@ func calcFeePerKb(txDesc *TxDesc, ancestorStats *TxAncestorStats) float64 {
 // priority).
 //
 // When the fees per kilobyte drop below the TxMinFreeFee policy setting, the
-// transaction will be skipped unless the BlockMinSize policy setting is
-// nonzero, in which case the block will be filled with the low-fee/free
-// transactions until the block size reaches that minimum size.
+// transaction will be skipped.
 //
 // Any transactions which would cause the block to exceed the BlockMaxSize
 // policy setting, exceed the maximum allowed signature operations per block, or
@@ -1165,10 +1163,6 @@ func calcFeePerKb(txDesc *TxDesc, ancestorStats *TxAncestorStats) float64 {
 //	|                                   |   |
 //	|                                   |   |
 //	|                                   |   |
-//	|-----------------------------------|   |
-//	|  Low-fee/Non high-priority (free) |   |
-//	|  transactions (while block size   |   |
-//	|  <= policy.BlockMinSize)          |   |
 //	 -----------------------------------  --
 //
 // Which also includes a stake tree that looks like the following:
@@ -1746,18 +1740,13 @@ nextPriorityQueueItem:
 			}
 		}
 
-		// Skip free transactions once the block is larger than the
-		// minimum block size, except for stake transactions.
+		// Skip free transactions except for stake transactions.
 		if sortedByFee &&
 			(prioItem.feePerKB < float64(g.cfg.Policy.TxMinFreeFee)) &&
-			(tx.Tree() != wire.TxTreeStake) &&
-			(blockPlusTxSize >= g.cfg.Policy.BlockMinSize) {
+			(tx.Tree() != wire.TxTreeStake) {
 
-			log.Tracef("Skipping tx %s with feePerKB %.2f "+
-				"< TxMinFreeFee %d and block size %d >= "+
-				"minBlockSize %d", tx.Hash(), prioItem.feePerKB,
-				g.cfg.Policy.TxMinFreeFee, blockPlusTxSize,
-				g.cfg.Policy.BlockMinSize)
+			log.Tracef("Skipping tx %s with feePerKB %.2f < TxMinFreeFee %d ",
+				tx.Hash(), prioItem.feePerKB, g.cfg.Policy.TxMinFreeFee)
 			logSkippedDeps(tx, deps)
 			miningView.reject(tx.Hash())
 			continue

--- a/internal/mining/mining_harness_test.go
+++ b/internal/mining/mining_harness_test.go
@@ -1357,7 +1357,6 @@ func newMiningHarness(chainParams *chaincfg.Params) (*miningHarness, []spendable
 
 	// Create a mining policy with defaults suitable for testing.
 	policy := &Policy{
-		BlockMinSize:      uint32(0),
 		BlockMaxSize:      uint32(375000),
 		BlockPrioritySize: uint32(20000),
 		TxMinFreeFee:      dcrutil.Amount(1e4),

--- a/internal/mining/policy.go
+++ b/internal/mining/policy.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2016 The btcsuite developers
-// Copyright (c) 2016-2020 The Decred developers
+// Copyright (c) 2016-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -22,10 +22,6 @@ const (
 // the generation of block templates.  See the documentation for
 // NewBlockTemplate for more details on each of these parameters are used.
 type Policy struct {
-	// BlockMinSize is the minimum block size in bytes to be used when
-	// generating a block template.
-	BlockMinSize uint32
-
 	// BlockMaxSize is the maximum block size in bytes to be used when
 	// generating a block template.
 	BlockMaxSize uint32

--- a/sampleconfig/sampleconfig.go
+++ b/sampleconfig/sampleconfig.go
@@ -300,13 +300,6 @@ const fileContents = `[Application Options]
 ; miningaddr=youraddress2
 ; miningaddr=youraddress3
 
-; Specify the minimum block size in bytes to create.  By default, only
-; transactions which have enough fees or a high enough priority will be included
-; in generated block templates.  Specifying a minimum block size will instead
-; attempt to fill generated block templates up with transactions until it is at
-; least the specified number of bytes.
-; blockminsize=0
-
 ; Specify the maximum block size in bytes to create.  This value will be limited
 ; to the consensus limit if it is larger than this value.
 ; blockmaxsize=375000

--- a/server.go
+++ b/server.go
@@ -3570,7 +3570,6 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB,
 		// NOTE: The CPU miner relies on the mempool, so the mempool has to be
 		// created before calling the function to create the CPU miner.
 		policy := mining.Policy{
-			BlockMinSize:      cfg.BlockMinSize,
 			BlockMaxSize:      cfg.BlockMaxSize,
 			BlockPrioritySize: cfg.BlockPrioritySize,
 			TxMinFreeFee:      cfg.minRelayTxFee,


### PR DESCRIPTION
Now that the old low-fee/free tx relay policy has been removed, there is no longer any need to consider a minimum block size for block templates since the option only applied to handling low-fee/free transactions.

Consequently, this deprecates the `--blockminsize` CLI option and removes the associated code that changes behavior based on the option.