### PR TITLE
mining: Update blk templ diff for too few voters.

### DIFF
--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -897,7 +897,15 @@ func (g *BlkTmplGenerator) handleTooFewVoters(nextHeight int64,
 			return nil, err
 		}
 		header := &block.Header
-		header.MerkleRoot = calcBlockMerkleRoot(block.Transactions, block.STransactions, hdrCmtActive)
+		header.MerkleRoot = calcBlockMerkleRoot(block.Transactions,
+			block.STransactions, hdrCmtActive)
+
+		// Calculate the required difficulty for the block.
+		reqDifficulty, err := g.cfg.CalcNextRequiredDifficulty(prevHash, ts)
+		if err != nil {
+			return nil, makeError(ErrGettingDifficulty, err.Error())
+		}
+		header.Bits = reqDifficulty
 
 		// Calculate the stake root or commitment root depending on the result
 		// of the header commitments agenda vote.


### PR DESCRIPTION
This updates the block template generation path for handling too few voters to also update the required difficulty bits in the created block template since the new ASERT difficulty algorithm changes every block and is influenced by the timestamp.

This is necessary to prevent the possibility of generating block templates that fail to validate and have to be discarded resulting in unnecessary additional work while aggressive mining in the aforementioned case of not having enough voters.