### PR TITLE
rpcserver: Improve internal error handling.

### DIFF
--- a/internal/rpcserver/rpcwebsocket.go
+++ b/internal/rpcserver/rpcwebsocket.go
@@ -1990,8 +1990,7 @@ func handleWebsocketHelp(_ context.Context, wsc *wsClient, icmd interface{}) (in
 	if method == "" {
 		usage, err := wsc.rpcServer.helpCacher.RPCUsage(true)
 		if err != nil {
-			context := "Failed to generate RPC usage"
-			return nil, rpcInternalError(err.Error(), context)
+			return nil, rpcInternalErr(err, "Failed to generate RPC usage")
 		}
 		return usage, nil
 	}
@@ -2013,8 +2012,7 @@ func handleWebsocketHelp(_ context.Context, wsc *wsClient, icmd interface{}) (in
 	// Get the help for the command.
 	help, err := wsc.rpcServer.helpCacher.RPCMethodHelp(method)
 	if err != nil {
-		context := "Failed to generate help"
-		return nil, rpcInternalError(err.Error(), context)
+		return nil, rpcInternalErr(err, "Failed to generate help")
 	}
 	return help, nil
 }


### PR DESCRIPTION
This cleans up the handling of internal errors in the RPC server to be more consistent and use the errors themselves as opposed to their stringized form.

There are far more instances of already having an error to pass along versus the ones that generate new errors at the call site.  Accepting the errors directly results in less noise and also makes it harder to misuse.