### PR TITLE
docker: Update image to golang:1.20.5-alpine3.18.

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -3,13 +3,13 @@
 ###############
 
 # Basic Go environment with git, SSL CA certs, and upx.
-# The image below is golang:1.20.1-alpine3.17 (linux/amd64)
+# The image below is golang:1.20.5-alpine3.18 (linux/amd64)
 # It's pulled by the digest (immutable id) to avoid supply-chain attacks.
 # Maintainer Note:
 #    To update to a new digest, you must first manually pull the new image:
 #    `docker pull golang:<new version>`
 #    Docker will print the digest of the new image after the pull has finished.
-FROM golang@sha256:48f336ef8366b9d6246293e3047259d0f614ee167db1869bdbc343d6e09aed8a AS builder
+FROM golang@sha256:5ee43f6d476721d9ae916afb84bac3d37488097a891cb3b65d9e889991977331 AS builder
 RUN apk add --no-cache git ca-certificates upx
 
 # Empty directory to be copied into place in the production image since it will


### PR DESCRIPTION
This updates the docker image to golang:1.20.5-alpine3.18.

To confirm the new digest:

```
$ docker pull golang:1.20.5-alpine3.18
...
1.20.5-alpine3.18: Pulling from library/golang
...
Digest: sha256:5ee43f6d476721d9ae916afb84bac3d37488097a891cb3b65d9e889991977331
...
```