### PR TITLE
build: Add errorlint linter.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - dupword
     - durationcheck
     - errchkjson
+    - errorlint
     - exportloopref
     - gofmt
     - goimports

--- a/dcrutil/wif_test.go
+++ b/dcrutil/wif_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013, 2014 The btcsuite developers
-// Copyright (c) 2015-2021 The Decred developers
+// Copyright (c) 2015-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -38,6 +38,7 @@ func TestWIF(t *testing.T) {
 		if (err == nil) != (target == nil) {
 			return false
 		}
+		// nolint: errorlint
 		return err == target || (err != nil && err.Error() == target.Error())
 	}
 

--- a/wire/error.go
+++ b/wire/error.go
@@ -189,6 +189,7 @@ func (e ErrorCode) Error() string {
 // - The target is a *MessageError and the error codes match
 // - The target is an ErrorCode and it the error codes match
 func (e ErrorCode) Is(target error) bool {
+	// nolint: errorlint
 	switch target := target.(type) {
 	case *MessageError:
 		return e == target.ErrorCode
@@ -232,6 +233,7 @@ func messageError(funcName string, c ErrorCode, desc string) *MessageError {
 // - The target is a *MessageError and the error codes match
 // - The target is an ErrorCode and it the error codes match
 func (m *MessageError) Is(target error) bool {
+	// nolint: errorlint
 	switch target := target.(type) {
 	case *MessageError:
 		return m.ErrorCode == target.ErrorCode


### PR DESCRIPTION
**This requires #3178**.

This adds the `errorlint` linter to the list of linters and addresses a few false positives it complains about.
