### PR TITLE
chaincfg: Introduce BLAKE3 PoW agenda.

### DIFF
--- a/blockchain/fullblocktests/params.go
+++ b/blockchain/fullblocktests/params.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2021 The Decred developers
+// Copyright (c) 2016-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -412,6 +412,34 @@ var regNetParams = &chaincfg.Params{
 					Id:          "yes",
 					Description: "change to the new consensus rules",
 					Bits:        0x0100, // Bit 8
+					IsAbstain:   false,
+					IsNo:        false,
+				}},
+			},
+			StartTime:  0,             // Always available for vote
+			ExpireTime: math.MaxInt64, // Never expires
+		}},
+		11: {{
+			Vote: chaincfg.Vote{
+				Id:          chaincfg.VoteIDBlake3Pow,
+				Description: "Change proof of work hashing algorithm to BLAKE3 as defined in in DCP0011",
+				Mask:        0x0006, // Bits 1 and 2
+				Choices: []chaincfg.Choice{{
+					Id:          "abstain",
+					Description: "abstain voting for change",
+					Bits:        0x0000,
+					IsAbstain:   true,
+					IsNo:        false,
+				}, {
+					Id:          "no",
+					Description: "keep the existing consensus rules",
+					Bits:        0x0002, // Bit 1
+					IsAbstain:   false,
+					IsNo:        true,
+				}, {
+					Id:          "yes",
+					Description: "change to the new consensus rules",
+					Bits:        0x0004, // Bit 2
 					IsAbstain:   false,
 					IsNo:        false,
 				}},

--- a/blockchain/go.mod
+++ b/blockchain/go.mod
@@ -21,3 +21,5 @@ require (
 	github.com/decred/dcrd/dcrec/edwards/v2 v2.0.2 // indirect
 	github.com/decred/slog v1.2.0 // indirect
 )
+
+replace github.com/decred/dcrd/chaincfg/v3 => ../chaincfg

--- a/blockchain/go.sum
+++ b/blockchain/go.sum
@@ -9,9 +9,6 @@ github.com/decred/base58 v1.0.3/go.mod h1:pXP9cXCfM2sFLb2viz2FNIdeMWmZDBKG3ZBYbi
 github.com/decred/dcrd/chaincfg/chainhash v1.0.2/go.mod h1:BpbrGgrPTr3YJYRN3Bm+D9NuaFd+zGyNeIKgrhCXK60=
 github.com/decred/dcrd/chaincfg/chainhash v1.0.3 h1:PF2czcYZGW3dz4i/35AUfVAgnqHl9TMNQt1ADTYGOoE=
 github.com/decred/dcrd/chaincfg/chainhash v1.0.3/go.mod h1:BpbrGgrPTr3YJYRN3Bm+D9NuaFd+zGyNeIKgrhCXK60=
-github.com/decred/dcrd/chaincfg/v3 v3.1.0/go.mod h1:4XF9nlx2NeGD4xzw1+L0DGICZMl0a5rKV8nnuHLgk8o=
-github.com/decred/dcrd/chaincfg/v3 v3.1.1 h1:Ki8kq5IXGmjriiQyPCrCTF1aZSBiORb91/Sr5xW4otw=
-github.com/decred/dcrd/chaincfg/v3 v3.1.1/go.mod h1:4XF9nlx2NeGD4xzw1+L0DGICZMl0a5rKV8nnuHLgk8o=
 github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
 github.com/decred/dcrd/crypto/ripemd160 v1.0.1 h1:TjRL4LfftzTjXzaufov96iDAkbY2R3aTvH2YMYa1IOc=

--- a/chaincfg/mainnetparams.go
+++ b/chaincfg/mainnetparams.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2016 The btcsuite developers
-// Copyright (c) 2015-2022 The Decred developers
+// Copyright (c) 2015-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -412,6 +412,34 @@ func MainNetParams() *Params {
 				},
 				StartTime:  1631750400, // Sep 16th, 2021
 				ExpireTime: 1694822400, // Sep 16th, 2023
+			}},
+			10: {{
+				Vote: Vote{
+					Id:          VoteIDBlake3Pow,
+					Description: "Change proof of work hashing algorithm to BLAKE3 as defined in in DCP0011",
+					Mask:        0x0006, // Bits 1 and 2
+					Choices: []Choice{{
+						Id:          "abstain",
+						Description: "abstain voting for change",
+						Bits:        0x0000,
+						IsAbstain:   true,
+						IsNo:        false,
+					}, {
+						Id:          "no",
+						Description: "keep the existing consensus rules",
+						Bits:        0x0002, // Bit 1
+						IsAbstain:   false,
+						IsNo:        true,
+					}, {
+						Id:          "yes",
+						Description: "change to the new consensus rules",
+						Bits:        0x0004, // Bit 2
+						IsAbstain:   false,
+						IsNo:        false,
+					}},
+				},
+				StartTime:  1682294400, // Apr 24th, 2023
+				ExpireTime: 1745452800, // Apr 24th, 2025
 			}},
 		},
 

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -164,6 +164,10 @@ const (
 	// block reward subsidy split to 10% PoW, 80% PoS, and 10% Treasury as
 	// defined in DCP0010.
 	VoteIDChangeSubsidySplit = "changesubsidysplit"
+
+	// VoteIDBlake3Pow is the vote ID for the agenda that changes the proof of
+	// work hashing algorithm to BLAKE3 as defined in DCP0011.
+	VoteIDBlake3Pow = "blake3pow"
 )
 
 // ConsensusDeployment defines details related to a specific consensus rule

