### PR TITLE
build: Only invoke tests once.

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -16,13 +16,16 @@ set -ex
 
 go version
 
-# run tests on all modules
 ROOTPATH=$(go list)
+
+# run tests on all modules
+echo "==> test all modules"
+go test -short -tags rpctest $ROOTPATH/...
+
 ROOTPATHPATTERN=$(echo $ROOTPATH | sed 's/\\/\\\\/g' | sed 's/\//\\\//g')
 MODPATHS=$(go list -m all | grep "^$ROOTPATHPATTERN" | cut -d' ' -f1)
 for module in $MODPATHS; do
-  echo "==> ${module}"
-  go test -short -tags rpctest ${module}/...
+  echo "==> lint ${module}"
 
   # check linters
   MODNAME=$(echo $module | sed -E -e "s/^$ROOTPATHPATTERN//" \


### PR DESCRIPTION
`go test $ROOTPATH/...` runs all tests in the root module, and all tests in submodules, so there is no need to run `go test` in the loop which descends into submodule directories. Doing this actually causes each test file to be run twice because the first iteration of the loop *is* the root module, and thus all tests.

Only the linter needs to be invoked from each module directory.