### PR TITLE
blockchain: Remove deprecated subscribers method.

### DIFF
--- a/internal/blockchain/indexers/common.go
+++ b/internal/blockchain/indexers/common.go
@@ -107,10 +107,6 @@ type Indexer interface {
 	// WaitForSync subscribes clients for the next index sync update.
 	WaitForSync() chan bool
 
-	// Subscribers returns all client channels waiting for the next index update.
-	// Deprecated: This will be removed in the next major version bump.
-	Subscribers() map[chan bool]struct{}
-
 	// NotifySyncSubscribers signals subscribers of an index sync update.
 	// This should only be called when an index is synced.
 	NotifySyncSubscribers()

--- a/internal/blockchain/indexers/existsaddrindex.go
+++ b/internal/blockchain/indexers/existsaddrindex.go
@@ -258,16 +258,6 @@ func (idx *ExistsAddrIndex) IndexSubscription() *IndexSubscription {
 	return idx.sub
 }
 
-// Subscribers returns all client channels waiting for the next index update.
-//
-// This is part of the Indexer interface.
-// Deprecated: This will be removed in the next major version bump.
-func (idx *ExistsAddrIndex) Subscribers() map[chan bool]struct{} {
-	idx.mtx.Lock()
-	defer idx.mtx.Unlock()
-	return idx.subscribers
-}
-
 // NotifySyncSubscribers signals subscribers of an index sync update.
 //
 // This is part of the Indexer interface.

--- a/internal/blockchain/indexers/txindex.go
+++ b/internal/blockchain/indexers/txindex.go
@@ -467,16 +467,6 @@ func (idx *TxIndex) IndexSubscription() *IndexSubscription {
 	return idx.sub
 }
 
-// Subscribers returns all client channels waiting for the next index update.
-//
-// This is part of the Indexer interface.
-// Deprecated: This will be removed in the next major version bump.
-func (idx *TxIndex) Subscribers() map[chan bool]struct{} {
-	idx.mtx.Lock()
-	defer idx.mtx.Unlock()
-	return idx.subscribers
-}
-
 // NotifySyncSubscribers signals subscribers of an index sync update.
 //
 // This is part of the Indexer interface.


### PR DESCRIPTION
This removes the Subscribers method from the blockchain code now that it is internal and thus no longer part of the old major module version.