### PR TITLE
blockchain: Reject params with mask approval bit.

### DIFF
--- a/internal/blockchain/chain.go
+++ b/internal/blockchain/chain.go
@@ -1997,6 +1997,14 @@ func validateDeploymentChoices(voteParams *chaincfg.Vote) error {
 		return contextError(ErrDeploymentBadMask, str)
 	}
 
+	// Ensure the mask does not use the bit reserved to specify whether or not
+	// the voters approve the regular transaction tree of the parent block.
+	if dcrutil.IsFlagSet16(voteParams.Mask, dcrutil.BlockValid) {
+		str := fmt.Sprintf("deployment ID %s mask %#04x uses reserved bit 0",
+			voteParams.Id, voteParams.Mask)
+		return contextError(ErrDeploymentBadMask, str)
+	}
+
 	// Count the number of consecutive 1 bits set in the mask.
 	var consecOnes uint8
 	for v := voteParams.Mask; v != 0; consecOnes++ {

--- a/internal/blockchain/chain_test.go
+++ b/internal/blockchain/chain_test.go
@@ -127,6 +127,13 @@ func TestDeploymentParamsValidation(t *testing.T) {
 		},
 		err: ErrDeploymentBadMask,
 	}, {
+		name: "reject mask with reserved parent regular tx tree approval bit",
+		munger: func(params *chaincfg.Params) {
+			vote := &params.Deployments[0][0].Vote
+			vote.Mask |= dcrutil.BlockValid
+		},
+		err: ErrDeploymentBadMask,
+	}, {
 		name: "require consecutive mask",
 		munger: func(params *chaincfg.Params) {
 			vote := &params.Deployments[0][0].Vote


### PR DESCRIPTION
This adds an additional validation check to the chain initialization process to validate that the mask of the deployments in the given chain params do not use the bit that is reserved for use to signal whether or not the regular transaction tree of the parent block should be considered valid.

It also adds a test for the new validation logic.