### PR TITLE
blockchain: Convert several test helpers.

### DIFF
--- a/internal/blockchain/agendas_test.go
+++ b/internal/blockchain/agendas_test.go
@@ -30,15 +30,9 @@ func testLNFeaturesDeployment(t *testing.T, params *chaincfg.Params) {
 	// constraints to prevent test failures when the real expiration time
 	// passes.
 	params = cloneParams(params)
-	deploymentVer, deployment, err := findDeployment(params,
+	deploymentVer, deployment := findDeployment(t, params,
 		chaincfg.VoteIDLNFeatures)
-	if err != nil {
-		t.Fatal(err)
-	}
-	yesChoice, err := findDeploymentChoice(deployment, "yes")
-	if err != nil {
-		t.Fatal(err)
-	}
+	yesChoice := findDeploymentChoice(t, deployment, "yes")
 	removeDeploymentTimeConstraints(deployment)
 
 	// Shorter versions of params for convenience.
@@ -420,15 +414,9 @@ func testHeaderCommitmentsDeployment(t *testing.T, params *chaincfg.Params) {
 	// time constraints to prevent test failures when the real expiration time
 	// passes.
 	params = cloneParams(params)
-	deploymentVer, deployment, err := findDeployment(params,
+	deploymentVer, deployment := findDeployment(t, params,
 		chaincfg.VoteIDHeaderCommitments)
-	if err != nil {
-		t.Fatal(err)
-	}
-	yesChoice, err := findDeploymentChoice(deployment, "yes")
-	if err != nil {
-		t.Fatal(err)
-	}
+	yesChoice := findDeploymentChoice(t, deployment, "yes")
 	removeDeploymentTimeConstraints(deployment)
 
 	// Shorter versions of params for convenience.
@@ -558,15 +546,9 @@ func testTreasuryFeaturesDeployment(t *testing.T, params *chaincfg.Params) {
 	// time constraints to prevent test failures when the real expiration time
 	// passes.
 	params = cloneParams(params)
-	deploymentVer, deployment, err := findDeployment(params,
+	deploymentVer, deployment := findDeployment(t, params,
 		chaincfg.VoteIDTreasury)
-	if err != nil {
-		t.Fatal(err)
-	}
-	yesChoice, err := findDeploymentChoice(deployment, "yes")
-	if err != nil {
-		t.Fatal(err)
-	}
+	yesChoice := findDeploymentChoice(t, deployment, "yes")
 	removeDeploymentTimeConstraints(deployment)
 
 	// Shorter versions of params for convenience.
@@ -704,15 +686,9 @@ func testExplicitVerUpgradesDeployment(t *testing.T, params *chaincfg.Params) {
 	// time constraints to prevent test failures when the real expiration time
 	// passes.
 	params = cloneParams(params)
-	deploymentVer, deployment, err := findDeployment(params,
+	deploymentVer, deployment := findDeployment(t, params,
 		chaincfg.VoteIDExplicitVersionUpgrades)
-	if err != nil {
-		t.Fatal(err)
-	}
-	yesChoice, err := findDeploymentChoice(deployment, "yes")
-	if err != nil {
-		t.Fatal(err)
-	}
+	yesChoice := findDeploymentChoice(t, deployment, "yes")
 	removeDeploymentTimeConstraints(deployment)
 
 	// Shorter versions of params for convenience.
@@ -821,15 +797,9 @@ func testAutoRevocationsDeployment(t *testing.T, params *chaincfg.Params) {
 	// the time constraints to prevent test failures when the real expiration time
 	// passes.
 	params = cloneParams(params)
-	deploymentVer, deployment, err := findDeployment(params,
+	deploymentVer, deployment := findDeployment(t, params,
 		chaincfg.VoteIDAutoRevocations)
-	if err != nil {
-		t.Fatal(err)
-	}
-	yesChoice, err := findDeploymentChoice(deployment, "yes")
-	if err != nil {
-		t.Fatal(err)
-	}
+	yesChoice := findDeploymentChoice(t, deployment, "yes")
 	removeDeploymentTimeConstraints(deployment)
 
 	// Shorter versions of params for convenience.
@@ -945,15 +915,9 @@ func testSubsidySplitDeployment(t *testing.T, params *chaincfg.Params) {
 	// removing the time constraints to prevent test failures when the real
 	// expiration time passes.
 	params = cloneParams(params)
-	deploymentVer, deployment, err := findDeployment(params,
+	deploymentVer, deployment := findDeployment(t, params,
 		chaincfg.VoteIDChangeSubsidySplit)
-	if err != nil {
-		t.Fatal(err)
-	}
-	yesChoice, err := findDeploymentChoice(deployment, "yes")
-	if err != nil {
-		t.Fatal(err)
-	}
+	yesChoice := findDeploymentChoice(t, deployment, "yes")
 	removeDeploymentTimeConstraints(deployment)
 
 	// Shorter versions of params for convenience.

--- a/internal/blockchain/chainio_test.go
+++ b/internal/blockchain/chainio_test.go
@@ -1062,12 +1062,12 @@ func TestNewDeploymentsStartTime(t *testing.T) {
 	params := cloneParams(chaincfg.RegNetParams())
 	defaultDeployments := map[uint32][]chaincfg.ConsensusDeployment{
 		7: {{
-			Vote:       testDummy1,
+			Vote:       mockVote1(),
 			StartTime:  1596240000,
 			ExpireTime: 1627776000,
 		}},
 		8: {{
-			Vote:       testDummy2,
+			Vote:       mockVote2(),
 			StartTime:  1631750400,
 			ExpireTime: 1694822400,
 		}},
@@ -1150,10 +1150,10 @@ func TestUpdateDeploymentVersion(t *testing.T) {
 	params := cloneParams(chaincfg.RegNetParams())
 	defaultDeployments := map[uint32][]chaincfg.ConsensusDeployment{
 		7: {{
-			Vote: testDummy1,
+			Vote: mockVote1(),
 		}},
 		8: {{
-			Vote: testDummy2,
+			Vote: mockVote2(),
 		}},
 	}
 

--- a/internal/blockchain/treasury_policy_test.go
+++ b/internal/blockchain/treasury_policy_test.go
@@ -56,10 +56,7 @@ func TestTSpendLegacyExpendituresPolicy(t *testing.T) {
 	// test failures when the real expiration time passes.
 	const tVoteID = chaincfg.VoteIDTreasury
 	params = cloneParams(params)
-	tVersion, deployment, err := findDeployment(params, tVoteID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tVersion, deployment := findDeployment(t, params, tVoteID)
 	removeDeploymentTimeConstraints(deployment)
 
 	// Shorter versions of useful params for convenience.
@@ -595,10 +592,7 @@ func TestTSpendExpendituresPolicyDCP0007(t *testing.T) {
 	const tVoteID = chaincfg.VoteIDTreasury
 	const tPolVoteID = chaincfg.VoteIDRevertTreasuryPolicy
 	params = cloneParams(params)
-	tVersion, err := mergeAgendas(params, []string{tVoteID, tPolVoteID})
-	if err != nil {
-		t.Fatal(err)
-	}
+	tVersion := mergeAgendas(t, params, []string{tVoteID, tPolVoteID})
 	for i := range params.Deployments[tVersion] {
 		removeDeploymentTimeConstraints(&params.Deployments[tVersion][i])
 	}

--- a/internal/blockchain/treasury_test.go
+++ b/internal/blockchain/treasury_test.go
@@ -499,10 +499,7 @@ func TestTSpendVoteCount(t *testing.T) {
 	// test failures when the real expiration time passes.
 	const tVoteID = chaincfg.VoteIDTreasury
 	params = cloneParams(params)
-	tVersion, deployment, err := findDeployment(params, tVoteID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tVersion, deployment := findDeployment(t, params, tVoteID)
 	removeDeploymentTimeConstraints(deployment)
 
 	// Shorter versions of useful params for convenience.
@@ -914,10 +911,7 @@ func TestTSpendEmptyTreasury(t *testing.T) {
 	// test failures when the real expiration time passes.
 	const tVoteID = chaincfg.VoteIDTreasury
 	params = cloneParams(params)
-	tVersion, deployment, err := findDeployment(params, tVoteID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tVersion, deployment := findDeployment(t, params, tVoteID)
 	removeDeploymentTimeConstraints(deployment)
 
 	// Shorter versions of useful params for convenience.
@@ -1054,10 +1048,7 @@ func TestExpendituresReorg(t *testing.T) {
 	// test failures when the real expiration time passes.
 	const tVoteID = chaincfg.VoteIDTreasury
 	params = cloneParams(params)
-	tVersion, deployment, err := findDeployment(params, tVoteID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tVersion, deployment := findDeployment(t, params, tVoteID)
 	removeDeploymentTimeConstraints(deployment)
 
 	// Shorter versions of useful params for convenience.
@@ -1306,10 +1297,7 @@ func TestSpendableTreasuryTxs(t *testing.T) {
 	// test failures when the real expiration time passes.
 	const tVoteID = chaincfg.VoteIDTreasury
 	params = cloneParams(params)
-	tVersion, deployment, err := findDeployment(params, tVoteID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tVersion, deployment := findDeployment(t, params, tVoteID)
 	removeDeploymentTimeConstraints(deployment)
 
 	// Shorter versions of useful params for convenience.
@@ -1605,10 +1593,7 @@ func TestTSpendDupVote(t *testing.T) {
 	// test failures when the real expiration time passes.
 	const tVoteID = chaincfg.VoteIDTreasury
 	params = cloneParams(params)
-	tVersion, deployment, err := findDeployment(params, tVoteID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tVersion, deployment := findDeployment(t, params, tVoteID)
 	removeDeploymentTimeConstraints(deployment)
 
 	// Shorter versions of useful params for convenience.
@@ -1753,10 +1738,7 @@ func TestTSpendTooManyTSpend(t *testing.T) {
 	// test failures when the real expiration time passes.
 	const tVoteID = chaincfg.VoteIDTreasury
 	params = cloneParams(params)
-	tVersion, deployment, err := findDeployment(params, tVoteID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tVersion, deployment := findDeployment(t, params, tVoteID)
 	removeDeploymentTimeConstraints(deployment)
 
 	// Shorter versions of useful params for convenience.
@@ -1868,10 +1850,7 @@ func TestTSpendWindow(t *testing.T) {
 	// test failures when the real expiration time passes.
 	const tVoteID = chaincfg.VoteIDTreasury
 	params = cloneParams(params)
-	tVersion, deployment, err := findDeployment(params, tVoteID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tVersion, deployment := findDeployment(t, params, tVoteID)
 	removeDeploymentTimeConstraints(deployment)
 
 	// Shorter versions of useful params for convenience.
@@ -1992,10 +1971,7 @@ func TestTSpendSignature(t *testing.T) {
 	// test failures when the real expiration time passes.
 	const tVoteID = chaincfg.VoteIDTreasury
 	params = cloneParams(params)
-	tVersion, deployment, err := findDeployment(params, tVoteID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tVersion, deployment := findDeployment(t, params, tVoteID)
 	removeDeploymentTimeConstraints(deployment)
 
 	// Shorter versions of useful params for convenience.
@@ -2211,10 +2187,7 @@ func TestTSpendSignatureInvalid(t *testing.T) {
 	// test failures when the real expiration time passes.
 	const tVoteID = chaincfg.VoteIDTreasury
 	params = cloneParams(params)
-	tVersion, deployment, err := findDeployment(params, tVoteID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tVersion, deployment := findDeployment(t, params, tVoteID)
 	removeDeploymentTimeConstraints(deployment)
 
 	// Shorter versions of useful params for convenience.
@@ -2359,10 +2332,7 @@ func TestTSpendExists(t *testing.T) {
 	// test failures when the real expiration time passes.
 	const tVoteID = chaincfg.VoteIDTreasury
 	params = cloneParams(params)
-	tVersion, deployment, err := findDeployment(params, tVoteID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tVersion, deployment := findDeployment(t, params, tVoteID)
 	removeDeploymentTimeConstraints(deployment)
 
 	// Shorter versions of useful params for convenience.
@@ -2630,10 +2600,7 @@ func TestTreasuryBalance(t *testing.T) {
 	// test failures when the real expiration time passes.
 	const tVoteID = chaincfg.VoteIDTreasury
 	params = cloneParams(params)
-	tVersion, deployment, err := findDeployment(params, tVoteID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tVersion, deployment := findDeployment(t, params, tVoteID)
 	removeDeploymentTimeConstraints(deployment)
 
 	// Create a test harness initialized with the genesis block as the tip.
@@ -2930,10 +2897,7 @@ func TestTAddCorners(t *testing.T) {
 	// test failures when the real expiration time passes.
 	const tVoteID = chaincfg.VoteIDTreasury
 	params = cloneParams(params)
-	tVersion, deployment, err := findDeployment(params, tVoteID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tVersion, deployment := findDeployment(t, params, tVoteID)
 	removeDeploymentTimeConstraints(deployment)
 
 	// Create a test harness initialized with the genesis block as the tip.
@@ -3125,10 +3089,7 @@ func TestTreasuryBaseCorners(t *testing.T) {
 	// test failures when the real expiration time passes.
 	const tVoteID = chaincfg.VoteIDTreasury
 	params = cloneParams(params)
-	tVersion, deployment, err := findDeployment(params, tVoteID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tVersion, deployment := findDeployment(t, params, tVoteID)
 	removeDeploymentTimeConstraints(deployment)
 
 	// Create a test harness initialized with the genesis block as the tip.
@@ -3325,10 +3286,7 @@ func TestTSpendCorners(t *testing.T) {
 	// test failures when the real expiration time passes.
 	const tVoteID = chaincfg.VoteIDTreasury
 	params = cloneParams(params)
-	tVersion, deployment, err := findDeployment(params, tVoteID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tVersion, deployment := findDeployment(t, params, tVoteID)
 	removeDeploymentTimeConstraints(deployment)
 
 	// Create a test harness initialized with the genesis block as the tip.
@@ -3432,9 +3390,8 @@ func TestTSpendFirstTVICorner(t *testing.T) {
 	// Clone the parameters so they can be mutated and mark the treasury agenda
 	// as always active.
 	const voteID = chaincfg.VoteIDTreasury
-	params := chaincfg.RegNetParams()
-	params = cloneParams(params)
-	forceDeploymentResult(params, voteID, "yes")
+	params := cloneParams(chaincfg.RegNetParams())
+	forceDeploymentResult(t, params, voteID, "yes")
 
 	// Change params to hit corner case.
 	params.StakeValidationHeight = 144
@@ -3649,10 +3606,7 @@ func TestTreasuryInRegularTree(t *testing.T) {
 	// test failures when the real expiration time passes.
 	const tVoteID = chaincfg.VoteIDTreasury
 	params = cloneParams(params)
-	tVersion, deployment, err := findDeployment(params, tVoteID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tVersion, deployment := findDeployment(t, params, tVoteID)
 	removeDeploymentTimeConstraints(deployment)
 
 	// Create a test harness initialized with the genesis block as the tip.
@@ -4222,10 +4176,7 @@ func TestTSpendTooManyTAdds(t *testing.T) {
 	// test failures when the real expiration time passes.
 	const tVoteID = chaincfg.VoteIDTreasury
 	params = cloneParams(params)
-	tVersion, deployment, err := findDeployment(params, tVoteID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tVersion, deployment := findDeployment(t, params, tVoteID)
 	removeDeploymentTimeConstraints(deployment)
 
 	// Create a test harness initialized with the genesis block as the tip.

--- a/internal/blockchain/validate_test.go
+++ b/internal/blockchain/validate_test.go
@@ -984,10 +984,7 @@ func TestExplicitVerUpgradesSemantics(t *testing.T) {
 	// real expiration time passes.
 	const voteID = chaincfg.VoteIDExplicitVersionUpgrades
 	params = cloneParams(params)
-	deploymentVer, deployment, err := findDeployment(params, voteID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	deploymentVer, deployment := findDeployment(t, params, voteID)
 	removeDeploymentTimeConstraints(deployment)
 
 	// Shorter versions of useful params for convenience.
@@ -1752,10 +1749,7 @@ func TestAutoRevocations(t *testing.T) {
 	// prevent test failures when the real expiration time passes.
 	const voteID = chaincfg.VoteIDAutoRevocations
 	params = cloneParams(params)
-	version, deployment, err := findDeployment(params, voteID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	version, deployment := findDeployment(t, params, voteID)
 	removeDeploymentTimeConstraints(deployment)
 
 	// Shorter versions of useful params for convenience.
@@ -1950,10 +1944,7 @@ func TestModifiedSubsidySplitSemantics(t *testing.T) {
 	// real expiration time passes.
 	const voteID = chaincfg.VoteIDChangeSubsidySplit
 	params = cloneParams(params)
-	deploymentVer, deployment, err := findDeployment(params, voteID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	deploymentVer, deployment := findDeployment(t, params, voteID)
 	removeDeploymentTimeConstraints(deployment)
 
 	// Create a test harness initialized with the genesis block as the tip.

--- a/internal/blockchain/votebits_test.go
+++ b/internal/blockchain/votebits_test.go
@@ -34,49 +34,11 @@ func TestVoting(t *testing.T) {
 	mockParams := cloneParams(chaincfg.RegNetParams())
 	mockParams.Deployments = map[uint32][]chaincfg.ConsensusDeployment{
 		posVersion: {{
-			Vote: chaincfg.Vote{
-				Id:          "vote1",
-				Description: "Vote 1",
-				Mask:        0x6, // 0b0110
-				Choices: []chaincfg.Choice{{
-					Id:          "abstain",
-					Description: "abstain voting for change",
-					Bits:        0x0000,
-					IsAbstain:   true,
-				}, {
-					Id:          "no",
-					Description: "vote no",
-					Bits:        0x0002, // Bit 1 (1 << 1)
-					IsNo:        true,
-				}, {
-					Id:          "yes",
-					Description: "vote yes",
-					Bits:        0x0004, // Bit 2 (2 << 1)
-				}},
-			},
+			Vote:       mockVote1(),
 			StartTime:  0,             // Always available for vote
 			ExpireTime: math.MaxInt64, // Never expires
 		}, {
-			Vote: chaincfg.Vote{
-				Id:          "vote2",
-				Description: "Vote 2",
-				Mask:        0x18, // 0b11000
-				Choices: []chaincfg.Choice{{
-					Id:          "abstain",
-					Description: "abstain voting for change",
-					Bits:        0x0000,
-					IsAbstain:   true,
-				}, {
-					Id:          "no",
-					Description: "vote no",
-					Bits:        0x0008, // Bit 3 (1 << 3)
-					IsNo:        true,
-				}, {
-					Id:          "yes",
-					Description: "vote yes",
-					Bits:        0x0010, // Bit 4 (2 << 3)
-				}},
-			},
+			Vote:       mockVote2(),
 			StartTime:  0,             // Always available for vote
 			ExpireTime: math.MaxInt64, // Never expires
 		}, {
@@ -90,7 +52,7 @@ func TestVoting(t *testing.T) {
 					Bits:        0x0,
 					IsAbstain:   true,
 				}, {
-					Id:          "vote against",
+					Id:          "no",
 					Description: "vote against all multiple",
 					Bits:        0x20, // Bit 5 (1 << 5)
 					IsNo:        true,
@@ -135,29 +97,18 @@ func TestVoting(t *testing.T) {
 	}
 
 	// Convenient references to the mock parameter votes and choices.
-	const (
-		vote1NoIdx      = 1
-		vote1YesIdx     = 2
-		vote2NoIdx      = 1
-		vote2YesIdx     = 2
-		vote3NoIdx      = 1
-		vote3Choice1Idx = 2
-		vote3Choice2Idx = 3
-		vote3Choice3Idx = 4
-		vote3Choice4Idx = 5
-	)
 	vote1 := &mockParams.Deployments[posVersion][0].Vote
-	vote1No := &vote1.Choices[vote1NoIdx]
-	vote1Yes := &vote1.Choices[vote1YesIdx]
+	vote1NoIdx, vote1No := findVoteChoiceIndex(t, vote1, "no")
+	vote1YesIdx, vote1Yes := findVoteChoiceIndex(t, vote1, "yes")
 	vote2 := &mockParams.Deployments[posVersion][1].Vote
-	vote2No := &vote2.Choices[vote2NoIdx]
-	vote2Yes := &vote2.Choices[vote2YesIdx]
+	vote2NoIdx, vote2No := findVoteChoiceIndex(t, vote2, "no")
+	vote2YesIdx, vote2Yes := findVoteChoiceIndex(t, vote2, "yes")
 	vote3 := &mockParams.Deployments[posVersion][2].Vote
-	vote3No := &vote3.Choices[vote3NoIdx]
-	vote3Choice1 := &vote3.Choices[vote3Choice1Idx]
-	vote3Choice2 := &vote3.Choices[vote3Choice2Idx]
-	vote3Choice3 := &vote3.Choices[vote3Choice3Idx]
-	vote3Choice4 := &vote3.Choices[vote3Choice4Idx]
+	vote3NoIdx, vote3No := findVoteChoiceIndex(t, vote3, "no")
+	vote3Choice1Idx, vote3Choice1 := findVoteChoiceIndex(t, vote3, "one")
+	vote3Choice2Idx, vote3Choice2 := findVoteChoiceIndex(t, vote3, "two")
+	vote3Choice3Idx, vote3Choice3 := findVoteChoiceIndex(t, vote3, "three")
+	vote3Choice4Idx, vote3Choice4 := findVoteChoiceIndex(t, vote3, "four")
 
 	// Determine what the vote bits for the next choice in the various votes
 	// would be if they existed.


### PR DESCRIPTION
~**This requires #3075**.~

This converts several of the funcs used in the tests that serve to find deployments, votes, and choices within parameters to fully fledged test helpers that invoke fatal upon error instead of returning the errors themselves.

This makes them more convenient to use and makes the tests slightly more compact in general as well.

It also modifies the tests to make use of a couple of functions to acquire mock votes instead of global ones.  This helps reduce global state in the tests and makes it much harder to inadvertently break test assumptions when they are modified since each test now has their own copy.

Finally, it uses the test helper funcs to look up the choices within the votes to avoid hard coded magic numbers.