### PR TITLE
blockchain: Remove several unused error returns.

### DIFF
--- a/internal/blockchain/chain.go
+++ b/internal/blockchain/chain.go
@@ -614,10 +614,7 @@ func (b *BlockChain) connectBlock(node *blockNode, block, parent *dcrutil.Block,
 	}
 
 	// Calculate the next stake difficulty.
-	nextStakeDiff, err := b.calcNextRequiredStakeDifficulty(node)
-	if err != nil {
-		return err
-	}
+	nextStakeDiff := b.calcNextRequiredStakeDifficulty(node)
 
 	// Determine the individual commitment hashes that comprise the leaves of
 	// the header commitment merkle tree depending on the active agendas.  These
@@ -760,12 +757,8 @@ func (b *BlockChain) connectBlock(node *blockNode, block, parent *dcrutil.Block,
 
 	// Send stake notifications about the new block.
 	if node.height >= b.chainParams.StakeEnabledHeight {
-		nextStakeDiff, err := b.calcNextRequiredStakeDifficulty(node)
-		if err != nil {
-			return err
-		}
-
 		// Notify of new tickets.
+		nextStakeDiff := b.calcNextRequiredStakeDifficulty(node)
 		b.sendNotification(NTNewTickets,
 			&TicketNotificationsData{
 				Hash:            node.hash,

--- a/internal/blockchain/chain.go
+++ b/internal/blockchain/chain.go
@@ -1623,16 +1623,13 @@ func (b *BlockChain) maxBlockSize(prevNode *blockNode) (int64, error) {
 	// NOTE: The choice field of the return threshold state is not examined
 	// here because there is only one possible choice that can be active
 	// for the agenda, which is yes, so there is no need to check it.
-	maxSize := int64(b.chainParams.MaximumBlockSizes[0])
-	state, err := b.deploymentState(prevNode, &deployment)
-	if err != nil {
-		return maxSize, err
-	}
+	state := b.deploymentState(prevNode, &deployment)
 	if state.State == ThresholdActive {
 		return int64(b.chainParams.MaximumBlockSizes[1]), nil
 	}
 
 	// The max block size is not changed in any other cases.
+	maxSize := int64(b.chainParams.MaximumBlockSizes[0])
 	return maxSize, nil
 }
 

--- a/internal/blockchain/chain.go
+++ b/internal/blockchain/chain.go
@@ -1607,14 +1607,14 @@ func (b *BlockChain) BestSnapshot() *BestState {
 // AFTER the given node.
 //
 // This function MUST be called with the chain state lock held (for reads).
-func (b *BlockChain) maxBlockSize(prevNode *blockNode) (int64, error) {
+func (b *BlockChain) maxBlockSize(prevNode *blockNode) int64 {
 	// Determine the correct deployment details for the block size consensus
 	// vote or treat it as inactive when voting is not enabled for the current
 	// network.
 	const deploymentID = chaincfg.VoteIDMaxBlockSize
 	deployment, ok := b.deploymentData[deploymentID]
 	if !ok {
-		return int64(b.chainParams.MaximumBlockSizes[0]), nil
+		return int64(b.chainParams.MaximumBlockSizes[0])
 	}
 
 	// Return the larger block size if the stake vote for the max block size
@@ -1625,12 +1625,12 @@ func (b *BlockChain) maxBlockSize(prevNode *blockNode) (int64, error) {
 	// for the agenda, which is yes, so there is no need to check it.
 	state := b.deploymentState(prevNode, &deployment)
 	if state.State == ThresholdActive {
-		return int64(b.chainParams.MaximumBlockSizes[1]), nil
+		return int64(b.chainParams.MaximumBlockSizes[1])
 	}
 
 	// The max block size is not changed in any other cases.
 	maxSize := int64(b.chainParams.MaximumBlockSizes[0])
-	return maxSize, nil
+	return maxSize
 }
 
 // MaxBlockSize returns the maximum permitted block size for the block AFTER
@@ -1644,9 +1644,9 @@ func (b *BlockChain) MaxBlockSize(hash *chainhash.Hash) (int64, error) {
 	}
 
 	b.chainLock.Lock()
-	maxSize, err := b.maxBlockSize(node)
+	maxSize := b.maxBlockSize(node)
 	b.chainLock.Unlock()
-	return maxSize, err
+	return maxSize, nil
 }
 
 // HeaderByHash returns the block header identified by the given hash or an

--- a/internal/blockchain/chainio.go
+++ b/internal/blockchain/chainio.go
@@ -1720,10 +1720,7 @@ func (b *BlockChain) initChainState(ctx context.Context,
 		numTxns := uint64(len(block.Transactions))
 
 		// Calculate the next stake difficulty.
-		nextStakeDiff, err := b.calcNextRequiredStakeDifficulty(tip)
-		if err != nil {
-			return err
-		}
+		nextStakeDiff := b.calcNextRequiredStakeDifficulty(tip)
 
 		// Attempt to discover and set the old fork rejection checkpoint node.
 		b.maybeSetForkRejectionCheckpoint()

--- a/internal/blockchain/difficulty.go
+++ b/internal/blockchain/difficulty.go
@@ -690,14 +690,14 @@ func (b *BlockChain) calcNextRequiredStakeDifficultyV2(curNode *blockNode) int64
 // difficulty retarget rules.
 //
 // This function MUST be called with the chain state lock held (for writes).
-func (b *BlockChain) calcNextRequiredStakeDifficulty(curNode *blockNode) (int64, error) {
+func (b *BlockChain) calcNextRequiredStakeDifficulty(curNode *blockNode) int64 {
 	// Determine the correct deployment details for the new stake difficulty
 	// algorithm consensus vote or treat it as active when voting is not enabled
 	// for the current network.
 	const deploymentID = chaincfg.VoteIDSDiffAlgorithm
 	deployment, ok := b.deploymentData[deploymentID]
 	if !ok {
-		return b.calcNextRequiredStakeDifficultyV2(curNode), nil
+		return b.calcNextRequiredStakeDifficultyV2(curNode)
 	}
 
 	// Use the new stake difficulty algorithm if the stake vote for the new
@@ -708,11 +708,11 @@ func (b *BlockChain) calcNextRequiredStakeDifficulty(curNode *blockNode) (int64,
 	// for the agenda, which is yes, so there is no need to check it.
 	state := b.deploymentState(curNode, &deployment)
 	if state.State == ThresholdActive {
-		return b.calcNextRequiredStakeDifficultyV2(curNode), nil
+		return b.calcNextRequiredStakeDifficultyV2(curNode)
 	}
 
 	// Use the old stake difficulty algorithm in any other case.
-	return b.calcNextRequiredStakeDifficultyV1(curNode), nil
+	return b.calcNextRequiredStakeDifficultyV1(curNode)
 }
 
 // CalcNextRequiredStakeDifficulty calculates the required stake difficulty for
@@ -727,9 +727,9 @@ func (b *BlockChain) CalcNextRequiredStakeDifficulty(hash *chainhash.Hash) (int6
 	}
 
 	b.chainLock.Lock()
-	nextDiff, err := b.calcNextRequiredStakeDifficulty(node)
+	nextDiff := b.calcNextRequiredStakeDifficulty(node)
 	b.chainLock.Unlock()
-	return nextDiff, err
+	return nextDiff, nil
 }
 
 // estimateNextStakeDifficultyV1 estimates the next stake difficulty by

--- a/internal/blockchain/difficulty.go
+++ b/internal/blockchain/difficulty.go
@@ -262,7 +262,7 @@ func mergeDifficulty(oldDiff int64, newDiff1 int64, newDiff2 int64) int64 {
 // launch.
 //
 // This function MUST be called with the chain state lock held (for writes).
-func (b *BlockChain) calcNextRequiredStakeDifficultyV1(curNode *blockNode) (int64, error) {
+func (b *BlockChain) calcNextRequiredStakeDifficultyV1(curNode *blockNode) int64 {
 	alpha := b.chainParams.StakeDiffAlpha
 	stakeDiffStartHeight := int64(b.chainParams.CoinbaseMaturity) +
 		1
@@ -283,14 +283,14 @@ func (b *BlockChain) calcNextRequiredStakeDifficultyV1(curNode *blockNode) (int6
 	// parameters.
 	if curNode == nil ||
 		curNode.height < stakeDiffStartHeight {
-		return b.chainParams.MinimumStakeDiff, nil
+		return b.chainParams.MinimumStakeDiff
 	}
 
 	// Get the old difficulty; if we aren't at a block height where it changes,
 	// just return this.
 	oldDiff := curNode.sbits
 	if (curNode.height+1)%b.chainParams.StakeDiffWindowSize != 0 {
-		return oldDiff, nil
+		return oldDiff
 	}
 
 	// The target size of the ticketPool in live tickets. Recast these as int64
@@ -378,7 +378,7 @@ func (b *BlockChain) calcNextRequiredStakeDifficultyV1(curNode *blockNode) (int6
 	// if we are, return the maximum or minimum except in the case that oldDiff
 	// is zero.
 	if oldDiff == 0 { // This should never really happen, but in case it does...
-		return nextDiffTicketPool, nil
+		return nextDiffTicketPool
 	} else if nextDiffTicketPool == 0 {
 		nextDiffTicketPool = oldDiff / maxRetarget
 	} else if (nextDiffTicketPool / oldDiff) > (maxRetarget - 1) {
@@ -465,7 +465,7 @@ func (b *BlockChain) calcNextRequiredStakeDifficultyV1(curNode *blockNode) (int6
 	// if we are, return the maximum or minimum except in the case that oldDiff
 	// is zero.
 	if oldDiff == 0 { // This should never really happen, but in case it does...
-		return nextDiffFreshStake, nil
+		return nextDiffFreshStake
 	} else if nextDiffFreshStake == 0 {
 		nextDiffFreshStake = oldDiff / maxRetarget
 	} else if (nextDiffFreshStake / oldDiff) > (maxRetarget - 1) {
@@ -481,7 +481,7 @@ func (b *BlockChain) calcNextRequiredStakeDifficultyV1(curNode *blockNode) (int6
 	// if we are, return the maximum or minimum except in the case that oldDiff
 	// is zero.
 	if oldDiff == 0 { // This should never really happen, but in case it does...
-		return oldDiff, nil
+		return oldDiff
 	} else if nextDiff == 0 {
 		nextDiff = oldDiff / maxRetarget
 	} else if (nextDiff / oldDiff) > (maxRetarget - 1) {
@@ -493,10 +493,10 @@ func (b *BlockChain) calcNextRequiredStakeDifficultyV1(curNode *blockNode) (int6
 	// If the next diff is below the network minimum, set the required stake
 	// difficulty to the minimum.
 	if nextDiff < b.chainParams.MinimumStakeDiff {
-		return b.chainParams.MinimumStakeDiff, nil
+		return b.chainParams.MinimumStakeDiff
 	}
 
-	return nextDiff, nil
+	return nextDiff
 }
 
 // estimateSupply returns an estimate of the coin supply for the provided block
@@ -712,7 +712,7 @@ func (b *BlockChain) calcNextRequiredStakeDifficulty(curNode *blockNode) (int64,
 	}
 
 	// Use the old stake difficulty algorithm in any other case.
-	return b.calcNextRequiredStakeDifficultyV1(curNode)
+	return b.calcNextRequiredStakeDifficultyV1(curNode), nil
 }
 
 // CalcNextRequiredStakeDifficulty calculates the required stake difficulty for

--- a/internal/blockchain/difficulty.go
+++ b/internal/blockchain/difficulty.go
@@ -706,10 +706,7 @@ func (b *BlockChain) calcNextRequiredStakeDifficulty(curNode *blockNode) (int64,
 	// NOTE: The choice field of the return threshold state is not examined
 	// here because there is only one possible choice that can be active
 	// for the agenda, which is yes, so there is no need to check it.
-	state, err := b.deploymentState(curNode, &deployment)
-	if err != nil {
-		return 0, err
-	}
+	state := b.deploymentState(curNode, &deployment)
 	if state.State == ThresholdActive {
 		return b.calcNextRequiredStakeDifficultyV2(curNode), nil
 	}
@@ -1196,10 +1193,7 @@ func (b *BlockChain) estimateNextStakeDifficulty(curNode *blockNode, newTickets 
 	// NOTE: The choice field of the return threshold state is not examined
 	// here because there is only one possible choice that can be active
 	// for the agenda, which is yes, so there is no need to check it.
-	state, err := b.deploymentState(curNode, &deployment)
-	if err != nil {
-		return 0, err
-	}
+	state := b.deploymentState(curNode, &deployment)
 	if state.State == ThresholdActive {
 		return b.estimateNextStakeDifficultyV2(curNode, newTickets,
 			useMaxTickets)

--- a/internal/blockchain/thresholdstate.go
+++ b/internal/blockchain/thresholdstate.go
@@ -400,12 +400,12 @@ func (b *BlockChain) nextThresholdState(prevNode *blockNode, deployment *deploym
 // AFTER the passed node.
 //
 // This function MUST be called with the chain state lock held (for writes).
-func (b *BlockChain) deploymentState(prevNode *blockNode, deployment *deploymentInfo) (ThresholdStateTuple, error) {
+func (b *BlockChain) deploymentState(prevNode *blockNode, deployment *deploymentInfo) ThresholdStateTuple {
 	if deployment.forcedState != nil {
-		return *deployment.forcedState, nil
+		return *deployment.forcedState
 	}
 
-	return b.nextThresholdState(prevNode, deployment), nil
+	return b.nextThresholdState(prevNode, deployment)
 }
 
 // stateLastChanged returns the node at which the provided consensus deployment
@@ -506,9 +506,9 @@ func (b *BlockChain) NextThresholdState(hash *chainhash.Hash, deploymentID strin
 	}
 
 	b.chainLock.Lock()
-	state, err := b.deploymentState(node, &deployment)
+	state := b.deploymentState(node, &deployment)
 	b.chainLock.Unlock()
-	return state, err
+	return state, nil
 }
 
 // isLNFeaturesAgendaActive returns whether or not the LN features agenda vote,
@@ -531,14 +531,10 @@ func (b *BlockChain) isLNFeaturesAgendaActive(prevNode *blockNode) (bool, error)
 		return false, contextError(ErrUnknownDeploymentID, str)
 	}
 
-	state, err := b.deploymentState(prevNode, &deployment)
-	if err != nil {
-		return false, err
-	}
-
 	// NOTE: The choice field of the return threshold state is not examined
 	// here because there is only one possible choice that can be active for
 	// the agenda, which is yes, so there is no need to check it.
+	state := b.deploymentState(prevNode, &deployment)
 	return state.State == ThresholdActive, nil
 }
 
@@ -579,14 +575,10 @@ func (b *BlockChain) isHeaderCommitmentsAgendaActive(prevNode *blockNode) (bool,
 		return false, contextError(ErrUnknownDeploymentID, str)
 	}
 
-	state, err := b.deploymentState(prevNode, &deployment)
-	if err != nil {
-		return false, err
-	}
-
 	// NOTE: The choice field of the return threshold state is not examined
 	// here because there is only one possible choice that can be active for
 	// the agenda, which is yes, so there is no need to check it.
+	state := b.deploymentState(prevNode, &deployment)
 	return state.State == ThresholdActive, nil
 }
 
@@ -632,14 +624,10 @@ func (b *BlockChain) isTreasuryAgendaActive(prevNode *blockNode) (bool, error) {
 		return false, contextError(ErrUnknownDeploymentID, str)
 	}
 
-	state, err := b.deploymentState(prevNode, &deployment)
-	if err != nil {
-		return false, err
-	}
-
 	// NOTE: The choice field of the return threshold state is not examined
 	// here because there is only one possible choice that can be active for
 	// the agenda, which is yes, so there is no need to check it.
+	state := b.deploymentState(prevNode, &deployment)
 	return state.State == ThresholdActive, nil
 }
 
@@ -685,14 +673,10 @@ func (b *BlockChain) isRevertTreasuryPolicyActive(prevNode *blockNode) (bool, er
 		return false, contextError(ErrUnknownDeploymentID, str)
 	}
 
-	state, err := b.deploymentState(prevNode, &deployment)
-	if err != nil {
-		return false, err
-	}
-
 	// NOTE: The choice field of the return threshold state is not examined
 	// here because there is only one possible choice that can be active for
 	// the agenda, which is yes, so there is no need to check it.
+	state := b.deploymentState(prevNode, &deployment)
 	return state.State == ThresholdActive, nil
 }
 
@@ -733,14 +717,10 @@ func (b *BlockChain) isExplicitVerUpgradesAgendaActive(prevNode *blockNode) (boo
 		return false, contextError(ErrUnknownDeploymentID, str)
 	}
 
-	state, err := b.deploymentState(prevNode, &deployment)
-	if err != nil {
-		return false, err
-	}
-
 	// NOTE: The choice field of the return threshold state is not examined
 	// here because there is only one possible choice that can be active for
 	// the agenda, which is yes, so there is no need to check it.
+	state := b.deploymentState(prevNode, &deployment)
 	return state.State == ThresholdActive, nil
 }
 
@@ -786,14 +766,10 @@ func (b *BlockChain) isAutoRevocationsAgendaActive(prevNode *blockNode) (bool, e
 		return false, contextError(ErrUnknownDeploymentID, str)
 	}
 
-	state, err := b.deploymentState(prevNode, &deployment)
-	if err != nil {
-		return false, err
-	}
-
 	// NOTE: The choice field of the return threshold state is not examined
 	// here because there is only one possible choice that can be active for
 	// the agenda, which is yes, so there is no need to check it.
+	state := b.deploymentState(prevNode, &deployment)
 	return state.State == ThresholdActive, nil
 }
 
@@ -839,14 +815,10 @@ func (b *BlockChain) isSubsidySplitAgendaActive(prevNode *blockNode) (bool, erro
 		return false, contextError(ErrUnknownDeploymentID, str)
 	}
 
-	state, err := b.deploymentState(prevNode, &deployment)
-	if err != nil {
-		return false, err
-	}
-
 	// NOTE: The choice field of the return threshold state is not examined
 	// here because there is only one possible choice that can be active for
 	// the agenda, which is yes, so there is no need to check it.
+	state := b.deploymentState(prevNode, &deployment)
 	return state.State == ThresholdActive, nil
 }
 
@@ -892,14 +864,10 @@ func (b *BlockChain) isSubsidySplitR2AgendaActive(prevNode *blockNode) (bool, er
 		return false, contextError(ErrUnknownDeploymentID, str)
 	}
 
-	state, err := b.deploymentState(prevNode, &deployment)
-	if err != nil {
-		return false, err
-	}
-
 	// NOTE: The choice field of the return threshold state is not examined
 	// here because there is only one possible choice that can be active for
 	// the agenda, which is yes, so there is no need to check it.
+	state := b.deploymentState(prevNode, &deployment)
 	return state.State == ThresholdActive, nil
 }
 

--- a/internal/blockchain/validate.go
+++ b/internal/blockchain/validate.go
@@ -1934,10 +1934,7 @@ func (b *BlockChain) checkBlockContext(block *dcrutil.Block, prevNode *blockNode
 		// A block must not exceed the maximum allowed size as defined by the
 		// network parameters and the current status of any hard fork votes to
 		// change it when serialized.
-		maxBlockSize, err := b.maxBlockSize(prevNode)
-		if err != nil {
-			return err
-		}
+		maxBlockSize := b.maxBlockSize(prevNode)
 		serializedSize := int64(block.MsgBlock().Header.Size)
 		if serializedSize > maxBlockSize {
 			str := fmt.Sprintf("serialized block is too big - got %d, max %d",

--- a/internal/blockchain/validate.go
+++ b/internal/blockchain/validate.go
@@ -1229,10 +1229,7 @@ func (b *BlockChain) checkBlockHeaderContext(header *wire.BlockHeader, prevNode 
 		// Ensure the stake difficulty specified in the block header
 		// matches the calculated difficulty based on the previous block
 		// and difficulty retarget rules.
-		expSDiff, err := b.calcNextRequiredStakeDifficulty(prevNode)
-		if err != nil {
-			return err
-		}
+		expSDiff := b.calcNextRequiredStakeDifficulty(prevNode)
 		if header.SBits != expSDiff {
 			errStr := fmt.Sprintf("block stake difficulty of %d "+
 				"is not the expected value of %d", header.SBits,


### PR DESCRIPTION
This consists of a series of commits to remove unused error returns from several internal `blockchain` methods one at a time for ease of review.

The error return is removed from the following methods:

- `blockchain.nextThresholdState `
- `blockchain.stateLastChanged`
- `blockchain.deploymentState`
- `blockchain.maxBlockSize`
- `blockchain.calcNextRequiredStakeDifficultyV1`
- `calcNextRequiredStakeDifficulty`