### PR TITLE
build: Move lint logic to its own script.

### DIFF
--- a/.github/stablilize_testdata_timestamps.sh
+++ b/.github/stablilize_testdata_timestamps.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 display_usage() {
 	echo -e "Usage: $0 PATH_TO_REPOSITORY_ROOT\n"

--- a/lint.sh
+++ b/lint.sh
@@ -1,0 +1,32 @@
+#/usr/bin/env bash
+
+set -ex
+
+# The script uses golangci-lint (github.com/golangci/golangci-lint) to run all
+# linters defined by the configuration in .golangci.yml on every module in the
+# repository.
+
+go version
+
+# loop all modules
+ROOTPKG=$(go list)
+ROOTPKGPATTERN=$(echo $ROOTPKG | sed 's,\\,\\\\,g' | sed 's,/,\\/,g')
+MODPATHS=$(go list -m all | grep "^$ROOTPKGPATTERN" | cut -d' ' -f1)
+for module in $MODPATHS; do
+  echo "==> lint ${module}"
+
+  # determine module directory
+  MODNAME=$(echo $module | sed -E -e "s/^$ROOTPKGPATTERN//" \
+    -e 's,^/,,' -e 's,/v[0-9]+$,,')
+  if [ -z "$MODNAME" ]; then
+    MODNAME=.
+  fi
+
+  # run commands in the module directory as a subshell
+  (
+    cd $MODNAME
+
+    # run linters
+    golangci-lint run
+  )
+done

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,18 +1,10 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -ex
 
-# The script does automatic checking on a Go package and its sub-packages,
-# including:
-# 1. gofmt         (https://golang.org/cmd/gofmt/)
-# 2. gosimple      (https://github.com/dominikh/go-simple)
-# 3. unconvert     (https://github.com/mdempsky/unconvert)
-# 4. ineffassign   (https://github.com/gordonklaus/ineffassign)
-# 5. go vet        (https://golang.org/cmd/vet)
-# 6. misspell      (https://github.com/client9/misspell)
-
-# golangci-lint (github.com/golangci/golangci-lint) is used to run each
-# static checker.
+# This script runs the tests for all packages in all Go modules in the
+# repository and then runs the linters for all Go modules in the repository by
+# invoking the separate linter script.
 
 go version
 
@@ -21,27 +13,8 @@ echo "==> test all modules"
 ROOTPKG=$(go list)
 go test -short -tags rpctest $ROOTPKG/...
 
-# loop all modules
-ROOTPKGPATTERN=$(echo $ROOTPKG | sed 's,\\,\\\\,g' | sed 's,/,\\/,g')
-MODPATHS=$(go list -m all | grep "^$ROOTPKGPATTERN" | cut -d' ' -f1)
-for module in $MODPATHS; do
-  echo "==> lint ${module}"
-
-  # determine module directory
-  MODNAME=$(echo $module | sed -E -e "s/^$ROOTPKGPATTERN//" \
-    -e 's,^/,,' -e 's,/v[0-9]+$,,')
-  if [ -z "$MODNAME" ]; then
-    MODNAME=.
-  fi
-
-  # run commands in the module directory as a subshell
-  (
-    cd $MODNAME
-
-    # run linters
-    golangci-lint run
-  )
-done
+# run linters on all modules
+. ./lint.sh
 
 echo "------------------------------------------"
 echo "Tests completed successfully!"


### PR DESCRIPTION
**This is rebased on #3157**.

This separates the logic in `run_tests.sh` that runs all of the linters on all modules in the repository to a separate `lint.sh` script and updates `run_tests.sh` to call that script instead.  Rather than listing every linter in the script comments, it refers to the `.golangci.yml` configuration file that specifies them now that it exists.

This allows developers to more easily selectively run only the linters without needing to run all of the tests again.

It also cleans up the comments in `run_test.sh` to match reality while here.