### PR TITLE
dcrjson: Prepare v4.0.1.

### DIFF
--- a/dcrjson/cmdparse.go
+++ b/dcrjson/cmdparse.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/dcrjson/error_test.go
+++ b/dcrjson/error_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/dcrjson/go.mod
+++ b/dcrjson/go.mod
@@ -2,6 +2,6 @@ module github.com/decred/dcrd/dcrjson/v4
 
 go 1.17
 
-require github.com/decred/dcrd/chaincfg/chainhash v1.0.3
+require github.com/decred/dcrd/chaincfg/chainhash v1.0.4
 
-require github.com/decred/dcrd/crypto/blake256 v1.0.0 // indirect
+require github.com/decred/dcrd/crypto/blake256 v1.0.1 // indirect

--- a/dcrjson/go.sum
+++ b/dcrjson/go.sum
@@ -1,4 +1,4 @@
-github.com/decred/dcrd/chaincfg/chainhash v1.0.3 h1:PF2czcYZGW3dz4i/35AUfVAgnqHl9TMNQt1ADTYGOoE=
-github.com/decred/dcrd/chaincfg/chainhash v1.0.3/go.mod h1:BpbrGgrPTr3YJYRN3Bm+D9NuaFd+zGyNeIKgrhCXK60=
-github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
-github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.4 h1:zRCv6tdncLfLTKYqu7hrXvs7hW+8FO/NvwoFvGsrluU=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.4/go.mod h1:hA86XxlBWwHivMvxzXTSD0ZCG/LoYsFdWnCekkTMCqY=
+github.com/decred/dcrd/crypto/blake256 v1.0.1 h1:7PltbUIQB7u/FfZ39+DGa/ShuMyJ5ilcvdfma9wOH6Y=
+github.com/decred/dcrd/crypto/blake256 v1.0.1/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=

--- a/dcrjson/help_test.go
+++ b/dcrjson/help_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/dcrjson/register_test.go
+++ b/dcrjson/register_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/decred/dcrd/blockchain/standalone/v2 v2.1.0
 	github.com/decred/dcrd/blockchain/v5 v5.0.0
 	github.com/decred/dcrd/certgen v1.1.1
-	github.com/decred/dcrd/chaincfg/chainhash v1.0.3
+	github.com/decred/dcrd/chaincfg/chainhash v1.0.4
 	github.com/decred/dcrd/chaincfg/v3 v3.1.1
 	github.com/decred/dcrd/connmgr/v3 v3.1.0
 	github.com/decred/dcrd/container/apbf v1.0.0


### PR DESCRIPTION
This updates the `dcrjson` module dependencies, the copyright year in the files modified since the previous release, and serves as a base for `dcrjson/v4.0.1`.

The updated direct dependencies in this commit are as follows:

- github.com/decred/dcrd/chaincfg/chainhash@v1.0.4

The updated indirect dependencies in this commit are as follows:

- github.com/decred/dcrd/crypto/blake256@v1.0.1

The full list of updated direct and indirect dependencies since the previous `dcrjson/v4.0.0` release are the same as above.

Finally, all modules in the repository that depend on the module are tidied to ensure they are updated to use the latest versions hoisted forward as a result.