### PR TITLE
blockchain: Make zero val threshold tuple invalid.

### DIFF
--- a/internal/blockchain/chain.go
+++ b/internal/blockchain/chain.go
@@ -2121,12 +2121,10 @@ func determineForcedThresholdState(deployment *chaincfg.ConsensusDeployment) (*T
 	// Attempt to find the choice with the ID that matches the forced choice
 	// specified in the deployment chain params and ensure it exists.
 	var forcedChoice *chaincfg.Choice
-	var forcedChoiceIdx uint32
 	for choiceIdx := range deployment.Vote.Choices {
 		choice := &deployment.Vote.Choices[choiceIdx]
 		if choice.Id == forcedChoiceID {
 			forcedChoice = choice
-			forcedChoiceIdx = uint32(choiceIdx)
 			break
 		}
 	}
@@ -2151,7 +2149,7 @@ func determineForcedThresholdState(deployment *chaincfg.ConsensusDeployment) (*T
 	if forcedChoice.IsNo {
 		state = ThresholdFailed
 	}
-	tuple := newThresholdState(state, forcedChoiceIdx)
+	tuple := newThresholdState(state, forcedChoice)
 	return &tuple, nil
 }
 

--- a/internal/blockchain/common_test.go
+++ b/internal/blockchain/common_test.go
@@ -1056,7 +1056,7 @@ func (g *chaingenHarness) TestThresholdState(id string, state ThresholdState) {
 // TestThresholdStateChoice queries the threshold state from the current tip
 // block associated with the harness generator and expects the returned state
 // and choice to match the provided value.
-func (g *chaingenHarness) TestThresholdStateChoice(id string, state ThresholdState, choice uint32) {
+func (g *chaingenHarness) TestThresholdStateChoice(id string, state ThresholdState, choice *chaincfg.Choice) {
 	g.t.Helper()
 
 	tipHash := g.Tip().BlockHash()
@@ -1073,10 +1073,17 @@ func (g *chaingenHarness) TestThresholdStateChoice(id string, state ThresholdSta
 			"state for %s -- got %v, want %v", g.TipName(), tipHash, tipHeight,
 			id, s.State, state)
 	}
-	if s.Choice != choice {
+	if !reflect.DeepEqual(s.Choice, choice) {
+		gotChoiceID, wantChoiceID := "<nil>", "<nil>"
+		if s.Choice != nil {
+			gotChoiceID = s.Choice.Id
+		}
+		if choice != nil {
+			wantChoiceID = choice.Id
+		}
 		g.t.Fatalf("block %q (hash %s, height %d) unexpected choice for %s -- "+
-			"got %v, want %v", g.TipName(), tipHash, tipHeight, id, s.Choice,
-			choice)
+			"got %v, want %v", g.TipName(), tipHash, tipHeight, id, gotChoiceID,
+			wantChoiceID)
 	}
 }
 

--- a/internal/blockchain/thresholdstate_test.go
+++ b/internal/blockchain/thresholdstate_test.go
@@ -213,11 +213,11 @@ func TestThresholdState(t *testing.T) {
 
 	// Convenient references to the mock parameter votes and choices.
 	vote1 := &params.Deployments[posVersion][numDeployments-2].Vote
-	vote1YesIdx, vote1Yes := findVoteChoiceIndex(t, vote1, "yes")
+	vote1Yes := findVoteChoice(t, vote1, "yes")
 	vote1No := findVoteChoice(t, vote1, "no")
 	vote2 := &params.Deployments[posVersion][numDeployments-1].Vote
 	vote2Yes := findVoteChoice(t, vote2, "yes")
-	vote2NoIdx, vote2No := findVoteChoiceIndex(t, vote2, "no")
+	vote2No := findVoteChoice(t, vote2, "no")
 
 	// Create a test harness initialized with the genesis block as the tip.
 	g := newChaingenHarness(t, params)
@@ -248,8 +248,8 @@ func TestThresholdState(t *testing.T) {
 	g.CreateBlockOne("bfb", 0)
 	g.AssertTipHeight(1)
 	g.AcceptTipBlock()
-	g.TestThresholdStateChoice(vote1.Id, ThresholdDefined, invalidChoice)
-	g.TestThresholdStateChoice(vote2.Id, ThresholdDefined, invalidChoice)
+	g.TestThresholdStateChoice(vote1.Id, ThresholdDefined, nil)
+	g.TestThresholdStateChoice(vote2.Id, ThresholdDefined, nil)
 
 	// ---------------------------------------------------------------------
 	// Generate enough blocks to have mature coinbase outputs to work with.
@@ -264,8 +264,8 @@ func TestThresholdState(t *testing.T) {
 		g.AcceptTipBlock()
 	}
 	g.AssertTipHeight(uint32(coinbaseMaturity) + 1)
-	g.TestThresholdStateChoice(vote1.Id, ThresholdDefined, invalidChoice)
-	g.TestThresholdStateChoice(vote2.Id, ThresholdDefined, invalidChoice)
+	g.TestThresholdStateChoice(vote1.Id, ThresholdDefined, nil)
+	g.TestThresholdStateChoice(vote2.Id, ThresholdDefined, nil)
 
 	// ---------------------------------------------------------------------
 	// Generate enough blocks to reach the stake enabled height while
@@ -286,8 +286,8 @@ func TestThresholdState(t *testing.T) {
 		g.AcceptTipBlock()
 	}
 	g.AssertTipHeight(uint32(stakeEnabledHeight))
-	g.TestThresholdStateChoice(vote1.Id, ThresholdDefined, invalidChoice)
-	g.TestThresholdStateChoice(vote2.Id, ThresholdDefined, invalidChoice)
+	g.TestThresholdStateChoice(vote1.Id, ThresholdDefined, nil)
+	g.TestThresholdStateChoice(vote2.Id, ThresholdDefined, nil)
 
 	// ---------------------------------------------------------------------
 	// Generate enough blocks to reach the stake validation height while
@@ -321,8 +321,8 @@ func TestThresholdState(t *testing.T) {
 		g.AcceptTipBlock()
 	}
 	g.AssertTipHeight(uint32(stakeValidationHeight))
-	g.TestThresholdStateChoice(vote1.Id, ThresholdDefined, invalidChoice)
-	g.TestThresholdStateChoice(vote2.Id, ThresholdDefined, invalidChoice)
+	g.TestThresholdStateChoice(vote1.Id, ThresholdDefined, nil)
+	g.TestThresholdStateChoice(vote2.Id, ThresholdDefined, nil)
 
 	// ---------------------------------------------------------------------
 	// Generate enough blocks to reach one block before the next stake
@@ -350,8 +350,8 @@ func TestThresholdState(t *testing.T) {
 	g.AssertTipHeight(uint32(stakeValidationHeight + stakeVerInterval - 1))
 	g.AssertBlockVersion(3)
 	g.AssertStakeVersion(0)
-	g.TestThresholdStateChoice(vote1.Id, ThresholdDefined, invalidChoice)
-	g.TestThresholdStateChoice(vote2.Id, ThresholdDefined, invalidChoice)
+	g.TestThresholdStateChoice(vote1.Id, ThresholdDefined, nil)
+	g.TestThresholdStateChoice(vote2.Id, ThresholdDefined, nil)
 
 	// ---------------------------------------------------------------------
 	// Generate enough blocks to reach one block before the next rule change
@@ -378,8 +378,8 @@ func TestThresholdState(t *testing.T) {
 	g.AssertTipHeight(uint32(stakeValidationHeight + ruleChangeInterval - 2))
 	g.AssertBlockVersion(3)
 	g.AssertStakeVersion(3)
-	g.TestThresholdStateChoice(vote1.Id, ThresholdDefined, invalidChoice)
-	g.TestThresholdStateChoice(vote2.Id, ThresholdDefined, invalidChoice)
+	g.TestThresholdStateChoice(vote1.Id, ThresholdDefined, nil)
+	g.TestThresholdStateChoice(vote2.Id, ThresholdDefined, nil)
 
 	// ---------------------------------------------------------------------
 	// Generate enough blocks to reach one block before the next stake
@@ -409,8 +409,8 @@ func TestThresholdState(t *testing.T) {
 	g.AssertTipHeight(uint32(stakeValidationHeight + stakeVerInterval*4 - 1))
 	g.AssertBlockVersion(3)
 	g.AssertStakeVersion(3)
-	g.TestThresholdStateChoice(vote1.Id, ThresholdDefined, invalidChoice)
-	g.TestThresholdStateChoice(vote2.Id, ThresholdDefined, invalidChoice)
+	g.TestThresholdStateChoice(vote1.Id, ThresholdDefined, nil)
+	g.TestThresholdStateChoice(vote2.Id, ThresholdDefined, nil)
 
 	// ---------------------------------------------------------------------
 	// Generate enough blocks to reach the next rule change interval with
@@ -442,8 +442,8 @@ func TestThresholdState(t *testing.T) {
 	g.AssertTipHeight(uint32(stakeValidationHeight + ruleChangeInterval*2 - 1))
 	g.AssertBlockVersion(4)
 	g.AssertStakeVersion(4)
-	g.TestThresholdStateChoice(vote1.Id, ThresholdDefined, invalidChoice)
-	g.TestThresholdStateChoice(vote2.Id, ThresholdDefined, invalidChoice)
+	g.TestThresholdStateChoice(vote1.Id, ThresholdDefined, nil)
+	g.TestThresholdStateChoice(vote2.Id, ThresholdDefined, nil)
 
 	// ---------------------------------------------------------------------
 	// Generate enough blocks to achieve proof-of-work block version lockin
@@ -476,8 +476,8 @@ func TestThresholdState(t *testing.T) {
 		1 + powNumToCheck))
 	g.AssertBlockVersion(4)
 	g.AssertStakeVersion(4)
-	g.TestThresholdStateChoice(vote1.Id, ThresholdDefined, invalidChoice)
-	g.TestThresholdStateChoice(vote2.Id, ThresholdDefined, invalidChoice)
+	g.TestThresholdStateChoice(vote1.Id, ThresholdDefined, nil)
+	g.TestThresholdStateChoice(vote2.Id, ThresholdDefined, nil)
 
 	// ---------------------------------------------------------------------
 	// Generate enough blocks to reach the next rule change interval with
@@ -508,8 +508,8 @@ func TestThresholdState(t *testing.T) {
 	g.AssertTipHeight(uint32(stakeValidationHeight + ruleChangeInterval*3 - 1))
 	g.AssertBlockVersion(4)
 	g.AssertStakeVersion(4)
-	g.TestThresholdStateChoice(vote1.Id, ThresholdStarted, invalidChoice)
-	g.TestThresholdStateChoice(vote2.Id, ThresholdStarted, invalidChoice)
+	g.TestThresholdStateChoice(vote1.Id, ThresholdStarted, nil)
+	g.TestThresholdStateChoice(vote2.Id, ThresholdStarted, nil)
 
 	// ---------------------------------------------------------------------
 	// Generate enough blocks to reach the next rule change interval with
@@ -538,8 +538,8 @@ func TestThresholdState(t *testing.T) {
 	g.AssertTipHeight(uint32(stakeValidationHeight + ruleChangeInterval*4 - 1))
 	g.AssertBlockVersion(4)
 	g.AssertStakeVersion(4)
-	g.TestThresholdStateChoice(vote1.Id, ThresholdStarted, invalidChoice)
-	g.TestThresholdStateChoice(vote2.Id, ThresholdStarted, invalidChoice)
+	g.TestThresholdStateChoice(vote1.Id, ThresholdStarted, nil)
+	g.TestThresholdStateChoice(vote2.Id, ThresholdStarted, nil)
 
 	// ---------------------------------------------------------------------
 	// Generate enough blocks to reach the next rule change interval with
@@ -573,8 +573,8 @@ func TestThresholdState(t *testing.T) {
 	g.AssertTipHeight(uint32(stakeValidationHeight + ruleChangeInterval*5 - 1))
 	g.AssertBlockVersion(4)
 	g.AssertStakeVersion(4)
-	g.TestThresholdStateChoice(vote1.Id, ThresholdStarted, invalidChoice)
-	g.TestThresholdStateChoice(vote2.Id, ThresholdStarted, invalidChoice)
+	g.TestThresholdStateChoice(vote1.Id, ThresholdStarted, nil)
+	g.TestThresholdStateChoice(vote2.Id, ThresholdStarted, nil)
 
 	// ---------------------------------------------------------------------
 	// Generate enough blocks to reach the next rule change interval with
@@ -615,8 +615,8 @@ func TestThresholdState(t *testing.T) {
 	g.AssertTipHeight(uint32(stakeValidationHeight + ruleChangeInterval*6 - 1))
 	g.AssertBlockVersion(4)
 	g.AssertStakeVersion(4)
-	g.TestThresholdStateChoice(vote1.Id, ThresholdStarted, invalidChoice)
-	g.TestThresholdStateChoice(vote2.Id, ThresholdStarted, invalidChoice)
+	g.TestThresholdStateChoice(vote1.Id, ThresholdStarted, nil)
+	g.TestThresholdStateChoice(vote2.Id, ThresholdStarted, nil)
 
 	// ---------------------------------------------------------------------
 	// Generate enough blocks to reach the next rule change interval with
@@ -646,8 +646,8 @@ func TestThresholdState(t *testing.T) {
 	g.AssertTipHeight(uint32(stakeValidationHeight + ruleChangeInterval*7 - 1))
 	g.AssertBlockVersion(4)
 	g.AssertStakeVersion(4)
-	g.TestThresholdStateChoice(vote1.Id, ThresholdLockedIn, vote1YesIdx)
-	g.TestThresholdStateChoice(vote2.Id, ThresholdFailed, vote2NoIdx)
+	g.TestThresholdStateChoice(vote1.Id, ThresholdLockedIn, vote1Yes)
+	g.TestThresholdStateChoice(vote2.Id, ThresholdFailed, vote2No)
 
 	// ---------------------------------------------------------------------
 	// Generate enough blocks to reach the next rule change interval with
@@ -679,6 +679,6 @@ func TestThresholdState(t *testing.T) {
 	g.AssertTipHeight(uint32(stakeValidationHeight + ruleChangeInterval*8 - 1))
 	g.AssertBlockVersion(4)
 	g.AssertStakeVersion(4)
-	g.TestThresholdStateChoice(vote1.Id, ThresholdActive, vote1YesIdx)
-	g.TestThresholdStateChoice(vote2.Id, ThresholdFailed, vote2NoIdx)
+	g.TestThresholdStateChoice(vote1.Id, ThresholdActive, vote1Yes)
+	g.TestThresholdStateChoice(vote2.Id, ThresholdFailed, vote2No)
 }

--- a/internal/blockchain/votebits_test.go
+++ b/internal/blockchain/votebits_test.go
@@ -98,17 +98,17 @@ func TestVoting(t *testing.T) {
 
 	// Convenient references to the mock parameter votes and choices.
 	vote1 := &mockParams.Deployments[posVersion][0].Vote
-	vote1NoIdx, vote1No := findVoteChoiceIndex(t, vote1, "no")
-	vote1YesIdx, vote1Yes := findVoteChoiceIndex(t, vote1, "yes")
+	vote1No := findVoteChoice(t, vote1, "no")
+	vote1Yes := findVoteChoice(t, vote1, "yes")
 	vote2 := &mockParams.Deployments[posVersion][1].Vote
-	vote2NoIdx, vote2No := findVoteChoiceIndex(t, vote2, "no")
-	vote2YesIdx, vote2Yes := findVoteChoiceIndex(t, vote2, "yes")
+	vote2No := findVoteChoice(t, vote2, "no")
+	vote2Yes := findVoteChoice(t, vote2, "yes")
 	vote3 := &mockParams.Deployments[posVersion][2].Vote
-	vote3NoIdx, vote3No := findVoteChoiceIndex(t, vote3, "no")
-	vote3Choice1Idx, vote3Choice1 := findVoteChoiceIndex(t, vote3, "one")
-	vote3Choice2Idx, vote3Choice2 := findVoteChoiceIndex(t, vote3, "two")
-	vote3Choice3Idx, vote3Choice3 := findVoteChoiceIndex(t, vote3, "three")
-	vote3Choice4Idx, vote3Choice4 := findVoteChoiceIndex(t, vote3, "four")
+	vote3No := findVoteChoice(t, vote3, "no")
+	vote3Choice1 := findVoteChoice(t, vote3, "one")
+	vote3Choice2 := findVoteChoice(t, vote3, "two")
+	vote3Choice3 := findVoteChoice(t, vote3, "three")
+	vote3Choice4 := findVoteChoice(t, vote3, "four")
 
 	// Determine what the vote bits for the next choice in the various votes
 	// would be if they existed.
@@ -150,9 +150,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   svh - 2,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdDefined, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdDefined, nil),
+				vote2.Id: newThresholdState(ThresholdDefined, nil),
+				vote3.Id: newThresholdState(ThresholdDefined, nil),
 			},
 		}},
 	}, {
@@ -171,9 +171,9 @@ func TestVoting(t *testing.T) {
 			name:      "svh",
 			numBlocks: svh - 1,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdDefined, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdDefined, nil),
+				vote2.Id: newThresholdState(ThresholdDefined, nil),
+				vote3.Id: newThresholdState(ThresholdDefined, nil),
 			},
 		}, {
 			// Cast votes with a newer stake version for a full stake version
@@ -185,9 +185,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   stakeVerInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdDefined, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdDefined, nil),
+				vote2.Id: newThresholdState(ThresholdDefined, nil),
+				vote3.Id: newThresholdState(ThresholdDefined, nil),
 			},
 		}, {
 			// Continue casting normal votes to reach the next rule change
@@ -198,9 +198,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval - stakeVerInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdStarted, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdStarted, nil),
+				vote3.Id: newThresholdState(ThresholdStarted, nil),
 			},
 		}, {
 			// Cast votes: 100% yes for vote 1, 100% no for vote 2, and 100%
@@ -212,9 +212,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid | vote1Yes.Bits | vote2No.Bits,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdLockedIn, vote1YesIdx),
-				vote2.Id: newThresholdState(ThresholdFailed, vote2NoIdx),
-				vote3.Id: newThresholdState(ThresholdStarted, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdLockedIn, vote1Yes),
+				vote2.Id: newThresholdState(ThresholdFailed, vote2No),
+				vote3.Id: newThresholdState(ThresholdStarted, nil),
 			},
 		}, {
 			// Cast normal votes for another rule change interval.  The state
@@ -225,9 +225,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdActive, vote1YesIdx),
-				vote2.Id: newThresholdState(ThresholdFailed, vote2NoIdx),
-				vote3.Id: newThresholdState(ThresholdStarted, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdActive, vote1Yes),
+				vote2.Id: newThresholdState(ThresholdFailed, vote2No),
+				vote3.Id: newThresholdState(ThresholdStarted, nil),
 			},
 		}},
 	}, {
@@ -248,9 +248,9 @@ func TestVoting(t *testing.T) {
 			name:      "svh",
 			numBlocks: svh - 1,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdDefined, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdDefined, nil),
+				vote2.Id: newThresholdState(ThresholdDefined, nil),
+				vote3.Id: newThresholdState(ThresholdDefined, nil),
 			},
 		}, {
 			// Cast votes with an older stake version for as many full stake
@@ -263,9 +263,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   rciDivSvi * stakeVerInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdDefined, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdDefined, nil),
+				vote2.Id: newThresholdState(ThresholdDefined, nil),
+				vote3.Id: newThresholdState(ThresholdDefined, nil),
 			},
 		}, {
 			// Reach the next rule change interval while casting votes with the
@@ -281,9 +281,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   rciModSvi,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdDefined, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdDefined, nil),
+				vote2.Id: newThresholdState(ThresholdDefined, nil),
+				vote3.Id: newThresholdState(ThresholdDefined, nil),
 			},
 		}, {
 			// Reach the next stake version interval while continuing to cast
@@ -296,9 +296,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   stakeVerInterval - rciModSvi,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdDefined, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdDefined, nil),
+				vote2.Id: newThresholdState(ThresholdDefined, nil),
+				vote3.Id: newThresholdState(ThresholdDefined, nil),
 			},
 		}, {
 			// Continue casting normal votes to reach the next rule change
@@ -309,9 +309,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval - (stakeVerInterval - rciModSvi),
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdStarted, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdStarted, nil),
+				vote3.Id: newThresholdState(ThresholdStarted, nil),
 			},
 		}, {
 			// Cast votes: 100% abstain for vote 1, 100% yes for vote 2, and
@@ -323,9 +323,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid | vote2Yes.Bits | vote3No.Bits,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdLockedIn, vote2YesIdx),
-				vote3.Id: newThresholdState(ThresholdFailed, vote3NoIdx),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdLockedIn, vote2Yes),
+				vote3.Id: newThresholdState(ThresholdFailed, vote3No),
 			},
 		}, {
 			// Cast normal votes for another rule change interval.  The state
@@ -336,9 +336,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdActive, vote2YesIdx),
-				vote3.Id: newThresholdState(ThresholdFailed, vote3NoIdx),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdActive, vote2Yes),
+				vote3.Id: newThresholdState(ThresholdFailed, vote3No),
 			},
 		}},
 	}, {
@@ -358,9 +358,9 @@ func TestVoting(t *testing.T) {
 			name:      "svh",
 			numBlocks: svh - 1,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdDefined, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdDefined, nil),
+				vote2.Id: newThresholdState(ThresholdDefined, nil),
+				vote3.Id: newThresholdState(ThresholdDefined, nil),
 			},
 		}, {
 			// Cast normal votes with the stake version that matches the
@@ -373,9 +373,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdStarted, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdStarted, nil),
+				vote3.Id: newThresholdState(ThresholdStarted, nil),
 			},
 		}, {
 			// Cast votes: 100% no for vote 1, 100% abstain for vote 2, and 100%
@@ -387,9 +387,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid | vote1No.Bits | vote3Choice1.Bits,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdFailed, vote1NoIdx),
-				vote2.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdLockedIn, vote3Choice1Idx),
+				vote1.Id: newThresholdState(ThresholdFailed, vote1No),
+				vote2.Id: newThresholdState(ThresholdStarted, nil),
+				vote3.Id: newThresholdState(ThresholdLockedIn, vote3Choice1),
 			},
 		}, {
 			// Cast normal votes for another rule change interval.  The state
@@ -400,9 +400,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdFailed, vote1NoIdx),
-				vote2.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdActive, vote3Choice1Idx),
+				vote1.Id: newThresholdState(ThresholdFailed, vote1No),
+				vote2.Id: newThresholdState(ThresholdStarted, nil),
+				vote3.Id: newThresholdState(ThresholdActive, vote3Choice1),
 			},
 		}},
 	}, {
@@ -415,9 +415,9 @@ func TestVoting(t *testing.T) {
 			name:      "svh",
 			numBlocks: svh - 1,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdDefined, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdDefined, nil),
+				vote2.Id: newThresholdState(ThresholdDefined, nil),
+				vote3.Id: newThresholdState(ThresholdDefined, nil),
 			},
 		}, {
 			// Cast normal votes to reach the next rule change interval.  The
@@ -428,9 +428,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdDefined, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdDefined, nil),
+				vote2.Id: newThresholdState(ThresholdDefined, nil),
+				vote3.Id: newThresholdState(ThresholdDefined, nil),
 			},
 		}, {
 			// Cast normal votes to reach the next rule change interval.  The
@@ -441,9 +441,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid | vote1Yes.Bits,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdDefined, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdDefined, nil),
+				vote2.Id: newThresholdState(ThresholdDefined, nil),
+				vote3.Id: newThresholdState(ThresholdDefined, nil),
 			},
 		}},
 	}, {
@@ -463,9 +463,9 @@ func TestVoting(t *testing.T) {
 			name:      "svh",
 			numBlocks: svh - 1,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdDefined, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdDefined, nil),
+				vote2.Id: newThresholdState(ThresholdDefined, nil),
+				vote3.Id: newThresholdState(ThresholdDefined, nil),
 			},
 		}, {
 			// Cast normal votes to reach the first rule change interval.  The
@@ -475,9 +475,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdStarted, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdStarted, nil),
+				vote3.Id: newThresholdState(ThresholdStarted, nil),
 			},
 		}, {
 			// Cast votes: 100% yes for vote 1, 100% abstain for vote 2, and
@@ -490,9 +490,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid | vote1Yes.Bits | vote3Choice2.Bits,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdLockedIn, vote1YesIdx),
-				vote2.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdLockedIn, vote3Choice2Idx),
+				vote1.Id: newThresholdState(ThresholdLockedIn, vote1Yes),
+				vote2.Id: newThresholdState(ThresholdStarted, nil),
+				vote3.Id: newThresholdState(ThresholdLockedIn, vote3Choice2),
 			},
 		}, {
 			// Cast normal votes for another rule change interval.  The state
@@ -503,9 +503,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdActive, vote1YesIdx),
-				vote2.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdActive, vote3Choice2Idx),
+				vote1.Id: newThresholdState(ThresholdActive, vote1Yes),
+				vote2.Id: newThresholdState(ThresholdStarted, nil),
+				vote3.Id: newThresholdState(ThresholdActive, vote3Choice2),
 			},
 		}},
 	}, {
@@ -526,9 +526,9 @@ func TestVoting(t *testing.T) {
 			name:      "svh",
 			numBlocks: svh - 1,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdDefined, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdDefined, nil),
+				vote2.Id: newThresholdState(ThresholdDefined, nil),
+				vote3.Id: newThresholdState(ThresholdDefined, nil),
 			},
 		}, {
 			// Cast normal votes with a vote version that is higher than the
@@ -539,9 +539,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdStarted, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdStarted, nil),
+				vote3.Id: newThresholdState(ThresholdStarted, nil),
 			},
 		}, {
 			// Cast votes with a vote version that is higher than the deployment
@@ -554,9 +554,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid | vote2Yes.Bits | vote3Choice3.Bits,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdStarted, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdStarted, nil),
+				vote3.Id: newThresholdState(ThresholdStarted, nil),
 			},
 		}, {
 			// Cast votes with a vote version that is higher than the deployment
@@ -569,9 +569,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid | vote2Yes.Bits | vote3Choice3.Bits,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdStarted, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdStarted, nil),
+				vote3.Id: newThresholdState(ThresholdStarted, nil),
 			},
 		}, {
 			// Cast votes with the correct vote version for the deployment this
@@ -583,9 +583,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid | vote2Yes.Bits | vote3Choice3.Bits,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdLockedIn, vote2YesIdx),
-				vote3.Id: newThresholdState(ThresholdLockedIn, vote3Choice3Idx),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdLockedIn, vote2Yes),
+				vote3.Id: newThresholdState(ThresholdLockedIn, vote3Choice3),
 			},
 		}, {
 			// Cast normal votes with a vote version that is higher than the
@@ -596,9 +596,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdActive, vote2YesIdx),
-				vote3.Id: newThresholdState(ThresholdActive, vote3Choice3Idx),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdActive, vote2Yes),
+				vote3.Id: newThresholdState(ThresholdActive, vote3Choice3),
 			},
 		}},
 	}, {
@@ -615,9 +615,9 @@ func TestVoting(t *testing.T) {
 			name:      "svh",
 			numBlocks: svh - 1,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdDefined, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdDefined, nil),
+				vote2.Id: newThresholdState(ThresholdDefined, nil),
+				vote3.Id: newThresholdState(ThresholdDefined, nil),
 			},
 		}, {
 			// Cast normal votes to reach the first rule change interval.  The
@@ -627,9 +627,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdStarted, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdStarted, nil),
+				vote3.Id: newThresholdState(ThresholdStarted, nil),
 			},
 		}, {
 			// Cast votes: 100% yes for vote 1, 100% yes for vote 2, and 100%
@@ -641,9 +641,9 @@ func TestVoting(t *testing.T) {
 				vote3Choice4.Bits,
 			numBlocks: ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdLockedIn, vote1YesIdx),
-				vote2.Id: newThresholdState(ThresholdLockedIn, vote2YesIdx),
-				vote3.Id: newThresholdState(ThresholdLockedIn, vote3Choice4Idx),
+				vote1.Id: newThresholdState(ThresholdLockedIn, vote1Yes),
+				vote2.Id: newThresholdState(ThresholdLockedIn, vote2Yes),
+				vote3.Id: newThresholdState(ThresholdLockedIn, vote3Choice4),
 			},
 		}, {
 			// Cast normal votes for another rule change interval.  The state
@@ -653,9 +653,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdActive, vote1YesIdx),
-				vote2.Id: newThresholdState(ThresholdActive, vote2YesIdx),
-				vote3.Id: newThresholdState(ThresholdActive, vote3Choice4Idx),
+				vote1.Id: newThresholdState(ThresholdActive, vote1Yes),
+				vote2.Id: newThresholdState(ThresholdActive, vote2Yes),
+				vote3.Id: newThresholdState(ThresholdActive, vote3Choice4),
 			},
 		}, {
 			// Cast normal votes for another rule change interval.  The state
@@ -665,9 +665,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdActive, vote1YesIdx),
-				vote2.Id: newThresholdState(ThresholdActive, vote2YesIdx),
-				vote3.Id: newThresholdState(ThresholdActive, vote3Choice4Idx),
+				vote1.Id: newThresholdState(ThresholdActive, vote1Yes),
+				vote2.Id: newThresholdState(ThresholdActive, vote2Yes),
+				vote3.Id: newThresholdState(ThresholdActive, vote3Choice4),
 			},
 		}},
 	}, {
@@ -684,9 +684,9 @@ func TestVoting(t *testing.T) {
 			name:      "svh",
 			numBlocks: svh - 1,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdDefined, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdDefined, nil),
+				vote2.Id: newThresholdState(ThresholdDefined, nil),
+				vote3.Id: newThresholdState(ThresholdDefined, nil),
 			},
 		}, {
 			// Cast normal votes to reach the first rule change interval.  The
@@ -696,9 +696,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdStarted, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdStarted, nil),
+				vote3.Id: newThresholdState(ThresholdStarted, nil),
 			},
 		}, {
 			// Cast votes: 100% no for vote 1, 100% no for vote 2, and 100% no
@@ -709,9 +709,9 @@ func TestVoting(t *testing.T) {
 				vote3No.Bits,
 			numBlocks: ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdFailed, vote1NoIdx),
-				vote2.Id: newThresholdState(ThresholdFailed, vote2NoIdx),
-				vote3.Id: newThresholdState(ThresholdFailed, vote3NoIdx),
+				vote1.Id: newThresholdState(ThresholdFailed, vote1No),
+				vote2.Id: newThresholdState(ThresholdFailed, vote2No),
+				vote3.Id: newThresholdState(ThresholdFailed, vote3No),
 			},
 		}, {
 			// Cast normal votes for another rule change interval.  The state
@@ -721,9 +721,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdFailed, vote1NoIdx),
-				vote2.Id: newThresholdState(ThresholdFailed, vote2NoIdx),
-				vote3.Id: newThresholdState(ThresholdFailed, vote3NoIdx),
+				vote1.Id: newThresholdState(ThresholdFailed, vote1No),
+				vote2.Id: newThresholdState(ThresholdFailed, vote2No),
+				vote3.Id: newThresholdState(ThresholdFailed, vote3No),
 			},
 		}},
 	}, {
@@ -740,9 +740,9 @@ func TestVoting(t *testing.T) {
 			name:      "svh",
 			numBlocks: svh - 1,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdDefined, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdDefined, nil),
+				vote2.Id: newThresholdState(ThresholdDefined, nil),
+				vote3.Id: newThresholdState(ThresholdDefined, nil),
 			},
 		}, {
 			// Cast normal votes to reach the first rule change interval.  The
@@ -752,9 +752,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdStarted, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdStarted, nil),
+				vote3.Id: newThresholdState(ThresholdStarted, nil),
 			},
 		}, {
 			// Cast normal votes while abstaining from all ongoing votes for a
@@ -765,9 +765,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdStarted, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdStarted, nil),
+				vote3.Id: newThresholdState(ThresholdStarted, nil),
 			},
 		}, {
 			// Continue cast normal votes while abstaining from all ongoing
@@ -778,9 +778,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdStarted, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdStarted, nil),
+				vote3.Id: newThresholdState(ThresholdStarted, nil),
 			},
 		}, {
 			// Continue cast normal votes while abstaining from all ongoing
@@ -791,9 +791,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdStarted, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdStarted, nil),
+				vote3.Id: newThresholdState(ThresholdStarted, nil),
 			},
 		}},
 	}, {
@@ -812,9 +812,9 @@ func TestVoting(t *testing.T) {
 			name:      "svh",
 			numBlocks: svh - 1,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdDefined, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdDefined, nil),
+				vote2.Id: newThresholdState(ThresholdDefined, nil),
+				vote3.Id: newThresholdState(ThresholdDefined, nil),
 			},
 		}, {
 			// Cast normal votes to reach the first rule change interval.  The
@@ -824,9 +824,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdStarted, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdStarted, nil),
+				vote3.Id: newThresholdState(ThresholdStarted, nil),
 			},
 		}, {
 			// Cast 100% invalid votes.  The state should remain started fore
@@ -838,9 +838,9 @@ func TestVoting(t *testing.T) {
 				vbVote3Invalid,
 			numBlocks: ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdStarted, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdStarted, nil),
+				vote3.Id: newThresholdState(ThresholdStarted, nil),
 			},
 		}, {
 			// Vote yes for vote 1.  Its state should move to locked in.  The
@@ -851,9 +851,9 @@ func TestVoting(t *testing.T) {
 				vote3No.Bits,
 			numBlocks: ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdLockedIn, vote1YesIdx),
-				vote2.Id: newThresholdState(ThresholdFailed, vote2NoIdx),
-				vote3.Id: newThresholdState(ThresholdFailed, vote3NoIdx),
+				vote1.Id: newThresholdState(ThresholdLockedIn, vote1Yes),
+				vote2.Id: newThresholdState(ThresholdFailed, vote2No),
+				vote3.Id: newThresholdState(ThresholdFailed, vote3No),
 			},
 		}, {
 			// Continue casting normal votes to reach the next rule change
@@ -864,9 +864,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdActive, vote1YesIdx),
-				vote2.Id: newThresholdState(ThresholdFailed, vote2NoIdx),
-				vote3.Id: newThresholdState(ThresholdFailed, vote3NoIdx),
+				vote1.Id: newThresholdState(ThresholdActive, vote1Yes),
+				vote2.Id: newThresholdState(ThresholdFailed, vote2No),
+				vote3.Id: newThresholdState(ThresholdFailed, vote3No),
 			},
 		}},
 	}, {
@@ -886,9 +886,9 @@ func TestVoting(t *testing.T) {
 			name:      "svh",
 			numBlocks: svh - 1,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdDefined, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdDefined, nil),
+				vote2.Id: newThresholdState(ThresholdDefined, nil),
+				vote3.Id: newThresholdState(ThresholdDefined, nil),
 			},
 		}, {
 			// Cast normal votes to reach the first rule change interval.  The
@@ -898,9 +898,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdStarted, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdStarted, nil),
+				vote3.Id: newThresholdState(ThresholdStarted, nil),
 			},
 		}, {
 			// Cast votes: 100% invalid for vote 1, 100% yes for vote 2, 100%
@@ -913,9 +913,9 @@ func TestVoting(t *testing.T) {
 				vote3Choice1.Bits,
 			numBlocks: ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdLockedIn, vote2YesIdx),
-				vote3.Id: newThresholdState(ThresholdLockedIn, vote3Choice1Idx),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdLockedIn, vote2Yes),
+				vote3.Id: newThresholdState(ThresholdLockedIn, vote3Choice1),
 			},
 		}, {
 			// Continue casting normal votes to reach the next rule change
@@ -926,9 +926,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdActive, vote2YesIdx),
-				vote3.Id: newThresholdState(ThresholdActive, vote3Choice1Idx),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdActive, vote2Yes),
+				vote3.Id: newThresholdState(ThresholdActive, vote3Choice1),
 			},
 		}},
 	}, {
@@ -943,9 +943,9 @@ func TestVoting(t *testing.T) {
 			name:      "svh",
 			numBlocks: svh - 1,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdDefined, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdDefined, nil),
+				vote2.Id: newThresholdState(ThresholdDefined, nil),
+				vote3.Id: newThresholdState(ThresholdDefined, nil),
 			},
 		}, {
 			// Cast normal votes with an older stake version until the first
@@ -958,9 +958,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdDefined, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdDefined, nil),
+				vote2.Id: newThresholdState(ThresholdDefined, nil),
+				vote3.Id: newThresholdState(ThresholdDefined, nil),
 			},
 		}, {
 			// Continue casting normal votes with an older stake version for
@@ -972,9 +972,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdFailed, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdFailed, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdFailed, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdFailed, nil),
+				vote2.Id: newThresholdState(ThresholdFailed, nil),
+				vote3.Id: newThresholdState(ThresholdFailed, nil),
 			},
 		}},
 	}, {
@@ -988,9 +988,9 @@ func TestVoting(t *testing.T) {
 			name:      "svh",
 			numBlocks: svh - 1,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdDefined, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdDefined, nil),
+				vote2.Id: newThresholdState(ThresholdDefined, nil),
+				vote3.Id: newThresholdState(ThresholdDefined, nil),
 			},
 		}, {
 			// Cast votes with a newer stake version for a full rule change
@@ -1002,9 +1002,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdStarted, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdStarted, nil),
+				vote3.Id: newThresholdState(ThresholdStarted, nil),
 			},
 		}, {
 			// Cast yes votes which would ordinarily cause all of the votes in
@@ -1017,9 +1017,9 @@ func TestVoting(t *testing.T) {
 				vote3Choice1.Bits,
 			numBlocks: ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdFailed, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdFailed, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdFailed, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdFailed, nil),
+				vote2.Id: newThresholdState(ThresholdFailed, nil),
+				vote3.Id: newThresholdState(ThresholdFailed, nil),
 			},
 		}},
 	}, {
@@ -1061,9 +1061,9 @@ func TestVoting(t *testing.T) {
 				return svh + firstAlignment - stakeVerInterval - 1
 			}(),
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdDefined, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdDefined, nil),
+				vote2.Id: newThresholdState(ThresholdDefined, nil),
+				vote3.Id: newThresholdState(ThresholdDefined, nil),
 			},
 		}, {
 			// Cast normal votes with the correct vote version in order to reach
@@ -1076,9 +1076,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   stakeVerInterval - 1,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdDefined, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdDefined, nil),
+				vote2.Id: newThresholdState(ThresholdDefined, nil),
+				vote3.Id: newThresholdState(ThresholdDefined, nil),
 			},
 		}, {
 			// Cast another normal vote with the correct vote version to reach
@@ -1091,9 +1091,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   1,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdStarted, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdStarted, nil),
+				vote3.Id: newThresholdState(ThresholdStarted, nil),
 			},
 		}, {
 			// Cast votes for one block less than a rule change interval: 100%
@@ -1106,9 +1106,9 @@ func TestVoting(t *testing.T) {
 				vote3Choice2.Bits,
 			numBlocks: ruleChangeInterval - 1,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdStarted, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdStarted, nil),
+				vote3.Id: newThresholdState(ThresholdStarted, nil),
 			},
 		}, {
 			// Cast one more vote with the same choices as the previous to reach
@@ -1120,9 +1120,9 @@ func TestVoting(t *testing.T) {
 				vote3Choice2.Bits,
 			numBlocks: 1,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdLockedIn, vote1YesIdx),
-				vote2.Id: newThresholdState(ThresholdLockedIn, vote2YesIdx),
-				vote3.Id: newThresholdState(ThresholdLockedIn, vote3Choice2Idx),
+				vote1.Id: newThresholdState(ThresholdLockedIn, vote1Yes),
+				vote2.Id: newThresholdState(ThresholdLockedIn, vote2Yes),
+				vote3.Id: newThresholdState(ThresholdLockedIn, vote3Choice2),
 			},
 		}, {
 			// Continue casting normal votes to reach the next rule change
@@ -1133,9 +1133,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdActive, vote1YesIdx),
-				vote2.Id: newThresholdState(ThresholdActive, vote2YesIdx),
-				vote3.Id: newThresholdState(ThresholdActive, vote3Choice2Idx),
+				vote1.Id: newThresholdState(ThresholdActive, vote1Yes),
+				vote2.Id: newThresholdState(ThresholdActive, vote2Yes),
+				vote3.Id: newThresholdState(ThresholdActive, vote3Choice2),
 			},
 		}},
 	}, {
@@ -1155,9 +1155,9 @@ func TestVoting(t *testing.T) {
 			name:      "svh",
 			numBlocks: svh - 1,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdDefined, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdDefined, nil),
+				vote2.Id: newThresholdState(ThresholdDefined, nil),
+				vote3.Id: newThresholdState(ThresholdDefined, nil),
 			},
 		}, {
 			// Cast normal votes to reach the first rule change interval.  The
@@ -1167,9 +1167,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdStarted, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdStarted, nil),
+				vote3.Id: newThresholdState(ThresholdStarted, nil),
 			},
 		}, {
 			// Cast votes such that:
@@ -1200,9 +1200,9 @@ func TestVoting(t *testing.T) {
 			}(),
 			numBlocks: ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdStarted, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdStarted, nil),
