### PR TITLE
main: improve test flag handling

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -1,15 +1,26 @@
-// Copyright (c) 2018 The Decred developers
+// Copyright (c) 2018-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package main
 
 import (
+	"flag"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	// Trim -test.* flags from the command line arguments list to allow
+	// go-flags tests to succeed.
+	os.Args = append([]string{os.Args[0]}, flag.Args()...)
+
+	os.Exit(m.Run())
+}
 
 // In order to test command line arguments and environment variables, append
 // the flags to the os.Args variable like so:
@@ -79,10 +90,4 @@ func TestAltDNSNamesWithArg(t *testing.T) {
 			hostnames)
 	}
 	os.Args = old
-}
-
-// init parses the -test.* flags from the command line arguments list and then
-// removes them to allow go-flags tests to succeed.
-func init() {
-	os.Args = os.Args[:1]
 }


### PR DESCRIPTION
A TestMain func is added to parse the test executable's flags.  Before running all tests, any flags that it did not parse (in particular, those following a double hyphen (--) which the flag package will stop parsing after) are retained in the modified os.Args value.  This allows the tests that exercise go-flags options to test these options with any user-provided flags prepended.

One such use case for this fix is to change the default appdata directory that tests will use, which allows tests to succeed when the default home directory is read only.  For example:

go test . -args -- --appdata=/some/other/appdata

This well cause the go-flags tests to perform their tests with their own options being tested following the appdata change.

Fixes #3150.