### PR TITLE
multi: Avoid range capture for Go 1.22 changes.

### DIFF
--- a/dcrjson/register_test.go
+++ b/dcrjson/register_test.go
@@ -52,10 +52,10 @@ func TestUsageFlagStringer(t *testing.T) {
 
 	// Detect additional usage flags that don't have the stringer added.
 	numUsageFlags := 0
-	highestUsageFlagBit := highestUsageFlagBit
-	for highestUsageFlagBit > 1 {
+	highestBit := highestUsageFlagBit
+	for highestBit > 1 {
 		numUsageFlags++
-		highestUsageFlagBit >>= 1
+		highestBit >>= 1
 	}
 	if len(tests)-3 != numUsageFlags {
 		t.Errorf("It appears a usage flag was added without adding " +

--- a/internal/blockchain/treasury.go
+++ b/internal/blockchain/treasury.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 The Decred developers
+// Copyright (c) 2020-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -863,13 +863,14 @@ func (b *BlockChain) checkTSpendExists(prevNode *blockNode, tspend chainhash.Has
 	}
 
 	// Do fork detection on all blocks.
-	for _, v := range blocks {
+	for i := range blocks {
 		// Lookup blockNode.
-		node := b.index.LookupNode(&v)
+		blockHash := &blocks[i]
+		node := b.index.LookupNode(blockHash)
 		if node == nil {
 			// This should not happen.
-			trsyLog.Errorf("checkTSpendExists: block not found %v tspend %v", v,
-				tspend)
+			trsyLog.Errorf("checkTSpendExists: block not found %v tspend %v",
+				blockHash, tspend)
 			continue
 		}
 

--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -1040,9 +1040,10 @@ func (g *BlkTmplGenerator) addAutoRevocationsToQueue(winningTickets map[chainhas
 
 	// Create revocation transactions for all tickets that will become missed
 	// or expired as of this block.
-	for _, ticketHash := range revokeTickets {
+	for i := range revokeTickets {
 		// Create the revocation transaction.
-		txDesc, err := g.createRevocationFromTicket(&ticketHash, blockUtxos,
+		ticketHash := &revokeTickets[i]
+		txDesc, err := g.createRevocationFromTicket(ticketHash, blockUtxos,
 			prevHeaderBytes, isTreasuryEnabled)
 		if err != nil {
 			return err

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -3319,14 +3319,15 @@ func handleGetTreasurySpendVotes(_ context.Context, s *Server, cmd interface{}) 
 			if !checkingMainChain {
 				continue
 			}
-			for _, block := range blocks {
-				if !chain.MainChainHasBlock(&block) {
+			for i := range blocks {
+				blockHash := &blocks[i]
+				if !chain.MainChainHasBlock(blockHash) {
 					continue
 				}
 
 				// Fetch the header to discover this block's
 				// height.
-				hdr, err := chain.HeaderByHash(&block)
+				hdr, err := chain.HeaderByHash(blockHash)
 				if err != nil {
 					// Shouldn't happen.
 					context := "block without associated header"

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -7990,8 +7990,8 @@ func TestHandleHelp(t *testing.T) {
 func testRPCServerHandler(t *testing.T, tests []rpcTest) {
 	t.Helper()
 
-	for _, test := range tests {
-		test := test // capture range variable
+	for i := range tests {
+		test := &tests[i]
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/txscript/script_test.go
+++ b/txscript/script_test.go
@@ -99,8 +99,8 @@ func TestGetSigOpCount(t *testing.T) {
 		wantTreasuryCount: 0,
 	}}
 
-	for _, tc := range testCases {
-		tc := tc
+	for i := range testCases {
+		tc := &testCases[i]
 		t.Run(tc.name, func(t *testing.T) {
 			script := mustParseShortFormV0(tc.script)
 			gotCount := GetSigOpCount(script, false)


### PR DESCRIPTION
Go 1.22 is introducing a change to the way the range statement works that is not entirely backward compatible.  In particular, the loop variable is changing from one instance per loop to one instance per iteration.

The existing semantics are well known and in order to ensure correct behavior and avoid potential races that would otherwise result, the current code typically opts for using ranges with an index and creating a local that points into the array when the range variable needs to be used as a pointer.

In addition, there are a few remaining cases that use the common alternative approach of capturing the range variable through self assignment.

Both approaches will work correctly when compiled with Go 1.22 as well as older version of Go so long as the module versions are not bumped.

However, once the modules are updated to allow support of all features introduced by go 1.22, the second approach of capturing the range variable would no longer be needed and as a result would very likely need to be removed to avoid vet/linter issues.  Unfortunately, the consequence of that change would mean building the code with older versions of Go would start to produce incorrect code.

The first approach of using a range index that is predominantly used throughout the code does not have that potential pitfall as it works equally well for all of the aforementioned cases.

Thus, in order to avoid any potential issues before they ever even have a chance to arise, this updates the few remaining instances of the second approach to the first one or to otherwise rework the code to avoid the need altogether.