### PR TITLE
rpc/jsonrpc/types: Prepare v4.0.0.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -175,7 +175,7 @@ The following versioned modules are provided by dcrd repository:
   a robust and easy to use Websocket-enabled Decred JSON-RPC client
 * [dcrjson/v4](https://github.com/decred/dcrd/tree/master/dcrjson) - Provides
   infrastructure for working with Decred JSON-RPC APIs
-* [rpc/jsonrpc/types/v3](https://github.com/decred/dcrd/tree/master/rpc/jsonrpc/types) -
+* [rpc/jsonrpc/types/v4](https://github.com/decred/dcrd/tree/master/rpc/jsonrpc/types) -
   Provides concrete types via dcrjson for the chain server JSON-RPC commands,
   return values, and notifications
 * [wire](https://github.com/decred/dcrd/tree/master/wire) - Implements the

--- a/docs/assets/module_hierarchy.gv
+++ b/docs/assets/module_hierarchy.gv
@@ -8,7 +8,7 @@ digraph {
 	bech32 [label="bech32" fillcolor=antiquewhite3]
 	chainhash [label="chaincfg/chainhash" fillcolor=aquamarine]
 	dcrjson [label="dcrjson/v4" fillcolor=indianred]
-	types [label="rpc/jsonrpc/types/v3" fillcolor=tomato]
+	types [label="rpc/jsonrpc/types/v4" fillcolor=tomato]
 	wire [label="wire" fillcolor=coral]
 	addrmgr [label="addrmgr/v2" fillcolor=lightsalmon]
 	chaincfg [label="chaincfg/v3" fillcolor=cadetblue]

--- a/docs/assets/module_hierarchy.svg
+++ b/docs/assets/module_hierarchy.svg
@@ -98,7 +98,7 @@
 <!-- types -->
 <g id="node7" class="node"><title>types</title>
 <path fill="tomato" stroke="black" d="M212.5,-468C212.5,-468 104.5,-468 104.5,-468 98.5,-468 92.5,-462 92.5,-456 92.5,-456 92.5,-444 92.5,-444 92.5,-438 98.5,-432 104.5,-432 104.5,-432 212.5,-432 212.5,-432 218.5,-432 224.5,-438 224.5,-444 224.5,-444 224.5,-456 224.5,-456 224.5,-462 218.5,-468 212.5,-468"/>
-<text text-anchor="middle" x="158.5" y="-446.3" font-family="Times New Roman,serif" font-size="14.00">rpc/jsonrpc/types/v3</text>
+<text text-anchor="middle" x="158.5" y="-446.3" font-family="Times New Roman,serif" font-size="14.00">rpc/jsonrpc/types/v4</text>
 </g>
 <!-- dcrjson&#45;&gt;types -->
 <g id="edge24" class="edge"><title>dcrjson&#45;&gt;types</title>

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/decred/dcrd/database/v3 v3.0.0
 	github.com/decred/dcrd/dcrec v1.0.0
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0
-	github.com/decred/dcrd/dcrjson/v4 v4.0.0
+	github.com/decred/dcrd/dcrjson/v4 v4.0.1
 	github.com/decred/dcrd/dcrutil/v4 v4.0.0
 	github.com/decred/dcrd/gcs/v4 v4.0.0
 	github.com/decred/dcrd/lru v1.1.1

--- a/rpc/jsonrpc/types/README.md
+++ b/rpc/jsonrpc/types/README.md
@@ -3,7 +3,7 @@ jsonrpc/types
 
 [![Build Status](https://github.com/decred/dcrd/workflows/Build%20and%20Test/badge.svg)](https://github.com/decred/dcrd/actions)
 [![ISC License](https://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![Doc](https://img.shields.io/badge/doc-reference-blue.svg)](https://pkg.go.dev/github.com/decred/dcrd/rpc/jsonrpc/types/v3)
+[![Doc](https://img.shields.io/badge/doc-reference-blue.svg)](https://pkg.go.dev/github.com/decred/dcrd/rpc/jsonrpc/types/v4)
 
 Package types implements concrete types for marshalling to and from the dcrd
 JSON-RPC commands, return values, and notifications.  A comprehensive suite of

--- a/rpc/jsonrpc/types/chainsvrwscmds.go
+++ b/rpc/jsonrpc/types/chainsvrwscmds.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2015 The btcsuite developers
-// Copyright (c) 2015-2021 The Decred developers
+// Copyright (c) 2015-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/rpc/jsonrpc/types/chainsvrwscmds_test.go
+++ b/rpc/jsonrpc/types/chainsvrwscmds_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015-2021 The Decred developers
+// Copyright (c) 2015-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/rpc/jsonrpc/types/chainsvrwsntfns.go
+++ b/rpc/jsonrpc/types/chainsvrwsntfns.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015-2021 The Decred developers
+// Copyright (c) 2015-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/rpc/jsonrpc/types/chainsvrwsntfns_test.go
+++ b/rpc/jsonrpc/types/chainsvrwsntfns_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015-2021 The Decred developers
+// Copyright (c) 2015-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/rpc/jsonrpc/types/go.mod
+++ b/rpc/jsonrpc/types/go.mod
@@ -2,9 +2,9 @@ module github.com/decred/dcrd/rpc/jsonrpc/types/v4
 
 go 1.17
 
-require github.com/decred/dcrd/dcrjson/v4 v4.0.0
+require github.com/decred/dcrd/dcrjson/v4 v4.0.1
 
 require (
-	github.com/decred/dcrd/chaincfg/chainhash v1.0.3 // indirect
-	github.com/decred/dcrd/crypto/blake256 v1.0.0 // indirect
+	github.com/decred/dcrd/chaincfg/chainhash v1.0.4 // indirect
+	github.com/decred/dcrd/crypto/blake256 v1.0.1 // indirect
 )

--- a/rpc/jsonrpc/types/go.sum
+++ b/rpc/jsonrpc/types/go.sum
@@ -1,6 +1,6 @@
-github.com/decred/dcrd/chaincfg/chainhash v1.0.3 h1:PF2czcYZGW3dz4i/35AUfVAgnqHl9TMNQt1ADTYGOoE=
-github.com/decred/dcrd/chaincfg/chainhash v1.0.3/go.mod h1:BpbrGgrPTr3YJYRN3Bm+D9NuaFd+zGyNeIKgrhCXK60=
-github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
-github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
-github.com/decred/dcrd/dcrjson/v4 v4.0.0 h1:KsaFhHAYO+vLYz7Qmx/fs1gOY5ouTEz8hRuDm8jmJtU=
-github.com/decred/dcrd/dcrjson/v4 v4.0.0/go.mod h1:DMnSpU8lsVh+Nt5kHl63tkrjBDA7UIs4+ov8Kwwgvjs=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.4 h1:zRCv6tdncLfLTKYqu7hrXvs7hW+8FO/NvwoFvGsrluU=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.4/go.mod h1:hA86XxlBWwHivMvxzXTSD0ZCG/LoYsFdWnCekkTMCqY=
+github.com/decred/dcrd/crypto/blake256 v1.0.1 h1:7PltbUIQB7u/FfZ39+DGa/ShuMyJ5ilcvdfma9wOH6Y=
+github.com/decred/dcrd/crypto/blake256 v1.0.1/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
+github.com/decred/dcrd/dcrjson/v4 v4.0.1 h1:vyQuB1miwGqbCVNm8P6br3V65WQ6wyrh0LycMkvaBBg=
+github.com/decred/dcrd/dcrjson/v4 v4.0.1/go.mod h1:2qVikafVF9/X3PngQVmqkbUbyAl32uik0k/kydgtqMc=

--- a/rpcclient/go.mod
+++ b/rpcclient/go.mod
@@ -3,8 +3,8 @@ module github.com/decred/dcrd/rpcclient/v8
 go 1.17
 
 require (
-	github.com/decred/dcrd/chaincfg/chainhash v1.0.3
-	github.com/decred/dcrd/dcrjson/v4 v4.0.0
+	github.com/decred/dcrd/chaincfg/chainhash v1.0.4
+	github.com/decred/dcrd/dcrjson/v4 v4.0.1
 	github.com/decred/dcrd/dcrutil/v4 v4.0.0
 	github.com/decred/dcrd/gcs/v4 v4.0.0
 	github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.0.0
@@ -21,7 +21,7 @@ require (
 	github.com/decred/base58 v1.0.3 // indirect
 	github.com/decred/dcrd/blockchain/stake/v5 v5.0.0 // indirect
 	github.com/decred/dcrd/chaincfg/v3 v3.1.0 // indirect
-	github.com/decred/dcrd/crypto/blake256 v1.0.0 // indirect
+	github.com/decred/dcrd/crypto/blake256 v1.0.1 // indirect
 	github.com/decred/dcrd/crypto/ripemd160 v1.0.1 // indirect
 	github.com/decred/dcrd/database/v3 v3.0.0 // indirect
 	github.com/decred/dcrd/dcrec v1.0.0 // indirect

--- a/rpcclient/go.sum
+++ b/rpcclient/go.sum
@@ -7,12 +7,14 @@ github.com/dchest/siphash v1.2.2/go.mod h1:q+IRvb2gOSrUnYoPqHiyHXS0FOBBOdl6tONBl
 github.com/decred/base58 v1.0.3 h1:KGZuh8d1WEMIrK0leQRM47W85KqCAdl2N+uagbctdDI=
 github.com/decred/base58 v1.0.3/go.mod h1:pXP9cXCfM2sFLb2viz2FNIdeMWmZDBKG3ZBYbiSM78E=
 github.com/decred/dcrd/chaincfg/chainhash v1.0.2/go.mod h1:BpbrGgrPTr3YJYRN3Bm+D9NuaFd+zGyNeIKgrhCXK60=
-github.com/decred/dcrd/chaincfg/chainhash v1.0.3 h1:PF2czcYZGW3dz4i/35AUfVAgnqHl9TMNQt1ADTYGOoE=
 github.com/decred/dcrd/chaincfg/chainhash v1.0.3/go.mod h1:BpbrGgrPTr3YJYRN3Bm+D9NuaFd+zGyNeIKgrhCXK60=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.4 h1:zRCv6tdncLfLTKYqu7hrXvs7hW+8FO/NvwoFvGsrluU=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.4/go.mod h1:hA86XxlBWwHivMvxzXTSD0ZCG/LoYsFdWnCekkTMCqY=
 github.com/decred/dcrd/chaincfg/v3 v3.1.0 h1:u8l+E6ryv8E0WY69pM/lUI36UeAVcLKBwD/Q3xPiuog=
 github.com/decred/dcrd/chaincfg/v3 v3.1.0/go.mod h1:4XF9nlx2NeGD4xzw1+L0DGICZMl0a5rKV8nnuHLgk8o=
-github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
+github.com/decred/dcrd/crypto/blake256 v1.0.1 h1:7PltbUIQB7u/FfZ39+DGa/ShuMyJ5ilcvdfma9wOH6Y=
+github.com/decred/dcrd/crypto/blake256 v1.0.1/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
 github.com/decred/dcrd/crypto/ripemd160 v1.0.1 h1:TjRL4LfftzTjXzaufov96iDAkbY2R3aTvH2YMYa1IOc=
 github.com/decred/dcrd/crypto/ripemd160 v1.0.1/go.mod h1:F0H8cjIuWTRoixr/LM3REB8obcWkmYx0gbxpQWR8RPg=
 github.com/decred/dcrd/database/v3 v3.0.0 h1:7VVN2sWjKB934jvXzjnyGJFUVH9d8Qh5VULi+NMRjek=
@@ -23,8 +25,8 @@ github.com/decred/dcrd/dcrec/edwards/v2 v2.0.2 h1:bX7rtGTMBDJxujZ29GNqtn7YCAdINj
 github.com/decred/dcrd/dcrec/edwards/v2 v2.0.2/go.mod h1:d0H8xGMWbiIQP7gN3v2rByWUcuZPm9YsgmnfoxgbINc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 h1:YLtO71vCjJRCBcrPMtQ9nqBsqpA1m5sE92cU+pd5Mcc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeCxkaw7y45JueMRL4DIyJDKs=
-github.com/decred/dcrd/dcrjson/v4 v4.0.0 h1:KsaFhHAYO+vLYz7Qmx/fs1gOY5ouTEz8hRuDm8jmJtU=
-github.com/decred/dcrd/dcrjson/v4 v4.0.0/go.mod h1:DMnSpU8lsVh+Nt5kHl63tkrjBDA7UIs4+ov8Kwwgvjs=
+github.com/decred/dcrd/dcrjson/v4 v4.0.1 h1:vyQuB1miwGqbCVNm8P6br3V65WQ6wyrh0LycMkvaBBg=
+github.com/decred/dcrd/dcrjson/v4 v4.0.1/go.mod h1:2qVikafVF9/X3PngQVmqkbUbyAl32uik0k/kydgtqMc=
 github.com/decred/dcrd/dcrutil/v4 v4.0.0 h1:AY00fWy/ETrMHN0DNV3XUbH1aip2RG1AoTy5dp0+sJE=
 github.com/decred/dcrd/dcrutil/v4 v4.0.0/go.mod h1:QQpX5WVH3/ixVtiW15xZMe+neugXX3l2bsrYgq6nz4M=
 github.com/decred/dcrd/txscript/v4 v4.0.0 h1:BwaBUCMCmg58MCYoBhxVjL8ZZKUIfoJuxu/djmh8h58=


### PR DESCRIPTION
This updates the `rpc/jsonrpc/types` module dependencies, the copyright year in the files modified since the previous release, and serves as a base for `rpc/jsonrpc/types/v4.0.0`.

The following are also updated to reflect the new module version:

- The `rpc/jsonrpc/types/README.md` file
- The `docs/README.md` file
- The module hierarchy graphviz
- The module hierarchy diagram

The updated direct dependencies in this commit are as follows:

- github.com/decred/dcrd/dcrjson/v4@v4.0.1

The updated indirect dependencies in this commit are as follows:

- github.com/decred/dcrd/chaincfg/chainhash@v1.0.4
- github.com/decred/dcrd/crypto/blake256@v1.0.1

The full list of updated direct and indirect dependencies since the previous `rpc/jsonrpc/types/v3.0.0` release are the same as above.

Finally, all modules in the repository are tidied to ensure they are updated to use the latest versions hoisted forward as a result.