### PR TITLE
peer: Correct known inventory check.

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -500,7 +500,7 @@ func (p *Peer) UpdateLastBlockHeight(newHeight int64) {
 //
 // This function is safe for concurrent access.
 func (p *Peer) AddKnownInventory(invVect *wire.InvVect) {
-	p.knownInventory.Add(invVect)
+	p.knownInventory.Add(*invVect)
 }
 
 // IsKnownInventory returns whether the passed inventory already exists in
@@ -508,7 +508,7 @@ func (p *Peer) AddKnownInventory(invVect *wire.InvVect) {
 //
 // This function is safe for concurrent access.
 func (p *Peer) IsKnownInventory(invVect *wire.InvVect) bool {
-	return p.knownInventory.Contains(invVect)
+	return p.knownInventory.Contains(*invVect)
 }
 
 // StatsSnapshot returns a snapshot of the current peer flags and statistics.


### PR DESCRIPTION
This updates `AddKnownInventory` `IsKnownInventory` in the `peer` module to use the concrete struct as opposed to a pointer to it in order to allow different instances of the struct to be used as a key versus needing to check with the same instance.
