### PR TITLE
server: Always serve known getcfilterv2 filters.

### DIFF
--- a/server.go
+++ b/server.go
@@ -1336,11 +1336,6 @@ func (sp *serverPeer) OnGetCFilter(_ *peer.Peer, msg *wire.MsgGetCFilter) {
 
 // OnGetCFilterV2 is invoked when a peer receives a getcfilterv2 wire message.
 func (sp *serverPeer) OnGetCFilterV2(_ *peer.Peer, msg *wire.MsgGetCFilterV2) {
-	// Ignore request if the chain is not yet synced.
-	if !sp.server.syncManager.IsCurrent() {
-		return
-	}
-
 	// Attempt to obtain the requested filter.
 	//
 	// Ignore request for unknown block or otherwise missing filters.


### PR DESCRIPTION
Similar to the recently changed `getheaders` handling, which also had the same semantics, the current logic for responding to `getcfilterv2` includes a check to avoid serving filters whenever the current local chain is not considered to be current.

Like the `getheaders` case, one less than ideal consequence of not responding is that it can lead to peers appearing to be unresponsive and/or stalled whenever the peer does not consider itself current, which can happen temporarily in a variety of corner cases such as after being unable to communicate with the network for a long time, or in testing scenarios where there are necessarily long periods of time without any new blocks.

This existing behavior for `getcfilterv2` handling was inherited from the older bloom filter logic where it mattered because bloom filters could potentially put a substantial strain on the server and also could significantly slow down the initial chain sync.

However, the aforementioned concerns no longer apply to version 2 block filters because they have a fixed creation cost per block, are required to exist for main chain blocks by consensus, and are the same for all peers.

Taken as a whole, this means that serving the filters is relatively cheap and therefore this modifies the semantics to always respond to `getcfilterv2` requests, even before the local chain is fully synced.