### PR TITLE
build: Add nilerr linter.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters:
     - grouper
     - ineffassign
     - misspell
+    - nilerr
     - nosprintfhostport
     - reassign
     - rowserrcheck

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -3957,7 +3957,7 @@ func handleGetWorkSubmission(_ context.Context, s *Server, hexData string) (inte
 	if _, err := s.cfg.Chain.HeaderByHash(prevBlkHash); err != nil {
 		log.Infof("Block submitted via getwork rejected: orphan building on "+
 			"parent %v", prevBlkHash)
-		return false, nil
+		return false, nil // nolint: nilerr
 	}
 
 	// Choose the proof of work mining algorithm based on the result of the vote
@@ -4892,7 +4892,7 @@ func handleValidateAddress(_ context.Context, s *Server, cmd interface{}) (inter
 	addr, err := stdaddr.DecodeAddress(c.Address, s.cfg.ChainParams)
 	if err != nil {
 		// Return the default value (false) for IsValid.
-		return result, nil
+		return result, nil // nolint: nilerr
 	}
 
 	result.Address = addr.String()
@@ -4989,7 +4989,7 @@ func handleVerifyMessage(_ context.Context, s *Server, cmd interface{}) (interfa
 	pk, wasCompressed, err := ecdsa.RecoverCompact(sig, expectedMessageHash)
 	if err != nil {
 		// Treat errors in RecoverCompact as an invalid signature.
-		return false, nil
+		return false, nil // nolint: nilerr
 	}
 
 	// Reconstruct the pubkey hash.
@@ -5002,7 +5002,7 @@ func handleVerifyMessage(_ context.Context, s *Server, cmd interface{}) (interfa
 	address, err := stdaddr.NewAddressPubKeyHashEcdsaSecp256k1V0(pkHash, params)
 	if err != nil {
 		// Treat error in reconstruction as an invalid signature.
-		return false, nil
+		return false, nil // nolint: nilerr
 	}
 
 	// Return boolean if addresses match.

--- a/txscript/opcode.go
+++ b/txscript/opcode.go
@@ -2483,19 +2483,19 @@ func opcodeCheckSig(op *opcode, data []byte, vm *Engine) error {
 		prefixHash)
 	if err != nil {
 		vm.dstack.PushBool(false)
-		return nil
+		return nil // nolint:nilerr
 	}
 
 	pubKey, err := secp256k1.ParsePubKey(pkBytes)
 	if err != nil {
 		vm.dstack.PushBool(false)
-		return nil
+		return nil // nolint:nilerr
 	}
 
 	signature, err := ecdsa.ParseDERSignature(sigBytes)
 	if err != nil {
 		vm.dstack.PushBool(false)
-		return nil
+		return nil // nolint:nilerr
 	}
 
 	var valid bool
@@ -2867,7 +2867,7 @@ func opcodeCheckSigAlt(op *opcode, data []byte, vm *Engine) error {
 		prefixHash)
 	if err != nil {
 		vm.dstack.PushBool(false)
-		return nil
+		return nil // nolint:nilerr
 	}
 
 	// Get the public key from bytes.
@@ -2876,12 +2876,12 @@ func opcodeCheckSigAlt(op *opcode, data []byte, vm *Engine) error {
 		pubKeyEd, err := edwards.ParsePubKey(pkBytes)
 		if err != nil {
 			vm.dstack.PushBool(false)
-			return nil
+			return nil // nolint:nilerr
 		}
 		sigEd, err := edwards.ParseSignature(sigBytes)
 		if err != nil {
 			vm.dstack.PushBool(false)
-			return nil
+			return nil // nolint:nilerr
 		}
 		ok := edwards.Verify(pubKeyEd, hash, sigEd.GetR(), sigEd.GetS())
 		vm.dstack.PushBool(ok)
@@ -2890,12 +2890,12 @@ func opcodeCheckSigAlt(op *opcode, data []byte, vm *Engine) error {
 		pubKeySec, err := schnorr.ParsePubKey(pkBytes)
 		if err != nil {
 			vm.dstack.PushBool(false)
-			return nil
+			return nil // nolint:nilerr
 		}
 		sigSec, err := schnorr.ParseSignature(sigBytes)
 		if err != nil {
 			vm.dstack.PushBool(false)
-			return nil
+			return nil // nolint:nilerr
 		}
 		ok := sigSec.Verify(hash, pubKeySec)
 		vm.dstack.PushBool(ok)


### PR DESCRIPTION
This adds the `nilerr` linter to the list of linters and addresses a few false positives it complains about.