### PR TITLE
build: Update to latest actions and linter.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           bash ./.github/stablilize_testdata_timestamps.sh "${{ github.workspace }}"
       - name: Install Linters
-        run: "go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.1"
+        run: "go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2"
       - name: Build
         run: go build ./...
       - name: Test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,13 +12,13 @@ jobs:
         go: ["1.20", "1.21"]
     steps:
       - name: Check out source
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       - name: Set up Go
-        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 #v5.0.0
         with:
           go-version: ${{ matrix.go }}
       - name: Use lint cache
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
           path: |
             ~/.cache/golangci-lint


### PR DESCRIPTION
This consists of a couple of commits to update the CI to the latest linter and action versions.

In particular:

- build: Update to latest action versions:
  - https://github.com/actions/checkout/commit/b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
  - https://github.com/actions/setup-go/commit/0c52d547c9bc32b1aa3301fd7a9cb496313a4491 #v5.0.0
  - https://github.com/actions/cache/commit/704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
- build: Update golangci-lint to v1.55.2