### PR TITLE
chaincfg: Update assume valid for release.

### DIFF
--- a/chaincfg/mainnetparams.go
+++ b/chaincfg/mainnetparams.go
@@ -133,9 +133,9 @@ func MainNetParams() *Params {
 		// forks rejection checkpoint.  This is intended to be updated
 		// periodically with new releases.
 		//
-		// Block 00000000000000008e50a3c18725d7272ec0057999a64aa62c15f398ffb7a0d7
-		// Height: 766600
-		AssumeValid: *newHashFromStr("00000000000000008e50a3c18725d7272ec0057999a64aa62c15f398ffb7a0d7"),
+		// Block f04628f2fe7fd0d33055dc326936a6af3772ec5226525bc8fca50631f3081faa
+		// Height: 865184
+		AssumeValid: *newHashFromStr("f04628f2fe7fd0d33055dc326936a6af3772ec5226525bc8fca50631f3081faa"),
 
 		// MinKnownChainWork is the minimum amount of known total work for the
 		// chain at a given point in time.  This is intended to be updated

--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -131,9 +131,9 @@ func TestNet3Params() *Params {
 		// forks rejection checkpoint.  This is intended to be updated
 		// periodically with new releases.
 		//
-		// Block 00000000787986d95cef3b42beee6cc3c8065f6e5338e17854b1ff4d16b6a396
-		// Height: 1138320
-		AssumeValid: *newHashFromStr("00000000787986d95cef3b42beee6cc3c8065f6e5338e17854b1ff4d16b6a396"),
+		// Block 88d61d7609c06c8e171f050789f6649d21525a144b820026f7b396476a05a44b
+		// Height: 1377455
+		AssumeValid: *newHashFromStr("88d61d7609c06c8e171f050789f6649d21525a144b820026f7b396476a05a44b"),
 
 		// MinKnownChainWork is the minimum amount of known total work for the
 		// chain at a given point in time.  This is intended to be updated


### PR DESCRIPTION
This updates the assumed valid block for the main and test networks as follows:

> mainnet: f04628f2fe7fd0d33055dc326936a6af3772ec5226525bc8fca50631f3081faa
> testnet: 88d61d7609c06c8e171f050789f6649d21525a144b820026f7b396476a05a44b

Reviewers should verify that:

- The mainnet block is at least 4032 blocks behind the current tip
- The testnet block is at least 10080 blocks behind the current tip
- The block hashes and heights match their local instances

The following commands may be used to verify the hashes:
```
$ dcrctl getblockhash 865184
f04628f2fe7fd0d33055dc326936a6af3772ec5226525bc8fca50631f3081faa
$ dcrctl --testnet getblockhash 1377455
88d61d7609c06c8e171f050789f6649d21525a144b820026f7b396476a05a44b
```

Closes #3252.