### PR TITLE
blockchain: Reject old block vers for pow vote.

### DIFF
--- a/internal/blockchain/validate.go
+++ b/internal/blockchain/validate.go
@@ -1011,7 +1011,7 @@ func isDCP0005Violation(network wire.CurrencyNet, header *wire.BlockHeader, bloc
 func (b *BlockChain) isOldBlockVersionByMajority(header *wire.BlockHeader, blockHash *chainhash.Hash, prevNode *blockNode) bool {
 	// Note that the latest block version for all networks other than the main
 	// network is one higher.
-	latestBlockVersion := int32(9)
+	latestBlockVersion := int32(10)
 	if b.chainParams.Net != wire.MainNet {
 		latestBlockVersion++
 	}


### PR DESCRIPTION
This updates the latest block version for the upcoming hard fork vote for DCP0011 and DCP0012 in order to reject old block versions once a super majority of the network has upgraded.