### PR TITLE
secp256k1: Add TinyGo support.

### DIFF
--- a/dcrec/secp256k1/curve.go
+++ b/dcrec/secp256k1/curve.go
@@ -1221,6 +1221,19 @@ func ScalarMultNonConst(k *ModNScalar, point, result *JacobianPoint) {
 //
 // NOTE: The resulting point will be normalized.
 func ScalarBaseMultNonConst(k *ModNScalar, result *JacobianPoint) {
+	scalarBaseMultNonConst(k, result)
+}
+
+// scalarBaseMultNonConstSlow computes k*G through ScalarMultNonConst.
+func scalarBaseMultNonConstSlow(k *ModNScalar, result *JacobianPoint) {
+	var G JacobianPoint
+	bigAffineToJacobian(curveParams.Gx, curveParams.Gy, &G)
+	ScalarMultNonConst(k, &G, result)
+}
+
+// scalarBaseMultNonConstFast computes k*G through the precomputed lookup
+// tables.
+func scalarBaseMultNonConstFast(k *ModNScalar, result *JacobianPoint) {
 	bytePoints := s256BytePoints()
 
 	// Start with the point at infinity.

--- a/dcrec/secp256k1/curve_embedded.go
+++ b/dcrec/secp256k1/curve_embedded.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2024 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+//go:build tinygo
+
+package secp256k1
+
+// This file contains the variants suitable for
+// memory or storage constrained environments.
+
+func scalarBaseMultNonConst(k *ModNScalar, result *JacobianPoint) {
+	scalarBaseMultNonConstSlow(k, result)
+}

--- a/dcrec/secp256k1/curve_precompute.go
+++ b/dcrec/secp256k1/curve_precompute.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2024 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+//go:build !tinygo
+
+package secp256k1
+
+// This file contains the variants that don't fit in
+// memory or storage constrained environments.
+
+func scalarBaseMultNonConst(k *ModNScalar, result *JacobianPoint) {
+	scalarBaseMultNonConstFast(k, result)
+}


### PR DESCRIPTION
The pre-computed table for speeding up `ScalarBaseMultNonConst` is several hundred kilobytes in the binary and even more when unpacked into working memory. Special-case `ScalarBaseMultNonConst` to fall back to `ScalarMultNonConst` when the 'tinygo' tag is specified, which is true when building a Go program with TinyGo.