### PR TITLE
multi: Add dynamic profile server infrastructure.

### DIFF
--- a/blockdb.go
+++ b/blockdb.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2022 The Decred developers
+// Copyright (c) 2015-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -8,7 +8,6 @@ package main
 import (
 	"encoding/binary"
 	"errors"
-	_ "net/http/pprof"
 	"os"
 	"path/filepath"
 

--- a/config.go
+++ b/config.go
@@ -931,25 +931,13 @@ func loadConfig(appName string) (*config, []string, error) {
 		cfg.UtxoCacheMaxSize = maxUtxoCacheMaxSize
 	}
 
-	// Validate format of profile, can be an address:port, or just a port.
+	// Validate format of profile address.  It may either be an address:port or
+	// just a port.  The port also must be between 1024 and 65535.
 	if cfg.Profile != "" {
-		// if profile is just a number, then add a default host of "127.0.0.1" such that Profile is a valid tcp address
-		if _, err := strconv.Atoi(cfg.Profile); err == nil {
-			cfg.Profile = net.JoinHostPort("127.0.0.1", cfg.Profile)
-		}
-
-		// check the Profile is a valid address
-		_, portStr, err := net.SplitHostPort(cfg.Profile)
-		if err != nil {
+		cfg.Profile = portToLocalHostAddr(cfg.Profile)
+		if err := validateProfileAddr(cfg.Profile); err != nil {
 			str := "%s: profile: %w"
 			err := fmt.Errorf(str, funcName, err)
-			return nil, nil, err
-		}
-
-		// finally, check the port is in range
-		if port, _ := strconv.Atoi(portStr); port < 1024 || port > 65535 {
-			str := "%s: profile: address %s: port must be between 1024 and 65535"
-			err := fmt.Errorf(str, funcName, cfg.Profile)
 			return nil, nil, err
 		}
 	}

--- a/dcrd.go
+++ b/dcrd.go
@@ -228,8 +228,8 @@ func dcrdMain() error {
 
 	// Create server.
 	lifetimeNotifier.notifyStartupEvent(lifetimeEventP2PServer)
-	svr, err := newServer(ctx, cfg.Listeners, db, utxoDb, cfg.params.Params,
-		cfg.DataDir)
+	svr, err := newServer(ctx, &profiler, cfg.Listeners, db, utxoDb,
+		cfg.params.Params, cfg.DataDir)
 	if err != nil {
 		dcrdLog.Errorf("Unable to start server: %v", err)
 		return err

--- a/dcrjson/jsonrpcerr.go
+++ b/dcrjson/jsonrpcerr.go
@@ -40,6 +40,7 @@ const (
 	ErrRPCDatabase            RPCErrorCode = -20
 	ErrRPCDeserialization     RPCErrorCode = -22
 	ErrRPCVerify              RPCErrorCode = -25
+	ErrRPCInvalidState        RPCErrorCode = -26
 )
 
 // Peer-to-peer client errors.
@@ -77,6 +78,7 @@ const (
 	ErrRPCNoMixMsgInfo      RPCErrorCode = -5
 	ErrRPCRawTxString       RPCErrorCode = -32602
 	ErrRPCDecodeHexString   RPCErrorCode = -22
+	ErrRPCProfilerState     RPCErrorCode = -26
 	ErrRPCDuplicateTx       RPCErrorCode = -40
 	ErrRPCReconsiderFailure RPCErrorCode = -50
 )

--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -380,9 +380,17 @@ the method name for further details such as parameter and return information.
 |N
 |Set the server to generate coins (mine) or not. NOTE: Since dcrd does not have the wallet integrated to provide payment addresses, dcrd must be configured via the <code>--miningaddr</code> option to provide which payment addresses to pay created blocks to for this RPC to function.
 |-
+|[[#startprofiler|startprofiler]]
+|N
+|Starts the HTTP profile server listening on a given address.
+|-
 |[[#stop|stop]]
 |N
 |Shutdown dcrd.
+|-
+|[[#stopprofiler|stopprofiler]]
+|N
+|Stops the running HTTP profiler server.
 |-
 |[[#submitblock|submitblock]]
 |Y
@@ -2367,6 +2375,37 @@ of the best block.
 
 ----
 
+====startprofiler====
+{|
+!Method
+|startprofiler
+|-
+!Parameters
+|
+# <code>address</code>: <code>(string, required)</code> the interface/port to listen for profile server connections (e.g. <code>127.0.0.1:6060</code>)
+# <code>allownonloopback</code>: <code>(boolean, optional, default=false)</code> whether or not to allow listening on non loopback addresses
+|-
+!Description
+|
+: Starts the HTTP profile server listening on a given address.
+: The provided address may either be a lone port or of the form <code>host:port</code>.  When a lone port is provided, the address will be normalized to a loopback address by prepending <code>127.0.0.1:</code>
+:
+: Note that all non loopback addresses are rejected by default unless the <code>allownonloopback</code> parameter is set to <code>true</code>.  This protection mechanism is in place to help prevent accidentally exposing the profile server publicly.
+:
+: If access to profiling data from outside of the local machine is required, users are highly encouraged to use a mechanism such as <code>ssh</code> local port forwarding with its <code>-L</code> flag instead.
+:
+: When the <code>allownonloopback</code> parameter is <code>true</code>, the <code>host</code> portion of the address may be an interface name to listen on all IP addresses associated with the interface.
+|-
+!Returns
+|<code>(json object)</code>
+: <code>listeners</code>: <code>(json array)</code> List of normalized listening addresses the profile server is listening on
+|-
+!Example Return
+|<code>{"listeners": ["127.0.0.1:6060",...]}</code>
+|}
+
+----
+
 ====stop====
 {|
 !Method
@@ -2380,6 +2419,24 @@ of the best block.
 |-
 !Returns
 |<code>"dcrd stopping."</code> <code>(string)</code>
+|-
+|}
+
+----
+
+====stopprofiler====
+{|
+!Method
+|stopprofiler
+|-
+!Parameters
+|None
+|-
+!Description
+|Stops the running HTTP profiler server.
+|-
+!Returns
+|<code>"profiler server stopped"</code> <code>(string)</code>
 |-
 |}
 

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -26,6 +26,38 @@ import (
 	"github.com/decred/dcrd/wire"
 )
 
+// ProfilerManager represents a profile server manager for use with the RPC
+// server.
+//
+// The interface contract requires that all of these methods are safe for
+// concurrent access.
+type ProfilerManager interface {
+	// Start binds a listener to the provided address and launches an HTTP
+	// server that handles profiling endpoints in the background using that
+	// listener.  An error must be returned when the listener fails to bind or
+	// when the profile server has already been started.
+	//
+	// An error must also be returned when the allow non loopback flag is not
+	// set and the provided listen address does not normalize to an IPv4 or IPv6
+	// loopback address.
+	//
+	// It must have no effect when the server is already running, so it may be
+	// called multiple times without error.
+	Start(listenAddr string, allowNonLoopback bool) error
+
+	// Listeners returns all listeners the profile server is currently listening
+	// on.  It may also be used as a means to tell if the server is currently
+	// running since there will only be active listeners when it is.
+	Listeners() []string
+
+	// Stop immediately closes the active listener and any connections to the
+	// profile server.
+	//
+	// It must have no effect when the server is not running, so it may be
+	// called multiple times without error.
+	Stop() error
+}
+
 // Peer represents a peer for use with the RPC server.
 //
 // The interface contract requires that all of these methods are safe for

--- a/internal/rpcserver/rpcserverhelp.go
+++ b/internal/rpcserver/rpcserverhelp.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2015 The btcsuite developers
-// Copyright (c) 2015-2023 The Decred developers
+// Copyright (c) 2015-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -725,9 +725,19 @@ var helpDescsEnUS = map[string]string{
 	"setgenerate-generate":     "Use true to enable generation, false to disable it",
 	"setgenerate-genproclimit": "The number of processors (cores) to limit generation to or -1 for default",
 
+	// StartProfilerCmd help.
+	"startprofiler--synopsis":        "Starts the HTTP profile server listening on a given address.",
+	"startprofiler-addr":             "The interface/port to listen for profile server connections (e.g. 127.0.0.1:6060)",
+	"startprofiler-allownonloopback": "Whether or not to allow listening on non loopback addresses",
+	"startprofilerresult-listeners":  "List of normalized listening addresses the profile server is listening on",
+
 	// StopCmd help.
 	"stop--synopsis": "Shutdown dcrd.",
 	"stop--result0":  "The string 'dcrd stopping.'",
+
+	// StopProfilerCmd help.
+	"stopprofiler--synopsis": "Stops the running HTTP profile server.",
+	"stopprofiler--result0":  "The string 'profile server stopped'",
 
 	// SubmitBlockOptions help.
 	"submitblockoptions-workid": "This parameter is currently ignored",
@@ -1007,7 +1017,9 @@ var rpcResultTypes = map[types.Method][]interface{}{
 	"sendrawmixmessage":     nil,
 	"sendrawtransaction":    {(*string)(nil)},
 	"setgenerate":           nil,
+	"startprofiler":         {(*types.StartProfilerResult)(nil)},
 	"stop":                  {(*string)(nil)},
+	"stopprofiler":          {(*string)(nil)},
 	"submitblock":           {nil, (*string)(nil)},
 	"ticketfeeinfo":         {(*types.TicketFeeInfoResult)(nil)},
 	"ticketsforaddress":     {(*types.TicketsForAddressResult)(nil)},

--- a/log.go
+++ b/log.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2017 The btcsuite developers
-// Copyright (c) 2015-2022 The Decred developers
+// Copyright (c) 2015-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -187,16 +187,6 @@ func pickNoun(n uint64, singular, plural string) string {
 		return singular
 	}
 	return plural
-}
-
-// fatalf logs a string, then cleanly exits.
-func fatalf(str string) {
-	dcrdLog.Errorf("Unable to create profiler: %v", str)
-	os.Stdout.Sync()
-	if logRotator != nil {
-		logRotator.Close()
-	}
-	os.Exit(1)
 }
 
 // humanizeBytes returns the provided number of bytes in humanized form with IEC

--- a/profiler.go
+++ b/profiler.go
@@ -1,0 +1,197 @@
+// Copyright (c) 2024 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	_ "net/http/pprof" // nolint:gosec
+	"net/netip"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// portToLocalHostAddr prepends a default host of 127.0.0.1 when the provided
+// address is solely a port number.
+func portToLocalHostAddr(addr string) string {
+	if _, err := strconv.Atoi(addr); err == nil {
+		addr = net.JoinHostPort("127.0.0.1", addr)
+	}
+	return addr
+}
+
+// validateProfileAddr ensures the provided address is of the form "host:port"
+// and that the port is between 1024 and 65535.
+func validateProfileAddr(addr string) error {
+	// Ensure the address is valid host:port syntax.
+	_, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return err
+	}
+
+	// Ensure the port is in range.
+	if port, _ := strconv.Atoi(portStr); port < 1024 || port > 65535 {
+		str := "address %q: port must be between 1024 and 65535"
+		return fmt.Errorf(str, addr)
+	}
+
+	return nil
+}
+
+// profileServer provides facilities for dynamically starting and stopping an
+// HTTP server that serves the pprof profiling endpoints.
+type profileServer struct {
+	wg         sync.WaitGroup
+	mtx        sync.Mutex
+	registered bool
+	server     *http.Server
+	listeners  []string
+}
+
+// Start binds a listener to the provided address and launches an HTTP server
+// that handles profiling endpoints in the background using that listener.  An
+// error is returned when the listener fails to bind.
+//
+// When the flag to allow non loopback addresses is set, an error is returned
+// when the provided listen address does not normalize to an IPv4 or IPv6
+// loopback address.
+//
+// It has no effect when the server is already running, so it may be called
+// multiple times without error.
+//
+// Callers can make use of [Listeners] to determine if the server is already
+// running since there will only be active listeners when it is.
+//
+// It is the caller's responsibility to call the Stop method to shutdown the
+// server.
+func (s *profileServer) Start(listenAddr string, allowNonLoopback bool) error {
+	defer s.mtx.Unlock()
+	s.mtx.Lock()
+
+	// Nothing to do when the server is already running.
+	if s.server != nil {
+		return nil
+	}
+
+	// Potentially convert a raw port to an IPv4 localhost address (aka prepend
+	// 127.0.0.1).
+	listenAddr = portToLocalHostAddr(listenAddr)
+
+	// Ensure the provided address is a valid hostname and port with a port that
+	// is in range.
+	if err := validateProfileAddr(listenAddr); err != nil {
+		return err
+	}
+
+	// Resolve interface names to associated IP addresses and remove duplicates.
+	// No default port is specified since a port is guaranteed to be present per
+	// the previous validation.
+	listenAddrs := []string{listenAddr}
+	listenAddrs = normalizeAddresses(listenAddrs, "", normalizeInterfaceAddrs)
+
+	// Reject non loopback addresses when requested.
+	if !allowNonLoopback {
+		for _, addrStr := range listenAddrs {
+			addr, _ := netip.ParseAddrPort(addrStr)
+			if !addr.IsValid() || !addr.Addr().IsLoopback() {
+				return fmt.Errorf("not permitted to listen on non loopback "+
+					"address %q without setting the flag to allow it", addrStr)
+			}
+		}
+	}
+
+	// Expand the provided listen address into relevant IPv4 and IPv6 net.Addrs
+	// to listen on with TCP.  This includes properly detecting addresses which
+	// apply to "all interfaces" and adds the address as both IPv4 and IPv6.
+	netAddrs, err := parseListeners(listenAddrs)
+	if err != nil {
+		return err
+	}
+
+	listeners := make([]net.Listener, 0, len(netAddrs))
+	s.listeners = make([]string, 0, len(netAddrs))
+	for _, addr := range netAddrs {
+		listener, err := net.Listen(addr.Network(), addr.String())
+		if err != nil {
+			return fmt.Errorf("unable to listen on %s: %w", listenAddr, err)
+		}
+		listeners = append(listeners, listener)
+		s.listeners = append(s.listeners, listener.Addr().String())
+	}
+
+	// Register a redirect to the profiling endpoints registered by the pprof
+	// package when not already done.
+	if !s.registered {
+		redirect := http.RedirectHandler("/debug/pprof", http.StatusSeeOther)
+		http.Handle("/", redirect)
+		s.registered = true
+	}
+
+	// Create a new HTTP server and serve it in a separate goroutine for each
+	// listener.
+	s.server = &http.Server{
+		Addr:              listenAddr,
+		ReadHeaderTimeout: time.Second * 3,
+	}
+	for listenerIdx := range listeners {
+		listener := listeners[listenerIdx]
+		dcrdLog.Infof("Profiling server listening on %s", listener.Addr())
+		s.wg.Add(1)
+		go func(httpServer *http.Server) {
+			defer s.wg.Done()
+
+			err := httpServer.Serve(listener)
+			if !errors.Is(err, http.ErrServerClosed) {
+				dcrdLog.Errorf("Profiling server listening on %s exited with "+
+					"unexpected error: %v", listener.Addr(), err)
+			}
+		}(s.server)
+	}
+
+	return nil
+}
+
+// Stop immediately closes the active listener and any connections to the
+// profile server.
+//
+// It has no effect when the server is not running, so it may be called multiple
+// times without error.
+func (s *profileServer) Stop() error {
+	defer s.mtx.Unlock()
+	s.mtx.Lock()
+
+	// Nothing to do when the server is not running.
+	if s.server == nil {
+		return nil
+	}
+
+	// Shutdown the server and wait for the serving goroutines to finish.  Also,
+	// clear the server field and listeners since they are no longer valid.
+	err := s.server.Close()
+	s.server = nil
+	s.listeners = nil
+	s.wg.Wait()
+	if err != nil {
+		dcrdLog.Errorf("Profiling server stopped with unexpected error: %v",
+			err)
+		return err
+	}
+
+	dcrdLog.Info("Profiling server stopped")
+	return nil
+}
+
+// Listeners returns all listeners the profile server is currently listening on.
+// It may also be used as a means to tell if the server is currently running
+// since there will only be active listeners when it is.
+func (s *profileServer) Listeners() []string {
+	defer s.mtx.Unlock()
+	s.mtx.Lock()
+
+	return s.listeners
+}

--- a/rpc/jsonrpc/types/chainsvrcmds.go
+++ b/rpc/jsonrpc/types/chainsvrcmds.go
@@ -971,6 +971,21 @@ func NewSetGenerateCmd(generate bool, genProcLimit *int) *SetGenerateCmd {
 	}
 }
 
+// StartProfilerCmd defines the startprofiler JSON-RPC command.
+type StartProfilerCmd struct {
+	Addr             string
+	AllowNonLoopback *bool `jsonrpcdefault:"false"`
+}
+
+// NewStartProfilerCmd returns a new instance which can be used to issue a
+// startprofiler JSON-RPC command.
+func NewStartProfilerCmd(addr string, allowNonLookback *bool) *StartProfilerCmd {
+	return &StartProfilerCmd{
+		Addr:             addr,
+		AllowNonLoopback: allowNonLookback,
+	}
+}
+
 // StopCmd defines the stop JSON-RPC command.
 type StopCmd struct{}
 
@@ -978,6 +993,15 @@ type StopCmd struct{}
 // command.
 func NewStopCmd() *StopCmd {
 	return &StopCmd{}
+}
+
+// StopProfilerCmd defines the stopprofiler JSON-RPC command.
+type StopProfilerCmd struct{}
+
+// NewStopProfilerCmd returns a new instance which can be used to issue a
+// stopprofiler JSON-RPC command.
+func NewStopProfilerCmd() *StopProfilerCmd {
+	return &StopProfilerCmd{}
 }
 
 // SubmitBlockOptions represents the optional options struct provided with a
@@ -1187,7 +1211,9 @@ func init() {
 	dcrjson.MustRegister(Method("sendrawmixmessage"), (*SendRawMixMessageCmd)(nil), flags)
 	dcrjson.MustRegister(Method("sendrawtransaction"), (*SendRawTransactionCmd)(nil), flags)
 	dcrjson.MustRegister(Method("setgenerate"), (*SetGenerateCmd)(nil), flags)
+	dcrjson.MustRegister(Method("startprofiler"), (*StartProfilerCmd)(nil), flags)
 	dcrjson.MustRegister(Method("stop"), (*StopCmd)(nil), flags)
+	dcrjson.MustRegister(Method("stopprofiler"), (*StopProfilerCmd)(nil), flags)
 	dcrjson.MustRegister(Method("submitblock"), (*SubmitBlockCmd)(nil), flags)
 	dcrjson.MustRegister(Method("ticketfeeinfo"), (*TicketFeeInfoCmd)(nil), flags)
 	dcrjson.MustRegister(Method("ticketsforaddress"), (*TicketsForAddressCmd)(nil), flags)

--- a/rpc/jsonrpc/types/chainsvrcmds_test.go
+++ b/rpc/jsonrpc/types/chainsvrcmds_test.go
@@ -896,6 +896,34 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 		},
 		{
+			name: "startprofiler",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd(Method("startprofiler"), "127.0.0.1:6060")
+			},
+			staticCmd: func() interface{} {
+				return NewStartProfilerCmd("127.0.0.1:6060", nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"startprofiler","params":["127.0.0.1:6060"],"id":1}`,
+			unmarshalled: &StartProfilerCmd{
+				Addr:             "127.0.0.1:6060",
+				AllowNonLoopback: dcrjson.Bool(false),
+			},
+		},
+		{
+			name: "startprofiler allownonloopback",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd(Method("startprofiler"), "127.0.0.1:6060", true)
+			},
+			staticCmd: func() interface{} {
+				return NewStartProfilerCmd("127.0.0.1:6060", dcrjson.Bool(true))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"startprofiler","params":["127.0.0.1:6060",true],"id":1}`,
+			unmarshalled: &StartProfilerCmd{
+				Addr:             "127.0.0.1:6060",
+				AllowNonLoopback: dcrjson.Bool(true),
+			},
+		},
+		{
 			name: "stop",
 			newCmd: func() (interface{}, error) {
 				return dcrjson.NewCmd(Method("stop"))
@@ -905,6 +933,17 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 			marshalled:   `{"jsonrpc":"1.0","method":"stop","params":[],"id":1}`,
 			unmarshalled: &StopCmd{},
+		},
+		{
+			name: "stopprofiler",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd(Method("stopprofiler"))
+			},
+			staticCmd: func() interface{} {
+				return NewStopProfilerCmd()
+			},
+			marshalled:   `{"jsonrpc":"1.0","method":"stopprofiler","params":[],"id":1}`,
+			unmarshalled: &StopProfilerCmd{},
 		},
 		{
 			name: "submitblock",
@@ -1036,6 +1075,7 @@ func TestChainSvrCmds(t *testing.T) {
 		if err != nil {
 			t.Errorf("Test #%d (%s) unexpected dcrjson.NewCmd error: %v",
 				i, test.name, err)
+			continue
 		}
 
 		// Marshal the command as created by the generic new command

--- a/rpc/jsonrpc/types/chainsvrresults.go
+++ b/rpc/jsonrpc/types/chainsvrresults.go
@@ -485,6 +485,11 @@ type LiveTicketsResult struct {
 	Tickets []string `json:"tickets"`
 }
 
+// StartProfilerResult models the data returned from the startprofiler command.
+type StartProfilerResult struct {
+	Listeners []string `json:"listeners"`
+}
+
 // FeeInfoBlock is ticket fee information about a block.
 type FeeInfoBlock struct {
 	Height uint32  `json:"height"`

--- a/server.go
+++ b/server.go
@@ -3678,9 +3678,9 @@ func setupRPCListeners() ([]net.Listener, error) {
 // newServer returns a new dcrd server configured to listen on addr for the
 // decred network type specified by chainParams.  Use start to begin accepting
 // connections from peers.
-func newServer(ctx context.Context, listenAddrs []string, db database.DB,
-	utxoDb *leveldb.DB, chainParams *chaincfg.Params,
-	dataDir string) (*server, error) {
+func newServer(ctx context.Context, profiler *profileServer,
+	listenAddrs []string, db database.DB, utxoDb *leveldb.DB,
+	chainParams *chaincfg.Params, dataDir string) (*server, error) {
 
 	amgr := addrmgr.New(cfg.DataDir, dcrdLookup)
 	services := defaultServices
@@ -4110,6 +4110,7 @@ func newServer(ctx context.Context, listenAddrs []string, db database.DB,
 
 		rpcsConfig := rpcserver.Config{
 			Listeners:    rpcListeners,
+			ProfilerMgr:  profiler,
 			ConnMgr:      &rpcConnManager{&s},
 			SyncMgr:      &rpcSyncMgr{server: &s, syncMgr: s.syncManager},
 			FeeEstimator: s.feeEstimator,


### PR DESCRIPTION
This adds support for dynamically starting and stopping the profile server via the RPC server by introducing two new rpc commands named `startprofiler` and `stopprofiler` and updates the JSON-RPC API documentation accordingly.

It also updates the code that allows the profile to be started via the `--profile` command line / `profile=` config file option to use the new infrastructure such that it retains the existing behavior.

As a part of the changes, it expands the capabilities of the aforementioned `profile` options to allow specifying an interface name so it is more consistent with the other options that deal with listeners.

---

A high level overview of the changes are:

- Refactors profile listening port normalization and validation
  - Helps ensure consistent behavior regardless of how the profile server listen address is obtained
- Introduces a profile server type with methods to dynamically start, stop, and query the profile server
  - Includes a new flag to control whether or not non loopback addresses are allowed for future dynamic control
- Adds support for resolving interface names for the profile server listen address to make the behavior more consistent
- Adds `startprofiler` and `stopprofiler` JSON-RPC types
  - Adds serialization tests for the new types 
- Implements the `startprofiler` and `stopprofiler` RPC methods and adds required help strings
  - Adds tests for the new handlers to help ensure they behave as intended
- Updates the JSON-RPC API documentation to add the new `startprofiler` and `stopprofiler` RPC methods

---

This consists of a series of commits to help ease the review process. Each commit is intended to be a self-contained and logically easy to follow change such that the code continues to compile and the tests continue to pass at each step.

See the description of each commit for further details.

---

Example commands showing the changes in action:

```
$ dcrctl startprofiler 127.0.0.1:5959
{
  "listeners": [
    "127.0.0.1:5959"
  ]
}

# Unable to change port without stopping running profile server first.
$ dcrctl startprofiler 127.0.0.1:1234
-26: profile server is already running
```

```
$ go tool pprof http://127.0.0.1:5959
Fetching profile over HTTP from http://127.0.0.1:5959/debug/pprof/profile
...
(pprof) top
Showing nodes accounting for 90ms, 100% of 90ms total
Showing top 10 nodes out of 38
      flat  flat%   sum%        cum   cum%
      40ms 44.44% 44.44%       40ms 44.44%  runtime.stdcall1
      10ms 11.11% 55.56%       10ms 11.11%  github.com/syndtr/goleveldb/leveldb.(*DB).newSnapshot
...
```

```
$ dcrctl stopprofiler
profile server stopped

$ dcrctl stopprofiler
-26: profile server is not started
```

```
# Unable to listen on non loopback addresses without flag.
$ dcrctl startprofiler :5959
-8: unable to start profile server: not permitted to listen on non loopback address ":5959" without setting the flag to allow it

$ dcrctl startprofiler :5959 true
{
  "listeners": [
    "0.0.0.0:5959",
    "[::]:5959"
  ]
}

$ dcrctl stopprofiler
profile server stopped

# Using a raw port as the address prepends "127.0.0.1:".
$ dcrctl startprofiler 5959
{
  "listeners": [
    "127.0.0.1:5959"
  ]
}
```