### PR TITLE
 [release-v1.8] main: Use backported rpc types updates.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/decred/dcrd/lru v1.1.2
 	github.com/decred/dcrd/math/uint256 v1.0.1
 	github.com/decred/dcrd/peer/v3 v3.0.2
-	github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.0.0
+	github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.1.0
 	github.com/decred/dcrd/rpcclient/v8 v8.0.0
 	github.com/decred/dcrd/txscript/v4 v4.1.0
 	github.com/decred/dcrd/wire v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/decred/dcrd/math/uint256 v1.0.1 h1:SUMHmqi4GQwBNdueS5Pjj6Pzr3fZrc31sk
 github.com/decred/dcrd/math/uint256 v1.0.1/go.mod h1:7M/y9wJJvlyNG/f/X6mxxhxo9dgloZHFiOfbiscl75A=
 github.com/decred/dcrd/peer/v3 v3.0.2 h1:akcB/L5tZcV/LV5LsiAAeShzvus8mjwvkLI20b1aSUM=
 github.com/decred/dcrd/peer/v3 v3.0.2/go.mod h1:J3Wwi3biKzsIoQS61LnpFyjDgP7oigdoptf2r6yNMBQ=
-github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.0.0 h1:4YUKsWKrKlkhVMYGRB6G0XI6QfwUnwEH18eoEbM1/+M=
-github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.0.0/go.mod h1:dDHO7ivrPAhZjFD3LoOJN/kdq5gi0sxie6zCsWHAiUo=
+github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.1.0 h1:kQFK7FMTmMDX9amyhh8IR0vwwI8dH0KCBm42C64bWVs=
+github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.1.0/go.mod h1:dDHO7ivrPAhZjFD3LoOJN/kdq5gi0sxie6zCsWHAiUo=
 github.com/decred/dcrd/rpcclient/v8 v8.0.0 h1:O4B5d+8e2OjbeFW+c1XcZNQzyp++04ArWhXgYrsURus=
 github.com/decred/dcrd/rpcclient/v8 v8.0.0/go.mod h1:gx4+DI5apuOEeLwPBJFlMoj3GFWq1I7/X8XCQmMTi8Q=
 github.com/decred/dcrd/txscript/v4 v4.1.0 h1:uEdcibIOl6BuWj3AqmXZ9xIK/qbo6lHY9aNk29FtkrU=

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -61,7 +61,7 @@ import (
 // API version constants
 const (
 	jsonrpcSemverMajor = 8
-	jsonrpcSemverMinor = 0
+	jsonrpcSemverMinor = 1
 	jsonrpcSemverPatch = 0
 )
 
@@ -1969,8 +1969,19 @@ func handleGetBlock(_ context.Context, s *Server, cmd interface{}) (interface{},
 		return nil, rpcInternalError(err.Error(), "Unable to retrieve median block time")
 	}
 
+	isBlake3PowActive, err := s.isBlake3PowAgendaActive(&blockHeader.PrevBlock)
+	if err != nil {
+		return nil, err
+	}
+	powHashFn := blockHeader.PowHashV1
+	if isBlake3PowActive {
+		powHashFn = blockHeader.PowHashV2
+	}
+	powHash := powHashFn()
+
 	blockReply := types.GetBlockVerboseResult{
 		Hash:          c.Hash,
+		PoWHash:       powHash.String(),
 		Version:       blockHeader.Version,
 		MerkleRoot:    blockHeader.MerkleRoot.String(),
 		StakeRoot:     blockHeader.StakeRoot.String(),
@@ -2249,8 +2260,19 @@ func handleGetBlockHeader(_ context.Context, s *Server, cmd interface{}) (interf
 		return nil, rpcInternalError(err.Error(), "Unable to retrieve median block time")
 	}
 
+	isBlake3PowActive, err := s.isBlake3PowAgendaActive(&blockHeader.PrevBlock)
+	if err != nil {
+		return nil, err
+	}
+	powHashFn := blockHeader.PowHashV1
+	if isBlake3PowActive {
+		powHashFn = blockHeader.PowHashV2
+	}
+	powHash := powHashFn()
+
 	blockHeaderReply := types.GetBlockHeaderVerboseResult{
 		Hash:          c.Hash,
+		PowHash:       powHash.String(),
 		Confirmations: confirmations,
 		Version:       blockHeader.Version,
 		MerkleRoot:    blockHeader.MerkleRoot.String(),

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -3763,6 +3763,8 @@ func TestHandleGetBlock(t *testing.T) {
 	blk := dcrutil.NewBlock(&block432100)
 	blkHash := blk.Hash()
 	blkHashString := blkHash.String()
+	powHash := blkHeader.PowHashV1() // pre-DCP0011 activation
+	powHashString := powHash.String()
 	blkBytes, err := blk.Bytes()
 	if err != nil {
 		t.Fatalf("error serializing block: %+v", err)
@@ -3827,6 +3829,7 @@ func TestHandleGetBlock(t *testing.T) {
 		}(),
 		result: types.GetBlockVerboseResult{
 			Hash:          blkHashString,
+			PoWHash:       powHashString,
 			Version:       blkHeader.Version,
 			MerkleRoot:    blkHeader.MerkleRoot.String(),
 			StakeRoot:     blkHeader.StakeRoot.String(),
@@ -3882,6 +3885,7 @@ func TestHandleGetBlock(t *testing.T) {
 		}(),
 		result: types.GetBlockVerboseResult{
 			Hash:          blkHashString,
+			PoWHash:       powHashString,
 			Version:       blkHeader.Version,
 			MerkleRoot:    blkHeader.MerkleRoot.String(),
 			StakeRoot:     blkHeader.StakeRoot.String(),
@@ -4032,6 +4036,7 @@ func TestHandleGetBlockHeader(t *testing.T) {
 		t.Fatalf("error serializing block header: %+v", err)
 	}
 	blkHeaderHexString := hex.EncodeToString(blkHeaderBytes)
+	powHashString := blkHeader.PowHashV1().String() // pre-DCP0011 block
 	blk := dcrutil.NewBlock(&block432100)
 	blkHash := blk.Hash()
 	blkHashString := blkHash.String()
@@ -4065,6 +4070,7 @@ func TestHandleGetBlockHeader(t *testing.T) {
 		}(),
 		result: types.GetBlockHeaderVerboseResult{
 			Hash:          blkHashString,
+			PowHash:       powHashString,
 			Confirmations: confirmations,
 			Version:       blkHeader.Version,
 			MerkleRoot:    blkHeader.MerkleRoot.String(),

--- a/internal/rpcserver/rpcserverhelp.go
+++ b/internal/rpcserver/rpcserverhelp.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2015 The btcsuite developers
-// Copyright (c) 2015-2022 The Decred developers
+// Copyright (c) 2015-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -276,6 +276,7 @@ var helpDescsEnUS = map[string]string{
 
 	// GetBlockVerboseResult help.
 	"getblockverboseresult-hash":              "The hash of the block (same as provided)",
+	"getblockverboseresult-powhash":           "The Proof-of-Work hash of the block (same as hash prior to DCP0011 activation)",
 	"getblockverboseresult-confirmations":     "The number of confirmations",
 	"getblockverboseresult-size":              "The size of the block",
 	"getblockverboseresult-height":            "The height of the block in the block chain",
@@ -323,6 +324,7 @@ var helpDescsEnUS = map[string]string{
 
 	// GetBlockHeaderVerboseResult help.
 	"getblockheaderverboseresult-hash":              "The hash of the block (same as provided)",
+	"getblockheaderverboseresult-powhash":           "The Proof-of-Work hash of the block (same as hash prior to DCP0011 activation)",
 	"getblockheaderverboseresult-confirmations":     "The number of confirmations",
 	"getblockheaderverboseresult-height":            "The height of the block in the block chain",
 	"getblockheaderverboseresult-version":           "The block version",

--- a/rpc/jsonrpc/types/chainsvrresults.go
+++ b/rpc/jsonrpc/types/chainsvrresults.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015-2022 The Decred developers
+// Copyright (c) 2015-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -62,6 +62,7 @@ type GetAddedNodeInfoResult struct {
 // hex-encoded string.  Contains Decred additions.
 type GetBlockVerboseResult struct {
 	Hash          string        `json:"hash"`
+	PoWHash       string        `json:"powhash"`
 	Confirmations int64         `json:"confirmations"`
 	Size          int32         `json:"size"`
 	Height        int64         `json:"height"`
@@ -137,6 +138,7 @@ type GetBlockChainInfoResult struct {
 // returns a hex-encoded string.
 type GetBlockHeaderVerboseResult struct {
 	Hash          string  `json:"hash"`
+	PowHash       string  `json:"powhash"`
 	Confirmations int64   `json:"confirmations"`
 	Version       int32   `json:"version"`
 	MerkleRoot    string  `json:"merkleroot"`


### PR DESCRIPTION
This updates the 1.8 release to use the latest version of the `rpc/jsonrpc/types` module which includes updates to expose the new proof of work hash in the verbose `getblock` and `getblockheader` results.

In particular, the following updated module version is used:

- github.com/decred/dcrd/rpc/jsonrpc/types/v4@v4.1.0

Note that it also cherry picks all of the commits included in updates to the `rpc/jsonrpc/types/v4` module to ensure they are also included in the release branch even though it is not strictly necessary since the `go.mod` has been updated to require the new `rpc/jsonrpc/types/v4.1.0` release and thus will pull in the new code.  However, from past experience, not having code backported to modules available in the release branch too leads to headaches for devs building from source in their local workspace with overrides such as those in `go.work`.