### PR TITLE
server: Bump supported wire pver for reject removal.

### DIFF
--- a/server.go
+++ b/server.go
@@ -73,7 +73,7 @@ const (
 	connectionRetryInterval = time.Second * 5
 
 	// maxProtocolVersion is the max protocol version the server supports.
-	maxProtocolVersion = wire.InitStateVersion
+	maxProtocolVersion = wire.RemoveRejectVersion
 
 	// These fields are used to track known addresses on a per-peer basis.
 	//


### PR DESCRIPTION
This bumps the supported wire protocol version for the server to the version that indicates the reject message has been removed.

This probably should have been done as a part of the v1.7.0 release so that peers would negotiate this version, but it wasn't, so rejecting older protocol versions will need to wait until this code is included in a release that also contains a consensus rule upgrade to piggyback on.

This completes the first part of #2546.