### PR TITLE
mixpool: Debug log all removed messages

### DIFF
--- a/mixing/mixpool/mixpool.go
+++ b/mixing/mixpool/mixpool.go
@@ -511,9 +511,14 @@ func (p *Pool) removeSession(sid [32]byte, txHash *chainhash.Hash, success bool)
 	}
 
 	delete(p.sessions, sid)
-	for _, r := range ses.runs {
+	for i, r := range ses.runs {
 		for hash := range r.hashes {
-			delete(p.pool, hash)
+			e, ok := p.pool[hash]
+			if ok {
+				log.Debugf("Removing session %x run %d %T %v by %x",
+					sid[:], i, e.msg, hash, e.msg.Pub())
+				delete(p.pool, hash)
+			}
 		}
 	}
 


### PR DESCRIPTION
Previously, only removed PRs were logged, but none of the other messages by the same identity or messages from the internal session tracking, which is less than optimal for debugging.