### PR TITLE
dcrutil: Simplify AppDataDir and fix tests.

### DIFF
--- a/dcrutil/appdata.go
+++ b/dcrutil/appdata.go
@@ -30,14 +30,11 @@ func appDataDir(goos, appName string, roaming bool) string {
 	appNameLower := string(unicode.ToLower(rune(appName[0]))) + appName[1:]
 
 	// Get the OS specific home directory via the Go standard lib.
-	homeDir, err := os.UserHomeDir()
-
-	// Fall back to standard HOME environment variable that works
-	// for most POSIX OSes if the directory from the Go standard
-	// lib failed.
-	if err != nil || homeDir == "" {
-		homeDir = os.Getenv("HOME")
-	}
+	//
+	// Note that the error is intentionally ignored here since an empty string
+	// for the home directory will be returned in the case of error which is the
+	// desired behavior.
+	homeDir, _ := os.UserHomeDir()
 
 	switch goos {
 	// Attempt to use the LOCALAPPDATA or APPDATA environment variable on

--- a/dcrutil/appdata_test.go
+++ b/dcrutil/appdata_test.go
@@ -7,7 +7,6 @@ package dcrutil
 
 import (
 	"os"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -39,13 +38,11 @@ func TestAppDataDir(t *testing.T) {
 	}
 
 	// Get the home directory to use for testing expected results.
-	var homeDir string
-	usr, err := user.Current()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		t.Errorf("user.Current: %v", err)
+		t.Errorf("os.UserHomeDir: %v", err)
 		return
 	}
-	homeDir = usr.HomeDir
 
 	// Mac app data directory.
 	macAppData := filepath.Join(homeDir, "Library", "Application Support")

--- a/dcrutil/appdata_test.go
+++ b/dcrutil/appdata_test.go
@@ -124,7 +124,7 @@ func TestAppDataDir(t *testing.T) {
 		ret := appDataDir(test.goos, test.appName, test.roaming)
 		if ret != test.want {
 			t.Errorf("appDataDir #%d (%s) does not match - "+
-				"expected got %s, want %s", i, test.goos, ret,
+				"got %s, expected %s", i, test.goos, ret,
 				test.want)
 			continue
 		}


### PR DESCRIPTION
This removes the `Getenv("HOME")` fallback for `dcrutil.AppDatadir` since it is no longer required after the switch to use `os.UserHomeDir` instead of the older `user.Current` approach that was not as robust.

It also updates the associated tests to correct a typo and make use of the newer `os.UserHomeDir` method as well.