### PR TITLE
rpcclient: Explicitly require TLS >= 1.2 for HTTP.

### DIFF
--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -1187,7 +1187,8 @@ func newHTTPClient(config *ConnConfig) (*http.Client, error) {
 			pool := x509.NewCertPool()
 			pool.AppendCertsFromPEM(config.Certificates)
 			tlsConfig = &tls.Config{
-				RootCAs: pool,
+				RootCAs:    pool,
+				MinVersion: tls.VersionTLS12,
 			}
 		}
 	}


### PR DESCRIPTION
This set the TLS config to explicitly require TLS 1.2 as the minimum version for HTTP connections to explicitly match the requirement it imposes for WebSocket connections.

This is technically a noop for the more recent Go releases that are officially supported since TLS 1.2 is the default minimum when acting as a client for those releases, however, it is preferable to be explicit and consistent.
