### PR TITLE
mempool: Accept expired prune height.

### DIFF
--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2022 The Decred developers
+// Copyright (c) 2015-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -2054,12 +2054,13 @@ func (mp *TxPool) PruneStakeTx(requiredStakeDifficulty, height int64) {
 	mp.mtx.Unlock()
 }
 
-// pruneExpiredTx prunes expired transactions from the mempool that are no
-// longer able to be included into a block.
+// pruneExpiredTx prunes expired transactions that are no longer able to be
+// included into a block from the mempool.  The height is expected to be the
+// height of the current best chain tip.
 //
 // This function MUST be called with the mempool lock held (for writes).
-func (mp *TxPool) pruneExpiredTx() {
-	nextBlockHeight := mp.cfg.BestHeight() + 1
+func (mp *TxPool) pruneExpiredTx(height int64) {
+	nextBlockHeight := height + 1
 
 	for _, txDesc := range mp.pool {
 		tx := txDesc.Tx
@@ -2080,14 +2081,15 @@ func (mp *TxPool) pruneExpiredTx() {
 	}
 }
 
-// PruneExpiredTx prunes expired transactions from the mempool that may no longer
-// be able to be included into a block.
+// PruneExpiredTx prunes expired transactions that are no longer able to be
+// included into a block from the mempool.  The height is expected to be the
+// height of the current best chain tip.
 //
 // This function is safe for concurrent access.
-func (mp *TxPool) PruneExpiredTx() {
+func (mp *TxPool) PruneExpiredTx(height int64) {
 	// Protect concurrent access.
 	mp.mtx.Lock()
-	mp.pruneExpiredTx()
+	mp.pruneExpiredTx(height)
 	mp.mtx.Unlock()
 }
 

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2016 The btcsuite developers
-// Copyright (c) 2017-2022 The Decred developers
+// Copyright (c) 2017-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -1384,13 +1384,14 @@ func TestExpirationPruning(t *testing.T) {
 		testPoolMembership(tc, tx, false, true)
 
 		// Simulate processing a new block that did not mine any of the txns.
-		harness.chain.SetHeight(harness.chain.BestHeight() + 1)
+		nextBlockHeight := harness.chain.BestHeight() + 1
+		harness.chain.SetHeight(nextBlockHeight)
 
 		// Prune any transactions that are now expired and ensure that the tx
 		// that was just added was pruned by checking that it is not in the
 		// orphan pool, not in the transaction pool, and not reported as
 		// available.
-		harness.txPool.PruneExpiredTx()
+		harness.txPool.PruneExpiredTx(nextBlockHeight)
 		testPoolMembership(tc, tx, false, false)
 	}
 }

--- a/internal/netsync/manager.go
+++ b/internal/netsync/manager.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2022 The Decred developers
+// Copyright (c) 2015-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -879,7 +879,7 @@ func (m *SyncManager) handleBlockMsg(bmsg *blockMsg) {
 		// Prune invalidated transactions.
 		best := chain.BestSnapshot()
 		m.cfg.TxMemPool.PruneStakeTx(best.NextStakeDiff, best.Height)
-		m.cfg.TxMemPool.PruneExpiredTx()
+		m.cfg.TxMemPool.PruneExpiredTx(best.Height)
 
 		// Clear the rejected transactions.
 		m.rejectedTxns.Reset()
@@ -1451,7 +1451,7 @@ out:
 					best := m.cfg.Chain.BestSnapshot()
 					m.cfg.TxMemPool.PruneStakeTx(best.NextStakeDiff,
 						best.Height)
-					m.cfg.TxMemPool.PruneExpiredTx()
+					m.cfg.TxMemPool.PruneExpiredTx(best.Height)
 				}
 
 				msg.reply <- processBlockResponse{


### PR DESCRIPTION
This modifies the method that prunes expired transactions to accept the current best height as opposed to looking it up internally.

While this change doesn't really have any effect in isolation, it is part of an ongoing effort to make the internal mempool state easier to reason about for correctness by removing hidden assumptions.  In this particular case, it removes the reliance on the assumption that the tip of the chain has not changed as compared to what the caller expects it to be.