### PR TITLE
server: Use server peer in log statements.

### DIFF
--- a/internal/netsync/manager.go
+++ b/internal/netsync/manager.go
@@ -92,8 +92,8 @@ const (
 // zeroHash is the zero value hash (all zeros).  It is defined as a convenience.
 var zeroHash chainhash.Hash
 
-// newPeerMsg signifies a newly connected peer to the event handler.
-type newPeerMsg struct {
+// peerConnectedMsg signifies a newly connected peer to the event handler.
+type peerConnectedMsg struct {
 	peer *peerpkg.Peer
 }
 
@@ -602,10 +602,10 @@ func (m *SyncManager) isSyncCandidate(peer *peerpkg.Peer) bool {
 	return peer.Services()&wire.SFNodeNetwork == wire.SFNodeNetwork
 }
 
-// handleNewPeerMsg deals with new peers that have signalled they may
+// handlePeerConnectedMsg deals with new peers that have signalled they may
 // be considered as a sync peer (they have already successfully negotiated).  It
 // also starts syncing if needed.  It is invoked from the syncHandler goroutine.
-func (m *SyncManager) handleNewPeerMsg(ctx context.Context, peer *peerpkg.Peer) {
+func (m *SyncManager) handlePeerConnectedMsg(ctx context.Context, peer *peerpkg.Peer) {
 	select {
 	case <-ctx.Done():
 	default:
@@ -1438,8 +1438,8 @@ out:
 		select {
 		case data := <-m.msgChan:
 			switch msg := data.(type) {
-			case *newPeerMsg:
-				m.handleNewPeerMsg(ctx, msg.peer)
+			case *peerConnectedMsg:
+				m.handlePeerConnectedMsg(ctx, msg.peer)
 
 			case *txMsg:
 				m.handleTxMsg(msg)
@@ -1528,10 +1528,10 @@ out:
 	log.Trace("Sync manager event handler done")
 }
 
-// NewPeer informs the sync manager of a newly active peer.
-func (m *SyncManager) NewPeer(peer *peerpkg.Peer) {
+// PeerConnected informs the sync manager of a newly active peer.
+func (m *SyncManager) PeerConnected(peer *peerpkg.Peer) {
 	select {
-	case m.msgChan <- &newPeerMsg{peer: peer}:
+	case m.msgChan <- &peerConnectedMsg{peer: peer}:
 	case <-m.quit:
 	}
 }

--- a/internal/netsync/manager.go
+++ b/internal/netsync/manager.go
@@ -126,8 +126,8 @@ type notFoundMsg struct {
 	peer     *peerpkg.Peer
 }
 
-// donePeerMsg signifies a newly disconnected peer to the event handler.
-type donePeerMsg struct {
+// peerDisconnectedMsg signifies a newly disconnected peer to the event handler.
+type peerDisconnectedMsg struct {
 	peer *peerpkg.Peer
 }
 
@@ -635,11 +635,11 @@ func (m *SyncManager) handlePeerConnectedMsg(ctx context.Context, peer *peerpkg.
 	}
 }
 
-// handleDonePeerMsg deals with peers that have signalled they are done.  It
-// removes the peer as a candidate for syncing and in the case where it was
+// handlePeerDisconnectedMsg deals with peers that have signalled they are done.
+// It removes the peer as a candidate for syncing and in the case where it was
 // the current sync peer, attempts to select a new best peer to sync from.  It
 // is invoked from the syncHandler goroutine.
-func (m *SyncManager) handleDonePeerMsg(p *peerpkg.Peer) {
+func (m *SyncManager) handlePeerDisconnectedMsg(p *peerpkg.Peer) {
 	peer := lookupPeer(p, m.peers)
 	if peer == nil {
 		return
@@ -1464,8 +1464,8 @@ out:
 			case *notFoundMsg:
 				m.handleNotFoundMsg(msg)
 
-			case *donePeerMsg:
-				m.handleDonePeerMsg(msg.peer)
+			case *peerDisconnectedMsg:
+				m.handlePeerDisconnectedMsg(msg.peer)
 
 			case getSyncPeerMsg:
 				var peerID int32
@@ -1582,10 +1582,10 @@ func (m *SyncManager) QueueNotFound(notFound *wire.MsgNotFound, peer *peerpkg.Pe
 	}
 }
 
-// DonePeer informs the sync manager that a peer has disconnected.
-func (m *SyncManager) DonePeer(peer *peerpkg.Peer) {
+// PeerDisconnected informs the sync manager that a peer has disconnected.
+func (m *SyncManager) PeerDisconnected(peer *peerpkg.Peer) {
 	select {
-	case m.msgChan <- &donePeerMsg{peer: peer}:
+	case m.msgChan <- &peerDisconnectedMsg{peer: peer}:
 	case <-m.quit:
 	}
 }

--- a/server.go
+++ b/server.go
@@ -656,7 +656,7 @@ func (sp *serverPeer) pushAddrMsg(addresses []*addrmgr.NetAddress) {
 	}
 	known, err := sp.PushAddrMsg(addrs)
 	if err != nil {
-		peerLog.Errorf("Can't push address message to %s: %v", sp.Peer, err)
+		peerLog.Errorf("Can't push address message to %s: %v", sp, err)
 		sp.Disconnect()
 		return
 	}
@@ -739,7 +739,7 @@ func (sp *serverPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) {
 	// Reject peers that have a protocol version that is too old.
 	if msg.ProtocolVersion < int32(wire.SendHeadersVersion) {
 		srvrLog.Debugf("Rejecting peer %s with protocol version %d prior to "+
-			"the required version %d", sp.Peer, msg.ProtocolVersion,
+			"the required version %d", sp, msg.ProtocolVersion,
 			wire.SendHeadersVersion)
 		sp.Disconnect()
 		return
@@ -750,8 +750,7 @@ func (sp *serverPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) {
 	if !isInbound && !hasServices(msg.Services, wantServices) {
 		missingServices := wantServices & ^msg.Services
 		srvrLog.Debugf("Rejecting peer %s with services %v due to not "+
-			"providing desired services %v", sp.Peer, msg.Services,
-			missingServices)
+			"providing desired services %v", sp, msg.Services, missingServices)
 		sp.Disconnect()
 		return
 	}
@@ -874,7 +873,7 @@ func (sp *serverPeer) pushMiningStateMsg(height uint32, blockHashes []chainhash.
 // mined on and pushes a miningstate wire message back to the requesting peer.
 func (sp *serverPeer) OnGetMiningState(_ *peer.Peer, msg *wire.MsgGetMiningState) {
 	if sp.getMiningStateSent {
-		peerLog.Tracef("Ignoring getminingstate from %v - already sent", sp.Peer)
+		peerLog.Tracef("Ignoring getminingstate from %v - already sent", sp)
 		return
 	}
 	sp.getMiningStateSent = true
@@ -961,7 +960,7 @@ func (sp *serverPeer) OnMiningState(_ *peer.Peer, msg *wire.MsgMiningState) {
 // It sends the available requested info to the remote peer.
 func (sp *serverPeer) OnGetInitState(_ *peer.Peer, msg *wire.MsgGetInitState) {
 	if sp.initStateSent {
-		peerLog.Tracef("Ignoring getinitstate from %v - already sent", sp.Peer)
+		peerLog.Tracef("Ignoring getinitstate from %v - already sent", sp)
 		return
 	}
 	sp.initStateSent = true
@@ -1264,8 +1263,7 @@ func (sp *serverPeer) OnGetHeaders(_ *peer.Peer, msg *wire.MsgGetHeaders) {
 	workSum, err := chain.ChainWork(&tipHash)
 	if err == nil && workSum.Lt(&sp.server.minKnownWork) {
 		srvrLog.Debugf("Sending empty headers to peer %s in response to "+
-			"getheaders due to local best known tip having too little work",
-			sp.Peer)
+			"getheaders due to local best known tip having too little work", sp)
 		sp.QueueMessage(&wire.MsgHeaders{}, nil)
 		return
 	}
@@ -1373,7 +1371,7 @@ func (sp *serverPeer) OnGetAddr(_ *peer.Peer, msg *wire.MsgGetAddr) {
 	// Only respond with addresses once per connection.  This helps reduce
 	// traffic and further reduces fingerprinting attacks.
 	if sp.addrsSent {
-		peerLog.Tracef("Ignoring getaddr from %v - already sent", sp.Peer)
+		peerLog.Tracef("Ignoring getaddr from %v - already sent", sp)
 		return
 	}
 	sp.addrsSent = true

--- a/server.go
+++ b/server.go
@@ -2314,7 +2314,7 @@ out:
 			// Signal the net sync manager this peer is a new sync candidate
 			// unless it was disconnected above.
 			if p.Connected() {
-				s.syncManager.NewPeer(p.Peer)
+				s.syncManager.PeerConnected(p.Peer)
 				p.syncNotifiedMtx.Lock()
 				p.syncNotified = true
 				p.syncNotifiedMtx.Unlock()

--- a/server.go
+++ b/server.go
@@ -2266,7 +2266,7 @@ func (s *server) peerDoneHandler(sp *serverPeer) {
 	syncNotified := sp.syncNotified
 	sp.syncNotifiedMtx.Unlock()
 	if syncNotified {
-		s.syncManager.DonePeer(sp.Peer)
+		s.syncManager.PeerDisconnected(sp.Peer)
 	}
 
 	if sp.VersionKnown() {


### PR DESCRIPTION
**This requires #3201**.

This change a few cases that log the peer to use the server peer instead of the underlying peer from the peer package.  This doesn't change the output in any way, but it is more consistent with the vast majority of other instances.  It also preferable since it ensures consistent logging output if a custom stringer is ever implemented on server peers.