### PR TITLE
mixing: Only validate compressed 33-byte pubkeys

### DIFF
--- a/mixing/signatures.go
+++ b/mixing/signatures.go
@@ -96,6 +96,9 @@ func sign(priv *secp256k1.PrivateKey, m Signed) ([]byte, error) {
 }
 
 func verify(h hash.Hash, pk []byte, sig []byte, sigHash []byte, command string, sid []byte, run uint32) bool {
+	if len(pk) != secp256k1.PubKeyBytesLenCompressed {
+		return false
+	}
 	pkParsed, err := secp256k1.ParsePubKey(pk)
 	if err != nil {
 		return false


### PR DESCRIPTION
The code already requires the mixing.Message.Pub method to return secp256k1 public keys.  Require them to be compressed as well.