### PR TITLE
server: Use atomic types for some svr peer fields.

### DIFF
--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -94,7 +94,7 @@ func (p *rpcPeer) LastPingNonce() uint64 {
 // This function is safe for concurrent access and is part of the rpcserver.Peer
 // interface implementation.
 func (p *rpcPeer) IsTxRelayDisabled() bool {
-	return (*serverPeer)(p).relayTxDisabled()
+	return (*serverPeer)(p).disableRelayTx.Load()
 }
 
 // BanScore returns the current integer value that represents how close the peer


### PR DESCRIPTION
This updates a couple of cases of server peer data fields protected by an individual mutex to make use of the newer atomic types introduced in Go 1.19 instead.

This is desirable since atomic types are both simpler to use and more efficient when the data being protected does not require additional logic in the critical section as is the case for the updated fields.