### PR TITLE
server: Add bound addresses IPC events

### DIFF
--- a/config.go
+++ b/config.go
@@ -213,9 +213,10 @@ type config struct {
 	DropExistsAddrIndex bool `long:"dropexistsaddrindex" description:"Deletes the exists address index from the database on start up and then exits"`
 
 	// IPC options.
-	PipeRx         uint `long:"piperx" description:"File descriptor of read end pipe to enable parent -> child process communication"`
-	PipeTx         uint `long:"pipetx" description:"File descriptor of write end pipe to enable parent <- child process communication"`
-	LifetimeEvents bool `long:"lifetimeevents" description:"Send lifetime notifications over the TX pipe"`
+	PipeRx          uint `long:"piperx" description:"File descriptor of read end pipe to enable parent -> child process communication"`
+	PipeTx          uint `long:"pipetx" description:"File descriptor of write end pipe to enable parent <- child process communication"`
+	LifetimeEvents  bool `long:"lifetimeevents" description:"Send lifetime notifications over the TX pipe"`
+	BoundAddrEvents bool `long:"boundaddrevents" description:"Send notifications with the locally bound addresses of the P2P and RPC subsystems over the TX pipe"`
 
 	// Cooked options ready for use.
 	onionlookup   func(string) ([]net.IP, error)


### PR DESCRIPTION
This adds a new set of IPC events sent over the TX pipe that report the locally bound addresses of the P2P and RPC interfaces.

The main goal for this feature is to enable binding dcrd to a random port (using for example, --listen :0) while enabling a controlling parent process to learn the address that was assigned to dcrd by the OS.

The events are only sent when the --boundaddrevents flag is specified.

Closes #3018
