### PR TITLE
cpuminer: Rework discrete mining vote wait logic.

### DIFF
--- a/internal/mining/cpuminer/cpuminer.go
+++ b/internal/mining/cpuminer/cpuminer.go
@@ -95,11 +95,6 @@ type Config struct {
 	// up orphaned anyways.
 	IsCurrent func() bool
 
-	// IsKnownInvalidBlock defines the function to use to obtain whether or
-	// not either the provided block is itself known to be invalid or is
-	// known to have an invalid ancestor.
-	IsKnownInvalidBlock func(*chainhash.Hash) bool
-
 	// IsBlake3PowAgendaActive returns whether or not the agenda to change the
 	// proof of work hash function to blake3, as defined in DCP0011, has passed
 	// and is now active for the block AFTER the given block.

--- a/server.go
+++ b/server.go
@@ -3957,7 +3957,6 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB,
 			ProcessBlock:               s.syncManager.ProcessBlock,
 			ConnectedCount:             s.ConnectedCount,
 			IsCurrent:                  s.syncManager.IsCurrent,
-			IsKnownInvalidBlock:        s.chain.IsKnownInvalidBlock,
 			IsBlake3PowAgendaActive:    s.chain.IsBlake3PowAgendaActive,
 		})
 	}


### PR DESCRIPTION
**This is rebased on #3241**.

In an effort to provide a better user experience for discrete mining which is only used in testing scenarios, it contains additional logic that ultimately aims to wait for votes to show up prior to mining a new block when it is invoked in rapid succession as opposed to just generating a bunch of side chain blocks which would otherwise happen.

The current logic attempts to accomplish that goal by storing the parent hash of the block the discrete mining process most recently mined and waiting for a new template if invoked again so long as the current block template continues to build on that stored parent hash.

Unfortunately, there are various scenarios where you still would want to generate a new block that builds on the same parent hash such as the case when the current tip is manually invalidated or when the current tip is unable to get enough votes to be built on.

Rather than trying to identify and special case those scenarios, this reworks the logic to instead just store a pointer to the template that the discrete mining process most recently mined instead and then wait for a new template if invoked again while the same template is still active.

This approach is much more robust and also provides additional flexibility such as allowing the caller to override the wait by manually regenerating a new template.