### PR TITLE
rpcserver: Convert ws client lifecycle to context.

### DIFF
--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -5178,13 +5178,14 @@ func (s *Server) standardCmdResult(ctx context.Context, cmd *parsedRPCCmd) (inte
 // is suitable for use in replies if the command is invalid in some way such as
 // an unregistered command or invalid parameters.
 func parseCmd(request *dcrjson.Request) *parsedRPCCmd {
+	method := types.Method(request.Method)
 	parsedCmd := parsedRPCCmd{
 		jsonrpc: request.Jsonrpc,
 		id:      request.ID,
-		method:  types.Method(request.Method),
+		method:  method,
 	}
 
-	params, err := dcrjson.ParseParams(types.Method(request.Method), request.Params)
+	params, err := dcrjson.ParseParams(method, request.Params)
 	if err != nil {
 		// Produce a relevant error when the requested method is not registered
 		// depending on whether or not it is recognized as being a wallet

--- a/internal/rpcserver/rpcwebsocket.go
+++ b/internal/rpcserver/rpcwebsocket.go
@@ -463,15 +463,7 @@ out:
 			}
 			switch n := n.(type) {
 			case *notificationBlockConnected:
-				block := (*dcrutil.Block)(n)
-
-				// Skip iterating through all txs if no tx
-				// notification requests exist.
-				if len(blockNotifications) == 0 {
-					continue
-				}
-
-				m.notifyBlockConnected(blockNotifications, block)
+				m.notifyBlockConnected(blockNotifications, (*dcrutil.Block)(n))
 
 			case *notificationBlockDisconnected:
 				m.notifyBlockDisconnected(blockNotifications,
@@ -710,6 +702,12 @@ func (m *wsNotificationManager) subscribedClients(tx *dcrutil.Tx, clients map[ch
 // notifyBlockConnected notifies websocket clients that have registered for
 // block updates when a block is connected to the main chain.
 func (m *wsNotificationManager) notifyBlockConnected(clients map[chan struct{}]*wsClient, block *dcrutil.Block) {
+	// Skip notification creation if no clients have requested block connected
+	// notifications.
+	if len(clients) == 0 {
+		return
+	}
+
 	// Create the common portion of the notification that is the same for
 	// every client.
 	headerBytes, err := block.MsgBlock().Header.Bytes()


### PR DESCRIPTION
~**This requires #3024**.~

This modifies the lifecycle of websocket clients to use the expected pattern for running subsystems based on contexts.

In particular, this replaces the `Start` and `WaitForShutdown` methods with a single method named `Run` and arranges for it to block until the provided context is cancelled.  This is more flexible for the caller since it can easily turn blocking code into async code while the reverse is not true.

The new `Run` method waits for all goroutines that it starts to shutdown before returning to help ensure an orderly shutdown.

Since there are exported methods that send messages to the output and notification handler goroutines via channels and those goroutines are stopped during the shutdown process, all sends select across both the channels in question as well as a quit channel which is closed when the context it cancelled.  This ensures callers can't end up blocking on send to a goroutine that is no longer running without needing additional mutexes.

It also contains a couple of other minor consistency cleanup commits.