### PR TITLE
rpc/jsonrpc/types: Add tests for new mix types.

### DIFF
--- a/rpc/jsonrpc/types/chainsvrcmds_test.go
+++ b/rpc/jsonrpc/types/chainsvrcmds_test.go
@@ -454,6 +454,17 @@ func TestChainSvrCmds(t *testing.T) {
 			unmarshalled: &GetMiningInfoCmd{},
 		},
 		{
+			name: "getmixpairrequests",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd(Method("getmixpairrequests"))
+			},
+			staticCmd: func() interface{} {
+				return NewGetMixPairRequestsCmd()
+			},
+			marshalled:   `{"jsonrpc":"1.0","method":"getmixpairrequests","params":[],"id":1}`,
+			unmarshalled: &GetMixPairRequestsCmd{},
+		},
+		{
 			name: "getnetworkinfo",
 			newCmd: func() (interface{}, error) {
 				return dcrjson.NewCmd(Method("getnetworkinfo"))
@@ -813,6 +824,20 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 			marshalled:   `{"jsonrpc":"1.0","method":"ping","params":[],"id":1}`,
 			unmarshalled: &PingCmd{},
+		},
+		{
+			name: "sendrawmixmessage",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd(Method("sendrawmixmessage"), "mixpairrequest", "1122")
+			},
+			staticCmd: func() interface{} {
+				return NewSendRawMixMessageCmd("mixpairrequest", "1122")
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"sendrawmixmessage","params":["mixpairrequest","1122"],"id":1}`,
+			unmarshalled: &SendRawMixMessageCmd{
+				Command: "mixpairrequest",
+				Message: "1122",
+			},
 		},
 		{
 			name: "sendrawtransaction",

--- a/rpc/jsonrpc/types/chainsvrwscmds.go
+++ b/rpc/jsonrpc/types/chainsvrwscmds.go
@@ -165,9 +165,9 @@ func NewNotifyMixMessagesCmd() *NotifyMixMessagesCmd {
 // StopNotifyMixMessagesCmd defines the stopnotifymixmessages JSON-RPC command.
 type StopNotifyMixMessagesCmd struct{}
 
-// StopNewNotifyMixMessagesCmd returns a new instance which can be used to issue a
+// NewStopNewNotifyMixMessagesCmd returns a new instance which can be used to issue a
 // stopnotifymixmessages JSON-RPC command.
-func StopNewNotifyMixMessagesCmd() *StopNotifyMixMessagesCmd {
+func NewStopNewNotifyMixMessagesCmd() *StopNotifyMixMessagesCmd {
 	return &StopNotifyMixMessagesCmd{}
 }
 

--- a/rpc/jsonrpc/types/chainsvrwscmds_test.go
+++ b/rpc/jsonrpc/types/chainsvrwscmds_test.go
@@ -130,6 +130,28 @@ func TestChainSvrWsCmds(t *testing.T) {
 			unmarshalled: &StopNotifyTSpendCmd{},
 		},
 		{
+			name: "notifymixmessages",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd(Method("notifymixmessages"))
+			},
+			staticCmd: func() interface{} {
+				return NewNotifyMixMessagesCmd()
+			},
+			marshalled:   `{"jsonrpc":"1.0","method":"notifymixmessages","params":[],"id":1}`,
+			unmarshalled: &NotifyMixMessagesCmd{},
+		},
+		{
+			name: "stopnotifymixmessages",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd(Method("stopnotifymixmessages"))
+			},
+			staticCmd: func() interface{} {
+				return NewStopNewNotifyMixMessagesCmd()
+			},
+			marshalled:   `{"jsonrpc":"1.0","method":"stopnotifymixmessages","params":[],"id":1}`,
+			unmarshalled: &StopNotifyMixMessagesCmd{},
+		},
+		{
 			name: "notifynewtransactions",
 			newCmd: func() (interface{}, error) {
 				return dcrjson.NewCmd(Method("notifynewtransactions"))

--- a/rpc/jsonrpc/types/chainsvrwsntfns_test.go
+++ b/rpc/jsonrpc/types/chainsvrwsntfns_test.go
@@ -144,6 +144,20 @@ func TestChainSvrWsNtfns(t *testing.T) {
 				Tickets:     map[string]string{"a": "b"},
 			},
 		},
+		{
+			name: "mixmessage",
+			newNtfn: func() (interface{}, error) {
+				return dcrjson.NewCmd(Method("mixmessage"), "mixpairrequest", "1122")
+			},
+			staticNtfn: func() interface{} {
+				return NewMixMessageNtfn("mixpairrequest", "1122")
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"mixmessage","params":["mixpairrequest","1122"],"id":null}`,
+			unmarshalled: &MixMessageNtfn{
+				Command: "mixpairrequest",
+				Payload: "1122",
+			},
+		},
 	}
 
 	t.Logf("Running %d tests", len(tests))


### PR DESCRIPTION
This adds tests for the recently added mix related commands and notification.

In particular:

- `getmixpairrequests` command
- `sendrawmixmessage` command
- `notifymixmessages` command
- `stopnotifymixmessages` command
-` mixmessage` notification