### PR TITLE
rpctests: Pass test loggers to dcrdtest package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/decred/dcrd/rpcclient/v8 v8.0.0
 	github.com/decred/dcrd/txscript/v4 v4.1.0
 	github.com/decred/dcrd/wire v1.6.0
-	github.com/decred/dcrtest/dcrdtest v1.0.0
+	github.com/decred/dcrtest/dcrdtest v1.0.1-0.20240404040015-9eed40164fec
 	github.com/decred/go-socks v1.1.0
 	github.com/decred/slog v1.2.0
 	github.com/gorilla/websocket v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/decred/dcrd/dcrec/edwards/v2 v2.0.3 h1:l/lhv2aJCUignzls81+wvga0TFlyoZ
 github.com/decred/dcrd/dcrec/edwards/v2 v2.0.3/go.mod h1:AKpV6+wZ2MfPRJnTbQ6NPgWrKzbe9RCIlCF/FKzMtM8=
 github.com/decred/dcrtest/dcrdtest v1.0.0 h1:M50BpCPwkCJLtRa2MAo7QMs9sQFgZdCjTnZahnak594=
 github.com/decred/dcrtest/dcrdtest v1.0.0/go.mod h1:kpuTg2gpr7ze14cumpsLa2ecRC1M4mt36IrRKzNRipU=
+github.com/decred/dcrtest/dcrdtest v1.0.1-0.20240404040015-9eed40164fec h1:yQaLIa3s7TEi6bTTh7MfM3P+5rRqykBuGl+EegdG10k=
+github.com/decred/dcrtest/dcrdtest v1.0.1-0.20240404040015-9eed40164fec/go.mod h1:kbRQzyWu1IfukYZqCioVyJokzu1ifvIXzVDrXReeOsQ=
 github.com/decred/go-socks v1.1.0 h1:dnENcc0KIqQo3HSXdgboXAHgqsCIutkqq6ntQjYtm2U=
 github.com/decred/go-socks v1.1.0/go.mod h1:sDhHqkZH0X4JjSa02oYOGhcGHYp12FsY1jQ/meV8md0=
 github.com/decred/slog v1.2.0 h1:soHAxV52B54Di3WtKLfPum9OFfWqwtf/ygf9njdfnPM=

--- a/internal/integration/rpctests/log_test.go
+++ b/internal/integration/rpctests/log_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2024 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+//go:build rpctest
+
+package rpctests
+
+import (
+	"testing"
+
+	"github.com/decred/dcrtest/dcrdtest"
+	"github.com/decred/slog"
+)
+
+type testLog struct {
+	*testing.T
+}
+
+func (t *testLog) Write(b []byte) (int, error) {
+	t.Logf("%s", b)
+	return len(b), nil
+}
+
+// useTestLogger sets the dcrdtest package-level logger to a backend that
+// writes trace-level logs to the test log.  A function is returned to set the
+// logger back to Disabled when finished.
+//
+// Due to dcrdtest's use of a global logger variable that must write to test
+// logs to individual test variables, it is not possible to parallelize tests.
+func useTestLogger(t *testing.T) func() {
+	backend := slog.NewBackend(&testLog{T: t})
+	l := backend.Logger("TEST")
+	l.SetLevel(slog.LevelTrace)
+	dcrdtest.UseLogger(l)
+	return func() {
+		dcrdtest.UseLogger(slog.Disabled)
+	}
+}

--- a/internal/integration/rpctests/rpcserver_test.go
+++ b/internal/integration/rpctests/rpcserver_test.go
@@ -95,6 +95,8 @@ func testGetBlockHash(ctx context.Context, r *dcrdtest.Harness, t *testing.T) {
 }
 
 func TestRpcServer(t *testing.T) {
+	defer useTestLogger(t)()
+
 	// In order to properly test scenarios on as if we were on mainnet,
 	// ensure that non-standard transactions aren't accepted into the
 	// mempool or relayed.

--- a/internal/integration/rpctests/treasury_test.go
+++ b/internal/integration/rpctests/treasury_test.go
@@ -206,6 +206,8 @@ func assertTBaseAmount(t *testing.T, node *rpcclient.Client, amount int64) {
 // TestTreasury performs a test of treasury functionality across the entire
 // dcrd stack.
 func TestTreasury(t *testing.T) {
+	defer useTestLogger(t)()
+
 	var handlers *rpcclient.NotificationHandlers
 	net := chaincfg.SimNetParams()
 


### PR DESCRIPTION
This sets the dcrdtest package-level logger to a backend that writes logs to each test variable.  It writes trace level logs as this was the only way to observe the node process' stdout and stderr.