### PR TITLE
rpcserver: Remove unneeded AddedNodeInfo method.

### DIFF
--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023 The Decred developers
+// Copyright (c) 2019-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -113,8 +113,7 @@ type ConnManager interface {
 	// ConnectedPeers returns an array consisting of all connected peers.
 	ConnectedPeers() []Peer
 
-	// PersistentPeers returns an array consisting of all the persistent
-	// peers.
+	// PersistentPeers returns an array consisting of all the persistent peers.
 	PersistentPeers() []Peer
 
 	// BroadcastMessage sends the provided message to all currently
@@ -129,9 +128,6 @@ type ConnManager interface {
 	// RelayTransactions generates and relays inventory vectors for all of
 	// the passed transactions to all connected peers.
 	RelayTransactions(txns []*dcrutil.Tx)
-
-	// AddedNodeInfo returns information describing persistent (added) nodes.
-	AddedNodeInfo() []Peer
 
 	// Lookup defines the DNS lookup function to be used.
 	Lookup(host string) ([]net.IP, error)

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2023 The Decred developers
+// Copyright (c) 2015-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -1795,7 +1795,7 @@ func handleGetAddedNodeInfo(_ context.Context, s *Server, cmd interface{}) (inte
 
 	// Retrieve a list of persistent (added) peers from the Decred server
 	// and filter the list of peers per the specified address (if any).
-	peers := s.cfg.ConnMgr.AddedNodeInfo()
+	peers := s.cfg.ConnMgr.PersistentPeers()
 	if c.Node != nil {
 		found := false
 		for i, peer := range peers {

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 The Decred developers
+// Copyright (c) 2020-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -802,7 +802,6 @@ type testConnManager struct {
 	netTotalSent        uint64
 	connectedPeers      []Peer
 	persistentPeers     []Peer
-	addedNodeInfo       []Peer
 	lookup              func(host string) ([]net.IP, error)
 }
 
@@ -869,11 +868,6 @@ func (c *testConnManager) AddRebroadcastInventory(iv *wire.InvVect, data interfa
 // RelayTransactions provides a mock implementation for generating and relaying
 // inventory vectors for all of the passed transactions to all connected peers.
 func (c *testConnManager) RelayTransactions(txns []*dcrutil.Tx) {}
-
-// AddedNodeInfo returns a mocked slice of persistent (added) peers.
-func (c *testConnManager) AddedNodeInfo() []Peer {
-	return c.addedNodeInfo
-}
 
 // Lookup defines a mocked DNS lookup function to be used.
 func (c *testConnManager) Lookup(host string) ([]net.IP, error) {
@@ -1699,12 +1693,6 @@ func defaultMockConnManager() *testConnManager {
 			testPeer4,
 		},
 		persistentPeers: []Peer{
-			testPeer1,
-			testPeer2,
-			testPeer3,
-			testPeer4,
-		},
-		addedNodeInfo: []Peer{
 			testPeer1,
 			testPeer2,
 			testPeer3,

--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2017 The btcsuite developers
-// Copyright (c) 2015-2022 The Decred developers
+// Copyright (c) 2015-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -247,7 +247,7 @@ func (cm *rpcConnManager) PersistentPeers() []rpcserver.Peer {
 	cm.server.query <- getAddedNodesMsg{reply: replyChan}
 	serverPeers := <-replyChan
 
-	// Convert to generic peers.
+	// Convert to RPC server peers.
 	peers := make([]rpcserver.Peer, 0, len(serverPeers))
 	for _, sp := range serverPeers {
 		peers = append(peers, (*rpcPeer)(sp))
@@ -280,22 +280,6 @@ func (cm *rpcConnManager) AddRebroadcastInventory(iv *wire.InvVect, data interfa
 // rpcserver.ConnManager interface implementation.
 func (cm *rpcConnManager) RelayTransactions(txns []*dcrutil.Tx) {
 	cm.server.relayTransactions(txns)
-}
-
-// AddedNodeInfo returns information describing persistent (added) nodes.
-//
-// This function is safe for concurrent access and is part of the
-// rpcserver.ConnManager interface implementation.
-func (cm *rpcConnManager) AddedNodeInfo() []rpcserver.Peer {
-	serverPeers := cm.server.AddedNodeInfo()
-
-	// Convert to RPC server peers.
-	peers := make([]rpcserver.Peer, 0, len(serverPeers))
-	for _, sp := range serverPeers {
-		peers = append(peers, (*rpcPeer)(sp))
-	}
-
-	return peers
 }
 
 // Lookup defines the DNS lookup function to be used.

--- a/server.go
+++ b/server.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2023 The Decred developers
+// Copyright (c) 2015-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -2526,18 +2526,6 @@ func (s *server) OutboundGroupCount(key string) int {
 	case <-s.quit:
 		return 0
 	case s.query <- getOutboundGroup{key: key, reply: replyChan}:
-		return <-replyChan
-	}
-}
-
-// AddedNodeInfo returns an array of dcrjson.GetAddedNodeInfoResult structures
-// describing the persistent (added) nodes.
-func (s *server) AddedNodeInfo() []*serverPeer {
-	replyChan := make(chan []*serverPeer)
-	select {
-	case <-s.quit:
-		return nil
-	case s.query <- getAddedNodesMsg{reply: replyChan}:
 		return <-replyChan
 	}
 }


### PR DESCRIPTION
The RPC server was refactored some time ago to decouple it from the internals of the main server and part of that refactoring modified the RPC server to make use of a local peer interface to obtain all necessary information about peers which is then used to create RPC server results. Due to that, the `AddedNodeInfo` and `PersistentPeers` methods now do the exact same thing.

This modifies the `rpcserver.ConnManager` interface to remove the now unnecessary `AddedNodeInfo` method in favor of the `PersistentPeers` method and updates all relevant code accordingly.