### PR TITLE
secp256k1: Prepare v4.3.0.

### DIFF
--- a/dcrec/secp256k1/bench_test.go
+++ b/dcrec/secp256k1/bench_test.go
@@ -1,5 +1,5 @@
+// Copyright (c) 2015-2024 The Decred developers
 // Copyright 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/dcrec/secp256k1/curve.go
+++ b/dcrec/secp256k1/curve.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2022 The Decred developers
+// Copyright (c) 2015-2024 The Decred developers
 // Copyright 2013-2014 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.

--- a/dcrec/secp256k1/curve_test.go
+++ b/dcrec/secp256k1/curve_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2022 The Decred developers
+// Copyright (c) 2015-2024 The Decred developers
 // Copyright 2013-2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.


### PR DESCRIPTION
This updates the `secp256k1` copyright year in the files modified since the previous release and serves as a base for `dcrec/secp256k1/v4.3.0`.

As compared to v4.2.0, this release includes the following modifications:

- Provides new exported methods for obtaining the `R` and `S` components of ECDSA signatures
- Adds support for `TinyGo` and other memory constrained environments via the use of the `tinygo` build tag
- Includes some additional quality assurance tests