### PR TITLE
server: Add missing ban reason.

### DIFF
--- a/server.go
+++ b/server.go
@@ -2481,7 +2481,7 @@ func (s *server) BanPeer(sp *serverPeer, reason string) {
 
 	direction := directionString(sp.Inbound())
 	srvrLog.Warnf("Misbehaving peer %s (%s): %s -- banned for %v", host,
-		direction, cfg.BanDuration)
+		direction, reason, cfg.BanDuration)
 	bannedUntil := time.Now().Add(cfg.BanDuration)
 	s.peerState.Lock()
 	s.peerState.banned[host] = bannedUntil


### PR DESCRIPTION
This corrects a log message for misbehaving peers to include the reason they were banned.
