### PR TITLE
build: Add dupword linter.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
     - asciicheck
     - bidichk
     - bodyclose
+    - dupword
     - durationcheck
     - errchkjson
     - exportloopref

--- a/blockchain/chaingen/generator.go
+++ b/blockchain/chaingen/generator.go
@@ -1221,6 +1221,8 @@ func calcASERTDiff(startDiffBits uint32, powLimit *big.Int, targetSecsPerBlock,
 		panic(fmt.Sprintf("provided height delta %d is negative", heightDelta))
 	}
 
+	// nolint: dupword
+	//
 	// Calculate the target difficulty by multiplying the provided starting
 	// target difficulty by an exponential scaling factor that is determined
 	// based on how far ahead or behind the ideal schedule the given time delta
@@ -1499,6 +1501,8 @@ func (g *Generator) CalcNextReqStakeDifficulty(prevBlock *wire.MsgBlock) int64 {
 	votesPerBlock := int64(g.params.TicketsPerBlock)
 	ticketPoolSize := int64(g.params.TicketPoolSize)
 
+	// nolint: dupword
+	//
 	// Calculate the difficulty by multiplying the old stake difficulty
 	// with two ratios that represent a force to counteract the relative
 	// change in the pool size (Fc) and a restorative force to push the pool

--- a/blockchain/stake/internal/tickettreap/immutable.go
+++ b/blockchain/stake/internal/tickettreap/immutable.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2015-2016 The btcsuite developers
-// Copyright (c) 2016-2017 The Decred developers
+// Copyright (c) 2016-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -212,6 +212,8 @@ func (t *Immutable) Put(key Key, value *Value) *Immutable {
 		// Perform a right rotation if the node is on the left side or
 		// a left rotation if the node is on the right side.
 		if parent.left == node {
+			// nolint: dupword
+			//
 			// just to help visualise right-rotation...
 			//        p               n
 			//       / \       ->    / \

--- a/blockchain/stake/tickets_test.go
+++ b/blockchain/stake/tickets_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2022 The Decred developers
+// Copyright (c) 2015-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -463,6 +463,8 @@ func TestTicketDBLongChain(t *testing.T) {
 	// A longer, more strenuous test is given below. Uncomment to execute it.
 	// ----------------------------------------------------------------------------
 
+	// nolint: dupword
+	//
 	/*
 		// Create a new database to store the accepted stake node data into.
 		dbName := "ffldb_staketest"

--- a/blockchain/stake/treasury_test.go
+++ b/blockchain/stake/treasury_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 The Decred developers
+// Copyright (c) 2020-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -91,6 +91,8 @@ var (
 		0x2c, // No OP_TSPEND
 	}
 
+	// nolint: dupword
+	//
 	// OP_DATA_64 <signature> <pikey> OP_TSPEND OP_TSPEND
 	tspendTwoTSpend = []byte{
 		0x40, // OP_DATA_64 valid signature

--- a/blockchain/standalone/inclusionproof_test.go
+++ b/blockchain/standalone/inclusionproof_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 The Decred developers
+// Copyright (c) 2019-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -63,6 +63,7 @@ func TestGenerateInclusionProof(t *testing.T) {
 			"b92bb84b19e850458f4eabc098e2990f3931e8b88e9a72a41162e9ae4e2a371a",
 		},
 	}, {
+		// nolint: dupword
 		name: "22 leaves, leaf index 17 (right, left, left, left, right)",
 		leaves: []string{
 			"46670d055dae85e8f9eceb5d30b1433c7232d3b09068fbde4741db3714dafdb7",
@@ -97,6 +98,7 @@ func TestGenerateInclusionProof(t *testing.T) {
 			"730ec07e8a5bde0d66aef48e59ccd3588ca7daf50428ef2584827542a6d3f50a",
 		},
 	}, {
+		// nolint: dupword
 		name: "22 leaves, leaf index 8 (left, left, left, right, left)",
 		leaves: []string{
 			"46670d055dae85e8f9eceb5d30b1433c7232d3b09068fbde4741db3714dafdb7",
@@ -280,6 +282,7 @@ func TestVerifyInclusionProof(t *testing.T) {
 		},
 		want: false,
 	}, {
+		// nolint: dupword
 		name:      "22 leaves, leaf index 17 (right, left, left, left, right)",
 		root:      "4aa7bcd77d51f6f4db4983e731b5e08b3ea724c5cb99d3debd3d75fd67e7c72b",
 		leaf:      "472c27828b8ecd51f038a676aa9dc2e8d144cc292885e342a37852ec6d0d78a7",
@@ -293,6 +296,7 @@ func TestVerifyInclusionProof(t *testing.T) {
 		},
 		want: true,
 	}, {
+		// nolint: dupword
 		name:      "22 leaves, leaf index 8 (left, left, left, right, left)",
 		root:      "4aa7bcd77d51f6f4db4983e731b5e08b3ea724c5cb99d3debd3d75fd67e7c72b",
 		leaf:      "25f65b3814c55de20576d35fc68ecc202bf058352746c9e2347f7e59f5a2c677",

--- a/blockchain/standalone/pow.go
+++ b/blockchain/standalone/pow.go
@@ -267,6 +267,8 @@ func CalcASERTDiff(startDiffBits uint32, powLimit *big.Int, targetSecsPerBlock,
 		panicf("provided height delta %d is negative", heightDelta)
 	}
 
+	// nolint: dupword
+	//
 	// Calculate the target difficulty by multiplying the provided starting
 	// target difficulty by an exponential scaling factor that is determined
 	// based on how far ahead or behind the ideal schedule the given time delta

--- a/crypto/blake256/blake256_test.go
+++ b/crypto/blake256/blake256_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 The Decred developers
+// Copyright (c) 2019-2023 The Decred developers
 // Originally written in 2011-2012 by Dmitry Chestnykh.
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
@@ -79,6 +79,7 @@ var vectors256 = []blakeVector{
 	},
 }
 
+// nolint: dupword
 var vectors224 = []blakeVector{
 	{"c8e92d7088ef87c1530aee2ad44dc720cc10589cc2ec58f95a15e51b",
 		"The quick brown fox jumps over the lazy dog"},

--- a/dcrec/secp256k1/modnscalar.go
+++ b/dcrec/secp256k1/modnscalar.go
@@ -46,6 +46,8 @@ const (
 	//
 	// The group order of the curve per [SECG] is:
 	// 0xffffffff ffffffff ffffffff fffffffe baaedce6 af48a03b bfd25e8c d0364141
+	//
+	// nolint: dupword
 	orderWordZero  uint32 = 0xd0364141
 	orderWordOne   uint32 = 0xbfd25e8c
 	orderWordTwo   uint32 = 0xaf48a03b
@@ -76,6 +78,8 @@ const (
 	//
 	// The half order of the secp256k1 curve group is:
 	// 0x7fffffff ffffffff ffffffff ffffffff 5d576e73 57a4501d dfe92f46 681b20a0
+	//
+	// nolint: dupword
 	halfOrderWordZero  uint32 = 0x681b20a0
 	halfOrderWordOne   uint32 = 0xdfe92f46
 	halfOrderWordTwo   uint32 = 0x57a4501d

--- a/internal/blockchain/blockindex.go
+++ b/internal/blockchain/blockindex.go
@@ -632,6 +632,8 @@ func (bi *blockIndex) HaveBlock(hash *chainhash.Hash) bool {
 // shortBlockKey generates a short identifier from a standard block hash for use
 // as a key in the block index.
 func shortBlockKey(hash *chainhash.Hash) uint32 {
+	// nolint: dupword
+	//
 	// Use the first bytes of the hash directly since it is the result of a hash
 	// function that produces a uniformly-random distribution.
 	//

--- a/internal/blockchain/difficulty.go
+++ b/internal/blockchain/difficulty.go
@@ -733,6 +733,8 @@ func calcNextStakeDiffV2(params *chaincfg.Params, nextHeight, curDiff, prevPoolS
 	ticketPoolSize := int64(params.TicketPoolSize)
 	ticketMaturity := int64(params.TicketMaturity)
 
+	// nolint: dupword
+	//
 	// Calculate the difficulty by multiplying the old stake difficulty
 	// with two ratios that represent a force to counteract the relative
 	// change in the pool size (Fc) and a restorative force to push the pool

--- a/internal/staging/primitives/inclusionproof_test.go
+++ b/internal/staging/primitives/inclusionproof_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021 The Decred developers
+// Copyright (c) 2019-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -66,6 +66,7 @@ func TestGenerateInclusionProof(t *testing.T) {
 			"b92bb84b19e850458f4eabc098e2990f3931e8b88e9a72a41162e9ae4e2a371a",
 		},
 	}, {
+		// nolint: dupword
 		name: "22 leaves, leaf index 17 (right, left, left, left, right)",
 		leaves: []string{
 			"46670d055dae85e8f9eceb5d30b1433c7232d3b09068fbde4741db3714dafdb7",
@@ -100,6 +101,7 @@ func TestGenerateInclusionProof(t *testing.T) {
 			"730ec07e8a5bde0d66aef48e59ccd3588ca7daf50428ef2584827542a6d3f50a",
 		},
 	}, {
+		// nolint: dupword
 		name: "22 leaves, leaf index 8 (left, left, left, right, left)",
 		leaves: []string{
 			"46670d055dae85e8f9eceb5d30b1433c7232d3b09068fbde4741db3714dafdb7",
@@ -285,6 +287,7 @@ func TestVerifyInclusionProof(t *testing.T) {
 		},
 		want: false,
 	}, {
+		// nolint: dupword
 		name:      "22 leaves, leaf index 17 (right, left, left, left, right)",
 		root:      "4aa7bcd77d51f6f4db4983e731b5e08b3ea724c5cb99d3debd3d75fd67e7c72b",
 		leaf:      "472c27828b8ecd51f038a676aa9dc2e8d144cc292885e342a37852ec6d0d78a7",
@@ -298,6 +301,7 @@ func TestVerifyInclusionProof(t *testing.T) {
 		},
 		want: true,
 	}, {
+		// nolint: dupword
 		name:      "22 leaves, leaf index 8 (left, left, left, right, left)",
 		root:      "4aa7bcd77d51f6f4db4983e731b5e08b3ea724c5cb99d3debd3d75fd67e7c72b",
 		leaf:      "25f65b3814c55de20576d35fc68ecc202bf058352746c9e2347f7e59f5a2c677",

--- a/txscript/engine.go
+++ b/txscript/engine.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2017 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -190,6 +190,8 @@ type Engine struct {
 	//
 	// condDisableDepth is the nesting depth that caused conditional branch
 	// execution to be disabled, or the value `noCondDisableDepth`.
+	//
+	// nolint: dupword
 	condNestDepth    int32
 	condDisableDepth int32
 }

--- a/txscript/engine_test.go
+++ b/txscript/engine_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2017 The btcsuite developers
-// Copyright (c) 2015-2021 The Decred developers
+// Copyright (c) 2015-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -113,6 +113,7 @@ func TestCheckErrorCondition(t *testing.T) {
 		},
 		LockTime: 0,
 	}
+	// nolint: dupword
 	pkScript := mustParseShortFormV0("NOP NOP NOP NOP NOP NOP NOP NOP NOP" +
 		" NOP TRUE")
 

--- a/txscript/stdscript/addressv0_test.go
+++ b/txscript/stdscript/addressv0_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 The Decred developers
+// Copyright (c) 2021-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -928,7 +928,7 @@ var addressV0Tests = func() []addressTest {
 		wantType: STNonStandard,
 	}, {
 		name:     "almost v0 treasury add -- two TADD",
-		script:   p("TADD TADD"),
+		script:   p("TADD TADD"), // nolint: dupword
 		params:   mainNetParams,
 		wantType: STNonStandard,
 	}, {

--- a/txscript/stdscript/scriptv0.go
+++ b/txscript/stdscript/scriptv0.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 The Decred developers
+// Copyright (c) 2021-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -275,6 +275,8 @@ type MultiSigDetailsV0 struct {
 // an allocation that the caller might wish to avoid.  The PubKeys member of the
 // returned details struct will be nil when the flag is false.
 func ExtractMultiSigScriptDetailsV0(script []byte, extractPubKeys bool) MultiSigDetailsV0 {
+	// nolint: dupword
+	//
 	// A multi-signature script is of the form:
 	//  REQ_SIGS PUBKEY PUBKEY PUBKEY ... NUM_PUBKEYS OP_CHECKMULTISIG
 

--- a/txscript/stdscript/scriptv0_test.go
+++ b/txscript/stdscript/scriptv0_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 The Decred developers
+// Copyright (c) 2021-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -696,7 +696,7 @@ var scriptV0Tests = func() []scriptTest {
 		wantType: STNonStandard,
 	}, {
 		name:     "almost v0 treasury add -- two TADD",
-		script:   p("TADD TADD"),
+		script:   p("TADD TADD"), // nolint: dupword
 		wantType: STNonStandard,
 	}, {
 		// ---------------------------------------------------------------------


### PR DESCRIPTION
**This requires #3174**.

This adds the `dupword` linter to the list of linters and addresses a few false positives it complains about.