### PR TITLE
rpctests: Build constraint for util too.

### DIFF
--- a/internal/integration/rpctests/util_test.go
+++ b/internal/integration/rpctests/util_test.go
@@ -1,7 +1,9 @@
 // Copyright (c) 2022 The Decred developers
-
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
+
+// This file is ignored during the regular tests due to the following build tag.
+//go:build rpctest
 
 package rpctests
 


### PR DESCRIPTION
This adds the same build constraint that is used on the other test files to  `util_test.go`  as well to avoid an unused method linter warning.