### PR TITLE
secp256k1: No allocs in slow scalar base mult path.

### DIFF
--- a/dcrec/secp256k1/curve.go
+++ b/dcrec/secp256k1/curve.go
@@ -1224,11 +1224,17 @@ func ScalarBaseMultNonConst(k *ModNScalar, result *JacobianPoint) {
 	scalarBaseMultNonConst(k, result)
 }
 
-// scalarBaseMultNonConstSlow computes k*G through ScalarMultNonConst.
-func scalarBaseMultNonConstSlow(k *ModNScalar, result *JacobianPoint) {
+// jacobianG is the secp256k1 base point converted to Jacobian coordinates and
+// is defined here to avoid repeatedly converting it.
+var jacobianG = func() JacobianPoint {
 	var G JacobianPoint
 	bigAffineToJacobian(curveParams.Gx, curveParams.Gy, &G)
-	ScalarMultNonConst(k, &G, result)
+	return G
+}()
+
+// scalarBaseMultNonConstSlow computes k*G through ScalarMultNonConst.
+func scalarBaseMultNonConstSlow(k *ModNScalar, result *JacobianPoint) {
+	ScalarMultNonConst(k, &jacobianG, result)
 }
 
 // scalarBaseMultNonConstFast computes k*G through the precomputed lookup


### PR DESCRIPTION
**This is rebased on #3224**.

This moves the conversion of the base point represented in Jacobian coordinates outside of the slow scalar base multiplication path used in resource constrained environments to avoid unnecessary allocations.

```
name                         old time/op    new time/op    delta
--------------------------------------------------------------------------------
ScalarBaseMultNonConstSlow   91.9µs ± 1%    91.5µs ± 1%    ~     (p=0.280 n=10+10)

name                         old alloc/op   new alloc/op   delta
--------------------------------------------------------------------------------
ScalarBaseMultNonConstSlow   64.0B ± 0%     0.0B           -100.00%  (p=0.000 n=10+10)

name                         old allocs/op  new allocs/op  delta
--------------------------------------------------------------------------------
ScalarBaseMultNonConstSlow   2.00 ± 0%      0.00           -100.00%  (p=0.000 n=10+10)
```
