### PR TITLE
netsync: Export opaque peer and require it in API.

### DIFF
--- a/internal/netsync/manager.go
+++ b/internal/netsync/manager.go
@@ -92,8 +92,8 @@ const (
 // zeroHash is the zero value hash (all zeros).  It is defined as a convenience.
 var zeroHash chainhash.Hash
 
-// newPeerMsg signifies a newly connected peer to the event handler.
-type newPeerMsg struct {
+// peerConnectedMsg signifies a newly connected peer to the event handler.
+type peerConnectedMsg struct {
 	peer *peerpkg.Peer
 }
 
@@ -602,10 +602,10 @@ func (m *SyncManager) isSyncCandidate(peer *peerpkg.Peer) bool {
 	return peer.Services()&wire.SFNodeNetwork == wire.SFNodeNetwork
 }
 
-// handleNewPeerMsg deals with new peers that have signalled they may
+// handlePeerConnectedMsg deals with new peers that have signalled they may
 // be considered as a sync peer (they have already successfully negotiated).  It
 // also starts syncing if needed.  It is invoked from the syncHandler goroutine.
-func (m *SyncManager) handleNewPeerMsg(ctx context.Context, peer *peerpkg.Peer) {
+func (m *SyncManager) handlePeerConnectedMsg(ctx context.Context, peer *peerpkg.Peer) {
 	select {
 	case <-ctx.Done():
 	default:
@@ -1438,8 +1438,8 @@ out:
 		select {
 		case data := <-m.msgChan:
 			switch msg := data.(type) {
-			case *newPeerMsg:
-				m.handleNewPeerMsg(ctx, msg.peer)
+			case *peerConnectedMsg:
+				m.handlePeerConnectedMsg(ctx, msg.peer)
 
 			case *txMsg:
 				m.handleTxMsg(msg)
@@ -1528,10 +1528,10 @@ out:
 	log.Trace("Sync manager event handler done")
 }
 
-// NewPeer informs the sync manager of a newly active peer.
-func (m *SyncManager) NewPeer(peer *peerpkg.Peer) {
+// PeerConnected informs the sync manager of a newly active peer.
+func (m *SyncManager) PeerConnected(peer *peerpkg.Peer) {
 	select {
-	case m.msgChan <- &newPeerMsg{peer: peer}:
+	case m.msgChan <- &peerConnectedMsg{peer: peer}:
 	case <-m.quit:
 	}
 }

--- a/internal/netsync/manager.go
+++ b/internal/netsync/manager.go
@@ -126,8 +126,8 @@ type notFoundMsg struct {
 	peer     *peerpkg.Peer
 }
 
-// donePeerMsg signifies a newly disconnected peer to the event handler.
-type donePeerMsg struct {
+// peerDisconnectedMsg signifies a newly disconnected peer to the event handler.
+type peerDisconnectedMsg struct {
 	peer *peerpkg.Peer
 }
 
@@ -635,11 +635,11 @@ func (m *SyncManager) handlePeerConnectedMsg(ctx context.Context, peer *peerpkg.
 	}
 }
 
-// handleDonePeerMsg deals with peers that have signalled they are done.  It
-// removes the peer as a candidate for syncing and in the case where it was
+// handlePeerDisconnectedMsg deals with peers that have signalled they are done.
+// It removes the peer as a candidate for syncing and in the case where it was
 // the current sync peer, attempts to select a new best peer to sync from.  It
 // is invoked from the syncHandler goroutine.
-func (m *SyncManager) handleDonePeerMsg(p *peerpkg.Peer) {
+func (m *SyncManager) handlePeerDisconnectedMsg(p *peerpkg.Peer) {
 	peer := lookupPeer(p, m.peers)
 	if peer == nil {
 		return
@@ -1464,8 +1464,8 @@ out:
 			case *notFoundMsg:
 				m.handleNotFoundMsg(msg)
 
-			case *donePeerMsg:
-				m.handleDonePeerMsg(msg.peer)
+			case *peerDisconnectedMsg:
+				m.handlePeerDisconnectedMsg(msg.peer)
 
 			case getSyncPeerMsg:
 				var peerID int32
@@ -1582,10 +1582,10 @@ func (m *SyncManager) QueueNotFound(notFound *wire.MsgNotFound, peer *peerpkg.Pe
 	}
 }
 
-// DonePeer informs the sync manager that a peer has disconnected.
-func (m *SyncManager) DonePeer(peer *peerpkg.Peer) {
+// PeerDisconnected informs the sync manager that a peer has disconnected.
+func (m *SyncManager) PeerDisconnected(peer *peerpkg.Peer) {
 	select {
-	case m.msgChan <- &donePeerMsg{peer: peer}:
+	case m.msgChan <- &peerDisconnectedMsg{peer: peer}:
 	case <-m.quit:
 	}
 }

--- a/server.go
+++ b/server.go
@@ -2314,7 +2314,7 @@ out:
 			// Signal the net sync manager this peer is a new sync candidate
 			// unless it was disconnected above.
 			if p.Connected() {
-				s.syncManager.NewPeer(p.Peer)
+				s.syncManager.PeerConnected(p.Peer)
 				p.syncNotifiedMtx.Lock()
 				p.syncNotified = true
 				p.syncNotifiedMtx.Unlock()

--- a/server.go
+++ b/server.go
@@ -2266,7 +2266,7 @@ func (s *server) peerDoneHandler(sp *serverPeer) {
 	syncNotified := sp.syncNotified
 	sp.syncNotifiedMtx.Unlock()
 	if syncNotified {
-		s.syncManager.DonePeer(sp.Peer)
+		s.syncManager.PeerDisconnected(sp.Peer)
 	}
 
 	if sp.VersionKnown() {


### PR DESCRIPTION
Currently the sync manager maintains additional state per peer in an        internal struct that wraps a base/common peer as well as a mapping keyed by that base/common peer.  The internal wrapped peer is then queried each time it is needed.  This leads to code that is harder to reason about and can fail to lookup the necessary state in some hard to hit corner cases.

With that in mind, this modifies the sync manager semantics to instead export the wrapped peer and require the caller to provide that wrapped peer in all of its APIs directly.  The server then creates and stores the wrapped peer instance at connection time and passes it to the sync manager.

The end result is the code is easier to reason about and resolves the aforementioned hard to hit corner cases since it is no longer possible for the sync manager to ever have access to a peer without the associated extra state.

It also renames a the `NewPeer` and `DonePeer` methods to `PeerConnected` `PeerDisconnected` in separate commits, respectively, to more clearly denote their purpose.