### PR TITLE
wire: Add Opcode field to MixPairReqUTXO

### DIFF
--- a/wire/msgmixpairreq_test.go
+++ b/wire/msgmixpairreq_test.go
@@ -56,6 +56,7 @@ func newMixPairReqArgs() *mixPairReqArgs {
 			Script:    []byte{},
 			PubKey:    repeat(0x8B, 33),
 			Signature: repeat(0x8C, 64),
+			Opcode:    0xBB, // OP_SSGEN
 		},
 		{
 			OutPoint: OutPoint{
@@ -66,6 +67,7 @@ func newMixPairReqArgs() *mixPairReqArgs {
 			Script:    repeat(0x90, 25),
 			PubKey:    repeat(0x91, 33),
 			Signature: repeat(0x92, 64),
+			Opcode:    0xBC, // OP_SSRTX
 		},
 	}
 
@@ -129,6 +131,7 @@ func TestMsgMixPairReqWire(t *testing.T) {
 	expected = append(expected, repeat(0x8b, 33)...)
 	expected = append(expected, 0x40) // 64-byte signature
 	expected = append(expected, repeat(0x8c, 64)...)
+	expected = append(expected, 0xBB) // Opcode
 	// Second UTXO 8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d:0x8e8e8e8e
 	expected = append(expected, repeat(0x8d, 32)...) // Hash
 	expected = append(expected, repeat(0x8e, 4)...)  // Index
@@ -139,6 +142,7 @@ func TestMsgMixPairReqWire(t *testing.T) {
 	expected = append(expected, repeat(0x91, 33)...)
 	expected = append(expected, 0x40) // 64-byte signature
 	expected = append(expected, repeat(0x92, 64)...)
+	expected = append(expected, 0xBC) // Opcode
 	// Change output
 	expected = append(expected, 0x01) // Has change = true
 	expected = append(expected, []byte{
@@ -285,7 +289,8 @@ func TestMsgMixPairReqMaxPayloadLength(t *testing.T) {
 		1 + // Tree
 		varBytesLen(MaxMixPairReqUTXOScriptLen) + // P2SH redeem script
 		varBytesLen(33) + // Pubkey
-		varBytesLen(64) // Signature
+		varBytesLen(64) + // Signature
+		1 // Opcode
 	var maxTxOutLen uint32 = 8 + // Value
 		2 + // Version
 		varBytesLen(16384) // PkScript (txscript.MaxScriptLen)


### PR DESCRIPTION
Validating contributed signatures of vote, revocation, and treasury generation outputs requires knowing the exact opcode tag used by the previous output script, as it is committed to by the sighash.  Include it in the MixPairReqUTXO so that all clients are able to validate the merged signatures in the coinjoin.  The special value 0 (OP_FALSE) will be used for regular tree outputs that do not use a no-op tag.

This is a breaking API change but the wire module has not seen a release since mixing messages were added.