### PR TITLE
chaincfg: Rework init time deployment val logic.

### DIFF
--- a/chaincfg/init_test.go
+++ b/chaincfg/init_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 The Decred developers
+// Copyright (c) 2017-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -324,17 +324,17 @@ func TestChoices(t *testing.T) {
 		{
 			name:     "2 IsAbstain",
 			vote:     twoIsAbstain,
-			expected: errInvalidIsAbstain,
+			expected: errTooManyAbstain,
 		},
 		{
 			name:     "2 IsNo",
 			vote:     twoIsNo,
-			expected: errInvalidIsNo,
+			expected: errTooManyNo,
 		},
 		{
 			name:     "both IsAbstain IsNo",
 			vote:     bothFlags,
-			expected: errInvalidBothFlags,
+			expected: errBothFlags,
 		},
 		{
 			name:     "duplicate choice id",
@@ -345,7 +345,7 @@ func TestChoices(t *testing.T) {
 
 	for _, test := range tests {
 		t.Logf("running: %v", test.name)
-		err := validateAgenda(test.vote)
+		err := validateChoices(test.vote.Mask, test.vote.Choices)
 		if !errors.Is(err, test.expected) {
 			t.Fatalf("%v: got '%v' expected '%v'", test.name, err,
 				test.expected)
@@ -363,19 +363,19 @@ var (
 func TestDeployments(t *testing.T) {
 	tests := []struct {
 		name        string
-		deployments []ConsensusDeployment
+		deployments map[uint32][]ConsensusDeployment
 		expected    error
 	}{
 		{
 			name:        "duplicate vote id",
-			deployments: dupVote,
+			deployments: map[uint32][]ConsensusDeployment{1: dupVote},
 			expected:    errDuplicateVoteId,
 		},
 	}
 
 	for _, test := range tests {
 		t.Logf("running: %v", test.name)
-		_, err := validateDeployments(test.deployments)
+		err := validateDeployments(test.deployments)
 		if !errors.Is(err, test.expected) {
 			t.Fatalf("%v: got '%v' expected '%v'", test.name, err,
 				test.expected)


### PR DESCRIPTION
This reworks the deployment validation logic that runs at initialization time to make it easier to modify and bring it more in line with the more modern coding practices used in the codebase.  Similarly, it also reworks the associated deployment validation tests to make them more consistent with modern practices in the code as well as to simplify them and make them more flexible by moving the primary logic for all of the expected results into the test definitions themselves.

The following is a high-level overview of the changes:

- Use `math/bits` from the `stdlib` for population and trailing zero counts
- Rework error handling to use wrapped errors for better error messages while still allowing testability
- Rename several internal errors to better describe what they represent
- Add additional checks for missing abstain and no choices
- Modify `validateDeployments` to accept all deployments for all versions
- Return errors from `validateDeployments`
- Only `panic` directly in the `init` func
- Add missing comments and make the existing ones match reality
- Rework associated deployment validation tests
- Adds test for the missing abstain and missing no choice cases
