### PR TITLE
chaincfg: Update min known chain work for release.

### DIFF
--- a/chaincfg/mainnetparams.go
+++ b/chaincfg/mainnetparams.go
@@ -141,9 +141,9 @@ func MainNetParams() *Params {
 		// chain at a given point in time.  This is intended to be updated
 		// periodically with new releases.
 		//
-		// Block 00000000000000001251efb83ad1a5c71351b50fe9195f009cf0bf5a7cd99d52
-		// Height: 606000
-		MinKnownChainWork: hexToBigInt("0000000000000000000000000000000000000000001d987ec2c7f4bc1199489e"),
+		// Block 0000000000000000149b797ca19e1b4a061ab0e28c73e9c02687c72c8a18bd22
+		// Height: 770630
+		MinKnownChainWork: hexToBigInt("00000000000000000000000000000000000000000023e312aba3df81d0c21ef0"),
 
 		// The miner confirmation window is defined as:
 		//   target proof of work timespan / target proof of work spacing

--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -139,9 +139,9 @@ func TestNet3Params() *Params {
 		// chain at a given point in time.  This is intended to be updated
 		// periodically with new releases.
 		//
-		// Block 00000000d64ceb1a686315ed56235e9a6838e3a22e9ec9bd92c2e04c09e0778b
-		// Height: 807905
-		MinKnownChainWork: hexToBigInt("000000000000000000000000000000000000000000000000e419ae4d750d4484"),
+		// Block 000000001ffc25cb2cd323c82c5838971a9b191c2d4cf9530e1582fcb8b4794e
+		// Height: 1148390
+		MinKnownChainWork: hexToBigInt("000000000000000000000000000000000000000000000000f376cd394f056477"),
 
 		// Consensus rule change deployments.
 		//


### PR DESCRIPTION
This updates the minimum known chain work values for the main and test networks as follows:

> mainnet: 0x00000000000000000000000000000000000000000023e312aba3df81d0c21ef0
> testnet: 0x000000000000000000000000000000000000000000000000f376cd394f056477