### PR TITLE
peer: Use latest pver by default.

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// MaxProtocolVersion is the max protocol version the peer supports.
-	MaxProtocolVersion = wire.InitStateVersion
+	MaxProtocolVersion = wire.RemoveRejectVersion
 
 	// outputBufferSize is the number of elements the output channels use.
 	outputBufferSize = 5000

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -553,10 +553,6 @@ func TestPeerListeners(t *testing.T) {
 		// only one version message is allowed
 		// only one verack message is allowed
 		{
-			"OnReject",
-			wire.NewMsgReject("block", wire.RejectDuplicate, "dupe block"),
-		},
-		{
 			"OnSendHeaders",
 			wire.NewMsgSendHeaders(),
 		},
@@ -582,6 +578,78 @@ func TestPeerListeners(t *testing.T) {
 	}
 	inPeer.Disconnect()
 	outPeer.Disconnect()
+}
+
+// TestDeprecatedRejectListener ensures that the deprecated on reject listener
+// is called as expected on older protocol versions.
+func TestDeprecatedRejectListener(t *testing.T) {
+	version := make(chan wire.Message, 1)
+	verack := make(chan struct{}, 1)
+	reject := make(chan wire.Message, 20)
+	peerCfg := &Config{
+		ProtocolVersion: wire.RemoveRejectVersion - 1,
+		Listeners: MessageListeners{
+			OnVersion: func(p *Peer, msg *wire.MsgVersion) {
+				version <- msg
+			},
+			OnVerAck: func(p *Peer, msg *wire.MsgVerAck) {
+				verack <- struct{}{}
+			},
+			OnReject: func(p *Peer, msg *wire.MsgReject) {
+				reject <- msg
+			},
+		},
+		UserAgentName:    "peer",
+		UserAgentVersion: "1.0",
+		Net:              wire.MainNet,
+		Services:         wire.SFNodeNetwork,
+	}
+	inConn, outConn := pipe(
+		&conn{raddr: "10.0.0.1:8333"},
+		&conn{raddr: "10.0.0.2:8333"},
+	)
+	inPeer := NewInboundPeer(peerCfg)
+	inPeer.AssociateConnection(inConn)
+	defer inPeer.Disconnect()
+
+	peerCfg.Listeners = MessageListeners{
+		OnVerAck: func(p *Peer, msg *wire.MsgVerAck) {
+			verack <- struct{}{}
+		},
+	}
+	outPeer, err := NewOutboundPeer(peerCfg, "10.0.0.1:8333")
+	if err != nil {
+		t.Errorf("NewOutboundPeer: unexpected err %v\n", err)
+		return
+	}
+	outPeer.AssociateConnection(outConn)
+	defer outPeer.Disconnect()
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-verack:
+		case <-time.After(time.Second * 1):
+			t.Error("TestPeerListeners: verack timeout\n")
+			return
+		}
+	}
+
+	select {
+	case <-version:
+	case <-time.After(time.Second * 1):
+		t.Error("TestPeerListeners: version timeout")
+		return
+	}
+
+	// Queue the reject message.
+	msg := wire.NewMsgReject("block", wire.RejectDuplicate, "dupe block")
+	outPeer.QueueMessage(msg, nil)
+	select {
+	case <-reject:
+	case <-time.After(time.Second * 1):
+		t.Error("TestPeerListeners: OnReject timeout")
+		return
+	}
 }
 
 // TestOutboundPeer tests that the outbound peer works as expected.


### PR DESCRIPTION
This updates the max and default protocol version the peer package uses to the latest protocol version (`wire.RemoveRejectVersion`) and updates the tests to account for the removal of the reject message.

It also adds a test that explicitly tests the handler on older protocol versions since the associated message is no longer sent on the latest one.
