### PR TITLE
secp256k1: Add scalar base mult variant benchmarks.

### DIFF
--- a/dcrec/secp256k1/bench_test.go
+++ b/dcrec/secp256k1/bench_test.go
@@ -53,7 +53,7 @@ func BenchmarkAddNonConstNotZOne(b *testing.B) {
 }
 
 // BenchmarkScalarBaseMultNonConst benchmarks multiplying a scalar by the base
-// point of the curve.
+// point of the curve using whichever variant is active.
 func BenchmarkScalarBaseMultNonConst(b *testing.B) {
 	k := hexToModNScalar("d74bf844b0862475103d96a611cf2d898447e288d34b360bc885cb8ce7c00575")
 
@@ -62,6 +62,32 @@ func BenchmarkScalarBaseMultNonConst(b *testing.B) {
 	var result JacobianPoint
 	for i := 0; i < b.N; i++ {
 		ScalarBaseMultNonConst(k, &result)
+	}
+}
+
+// BenchmarkScalarBaseMultNonConstFast benchmarks multiplying a scalar by the
+// base point of the curve using the fast variant.
+func BenchmarkScalarBaseMultNonConstFast(b *testing.B) {
+	k := hexToModNScalar("d74bf844b0862475103d96a611cf2d898447e288d34b360bc885cb8ce7c00575")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	var result JacobianPoint
+	for i := 0; i < b.N; i++ {
+		scalarBaseMultNonConstFast(k, &result)
+	}
+}
+
+// BenchmarkScalarBaseMultNonConstSlow benchmarks multiplying a scalar by the
+// base point of the curve using the resource-constrained slow variant.
+func BenchmarkScalarBaseMultNonConstSlow(b *testing.B) {
+	k := hexToModNScalar("d74bf844b0862475103d96a611cf2d898447e288d34b360bc885cb8ce7c00575")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	var result JacobianPoint
+	for i := 0; i < b.N; i++ {
+		scalarBaseMultNonConstSlow(k, &result)
 	}
 }
 


### PR DESCRIPTION
~**This requires #3223**.~

This adds benchmarks for the recently added slow resource-constrained variant of `ScalarBaseMult` as well as an explicit one for the existing fast variant for comparison purposes.

```
ScalarBaseMultNonConstFast   64886   18242 ns/op    0 B/op   0 allocs/op
ScalarBaseMultNonConstSlow   13261   91696 ns/op   64 B/op   2 allocs/op
```