### PR TITLE
multi: Simplify threshold state determination.

### DIFF
--- a/internal/blockchain/chain.go
+++ b/internal/blockchain/chain.go
@@ -363,7 +363,7 @@ func (b *BlockChain) GetVoteInfo(hash *chainhash.Hash, version uint32) (*VoteInf
 	}
 	for _, deployment := range deployments {
 		vi.Agendas = append(vi.Agendas, deployment)
-		status, err := b.NextThresholdState(hash, version, deployment.Vote.Id)
+		status, err := b.NextThresholdState(hash, deployment.Vote.Id)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/blockchain/common_test.go
+++ b/internal/blockchain/common_test.go
@@ -600,9 +600,8 @@ func removeDeploymentTimeConstraints(deployment *chaincfg.ConsensusDeployment) {
 type chaingenHarness struct {
 	*chaingen.Generator
 
-	t                  *testing.T
-	chain              *BlockChain
-	deploymentVersions map[string]uint32
+	t     *testing.T
+	chain *BlockChain
 }
 
 // newChaingenHarnessWithGen creates and returns a new instance of a chaingen
@@ -623,10 +622,9 @@ func newChaingenHarnessWithGen(t *testing.T, g *chaingen.Generator) *chaingenHar
 	}
 
 	harness := chaingenHarness{
-		Generator:          g,
-		t:                  t,
-		chain:              chain,
-		deploymentVersions: make(map[string]uint32),
+		Generator: g,
+		t:         t,
+		chain:     chain,
 	}
 	return &harness
 }
@@ -1002,23 +1000,6 @@ func (g *chaingenHarness) ExpectIsCurrent(expected bool) {
 			"height %d) -- got %v, want %v", g.BlockName(&best.Hash), best.Hash,
 			best.Height, isCurrent, expected)
 	}
-}
-
-// lookupDeploymentVersion returns the version of the deployment with the
-// provided ID and caches the result for future invocations.  An error is
-// returned if the ID is not found.
-func (g *chaingenHarness) lookupDeploymentVersion(voteID string) (uint32, error) {
-	if version, ok := g.deploymentVersions[voteID]; ok {
-		return version, nil
-	}
-
-	version, _, err := findDeployment(g.Params(), voteID)
-	if err != nil {
-		return 0, err
-	}
-
-	g.deploymentVersions[voteID] = version
-	return version, nil
 }
 
 // TestThresholdState queries the threshold state from the current tip block

--- a/internal/blockchain/common_test.go
+++ b/internal/blockchain/common_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2022 The Decred developers
+// Copyright (c) 2015-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -187,16 +187,15 @@ func newFakeChain(params *chaincfg.Params) *BlockChain {
 	index.bestHeader = node
 	index.AddNode(node)
 
