### PR TITLE
chaincfg: Update min known chain work for release.

### DIFF
--- a/chaincfg/mainnetparams.go
+++ b/chaincfg/mainnetparams.go
@@ -141,9 +141,9 @@ func MainNetParams() *Params {
 		// chain at a given point in time.  This is intended to be updated
 		// periodically with new releases.
 		//
-		// Block 0000000000000000149b797ca19e1b4a061ab0e28c73e9c02687c72c8a18bd22
-		// Height: 770630
-		MinKnownChainWork: hexToBigInt("00000000000000000000000000000000000000000023e312aba3df81d0c21ef0"),
+		// Block bf7f2d914bea1b97f5db0cd914f0ff6ca7f8675e1c4d0984776a74de48948568
+		// Height: 869216
+		MinKnownChainWork: hexToBigInt("000000000000000000000000000000000000000000243845fb2fb3d8f20ddfeb"),
 
 		// The miner confirmation window is defined as:
 		//   target proof of work timespan / target proof of work spacing

--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -139,9 +139,9 @@ func TestNet3Params() *Params {
 		// chain at a given point in time.  This is intended to be updated
 		// periodically with new releases.
 		//
-		// Block 000000001ffc25cb2cd323c82c5838971a9b191c2d4cf9530e1582fcb8b4794e
-		// Height: 1148390
-		MinKnownChainWork: hexToBigInt("000000000000000000000000000000000000000000000000f376cd394f056477"),
+		// Block 50f244d269a61de438a9075f7f5477a785f3f2060d2c7127f000093176a386fa
+		// Height: 1387535
+		MinKnownChainWork: hexToBigInt("000000000000000000000000000000000000000000000000f376ddb1ab3a5a2e"),
 
 		// Consensus rule change deployments.
 		//


### PR DESCRIPTION
This updates the minimum known chain work values for the main and test networks as follows:

> mainnet: 0x000000000000000000000000000000000000000000243845fb2fb3d8f20ddfeb
> testnet: 0x000000000000000000000000000000000000000000000000f376ddb1ab3a5a2e

```sh
$ dcrctl getblockhash 869216 | dcrctl getblockheader - | jq -r .chainwork
000000000000000000000000000000000000000000243845fb2fb3d8f20ddfeb
$ dcrctl --testnet getblockhash 1387535 | dcrctl --testnet getblockheader - | jq -r .chainwork
000000000000000000000000000000000000000000000000f376ddb1ab3a5a2e
```

Closes #3253.