### PR TITLE
[release-v1.8] rpcserver: Modify getnetworkhashps -1 blocks logic.

### DIFF
--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -2599,27 +2599,15 @@ func handleGetNetworkHashPS(_ context.Context, s *Server, cmd interface{}) (inte
 		endHeight = best.Height
 	}
 
-	// Calculate the number of blocks per retarget interval based on the
-	// chain parameters.
-	params := s.cfg.ChainParams
-	blocksPerRetarget := int64(params.TargetTimespan / params.TargetTimePerBlock)
-
-	// Calculate the starting block height based on the passed number of
-	// blocks.  When the passed value is negative, use the last block the
-	// difficulty changed as the starting height.  Also make sure the
+	// Calculate the starting block height based on the passed number of blocks.
+	// When the passed value is negative, use the default.  Also, make sure the
 	// starting height is not before the beginning of the chain.
-
 	numBlocks := int64(120)
-	if c.Blocks != nil {
+	if c.Blocks != nil && *c.Blocks >= 0 {
 		numBlocks = int64(*c.Blocks)
 	}
 
-	var startHeight int64
-	if numBlocks <= 0 {
-		startHeight = endHeight - ((endHeight % blocksPerRetarget) + 1)
-	} else {
-		startHeight = endHeight - numBlocks
-	}
+	startHeight := endHeight - numBlocks
 	if startHeight < 0 {
 		startHeight = 0
 	}

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -4567,11 +4567,9 @@ func TestHandleGetNetworkHashPS(t *testing.T) {
 	networkHashPSResult := int64(2014899978133500709)
 
 	testRPCServerHandler(t, []rpcTest{{
-		name:    "handleGetNetworkHashPS: ok",
-		handler: handleGetNetworkHashPS,
-		cmd: &types.GetNetworkHashPSCmd{
-			Blocks: dcrjson.Int(0),
-		},
+		name:      "handleGetNetworkHashPS: ok",
+		handler:   handleGetNetworkHashPS,
+		cmd:       &types.GetNetworkHashPSCmd{},
 		mockChain: mc(),
 		result:    networkHashPSResult,
 	}, {

--- a/internal/rpcserver/rpcserverhelp.go
+++ b/internal/rpcserver/rpcserverhelp.go
@@ -512,7 +512,7 @@ var helpDescsEnUS = map[string]string{
 
 	// GetNetworkHashPSCmd help.
 	"getnetworkhashps--synopsis": "Returns the estimated network hashes per second for the block heights provided by the parameters.",
-	"getnetworkhashps-blocks":    "The number of blocks, or -1 for blocks since last difficulty change",
+	"getnetworkhashps-blocks":    "The number of blocks or -1 for the default number of blocks",
 	"getnetworkhashps-height":    "Perform estimate ending with this height or -1 for current best chain block height",
 	"getnetworkhashps--result0":  "Estimated hashes per second",
 


### PR DESCRIPTION
This is a backport of #3181 to the 1.8 release branch.