### PR TITLE
dcrjson,rpcserver,types: Add getmixmessage

### DIFF
--- a/dcrjson/jsonrpcerr.go
+++ b/dcrjson/jsonrpcerr.go
@@ -74,6 +74,7 @@ const (
 	ErrRPCNoNewestBlockInfo RPCErrorCode = -5
 	ErrRPCInvalidTxVout     RPCErrorCode = -5
 	ErrRPCNoTreasury        RPCErrorCode = -5
+	ErrRPCNoMixMsgInfo      RPCErrorCode = -5
 	ErrRPCRawTxString       RPCErrorCode = -32602
 	ErrRPCDecodeHexString   RPCErrorCode = -22
 	ErrRPCDuplicateTx       RPCErrorCode = -40

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -633,6 +633,9 @@ type MixPooler interface {
 	// If query is nil, all PRs are returned.
 	MixPRs(query []chainhash.Hash) []*wire.MsgMixPairReq
 
+	// Message searches the mixing pool for a message by its hash.
+	Message(query *chainhash.Hash) (mixing.Message, error)
+
 	// RemoveConfirmedRuns removes all messages including pair requests
 	// from runs which ended in each peer sending a confirm mix message.
 	RemoveConfirmedRuns()

--- a/internal/rpcserver/rpcserverhelp.go
+++ b/internal/rpcserver/rpcserverhelp.go
@@ -510,6 +510,15 @@ var helpDescsEnUS = map[string]string{
 	// GetMiningInfoCmd help.
 	"getmininginfo--synopsis": "Returns a JSON object containing mining-related information.",
 
+	// GetMixMessage help.
+	"getmixmessage--synopsis": "Returns a mix message if it is currently accepted by the mixpool.",
+	"getmixmessage-hash":      "Hash of the message being queried",
+	"getmixmessage--result0":  "JSON object describing the message command type and the serialized message in hex encoding.",
+
+	// GetMixMessageResult help.
+	"getmixmessageresult-type":    "Command type of the message",
+	"getmixmessageresult-message": "Serialized message in hex encoding",
+
 	// GetMixPairRequests help.
 	"getmixpairrequests--synopsis": "Returns current set of mixing pair request messages from mixpool.",
 	"getmixpairrequests--result0":  "JSON array of hex-encoded mixing pair request messages.",
@@ -970,6 +979,7 @@ var rpcResultTypes = map[types.Method][]interface{}{
 	"getinfo":               {(*types.InfoChainResult)(nil)},
 	"getmempoolinfo":        {(*types.GetMempoolInfoResult)(nil)},
 	"getmininginfo":         {(*types.GetMiningInfoResult)(nil)},
+	"getmixmessage":         {(*types.GetMixMessageResult)(nil)},
 	"getmixpairrequests":    {(*[]string)(nil)},
 	"getnettotals":          {(*types.GetNetTotalsResult)(nil)},
 	"getnetworkhashps":      {(*int64)(nil)},

--- a/rpc/jsonrpc/types/chainsvrcmds.go
+++ b/rpc/jsonrpc/types/chainsvrcmds.go
@@ -552,6 +552,19 @@ func NewGetMiningInfoCmd() *GetMiningInfoCmd {
 	return &GetMiningInfoCmd{}
 }
 
+// GetMixMessageCmd defines the getmixmessage JSON-RPC command.
+type GetMixMessageCmd struct {
+	Hash string
+}
+
+// NewGetMixMessageCmd returns a new instance which can be used to issue a
+// getmixmessage JSON-RPC command.
+func NewGetMixMessageCmd(hash string) *GetMixMessageCmd {
+	return &GetMixMessageCmd{
+		Hash: hash,
+	}
+}
+
 // GetMixPairRequestsCmd defines the getmixpairrequests JSON-RPC command.
 type GetMixPairRequestsCmd struct{}
 
@@ -1146,6 +1159,7 @@ func init() {
 	dcrjson.MustRegister(Method("getinfo"), (*GetInfoCmd)(nil), flags)
 	dcrjson.MustRegister(Method("getmempoolinfo"), (*GetMempoolInfoCmd)(nil), flags)
 	dcrjson.MustRegister(Method("getmininginfo"), (*GetMiningInfoCmd)(nil), flags)
+	dcrjson.MustRegister(Method("getmixmessage"), (*GetMixMessageCmd)(nil), flags)
 	dcrjson.MustRegister(Method("getmixpairrequests"), (*GetMixPairRequestsCmd)(nil), flags)
 	dcrjson.MustRegister(Method("getnetworkinfo"), (*GetNetworkInfoCmd)(nil), flags)
 	dcrjson.MustRegister(Method("getnettotals"), (*GetNetTotalsCmd)(nil), flags)

--- a/rpc/jsonrpc/types/chainsvrresults.go
+++ b/rpc/jsonrpc/types/chainsvrresults.go
@@ -234,6 +234,12 @@ type GetMiningInfoResult struct {
 	TestNet          bool    `json:"testnet"`
 }
 
+// GetMixMessageResult models the data from the getmixmessage command.
+type GetMixMessageResult struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}
+
 // LocalAddressesResult models the localaddresses data from the getnetworkinfo
 // command.
 type LocalAddressesResult struct {


### PR DESCRIPTION
This adds a new RPC named getmixmessage to the JSON-RPC server which queries the current mixpool for a mixing message by its hash.

This RPC will be used in later wallet releases to fetch unknown pair request messages when a run-0 key exchange is rejected from the wallet's mixpool for referencing an unknown PR by the same identity.  This is also how initial PR sync occurs during the warmup period, replacing the earlier use of getmixpairrequests.