### PR TITLE
mixpool: Require 1 block confirmation

### DIFF
--- a/mixing/mixpool/mixpool.go
+++ b/mixing/mixpool/mixpool.go
@@ -24,7 +24,7 @@ import (
 	"github.com/decred/dcrd/wire"
 )
 
-const minconf = 2
+const minconf = 1
 const feeRate = 0.0001e8
 
 type idPubKey = [33]byte


### PR DESCRIPTION
This value needs to be lower than the confirmations wallet requires (2) before mixing any output, otherwise it is very easy to race on rejecting these messages as new blocks were just created.

This is a backport candidate for 2.0.1.