### PR TITLE
server: Implement separate mutex for peer state.

### DIFF
--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -299,15 +299,14 @@ func (cm *rpcConnManager) ConnectedPeers() []rpcserver.Peer {
 // This function is safe for concurrent access and is part of the
 // rpcserver.ConnManager interface implementation.
 func (cm *rpcConnManager) PersistentPeers() []rpcserver.Peer {
-	replyChan := make(chan []*serverPeer)
-	cm.server.query <- getAddedNodesMsg{reply: replyChan}
-	serverPeers := <-replyChan
-
-	// Convert to RPC server peers.
-	peers := make([]rpcserver.Peer, 0, len(serverPeers))
-	for _, sp := range serverPeers {
+	// Return a slice of the relevant peers converted to RPC server peers.
+	state := &cm.server.peerState
+	state.Lock()
+	peers := make([]rpcserver.Peer, 0, len(state.persistentPeers))
+	for _, sp := range state.persistentPeers {
 		peers = append(peers, (*rpcPeer)(sp))
 	}
+	state.Unlock()
 	return peers
 }
 

--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -198,12 +198,11 @@ func (cm *rpcConnManager) RemoveByAddr(addr string) error {
 	// Cancel the connection if it could still be pending.
 	err := <-replyChan
 	if err != nil {
-		cm.server.query <- cancelPendingMsg{
-			addr:  addr,
-			reply: replyChan,
+		netAddr, err := addrStringToNetAddr(addr)
+		if err != nil {
+			return err
 		}
-
-		return <-replyChan
+		return cm.server.connManager.CancelPending(netAddr)
 	}
 	return nil
 }

--- a/server.go
+++ b/server.go
@@ -2102,11 +2102,6 @@ type removeNodeMsg struct {
 	reply chan error
 }
 
-type cancelPendingMsg struct {
-	addr  string
-	reply chan error
-}
-
 // handleQuery is the central handler for all queries and commands from other
 // goroutines related to peer state.
 func (s *server) handleQuery(ctx context.Context, state *peerState, querymsg interface{}) {
@@ -2135,14 +2130,6 @@ func (s *server) handleQuery(ctx context.Context, state *peerState, querymsg int
 		} else {
 			msg.reply <- errors.New("peer not found")
 		}
-
-	case cancelPendingMsg:
-		netAddr, err := addrStringToNetAddr(msg.addr)
-		if err != nil {
-			msg.reply <- err
-			return
-		}
-		msg.reply <- s.connManager.CancelPending(netAddr)
 
 	case getAddedNodesMsg:
 		// Respond with a slice of the relevant peers.

--- a/server.go
+++ b/server.go
@@ -2088,10 +2088,6 @@ func (s *server) handleBroadcastMsg(state *peerState, bmsg *broadcastMsg) {
 	})
 }
 
-type getAddedNodesMsg struct {
-	reply chan []*serverPeer
-}
-
 type disconnectNodeMsg struct {
 	cmp   func(*serverPeer) bool
 	reply chan error
@@ -2101,16 +2097,6 @@ type disconnectNodeMsg struct {
 // goroutines related to peer state.
 func (s *server) handleQuery(ctx context.Context, state *peerState, querymsg interface{}) {
 	switch msg := querymsg.(type) {
-	case getAddedNodesMsg:
-		// Respond with a slice of the relevant peers.
-		state.Lock()
-		peers := make([]*serverPeer, 0, len(state.persistentPeers))
-		for _, sp := range state.persistentPeers {
-			peers = append(peers, sp)
-		}
-		state.Unlock()
-		msg.reply <- peers
-
 	case disconnectNodeMsg:
 		// Check inbound peers. We pass a nil callback since we don't
 		// require any additional actions on disconnect for inbound peers.

--- a/server.go
+++ b/server.go
@@ -554,7 +554,6 @@ type server struct {
 	modifyRebroadcastInv chan interface{}
 	peerState            peerState
 	banPeers             chan *serverPeer
-	query                chan interface{}
 	relayInv             chan relayMsg
 	broadcast            chan broadcastMsg
 	nat                  *upnpNAT
@@ -2088,11 +2087,6 @@ func (s *server) handleBroadcastMsg(state *peerState, bmsg *broadcastMsg) {
 	})
 }
 
-// handleQuery is the central handler for all queries and commands from other
-// goroutines related to peer state.
-func (s *server) handleQuery(ctx context.Context, state *peerState, querymsg interface{}) {
-}
-
 // disconnectPeer attempts to drop the connection of a targeted peer in the
 // passed peer list. Targets are identified via usage of the passed
 // `compareFunc`, which should return `true` if the passed peer is the target
@@ -2241,9 +2235,6 @@ out:
 		// which are excluded by the message.
 		case bmsg := <-s.broadcast:
 			s.handleBroadcastMsg(&s.peerState, &bmsg)
-
-		case qmsg := <-s.query:
-			s.handleQuery(ctx, &s.peerState, qmsg)
 
 		case <-ctx.Done():
 			close(s.quit)
@@ -3722,7 +3713,6 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB,
 		addrManager:          amgr,
 		peerState:            makePeerState(),
 		banPeers:             make(chan *serverPeer, cfg.MaxPeers),
-		query:                make(chan interface{}),
 		relayInv:             make(chan relayMsg, cfg.MaxPeers),
 		broadcast:            make(chan broadcastMsg, cfg.MaxPeers),
 		modifyRebroadcastInv: make(chan interface{}),

--- a/server.go
+++ b/server.go
@@ -363,29 +363,6 @@ func makePeerState() peerState {
 	}
 }
 
-// connectionsWithIP returns the number of connections with the given IP.
-//
-// This function MUST be called with the embedded mutex locked (for reads).
-func (ps *peerState) connectionsWithIP(ip net.IP) int {
-	var total int
-	for _, p := range ps.inboundPeers {
-		if ip.Equal(p.NA().IP) {
-			total++
-		}
-	}
-	for _, p := range ps.outboundPeers {
-		if ip.Equal(p.NA().IP) {
-			total++
-		}
-	}
-	for _, p := range ps.persistentPeers {
-		if ip.Equal(p.NA().IP) {
-			total++
-		}
-	}
-	return total
-}
-
 // count returns the count of all known peers.
 //
 // This function MUST be called with the embedded mutex locked (for reads).
@@ -426,6 +403,20 @@ func (ps *peerState) ForAllPeers(closure func(sp *serverPeer)) {
 	ps.Lock()
 	ps.forAllPeers(closure)
 	ps.Unlock()
+}
+
+// connectionsWithIP returns the number of connections with the given IP.
+//
+// This function MUST be called with the embedded mutex locked (for reads).
+func (ps *peerState) connectionsWithIP(ip net.IP) int {
+	var total int
+	ps.forAllPeers(func(sp *serverPeer) {
+		if ip.Equal(sp.NA().IP) {
+			total++
+		}
+
+	})
+	return total
 }
 
 // ResolveLocalAddress picks the best suggested network address from available


### PR DESCRIPTION
Currently, all operations related to adding, removing, and banning peers are implemented via a single goroutine and channels to protect concurrent access.

The existing implementation has worked well for over a decade, however, it is really not ideal in a few ways:

- It is difficult to improve parallel processing since everything is forced into a single goroutine
- It requires a lot of plumbing to provide access to any related information
- The use of multiple channels means the ordering of events is not entirely well defined.

In regards to the final point about event ordering, one example is that it's possible for a peer to be removed before it was ever added.  The surrounding code is aware of these possibilities and handles things gracefully, but it really is not ideal.

In practice, channels are best suited for passing ownership of data, distributing units of work, and communicating async results while mutexes are better suited for caches and state.

Converting all of the code the code related to updating and querying the server's peer state to synchronous code that makes use of a separate mutex to protect it will address the aforementioned concerns.  Namely, it:

- Improves the semantics in regards to the aforementioned ordering
- Ultimately allows more code to run in parallel in the individual peer goroutines
- Requires less plumbing for updating and querying the state
- Makes the state available to calling code so it can make better decisions

This consists of a series of commits to help ease the review process.  Each commit is intended to be a self-contained and logically easy to follow change such that the code continues to compile and the tests continue to pass at each step.

See the description of each commit for further details.

Fixes #2694.