### PR TITLE
docker: Add ability to build versioned docker images.

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -32,7 +32,8 @@ RUN adduser \
 
 # Build dcrd and other commands it provides.
 WORKDIR /go/src/github.com/decred/dcrd
-RUN git clone https://github.com/decred/dcrd . && \
+ARG DCRD_BUILD_TAG=master
+RUN git clone --branch ${DCRD_BUILD_TAG} -c advice.detachedHead=false https://github.com/decred/dcrd . && \
     CGO_ENABLED=0 GOOS=linux \
     go install -trimpath -tags safe,netgo,timetzdata \
       -ldflags="-s -w" \
@@ -40,7 +41,8 @@ RUN git clone https://github.com/decred/dcrd . && \
 
 # Build dcrctl.
 WORKDIR /go/src/github.com/decred/dcrctl
-RUN git clone https://github.com/decred/dcrctl . && \
+ARG DCRCTL_BUILD_TAG=${DCRD_BUILD_TAG}
+RUN git clone --branch ${DCRCTL_BUILD_TAG} -c advice.detachedHead=false https://github.com/decred/dcrctl . && \
     CGO_ENABLED=0 GOOS=linux \
     go install -trimpath -tags safe,netgo -ldflags="-s -w"
 

--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -55,6 +55,20 @@ concrete value.
    $ docker build -t "${DCRD_IMAGE_NAME}" -f contrib/docker/Dockerfile .
    ```
 
+   To build a specific `git` tag or branch, the `DCRD_BUILD_TAG` argument can be specified.  The argument is optional and defaults to `master`.
+
+   ```
+    $ docker build --build-arg DCRD_BUILD_TAG=release-v1.x.x \
+        -t "${DCRD_IMAGE_NAME}" -f contrib/docker/Dockerfile .
+   ```
+
+    By default, the `DCRD_BUILD_TAG` will also specify the tag or branch of the `dcrctl` utility to be built, as well.  It is feasible that `dcrctl` and `dcrd` don't use the same tags; if that's the case then the `DCRCTL_BUILD_TAG` can be used (on its own or alongside `DCRD_BUILD_TAG`):
+
+   ```
+    $ docker build --build-arg DCRCTL_BUILD_TAG=release-v1.x.x \
+        -t "${DCRD_IMAGE_NAME}" -f contrib/docker/Dockerfile .
+   ```
+
 2. Create a data volume and change its ownership to the user id of the user
    inside of the container so it has the necessary permissions to write to it:
 


### PR DESCRIPTION
Build the locally cloned code instead of issuing a `git clone`.  This makes it possible to build versioned `docker` images, i.e. not from `master` only.