### PR TITLE
blockchain: Correct total subsidy snapshot.

### DIFF
--- a/internal/blockchain/chain.go
+++ b/internal/blockchain/chain.go
@@ -414,7 +414,7 @@ func (b *BlockChain) ChainWork(hash *chainhash.Hash) (uint256.Uint256, error) {
 // parent of the current tip.
 //
 // The function is safe for concurrent access.
-func (b *BlockChain) TipGeneration() ([]chainhash.Hash, error) {
+func (b *BlockChain) TipGeneration() []chainhash.Hash {
 	var nodeHashes []chainhash.Hash
 	b.chainLock.Lock()
 	b.index.RLock()
@@ -428,7 +428,7 @@ func (b *BlockChain) TipGeneration() ([]chainhash.Hash, error) {
 	}
 	b.index.RUnlock()
 	b.chainLock.Unlock()
-	return nodeHashes, nil
+	return nodeHashes
 }
 
 // addRecentBlock adds a block to the recent block LRU cache and evicts the

--- a/internal/blockchain/chainio.go
+++ b/internal/blockchain/chainio.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2015-2016 The btcsuite developers
-// Copyright (c) 2016-2022 The Decred developers
+// Copyright (c) 2016-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -26,7 +26,7 @@ import (
 
 const (
 	// currentDatabaseVersion indicates the current database version.
-	currentDatabaseVersion = 13
+	currentDatabaseVersion = 14
 
 	// currentBlockIndexVersion indicates the current block index database
 	// version.

--- a/internal/blockchain/subsidy.go
+++ b/internal/blockchain/subsidy.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015-2022 The Decred developers
+// Copyright (c) 2015-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -183,8 +183,8 @@ func calculateAddedSubsidy(block, parent *dcrutil.Block) int64 {
 		subsidy += parent.MsgBlock().Transactions[0].TxIn[0].ValueIn
 	}
 
-	for _, stx := range block.MsgBlock().STransactions {
-		if stake.IsSSGen(stx) {
+	for txIdx, stx := range block.MsgBlock().STransactions {
+		if (txIdx == 0 && stake.IsTreasuryBase(stx)) || stake.IsSSGen(stx) {
 			subsidy += stx.TxIn[0].ValueIn
 		}
 	}

--- a/internal/mining/bgblktmplgenerator.go
+++ b/internal/mining/bgblktmplgenerator.go
@@ -1240,8 +1240,8 @@ func (g *BgBlkTmplGenerator) handleRegenEvent(ctx context.Context, state *regenH
 // descending order.
 func (g *BgBlkTmplGenerator) tipSiblingsSortedByVotes(state *regenHandlerState) []*blockWithNumVotes {
 	// Obtain all of the current blocks that extend the same parent as the
-	// current tip.  The error is ignored here because it is deprecated.
-	generation, _ := g.tg.cfg.TipGeneration()
+	// current tip.
+	generation := g.tg.cfg.TipGeneration()
 
 	// Nothing else to consider if there is only a single block which will be
 	// the current tip itself.

--- a/internal/mining/error.go
+++ b/internal/mining/error.go
@@ -15,10 +15,6 @@ const (
 	// build a block on top of HEAD.
 	ErrNotEnoughVoters = ErrorKind("ErrNotEnoughVoters")
 
-	// ErrFailedToGetGeneration specifies that the current generation for
-	// a block could not be obtained from blockchain.
-	ErrFailedToGetGeneration = ErrorKind("ErrFailedToGetGeneration")
-
 	// ErrGetTopBlock indicates that the current top block of the
 	// blockchain could not be obtained.
 	ErrGetTopBlock = ErrorKind("ErrGetTopBlock")

--- a/internal/mining/error_test.go
+++ b/internal/mining/error_test.go
@@ -17,7 +17,6 @@ func TestErrorKindStringer(t *testing.T) {
 		want string
 	}{
 		{ErrNotEnoughVoters, "ErrNotEnoughVoters"},
-		{ErrFailedToGetGeneration, "ErrFailedToGetGeneration"},
 		{ErrGetTopBlock, "ErrGetTopBlock"},
 		{ErrGettingDifficulty, "ErrGettingDifficulty"},
 		{ErrTransactionAppend, "ErrTransactionAppend"},

--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -194,7 +194,7 @@ type Config struct {
 
 	// TipGeneration defines the function to use to get the entire generation of
 	// blocks stemming from the parent of the current tip.
-	TipGeneration func() ([]chainhash.Hash, error)
+	TipGeneration func() []chainhash.Hash
 
 	// ValidateTransactionScripts defines the function to use to validate the
 	// scripts for the passed transaction.
@@ -1231,10 +1231,7 @@ func (g *BlkTmplGenerator) NewBlockTemplate(payToAddress stdaddr.Address) (*Bloc
 
 	if nextBlockHeight >= stakeValidationHeight {
 		// Obtain the entire generation of blocks stemming from this parent.
-		children, err := g.cfg.TipGeneration()
-		if err != nil {
-			return nil, makeError(ErrFailedToGetGeneration, err.Error())
-		}
+		children := g.cfg.TipGeneration()
 
 		// Get the list of blocks that we can actually build on top of. If we're
 		// not currently on the block that has the most votes, switch to that

--- a/internal/mining/mining_harness_test.go
+++ b/internal/mining/mining_harness_test.go
@@ -80,7 +80,6 @@ type fakeChain struct {
 	maxTreasuryExpenditureErr          error
 	parentUtxos                        *blockchain.UtxoViewpoint
 	tipGeneration                      []chainhash.Hash
-	tipGenerationErr                   error
 	utxos                              *blockchain.UtxoViewpoint
 }
 
@@ -260,8 +259,8 @@ func (c *fakeChain) NewUtxoViewpoint() *blockchain.UtxoViewpoint {
 
 // TipGeneration returns a mocked entire generation of blocks stemming from the
 // parent of the current tip.
-func (c *fakeChain) TipGeneration() ([]chainhash.Hash, error) {
-	return c.tipGeneration, c.tipGenerationErr
+func (c *fakeChain) TipGeneration() []chainhash.Hash {
+	return c.tipGeneration
 }
 
 // fakeTxSource provides a mocked source of transactions to consider for

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -371,7 +371,7 @@ type Chain interface {
 
 	// TipGeneration returns the entire generation of blocks stemming from the
 	// parent of the current tip.
-	TipGeneration() ([]chainhash.Hash, error)
+	TipGeneration() []chainhash.Hash
 
 	// TreasuryBalance returns the treasury balance at the provided block.
 	TreasuryBalance(*chainhash.Hash) (*blockchain.TreasuryBalanceInfo, error)

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -400,8 +400,8 @@ func (c *testRPCChain) TicketsWithAddress(address stdaddr.StakeAddress) ([]chain
 
 // TipGeneration returns a mocked slice of the entire generation of blocks
 // stemming from the parent of the current tip.
-func (c *testRPCChain) TipGeneration() ([]chainhash.Hash, error) {
-	return c.tipGeneration, nil
+func (c *testRPCChain) TipGeneration() []chainhash.Hash {
+	return c.tipGeneration
 }
 
 // TreasuryBalance returns the treasury balance at the provided block.

--- a/internal/rpcserver/rpcwebsocket.go
+++ b/internal/rpcserver/rpcwebsocket.go
@@ -2088,11 +2088,7 @@ func handleNotifyBlocks(_ context.Context, wsc *wsClient, _ interface{}) (interf
 func handleRebroadcastWinners(_ context.Context, wsc *wsClient, _ interface{}) (interface{}, error) {
 	cfg := wsc.rpcServer.cfg
 	bestHeight := cfg.Chain.BestSnapshot().Height
-	blocks, err := cfg.Chain.TipGeneration()
-	if err != nil {
-		return nil, rpcInternalError("Could not get generation "+
-			err.Error(), "")
-	}
+	blocks := cfg.Chain.TipGeneration()
 
 	for i := range blocks {
 		winningTickets, _, _, err := cfg.Chain.LotteryDataForBlock(&blocks[i])

--- a/server.go
+++ b/server.go
@@ -890,14 +890,9 @@ func (sp *serverPeer) OnGetMiningState(_ *peer.Peer, msg *wire.MsgGetMiningState
 		return
 	}
 
-	// Obtain the entire generation of blocks stemming from the parent of
-	// the current tip.
-	children, err := sp.server.chain.TipGeneration()
-	if err != nil {
-		peerLog.Warnf("failed to access sync manager to get the generation "+
-			"for a mining state request (block: %v): %v", best.Hash, err)
-		return
-	}
+	// Obtain the entire generation of blocks stemming from the parent of the
+	// current tip.
+	children := sp.server.chain.TipGeneration()
 
 	// Get the list of blocks that are eligible to build on and limit the
 	// list to the maximum number of allowed eligible block hashes per
@@ -929,7 +924,7 @@ func (sp *serverPeer) OnGetMiningState(_ *peer.Peer, msg *wire.MsgGetMiningState
 		voteHashes = append(voteHashes, vhsForBlock...)
 	}
 
-	err = sp.pushMiningStateMsg(uint32(best.Height), blockHashes, voteHashes)
+	err := sp.pushMiningStateMsg(uint32(best.Height), blockHashes, voteHashes)
 	if err != nil {
 		peerLog.Warnf("unexpected error while pushing data for "+
 			"mining state request: %v", err.Error())
@@ -993,14 +988,9 @@ func (sp *serverPeer) OnGetInitState(_ *peer.Peer, msg *wire.MsgGetInitState) {
 	// votes.
 	mp := sp.server.txMemPool
 	if wantBlocks || wantVotes {
-		// Obtain the entire generation of blocks stemming from the
-		// parent of the current tip.
-		children, err := sp.server.chain.TipGeneration()
-		if err != nil {
-			peerLog.Warnf("Failed to access sync manager to get the generation "+
-				"for a init state request (block: %v): %v", best.Hash, err)
-			return
-		}
+		// Obtain the entire generation of blocks stemming from the parent of
+		// the current tip.
+		children := sp.server.chain.TipGeneration()
 
 		// Get the list of blocks that are eligible to build on and
 		// limit the list to the maximum number of allowed eligible


### PR DESCRIPTION
### Testing Notes

As of this PR, the expected behavior is that there is a single migration that takes around 2 to 3 minutes to complete after which it will no longer be possible to downgrade.

As the warning above notes, if you try to run an older software version after this migration has completed, you will get an error message similar to `Unable to start server: the current blockchain database is no longer compatible with this version of the software (14 > 13)`

---

This modifies `calculateAddedSubsidy` to also include the subsidy generated by treasurybases to ensure the total reported coin supply is the expected value.

It should be noted that this commit only corrects the function and the issue does not affect consensus in any way since the calculated value is only used when providing the information via RPC.

However, it does mean the database has an incorrect value stored and therefore requires a database migration to correct.

The migration involves loading and iterating through all of the main chain blocks and to recalculate the total subsidy and then updating the best chain state that houses the stored value.  The process can be interrupted at any point and future invocations will resume from the point it was interrupted.

Also, this takes advantage of the database version bump to only check and remove  the legacy spend consumer dependencies bucket once during the upgrade instead of at every startup.

Fixes #3111.