### PR TITLE
mixclient: Avoid overwriting prev PRs slice

### DIFF
--- a/mixing/mixclient/client.go
+++ b/mixing/mixclient/client.go
@@ -917,7 +917,7 @@ func (c *Client) pairSession(ctx context.Context, ps *pairedSessions, prs []*wir
 			}
 		}
 		if blamed != nil || errors.As(err, &blamed) {
-			sesLog.logf("Identified %d blamed peers", len(blamed))
+			sesLog.logf("Identified %d blamed peers %x", len(blamed), []identity(blamed))
 
 			// Blamed peers were identified, either during the run
 			// in a way that all participants could have observed,

--- a/mixing/mixclient/client.go
+++ b/mixing/mixclient/client.go
@@ -1897,7 +1897,7 @@ func excludeBlamed(prevRun *sessionRun, blamed blamedIdentities, revealedSecrets
 		blamedMap[id] = struct{}{}
 	}
 
-	prs := prevRun.prs[:0]
+	prs := make([]*wire.MsgMixPairReq, 0, len(prevRun.prs)-1)
 	for _, p := range prevRun.peers {
 		if _, ok := blamedMap[*p.id]; ok {
 			// Should never happen except during tests.


### PR DESCRIPTION
In the case that blame assignment occurs, create a frech allocation for a new
slice of PRs instead of writing into the memory of the previous slice.