### PR TITLE
multi: Build and doco updates for Go 1.22. 

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           bash ./.github/stablilize_testdata_timestamps.sh "${{ github.workspace }}"
       - name: Install Linters
-        run: "go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2"
+        run: "go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.0"
       - name: Build
         run: go build ./...
       - name: Test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.20", "1.21"]
+        go: ["1.21", "1.22"]
     steps:
       - name: Check out source
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ https://decred.org/downloads/
 
 <details><summary><b>Install Dependencies</b></summary>
 
-- **Go 1.20 or 1.21**
+- **Go 1.21 or 1.22**
 
   Installation instructions can be found here: https://golang.org/doc/install.
   Ensure Go was installed properly and is a supported version:


### PR DESCRIPTION
This consists of several commits to update the CI and documentation for Go 1.21. It also takes the opportunity to bump to the latest linter and action versions.

In particular:

- build: Update golangci-lint to v1.56.0.
- build: Test against Go 1.22 and remove Go 1.20 accordingly.
- docs: Update README.md to required Go 1.21/1.22.