### PR TITLE
build: Use go install for linter and add cache.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,19 +17,20 @@ jobs:
           go-version: ${{ matrix.go }}
       - name: Check out source
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - name: Install Linters
-        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.53.1"
       - name: Use test and module cache
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
+            ~/.cache/golangci-lint
           key: go-test-${{ matrix.go }}-${{ github.sha }}
           restore-keys: go-test-${{ matrix.go }}
       - name: Stablilize testdata timestamps
         run: |
           bash ./.github/stablilize_testdata_timestamps.sh "${{ github.workspace }}"
+      - name: Install Linters
+        run: "go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.1"
       - name: Build
         run: go build ./...
       - name: Test


### PR DESCRIPTION
**This is rebased on #3161**.

This modifies the GitHub Action workflow to install `golangci-lint` from source with `go install` instead of using the separate install script and adds `~/.cache/golangci-lint` to the saved cache for faster future runs.

The goal is to pin the dependency for the same reason the GitHub actions are pinned by hash.  Namely, it reduces potential security risks such as compromised dependencies and dependency substitution attacks.

Using `go install` serves to pin the dependency because go verifies the downloaded module contents against the original checksum hashes they were first created with.
