### PR TITLE
docker: Update image to golang:1.22.2-alpine3.19.

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -3,13 +3,13 @@
 ###############
 
 # Basic Go environment with git, SSL CA certs, and upx.
-# The image below is golang:1.22.1-alpine3.19 (linux/amd64)
+# The image below is golang:1.22.2-alpine3.19 (linux/amd64)
 # It's pulled by the digest (immutable id) to avoid supply-chain attacks.
 # Maintainer Note:
 #    To update to a new digest, you must first manually pull the new image:
 #    `docker pull golang:<new version>`
 #    Docker will print the digest of the new image after the pull has finished.
-FROM golang@sha256:fc5e5848529786cf1136563452b33d713d5c60b2c787f6b2a077fa6eeefd9114 AS builder
+FROM golang@sha256:cdc86d9f363e8786845bea2040312b4efa321b828acdeb26f393faa864d887b0 AS builder
 RUN apk add --no-cache git ca-certificates upx
 
 # Empty directory to be copied into place in the production image since it will


### PR DESCRIPTION
This updates the docker image to golang:1.22.2-alpine3.19.

To confirm the new digest:

```
$ docker pull golang:1.22.2-alpine3.19
1.22.2-alpine3.19: Pulling from library/golang
...
Digest: sha256:cdc86d9f363e8786845bea2040312b4efa321b828acdeb26f393faa864d887b0
...
```