### PR TITLE
build: Enable run_tests.sh to work with go.work.

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -17,7 +17,7 @@ set -ex
 go version
 
 # run tests on all modules
-ROOTPATH=$(go list -m)
+ROOTPATH=$(go list)
 ROOTPATHPATTERN=$(echo $ROOTPATH | sed 's/\\/\\\\/g' | sed 's/\//\\\//g')
 MODPATHS=$(go list -m all | grep "^$ROOTPATHPATTERN" | cut -d' ' -f1)
 for module in $MODPATHS; do


### PR DESCRIPTION
The script `run_tests.sh` does not work if a go.work file is present in the project root. This is because when a `go.work` file is present, `go list -m` returns the names of all modules in the workspace rather than just the parent module in the root directory. Removing the `-m` flag fixes this.