### PR TITLE
config: Support DCRD_APPDATA env variable.

### DIFF
--- a/config.go
+++ b/config.go
@@ -112,7 +112,7 @@ var runServiceCommand func(string) error
 type config struct {
 	// General application behavior.
 	ShowVersion      bool   `short:"V" long:"version" description:"Display version information and exit"`
-	HomeDir          string `short:"A" long:"appdata" description:"Path to application home directory"`
+	HomeDir          string `short:"A" long:"appdata" description:"Path to application home directory" env:"DCRD_APPDATA"`
 	ConfigFile       string `short:"C" long:"configfile" description:"Path to configuration file"`
 	DataDir          string `short:"b" long:"datadir" description:"Directory to store data"`
 	LogDir           string `long:"logdir" description:"Directory to log output"`


### PR DESCRIPTION
This modifies the config parsing to use the `DCRD_APPDATA` environment variable to override the overall application data directory as an alternative to the `--appdata CLI` option.

Note that the `--appdata` CLI option takes precedence over the environment variable if both are specified.

Environment variables are generally the preferred approach for overriding defaults in containers.

See discussion in #3150.