### PR TITLE
build: Use setup-go action cache.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,15 +17,13 @@ jobs:
         uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version: ${{ matrix.go }}
-      - name: Use test and module cache
+      - name: Use lint cache
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
             ~/.cache/golangci-lint
-          key: go-test-${{ matrix.go }}-${{ github.sha }}
-          restore-keys: go-test-${{ matrix.go }}
+          key: go-lint-${{ matrix.go }}-${{ hashFiles('./go.sum') }}
+          restore-keys: go-lint-${{ matrix.go }}
       - name: Stablilize testdata timestamps
         run: |
           bash ./.github/stablilize_testdata_timestamps.sh "${{ github.workspace }}"


### PR DESCRIPTION
The latest version of the setup-go action now caches the go module and build cache by default, so it should no longer be done separately to avoid saving the same data under two different cache keys.

This updates the caching logic accordingly to remove those directories from the separate cache step and renames the step to reflect that it now only involves the lint cache.

Finally, while here, it also switches the key over to use the hash of the 'go.sum' file in the root of the repository as opposed to using the commit hash as it produces significantly less cache objects.