### PR TITLE
database: Minor test cleanup.

### DIFF
--- a/database/driver_test.go
+++ b/database/driver_test.go
@@ -17,9 +17,11 @@ import (
 // checkDbError ensures the passed error is an Error that matches the passed
 // error kind.
 func checkDbError(t *testing.T, testName string, gotErr error, wantErr database.ErrorKind) bool {
+	t.Helper()
+
 	if !errors.Is(gotErr, wantErr) {
-		t.Errorf("%s: unexpected error - got %v, want %v",
-			testName, gotErr, wantErr)
+		t.Errorf("%s: unexpected error - got %v, want %v", testName, gotErr,
+			wantErr)
 		return false
 	}
 

--- a/database/ffldb/bench_test.go
+++ b/database/ffldb/bench_test.go
@@ -6,8 +6,6 @@
 package ffldb
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/decred/dcrd/chaincfg/v3"
@@ -20,14 +18,14 @@ import (
 func BenchmarkBlockHeader(b *testing.B) {
 	// Start by creating a new database and populating it with the mainnet
 	// genesis block.
-	dbPath := filepath.Join(os.TempDir(), "ffldb-benchblkhdr")
-	_ = os.RemoveAll(dbPath)
+	dbPath := b.TempDir()
 	db, err := database.Create("ffldb", dbPath, blockDataNet)
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer os.RemoveAll(dbPath)
-	defer db.Close()
+	b.Cleanup(func() {
+		db.Close()
+	})
 	mainNetParams := chaincfg.MainNetParams()
 	err = db.Update(func(tx database.Tx) error {
 		block := dcrutil.NewBlock(mainNetParams.GenesisBlock)
@@ -62,14 +60,14 @@ func BenchmarkBlockHeader(b *testing.B) {
 func BenchmarkBlock(b *testing.B) {
 	// Start by creating a new database and populating it with the mainnet
 	// genesis block.
-	dbPath := filepath.Join(os.TempDir(), "ffldb-benchblk")
-	_ = os.RemoveAll(dbPath)
+	dbPath := b.TempDir()
 	db, err := database.Create("ffldb", dbPath, blockDataNet)
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer os.RemoveAll(dbPath)
-	defer db.Close()
+	b.Cleanup(func() {
+		db.Close()
+	})
 	mainNetParams := chaincfg.MainNetParams()
 	err = db.Update(func(tx database.Tx) error {
 		block := dcrutil.NewBlock(mainNetParams.GenesisBlock)

--- a/database/ffldb/driver_test.go
+++ b/database/ffldb/driver_test.go
@@ -7,8 +7,6 @@ package ffldb_test
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"reflect"
 	"runtime"
 	"testing"
@@ -103,14 +101,12 @@ func TestCreateOpenFail(t *testing.T) {
 
 	// Ensure operations against a closed database return the expected
 	// error.
-	dbPath := filepath.Join(os.TempDir(), "ffldb-createfail-v2")
-	_ = os.RemoveAll(dbPath)
+	dbPath := t.TempDir()
 	db, err := database.Create(dbType, dbPath, blockDataNet)
 	if err != nil {
 		t.Errorf("Create: unexpected error: %v", err)
 		return
 	}
-	defer os.RemoveAll(dbPath)
 	db.Close()
 
 	wantErrKind = database.ErrDbNotOpen
@@ -154,15 +150,15 @@ func TestPersistence(t *testing.T) {
 	t.Parallel()
 
 	// Create a new database to run tests against.
-	dbPath := filepath.Join(os.TempDir(), "ffldb-persistencetest-v2")
-	_ = os.RemoveAll(dbPath)
+	dbPath := t.TempDir()
 	db, err := database.Create(dbType, dbPath, blockDataNet)
 	if err != nil {
 		t.Errorf("Failed to create test database (%s) %v", dbType, err)
 		return
 	}
-	defer os.RemoveAll(dbPath)
-	defer db.Close()
+	t.Cleanup(func() {
+		db.Close()
+	})
 
 	// Create a bucket, put some values into it, and store a block so they
 	// can be tested for existence on re-open.
@@ -261,15 +257,15 @@ func TestInterface(t *testing.T) {
 	t.Parallel()
 
 	// Create a new database to run tests against.
-	dbPath := filepath.Join(os.TempDir(), "ffldb-interfacetest-v2")
-	_ = os.RemoveAll(dbPath)
+	dbPath := t.TempDir()
 	db, err := database.Create(dbType, dbPath, blockDataNet)
 	if err != nil {
 		t.Errorf("failed to create test database (%s) %v", dbType, err)
 		return
 	}
-	defer os.RemoveAll(dbPath)
-	defer db.Close()
+	t.Cleanup(func() {
+		db.Close()
+	})
 
 	// Ensure the driver type is the expected value.
 	gotDbType := db.Type()

--- a/database/ffldb/interface_test.go
+++ b/database/ffldb/interface_test.go
@@ -47,6 +47,8 @@ var (
 // loadBlocks loads the blocks contained in the testdata directory and returns
 // a slice of them.
 func loadBlocks(t *testing.T, dataFile string, network wire.CurrencyNet) ([]*dcrutil.Block, error) {
+	t.Helper()
+
 	// Open the file that contains the blocks for reading.
 	fi, err := os.Open(dataFile)
 	if err != nil {
@@ -92,6 +94,8 @@ func loadBlocks(t *testing.T, dataFile string, network wire.CurrencyNet) ([]*dcr
 // checkDbError ensures the passed error is a database.Error that matches the
 // passed error kind.
 func checkDbError(t *testing.T, testName string, gotErr error, wantErr database.ErrorKind) bool {
+	t.Helper()
+
 	if !errors.Is(gotErr, wantErr) {
 		t.Errorf("%s: unexpected error code - got %v, want %v",
 			testName, gotErr, wantErr)
@@ -597,6 +601,8 @@ func testBucketInterface(tc *testContext, bucket database.Bucket) bool {
 // thereby leading to a deadlock and masking the real reason for the panic.  It
 // also logs a test error and repanics so the original panic can be traced.
 func rollbackOnPanic(t *testing.T, tx database.Tx) {
+	t.Helper()
+
 	if err := recover(); err != nil {
 		t.Errorf("Unexpected panic: %v", err)
 		_ = tx.Rollback()
@@ -2225,6 +2231,8 @@ func testConcurrentClose(tc *testContext) bool {
 // testInterface tests performs tests for the various interfaces of the database
 // package which require state in the database for the given database type.
 func testInterface(t *testing.T, db database.DB) {
+	t.Helper()
+
 	// Create a test context to pass around.
 	context := testContext{t: t, db: db}
 

--- a/database/ffldb/whitebox_test.go
+++ b/database/ffldb/whitebox_test.go
@@ -141,7 +141,7 @@ func TestCornerCases(t *testing.T) {
 	t.Parallel()
 
 	// Create a file at the database path to force the open below to fail.
-	dbPath := filepath.Join(os.TempDir(), "ffldb-errors-v2")
+	dbPath := t.TempDir()
 	_ = os.RemoveAll(dbPath)
 	fi, err := os.Create(dbPath)
 	if err != nil {
@@ -159,7 +159,6 @@ func TestCornerCases(t *testing.T) {
 		if err == nil {
 			idb.Close()
 		}
-		_ = os.RemoveAll(dbPath)
 		return
 	}
 
@@ -171,8 +170,9 @@ func TestCornerCases(t *testing.T) {
 		t.Errorf("openDB: unexpected error: %v", err)
 		return
 	}
-	defer os.RemoveAll(dbPath)
-	defer idb.Close()
+	t.Cleanup(func() {
+		idb.Close()
+	})
 
 	// Ensure attempting to write to a file that can't be created returns
 	// the expected error.
@@ -578,14 +578,12 @@ func testCorruption(tc *testContext) bool {
 // correctly.
 func TestFailureScenarios(t *testing.T) {
 	// Create a new database to run tests against.
-	dbPath := filepath.Join(os.TempDir(), "ffldb-failurescenarios-v2")
-	_ = os.RemoveAll(dbPath)
+	dbPath := t.TempDir()
 	idb, err := database.Create(dbType, dbPath, blockDataNet)
 	if err != nil {
 		t.Errorf("Failed to create test database (%s) %v", dbType, err)
 		return
 	}
-	defer os.RemoveAll(dbPath)
 	defer idb.Close()
 
 	// Create a test context to pass around.

--- a/database/ffldb/whitebox_test.go
+++ b/database/ffldb/whitebox_test.go
@@ -42,6 +42,8 @@ var (
 // loadBlocks loads the blocks contained in the testdata directory and returns
 // a slice of them.
 func loadBlocks(t *testing.T, dataFile string, network wire.CurrencyNet) ([]*dcrutil.Block, error) {
+	t.Helper()
+
 	// Open the file that contains the blocks for reading.
 	fi, err := os.Open(dataFile)
 	if err != nil {
@@ -87,6 +89,8 @@ func loadBlocks(t *testing.T, dataFile string, network wire.CurrencyNet) ([]*dcr
 // checkDbError ensures the passed error is a database.Error that matches the
 // passed error kind.
 func checkDbError(t *testing.T, testName string, gotErr error, wantErr database.ErrorKind) bool {
+	t.Helper()
+
 	if !errors.Is(gotErr, wantErr) {
 		t.Errorf("%s: unexpected error - got %v, want %v",
 			testName, gotErr, wantErr)


### PR DESCRIPTION
This modifies several of the tests in the `database` module to use `t.TempDir` and marks several of the funcs that are used as helpers as test helpers so any failures will be attributed to the caller as opposed to the methods themselves.

The directory ` t.TempDir` creates is automatically removed when the test and all its subtests complete.

Finally, it changes out some of the cleanup logic for closing the database to use `t.Cleanup` instead of defer to ensure the close happens during test cleanup after the directories created by `t.TempDir` have been removed.

