### PR TITLE
[release-v1.8] release: Bump for 1.8.1.

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -56,7 +56,7 @@ var (
 	// the package will panic at runtime.  Of particular note is the pre-release
 	// and build metadata portions MUST only contain characters from
 	// semanticAlphabet.
-	Version = "1.8.0+release.local"
+	Version = "1.8.1+release.local"
 
 	// NOTE: The following values are set via init by parsing the above Version
 	// string.


### PR DESCRIPTION
**This requires #3192 and #3193**.