### PR TITLE
blockchain: Remove a couple of unused params.

### DIFF
--- a/internal/blockchain/indexers/common.go
+++ b/internal/blockchain/indexers/common.go
@@ -480,7 +480,7 @@ func recoverIndex(ctx context.Context, idx Indexer) error {
 		hash = &block.MsgBlock().Header.PrevBlock
 		height--
 
-		progressLogger.LogBlockHeight(block.MsgBlock(), parent.MsgBlock())
+		progressLogger.LogBlockHeight(block.MsgBlock())
 	}
 
 	log.Infof("%s: index recovered to tip %d (%s)", idx.Name(),

--- a/internal/blockchain/indexers/indexsubscriber.go
+++ b/internal/blockchain/indexers/indexsubscriber.go
@@ -326,7 +326,7 @@ func (s *IndexSubscriber) CatchUp(ctx context.Context, _ database.DB, queryer Ch
 
 		cachedParent = child
 
-		progressLogger.LogBlockHeight(child.MsgBlock(), parent.MsgBlock())
+		progressLogger.LogBlockHeight(child.MsgBlock())
 	}
 
 	log.Infof("Caught up to height %d", bestHeight)

--- a/internal/blockchain/progresslog/blocklogger.go
+++ b/internal/blockchain/progresslog/blocklogger.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2016 The btcsuite developers
-// Copyright (c) 2016-2022 The Decred developers
+// Copyright (c) 2016-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -9,9 +9,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/decred/slog"
-
 	"github.com/decred/dcrd/wire"
+	"github.com/decred/slog"
 )
 
 // BlockProgressLogger provides periodic logging for other services in order
@@ -43,7 +42,7 @@ func NewBlockProgressLogger(progressMessage string, logger slog.Logger) *BlockPr
 // LogBlockHeight logs a new block height as an information message to show
 // progress to the user. In order to prevent spam, it limits logging to one
 // message every 10 seconds with duration and totals included.
-func (b *BlockProgressLogger) LogBlockHeight(block, parent *wire.MsgBlock) {
+func (b *BlockProgressLogger) LogBlockHeight(block *wire.MsgBlock) {
 	b.Lock()
 	defer b.Unlock()
 

--- a/internal/blockchain/validate.go
+++ b/internal/blockchain/validate.go
@@ -3609,7 +3609,7 @@ func checkStakeBaseAmounts(subsidyCache *standalone.SubsidyCache, height int64,
 // getStakeBaseAmounts calculates the total amount given as subsidy from the
 // collective stakebase transactions (votes) within a block.  This function
 // skips a ton of checks already performed by CheckTransactionInputs.
-func getStakeBaseAmounts(txs []*dcrutil.Tx, view *UtxoViewpoint, isTreasuryEnabled bool) (int64, error) {
+func getStakeBaseAmounts(txs []*dcrutil.Tx, view *UtxoViewpoint) (int64, error) {
 	totalInputs := int64(0)
 	totalOutputs := int64(0)
 	for _, tx := range txs {
@@ -3812,7 +3812,7 @@ func (b *BlockChain) checkTransactionsAndConnect(inputFees dcrutil.Amount,
 	// mining the block.  It is safe to ignore overflow and out of range
 	// errors here because those error conditions would have already been
 	// caught by the transaction sanity checks.
-	if !stakeTree { //TxTreeRegular
+	if !stakeTree { // TxTreeRegular
 		// Apply penalty to fees if we're at stake validation height.
 		if node.height >= b.chainParams.StakeValidationHeight {
 			totalFees *= int64(node.voters)
@@ -3900,8 +3900,7 @@ func (b *BlockChain) checkTransactionsAndConnect(inputFees dcrutil.Amount,
 			return err
 		}
 
-		totalAtomOutStake, err := getStakeBaseAmounts(txs, view,
-			isTreasuryEnabled)
+		totalAtomOutStake, err := getStakeBaseAmounts(txs, view)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This consists of a series of a couple of commits to remove unused parameters from `blockchain` methods.

The following parameters are removed:

- `isTreasuryEnabled` from `getStakeBaseAmounts`
- `parent` from `progressLogger.LogBlockHeight`