### PR TITLE
addrmgr: Mitigate high CPU use when attempts become large.

### DIFF
--- a/addrmgr/addrmanager.go
+++ b/addrmgr/addrmanager.go
@@ -840,6 +840,7 @@ func (a *AddrManager) GetAddress() *KnownAddress {
 			for _, value := range a.addrNew[bucket] {
 				if nth == 0 {
 					ka = value
+					break
 				}
 				nth--
 			}

--- a/addrmgr/knownaddress.go
+++ b/addrmgr/knownaddress.go
@@ -6,6 +6,7 @@
 package addrmgr
 
 import (
+	"math"
 	"sync"
 	"time"
 )
@@ -69,19 +70,18 @@ func (ka *KnownAddress) chance() float64 {
 		lastAttempt = 0
 	}
 
-	c := 1.0
+	// Apply a lower limit to the value returned.
+	const minChance = 0.01
 
 	// Very recent attempts are less likely to be retried.
 	if lastAttempt < 10*time.Minute {
-		c *= 0.01
+		return minChance
 	}
 
 	// Failed attempts deprioritise.
-	for i := ka.attempts; i > 0; i-- {
-		c /= 1.5
-	}
+	c := 1.0 / math.Pow(1.5, float64(ka.attempts))
 
-	return c
+	return math.Max(c, minChance)
 }
 
 // isBad returns true if the address in question has not been tried in the last


### PR DESCRIPTION
This PR contains two commits aimed at avoiding debilitating CPU use by the `AddrManager` when a `KnownAddress`' attempts becomes large.  On testnet, the dex native SPV wallet reproducibly becomes crippled without these changes, causing both high CPU use and peering timeouts as the `GetAddress` method blocks for long periods.

```
addrmgr: break after selecting random address

This adds a missing break statement to the range over the map of
addresses used to select a random entry from the map.  Previously
the loop would continue needlessly until the entire map was traversed.
This is a minor optimization.
```


```
addrmgr: set min value and optimize address chance

This updates the (*KnownAddress).chance method in the following ways:
1. Apply a lower limit to the return value.  Using 0.01  as this minimum
   prevents tiny chance values from causing excessive iterations in
   (*AddrManager).GetAddress, currently the only caller.
2. Replace an inefficient loop with a single math.Pow.

These changes are mitigations to excessive CPU use in the GetAddress
method that manifest when the number of attempts for a KnownAddress
becomes large.  However, this method and much of addrmgr should be
rewritten in the future since there are some ad hoc and questionable
approaches to candidate address selection.
```