+				vote3.Id: newThresholdState(ThresholdStarted, nil),
 			},
 		}, {
 			// Cast votes such that:
@@ -1239,9 +1239,9 @@ func TestVoting(t *testing.T) {
 			}(),
 			numBlocks: ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdStarted, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdStarted, nil),
+				vote3.Id: newThresholdState(ThresholdStarted, nil),
 			},
 		}, {
 			// Cast votes such that:
@@ -1278,9 +1278,9 @@ func TestVoting(t *testing.T) {
 			}(),
 			numBlocks: ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdFailed, vote1NoIdx),
-				vote2.Id: newThresholdState(ThresholdLockedIn, vote2YesIdx),
-				vote3.Id: newThresholdState(ThresholdLockedIn, vote3Choice3Idx),
+				vote1.Id: newThresholdState(ThresholdFailed, vote1No),
+				vote2.Id: newThresholdState(ThresholdLockedIn, vote2Yes),
+				vote3.Id: newThresholdState(ThresholdLockedIn, vote3Choice3),
 			},
 		}, {
 			// Cast normal votes for another rule change interval.  The state
@@ -1291,9 +1291,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdFailed, vote1NoIdx),
-				vote2.Id: newThresholdState(ThresholdActive, vote2YesIdx),
-				vote3.Id: newThresholdState(ThresholdActive, vote3Choice3Idx),
+				vote1.Id: newThresholdState(ThresholdFailed, vote1No),
+				vote2.Id: newThresholdState(ThresholdActive, vote2Yes),
+				vote3.Id: newThresholdState(ThresholdActive, vote3Choice3),
 			},
 		}},
 	}, {
@@ -1306,9 +1306,9 @@ func TestVoting(t *testing.T) {
 			name:      "svh",
 			numBlocks: svh - 1,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdDefined, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdDefined, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdDefined, nil),
+				vote2.Id: newThresholdState(ThresholdDefined, nil),
+				vote3.Id: newThresholdState(ThresholdDefined, nil),
 			},
 		}, {
 			// Cast normal votes to reach the first rule change interval.  The
@@ -1318,9 +1318,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote2.Id: newThresholdState(ThresholdStarted, invalidChoice),
-				vote3.Id: newThresholdState(ThresholdStarted, invalidChoice),
+				vote1.Id: newThresholdState(ThresholdStarted, nil),
+				vote2.Id: newThresholdState(ThresholdStarted, nil),
+				vote3.Id: newThresholdState(ThresholdStarted, nil),
 			},
 		}, {
 			// Cast votes: 100% yes for vote 1, 100% no for vote 2, and 100%
@@ -1332,9 +1332,9 @@ func TestVoting(t *testing.T) {
 				vote3Choice1.Bits,
 			numBlocks: ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdLockedIn, vote1YesIdx),
-				vote2.Id: newThresholdState(ThresholdFailed, vote2NoIdx),
-				vote3.Id: newThresholdState(ThresholdLockedIn, vote3Choice1Idx),
+				vote1.Id: newThresholdState(ThresholdLockedIn, vote1Yes),
+				vote2.Id: newThresholdState(ThresholdFailed, vote2No),
+				vote3.Id: newThresholdState(ThresholdLockedIn, vote3Choice1),
 			},
 		}, {
 			// Cast votes that are different than they majority results already
@@ -1348,9 +1348,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdActive, vote1YesIdx),
-				vote2.Id: newThresholdState(ThresholdFailed, vote2NoIdx),
-				vote3.Id: newThresholdState(ThresholdActive, vote3Choice1Idx),
+				vote1.Id: newThresholdState(ThresholdActive, vote1Yes),
+				vote2.Id: newThresholdState(ThresholdFailed, vote2No),
+				vote3.Id: newThresholdState(ThresholdActive, vote3Choice1),
 			},
 		}, {
 			// Cast normal votes for another rule change interval.  The state
@@ -1360,9 +1360,9 @@ func TestVoting(t *testing.T) {
 			voteBits:    vbPrevBlockValid,
 			numBlocks:   ruleChangeInterval,
 			wantStates: wantStatesMap{
-				vote1.Id: newThresholdState(ThresholdActive, vote1YesIdx),
-				vote2.Id: newThresholdState(ThresholdFailed, vote2NoIdx),
-				vote3.Id: newThresholdState(ThresholdActive, vote3Choice1Idx),
+				vote1.Id: newThresholdState(ThresholdActive, vote1Yes),
+				vote2.Id: newThresholdState(ThresholdFailed, vote2No),
+				vote3.Id: newThresholdState(ThresholdActive, vote3Choice1),
 			},
 		}},
 	}}

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -1500,7 +1500,7 @@ func defaultMockRPCChain() *testRPCChain {
 			Agendas: defaultChainParams.Deployments[0],
 			AgendaStatus: []blockchain.ThresholdStateTuple{{
 				State:  blockchain.ThresholdStarted,
-				Choice: uint32(0xffffffff),
+				Choice: nil,
 			}},
 		},
 		headerByHashFn:    headerByHashFn,
