### PR TITLE
txscript: remove obsolete requireMinimal comment

### DIFF
--- a/txscript/scriptnum.go
+++ b/txscript/scriptnum.go
@@ -197,17 +197,17 @@ func (n ScriptNum) Int32() int32 {
 // bytes and therefore will pass that value to this function resulting in an
 // allowed range of [-2^31 + 1, 2^31 - 1].
 //
-// The requireMinimal flag causes an error to be returned if additional checks
-// on the encoding determine it is not represented with the smallest possible
-// number of bytes or is the negative 0 encoding, [0x80].  For example, consider
-// the number 127.  It could be encoded as [0x7f], [0x7f 0x00],
-// [0x7f 0x00 0x00 ...], etc.  All forms except [0x7f] will return an error with
-// requireMinimal enabled.
+// An error will be returned if the encoding is not represented with the
+// smallest possible number of bytes or is the negative 0 encoding, [0x80].  For
+// example, consider the number 127.  It could be encoded as [0x7f], [0x7f
+// 0x00], [0x7f 0x00 0x00 ...], etc.  All forms except [0x7f] will return an
+// error.
 //
 // The scriptNumLen is the maximum number of bytes the encoded value can be
-// before an ErrNumberTooBig is returned.  This effectively limits the range of
+// before an ErrNumOutOfRange is returned.  This effectively limits the range of
 // allowed values.
-// WARNING:  Great care should be taken if passing a value larger than
+//
+// WARNING: Great care should be taken if passing a value larger than
 // defaultScriptNumLen, which could lead to addition and multiplication
 // overflows.
 //


### PR DESCRIPTION
The requireMinimal flag for MakeScriptNum was removed in 84b65d049b053defb89b6466b5d49fcb06fbc207 but the description was left in the comment for MakeScriptNum.  This removes that part of the docs.