### PR TITLE
wire: Mark legacy message types as deprecated.

### DIFF
--- a/wire/message.go
+++ b/wire/message.go
@@ -48,16 +48,36 @@ const (
 	CmdReject         = "reject"
 	CmdSendHeaders    = "sendheaders"
 	CmdFeeFilter      = "feefilter"
-	CmdGetCFilter     = "getcfilter"
-	CmdGetCFHeaders   = "getcfheaders"
-	CmdGetCFTypes     = "getcftypes"
-	CmdCFilter        = "cfilter"
-	CmdCFHeaders      = "cfheaders"
-	CmdCFTypes        = "cftypes"
 	CmdGetCFilterV2   = "getcfilterv2"
 	CmdCFilterV2      = "cfilterv2"
 	CmdGetInitState   = "getinitstate"
 	CmdInitState      = "initstate"
+)
+
+const (
+	// Deprecated: This command is no longer valid as of protocol version
+	// CFilterV2Version.
+	CmdGetCFilter = "getcfilter"
+
+	// Deprecated: This command is no longer valid as of protocol version
+	// CFilterV2Version.
+	CmdGetCFHeaders = "getcfheaders"
+
+	// Deprecated: This command is no longer valid as of protocol version
+	// CFilterV2Version.
+	CmdGetCFTypes = "getcftypes"
+
+	// Deprecated: This command is no longer valid as of protocol version
+	// CFilterV2Version.
+	CmdCFilter = "cfilter"
+
+	// Deprecated: This command is no longer valid as of protocol version
+	// CFilterV2Version.
+	CmdCFHeaders = "cfheaders"
+
+	// Deprecated: This command is no longer valid as of protocol version
+	// CFilterV2Version.
+	CmdCFTypes = "cftypes"
 )
 
 // Message is an interface that describes a Decred message.  A type that

--- a/wire/msgcfheaders.go
+++ b/wire/msgcfheaders.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2017 The btcsuite developers
 // Copyright (c) 2017 The Lightning Network Developers
-// Copyright (c) 2018-2020 The Decred developers
+// Copyright (c) 2018-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -28,6 +28,9 @@ const (
 // response to a getcfheaders message (MsgGetCFHeaders). The maximum number of
 // committed filter headers per message is currently 2000. See MsgGetCFHeaders
 // for details on requesting the headers.
