### PR TITLE
docker: Update image to golang:1.20.7-alpine3.18.

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -3,13 +3,13 @@
 ###############
 
 # Basic Go environment with git, SSL CA certs, and upx.
-# The image below is golang:1.20.6-alpine3.18 (linux/amd64)
+# The image below is golang:1.20.7-alpine3.18 (linux/amd64)
 # It's pulled by the digest (immutable id) to avoid supply-chain attacks.
 # Maintainer Note:
 #    To update to a new digest, you must first manually pull the new image:
 #    `docker pull golang:<new version>`
 #    Docker will print the digest of the new image after the pull has finished.
-FROM golang@sha256:7839c9f01b5502d7cb5198b2c032857023424470b3e31ae46a8261ffca72912a AS builder
+FROM golang@sha256:7efb78dac256c450d194e556e96f80936528335033a26d703ec8146cec8c2090 AS builder
 RUN apk add --no-cache git ca-certificates upx
 
 # Empty directory to be copied into place in the production image since it will


### PR DESCRIPTION
This updates the docker image to golang:1.20.7-alpine3.18.

To confirm the new digest:

```
$ docker pull golang:1.20.7-alpine3.18
...
1.20.7-alpine3.18: Pulling from library/golang
...
Digest: sha256:7efb78dac256c450d194e556e96f80936528335033a26d703ec8146cec8c2090
...
```