### PR TITLE
main: Remove old style build constraints.

### DIFF
--- a/internal/integration/rpctests/rpcserver_test.go
+++ b/internal/integration/rpctests/rpcserver_test.go
@@ -6,7 +6,6 @@
 
 // This file is ignored during the regular tests due to the following build tag.
 //go:build rpctest
-// +build rpctest
 
 package rpctests
 

--- a/internal/integration/rpctests/treasury_test.go
+++ b/internal/integration/rpctests/treasury_test.go
@@ -5,7 +5,6 @@
 
 // This file is ignored during the regular tests due to the following build tag.
 //go:build rpctest
-// +build rpctest
 
 package rpctests
 

--- a/internal/limits/limits_unix.go
+++ b/internal/limits/limits_unix.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows && !plan9
-// +build !windows,!plan9
 
 package limits
 

--- a/internal/limits/memlimit.go
+++ b/internal/limits/memlimit.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build go1.19
-// +build go1.19
 
 package limits
 

--- a/internal/limits/memlimit_old.go
+++ b/internal/limits/memlimit_old.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !go1.19
-// +build !go1.19
 
 package limits
 

--- a/internal/version/version_buildinfo.go
+++ b/internal/version/version_buildinfo.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build go1.18
-// +build go1.18
 
 package version
 

--- a/internal/version/version_nobuildinfo.go
+++ b/internal/version/version_nobuildinfo.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !go1.18
-// +build !go1.18
 
 package version
 

--- a/signal_syscall.go
+++ b/signal_syscall.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 //
 //go:build windows || aix || android || darwin || dragonfly || freebsd || hurd || illumos || ios || linux || netbsd || openbsd || solaris
-// +build windows aix android darwin dragonfly freebsd hurd illumos ios linux netbsd openbsd solaris
 
 package main
 


### PR DESCRIPTION
This removes the old style build constraints that were required for versions of Go prior to version 1.17 now that the minimum actively supported version of Go is 1.18.

Note that it intentionally does not remove them from the modules to avoid needlessly breaking any consumers that might still be using them from older versions of Go.