### PR TITLE
netsync: Handle notfound mix messages

### DIFF
--- a/internal/netsync/manager.go
+++ b/internal/netsync/manager.go
@@ -1396,6 +1396,11 @@ func (m *SyncManager) handleNotFoundMsg(nfmsg *notFoundMsg) {
 				delete(peer.requestedTxns, inv.Hash)
 				delete(m.requestedTxns, inv.Hash)
 			}
+		case wire.InvTypeMix:
+			if _, exists := peer.requestedMixMsgs[inv.Hash]; exists {
+				delete(peer.requestedMixMsgs, inv.Hash)
+				delete(m.requestedMixMsgs, inv.Hash)
+			}
 		}
 	}
 }


### PR DESCRIPTION
When a peer responds to an unknown mix message and this does not result in a ban, the requested message must be removed from the sync manager's current state for in-flight requested messages.