### PR TITLE
mixing: Use stdaddr.Hash160 instead of dcrutil.

### DIFF
--- a/mixing/mixclient/client.go
+++ b/mixing/mixclient/client.go
@@ -24,11 +24,11 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/crypto/blake256"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
-	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/mixing"
 	"github.com/decred/dcrd/mixing/internal/chacha20prng"
 	"github.com/decred/dcrd/mixing/mixpool"
 	"github.com/decred/dcrd/txscript/v4"
+	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/slog"
 	"golang.org/x/sync/errgroup"
@@ -1615,12 +1615,12 @@ func (c *Client) validateMergedCoinjoin(cj *CoinJoin, prs []*wire.MsgMixPairReq,
 	prevScriptForUTXO := func(utxo *wire.MixPairReqUTXO) []byte {
 		switch utxo.Opcode {
 		case 0:
-			copy(hash160, dcrutil.Hash160(utxo.PubKey))
+			copy(hash160, stdaddr.Hash160(utxo.PubKey))
 			return prevScript[1:]
 
 		case txscript.OP_SSGEN, txscript.OP_SSRTX, txscript.OP_TGEN:
 			*opcode = utxo.Opcode
-			copy(hash160, dcrutil.Hash160(utxo.PubKey))
+			copy(hash160, stdaddr.Hash160(utxo.PubKey))
 			return prevScript
 
 		default:

--- a/mixing/mixclient/client_test.go
+++ b/mixing/mixclient/client_test.go
@@ -18,11 +18,11 @@ import (
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/dcrec"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
-	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/mixing"
 	"github.com/decred/dcrd/mixing/mixpool"
 	"github.com/decred/dcrd/txscript/v4"
 	"github.com/decred/dcrd/txscript/v4/sign"
+	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/slog"
 	"golang.org/x/sync/errgroup"
@@ -127,7 +127,7 @@ func (w *testWallet) gen(mcount uint32) (wire.MixVect, error) {
 			return nil, err
 		}
 		serializedPub := pub.SerializeCompressed()
-		hash160 := *(*[20]byte)(dcrutil.Hash160(serializedPub))
+		hash160 := *(*[20]byte)(stdaddr.Hash160(serializedPub))
 
 		w.mu.Lock()
 		w.keys[hash160] = priv
@@ -145,7 +145,7 @@ func (w *testWallet) outputScript() ([]byte, error) {
 	}
 
 	serializedPub := pub.SerializeCompressed()
-	hash160 := *(*[20]byte)(dcrutil.Hash160(serializedPub))
+	hash160 := *(*[20]byte)(stdaddr.Hash160(serializedPub))
 	pkScript := []byte{
 		0:  txscript.OP_DUP,
 		1:  txscript.OP_HASH160,

--- a/mixing/mixpool/mixpool.go
+++ b/mixing/mixpool/mixpool.go
@@ -16,10 +16,10 @@ import (
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v3"
-	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/mixing"
 	"github.com/decred/dcrd/mixing/utxoproof"
 	"github.com/decred/dcrd/txscript/v4"
+	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/txscript/v4/stdscript"
 	"github.com/decred/dcrd/wire"
 )
@@ -1297,7 +1297,7 @@ func (p *Pool) checkUTXOs(pr *wire.MsgMixPairReq, curHeight int64) error {
 
 func validateOwnerProofP2PKHv0(extractFunc func([]byte) []byte, pkscript, pubkey, sig []byte, expires uint32) bool {
 	extractedHash160 := extractFunc(pkscript)
-	pubkeyHash160 := dcrutil.Hash160(pubkey)
+	pubkeyHash160 := stdaddr.Hash160(pubkey)
 	if !bytes.Equal(extractedHash160, pubkeyHash160) {
 		return false
 	}

--- a/mixing/mixpool/mixpool_test.go
+++ b/mixing/mixpool/mixpool_test.go
@@ -21,11 +21,11 @@ import (
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/crypto/blake256"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
-	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/mixing"
 	"github.com/decred/dcrd/mixing/internal/chacha20prng"
 	"github.com/decred/dcrd/mixing/utxoproof"
 	"github.com/decred/dcrd/txscript/v4"
+	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -118,7 +118,7 @@ func makeMockUTXO(rand io.Reader, value int64) *mockUTXO {
 		23: txscript.OP_EQUALVERIFY,
 		24: txscript.OP_CHECKSIG,
 	}
-	hash160 := dcrutil.Hash160(pubSerialized)
+	hash160 := stdaddr.Hash160(pubSerialized)
 	copy(p2pkhScript[3:23], hash160)
 
 	output := wire.NewTxOut(value, p2pkhScript)


### PR DESCRIPTION
The `Hash160` method in the `stdaddr` package is preferred over `dcrutil` since ideally `dcrutil` will be removed one day.