### PR TITLE
secp256k1: Prepare v4.1.1.

### DIFF
--- a/dcrec/secp256k1/ecdh.go
+++ b/dcrec/secp256k1/ecdh.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2015 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/dcrec/secp256k1/go.mod
+++ b/dcrec/secp256k1/go.mod
@@ -2,4 +2,4 @@ module github.com/decred/dcrd/dcrec/secp256k1/v4
 
 go 1.17
 
-require github.com/decred/dcrd/crypto/blake256 v1.0.0
+require github.com/decred/dcrd/crypto/blake256 v1.0.1

--- a/dcrec/secp256k1/go.sum
+++ b/dcrec/secp256k1/go.sum
@@ -1,2 +1,2 @@
-github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
-github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
+github.com/decred/dcrd/crypto/blake256 v1.0.1 h1:7PltbUIQB7u/FfZ39+DGa/ShuMyJ5ilcvdfma9wOH6Y=
+github.com/decred/dcrd/crypto/blake256 v1.0.1/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/decred/dcrd/chaincfg/v3 v3.1.1
 	github.com/decred/dcrd/connmgr/v3 v3.1.0
 	github.com/decred/dcrd/container/apbf v1.0.0
-	github.com/decred/dcrd/crypto/blake256 v1.0.0
+	github.com/decred/dcrd/crypto/blake256 v1.0.1
 	github.com/decred/dcrd/crypto/ripemd160 v1.0.1
 	github.com/decred/dcrd/database/v3 v3.0.0
 	github.com/decred/dcrd/dcrec v1.0.0


### PR DESCRIPTION
This updates the `secp256k1` module dependencies, the copyright year in the files modified since the previous release, and serves as a base for dcrec/secp256k1/v4.1.1.

The updated direct dependencies in this commit are as follows:

- github.com/decred/dcrd/crypto/blake256@v1.0.1

The full list of updated direct dependencies since the previous `dcrec/secp256k1/v4.1.0` release are the same as above.

Finally, all modules in the repository that depend on the module are tidied to ensure they are updated to use the latest versions hoisted forward as a result.