-	// Generate a deployment ID to version map from the provided params.
-	deploymentVers, err := extractDeploymentIDVersions(params)
+	// Generate a deployment ID map from the provided params.
+	deploymentData, err := extractDeployments(params)
 	if err != nil {
 		panic(err)
 	}
 
 	return &BlockChain{
-		deploymentVers:                deploymentVers,
+		deploymentData:                deploymentData,
 		chainParams:                   params,
-		deploymentCaches:              newThresholdCaches(params),
 		index:                         index,
 		bestChain:                     newChainView(node),
 		recentBlocks:                  lru.NewKVCache(recentBlockCacheSize),

--- a/internal/blockchain/common_test.go
+++ b/internal/blockchain/common_test.go
@@ -1029,14 +1029,7 @@ func (g *chaingenHarness) TestThresholdState(id string, state ThresholdState) {
 
 	tipHash := g.Tip().BlockHash()
 	tipHeight := g.Tip().Header.Height
-	deploymentVer, err := g.lookupDeploymentVersion(id)
-	if err != nil {
-		g.t.Fatalf("block %q (hash %s, height %d) unexpected error when "+
-			"retrieving threshold state: %v", g.TipName(), tipHash, tipHeight,
-			err)
-	}
-
-	s, err := g.chain.NextThresholdState(&tipHash, deploymentVer, id)
+	s, err := g.chain.NextThresholdState(&tipHash, id)
 	if err != nil {
 		g.t.Fatalf("block %q (hash %s, height %d) unexpected error when "+
 			"retrieving threshold state: %v", g.TipName(), tipHash, tipHeight,
@@ -1058,14 +1051,7 @@ func (g *chaingenHarness) TestThresholdStateChoice(id string, state ThresholdSta
 
 	tipHash := g.Tip().BlockHash()
 	tipHeight := g.Tip().Header.Height
-	deploymentVer, err := g.lookupDeploymentVersion(id)
-	if err != nil {
-		g.t.Fatalf("block %q (hash %s, height %d) unexpected error when "+
-			"retrieving threshold state: %v", g.TipName(), tipHash, tipHeight,
-			err)
-	}
-
-	s, err := g.chain.NextThresholdState(&tipHash, deploymentVer, id)
+	s, err := g.chain.NextThresholdState(&tipHash, id)
 	if err != nil {
 		g.t.Fatalf("block %q (hash %s, height %d) unexpected error when "+
 			"retrieving threshold state: %v", g.TipName(), tipHash, tipHeight,

--- a/internal/blockchain/difficulty.go
+++ b/internal/blockchain/difficulty.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2021 The Decred developers
+// Copyright (c) 2015-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -691,11 +691,11 @@ func (b *BlockChain) calcNextRequiredStakeDifficultyV2(curNode *blockNode) int64
 //
 // This function MUST be called with the chain state lock held (for writes).
 func (b *BlockChain) calcNextRequiredStakeDifficulty(curNode *blockNode) (int64, error) {
-	// Determine the correct deployment version for the new stake difficulty
+	// Determine the correct deployment details for the new stake difficulty
 	// algorithm consensus vote or treat it as active when voting is not enabled
 	// for the current network.
 	const deploymentID = chaincfg.VoteIDSDiffAlgorithm
-	deploymentVer, ok := b.deploymentVers[deploymentID]
+	deployment, ok := b.deploymentData[deploymentID]
 	if !ok {
 		return b.calcNextRequiredStakeDifficultyV2(curNode), nil
 	}
@@ -706,7 +706,7 @@ func (b *BlockChain) calcNextRequiredStakeDifficulty(curNode *blockNode) (int64,
 	// NOTE: The choice field of the return threshold state is not examined
 	// here because there is only one possible choice that can be active
 	// for the agenda, which is yes, so there is no need to check it.
-	state, err := b.deploymentState(curNode, deploymentVer, deploymentID)
+	state, err := b.deploymentState(curNode, &deployment)
 	if err != nil {
 		return 0, err
 	}
@@ -1181,11 +1181,11 @@ func (b *BlockChain) estimateNextStakeDifficultyV2(curNode *blockNode, newTicket
 //
 // This function MUST be called with the chain state lock held (for writes).
 func (b *BlockChain) estimateNextStakeDifficulty(curNode *blockNode, newTickets int64, useMaxTickets bool) (int64, error) {
-	// Determine the correct deployment version for the new stake difficulty
+	// Determine the correct deployment details for the new stake difficulty
 	// algorithm consensus vote or treat it as active when voting is not enabled
 	// for the current network.
 	const deploymentID = chaincfg.VoteIDSDiffAlgorithm
-	deploymentVer, ok := b.deploymentVers[deploymentID]
+	deployment, ok := b.deploymentData[deploymentID]
 	if !ok {
 		return b.calcNextRequiredStakeDifficultyV2(curNode), nil
 	}
@@ -1196,7 +1196,7 @@ func (b *BlockChain) estimateNextStakeDifficulty(curNode *blockNode, newTickets 
 	// NOTE: The choice field of the return threshold state is not examined
 	// here because there is only one possible choice that can be active
 	// for the agenda, which is yes, so there is no need to check it.
-	state, err := b.deploymentState(curNode, deploymentVer, deploymentID)
+	state, err := b.deploymentState(curNode, &deployment)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/blockchain/thresholdstate.go
+++ b/internal/blockchain/thresholdstate.go
@@ -574,7 +574,7 @@ func (b *BlockChain) StateLastChangedHeight(hash *chainhash.Hash, deploymentID s
 // given deployment ID for the block AFTER the provided block hash.
 //
 // This function is safe for concurrent access.
-func (b *BlockChain) NextThresholdState(hash *chainhash.Hash, version uint32, deploymentID string) (ThresholdStateTuple, error) {
+func (b *BlockChain) NextThresholdState(hash *chainhash.Hash, deploymentID string) (ThresholdStateTuple, error) {
 	node := b.index.LookupNode(hash)
 	if node == nil || !b.index.CanValidate(node) {
 		return invalidThresholdState, unknownBlockError(hash)

--- a/internal/blockchain/thresholdstate.go
+++ b/internal/blockchain/thresholdstate.go
@@ -538,7 +538,7 @@ func (b *BlockChain) stateLastChanged(node *blockNode, deployment *deploymentInf
 // passed block hash.
 //
 // This function is safe for concurrent access.
-func (b *BlockChain) StateLastChangedHeight(hash *chainhash.Hash, version uint32, deploymentID string) (int64, error) {
+func (b *BlockChain) StateLastChangedHeight(hash *chainhash.Hash, deploymentID string) (int64, error) {
 	node := b.index.LookupNode(hash)
 	if node == nil || !b.index.CanValidate(node) {
 		return 0, unknownBlockError(hash)

--- a/internal/blockchain/votebits_test.go
+++ b/internal/blockchain/votebits_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022 The Decred developers
+// Copyright (c) 2017-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -128,7 +128,7 @@ func TestNoQuorum(t *testing.T) {
 		bc.index.AddNode(node)
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
-	ts, err := bc.NextThresholdState(&node.hash, posVersion, pedro.Id)
+	ts, err := bc.NextThresholdState(&node.hash, pedro.Id)
 	if err != nil {
 		t.Fatalf("NextThresholdState(SVI): %v", err)
 	}
@@ -150,7 +150,7 @@ func TestNoQuorum(t *testing.T) {
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
 
-	ts, err = bc.NextThresholdState(&node.hash, posVersion, pedro.Id)
+	ts, err = bc.NextThresholdState(&node.hash, pedro.Id)
 	if err != nil {
 		t.Fatalf("NextThresholdState(started): %v", err)
 	}
@@ -181,7 +181,7 @@ func TestNoQuorum(t *testing.T) {
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
 
-	ts, err = bc.NextThresholdState(&node.hash, posVersion, pedro.Id)
+	ts, err = bc.NextThresholdState(&node.hash, pedro.Id)
 	if err != nil {
 		t.Fatalf("NextThresholdState(quorum-1): %v", err)
 	}
@@ -218,7 +218,7 @@ func TestNoQuorum(t *testing.T) {
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
 
-	ts, err = bc.NextThresholdState(&node.hash, posVersion, pedro.Id)
+	ts, err = bc.NextThresholdState(&node.hash, pedro.Id)
 	if err != nil {
 		t.Fatalf("NextThresholdState(quorum 75%%-1): %v", err)
 	}
@@ -255,7 +255,7 @@ func TestNoQuorum(t *testing.T) {
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
 
-	ts, err = bc.NextThresholdState(&node.hash, posVersion, pedro.Id)
+	ts, err = bc.NextThresholdState(&node.hash, pedro.Id)
 	if err != nil {
 		t.Fatalf("NextThresholdState(quorum 75%%): %v", err)
 	}
@@ -285,7 +285,7 @@ func TestYesQuorum(t *testing.T) {
 		bc.index.AddNode(node)
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
-	ts, err := bc.NextThresholdState(&node.hash, posVersion, pedro.Id)
+	ts, err := bc.NextThresholdState(&node.hash, pedro.Id)
 	if err != nil {
 		t.Fatalf("NextThresholdState(SVI): %v", err)
 	}
@@ -307,7 +307,7 @@ func TestYesQuorum(t *testing.T) {
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
 
-	ts, err = bc.NextThresholdState(&node.hash, posVersion, pedro.Id)
+	ts, err = bc.NextThresholdState(&node.hash, pedro.Id)
 	if err != nil {
 		t.Fatalf("NextThresholdState(started): %v", err)
 	}
@@ -338,7 +338,7 @@ func TestYesQuorum(t *testing.T) {
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
 
-	ts, err = bc.NextThresholdState(&node.hash, posVersion, pedro.Id)
+	ts, err = bc.NextThresholdState(&node.hash, pedro.Id)
 	if err != nil {
 		t.Fatalf("NextThresholdState(quorum-1): %v", err)
 	}
@@ -375,7 +375,7 @@ func TestYesQuorum(t *testing.T) {
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
 
-	ts, err = bc.NextThresholdState(&node.hash, posVersion, pedro.Id)
+	ts, err = bc.NextThresholdState(&node.hash, pedro.Id)
 	if err != nil {
 		t.Fatalf("NextThresholdState(quorum 75%%-1): %v", err)
 	}
@@ -412,7 +412,7 @@ func TestYesQuorum(t *testing.T) {
 		curTimestamp = curTimestamp.Add(time.Second)
 	}
 
-	ts, err = bc.NextThresholdState(&node.hash, posVersion, pedro.Id)
+	ts, err = bc.NextThresholdState(&node.hash, pedro.Id)
 	if err != nil {
 		t.Fatalf("NextThresholdState(quorum 75%%): %v", err)
 	}
@@ -1484,8 +1484,7 @@ func TestVoting(t *testing.T) {
 				node.height, params.Deployments[4][0].StartTime,
 				node.timestamp, node.timestamp-
 					int64(params.Deployments[4][0].StartTime))
-			ts, err := bc.NextThresholdState(&node.hash, posVersion,
-				test.vote.Id)
+			ts, err := bc.NextThresholdState(&node.hash, test.vote.Id)
 			if err != nil {
 				t.Fatalf("NextThresholdState(%v): %v", k, err)
 			}
@@ -1649,8 +1648,7 @@ func TestParallelVoting(t *testing.T) {
 				curTimestamp = curTimestamp.Add(time.Second)
 			}
 			for i := range test.vote {
-				ts, err := bc.NextThresholdState(&node.hash,
-					posVersion, test.vote[i].Id)
+				ts, err := bc.NextThresholdState(&node.hash, test.vote[i].Id)
 				if err != nil {
 					t.Fatalf("NextThresholdState(%v): %v", k, err)
 				}

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -353,7 +353,7 @@ type Chain interface {
 
 	// NextThresholdState returns the current rule change threshold state of the
 	// given deployment ID for the block AFTER the provided block hash.
-	NextThresholdState(hash *chainhash.Hash, version uint32, deploymentID string) (blockchain.ThresholdStateTuple, error)
+	NextThresholdState(hash *chainhash.Hash, deploymentID string) (blockchain.ThresholdStateTuple, error)
 
 	// StateLastChangedHeight returns the height at which the provided consensus
 	// deployment agenda last changed state.  Note that, unlike the

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022 The Decred developers
+// Copyright (c) 2019-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -357,9 +357,9 @@ type Chain interface {
 
 	// StateLastChangedHeight returns the height at which the provided consensus
 	// deployment agenda last changed state.  Note that, unlike the
-	// NextThresholdState function, this function returns the information as of the
-	// passed block hash.
-	StateLastChangedHeight(hash *chainhash.Hash, version uint32, deploymentID string) (int64, error)
+	// NextThresholdState function, this function returns the information as of
+	// the passed block hash.
+	StateLastChangedHeight(hash *chainhash.Hash, deploymentID string) (int64, error)
 
 	// TicketPoolValue returns the current value of all the locked funds in the
 	// ticket pool.

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -2119,7 +2119,7 @@ func handleGetBlockchainInfo(_ context.Context, s *Server, _ interface{}) (inter
 			}
 
 			stateChangedHeight, err := chain.StateLastChangedHeight(
-				&best.Hash, version, agenda.Vote.Id)
+				&best.Hash, agenda.Vote.Id)
 			if err != nil {
 				return nil, rpcInternalError(err.Error(),
 					fmt.Sprintf("Could not fetch state last changed "+

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -2095,7 +2095,7 @@ func handleGetBlockchainInfo(_ context.Context, s *Server, _ interface{}) (inter
 	// threshold states and state activation heights.
 	dInfo := make(map[string]types.AgendaInfo)
 	defaultStatus := types.AgendaInfoStatusDefined
-	for version, deployments := range params.Deployments {
+	for _, deployments := range params.Deployments {
 		for _, agenda := range deployments {
 			aInfo := types.AgendaInfo{
 				StartTime:  agenda.StartTime,
@@ -2110,7 +2110,7 @@ func handleGetBlockchainInfo(_ context.Context, s *Server, _ interface{}) (inter
 				continue
 			}
 
-			state, err := chain.NextThresholdState(&best.PrevHash, version,
+			state, err := chain.NextThresholdState(&best.PrevHash,
 				agenda.Vote.Id)
 			if err != nil {
 				return nil, rpcInternalError(err.Error(),
@@ -3412,8 +3412,7 @@ func handleGetVoteInfo(_ context.Context, s *Server, cmd interface{}) (interface
 	result.Agendas = make([]types.Agenda, 0, len(vi.Agendas))
 	for _, agenda := range vi.Agendas {
 		// Obtain status of agenda.
-		state, err := chain.NextThresholdState(&snapshot.Hash, c.Version,
-			agenda.Vote.Id)
+		state, err := chain.NextThresholdState(&snapshot.Hash, agenda.Vote.Id)
 		if err != nil {
 			return nil, rpcInternalError(err.Error(),
 				"could not fetch next threshold state")

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -368,7 +368,7 @@ func (c *testRPCChain) MissedTickets() ([]chainhash.Hash, error) {
 
 // NextThresholdState returns a mocked current rule change threshold state of
 // the given deployment ID for the block AFTER the provided block hash.
-func (c *testRPCChain) NextThresholdState(hash *chainhash.Hash, version uint32, deploymentID string) (blockchain.ThresholdStateTuple, error) {
+func (c *testRPCChain) NextThresholdState(hash *chainhash.Hash, deploymentID string) (blockchain.ThresholdStateTuple, error) {
 	return c.nextThresholdState, c.nextThresholdStateErr
 }
 

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 The Decred developers
+// Copyright (c) 2020-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -380,7 +380,7 @@ func (c *testRPCChain) ReconsiderBlock(hash *chainhash.Hash) error {
 
 // StateLastChangedHeight returns a mocked height at which the provided
 // consensus deployment agenda last changed state.
-func (c *testRPCChain) StateLastChangedHeight(hash *chainhash.Hash, version uint32, deploymentID string) (int64, error) {
+func (c *testRPCChain) StateLastChangedHeight(hash *chainhash.Hash, deploymentID string) (int64, error) {
 	return c.stateLastChangedHeight, c.stateLastChangedHeightErr
 }
 


### PR DESCRIPTION
~**This is rebased on #3057**.~

This simplifies the internal logic for determining threshold states for various deployments by introducing a structure to house additional information about a deployment and passing that around as opposed to previous approach of passing around the information needed to lookup the relevant information and associated caches.

The individual structs are created from the chain parameters and stored in a map when the chain instance is initialized.

It also removes the no longer needed deployment version parameters from the `StateLastChangedHeight` and `NextThresholdState` methods as well as the no longer resulting unused internal `lookupDeploymentVersion` method.

This is work towards #3058.