### PR TITLE
main: Tweak runtime GC params for Go 1.19.

### DIFF
--- a/dcrd.go
+++ b/dcrd.go
@@ -228,9 +228,6 @@ func dcrdMain() error {
 }
 
 func main() {
-	// Use all processor cores.
-	runtime.GOMAXPROCS(runtime.NumCPU())
-
 	// Block and transaction processing can cause bursty allocations.  This
 	// limits the garbage collector from excessively overallocating during
 	// bursts.  This value was arrived at with the help of profiling live

--- a/internal/limits/README.md
+++ b/internal/limits/README.md
@@ -5,7 +5,7 @@ limits
 [![ISC License](https://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
 [![Doc](https://img.shields.io/badge/doc-reference-blue.svg)](https://pkg.go.dev/github.com/decred/dcrd/internal/limits)
 
-Package limits allows some process limits to be raised.
+Package limits modifies process limits depending on the OS and Go runtime.
 
 ## Installation and Updating
 

--- a/internal/limits/memlimit.go
+++ b/internal/limits/memlimit.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2022 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+//go:build go1.19
+// +build go1.19
+
+package limits
+
+import "runtime/debug"
+
+// SupportsMemoryLimit indicates that a runtime enforced soft memory limit is
+// supported starting with Go 1.19.
+const SupportsMemoryLimit = true
+
+// SetMemoryLimit configures the runtime to use the provided limit as a soft
+// memory limit starting with Go 1.19.
+func SetMemoryLimit(limit int64) {
+	debug.SetMemoryLimit(limit)
+}

--- a/internal/limits/memlimit_old.go
+++ b/internal/limits/memlimit_old.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2022 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+//go:build !go1.19
+// +build !go1.19
+
+package limits
+
+// SupportsMemoryLimit indicates that a runtime enforced soft memory limit is
+// not supported for versions of Go prior to version 1.19.
+const SupportsMemoryLimit = false
+
+// SetMemoryLimit is a no-op on versions of Go prior to version 1.19 since the
+// the ability is not supported on those versions.
+func SetMemoryLimit(_ int64) {
+}

--- a/log.go
+++ b/log.go
@@ -194,3 +194,18 @@ func fatalf(str string) {
 	}
 	os.Exit(1)
 }
+
+// humanizeBytes returns the provided number of bytes in humanized form with IEC
+// units (aka binary prefixes such as KiB and MiB).
+func humanizeBytes(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.2f %ciB", float64(b)/float64(div), "KMGTPE"[exp])
+}


### PR DESCRIPTION
Go 1.19 introduced the ability to specify a soft upper memory limit to help deal with transient memory spikes without needing to set the GC percent to an artificially low value.

This takes advantage of that to impose an upper memory limit that leaves plenty of headroom for the minimum recommended value while taking into account the max utxo cache size configuration option and increase the GC percent to the default value of 100% which allows the mem usage to expand more in between each GC cycle which in turn significantly reduces the number of GC cycles that need to be performed, particularly while performing the initial chain sync.

The end result is much less CPU time spent doing garbage collection and thus reduces the amount of time it takes to perform the initial chain sync by about 10%.

The update also has the nice side benefit that the `GOGC` environment variable can be used if an advanced sysadmin really wanted to tune it since it is no longer being overridden.

Finally, it also removes the code that explicitly configures the runtime to use all processor cores because that has been the default since Go 1.5.

The following graphs show OS-reported CPU and memory usage for an initial sync of the first 500k blocks for the existing code vs the updates in this PR.  As can be seen, there is about a 10% speedup in exchange for using more of the available memory:

![dcrd_initial_sync_os_cpu_usage_comparison_500k_blocks_mem_limit_vs_1_8_0_ab226e09](https://user-images.githubusercontent.com/2115102/202367604-95a4df46-dbe9-43d8-8c35-3a7b1da5e2e2.svg)

![dcrd_initial_sync_os_mem_usage_comparison_500k_blocks_mem_limit_vs_1_8_0_ab226e09](https://user-images.githubusercontent.com/2115102/202367623-aa725faf-8a35-45d3-8377-05e0eaa7fb78.svg)
