### PR TITLE
wire: Include unmixed session position in KE

### DIFF
--- a/wire/message_test.go
+++ b/wire/message_test.go
@@ -83,7 +83,7 @@ func TestMessage(t *testing.T) {
 	if err != nil {
 		t.Errorf("NewMsgMixPairReq: %v", err)
 	}
-	msgMixKE := NewMsgMixKeyExchange([33]byte{}, [32]byte{}, 1, 1, [33]byte{}, [1218]byte{}, [32]byte{}, []chainhash.Hash{})
+	msgMixKE := NewMsgMixKeyExchange([33]byte{}, [32]byte{}, 1, 1, 1, [33]byte{}, [1218]byte{}, [32]byte{}, []chainhash.Hash{})
 	msgMixCT := NewMsgMixCiphertexts([33]byte{}, [32]byte{}, 1, [][1047]byte{}, []chainhash.Hash{})
 	msgMixSR := NewMsgMixSlotReserve([33]byte{}, [32]byte{}, 1, [][][]byte{{{}}}, []chainhash.Hash{})
 	msgMixFP := NewMsgMixFactoredPoly([33]byte{}, [32]byte{}, 1, [][]byte{}, []chainhash.Hash{})
@@ -122,7 +122,7 @@ func TestMessage(t *testing.T) {
 		{msgGetInitState, msgGetInitState, pver, MainNet, 25},
 		{msgInitState, msgInitState, pver, MainNet, 27},
 		{msgMixPR, msgMixPR, pver, MainNet, 167},
-		{msgMixKE, msgMixKE, pver, MainNet, 1449},
+		{msgMixKE, msgMixKE, pver, MainNet, 1453},
 		{msgMixCT, msgMixCT, pver, MainNet, 158},
 		{msgMixSR, msgMixSR, pver, MainNet, 161},
 		{msgMixFP, msgMixFP, pver, MainNet, 159},

--- a/wire/msgmixkeyexchange.go
+++ b/wire/msgmixkeyexchange.go
@@ -32,6 +32,7 @@ type MsgMixKeyExchange struct {
 	SessionID  [32]byte
 	Epoch      uint64
 	Run        uint32
+	Pos        uint32
 	ECDH       [33]byte   // Secp256k1 public key
 	PQPK       [1218]byte // Sntrup4591761 public key
 	Commitment [32]byte
@@ -54,7 +55,7 @@ func (msg *MsgMixKeyExchange) BtcDecode(r io.Reader, pver uint32) error {
 	}
 
 	err := readElements(r, &msg.Signature, &msg.Identity, &msg.SessionID,
-		&msg.Epoch, &msg.Run, &msg.ECDH, &msg.PQPK, &msg.Commitment)
+		&msg.Epoch, &msg.Run, &msg.Pos, &msg.ECDH, &msg.PQPK, &msg.Commitment)
 	if err != nil {
 		return err
 	}
@@ -148,7 +149,7 @@ func (msg *MsgMixKeyExchange) writeMessageNoSignature(op string, w io.Writer, pv
 	}
 
 	err := writeElements(w, &msg.Identity, &msg.SessionID, msg.Epoch,
-		msg.Run, &msg.ECDH, &msg.PQPK, &msg.Commitment)
+		msg.Run, &msg.Pos, &msg.ECDH, &msg.PQPK, &msg.Commitment)
 	if err != nil {
 		return err
 	}
@@ -189,7 +190,7 @@ func (msg *MsgMixKeyExchange) MaxPayloadLength(pver uint32) uint32 {
 	}
 
 	// See tests for this calculation.
-	return 17811
+	return 17815
 }
 
 // Pub returns the message sender's public key identity.
@@ -221,7 +222,7 @@ func (msg *MsgMixKeyExchange) GetRun() uint32 {
 // Message interface using the passed parameters and defaults for the
 // remaining fields.
 func NewMsgMixKeyExchange(identity [33]byte, sid [32]byte, epoch uint64,
-	run uint32, ecdh [33]byte, pqpk [1218]byte, commitment [32]byte,
+	run uint32, pos uint32, ecdh [33]byte, pqpk [1218]byte, commitment [32]byte,
 	seenPRs []chainhash.Hash) *MsgMixKeyExchange {
 
 	return &MsgMixKeyExchange{
@@ -229,6 +230,7 @@ func NewMsgMixKeyExchange(identity [33]byte, sid [32]byte, epoch uint64,
 		SessionID:  sid,
 		Epoch:      epoch,
 		Run:        run,
+		Pos:        pos,
 		ECDH:       ecdh,
 		PQPK:       pqpk,
 		Commitment: commitment,

--- a/wire/msgmixkeyexchange_test.go
+++ b/wire/msgmixkeyexchange_test.go
@@ -23,6 +23,7 @@ func newTestMixKeyExchange() *MsgMixKeyExchange {
 
 	const epoch = uint64(0x8383838383838383)
 	const run = uint32(0x84848484)
+	const pos = uint32(0x8C8C8C8C)
 
 	ecdh := *(*[33]byte)(repeat(0x85, 33))
 	pqpk := *(*[1218]byte)(repeat(0x86, 1218))
@@ -33,7 +34,7 @@ func newTestMixKeyExchange() *MsgMixKeyExchange {
 		copy(seenPRs[b-0x88][:], repeat(b, 32))
 	}
 
-	ke := NewMsgMixKeyExchange(id, sid, epoch, run, ecdh, pqpk, commitment, seenPRs)
+	ke := NewMsgMixKeyExchange(id, sid, epoch, run, pos, ecdh, pqpk, commitment, seenPRs)
 	ke.Signature = sig
 
 	return ke
@@ -56,6 +57,7 @@ func TestMsgMixKeyExchangeWire(t *testing.T) {
 	expected = append(expected, repeat(0x82, 32)...)   // Session ID
 	expected = append(expected, repeat(0x83, 8)...)    // Epoch
 	expected = append(expected, repeat(0x84, 4)...)    // Run
+	expected = append(expected, repeat(0x8c, 4)...)    // Unmixed position in session
 	expected = append(expected, repeat(0x85, 33)...)   // ECDH public key
 	expected = append(expected, repeat(0x86, 1218)...) // PQ public key
 	expected = append(expected, repeat(0x87, 32)...)   // Secrets commitment
@@ -159,6 +161,7 @@ func TestMsgMixKeyExchangeMaxPayloadLength(t *testing.T) {
 		32 + // Session ID
 		8 + // Epoch
 		4 + // Run
+		4 + // Unmixed position
 		33 + // ECDH public key
 		1218 + // sntrup4591761 public key
 		32 + // Secrets commitment


### PR DESCRIPTION
This will simplify the check that mixpool needs to perform to find a matching pair request by the same identity (rather than just any PR submitted by the same identity) as well as improve the PR syncing by only fetching unknown PRs by peers who are actively submitting key exchanges.