### PR TITLE
chaincfg: Introduce subsidy split change r2 agenda.

### DIFF
--- a/blockchain/fullblocktests/params.go
+++ b/blockchain/fullblocktests/params.go
@@ -446,6 +446,33 @@ var regNetParams = &chaincfg.Params{
 			},
 			StartTime:  0,             // Always available for vote
 			ExpireTime: math.MaxInt64, // Never expires
+		}, {
+			Vote: chaincfg.Vote{
+				Id:          chaincfg.VoteIDChangeSubsidySplitR2,
+				Description: "Change block reward subsidy split to 1/89/10 as defined in DCP0012",
+				Mask:        0x0060, // Bits 5 and 6
+				Choices: []chaincfg.Choice{{
+					Id:          "abstain",
+					Description: "abstain voting for change",
+					Bits:        0x0000,
+					IsAbstain:   true,
+					IsNo:        false,
+				}, {
+					Id:          "no",
+					Description: "keep the existing consensus rules",
+					Bits:        0x0020, // Bit 5
+					IsAbstain:   false,
+					IsNo:        true,
+				}, {
+					Id:          "yes",
+					Description: "change to the new consensus rules",
+					Bits:        0x0040, // Bit 6
+					IsAbstain:   false,
+					IsNo:        false,
+				}},
+			},
+			StartTime:  0,             // Always available for vote
+			ExpireTime: math.MaxInt64, // Never expires
 		}},
 	},
 

--- a/chaincfg/mainnetparams.go
+++ b/chaincfg/mainnetparams.go
@@ -440,6 +440,33 @@ func MainNetParams() *Params {
 				},
 				StartTime:  1682294400, // Apr 24th, 2023
 				ExpireTime: 1745452800, // Apr 24th, 2025
+			}, {
+				Vote: Vote{
+					Id:          VoteIDChangeSubsidySplitR2,
+					Description: "Change block reward subsidy split to 1/89/10 as defined in DCP0012",
+					Mask:        0x0060, // Bits 5 and 6
+					Choices: []Choice{{
+						Id:          "abstain",
+						Description: "abstain voting for change",
+						Bits:        0x0000,
+						IsAbstain:   true,
+						IsNo:        false,
+					}, {
+						Id:          "no",
+						Description: "keep the existing consensus rules",
+						Bits:        0x0020, // Bit 5
+						IsAbstain:   false,
+						IsNo:        true,
+					}, {
+						Id:          "yes",
+						Description: "change to the new consensus rules",
+						Bits:        0x0040, // Bit 6
+						IsAbstain:   false,
+						IsNo:        false,
+					}},
+				},
+				StartTime:  1682294400, // Apr 24th, 2023
+				ExpireTime: 1745452800, // Apr 24th, 2025
 			}},
 		},
 

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -168,6 +168,11 @@ const (
 	// VoteIDBlake3Pow is the vote ID for the agenda that changes the proof of
 	// work hashing algorithm to BLAKE3 as defined in DCP0011.
 	VoteIDBlake3Pow = "blake3pow"
+
+	// VoteIDChangeSubsidySplitR2 is the vote ID for the agenda that changes the
+	// block reward subsidy split to 1% PoW, 89% PoS, and 10% Treasury as
+	// defined in DCP0012.
+	VoteIDChangeSubsidySplitR2 = "changesubsidysplitr2"
 )
 
 // ConsensusDeployment defines details related to a specific consensus rule

--- a/chaincfg/regnetparams.go
+++ b/chaincfg/regnetparams.go
@@ -437,6 +437,33 @@ func RegNetParams() *Params {
 				},
 				StartTime:  0,             // Always available for vote
 				ExpireTime: math.MaxInt64, // Never expires
+			}, {
+				Vote: Vote{
+					Id:          VoteIDChangeSubsidySplitR2,
+					Description: "Change block reward subsidy split to 1/89/10 as defined in DCP0012",
+					Mask:        0x0060, // Bits 5 and 6
+					Choices: []Choice{{
+						Id:          "abstain",
+						Description: "abstain voting for change",
+						Bits:        0x0000,
+						IsAbstain:   true,
+						IsNo:        false,
+					}, {
+						Id:          "no",
+						Description: "keep the existing consensus rules",
+						Bits:        0x0020, // Bit 5
+						IsAbstain:   false,
+						IsNo:        true,
+					}, {
+						Id:          "yes",
+						Description: "change to the new consensus rules",
+						Bits:        0x0040, // Bit 6
+						IsAbstain:   false,
+						IsNo:        false,
+					}},
+				},
+				StartTime:  0,             // Always available for vote
+				ExpireTime: math.MaxInt64, // Never expires
 			}},
 		},
 

--- a/chaincfg/simnetparams.go
+++ b/chaincfg/simnetparams.go
@@ -448,6 +448,34 @@ func SimNetParams() *Params {
 				ForcedChoiceID: "yes",
 				StartTime:      0,             // Always available for vote
 				ExpireTime:     math.MaxInt64, // Never expires
+			}, {
+				Vote: Vote{
+					Id:          VoteIDChangeSubsidySplitR2,
+					Description: "Change block reward subsidy split to 1/89/10 as defined in DCP0012",
+					Mask:        0x0060, // Bits 5 and 6
+					Choices: []Choice{{
+						Id:          "abstain",
+						Description: "abstain voting for change",
+						Bits:        0x0000,
+						IsAbstain:   true,
+						IsNo:        false,
+					}, {
+						Id:          "no",
+						Description: "keep the existing consensus rules",
+						Bits:        0x0020, // Bit 5
+						IsAbstain:   false,
+						IsNo:        true,
+					}, {
+						Id:          "yes",
+						Description: "change to the new consensus rules",
+						Bits:        0x0040, // Bit 6
+						IsAbstain:   false,
+						IsNo:        false,
+					}},
+				},
+				ForcedChoiceID: "yes",
+				StartTime:      0,             // Always available for vote
+				ExpireTime:     math.MaxInt64, // Never expires
 			}},
 		},
 

--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -415,6 +415,33 @@ func TestNet3Params() *Params {
 				},
 				StartTime:  1682294400, // Apr 24th, 2023
 				ExpireTime: 1745452800, // Apr 24th, 2025
+			}, {
+				Vote: Vote{
+					Id:          VoteIDChangeSubsidySplitR2,
+					Description: "Change block reward subsidy split to 1/89/10 as defined in DCP0012",
+					Mask:        0x0060, // Bits 5 and 6
+					Choices: []Choice{{
+						Id:          "abstain",
+						Description: "abstain voting for change",
+						Bits:        0x0000,
+						IsAbstain:   true,
+						IsNo:        false,
+					}, {
+						Id:          "no",
+						Description: "keep the existing consensus rules",
+						Bits:        0x0020, // Bit 5
+						IsAbstain:   false,
+						IsNo:        true,
+					}, {
+						Id:          "yes",
+						Description: "change to the new consensus rules",
+						Bits:        0x0040, // Bit 6
+						IsAbstain:   false,
+						IsNo:        false,
+					}},
+				},
+				StartTime:  1682294400, // Apr 24th, 2023
+				ExpireTime: 1745452800, // Apr 24th, 2025
 			}},
 		},
 


### PR DESCRIPTION
**This requires #3089.**

This adds a new definition for the upcoming agenda vote to change the subsidy split to 1% PoW, 89% PoS, and 10% Treasury defined in DCP0012.

It does not include any code to make decisions based on the status of the agenda or bump block versions.  It only adds the definition for the agenda.