### PR TITLE
server: Retry seeder connections

### DIFF
--- a/server.go
+++ b/server.go
@@ -3145,7 +3145,11 @@ func (s *server) querySeeders(ctx context.Context) {
 			return
 		}
 
-		time.Sleep(backoff)
+		select {
+		case <-time.After(backoff):
+		case <-ctx.Done():
+			return
+		}
 		if backoff < 10*time.Second {
 			backoff += time.Second
 		}


### PR DESCRIPTION
If all seeders are unreachable (e.g. the network is not up yet, or DNS lookups are failing) and the address manager is flagged as needing more addresses, continue to try and reach the seeders in additional background goroutines with an increasing backoff timeout.