### PR TITLE
mixpool: Wrap non-bannable errors with RuleError

### DIFF
--- a/mixing/mixpool/errors.go
+++ b/mixing/mixpool/errors.go
@@ -12,7 +12,8 @@ import (
 
 // RuleError represents a mixpool rule violation.
 //
-// RuleErrors can be treated as a bannable offense.
+// Some RuleErrors should be treated as an automatic bannable offense.  Use
+// IsBannable to test for this condition.
 type RuleError struct {
 	Err error
 }
@@ -29,41 +30,73 @@ func (e *RuleError) Unwrap() error {
 	return e.Err
 }
 
-// Errors wrapped by RuleError.
+type bannableError struct {
+	s string
+}
+
+func (e *bannableError) Error() string {
+	return e.s
+}
+
+func newBannableError(s string) error {
+	return &bannableError{
+		s: s,
+	}
+}
+
+// Bannable errors wrapped by RuleError.
 var (
 	// ErrChangeDust is returned by AcceptMessage if a pair request's
 	// change amount is dust.
-	ErrChangeDust = errors.New("change output is dust")
+	ErrChangeDust = newBannableError("change output is dust")
+
+	// ErrLowInput is returned by AcceptMessage when not enough input value
+	// is provided by a pair request to cover the mixed output, any change
+	// output, and the minimum required fee.
+	ErrLowInput = newBannableError("not enough input value, or too low fee")
 
 	// ErrInvalidMessageCount is returned by AcceptMessage if a
 	// pair request contains an invalid message count.
-	ErrInvalidMessageCount = errors.New("message count must be positive")
+	ErrInvalidMessageCount = newBannableError("message count must be positive")
 
 	// ErrInvalidScript is returned by AcceptMessage if a pair request
 	// contains an invalid script.
-	ErrInvalidScript = errors.New("invalid script")
+	ErrInvalidScript = newBannableError("invalid script")
 
 	// ErrInvalidSessionID is returned by AcceptMessage if the message
 	// contains an invalid session id.
-	ErrInvalidSessionID = errors.New("invalid session ID")
+	ErrInvalidSessionID = newBannableError("invalid session ID")
 
 	// ErrInvalidSignature is returned by AcceptMessage if the message is
 	// not properly signed for the claimed identity.
-	ErrInvalidSignature = errors.New("invalid message signature")
+	ErrInvalidSignature = newBannableError("invalid message signature")
 
 	// ErrInvalidTotalMixAmount is returned by AcceptMessage if a pair
 	// request contains the product of the message count and mix amount
 	// that exceeds the total input value.
-	ErrInvalidTotalMixAmount = errors.New("invalid total mix amount")
+	ErrInvalidTotalMixAmount = newBannableError("invalid total mix amount")
 
 	// ErrInvalidUTXOProof is returned by AcceptMessage if a pair request
 	// fails to prove ownership of each utxo.
-	ErrInvalidUTXOProof = errors.New("invalid UTXO ownership proof")
+	ErrInvalidUTXOProof = newBannableError("invalid UTXO ownership proof")
 
 	// ErrMissingUTXOs is returned by AcceptMessage if a pair request
 	// message does not reference any previous UTXOs.
-	ErrMissingUTXOs = errors.New("pair request contains no UTXOs")
+	ErrMissingUTXOs = newBannableError("pair request contains no UTXOs")
+
+	// ErrPeerPositionOutOfBounds is returned by AcceptMessage if the
+	// position of a peer's own PR is outside of the possible bounds of
+	// the previously seen messages.
+	ErrPeerPositionOutOfBounds = newBannableError("peer position cannot be a valid seen PRs index")
 )
+
+// IsBannable returns whether the error condition is such that the peer who
+// sent the message should be immediately banned for malicious or buggy
+// behavior.
+func IsBannable(err error) bool {
+	var be *bannableError
+	return errors.As(err, &be)
+}
 
 var (
 	// ErrSecretsRevealed is returned by Receive if any peer has

--- a/server.go
+++ b/server.go
@@ -1729,8 +1729,7 @@ func (sp *serverPeer) onMixMessage(msg mixing.Message) {
 			nil, nil, nil, mixHashes)
 		return
 	}
-	var ruleError *mixpool.RuleError
-	if errors.As(err, &ruleError) {
+	if mixpool.IsBannable(err) {
 		sp.server.BanPeer(sp)
 		sp.Disconnect()
 	}


### PR DESCRIPTION
To reduce spurious error logs when invalid messages are received off the network, the RuleError type is expanded to cover submission errors that should not necessarily result in an instant permanent ban.

A new function IsBannable is added to check whether the error condition is still such that it should be treated as bannable.
