### PR TITLE
multi: Remove reject wire protocol support.

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1842,9 +1842,10 @@ func (p *Peer) readRemoteVersionMsg() error {
 	}
 
 	// Disconnect clients that have a protocol version that is too old.
-	if msg.ProtocolVersion < int32(wire.InitialProcotolVersion) {
+	const reqProtocolVersion = int32(wire.RemoveRejectVersion)
+	if msg.ProtocolVersion < reqProtocolVersion {
 		return fmt.Errorf("protocol version must be %d or greater",
-			wire.InitialProcotolVersion)
+			reqProtocolVersion)
 	}
 
 	return nil

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2016-2021 The Decred developers
+// Copyright (c) 2016-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -182,8 +182,9 @@ type MessageListeners struct {
 
 	// OnReject is invoked when a peer receives a reject wire message.
 	//
-	// Deprecated: This will be removed in a future release.  Callers should
-	// avoid using it.
+	// Deprecated: This will be removed in a future release.  The underlying
+	// message is no longer valid and thus this will no longer ever be invoked.
+	// Callers should avoid using it.
 	OnReject func(p *Peer, msg *wire.MsgReject)
 
 	// OnSendHeaders is invoked when a peer receives a sendheaders wire
@@ -1401,11 +1402,6 @@ out:
 		case *wire.MsgFeeFilter:
 			if p.cfg.Listeners.OnFeeFilter != nil {
 				p.cfg.Listeners.OnFeeFilter(p, msg)
-			}
-
-		case *wire.MsgReject:
-			if p.cfg.Listeners.OnReject != nil {
-				p.cfg.Listeners.OnReject(p, msg)
 			}
 
 		case *wire.MsgSendHeaders:

--- a/server.go
+++ b/server.go
@@ -950,11 +950,11 @@ func (sp *serverPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) {
 	}
 
 	// Reject peers that have a protocol version that is too old.
-	// This is the maximum protocol version negotiated by dcrwallet 1.8.0.
-	if msg.ProtocolVersion < int32(wire.InitStateVersion) {
+	const reqProtocolVersion = int32(wire.RemoveRejectVersion)
+	if msg.ProtocolVersion < reqProtocolVersion {
 		srvrLog.Debugf("Rejecting peer %s with protocol version %d prior to "+
 			"the required version %d", sp, msg.ProtocolVersion,
-			wire.InitStateVersion)
+			reqProtocolVersion)
 		sp.Disconnect()
 		return
 	}

--- a/wire/message.go
+++ b/wire/message.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2023 The Decred developers
+// Copyright (c) 2015-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -156,9 +156,6 @@ func makeEmptyMessage(command string) (Message, error) {
 
 	case CmdGetMiningState:
 		msg = &MsgGetMiningState{}
-
-	case CmdReject:
-		msg = &MsgReject{}
 
 	case CmdSendHeaders:
 		msg = &MsgSendHeaders{}

--- a/wire/message_test.go
+++ b/wire/message_test.go
@@ -77,7 +77,6 @@ func TestMessage(t *testing.T) {
 		[]byte("payload"))
 	msgCFHeaders := NewMsgCFHeaders()
 	msgCFTypes := NewMsgCFTypes([]FilterType{GCSFilterExtended})
-	msgReject := NewMsgReject("block", RejectDuplicate, "duplicate block")
 	msgGetInitState := NewMsgGetInitState()
 	msgInitState := NewMsgInitState()
 	msgMixPR, err := NewMsgMixPairReq([33]byte{}, 1, 1, "", 1, 1, 1, 1, []MixPairReqUTXO{}, NewTxOut(0, []byte{}), 1, 1)
@@ -114,7 +113,6 @@ func TestMessage(t *testing.T) {
 		{msgGetHeaders, msgGetHeaders, pver, MainNet, 61},
 		{msgHeaders, msgHeaders, pver, MainNet, 25},
 		{msgMemPool, msgMemPool, pver, MainNet, 24},
-		{msgReject, msgReject, RemoveRejectVersion - 1, MainNet, 79},
 		{msgGetCFilter, msgGetCFilter, pver, MainNet, 57},
 		{msgGetCFHeaders, msgGetCFHeaders, pver, MainNet, 58},
 		{msgGetCFTypes, msgGetCFTypes, pver, MainNet, 24},


### PR DESCRIPTION
This completes the deprecation and code removal for the `reject` message as previously detailed by #2546.

In particular, it consists of a series of commits that:

- Bumps the minimum required server protocol version to the version that no longer supports the `reject` message (v9)
- Bumps the minimum required peer protocol version to the version that no longer supports the `reject` message (v9)
- Removes peer code for handling the no longer supported `reject` message
- Updates the mock connection used in the peer tests to close the underlying readers and writers when the connection is closed to more closely match the behavior of real connections when they are closed
- Removes `wire` code for accepting `reject` messages which are no longer supported by the network

Closes #2546.