### PR TITLE
rpcserver: Support getwork cancellation.

### DIFF
--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -1542,7 +1542,7 @@ func defaultMockMiningState() *testMiningState {
 	tmplKey := getWorkTemplateKey(&block432100.Header)
 	workState := newWorkState()
 	workState.templatePool[tmplKey] = &block432100
-	workState.prevHash = &blk.Header.PrevBlock
+	workState.prevBestHash = &blk.Header.PrevBlock
 	return &testMiningState{
 		workState: workState,
 	}
@@ -5763,7 +5763,7 @@ func TestHandleGetWork(t *testing.T) {
 			mockChain := defaultMockRPCChain()
 			ms := defaultMockMiningState()
 			ms.miningAddrs = []stdaddr.Address{miningaddr}
-			ms.workState.prevHash = &mockChain.bestSnapshot.Hash
+			ms.workState.prevBestHash = &mockChain.bestSnapshot.Hash
 			return ms
 		}(),
 		mockBlockTemplater: func() *testBlockTemplater {
@@ -7934,13 +7934,14 @@ func testRPCServerHandler(t *testing.T, tests []rpcTest) {
 				helpCacher = test.mockHelpCacher
 			}
 
+			ctx := context.Background()
 			testServer := &Server{
 				cfg:        *rpcserverConfig,
 				ntfnMgr:    new(testNtfnManager),
 				workState:  workState,
 				helpCacher: helpCacher,
 			}
-			result, err := test.handler(nil, testServer, test.cmd)
+			result, err := test.handler(ctx, testServer, test.cmd)
 			if test.wantErr {
 				var rpcErr *dcrjson.RPCError
 				if !errors.As(err, &rpcErr) || rpcErr.Code != test.errCode {


### PR DESCRIPTION
~**This requires #3026**.~

Currently, a mutex is used in order to protect concurrent access from multiple RPC invocations for work requests and submission.  While this approach achieves the desired result and is logically correct, it also means that any requests that are cancelled needlessly block those that haven't been cancelled.

This is particularly noteworthy around initial startup where it can take a while to reach the initial state sync and provide a usable template and thus any callers, such as gominer, that have timeouts involved will cancel request and make new ones.

In order to better handle cases such as the aforementioned, this modifies the `getwork` handler to support cancellation in both the concurrent access blocking behavior as well as when waiting for template generation.

It also reduces the time spent in the critical section of the work state mutex which can help with the throughput of work notifications in high contention scenarios.
