### PR TITLE
wire: Remove PR hashes from (get)initstate

### DIFF
--- a/wire/message_test.go
+++ b/wire/message_test.go
@@ -121,7 +121,7 @@ func TestMessage(t *testing.T) {
 		{msgCFHeaders, msgCFHeaders, pver, MainNet, 58},
 		{msgCFTypes, msgCFTypes, pver, MainNet, 26},
 		{msgGetInitState, msgGetInitState, pver, MainNet, 25},
-		{msgInitState, msgInitState, pver, MainNet, 28},
+		{msgInitState, msgInitState, pver, MainNet, 27},
 		{msgMixPR, msgMixPR, pver, MainNet, 165},
 		{msgMixKE, msgMixKE, pver, MainNet, 1441},
 		{msgMixCT, msgMixCT, pver, MainNet, 158},

--- a/wire/msggetinitstate.go
+++ b/wire/msggetinitstate.go
@@ -29,10 +29,6 @@ const (
 	// InitStateTSpends is the init state type used to request tpends for
 	// voting.
 	InitStateTSpends = "tspends"
-
-	// InitStateMixPairReqs is the init state type used to request mixing pair
-	// request messages.
-	InitStateMixPairReqs = "mixpairreqs"
 )
 
 // MsgGetInitState implements the Message interface and represents a

--- a/wire/msginitstate.go
+++ b/wire/msginitstate.go
@@ -22,10 +22,6 @@ const MaxISVotesAtHeadPerMsg = 40 // 8 * 5
 // message.
 const MaxISTSpendsAtHeadPerMsg = 7
 
-// MaxISMixPairReqsPerMsg is the maximum number of pair request mix messages
-// at head per message.
-const MaxISMixPairReqsPerMsg = 100
-
 // MsgInitState implements the Message interface and represents an initial
 // state message.  It is used to receive ephemeral startup information from a
 // remote peer, such as blocks that can be mined upon, votes for such blocks
@@ -34,10 +30,9 @@ const MaxISMixPairReqsPerMsg = 100
 // The content of such a message depends upon what the local peer requested
 // during a previous GetInitState msg.
 type MsgInitState struct {
-	BlockHashes      []chainhash.Hash
-	VoteHashes       []chainhash.Hash
-	TSpendHashes     []chainhash.Hash
-	MixPairReqHashes []chainhash.Hash
+	BlockHashes  []chainhash.Hash
+	VoteHashes   []chainhash.Hash
+	TSpendHashes []chainhash.Hash
 }
 
 // AddBlockHash adds a new block hash to the message. Up to
@@ -79,20 +74,6 @@ func (msg *MsgInitState) AddTSpendHash(hash *chainhash.Hash) error {
 	}
 
 	msg.TSpendHashes = append(msg.TSpendHashes, *hash)
-	return nil
-}
-
-// AddMixPairReqHash adds a new mixing pair request message hash to the message.
-// Up to MaxISMixPRsPerMsg may be added before this function errors out.
-func (msg *MsgInitState) AddMixPairReqHash(hash *chainhash.Hash) error {
-	const op = "MsgInitState.AddMixPairReqHash"
-	if len(msg.MixPairReqHashes)+1 > MaxISMixPairReqsPerMsg {
-		msg := fmt.Sprintf("too many mixpairreq hashes for message [max %v]",
-			MaxISMixPairReqsPerMsg)
-		return messageError(op, ErrTooManyManyMixPairReqs, msg)
-	}
-
-	msg.MixPairReqHashes = append(msg.MixPairReqHashes, *hash)
 	return nil
 }
 
