### PR TITLE
server: Force PoW upgrade to v10.

### DIFF
--- a/server.go
+++ b/server.go
@@ -2576,7 +2576,7 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 		// namely blocks 101, 102, 103, 104, 105, and 106.
 		//
 		// Additionally, a notification will NOT be sent for mainnet once block
-		// height 635775 has been reached and the block version is prior to 9.
+		// height 777240 has been reached and the block version is prior to 10.
 		// The intent is for future code to perform this type of check more
 		// dynamically so it happens for all upgrades after a certain time frame
 		// is provided for upgrades to occur, but it is hard coded for now in
@@ -2587,7 +2587,7 @@ func (s *server) handleBlockchainNotification(notification *blockchain.Notificat
 		blockHeight := int64(blockHeader.Height)
 		reorgDepth := bestHeight - (blockHeight - band.ForkLen)
 		isOldMainnetBlock := s.chainParams.Net == wire.MainNet &&
-			blockHeight >= 635775 && blockHeader.Version < 9
+			blockHeight >= 777240 && blockHeader.Version < 10
 		if s.rpcServer != nil &&
 			blockHeight >= s.chainParams.StakeValidationHeight-1 &&
 			reorgDepth < maxReorgDepthNotify &&


### PR DESCRIPTION
This modifies the vote notification logic so that wallets will no longer vote on mainnet blocks once height 777240 has been reached and the block version is prior to 10.

This change is being made to make use of the staking system to force proof-of-work miners to upgrade to the latest version in a timely fashion so voting on the new consensus changes can commence.
