### PR TITLE
chaincfg: Enforce globally unique vote IDs.

### DIFF
--- a/chaincfg/init.go
+++ b/chaincfg/init.go
@@ -111,9 +111,9 @@ func validateChoices(mask uint16, choices []Choice) error {
 // there are no duplicate vote IDs and that all choices conform to the required
 // voting choice semantics.
 func validateDeployments(allDeployments map[uint32][]ConsensusDeployment) error {
+	// Ensure there are no duplicate vote IDs across all deployments.
+	dups := make(map[string]struct{})
 	for version, deployments := range allDeployments {
-		// Ensure there are no duplicate vote IDs across the deployment version.
-		dups := make(map[string]struct{})
 		for index, deployment := range deployments {
 			voteID := strings.ToLower(deployment.Vote.Id)
 			if _, found := dups[voteID]; found {

--- a/chaincfg/init_test.go
+++ b/chaincfg/init_test.go
@@ -151,8 +151,7 @@ func TestValidateChoices(t *testing.T) {
 }
 
 // TestRejectDuplicateVoteIDs ensures the validation logic for enforcing unique
-// deployment/vote IDs across the deployments for a given deployment version
-// works as intended.
+// deployment/vote IDs across all deployments works as intended.
 func TestRejectDuplicateVoteIDs(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -168,12 +167,12 @@ func TestRejectDuplicateVoteIDs(t *testing.T) {
 		},
 		expected: errDuplicateVoteId,
 	}, {
-		name: "allow duplicate vote id in different versions",
+		name: "reject duplicate vote id in different versions",
 		deployments: map[uint32][]ConsensusDeployment{
 			1: {{Vote: mockVote()}},
 			2: {{Vote: mockVote()}},
 		},
-		expected: nil,
+		expected: errDuplicateVoteId,
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
~**This requires #3056**~.

The code currently supports reusing the same vote ID to refer to different agendas as long as they are in different agenda versions.

While there is nothing technically incorrect about this, and part of the design is to allow it, various other software in the ecosystem implicitly assumes the IDs are globally unique across all agendas.

Due to this, and also because supporting it makes the internal code more complex to deal with as well, there is currently a bit of an unwritten rule that the vote ID for every agenda across all versions should be unique.

This change effectively formalizes that unwritten rule by modifying the validation logic that happens at initialization time to reject deployments that have duplicate IDs across agenda versions.