--- a/chaincfg/regnetparams.go
+++ b/chaincfg/regnetparams.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2021 The Decred developers
+// Copyright (c) 2018-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -403,6 +403,34 @@ func RegNetParams() *Params {
 						Id:          "yes",
 						Description: "change to the new consensus rules",
 						Bits:        0x0100, // Bit 8
+						IsAbstain:   false,
+						IsNo:        false,
+					}},
+				},
+				StartTime:  0,             // Always available for vote
+				ExpireTime: math.MaxInt64, // Never expires
+			}},
+			11: {{
+				Vote: Vote{
+					Id:          VoteIDBlake3Pow,
+					Description: "Change proof of work hashing algorithm to BLAKE3 as defined in in DCP0011",
+					Mask:        0x0006, // Bits 1 and 2
+					Choices: []Choice{{
+						Id:          "abstain",
+						Description: "abstain voting for change",
+						Bits:        0x0000,
+						IsAbstain:   true,
+						IsNo:        false,
+					}, {
+						Id:          "no",
+						Description: "keep the existing consensus rules",
+						Bits:        0x0002, // Bit 1
+						IsAbstain:   false,
+						IsNo:        true,
+					}, {
+						Id:          "yes",
+						Description: "change to the new consensus rules",
+						Bits:        0x0004, // Bit 2
 						IsAbstain:   false,
 						IsNo:        false,
 					}},

--- a/chaincfg/simnetparams.go
+++ b/chaincfg/simnetparams.go
@@ -420,6 +420,35 @@ func SimNetParams() *Params {
 				StartTime:      0,             // Always available for vote
 				ExpireTime:     math.MaxInt64, // Never expires
 			}},
+			11: {{
+				Vote: Vote{
+					Id:          VoteIDBlake3Pow,
+					Description: "Change proof of work hashing algorithm to BLAKE3 as defined in in DCP0011",
+					Mask:        0x0006, // Bits 1 and 2
+					Choices: []Choice{{
+						Id:          "abstain",
+						Description: "abstain voting for change",
+						Bits:        0x0000,
+						IsAbstain:   true,
+						IsNo:        false,
+					}, {
+						Id:          "no",
+						Description: "keep the existing consensus rules",
+						Bits:        0x0002, // Bit 1
+						IsAbstain:   false,
+						IsNo:        true,
+					}, {
+						Id:          "yes",
+						Description: "change to the new consensus rules",
+						Bits:        0x0004, // Bit 2
+						IsAbstain:   false,
+						IsNo:        false,
+					}},
+				},
+				ForcedChoiceID: "yes",
+				StartTime:      0,             // Always available for vote
+				ExpireTime:     math.MaxInt64, // Never expires
+			}},
 		},
 
 		// Enforce current block version once majority of the network has

--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -388,6 +388,34 @@ func TestNet3Params() *Params {
 				StartTime:  1631750400, // Sep 16th, 2021
 				ExpireTime: 1694822400, // Sep 16th, 2023
 			}},
+			11: {{
+				Vote: Vote{
+					Id:          VoteIDBlake3Pow,
+					Description: "Change proof of work hashing algorithm to BLAKE3 as defined in in DCP0011",
+					Mask:        0x0006, // Bits 1 and 2
+					Choices: []Choice{{
+						Id:          "abstain",
+						Description: "abstain voting for change",
+						Bits:        0x0000,
+						IsAbstain:   true,
+						IsNo:        false,
+					}, {
+						Id:          "no",
+						Description: "keep the existing consensus rules",
+						Bits:        0x0002, // Bit 1
+						IsAbstain:   false,
+						IsNo:        true,
+					}, {
+						Id:          "yes",
+						Description: "change to the new consensus rules",
+						Bits:        0x0004, // Bit 2
+						IsAbstain:   false,
+						IsNo:        false,
+					}},
+				},
+				StartTime:  1682294400, // Apr 24th, 2023
+				ExpireTime: 1745452800, // Apr 24th, 2025
+			}},
 		},
 
 		// Enforce current block version once majority of the network has


### PR DESCRIPTION
This adds a new definition for the upcoming agenda vote to change the proof-of-work hashing function to BLAKE3 as defined in DCP0011.

It does not include any code to make decisions based on the status of the agenda or bump block versions.  It only adds the definition for the agenda.