@@ -1511,7 +1511,7 @@ func defaultMockRPCChain() *testRPCChain {
 		medianTimeByHash:  time.Time{},
 		nextThresholdState: blockchain.ThresholdStateTuple{
 			State:  blockchain.ThresholdStarted,
-			Choice: uint32(0xffffffff),
+			Choice: nil,
 		},
 		ticketPoolValue: 570678298669222,
 		treasuryBalance: &blockchain.TreasuryBalanceInfo{
@@ -3637,7 +3637,7 @@ func TestHandleGetBlockchainInfo(t *testing.T) {
 			chain.maxBlockSize = 393216
 			chain.nextThresholdState = blockchain.ThresholdStateTuple{
 				State:  blockchain.ThresholdDefined,
-				Choice: uint32(0xffffffff),
+				Choice: nil,
 			}
 			chain.stateLastChangedHeight = int64(0)
 			return chain
@@ -7006,7 +7006,7 @@ func TestHandleGetVoteInfo(t *testing.T) {
 				Agendas: defaultChainParams.Deployments[v7],
 				AgendaStatus: []blockchain.ThresholdStateTuple{{
 					State:  blockchain.ThresholdStarted,
-					Choice: uint32(0xffffffff),
+					Choice: nil,
 				}},
 			}
 			chain.nextThresholdStateErr = errors.New("unable to fetch next threshold state")
@@ -7026,7 +7026,7 @@ func TestHandleGetVoteInfo(t *testing.T) {
 				Agendas: defaultChainParams.Deployments[v7],
 				AgendaStatus: []blockchain.ThresholdStateTuple{{
 					State:  blockchain.ThresholdStarted,
-					Choice: uint32(0xffffffff),
+					Choice: nil,
 				}},
 			}
 			chain.getVoteCountsErr = errors.New("unable to get vote counts")
@@ -7046,12 +7046,12 @@ func TestHandleGetVoteInfo(t *testing.T) {
 				Agendas: defaultChainParams.Deployments[v7],
 				AgendaStatus: []blockchain.ThresholdStateTuple{{
 					State:  blockchain.ThresholdDefined,
-					Choice: uint32(0xffffffff),
+					Choice: nil,
 				}},
 			}
 			chain.nextThresholdState = blockchain.ThresholdStateTuple{
 				State:  blockchain.ThresholdDefined,
-				Choice: uint32(0xffffffff),
+				Choice: nil,
 			}
 			return chain
 		}(),
@@ -7073,7 +7073,7 @@ func TestHandleGetVoteInfo(t *testing.T) {
 				Agendas: defaultChainParams.Deployments[v7],
 				AgendaStatus: []blockchain.ThresholdStateTuple{{
 					State:  blockchain.ThresholdStarted,
-					Choice: uint32(0xffffffff),
+					Choice: nil,
 				}},
 			}
 			return chain


### PR DESCRIPTION
~**This requires #3079**.~

This makes the zero value for a threshold state tuple act as the invalid state and choice instead of using magic sentinel values.

In practice, callers should be checking the error of any methods before using any other returned values, however, the code typically tries to adopt a defense in depth model where it makes sure unusable/invalid values are also returned in error cases to help make it obvious when a caller incorrectly uses the returned value without checking the error.

It accomplishes this by reording the threshold states so that the invalid state is 0 and converting the choice field to a pointer to the relevant choice as opposed to a choice index.  That way the zero value for the overall type is the invalid state and nil the choice, exactly as expected.

In addition to being more ergonomic and inline with typical Go code, it has a few additional benefits:

* Makes the type harder to misuse
* Simplifies identification of a specific resulting choice for votes that have multiple affirmative choices since the choice can be checked by its ID instead of a tightly coupled array index
* Provides an easy method to distinguish between a vote that failed due to a majority vote and one that failed due to expiring before a majority result was achieved

Closes #3078.