### PR TITLE
wire: add flag bits to PR message

### DIFF
--- a/wire/message_test.go
+++ b/wire/message_test.go
@@ -80,7 +80,7 @@ func TestMessage(t *testing.T) {
 	msgReject := NewMsgReject("block", RejectDuplicate, "duplicate block")
 	msgGetInitState := NewMsgGetInitState()
 	msgInitState := NewMsgInitState()
-	msgMixPR, err := NewMsgMixPairReq([33]byte{}, 1, 1, "", 1, 1, 1, 1, []MixPairReqUTXO{}, NewTxOut(0, []byte{}))
+	msgMixPR, err := NewMsgMixPairReq([33]byte{}, 1, 1, "", 1, 1, 1, 1, []MixPairReqUTXO{}, NewTxOut(0, []byte{}), 1, 1)
 	if err != nil {
 		t.Errorf("NewMsgMixPairReq: %v", err)
 	}
@@ -122,7 +122,7 @@ func TestMessage(t *testing.T) {
 		{msgCFTypes, msgCFTypes, pver, MainNet, 26},
 		{msgGetInitState, msgGetInitState, pver, MainNet, 25},
 		{msgInitState, msgInitState, pver, MainNet, 27},
-		{msgMixPR, msgMixPR, pver, MainNet, 165},
+		{msgMixPR, msgMixPR, pver, MainNet, 167},
 		{msgMixKE, msgMixKE, pver, MainNet, 1449},
 		{msgMixCT, msgMixCT, pver, MainNet, 158},
 		{msgMixSR, msgMixSR, pver, MainNet, 161},

--- a/wire/msgmixpairreq_test.go
+++ b/wire/msgmixpairreq_test.go
@@ -25,11 +25,14 @@ type mixPairReqArgs struct {
 	inputValue             int64
 	utxos                  []MixPairReqUTXO
 	change                 *TxOut
+	flags                  byte
+	pairingFlags           byte
 }
 
 func (a *mixPairReqArgs) msg() (*MsgMixPairReq, error) {
 	return NewMsgMixPairReq(a.identity, a.expiry, a.mixAmount, a.scriptClass,
-		a.txVersion, a.lockTime, a.messageCount, a.inputValue, a.utxos, a.change)
+		a.txVersion, a.lockTime, a.messageCount, a.inputValue, a.utxos,
+		a.change, a.flags, a.pairingFlags)
 }
 
 func newMixPairReqArgs() *mixPairReqArgs {
@@ -74,6 +77,8 @@ func newMixPairReqArgs() *mixPairReqArgs {
 	const changeValue = int64(0x1393939393939393)
 	pkScript := repeat(0x94, 25)
 	change := NewTxOut(changeValue, pkScript)
+	flags := byte(0x95)
+	pairingFlags := byte(0x96)
 
 	return &mixPairReqArgs{
 		identity:     id,
@@ -87,6 +92,8 @@ func newMixPairReqArgs() *mixPairReqArgs {
 		inputValue:   inputValue,
 		utxos:        utxos,
 		change:       change,
+		flags:        flags,
+		pairingFlags: pairingFlags,
 	}
 }
 
@@ -154,6 +161,8 @@ func TestMsgMixPairReqWire(t *testing.T) {
 		0x94, 0x94, 0x94, 0x94, 0x94, 0x94, 0x94, 0x94,
 		0x94,
 	}...)
+	expected = append(expected, 0x95) // Flags
+	expected = append(expected, 0x96) // Pairing flags
 
 	expectedSerializationEqual(t, buf.Bytes(), expected)
 


### PR DESCRIPTION
Two new flag fields are introduced to the pair request message, both of which are application specific and have no meaning to the wire package.  The first is a Flags field which will be used to describe capabilities that do not affect the pairing type.  This will be used in the initial release to allow wallets to advertise support for solving and publishing the factored polynomial.  While here, a second flags field which affects the pairing compatibility is also added, as this will aid in any future incompatibility in the client behavior without disturbing clients who have not upgraded.