### PR TITLE
[release-v1.7] main: Use backported blockchain updates.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1020,7 +1020,8 @@ func countSpentStakeOutputs(block *dcrutil.Block, isTreasuryEnabled bool) int {
 			continue
 		}
 
-		// Exclude TreasuryBase and TSpend.
+		// Exclude treasurybase and treasury spends since neither have any
+		// inputs.
 		if stake.IsTreasuryBase(stx) || stake.IsTSpend(stx) {
 			continue
 		}

--- a/blockchain/chainio_test.go
+++ b/blockchain/chainio_test.go
@@ -309,7 +309,7 @@ func TestBlockIndexDecodeErrors(t *testing.T) {
 		// Ensure the expected error type is returned.
 		gotBytesRead, err := decodeBlockIndexEntry(test.serialized,
 			&test.entry)
-		if !errors.As(err, &test.errType) {
+		if !errors.Is(err, test.errType) {
 			t.Errorf("%q: expected error type does not match - got %T, want %T",
 				test.name, err, test.errType)
 			continue
@@ -525,7 +525,7 @@ func TestStxoDecodeErrors(t *testing.T) {
 		gotBytesRead, err := decodeSpentTxOut(test.serialized,
 			&test.stxo, test.stxo.amount, test.stxo.blockHeight, test.stxo.blockIndex,
 			test.txOutIndex)
-		if !errors.As(err, &test.errType) {
+		if !errors.Is(err, test.errType) {
 			t.Errorf("%q: expected error type does not match - got %T, want %T",
 				test.name, err, test.errType)
 			continue
@@ -777,7 +777,7 @@ func TestSpendJournalErrors(t *testing.T) {
 		// slice is nil.
 		stxos, err := deserializeSpendJournalEntry(test.serialized,
 			test.blockTxns, noTreasury)
-		if !errors.As(err, &test.errType) {
+		if !errors.Is(err, test.errType) {
 			t.Errorf("%q: expected error type does not match - got %T, want %T",
 				test.name, err, test.errType)
 			continue

--- a/blockchain/common_test.go
+++ b/blockchain/common_test.go
@@ -926,8 +926,10 @@ func (g *chaingenHarness) ExpectUtxoSetState(blockName string) {
 		lastFlushHash:   block.BlockHash(),
 	}
 	if !reflect.DeepEqual(gotState, wantState) {
-		g.t.Fatalf("mismatched utxo set state:\nwant: %+v\n got: %+v\n", wantState,
-			gotState)
+		g.t.Fatalf("mismatched utxo set state:\nwant: hash %s, height %d\n "+
+			"got: hash %s, height %d\n", wantState.lastFlushHash,
+			wantState.lastFlushHeight, gotState.lastFlushHash,
+			gotState.lastFlushHeight)
 	}
 }
 

--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -24,6 +24,15 @@ func (e AssertError) Error() string {
 	return "assertion failed: " + string(e)
 }
 
+// Is implements the interface to work with the standard library's errors.Is.
+//
+// It returns true in the following cases:
+// - The target is AssertError
+func (e AssertError) Is(target error) bool {
+	var err AssertError
+	return errors.As(target, &err)
+}
+
 // ErrorKind identifies a kind of error.  It has full support for errors.Is and
 // errors.As, so the caller can directly check against an error kind when
 // determining the reason for an error.

--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -67,9 +67,9 @@ const (
 	// timestamps to have a maximum precision of one second.
 	ErrInvalidTime = ErrorKind("ErrInvalidTime")
 
-	// ErrTimeTooOld indicates the time is either before the median time of
-	// the last several blocks per the chain consensus rules or prior to the
-	// most recent checkpoint.
+	// ErrTimeTooOld indicates the time is either before the median time of the
+	// last several blocks per the chain consensus rules or prior to the time
+	// that is required by max difficulty limitations on the test network.
 	ErrTimeTooOld = ErrorKind("ErrTimeTooOld")
 
 	// ErrTimeTooNew indicates the time is too far in the future as compared
@@ -109,6 +109,11 @@ const (
 	// ErrCheckpointTimeTooOld indicates a block has a timestamp before the
 	// most recent checkpoint.
 	ErrCheckpointTimeTooOld = ErrorKind("ErrCheckpointTimeTooOld")
+
+	// ErrBadMaxDiffCheckpoint indicates a block on the version 3 test network
+	// at the height used to activate maximum difficulty semantics does not
+	// match the expected one.
+	ErrBadMaxDiffCheckpoint = ErrorKind("ErrBadMaxDiffCheckpoint")
 
 	// ErrNoTransactions indicates the block does not have a least one
 	// transaction.  A valid block must have at least the coinbase

--- a/blockchain/error_test.go
+++ b/blockchain/error_test.go
@@ -35,6 +35,7 @@ func TestErrorKindStringer(t *testing.T) {
 		{ErrBadCheckpoint, "ErrBadCheckpoint"},
 		{ErrForkTooOld, "ErrForkTooOld"},
 		{ErrCheckpointTimeTooOld, "ErrCheckpointTimeTooOld"},
+		{ErrBadMaxDiffCheckpoint, "ErrBadMaxDiffCheckpoint"},
 		{ErrNoTransactions, "ErrNoTransactions"},
 		{ErrTooManyTransactions, "ErrTooManyTransactions"},
 		{ErrNoTxInputs, "ErrNoTxInputs"},

--- a/blockchain/indexers/addrindex_test.go
+++ b/blockchain/indexers/addrindex_test.go
@@ -682,7 +682,14 @@ func TestAddrIndexAsync(t *testing.T) {
 	// Wait for the index to sync with the main chain.
 	select {
 	case <-addrIdx.WaitForSync():
-		// Nothing to do.
+		// Ensure there are no subscribers for the indexer.
+		addrIdx.mtx.Lock()
+		subs := len(addrIdx.subscribers)
+		addrIdx.mtx.Unlock()
+		if subs != 0 {
+			t.Fatalf("expected no indexer subscribers, got %d", subs)
+		}
+
 	case <-time.After(time.Second):
 		panic("timeout waiting for index to synchronize")
 	}
@@ -716,5 +723,25 @@ func TestAddrIndexAsync(t *testing.T) {
 	if *addrIdxTipHash != *bk4a.Hash() {
 		t.Fatalf("expected tip hash to be %s, got %s",
 			bk4a.Hash().String(), addrIdxTipHash.String())
+	}
+
+	// Ensure indexer subscribers are cleaned up after waiting for an update
+	// beyond the indexer sync wait threshold.
+	_ = addrIdx.WaitForSync()
+
+	addrIdx.mtx.Lock()
+	subs := len(addrIdx.subscribers)
+	addrIdx.mtx.Unlock()
+	if subs != 1 {
+		t.Fatalf("expected one indexer subscriber, got %d", subs)
+	}
+
+	time.Sleep(syncWait + (syncWait / 2))
+
+	addrIdx.mtx.Lock()
+	subs = len(addrIdx.subscribers)
+	addrIdx.mtx.Unlock()
+	if subs != 0 {
+		t.Fatalf("expected no indexer subscribers, got %d", subs)
 	}
 }

--- a/blockchain/indexers/existsaddrindex_test.go
+++ b/blockchain/indexers/existsaddrindex_test.go
@@ -284,7 +284,13 @@ func TestExistsAddrIndexAsync(t *testing.T) {
 	// Wait for the index to sync with the main chain before terminating.
 	select {
 	case <-idx.WaitForSync():
-		// Nothing to do.
+		// Ensure there are no subscribers for the indexer.
+		idx.mtx.Lock()
+		subs := len(idx.subscribers)
+		idx.mtx.Unlock()
+		if subs != 0 {
+			t.Fatalf("expected no indexer subscribers, got %d", subs)
+		}
 	case <-time.After(time.Second):
 		panic("timeout waiting for index to synchronize")
 	}
@@ -318,5 +324,25 @@ func TestExistsAddrIndexAsync(t *testing.T) {
 	if *tipHash != *bk4a.Hash() {
 		t.Fatalf("expected tip hash to be %s, got %s",
 			bk4a.Hash().String(), tipHash.String())
+	}
+
+	// Ensure indexer subscribers are cleaned up after waiting for an update
+	// beyond the indexer sync wait threshold.
+	_ = idx.WaitForSync()
+
+	idx.mtx.Lock()
+	subs := len(idx.subscribers)
+	idx.mtx.Unlock()
+	if subs != 1 {
+		t.Fatalf("expected one indexer subscriber, got %d", subs)
+	}
+
+	time.Sleep(syncWait + (syncWait / 2))
+
+	idx.mtx.Lock()
+	subs = len(idx.subscribers)
+	idx.mtx.Unlock()
+	if subs != 0 {
+		t.Fatalf("expected no indexer subscribers, got %d", subs)
 	}
 }

--- a/blockchain/indexers/indexsubscriber.go
+++ b/blockchain/indexers/indexsubscriber.go
@@ -238,8 +238,8 @@ func (s *IndexSubscriber) findLowestIndexTipHeight(queryer ChainQueryer) (int64,
 	return lowestHeight, bestHeight, nil
 }
 
-// CatchUp syncs all subscribed indexes to the the main chain by connecting
-// blocks from after the lowest index tip to the current main chain tip.
+// CatchUp syncs all subscribed indexes to the main chain by connecting blocks
+// from after the lowest index tip to the current main chain tip.
 //
 // This should be called after all indexes have subscribed for updates.
 func (s *IndexSubscriber) CatchUp(ctx context.Context, db database.DB, queryer ChainQueryer) error {

--- a/blockchain/indexers/txindex.go
+++ b/blockchain/indexers/txindex.go
@@ -485,7 +485,7 @@ func (idx *TxIndex) IndexSubscription() *IndexSubscription {
 func (idx *TxIndex) Subscribers() map[chan bool]struct{} {
 	idx.mtx.Lock()
 	defer idx.mtx.Unlock()
-	return idx.subscribers
+	return fetchIndexerSubscribers(idx.subscribers)
 }
 
 // WaitForSync subscribes clients for the next index sync update.
@@ -493,6 +493,14 @@ func (idx *TxIndex) Subscribers() map[chan bool]struct{} {
 // This is part of the Indexer interface.
 func (idx *TxIndex) WaitForSync() chan bool {
 	c := make(chan bool)
+
+	removeIndexerSub := func() {
+		idx.mtx.Lock()
+		delete(idx.subscribers, c)
+		idx.mtx.Unlock()
+	}
+
+	go purgeIndexerSubscription(c, removeIndexerSub)
 
 	idx.mtx.Lock()
 	idx.subscribers[c] = struct{}{}

--- a/blockchain/indexers/txindex_test.go
+++ b/blockchain/indexers/txindex_test.go
@@ -109,8 +109,7 @@ func (tc *testChain) MainChainHasBlock(hash *chainhash.Hash) bool {
 	return ok
 }
 
-// Best returns the height and block hash of the the current
-// chain tip.
+// Best returns the height and block hash of the current chain tip.
 func (tc *testChain) Best() (int64, *chainhash.Hash) {
 	tc.mtx.Lock()
 	defer tc.mtx.Unlock()

--- a/blockchain/upgrade_test.go
+++ b/blockchain/upgrade_test.go
@@ -142,7 +142,7 @@ func TestBlockIndexDecodeErrorsV2(t *testing.T) {
 		// Ensure the expected error type is returned.
 		gotBytesRead, err := decodeBlockIndexEntryV2(test.serialized,
 			&test.entry)
-		if !errors.As(err, &test.errType) {
+		if !errors.Is(err, test.errType) {
 			t.Errorf("decodeBlockIndexEntry (%s): expected error "+
 				"type does not match - got %T, want %T",
 				test.name, err, test.errType)

--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -329,17 +329,91 @@ func (c *UtxoCache) AddEntry(outpoint wire.OutPoint, entry *UtxoEntry) error {
 
 // spendEntry marks the specified output as spent.
 //
+// When the provided output does not already have an associated entry in the
+// cache, the cache will be populated with the entry from the backend (if one
+// exists) and marked spent to ensure the utxo is later removed from the backend
+// on the next cache flush.
+//
+// An error will be returned in the case the output exists in the cache and is
+// already spent.
+//
 // This function MUST be called with the cache lock held.
-func (c *UtxoCache) spendEntry(outpoint wire.OutPoint) {
-	// Attempt to get an existing entry from the cache.
-	cachedEntry := c.entries[outpoint]
-
-	// If the entry is nil or already spent, return immediately.
-	if cachedEntry == nil || cachedEntry.IsSpent() {
-		return
+func (c *UtxoCache) spendEntry(outpoint wire.OutPoint) error {
+	// Attempt to get the entry associated with the output from the cache.
+	//
+	// In the case there is a nil entry in the cache for the output, it does not
+	// exist in the backend.  This is because either an attempt to load the utxo
+	// from the backend was made and the nil entry was added to the cache to
+	// avoid further lookups against the backend when the output is known to not
+	// exist or the output was added to the cache and spent in between flushes
+	// to the backend and thus has been pruned.
+	//
+	// In either case, the cache does not need to be updated, so there is
+	// nothing more to do.
+	cachedEntry, found := c.entries[outpoint]
+	if found && cachedEntry == nil {
+		return nil
 	}
 
-	// If the entry is fresh, and is now being spent, it can safely be removed.
+	// Sanity check double spends of existing entries.  This should be
+	// impossible to hit since a view should never be committed until after
+	// double spend checks have already been done.  However, it is good practice
+	// to be paranoid and double check assumptions when it comes to potential
+	// double spends.
+	if cachedEntry != nil && cachedEntry.IsSpent() {
+		return AssertError(fmt.Sprintf("attempt to double spend output %v in "+
+			"view commit", outpoint))
+	}
+
+	// Attempt to repopulate the cache from the backend when there is no entry
+	// for the output in the cache.  This is necessary because the associated
+	// utxo might exist in the backend but not have been loaded into the cache
+	// yet or have otherwise been evicted.
+	//
+	// Thus, in order to ensure the utxo is removed from the backend on the next
+	// cache flush in the case it exists, the associated cache entry from the
+	// backend is loaded and marked spent.
+	if !found {
+		// Account for the cache miss and attempt to load the entry for the utxo
+		// from the backend.
+		//
+		// Notice that this intentionally attempts to load the entry from the
+		// backend directly as opposed to using the normal cache entry fetching
+		// method since that involves querying the cache again which would be
+		// wasteful since it is already known to not exist and also employs
+		// slightly different logic regarding populating the cache.
+		//
+		// NOTE: Missing backend entries are not an error.
+		c.misses++
+		backendEntry, err := c.backend.FetchEntry(outpoint)
+		if err != nil {
+			return err
+		}
+
+		// The cache does not need to be updated when the associated utxo does
+		// not exist in the backend, so there is nothing more to do in that
+		// case.
+		//
+		// Note that a nil entry is not added to cache for the output here since
+		// there should realistically never be any future lookups for the spent
+		// output given that would be a double spend.
+		if backendEntry == nil {
+			return nil
+		}
+
+		// Add the entry to the cache and update its total entry size.
+		c.entries[outpoint] = backendEntry
+		c.totalEntrySize += backendEntry.size()
+
+		// Mark the output as spent and modified.
+		backendEntry.Spend()
+		return nil
+	}
+
+	// Remove the entry associated with the output from the cache when the
+	// backend does not need to be updated because the backend does not have an
+	// associated utxo (aka the cache entry is fresh).
+	//
 	// This is an optimization to skip writing to the backend for outputs that
 	// are added and spent in between flushes to the backend.
 	if cachedEntry.isFresh() {
@@ -348,11 +422,12 @@ func (c *UtxoCache) spendEntry(outpoint wire.OutPoint) {
 		// and avoid querying the backend.
 		c.entries[outpoint] = nil
 		c.totalEntrySize -= cachedEntry.size()
-		return
+		return nil
 	}
 
 	// Mark the output as spent and modified.
 	cachedEntry.Spend()
+	return nil
 }
 
 // SpendEntry marks the specified output as spent.
@@ -360,8 +435,11 @@ func (c *UtxoCache) spendEntry(outpoint wire.OutPoint) {
 // This function is safe for concurrent access.
 func (c *UtxoCache) SpendEntry(outpoint wire.OutPoint) {
 	c.cacheLock.Lock()
-	c.spendEntry(outpoint)
+	err := c.spendEntry(outpoint)
 	c.cacheLock.Unlock()
+	if err != nil {
+		panic(err)
+	}
 }
 
 // fetchEntry returns the specified transaction output from the utxo set.  If
@@ -495,9 +573,12 @@ func (c *UtxoCache) FetchStats(bestHash *chainhash.Hash, bestHeight uint32) (*Ut
 //
 // This function is safe for concurrent access.
 func (c *UtxoCache) Commit(view *UtxoViewpoint) error {
+	defer c.cacheLock.Unlock()
 	c.cacheLock.Lock()
+
 	for outpoint, entry := range view.entries {
-		// If the entry is nil, delete it from the view and continue.
+		// There is nothing to update in the cache when the view entry is nil,
+		// so remove it from the view and continue to the next entry.
 		if entry == nil {
 			delete(view.entries, outpoint)
 			continue
@@ -509,34 +590,42 @@ func (c *UtxoCache) Commit(view *UtxoViewpoint) error {
 			continue
 		}
 
-		// If the entry is modified and spent, mark it as spent in the cache and
-		// then delete it from the view.
-		if entry.IsSpent() {
-			// Mark the entry as spent in the cache.
-			c.spendEntry(outpoint)
-
-			// Delete the entry from the view.
-			delete(view.entries, outpoint)
-			continue
-		}
-
-		// If we passed all of the conditions above, the entry is modified or
-		// fresh, but not spent, and should be added to the cache.
-		c.addEntry(outpoint, entry)
-
-		// All entries that are added to the cache should be removed from the
-		// provided view.  This is an optimization to allow the cache to take
-		// ownership of the entry from the view and avoid an additional
-		// allocation.  It is removed from the view to ensure that it is not
-		// mutated by the caller after being added to the cache.
+		// ---------------------------------------------------------------------
+		// NOTE: As an optimization in order to avoid an additional allocation,
+		// the cache takes ownership of all modified entries from the view.
+		//
+		// Thus, unless there is an error preventing the cache from taking
+		// ownership and ultimately causing the commit to fail, the entry will
+		// be removed from the view in all remaining paths to ensure that it is
+		// not mutated by the caller after being added to the cache.
 		//
 		// This does cause the view to refetch the entry if it is requested
 		// again after being removed.  However, this only really occurs during
 		// reorgs, whereas committing the view to the cache happens with every
 		// connected block, so this optimizes for the much more common case.
+		// ---------------------------------------------------------------------
+
+		// Mark the spent view entry as modified and spent in the cache and
+		// remove it from the view.
+		//
+		// This might entail populating the cache with the unspent output from
+		// the backend when there is not already a corresponding entry in the
+		// cache to ensure the utxo is later removed from the backend on the
+		// next cache flush.
+		if entry.IsSpent() {
+			if err := c.spendEntry(outpoint); err != nil {
+				return err
+			}
+
+			delete(view.entries, outpoint)
+			continue
+		}
+
+		// Update the existing entry in the cache or add a new one whenever the
+		// view entry is both modified and unspent and remove it from the view.
+		c.addEntry(outpoint, entry)
 		delete(view.entries, outpoint)
 	}
-	c.cacheLock.Unlock()
 
 	return nil
 }

--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -846,7 +846,8 @@ func (c *UtxoCache) Initialize(ctx context.Context, b *BlockChain, tip *blockNod
 		// succession when initializing.
 		const forceFlush = false
 		const logFlush = true
-		err = c.maybeFlushFn(&n.hash, uint32(n.height), forceFlush, logFlush)
+		err = c.maybeFlushFn(&n.parent.hash, uint32(n.parent.height),
+			forceFlush, logFlush)
 		if err != nil {
 			return err
 		}

--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -475,15 +475,15 @@ func (c *UtxoCache) Commit(view *UtxoViewpoint) error {
 			continue
 		}
 
-		// If the entry is not modified and not fresh, continue as there is
-		// nothing to do.
-		if !entry.isModified() && !entry.isFresh() {
+		// There is nothing to update in the cache nor the view when the view
+		// entry was not modified.
+		if !entry.isModified() {
 			continue
 		}
 
 		// If the entry is modified and spent, mark it as spent in the cache and
 		// then delete it from the view.
-		if entry.isModified() && entry.IsSpent() {
+		if entry.IsSpent() {
 			// Mark the entry as spent in the cache.
 			c.spendEntry(outpoint)
 

--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -186,6 +186,12 @@ type UtxoCache struct {
 	// defaults to time.Now but an alternative function can be provided for
 	// testing purposes.
 	timeNow func() time.Time
+
+	// maybeFlushFn defines the function to use for potentially flushing the
+	// cache to the backend.  It defaults to the exported MaybeFlush method of
+	// this cache instance, but an alternative can be provided for testing
+	// purposes.
+	maybeFlushFn func(*chainhash.Hash, uint32, bool, bool) error
 }
 
 // Ensure UtxoCache implements the UtxoCacher interface.
@@ -222,7 +228,7 @@ func NewUtxoCache(config *UtxoCacheConfig) *UtxoCache {
 		p2pkhScriptLen
 	maxEntries := math.Ceil(float64(config.MaxSize) / float64(avgEntrySize))
 
-	return &UtxoCache{
+	c := &UtxoCache{
 		backend:       config.Backend,
 		flushBlockDB:  config.FlushBlockDB,
 		maxSize:       config.MaxSize,
@@ -230,6 +236,8 @@ func NewUtxoCache(config *UtxoCacheConfig) *UtxoCache {
 		lastFlushTime: time.Now(),
 		timeNow:       time.Now,
 	}
+	c.maybeFlushFn = c.MaybeFlush
+	return c
 }
 
 // totalSize returns the total size of the cache on a 64-bit platform, in bytes.
@@ -442,7 +450,7 @@ func (c *UtxoCache) FetchBackendState() (*UtxoSetState, error) {
 func (c *UtxoCache) FetchStats(bestHash *chainhash.Hash, bestHeight uint32) (*UtxoStats, error) {
 	// Force a UTXO cache flush.  This is required in order for the backend to
 	// fetch statistics on the full UTXO set.
-	err := c.MaybeFlush(bestHash, bestHeight, true, false)
+	err := c.maybeFlushFn(bestHash, bestHeight, true, false)
 	if err != nil {
 		return nil, err
 	}
@@ -836,7 +844,9 @@ func (c *UtxoCache) Initialize(ctx context.Context, b *BlockChain, tip *blockNod
 		// Conditionally flush the utxo cache to the backend.  Don't force flush
 		// since many blocks may be disconnected and connected in quick
 		// succession when initializing.
-		err = c.MaybeFlush(&n.hash, uint32(n.height), false, true)
+		const forceFlush = false
+		const logFlush = true
+		err = c.maybeFlushFn(&n.hash, uint32(n.height), forceFlush, logFlush)
 		if err != nil {
 			return err
 		}
@@ -918,7 +928,9 @@ func (c *UtxoCache) Initialize(ctx context.Context, b *BlockChain, tip *blockNod
 		// Conditionally flush the utxo cache to the backend.  Don't force flush
 		// since many blocks may be connected in quick succession when
 		// initializing.
-		err = c.MaybeFlush(&n.hash, uint32(n.height), false, true)
+		const forceFlush = false
+		const logFlush = true
+		err = c.maybeFlushFn(&n.hash, uint32(n.height), forceFlush, logFlush)
 		if err != nil {
 			return err
 		}

--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -265,7 +265,7 @@ func (c *UtxoCache) hitRatio() float64 {
 // it to the cache.
 //
 // This function MUST be called with the cache lock held.
-func (c *UtxoCache) addEntry(outpoint wire.OutPoint, entry *UtxoEntry) error {
+func (c *UtxoCache) addEntry(outpoint wire.OutPoint, entry *UtxoEntry) {
 	// Attempt to get an existing entry from the cache.
 	cachedEntry := c.entries[outpoint]
 
@@ -287,8 +287,6 @@ func (c *UtxoCache) addEntry(outpoint wire.OutPoint, entry *UtxoEntry) error {
 		c.totalEntrySize -= cachedEntry.size()
 	}
 	c.totalEntrySize += entry.size()
-
-	return nil
 }
 
 // AddEntry adds the specified output to the cache.  The entry being added MUST
@@ -301,9 +299,9 @@ func (c *UtxoCache) addEntry(outpoint wire.OutPoint, entry *UtxoEntry) error {
 // This function is safe for concurrent access.
 func (c *UtxoCache) AddEntry(outpoint wire.OutPoint, entry *UtxoEntry) error {
 	c.cacheLock.Lock()
-	err := c.addEntry(outpoint, entry)
+	c.addEntry(outpoint, entry)
 	c.cacheLock.Unlock()
-	return err
+	return nil
 }
 
 // spendEntry marks the specified output as spent.
@@ -488,11 +486,7 @@ func (c *UtxoCache) Commit(view *UtxoViewpoint) error {
 
 		// If we passed all of the conditions above, the entry is modified or
 		// fresh, but not spent, and should be added to the cache.
-		err := c.addEntry(outpoint, entry)
-		if err != nil {
-			c.cacheLock.Unlock()
-			return err
-		}
+		c.addEntry(outpoint, entry)
 
 		// All entries that are added to the cache should be removed from the
 		// provided view.  This is an optimization to allow the cache to take

--- a/blockchain/utxocache_test.go
+++ b/blockchain/utxocache_test.go
@@ -193,10 +193,7 @@ func createTestUtxoCache(t *testing.T, entries map[wire.OutPoint]*UtxoEntry) *Ut
 		// Add the entry to the cache.  The entry is cloned before being added
 		// so that any modifications that the cache makes to the entry are not
 		// reflected in the provided test entry.
-		err := utxoCache.AddEntry(outpoint, entry.Clone())
-		if err != nil {
-			t.Fatalf("unexpected error when adding entry: %v", err)
-		}
+		utxoCache.addEntry(outpoint, entry.Clone())
 
 		// Set the state of the cached entries based on the provided entries.
 		// This is allowed for tests to easily simulate entries in the cache
@@ -343,11 +340,7 @@ func TestAddEntry(t *testing.T) {
 		}
 
 		// Add the entry specified by the test.
-		err := utxoCache.AddEntry(test.outpoint, test.entry)
-		if err != nil {
-			t.Fatalf("%q: unexpected error when adding entry: %v", test.name,
-				err)
-		}
+		utxoCache.addEntry(test.outpoint, test.entry)
 		wantTotalEntrySize += test.entry.size()
 
 		// Attempt to get the added entry from the cache.

--- a/blockchain/utxocache_test.go
+++ b/blockchain/utxocache_test.go
@@ -432,6 +432,9 @@ func TestAddEntry(t *testing.T) {
 func TestSpendEntry(t *testing.T) {
 	t.Parallel()
 
+	// Create a test backend.
+	backend := createTestUtxoBackend(t)
+
 	// Create test entries to be used throughout the tests.
 	outpoint, entry := outpoint299(), makeEntryStates(entry299())
 
@@ -443,23 +446,29 @@ func TestSpendEntry(t *testing.T) {
 		outpoint       wire.OutPoint // outpoint for the entry to spend
 		wantEntry      *UtxoEntry    // expected entry in cache after spend
 		wantCacheSize  uint64        // expected size of the cache after spend
+		err            error         // expected error
 	}{{
+		name:          "spending cache entry already marked spent asserts",
+		cachedEntries: entriesMap{outpoint: entry.modifiedSpent},
+		outpoint:      outpoint,
+		err:           AssertError(""),
+	}, {
 		name:          "spending nil (aka pruned) cache entry is a noop",
 		cachedEntries: entriesMap{outpoint: nil},
 		outpoint:      outpoint,
 		wantEntry:     nil,
 		wantCacheSize: 0,
 	}, {
-		name:          "spending entry not in cache is a noop",
+		name:          "spending entry not in cache queries backend (no utxo)",
 		outpoint:      outpoint,
 		wantEntry:     nil,
 		wantCacheSize: 0,
 	}, {
-		name:          "spending cache entry already marked spent is a noop",
-		cachedEntries: entriesMap{outpoint: entry.modifiedSpent},
-		outpoint:      outpoint,
-		wantEntry:     entry.modifiedSpent,
-		wantCacheSize: entry.modifiedSpent.size(),
+		name:           "spending entry not in cache queries backend (with utxo)",
+		outpoint:       outpoint,
+		backendEntries: entriesMap{outpoint: entry.modified},
+		wantEntry:      entry.modifiedSpent,
+		wantCacheSize:  entry.modifiedSpent.size(),
 	}, {
 		name:          "spending cache entry marked fresh makes it nil",
 		cachedEntries: entriesMap{outpoint: entry.modifiedFresh},
@@ -477,9 +486,25 @@ func TestSpendEntry(t *testing.T) {
 	for _, test := range tests {
 		// Create a utxo cache with the existing entries specified by the test.
 		utxoCache := createTestUtxoCache(t, test.cachedEntries)
+		utxoCache.backend = backend
 
-		// Spend the entry specified by the test.
-		utxoCache.SpendEntry(test.outpoint)
+		// Add entries specified by the test to the test backend.
+		err := backend.PutUtxos(test.backendEntries, &UtxoSetState{})
+		if err != nil {
+			t.Fatalf("%q: unexpected error adding entries to test backend: %v",
+				test.name, err)
+		}
+
+		// Spend the entry specified by the test and ensure the error matches
+		// the expected one.
+		err = utxoCache.spendEntry(test.outpoint)
+		if !errors.Is(err, test.err) {
+			t.Fatalf("%q: unexpected error spending outpoint %v -- got %v, "+
+				"want %v (%[4]T)", test.name, test.outpoint, err, test.err)
+		}
+		if test.err != nil {
+			continue
+		}
 
 		// Get the entry associated with the output from the cache and ensure it
 		// matches the expected one.
@@ -660,6 +685,9 @@ func TestFetchEntries(t *testing.T) {
 func TestCommit(t *testing.T) {
 	t.Parallel()
 
+	// Create a test backend.
+	backend := createTestUtxoBackend(t)
+
 	// Create test entries to be used throughout the tests.
 	outpoint299, entry299 := outpoint299(), makeEntryStates(entry299())
 	outpoint1100, entry1100 := outpoint1100(), makeEntryStates(entry1100())
@@ -670,21 +698,19 @@ func TestCommit(t *testing.T) {
 		name              string                       // test description
 		viewEntries       map[wire.OutPoint]*UtxoEntry // view to commit
 		cachedEntries     map[wire.OutPoint]*UtxoEntry // existing cache entries
+		backendEntries    map[wire.OutPoint]*UtxoEntry // existing backend entries
 		wantViewEntries   map[wire.OutPoint]*UtxoEntry // expected committed view
 		wantCachedEntries map[wire.OutPoint]*UtxoEntry // expected committed cache
 		err               error                        // expected error
 	}{{
-		name: "modified spent view entry w/ existing spent cache entry is noop",
+		name: "modified spent view entry w/ existing spent cache entry asserts",
 		viewEntries: map[wire.OutPoint]*UtxoEntry{
 			outpoint1200: entry1200.modifiedSpent,
 		},
 		cachedEntries: map[wire.OutPoint]*UtxoEntry{
 			outpoint1200: entry1200.modifiedSpent,
 		},
-		wantViewEntries: map[wire.OutPoint]*UtxoEntry{},
-		wantCachedEntries: map[wire.OutPoint]*UtxoEntry{
-			outpoint1200: entry1200.modifiedSpent,
-		},
+		err: AssertError(""),
 	}, {
 		name: "nil view entries are removed from view and do not affect cache",
 		viewEntries: map[wire.OutPoint]*UtxoEntry{
@@ -824,6 +850,28 @@ func TestCommit(t *testing.T) {
 	}, {
 		// This covers the following scenarios:
 		//
+		// - modified spent view entries without a corresponding cache entry nor
+		//   corresponding backend entry are removed from the view and a noop to
+		//   the cache
+		// - modified spent view entries without a corresponding cache entry
+		//   but with a corresponding backend entry loads the entry from the
+		//   backend, spends it, and adds the spent entry to the cache
+		name: "modified spent view entries not in backend",
+		viewEntries: map[wire.OutPoint]*UtxoEntry{
+			outpoint299:  entry299.modifiedSpent,
+			outpoint1100: entry1100.modifiedSpent,
+		},
+		cachedEntries: map[wire.OutPoint]*UtxoEntry{},
+		backendEntries: map[wire.OutPoint]*UtxoEntry{
+			outpoint1100: entry1100.modified,
+		},
+		wantViewEntries: map[wire.OutPoint]*UtxoEntry{},
+		wantCachedEntries: map[wire.OutPoint]*UtxoEntry{
+			outpoint1100: entry1100.modifiedSpent,
+		},
+	}, {
+		// This covers the following scenarios:
+		//
 		// - modified unspent view entries with no corresponding cache entry are
 		//   removed from view and added to the cache as fresh entries
 		// - modified unspent view entries with a corresponding unmodified cache
@@ -864,6 +912,14 @@ func TestCommit(t *testing.T) {
 	for _, test := range tests {
 		// Create a utxo cache with the cached entries specified by the test.
 		utxoCache := createTestUtxoCache(t, test.cachedEntries)
+		utxoCache.backend = backend
+
+		// Add entries specified by the test to the test backend.
+		err := backend.PutUtxos(test.backendEntries, &UtxoSetState{})
+		if err != nil {
+			t.Fatalf("%q: unexpected error adding entries to test backend: %v",
+				test.name, err)
+		}
 
 		// Create a utxo view with the entries specified by the test.  The view
 		// entries are cloned first in order to ensure the shared instances are
@@ -878,7 +934,7 @@ func TestCommit(t *testing.T) {
 		}
 
 		// Commit the view to the cache.
-		err := utxoCache.Commit(view)
+		err = utxoCache.Commit(view)
 		if !errors.Is(err, test.err) {
 			t.Fatalf("%q: unexpected error committing view to the cache -- "+
 				"got %v (%[2]T), want %v (%[3]T)", test.name, err, test.err)

--- a/blockchain/utxocache_test.go
+++ b/blockchain/utxocache_test.go
@@ -172,9 +172,12 @@ func (c *testUtxoCache) MaybeFlush(bestHash *chainhash.Hash, bestHeight uint32,
 // newTestUtxoCache returns a testUtxoCache instance using the provided
 // configuration details.
 func newTestUtxoCache(config *UtxoCacheConfig) *testUtxoCache {
-	return &testUtxoCache{
-		UtxoCache: NewUtxoCache(config),
+	utxoCache := NewUtxoCache(config)
+	c := &testUtxoCache{
+		UtxoCache: utxoCache,
 	}
+	utxoCache.maybeFlushFn = c.MaybeFlush
+	return c
 }
 
 // Ensure testUtxoCache implements the UtxoCacher interface.

--- a/blockchain/utxocache_test.go
+++ b/blockchain/utxocache_test.go
@@ -246,7 +246,11 @@ func createTestUtxoCache(t *testing.T, entries map[wire.OutPoint]*UtxoEntry) *Ut
 		// Add the entry to the cache.  The entry is cloned before being added
 		// so that any modifications that the cache makes to the entry are not
 		// reflected in the provided test entry.
-		utxoCache.addEntry(outpoint, entry.Clone())
+		if entry != nil {
+			utxoCache.addEntry(outpoint, entry.Clone())
+		} else {
+			utxoCache.entries[outpoint] = nil
+		}
 
 		// Set the state of the cached entries based on the provided entries.
 		// This is allowed for tests to easily simulate entries in the cache
@@ -428,83 +432,64 @@ func TestSpendEntry(t *testing.T) {
 	// Create test entries to be used throughout the tests.
 	outpoint, entry := outpoint299(), makeEntryStates(entry299())
 
+	type entriesMap map[wire.OutPoint]*UtxoEntry
 	tests := []struct {
-		name            string
-		existingEntries map[wire.OutPoint]*UtxoEntry
-		outpoint        wire.OutPoint
-		entry           *UtxoEntry
+		name           string        // test description
+		cachedEntries  entriesMap    // existing cache entries
+		backendEntries entriesMap    // existing backend entries
+		outpoint       wire.OutPoint // outpoint for the entry to spend
+		wantEntry      *UtxoEntry    // expected entry in cache after spend
+		wantCacheSize  uint64        // expected size of the cache after spend
 	}{{
-		name:     "spend an entry that does not exist in the cache",
-		outpoint: outpoint,
-		entry:    entry.unmodified,
+		name:          "spending nil (aka pruned) cache entry is a noop",
+		cachedEntries: entriesMap{outpoint: nil},
+		outpoint:      outpoint,
+		wantEntry:     nil,
+		wantCacheSize: 0,
 	}, {
-		name: "spend an entry that exists in the cache but is already spent",
-		existingEntries: map[wire.OutPoint]*UtxoEntry{
-			outpoint: entry.unmodifiedSpent,
-		},
-		outpoint: outpoint,
-		entry:    entry.unmodifiedSpent,
+		name:          "spending entry not in cache is a noop",
+		outpoint:      outpoint,
+		wantEntry:     nil,
+		wantCacheSize: 0,
 	}, {
-		name: "spend an entry that exists in the cache and is fresh",
-		existingEntries: map[wire.OutPoint]*UtxoEntry{
-			outpoint: entry.modifiedFresh,
-		},
-		outpoint: outpoint,
-		entry:    entry.modifiedFresh,
+		name:          "spending cache entry already marked spent is a noop",
+		cachedEntries: entriesMap{outpoint: entry.modifiedSpent},
+		outpoint:      outpoint,
+		wantEntry:     entry.modifiedSpent,
+		wantCacheSize: entry.modifiedSpent.size(),
 	}, {
-		name: "spend an entry that exists in the cache and is not fresh",
-		existingEntries: map[wire.OutPoint]*UtxoEntry{
-			outpoint: entry.unmodified,
-		},
-		outpoint: outpoint,
-		entry:    entry.unmodified,
+		name:          "spending cache entry marked fresh makes it nil",
+		cachedEntries: entriesMap{outpoint: entry.modifiedFresh},
+		outpoint:      outpoint,
+		wantEntry:     nil,
+		wantCacheSize: 0,
+	}, {
+		name:          "spending cache entry not marked fresh makes it spent",
+		cachedEntries: entriesMap{outpoint: entry.modified},
+		outpoint:      outpoint,
+		wantEntry:     entry.modifiedSpent,
+		wantCacheSize: entry.modifiedSpent.size(),
 	}}
 
 	for _, test := range tests {
 		// Create a utxo cache with the existing entries specified by the test.
-		utxoCache := createTestUtxoCache(t, test.existingEntries)
-		wantTotalEntrySize := utxoCache.totalEntrySize
-
-		// Attempt to get an existing entry from the cache.
-		entry := utxoCache.entries[test.outpoint]
-		var entryAlreadySpent bool
-		if entry != nil {
-			entryAlreadySpent = entry.IsSpent()
-		}
+		utxoCache := createTestUtxoCache(t, test.cachedEntries)
 
 		// Spend the entry specified by the test.
 		utxoCache.SpendEntry(test.outpoint)
 
-		// If the existing entry was nil or spent, continue as there is nothing
-		// else to validate.
-		if entry == nil || entryAlreadySpent {
-			continue
-		}
-
-		// If the entry is fresh, validate that it was removed from the cache
-		// when spent.
-		if entry.isFresh() {
-			wantTotalEntrySize -= test.entry.size()
-			if utxoCache.entries[test.outpoint] != nil {
-				t.Fatalf("%q: entry for outpoint %v was not removed from the "+
-					"cache", test.name, test.outpoint)
-			}
+		// Get the entry associated with the output from the cache and ensure it
+		// matches the expected one.
+		gotEntry := utxoCache.entries[test.outpoint]
+		if !reflect.DeepEqual(gotEntry, test.wantEntry) {
+			t.Fatalf("%q: unexpected entry after spend -- got: %+v, want %+v",
+				test.name, gotEntry, test.wantEntry)
 		}
 
 		// Validate that the total entry size was updated as expected.
-		if utxoCache.totalEntrySize != wantTotalEntrySize {
+		if utxoCache.totalEntrySize != test.wantCacheSize {
 			t.Fatalf("%q: unexpected total entry size -- got %v, want %v",
-				test.name, utxoCache.totalEntrySize, wantTotalEntrySize)
-		}
-
-		// If entry is not fresh, validate that it still exists in the cache and
-		// is now marked as spent.
-		if !entry.isFresh() {
-			cachedEntry := utxoCache.entries[test.outpoint]
-			if cachedEntry == nil || !cachedEntry.IsSpent() {
-				t.Fatalf("%q: expected entry for outpoint %v to exist in the "+
-					"cache and be marked spent", test.name, test.outpoint)
-			}
+				test.name, utxoCache.totalEntrySize, test.wantCacheSize)
 		}
 	}
 }

--- a/blockchain/utxoentry.go
+++ b/blockchain/utxoentry.go
@@ -19,19 +19,25 @@ const (
 // utxoState defines the in-memory state of a utxo entry.
 //
 // The bit representation is:
-//   bit  0    - transaction output has been spent
-//   bit  1    - transaction output has been modified since it was loaded
-//   bit  2    - transaction output is fresh
-//   bits 3-7  - unused
+//
+//	bit  0    - transaction output has been modified since it was loaded
+//	bit  1    - transaction output has been spent
+//	bit  2    - transaction output has been spent by tx later in the same block
+//	bit  3    - transaction output is fresh
+//	bits 4-7  - unused
 type utxoState uint8
 
 const (
-	// utxoStateSpent indicates that a txout is spent.
-	utxoStateSpent utxoState = 1 << iota
-
 	// utxoStateModified indicates that a txout has been modified since it was
 	// loaded.
-	utxoStateModified
+	utxoStateModified utxoState = 1 << iota
+
+	// utxoStateSpent indicates that a txout is spent.
+	utxoStateSpent
+
+	// utxoStateSpentByZeroConf indicates that a txout was spent by another
+	// transaction later in the same block.
+	utxoStateSpentByZeroConf
 
 	// utxoStateFresh indicates that a txout is fresh, which means that it
 	// exists in the utxo cache but does not exist in the underlying database.
@@ -42,9 +48,10 @@ const (
 // utxo entry.
 //
 // The bit representation is:
-//   bit  0    - containing transaction is a coinbase
-//   bit  1    - containing transaction has an expiry
-//   bits 2-5  - transaction type
+//
+//	bit  0    - containing transaction is a coinbase
+//	bit  1    - containing transaction has an expiry
+//	bits 2-5  - transaction type
 type utxoFlags uint8
 
 const (
@@ -145,6 +152,13 @@ func (entry *UtxoEntry) isModified() bool {
 // isFresh returns whether or not the output is fresh.
 func (entry *UtxoEntry) isFresh() bool {
 	return entry.state&utxoStateFresh == utxoStateFresh
+}
+
+// isSpentByZeroConf returns whether or not the output is marked as spent by a
+// zero confirmation transaction.  In other words, it is an output that was
+// created in a block and later spent by another transaction in the same block.
+func (entry *UtxoEntry) isSpentByZeroConf() bool {
+	return entry.state&utxoStateSpentByZeroConf == utxoStateSpentByZeroConf
 }
 
 // IsCoinBase returns whether or not the output was contained in a coinbase

--- a/blockchain/utxoio_test.go
+++ b/blockchain/utxoio_test.go
@@ -303,7 +303,7 @@ func TestUtxoEntryDeserializeErrors(t *testing.T) {
 		// Ensure the expected error type is returned and the returned
 		// entry is nil.
 		entry, err := deserializeUtxoEntry(test.serialized, test.txOutIndex)
-		if !errors.As(err, &test.errType) {
+		if !errors.Is(err, test.errType) {
 			t.Errorf("%q: expected error type does not match - got %T, want %T",
 				test.name, err, test.errType)
 			continue
@@ -397,7 +397,7 @@ func TestUtxoSetStateDeserializeErrors(t *testing.T) {
 		// Ensure the expected error type is returned and the returned
 		// utxo set state is nil.
 		entry, err := deserializeUtxoSetState(test.serialized)
-		if !errors.As(err, &test.errType) {
+		if !errors.Is(err, test.errType) {
 			t.Errorf("%q: expected error type does not match - got %T, want %T",
 				test.name, err, test.errType)
 			continue
@@ -509,7 +509,7 @@ func TestDecodeOutpointKeyErrors(t *testing.T) {
 		// Ensure the expected error type is returned.
 		var gotOutpoint wire.OutPoint
 		err := decodeOutpointKey(test.serialized, &gotOutpoint)
-		if !errors.As(err, &test.errType) {
+		if !errors.Is(err, test.errType) {
 			t.Errorf("%q: expected error type does not match - got %T, want %T",
 				test.name, err, test.errType)
 			continue

--- a/blockchain/utxoviewpoint.go
+++ b/blockchain/utxoviewpoint.go
@@ -680,8 +680,8 @@ func (view *UtxoViewpoint) addRegularInputUtxos(block *dcrutil.Block,
 	// Build a map of in-flight transactions because some of the inputs in the
 	// regular transaction tree of this block could be referencing other
 	// transactions earlier in the block which are not yet in the chain.
-	txInFlight := map[chainhash.Hash]int{}
 	regularTxns := block.Transactions()
+	txInFlight := make(map[chainhash.Hash]int, len(regularTxns))
 	for i, tx := range regularTxns {
 		txInFlight[*tx.Hash()] = i
 	}

--- a/blockchain/utxoviewpoint.go
+++ b/blockchain/utxoviewpoint.go
@@ -224,17 +224,21 @@ func (view *UtxoViewpoint) connectTransaction(tx *dcrutil.Tx, blockHeight int64,
 	blockIndex uint32, stxos *[]spentTxOut, isTreasuryEnabled,
 	isAutoRevocationsEnabled bool) error {
 
-	// Coinbase transactions don't have any inputs to spend.
+	// Treasurybase transactions don't have any inputs to spend.
+	//
+	// NOTE: This check MUST come before the coinbase check because a
+	// treasurybase is identified as a coinbase as of the time this comment is
+	// being written.
 	msgTx := tx.MsgTx()
+	if isTreasuryEnabled && standalone.IsTreasuryBase(msgTx) {
+		return nil
+	}
+
+	// Coinbase transactions don't have any inputs to spend.
 	if standalone.IsCoinBaseTx(msgTx, isTreasuryEnabled) {
 		// Add the transaction's outputs as available utxos.
 		view.AddTxOuts(tx, blockHeight, blockIndex, isTreasuryEnabled,
 			isAutoRevocationsEnabled)
-		return nil
-	}
-
-	// Treasurybase transactions don't have any inputs to spend.
-	if isTreasuryEnabled && standalone.IsTreasuryBase(msgTx) {
 		return nil
 	}
 

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -3575,7 +3575,11 @@ func (b *BlockChain) checkTransactionsAndConnect(inputFees dcrutil.Amount, node 
 		//
 		// Also, update the passed spent txos slice to contain an entry for each
 		// output the transaction spends.
-		err = view.connectTransaction(tx, node.height, uint32(idx), stxos,
+		connectTransaction := view.connectRegularTransaction
+		if stakeTree {
+			connectTransaction = view.connectStakeTransaction
+		}
+		err = connectTransaction(tx, node.height, uint32(idx), stxos,
 			isTreasuryEnabled, isAutoRevocationsEnabled)
 		if err != nil {
 			return err

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -3529,6 +3529,10 @@ func (b *BlockChain) checkTransactionsAndConnect(inputFees dcrutil.Amount, node 
 	// expensive (though still relatively cheap as compared to running the
 	// scripts) checks against all the inputs when the signature operations
 	// are out of bounds.
+	var inFlightRegularTx map[chainhash.Hash]uint32
+	if !stakeTree {
+		inFlightRegularTx = make(map[chainhash.Hash]uint32, len(txs))
+	}
 	totalFees := int64(inputFees) // Stake tx tree carry forward
 	prevHeader := node.parent.Header()
 	var cumulativeSigOps int
@@ -3573,16 +3577,25 @@ func (b *BlockChain) checkTransactionsAndConnect(inputFees dcrutil.Amount, node 
 		// and add all of the outputs for this transaction which are not
 		// provably unspendable as available utxos.
 		//
+		// For the regular transaction tree, keep track of in-flight
+		// transactions in order detect spends of earlier outputs by
+		// transactions later in the same block.
+		//
 		// Also, update the passed spent txos slice to contain an entry for each
 		// output the transaction spends.
-		connectTransaction := view.connectRegularTransaction
-		if stakeTree {
-			connectTransaction = view.connectStakeTransaction
-		}
-		err = connectTransaction(tx, node.height, uint32(idx), stxos,
-			isTreasuryEnabled, isAutoRevocationsEnabled)
-		if err != nil {
-			return err
+		if !stakeTree {
+			err := view.connectRegularTransaction(tx, node.height, uint32(idx),
+				inFlightRegularTx, stxos, isTreasuryEnabled,
+				isAutoRevocationsEnabled)
+			if err != nil {
+				return err
+			}
+		} else {
+			err := view.connectStakeTransaction(tx, node.height, uint32(idx),
+				stxos, isTreasuryEnabled, isAutoRevocationsEnabled)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -98,6 +98,10 @@ const (
 	// another. However, because there is a 2^128 chance of a collision, the
 	// paranoid user may wish to turn this feature on.
 	checkForDuplicateHashes = false
+
+	// testNet3MaxDiffActivationHeight is the height that enforcement of the
+	// maximum difficulty rules starts.
+	testNet3MaxDiffActivationHeight = 962928
 )
 
 // mustParseHash converts the passed big-endian hex string into a
@@ -133,6 +137,10 @@ var (
 	block424011Hash = mustParseHash("0000000000000000317fc6c7a8a6578be7dfa9c96eb81d620050a3732b02d572")
 	block428809Hash = mustParseHash("00000000000000003147798ccffcecaa420fb1c7934d8f4e33809a871ee34aaa")
 	block430191Hash = mustParseHash("00000000000000002127ad6d4cb30cc16f6344589b417e42650388bb0690a88e")
+
+	// block962928Hash is the hash of the checkpoint used to activate maximum
+	// difficulty semantics on the version 3 test network.
+	block962928Hash = mustParseHash("0000004fd1b267fd39111d456ff557137824538e6f6776168600e56002e23b93")
 )
 
 // voteBitsApproveParent returns whether or not the passed vote bits indicate
@@ -1051,6 +1059,27 @@ func (b *BlockChain) checkBlockHeaderPositional(header *wire.BlockHeader, prevNo
 			str = fmt.Sprintf(str, header.Timestamp, medianTime)
 			return ruleError(ErrTimeTooOld, str)
 		}
+
+		// A block on the test network must have a timestamp that is at least
+		// one minute after the previous one once the maximum allowed difficulty
+		// has been reached.  This helps throttle ASICs and GPUs since it's not
+		// reasonable to require high-powered hardware to keep the test network
+		// running smoothly.
+		//
+		// This rule is only active on the version 3 test network once the max
+		// diff activation height has been reached.
+		blockHeight := prevNode.height + 1
+		if b.minTestNetTarget != nil &&
+			expDiff <= standalone.BigToCompact(b.minTestNetTarget) &&
+			(!b.isTestNet3() || blockHeight >= testNet3MaxDiffActivationHeight) {
+
+			minTime := time.Unix(prevNode.timestamp, 0).Add(time.Minute)
+			if header.Timestamp.Before(minTime) {
+				str := "testnet block timestamp of %v is before required %v"
+				str = fmt.Sprintf(str, header.Timestamp, minTime)
+				return ruleError(ErrTimeTooOld, str)
+			}
+		}
 	}
 
 	// The height of this block is one more than the referenced previous
@@ -1087,6 +1116,16 @@ func (b *BlockChain) checkBlockHeaderPositional(header *wire.BlockHeader, prevNo
 		str := fmt.Sprintf("block at height %d does not match "+
 			"checkpoint hash", blockHeight)
 		return ruleError(ErrBadCheckpoint, str)
+	}
+
+	// Reject version 3 test network chains that are not specifically the chain
+	// used to activate maximum difficulty semantics.
+	if b.isTestNet3() && blockHeight == testNet3MaxDiffActivationHeight &&
+		blockHash != *block962928Hash {
+
+		str := fmt.Sprintf("block at height %d does not match checkpoint hash",
+			blockHeight)
+		return ruleError(ErrBadMaxDiffCheckpoint, str)
 	}
 
 	if !fastAdd {

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -1997,7 +1997,7 @@ func TestModifiedSubsidySplitSemantics(t *testing.T) {
 		trsySubsidy := cache.CalcTreasurySubsidy(height, numVotes, noTreasury)
 		powSubsidy := cache.CalcWorkSubsidyV2(height, numVotes, withDCP0010)
 
-		// Update the input value to the the new expected subsidy sum.
+		// Update the input value to the new expected subsidy sum.
 		coinbaseTx := b.Transactions[0]
 		coinbaseTx.TxIn[0].ValueIn = trsySubsidy + powSubsidy
 

--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -78,7 +78,10 @@ func TestNet3Params() *Params {
 			{"testnet-seed.decred.org", true},
 		},
 
-		// Chain parameters
+		// Chain parameters.
+		//
+		// Note that the minimum difficulty reduction parameter only applies up
+		// to and including block height 962927.
 		GenesisBlock:             &genesisBlock,
 		GenesisHash:              genesisBlock.BlockHash(),
 		PowLimit:                 testNetPowLimit,

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/decred/dcrd/bech32 v1.1.2
 	github.com/decred/dcrd/blockchain/stake/v4 v4.0.0
 	github.com/decred/dcrd/blockchain/standalone/v2 v2.1.0
-	github.com/decred/dcrd/blockchain/v4 v4.0.2
+	github.com/decred/dcrd/blockchain/v4 v4.1.0
 	github.com/decred/dcrd/certgen v1.1.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.3
 	github.com/decred/dcrd/chaincfg/v3 v3.1.1

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/decred/dcrd/blockchain/stake/v4 v4.0.0 h1:PwoCjCTbRvDUZKKs6N2Haus8Xcb
 github.com/decred/dcrd/blockchain/stake/v4 v4.0.0/go.mod h1:bOgG7YTbTOWQgtHLL2l1Y9gBHIuM86zwVcQtsoGlZlQ=
 github.com/decred/dcrd/blockchain/standalone/v2 v2.1.0 h1:aXh7a+86p+H65MGy0QKu4Juf3/j+Y5koVSyVYFMdqP0=
 github.com/decred/dcrd/blockchain/standalone/v2 v2.1.0/go.mod h1:t2qaZ3hNnxHZ5kzVJDgW5sp47/8T5hYJt7SR+/JtRhI=
-github.com/decred/dcrd/blockchain/v4 v4.0.2 h1:2hV4/KptuFcjpADaauVmJEmsT6kZcEoDd26Y6M3uk5I=
-github.com/decred/dcrd/blockchain/v4 v4.0.2/go.mod h1:i1FeTNN0LUEWBSMoI3riAFgfVE1X/7Seoz1aJ7YQGbk=
+github.com/decred/dcrd/blockchain/v4 v4.1.0 h1:R/Fz13mdyVHHSs7QjbHbs2IH2P4/cnZ4HNGcSN7NVD8=
+github.com/decred/dcrd/blockchain/v4 v4.1.0/go.mod h1:i1FeTNN0LUEWBSMoI3riAFgfVE1X/7Seoz1aJ7YQGbk=
 github.com/decred/dcrd/certgen v1.1.1 h1:MYPG5jCysnbF4OiJ1++YumFEu2p/MsM/zxmmqC9mVFg=
 github.com/decred/dcrd/certgen v1.1.1/go.mod h1:ivkPLChfjdAgFh7ZQOtl6kJRqVkfrCq67dlq3AbZBQE=
 github.com/decred/dcrd/chaincfg/chainhash v1.0.2/go.mod h1:BpbrGgrPTr3YJYRN3Bm+D9NuaFd+zGyNeIKgrhCXK60=


### PR DESCRIPTION
This updates the 1.7 release to use the latest version of the `blockchain` module which includes updates to the utxo cache to improve its robustness, optimize it, and correct some hard to hit corner cases that involve a mix of manual block invalidation, conditional flushing, and successive unclean shutdowns.

In particular, the following updated module version is used:

- github.com/decred/dcrd/blockchain/v4@v4.1.0

Note that it also cherry picks all of the commits included in updates to the `blockchain/v4` module to ensure they are also included in the release branch even though it is not strictly necessary since `go.mod` has been updated to require the new `blockchain/v4.1.0` release and thus will pull in the new code.  However, from past experience, not having code backported to modules available in the release branch too leads to headaches for devs building from source in their local workspace with overrides such as those in `go.work`.