### PR TITLE
multi: Use atomic types in unexported modules.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrd
 
-go 1.17
+go 1.19
 
 require (
 	github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
go 1.19 introduced [new atomic types](https://go.dev/doc/go1.19#atomic_types) which hide the underlying primitive types so that all accesses are forced to use the atomic APIs. This makes the code less prone to human error and a bit less verbose.

Of particular note is the introduction of the type `atomic.Bool`. Previously this repo made use of atomic integers to track properties with boolean values, but this PR updates those to use `atomic.Bool` instead.