### PR TITLE
rpcserver: Decouple RPC agenda info status strings.

### DIFF
--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -3425,7 +3425,7 @@ func handleGetVoteInfo(_ context.Context, s *Server, cmd interface{}) (interface
 			Choices:     make([]types.Choice, 0, len(agenda.Vote.Choices)),
 			StartTime:   agenda.StartTime,
 			ExpireTime:  agenda.ExpireTime,
-			Status:      state.String(),
+			Status:      thresholdStateToAgendaStatus(state),
 		}
 
 		// Handle choices.


### PR DESCRIPTION
Similar to the case that previously existed for `getblockchainfo`, currently, the `getvoteinfo` RPC implementation directly returns the internal threshold state strings defined in `blockchain`.  This is not ideal since it means that any changes to the internal implementation could inadvertently change the RPC results without being noticed.

Further, the `blockchain` package is now internal which means external callers don't have access to those constants.

Consequently, this makes the same change to `getvoteinfo` as was previously made to `getblockchaininfo` to decouple the agenda status strings by converting the internal `blockchain` threshold state to use the agenda status string constants defined in the `rpc/jsonrpc/types` module.