### PR TITLE
chaincfg: Remove planetdecred seeders.

### DIFF
--- a/chaincfg/mainnetparams.go
+++ b/chaincfg/mainnetparams.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2016 The btcsuite developers
-// Copyright (c) 2015-2021 The Decred developers
+// Copyright (c) 2015-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -512,7 +512,6 @@ func MainNetParams() *Params {
 		seeders: []string{
 			"mainnet-seed-1.decred.org",
 			"mainnet-seed-2.decred.org",
-			"mainnet-seed.planetdecred.org",
 			"mainnet-seed.dcrdata.org",
 			"mainnet-seed.jholdstock.uk",
 		},

--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2016 The btcsuite developers
-// Copyright (c) 2015-2021 The Decred developers
+// Copyright (c) 2015-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -425,7 +425,6 @@ func TestNet3Params() *Params {
 		seeders: []string{
 			"testnet-seed-1.decred.org",
 			"testnet-seed-2.decred.org",
-			"testnet-seed.planetdecred.org",
 			"testnet-seed.dcrdata.org",
 			"testnet-seed.jholdstock.uk",
 		},


### PR DESCRIPTION
This grabs https://github.com/decred/dcrd/pull/2974 for the v1.7 release branch.
While this may not be significant enough to cut a new release, it is helpful to have on `release-v1.7`.  Alright to backport without necessarily having the intent to push a new release?