### PR TITLE
blockchain: Remove unused db update tracking.

### DIFF
--- a/internal/blockchain/chain.go
+++ b/internal/blockchain/chain.go
@@ -2072,8 +2072,7 @@ func extractDeployments(params *chaincfg.Params) (map[string]deploymentInfo, err
 				deployment:  deployment,
 				forcedState: forcedState,
 				cache: &thresholdStateCache{
-					entries:   make(map[chainhash.Hash]ThresholdStateTuple),
-					dbUpdates: make(map[chainhash.Hash]ThresholdStateTuple),
+					entries: make(map[chainhash.Hash]ThresholdStateTuple),
 				},
 			}
 		}

--- a/internal/blockchain/thresholdstate.go
+++ b/internal/blockchain/thresholdstate.go
@@ -172,8 +172,7 @@ type thresholdConditionChecker interface {
 // threshold window for a set of IDs.  It also keeps track of which entries have
 // been modified and therefore need to be written to the database.
 type thresholdStateCache struct {
-	dbUpdates map[chainhash.Hash]ThresholdStateTuple
-	entries   map[chainhash.Hash]ThresholdStateTuple
+	entries map[chainhash.Hash]ThresholdStateTuple
 }
 
 // Lookup returns the threshold state associated with the given hash along with
@@ -184,23 +183,13 @@ func (c *thresholdStateCache) Lookup(hash chainhash.Hash) (ThresholdStateTuple, 
 }
 
 // Update updates the cache to contain the provided hash to threshold state
-// mapping while properly tracking needed updates flush changes to the database.
+// mapping.
 func (c *thresholdStateCache) Update(hash chainhash.Hash, state ThresholdStateTuple) {
 	if existing, ok := c.entries[hash]; ok && existing == state {
 		return
 	}
 
-	c.dbUpdates[hash] = state
 	c.entries[hash] = state
-}
-
-// MarkFlushed marks all of the current updates as flushed to the database.
-// This is useful so the caller can ensure the needed database updates are not
-// lost until they have successfully been written to the database.
-func (c *thresholdStateCache) MarkFlushed() {
-	for hash := range c.dbUpdates {
-		delete(c.dbUpdates, hash)
-	}
 }
 
 // currentDeploymentVersion returns the highest deployment version that is


### PR DESCRIPTION
~**This is rebased on #3060**.~

Many years ago, the various threshold states were stored in the database due to performance reasons.  However, that logic was removed when the code was updated to support voting since other changes made it quite efficient to simply calculate the states at startup.

However, it appears that the `dbUpdates` field was not removed even though it's not actually used anymore.  This removes the field and associated logic accordingly.