### PR TITLE
dcrutil: Use os.UserHomeDir in appDataDir.

### DIFF
--- a/dcrutil/appdata.go
+++ b/dcrutil/appdata.go
@@ -7,7 +7,6 @@ package dcrutil
 
 import (
 	"os"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -31,11 +30,7 @@ func appDataDir(goos, appName string, roaming bool) string {
 	appNameLower := string(unicode.ToLower(rune(appName[0]))) + appName[1:]
 
 	// Get the OS specific home directory via the Go standard lib.
-	var homeDir string
-	usr, err := user.Current()
-	if err == nil {
-		homeDir = usr.HomeDir
-	}
+	homeDir, err := os.UserHomeDir()
 
 	// Fall back to standard HOME environment variable that works
 	// for most POSIX OSes if the directory from the Go standard


### PR DESCRIPTION
This PR swaps out the `user.Current().HomeDir` with `os.UserHomeDir()`, which has been the recommended way of obtaining the user's home directory path since go 1.12

Rationale for the change: packaging systems like Flatpak and Snap provide sandboxed environments for applications and don't allow binaries to directly write to the home directory.  Instead, they designate a separate directory per app and set `$HOME` accordingly.  `user.Current().HomeDir` parses `/etc/passwd`, `os.UserHomeDir` uses environment variables, thus the latter enables consumers of `appDataDir` to run inside these sandboxes.

This change is specifically required for the snap and flatpak packaging effort underway for the DCRDEX desktop app.