### PR TITLE
chainhash: Add function to return a hash.Hash

### DIFF
--- a/chaincfg/chainhash/hashfuncs.go
+++ b/chaincfg/chainhash/hashfuncs.go
@@ -6,6 +6,8 @@
 package chainhash
 
 import (
+	"hash"
+
 	"github.com/decred/dcrd/crypto/blake256"
 )
 
@@ -30,3 +32,8 @@ func HashH(b []byte) Hash {
 
 // HashBlockSize is the block size of the hash algorithm in bytes.
 const HashBlockSize = blake256.BlockSize
+
+// New returns a new hash.Hash computing the hash written to the object.
+func New() hash.Hash {
+	return blake256.New()
+}

--- a/chaincfg/chainhash/hashfuncs_test.go
+++ b/chaincfg/chainhash/hashfuncs_test.go
@@ -84,3 +84,18 @@ func TestHashFunc(t *testing.T) {
 		}
 	}
 }
+
+// TestNew ensures New returns a object that calculates the correct hashes.
+func TestNew(t *testing.T) {
+	h := New()
+	for _, test := range hashTests {
+		h.Reset()
+		h.Write([]byte(test.in))
+		digest := h.Sum(nil)
+		result := fmt.Sprintf("%x", digest)
+		if result != test.out {
+			t.Errorf("hash.Hash (%q) = %s, want %s", test.in, h, test.out)
+			continue
+		}
+	}
+}


### PR DESCRIPTION
hash.Hash allows the data being hashed to be written to incrementally,
as it implements io.Writer.  This allows large byte sequences to be
hashed without needing a single large byte slice in memory.  While the
hash.Hash object requires an allocation, the trade-off of not needing
the entire byte sequence in a single byte slice may be worthwhile.