### PR TITLE
server: Remove dup min protocol version check.

### DIFF
--- a/server.go
+++ b/server.go
@@ -1001,15 +1001,6 @@ func (sp *serverPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) {
 		}
 	}
 
-	// Enforce the minimum protocol limit on outbound connections.
-	if !isInbound && msg.ProtocolVersion < int32(wire.RemoveRejectVersion) {
-		srvrLog.Debugf("Rejecting outbound peer %s with protocol version %d prior to "+
-			"the required version %d", sp, msg.ProtocolVersion,
-			wire.RemoveRejectVersion)
-		sp.Disconnect()
-		return
-	}
-
 	// Reject peers that have a protocol version that is too old.
 	const reqProtocolVersion = int32(wire.RemoveRejectVersion)
 	if msg.ProtocolVersion < reqProtocolVersion {


### PR DESCRIPTION
Previously, outbound peers were required to have a newer minimum protocol version than inbound peers, so two different checks were needed to differentiate.

However, now that both inbound and outbound peers are required to have the same minimum version, there is no longer any need to have both checks for the same thing.

Thus, this removes the additional check that is no longer needed.