@@ -158,29 +139,6 @@ func (msg *MsgInitState) BtcDecode(r io.Reader, pver uint32) error {
 	msg.TSpendHashes = make([]chainhash.Hash, count)
 	for i := uint64(0); i < count; i++ {
 		err := readElement(r, &msg.TSpendHashes[i])
-		if err != nil {
-			return err
-		}
-	}
-
-	// Read num mixpairreq hashes (when enabled by protocol).
-	if pver < MixVersion {
-		return nil
-	}
-
-	count, err = ReadVarInt(r, pver)
-	if err != nil {
-		return err
-	}
-	if count > MaxISMixPairReqsPerMsg {
-		msg := fmt.Sprintf("too many mixpairreq hashes for message "+
-			"[count %v, max %v]", count, MaxISMixPairReqsPerMsg)
-		return messageError(op, ErrTooManyManyMixPairReqs, msg)
-	}
-
-	msg.MixPairReqHashes = make([]chainhash.Hash, count)
-	for i := uint64(0); i < count; i++ {
-		err := readElement(r, &msg.MixPairReqHashes[i])
 		if err != nil {
 			return err
 		}
@@ -259,30 +217,6 @@ func (msg *MsgInitState) BtcEncode(w io.Writer, pver uint32) error {
 		}
 	}
 
-	// Write mixpairreq hashes when enabled by protocol.
-	if pver < MixVersion {
-		return nil
-	}
-
-	count = len(msg.MixPairReqHashes)
-	if count > MaxISMixPairReqsPerMsg {
-		msg := fmt.Sprintf("too many mixpairreq hashes for message "+
-			"[count %v, max %v]", count, MaxISMixPairReqsPerMsg)
-		return messageError(op, ErrTooManyManyMixPairReqs, msg)
-	}
-
-	err = WriteVarInt(w, pver, uint64(count))
-	if err != nil {
-		return err
-	}
-
-	for i := range msg.MixPairReqHashes {
-		err = writeElement(w, &msg.MixPairReqHashes[i])
-		if err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 
@@ -299,29 +233,21 @@ func (msg *MsgInitState) MaxPayloadLength(pver uint32) uint32 {
 		return 0
 	}
 
-	max := uint32(VarIntSerializeSize(MaxISBlocksAtHeadPerMsg)) +
+	return uint32(VarIntSerializeSize(MaxISBlocksAtHeadPerMsg)) +
 		(MaxISBlocksAtHeadPerMsg * chainhash.HashSize) +
 		uint32(VarIntSerializeSize(MaxISVotesAtHeadPerMsg)) +
 		(MaxISVotesAtHeadPerMsg * chainhash.HashSize) +
 		uint32(VarIntSerializeSize(MaxISTSpendsAtHeadPerMsg)) +
 		(MaxISTSpendsAtHeadPerMsg * chainhash.HashSize)
-
-	if pver >= MixVersion {
-		max += uint32(VarIntSerializeSize(MaxISMixPairReqsPerMsg)) +
-			(MaxISMixPairReqsPerMsg * chainhash.HashSize)
-	}
-
-	return max
 }
 
 // NewMsgInitState returns a new Decred initstate message that conforms to the
 // Message interface using the defaults for the fields.
 func NewMsgInitState() *MsgInitState {
 	return &MsgInitState{
-		BlockHashes:      make([]chainhash.Hash, 0, MaxISBlocksAtHeadPerMsg),
-		VoteHashes:       make([]chainhash.Hash, 0, MaxISVotesAtHeadPerMsg),
-		TSpendHashes:     make([]chainhash.Hash, 0, MaxISTSpendsAtHeadPerMsg),
-		MixPairReqHashes: make([]chainhash.Hash, 0, MaxISMixPairReqsPerMsg),
+		BlockHashes:  make([]chainhash.Hash, 0, MaxISBlocksAtHeadPerMsg),
+		VoteHashes:   make([]chainhash.Hash, 0, MaxISVotesAtHeadPerMsg),
+		TSpendHashes: make([]chainhash.Hash, 0, MaxISTSpendsAtHeadPerMsg),
 	}
 }
 
@@ -356,17 +282,9 @@ func NewMsgInitStateFilled(blockHashes []chainhash.Hash, voteHashes []chainhash.
 		return nil, messageError(op, ErrTooManyTSpends, msg)
 	}
 
-	// Not preallocated.  The purpose of this function is to create a
-	// MsgInitState from already allocated data.  Assume that if the
-	// caller also has mixpairreq hashes to include, they have also been
-	// preallocated, so there is no reason to allocate the memory here
-	// too.
-	var mixPairReqHashes []chainhash.Hash
-
 	return &MsgInitState{
-		BlockHashes:      blockHashes,
-		VoteHashes:       voteHashes,
-		TSpendHashes:     tspendHashes,
-		MixPairReqHashes: mixPairReqHashes,
+		BlockHashes:  blockHashes,
+		VoteHashes:   voteHashes,
+		TSpendHashes: tspendHashes,
 	}, nil
 }

