### PR TITLE
docs: Remove old JSON-RPC API methods/ntfns.

### DIFF
--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -3009,10 +3009,6 @@ The following is an overview of the JSON-RPC notifications used for Websocket co
 |Block disconnected from the main chain.
 |[[#notifyblocks|notifyblocks]]
 |-
-|[[#recvtx|recvtx]]
-|Processed a transaction output spending to a wallet address.
-|
-|-
 |[[#work|work]]
 |New generated block template.
 |[[#notifywork|notifywork]]
@@ -3091,34 +3087,6 @@ The following is an overview of the JSON-RPC notifications used for Websocket co
 |Example blockdisconnected notification for mainnet block 280330:
 
 : <code>{"jsonrpc": "1.0","method": "blockdisconnected", "params": ["05000000be1e39c54738d534a55e6ee8d2fc62433857368041def11b000000000000000085d..."], "id": null}</code>
-|}
-
-----
-
-====recvtx====
-{|
-!Method
-|recvtx
-|-
-!Request
-|
-|-
-!Parameters
-|
-# <code>Transaction</code>: <code>(string)</code> full transaction encoded as a hex string.
-# <code>Block details</code>: <code>(object, optional)</code> details about a block and the index of the transaction within a block, if the transaction is mined.
-|-
-!Description
-|Notifies a client when a transaction is processed that contains at least a single output with a pkScript sending to a requested address.  If multiple outputs send to requested addresses, a single notification is sent.  If a mempool (unmined) transaction is processed, the block details object (second parameter) is excluded.
-|-
-!Example
-|Example recvtx notification for mainnet transaction <code>61d3696de4c888730cbe06b0ad8ecb6d72d6108e893895aa9bc067bd7eba3fad</code> when processed by mempool:
-
-: <code>{"jsonrpc": "1.0", "method": "recvtx", "params": ["010000000114d9ff358894c486b4ae11c2a8cf7851b1df64c53d2e511278eff17c22fb737300000000...], "id": null }</code>
-
-The recvtx notification for the same txout, after the transaction was mined into block 276425:
-
-: <code>{"jsonrpc": "1.0","method": "recvtx", "params": ["010000000114d9ff358894c486b4ae11c2a8cf7851b1df64c53d2e511278eff17c22fb737300000000...", {"height": 276425, "hash": "000000000000000325474bb799b9e591f965ca4461b72cb7012b808db92bb2fc", "index": 684, "time": 1387737310 }], "id": null }</code>
 |}
 
 ----

--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -2576,14 +2576,6 @@ user.  Click the method name for further details such as parameter and return in
 |Cancel registered notifications for whenever when a new tspend arrives in the mempool.
 |None
 |-
-|[[#notifyreceived|notifyreceived]]
-|Send notifications when a txout spends to an address.
-|[[#recvtx|recvtx]] and [[#redeemingtx|redeemingtx]]
-|-
-|[[#stopnotifyreceived|stopnotifyreceived]]
-|Cancel registered notifications for when a txout spends to any of the passed addresses.
-|None
-|-
 |[[#notifyspent|notifyspent]]
 |Send notification when a txout is spent.
 |[[#redeemingtx|redeemingtx]]
@@ -2762,54 +2754,6 @@ NOTE: This is only required if an HTTP Authorization header is not being used.
 |-
 !Description
 |Cancel sending notifications for whenever a new tspend arrives in the mempool.
-|-
-!Returns
-|Nothing
-|}
-
-----
-
-====notifyreceived====
-{|
-!Method
-|notifyreceived
-|-
-!Notifications
-|[[#recvtx|recvtx]] and [[#redeemingtx|redeemingtx]]
-|-
-!Parameters
-|
-# <code>Addresses</code>: <code>(JSON array, required)</code>
-: <code>decredaddress</code>: <code>(string)</code> the Decred address.
-
-<code>["decredaddress", ...]</code>
-|-
-!Description
-|Send a recvtx notification when a transaction added to mempool or appears in a newly-attached block contains a txout pkScript sending to any of the passed addresses.  Matching outpoints are automatically registered for redeemingtx notifications.
-|-
-!Returns
-|Nothing
-|}
-
-----
-
-====stopnotifyreceived====
-{|
-!Method
-|stopnotifyreceived
-|-
-!Notifications
-|None
-|-
-!Parameters
-|
-# <code>Addresses</code>: <code>(JSON array, required)</code>
-: <code>decredaddress</code>: <code>(string)</code> the Decred address.
-
-<code>["decredaddress", ...]</code>
-|-
-!Description
-|Cancel registered receive notifications for each passed address.
 |-
 !Returns
 |Nothing
@@ -3067,7 +3011,7 @@ The following is an overview of the JSON-RPC notifications used for Websocket co
 |-
 |[[#recvtx|recvtx]]
 |Processed a transaction output spending to a wallet address.
-|[[#notifyreceived|notifyreceived]]
+|
 |-
 |[[#work|work]]
 |New generated block template.
@@ -3157,7 +3101,7 @@ The following is an overview of the JSON-RPC notifications used for Websocket co
 |recvtx
 |-
 !Request
-|[[#notifyreceived|notifyreceived]]
+|
 |-
 !Parameters
 |

--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -2576,14 +2576,6 @@ user.  Click the method name for further details such as parameter and return in
 |Cancel registered notifications for whenever when a new tspend arrives in the mempool.
 |None
 |-
-|[[#notifyspent|notifyspent]]
-|Send notification when a txout is spent.
-|[[#redeemingtx|redeemingtx]]
-|-
-|[[#stopnotifyspent|stopnotifyspent]]
-|Cancel registered spending notifications for each passed outpoint.
-|None
-|-
 |[[#loadtxfilter|loadtxfilter]]
 |Load, add to, or reload a websocket client's transaction filter for mempool transactions, new blocks and [[#rescan|rescan]].
 |[[#blockconnected|blockconnected]], [[#relevanttxaccepted|relevanttxaccepted]]
@@ -2761,55 +2753,6 @@ NOTE: This is only required if an HTTP Authorization header is not being used.
 
 ----
 
-====notifyspent====
-{|
-!Method
-|notifyspent
-|-
-!Notifications
-|[[#redeemingtx|redeemingtx]]
-|-
-!Parameters
-|
-# <code>Outpoints</code>: <code>(json array, required)</code>
-:  <code>hash</code>: <code>(string)</code> the hex-encoded bytes of the outpoint hash.
-: <code>index</code>: <code>(numeric)</code> the txout index of the outpoint.
-
-<code>[{"hash":"data", "index":n }, ...]</code>
-|-
-!Description
-|Send a redeemingtx notification when a transaction spending an outpoint appears in mempool (if relayed to this dcrd instance) and when such a transaction first appears in a newly-attached block.
-|-
-!Returns
-|Nothing
-|}
-
-----
-
-====stopnotifyspent====
-{|
-!Method
-|stopnotifyspent
-|-
-!Notifications
-|None
-|-
-!Parameters
-|
-# <code>Outpoints</code>: <code>(json array, required)</code>
-: <code>hash</code>: <code>(string)</code> the hex-encoded bytes of the outpoint hash.
-: <code>index</code>: <code>(numeric)</code> the txout index of the outpoint.
-
-<code>[{"hash":"data", "index":n }, ...]</code>
-|-
-!Description
-|Cancel registered spending notifications for each passed outpoint.
-|-
-!Returns
-|Nothing
-
-----
-|}
 ====loadtxfilter====
 {|
 !Method
@@ -3019,7 +2962,7 @@ The following is an overview of the JSON-RPC notifications used for Websocket co
 |-
 |[[#redeemingtx|redeemingtx]]
 |Processed a transaction that spends a registered outpoint.
-|[[#notifyspent|notifyspent]]
+|
 |-
 |[[#txaccepted|txaccepted]]
 |Received a new transaction after requesting simple notifications of all new transactions accepted into the mempool.
@@ -3149,7 +3092,7 @@ The following is an overview of the JSON-RPC notifications used for Websocket co
 |redeemingtx
 |-
 !Requests
-|[[#notifyspent|notifyspent]]
+|
 |-
 !Parameters
 |

--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -2960,10 +2960,6 @@ The following is an overview of the JSON-RPC notifications used for Websocket co
 |New generated tspend.
 |[[#notifytspend|notifytspend]]
 |-
-|[[#redeemingtx|redeemingtx]]
-|Processed a transaction that spends a registered outpoint.
-|
-|-
 |[[#txaccepted|txaccepted]]
 |Received a new transaction after requesting simple notifications of all new transactions accepted into the mempool.
 |[[#notifynewtransactions|notifynewtransactions]]
@@ -3082,34 +3078,6 @@ The following is an overview of the JSON-RPC notifications used for Websocket co
 |Example tspend notification on simnet:
 
 : <code>{"jsonrpc":"1.0","method":"tspend","params":["03000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff0300000000000000000000226a203ff1461b188e100f6fed467eb9b12e2d10ed86446df6c3a99c1df4af159d39f70065cd1d0000000000001ac376a91449a6061cda6d9243cecf3186af60caefc613904988ac0027b9290000000000001ac376a9145722802cd0905b4589d2094fcb6b76f746dcf18988ac000000002200000001c29786470000000000000000ffffffff644039401cb6daacd3310cd282abcc04f92649a3f27d3fd9be2038c94d531addb2ced539a25dbb186fc4c572054d36d457b1416008ac11033175e31d68a5d97877d42102a36b785d584555696b69d1b2bbeff4010332b301e3edd316d79438554cacb3e7c2"],"id":null}</code>
-|}
-
-----
-
-====redeemingtx====
-{|
-!Method
-|redeemingtx
-|-
-!Requests
-|
-|-
-!Parameters
-|
-# <code>Transaction</code>: <code>(string)</code> full transaction encoded as a hex string.
-# <code>Block details</code>: <code>(object, optional)</code> details about a block and the index of the transaction within a block, if the transaction is mined.
-|-
-!Description
-|Notifies a client when a registered outpoint is spent by a transaction accepted to mempool and/or mined into a block.
-|-
-!Example
-|Example redeemingtx notification for mainnet outpoint <code>61d3696de4c888730cbe06b0ad8ecb6d72d6108e893895aa9bc067bd7eba3fad:0</code> after being spent by transaction <code>4ad0c16ac973ff675dec1f3e5f1273f1c45be2a63554343f21b70240a1e43ece</code>:
-
-: <code>{"jsonrpc": "1.0", "method": "redeemingtx", "params": ["0100000003ad3fba7ebd67c09baa9538898e10d6726dcb8eadb006be0c7388c8e46d69d3610000000..."],"id": null}</code>
-
-The redeemingtx notification for the same txout, after the spending transaction was mined into block 279143:
-
-: <code>{"jsonrpc": "1.0", "method": "recvtx", "params": ["0100000003ad3fba7ebd67c09baa9538898e10d6726dcb8eadb006be0c7388c8e46d69d3610000000...", {"height": 279143, "hash": "00000000000000017188b968a371bab95aa43522665353b646e41865abae02a4", "index": 6, "time": 1389115004 }], "id": null }</code>
 |}
 
 ----


### PR DESCRIPTION
**This is rebased on #3033**.

This removes the following methods and notifications that no longer exist from from the JSON-RPC API documentation:

- `notifyreceived` method
- `stopnotifyrecieved` method
- `recvtx` notification 
- `notifyspent` method
- `stopnotifyspent` method
- `redeemingtx` notification 