### PR TITLE
docker: Add dcrctl version output.

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -80,6 +80,7 @@ EXPOSE 9108 9109 19108 19109 18555 19556
 ENTRYPOINT [ "/bin/entrypoint" ]
 
 RUN [ "dcrd", "--version" ]
+RUN [ "dcrctl", "--version" ]
 
 # The volume instruction is intentionally commented here since it has many
 # well-known pitfalls.  It is only provided here for documentation purposes.


### PR DESCRIPTION
This adds another `RUN` command to the docker image to display the dcrctl version in addition to the dcrd version since they come from separate repositories now.