### PR TITLE
dcrjson: Prepare v4.1.0.

### DIFF
--- a/dcrjson/jsonrpcerr.go
+++ b/dcrjson/jsonrpcerr.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 


### PR DESCRIPTION
This updates the `dcrjson` module copyright year in the files modified since the previous release and serves as a base for `dcrjson/v4.1.0`.
