### PR TITLE
multi: Reduce done goroutines.

### DIFF
--- a/internal/mining/bgblktmplgenerator.go
+++ b/internal/mining/bgblktmplgenerator.go
@@ -1515,15 +1515,14 @@ func (g *BgBlkTmplGenerator) initialStartupHandler(ctx context.Context) {
 // necessary for it to function properly and blocks until the provided context
 // is cancelled.
 func (g *BgBlkTmplGenerator) Run(ctx context.Context) {
-	g.wg.Add(5)
+	g.wg.Add(4)
 	go g.regenQueueHandler(ctx)
 	go g.regenHandler(ctx)
 	go g.notifySubscribersHandler(ctx)
 	go g.initialStartupHandler(ctx)
-	go func() {
-		<-ctx.Done()
-		close(g.quit)
-		g.wg.Done()
-	}()
+
+	// Shutdown the generator when the context is cancelled.
+	<-ctx.Done()
+	close(g.quit)
 	g.wg.Wait()
 }

--- a/internal/mining/cpuminer/cpuminer.go
+++ b/internal/mining/cpuminer/cpuminer.go
@@ -617,15 +617,13 @@ out:
 func (m *CPUMiner) Run(ctx context.Context) {
 	log.Trace("Starting CPU miner in idle state")
 
-	m.wg.Add(3)
+	m.wg.Add(2)
 	go m.speedMonitor(ctx)
 	go m.miningWorkerController(ctx)
-	go func(ctx context.Context) {
-		<-ctx.Done()
-		close(m.quit)
-		m.wg.Done()
-	}(ctx)
 
+	// Shutdown the miner when the context is cancelled.
+	<-ctx.Done()
+	close(m.quit)
 	m.wg.Wait()
 	log.Trace("CPU miner stopped")
 }

--- a/internal/netsync/manager.go
+++ b/internal/netsync/manager.go
@@ -1796,13 +1796,8 @@ func (m *SyncManager) Run(ctx context.Context) {
 	go m.eventHandler(ctx)
 
 	// Shutdown the sync manager when the context is cancelled.
-	m.wg.Add(1)
-	go func(ctx context.Context) {
-		<-ctx.Done()
-		close(m.quit)
-		m.wg.Done()
-	}(ctx)
-
+	<-ctx.Done()
+	close(m.quit)
 	m.wg.Wait()
 	log.Trace("Sync manager stopped")
 }


### PR DESCRIPTION
This modifies the logic in several Run methods to block until the context is cancelled directly in the Run method instead of launching a separate goroutine for that purpose.

This approach is preferred since it provides the same functionality without additional long-running goroutines.