### PR TITLE
peer,server: Hash mix messages ASAP

### DIFF
--- a/peer/go.mod
+++ b/peer/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.4
+	github.com/decred/dcrd/crypto/blake256 v1.0.1
 	github.com/decred/dcrd/lru v1.1.2
 	github.com/decred/dcrd/txscript/v4 v4.1.1
 	github.com/decred/dcrd/wire v1.7.0
@@ -15,7 +16,6 @@ require (
 require (
 	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 // indirect
 	github.com/dchest/siphash v1.2.3 // indirect
-	github.com/decred/dcrd/crypto/blake256 v1.0.1 // indirect
 	github.com/decred/dcrd/crypto/ripemd160 v1.0.2 // indirect
 	github.com/decred/dcrd/dcrec v1.0.1 // indirect
 	github.com/decred/dcrd/dcrec/edwards/v2 v2.0.3 // indirect


### PR DESCRIPTION
When a mixing message (implementing the WriteHash(hash.Hash) method) is read from another peer, it is improper to use its Hash() method before calculating and storing the hash using WriteHash.  Do this as early as possible in readMessage in the peer package.  This avoids the need for callers to remember to do this step manually in the OnMix* callbacks.