### PR TITLE
multi: Build and doco updates for Go 1.21.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           bash ./.github/stablilize_testdata_timestamps.sh "${{ github.workspace }}"
       - name: Install Linters
-        run: "go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.3"
+        run: "go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.1"
       - name: Build
         run: go build ./...
       - name: Test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.19", "1.20"]
+        go: ["1.20", "1.21"]
     steps:
       - name: Check out source
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Set up Go
-        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version: ${{ matrix.go }}
       - name: Use lint cache

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ https://decred.org/downloads/
 
 <details><summary><b>Install Dependencies</b></summary>
 
-- **Go 1.19 or 1.20**
+- **Go 1.20 or 1.21**
 
   Installation instructions can be found here: https://golang.org/doc/install.
   Ensure Go was installed properly and is a supported version:


### PR DESCRIPTION
This consists of several commits to update the CI and documentation for Go 1.21. It also takes the opportunity to bump to the latest linter and action versions.

In particular:

- build: Update to latest action versions.
  - actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
- build: Update golangci-lint to v1.54.1.
- build: Test against Go 1.21 and remove Go 1.19 accordingly.
- docs: Update README.md to required Go 1.20/1.21.