+//
+// Deprecated: This message is no longer valid as of protocol version
+// CFilterV2Version.
 type MsgCFHeaders struct {
 	StopHash     chainhash.Hash
 	FilterType   FilterType
@@ -174,6 +177,9 @@ func (msg *MsgCFHeaders) MaxPayloadLength(pver uint32) uint32 {
 
 // NewMsgCFHeaders returns a new cfheaders message that conforms to the Message
 // interface. See MsgCFHeaders for details.
+//
+// Deprecated: This message is no longer valid as of protocol version
+// CFilterV2Version.
 func NewMsgCFHeaders() *MsgCFHeaders {
 	return &MsgCFHeaders{
 		HeaderHashes: make([]*chainhash.Hash, 0, MaxCFHeadersPerMsg),

--- a/wire/msgcfilter.go
+++ b/wire/msgcfilter.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2017 The btcsuite developers
 // Copyright (c) 2017 The Lightning Network Developers
-// Copyright (c) 2018-2020 The Decred developers
+// Copyright (c) 2018-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -22,6 +22,9 @@ const (
 // MsgCFilter implements the Message interface and represents a cfilter message.
 // It is used to deliver a committed filter in response to a getcfilter
 // (MsgGetCFilter) message.
+//
+// Deprecated: This message is no longer valid as of protocol version
+// CFilterV2Version.
 type MsgCFilter struct {
 	BlockHash  chainhash.Hash
 	FilterType FilterType
@@ -115,6 +118,9 @@ func (msg *MsgCFilter) MaxPayloadLength(pver uint32) uint32 {
 
 // NewMsgCFilter returns a new cfilter message that conforms to the Message
 // interface. See MsgCFilter for details.
+//
+// Deprecated: This message is no longer valid as of protocol version
+// CFilterV2Version.
 func NewMsgCFilter(blockHash *chainhash.Hash, filterType FilterType,
 	data []byte) *MsgCFilter {
 	return &MsgCFilter{

--- a/wire/msgcftypes.go
+++ b/wire/msgcftypes.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2017 The btcsuite developers
 // Copyright (c) 2017 The Lightning Network Developers
-// Copyright (c) 2018-2020 The Decred developers
+// Copyright (c) 2018-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -27,6 +27,9 @@ const (
 )
 
 // MsgCFTypes is the cftypes message.
+//
+// Deprecated: This message is no longer valid as of protocol version
+// CFilterV2Version.
 type MsgCFTypes struct {
 	SupportedFilters []FilterType
 }
@@ -129,6 +132,9 @@ func (msg *MsgCFTypes) MaxPayloadLength(pver uint32) uint32 {
 
 // NewMsgCFTypes returns a new cftypes message that conforms to the Message
 // interface. See MsgCFTypes for details.
+//
+// Deprecated: This message is no longer valid as of protocol version
+// CFilterV2Version.
 func NewMsgCFTypes(filterTypes []FilterType) *MsgCFTypes {
 	return &MsgCFTypes{
 		SupportedFilters: filterTypes,

--- a/wire/msggetcfheaders.go
+++ b/wire/msggetcfheaders.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2017 The btcsuite developers
 // Copyright (c) 2017 The Lightning Network Developers
-// Copyright (c) 2018-2020 The Decred developers
+// Copyright (c) 2018-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -16,6 +16,9 @@ import (
 // MsgGetCFHeaders is a message similar to MsgGetHeaders, but for committed
 // filter headers. It allows to set the FilterType field to get headers in the
 // chain of basic (0x00) or extended (0x01) headers.
+//
+// Deprecated: This message is no longer valid as of protocol version
+// CFilterV2Version.
 type MsgGetCFHeaders struct {
 	BlockLocatorHashes []*chainhash.Hash
 	HashStop           chainhash.Hash
@@ -133,6 +136,9 @@ func (msg *MsgGetCFHeaders) MaxPayloadLength(pver uint32) uint32 {
 // NewMsgGetCFHeaders returns a new getcfheader message that conforms to the
 // Message interface using the passed parameters and defaults for the remaining
 // fields.
+//
+// Deprecated: This message is no longer valid as of protocol version
+// CFilterV2Version.
 func NewMsgGetCFHeaders() *MsgGetCFHeaders {
 	return &MsgGetCFHeaders{
 		BlockLocatorHashes: make([]*chainhash.Hash, 0,

--- a/wire/msggetcfilter.go
+++ b/wire/msggetcfilter.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2017 The btcsuite developers
 // Copyright (c) 2017 The Lightning Network Developers
-// Copyright (c) 2018-2020 The Decred developers
+// Copyright (c) 2018-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -15,6 +15,9 @@ import (
 
 // MsgGetCFilter implements the Message interface and represents a getcfilter
 // message. It is used to request a committed filter for a block.
+//
+// Deprecated: This message is no longer valid as of protocol version
+// CFilterV2Version.
 type MsgGetCFilter struct {
 	BlockHash  chainhash.Hash
 	FilterType FilterType
@@ -70,6 +73,9 @@ func (msg *MsgGetCFilter) MaxPayloadLength(pver uint32) uint32 {
 // NewMsgGetCFilter returns a new getcfilter message that conforms to the
 // Message interface using the passed parameters and defaults for the remaining
 // fields.
+//
+// Deprecated: This message is no longer valid as of protocol version
+// CFilterV2Version.
 func NewMsgGetCFilter(blockHash *chainhash.Hash, filterType FilterType) *MsgGetCFilter {
 	return &MsgGetCFilter{
 		BlockHash:  *blockHash,

--- a/wire/msggetcftypes.go
+++ b/wire/msggetcftypes.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2017 The btcsuite developers
 // Copyright (c) 2017 The Lightning Network Developers
-// Copyright (c) 2018-2020 The Decred developers
+// Copyright (c) 2018-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -12,6 +12,9 @@ import (
 )
 
 // MsgGetCFTypes is the getcftypes message.
+//
+// Deprecated: This message is no longer valid as of protocol version
+// CFilterV2Version.
 type MsgGetCFTypes struct{}
 
 // BtcDecode decodes the receiver from w using the wire protocol encoding.
@@ -55,6 +58,9 @@ func (msg *MsgGetCFTypes) MaxPayloadLength(pver uint32) uint32 {
 
 // NewMsgGetCFTypes returns a new getcftypes message that conforms to the
 // Message interface.
+//
+// Deprecated: This message is no longer valid as of protocol version
+// CFilterV2Version.
 func NewMsgGetCFTypes() *MsgGetCFTypes {
 	return &MsgGetCFTypes{}
 }


### PR DESCRIPTION
This marks the various message types and commands associated with version 1 `cfilters` as deprecated since they are no longer valid and will eventually be removed whenever a new major version of the wire module is released..