### PR TITLE
run_tests.sh: allow passing of additional test arguments

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -11,7 +11,7 @@ go version
 # run tests on all modules
 echo "==> test all modules"
 ROOTPKG=$(go list)
-go test -short -tags rpctest $ROOTPKG/...
+go test -short -tags rpctest $ROOTPKG/... -- "$@"
 
 # run linters on all modules
 . ./lint.sh


### PR DESCRIPTION
In 39e2cc2eca1f850404f284866c95c863af7aa1df a TestMain was added that parsed all of the arguments passed to the dcrd.test executable, allowing any additional arguments not parsed by the test binary to be used by dcrd code. This change modifies the run_tests.sh script to allow passing of additional arguments as well, which allows doing:

./run_tests.sh -- --appdata=$(mktemp -d)

This allows the config tests to pass even when run under a sandboxed environment without a home directory, or where the home directory is read-only.