--- a/wire/msginitstate_test.go
+++ b/wire/msginitstate_test.go
@@ -30,7 +30,7 @@ func TestInitState(t *testing.T) {
 	// Ensure max payload returns the expected value for latest protocol
 	// version. a var int and n * hashes for each of block, vote and tspend
 	// hashes.
-	wantPayload := uint32((1 + 32*8) + (1 + 32*40) + (1 + 32*7) + (1 + 32*100))
+	wantPayload := uint32((1 + 32*8) + (1 + 32*40) + (1 + 32*7))
 	maxPayload := msg.MaxPayloadLength(pver)
 	if maxPayload != wantPayload {
 		t.Errorf("MaxPayloadLength: wrong max payload length for "+
@@ -119,7 +119,6 @@ func TestInitStateWire(t *testing.T) {
 		0x00, // Varint for number of blocks
 		0x00, // Varint for number of votes
 		0x00, // Varint for number of tspends
-		0x00, // Varint for number of mixpairreqs
 	}
 
 	fakeBlock1, _ := chainhash.NewHashFromStr("4433221144332211443322114" +
@@ -138,12 +137,6 @@ func TestInitStateWire(t *testing.T) {
 		"999999999999999999991199999999999999919")
 	fakeTSpend3, _ := chainhash.NewHashFromStr("aaaaaaaaaaaa9200aaaaaa" +
 		"aaaaaaaaaaaaaaaaaaa9a9a9aaaaaaaaaaaaaaa")
-	fakeMixPairReq1, _ := chainhash.NewHashFromStr("bbbbbbbbbbbb9200bbbbbb" +
-		"bbbbbbbbbbbbbbbbbbb9b9b9bbbbbbbbbbbbbbb")
-	fakeMixPairReq2, _ := chainhash.NewHashFromStr("cccccccccccc9200cccccc" +
-		"ccccccccccccccccccc9c9c9ccccccccccccccc")
-	fakeMixPairReq3, _ := chainhash.NewHashFromStr("dddddddddddd9200dddddd" +
-		"ddddddddddddddddddd9d9d9ddddddddddddddd")
 
 	// MsgInitState message with multiple values for each hash.
 	multiData := NewMsgInitState()
@@ -155,9 +148,6 @@ func TestInitStateWire(t *testing.T) {
 	multiData.AddTSpendHash(fakeTSpend1)
 	multiData.AddTSpendHash(fakeTSpend2)
 	multiData.AddTSpendHash(fakeTSpend3)
-	multiData.AddMixPairReqHash(fakeMixPairReq1)
-	multiData.AddMixPairReqHash(fakeMixPairReq2)
-	multiData.AddMixPairReqHash(fakeMixPairReq3)
 
 	multiDataEncoded := []byte{
 		0x02,                                           // Varint for number of block hashes
@@ -195,19 +185,6 @@ func TestInitStateWire(t *testing.T) {
 		0x9a, 0x9a, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
 		0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0x0a, 0x20,
 		0xa9, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0x0a, 0x00,
-		0x03,                                           // Varint for number of mixpr hashes
-		0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0x9b, // Fake mixpairreq 1
-		0x9b, 0x9b, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb,
-		0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0x0b, 0x20,
-		0xb9, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0x0b, 0x00,
-		0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0x9c, // Fake mixpairreq 2
-		0x9c, 0x9c, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc,
-		0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0x0c, 0x20,
-		0xc9, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0x0c, 0x00,
-		0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0x9d, // Fake mixpairreq 3
-		0x9d, 0x9d, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd,
-		0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0x0d, 0x20,
-		0xd9, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0x0d, 0x00,
 	}
 
 	tests := []struct {
@@ -278,12 +255,6 @@ func TestInitStateWireErrors(t *testing.T) {
 		"999999999999999999991199999999999999919")
 	fakeTSpend3, _ := chainhash.NewHashFromStr("aaaaaaaaaaaa9200aaaaaa" +
 		"aaaaaaaaaaaaaaaaaaa9a9a9aaaaaaaaaaaaaaa")
-	fakeMixPairReq1, _ := chainhash.NewHashFromStr("bbbbbbbbbbbb9200bbbbbb" +
-		"bbbbbbbbbbbbbbbbbbb9b9b9bbbbbbbbbbbbbbb")
-	fakeMixPairReq2, _ := chainhash.NewHashFromStr("cccccccccccc9200cccccc" +
-		"ccccccccccccccccccc9c9c9ccccccccccccccc")
-	fakeMixPairReq3, _ := chainhash.NewHashFromStr("dddddddddddd9200dddddd" +
-		"ddddddddddddddddddd9d9d9ddddddddddddddd")
 
 	// MsgInitState message with multiple values for each hash.
 	baseMsg := NewMsgInitState()
@@ -295,9 +266,6 @@ func TestInitStateWireErrors(t *testing.T) {
 	baseMsg.AddTSpendHash(fakeTSpend1)
 	baseMsg.AddTSpendHash(fakeTSpend2)
 	baseMsg.AddTSpendHash(fakeTSpend3)
-	baseMsg.AddMixPairReqHash(fakeMixPairReq1)
-	baseMsg.AddMixPairReqHash(fakeMixPairReq2)
-	baseMsg.AddMixPairReqHash(fakeMixPairReq3)
 
 	baseMsgEncoded := []byte{
 		0x02,                                           // Varint for number of block hashes
@@ -335,19 +303,6 @@ func TestInitStateWireErrors(t *testing.T) {
 		0x9a, 0x9a, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
 		0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0x0a, 0x20,
 		0xa9, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0x0a, 0x00,
-		0x03,                                           // Varint for number of mixpairreq hashes
-		0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0x9b, // Fake mixpairreq 1
-		0x9b, 0x9b, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb,
-		0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0x0b, 0x20,
-		0xb9, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0x0b, 0x00,
-		0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0x9c, // Fake mixpairreq 2
-		0x9c, 0x9c, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc,
-		0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0x0c, 0x20,
-		0xc9, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0x0c, 0x00,
-		0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0x9d, // Fake mixpairreq 3
-		0x9d, 0x9d, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd,
-		0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0x0d, 0x20,
-		0xd9, 0xdd, 0xdd, 0xdd, 0xdd, 0xdd, 0x0d, 0x00,
 	}
 
 	// Message that forces an error by having more than the max allowed


### PR DESCRIPTION
This reverts all of the initstate changes made in
b9d8d49c901bb7cbb19ed36d636c3e3d86a1fe43.

The limit of 100 was too too low to be useful and cranking this value up was not a proper solution either.  It also only synced pair request messages, which would cause mid-run mixes to leave stale PRs around in the mixpool until they expired.

This is handled better in newer mixpool code by requesting unknown pair request messages when they are seen in a key exchange.  The mixpool records the KE as an orphan and will process it after all missing PRs have been requested and processed.