### PR TITLE
rpc/jsonrpc/types: Prepare v4.2.0.

### DIFF
--- a/rpc/jsonrpc/types/chainsvrcmds.go
+++ b/rpc/jsonrpc/types/chainsvrcmds.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015-2023 The Decred developers
+// Copyright (c) 2015-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/rpc/jsonrpc/types/chainsvrcmds_test.go
+++ b/rpc/jsonrpc/types/chainsvrcmds_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2016-2022 The Decred developers
+// Copyright (c) 2016-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/rpc/jsonrpc/types/chainsvrwscmds.go
+++ b/rpc/jsonrpc/types/chainsvrwscmds.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2015 The btcsuite developers
-// Copyright (c) 2015-2022 The Decred developers
+// Copyright (c) 2015-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/rpc/jsonrpc/types/chainsvrwscmds_test.go
+++ b/rpc/jsonrpc/types/chainsvrwscmds_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015-2022 The Decred developers
+// Copyright (c) 2015-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/rpc/jsonrpc/types/chainsvrwsntfns.go
+++ b/rpc/jsonrpc/types/chainsvrwsntfns.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015-2022 The Decred developers
+// Copyright (c) 2015-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/rpc/jsonrpc/types/chainsvrwsntfns_test.go
+++ b/rpc/jsonrpc/types/chainsvrwsntfns_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015-2022 The Decred developers
+// Copyright (c) 2015-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 


### PR DESCRIPTION
This updates the `rpc/jsonrpc/types` module copyright year in the files modified since the previous release and serves as a base for `rpc/jsonrpc/types/v4.2.0`.