### PR TITLE
wire: Zero out secrets signature for commitment hash

### DIFF
--- a/wire/msgmixsecrets.go
+++ b/wire/msgmixsecrets.go
@@ -202,6 +202,7 @@ func (msg *MsgMixSecrets) Hash() chainhash.Hash {
 // messages.
 func (msg *MsgMixSecrets) Commitment(h hash.Hash) chainhash.Hash {
 	msgCopy := *msg
+	msgCopy.Signature = [64]byte{}
 	msgCopy.SeenSecrets = nil
 	msgCopy.WriteHash(h)
 	return msgCopy.hash


### PR DESCRIPTION
The signature changes depending on the published previous RS message hashes, and therefore cannot be used to create the commitment hash covering the actual secrets being published by the message.