### PR TITLE
mixpool: Remove unused exported methods

### DIFF
--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -659,18 +659,11 @@ type TxMempooler interface {
 // The interface contract requires that all of these methods are safe for
 // concurrent access.
 type MixPooler interface {
-	// MixPRs returns all MixPR messages with hashes matching the query.
-	// Unknown messages are ignored.
-	//
-	// If query is nil, all PRs are returned.
-	MixPRs(query []chainhash.Hash) []*wire.MsgMixPairReq
+	// MixPRs returns all MixPR messages.
+	MixPRs() []*wire.MsgMixPairReq
 
 	// Message searches the mixing pool for a message by its hash.
 	Message(query *chainhash.Hash) (mixing.Message, error)
-
-	// RemoveConfirmedRuns removes all messages including pair requests
-	// from runs which ended in each peer sending a confirm mix message.
-	RemoveConfirmedRuns()
 }
 
 // TxIndexer provides an interface for retrieving details for a given

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -2608,8 +2608,7 @@ func handleGetMixMessage(_ context.Context, s *Server, cmd interface{}) (interfa
 func handleGetMixPairRequests(_ context.Context, s *Server, _ interface{}) (interface{}, error) {
 	mp := s.cfg.MixPooler
 
-	mp.RemoveConfirmedRuns() // XXX: a bit hacky to do this here
-	prs := mp.MixPRs(nil)
+	prs := mp.MixPRs()
 
 	buf := new(strings.Builder)
 	res := make([]string, 0, len(prs))

--- a/mixing/mixclient/client.go
+++ b/mixing/mixclient/client.go
@@ -538,7 +538,7 @@ func (c *Client) removeUnresponsiveDuringEpoch(prs []*wire.MsgMixPairReq, prevEp
 }
 
 func (c *Client) epochTicker(ctx context.Context) error {
-	prevPRs := c.mixpool.MixPRs(nil)
+	prevPRs := c.mixpool.MixPRs()
 
 	// Wait for the next epoch + the KE timeout + extra duration for local
 	// clock differences, then remove any previous pair requests that are


### PR DESCRIPTION
The MixPRs method has been modified to remove the query parameter, as it was
only ever called with nil.

The RPC server no longer needs access to directly call RemoveConfirmedMixes.
This same operation is already (and incorrectly) done by MixPRs, and it will
need the eventual fix.

One exception: we are keeping RemoveConfirmedMixes which is still not used
anywhere.  This method behaves similarly to RemoveSpentPRs but removes mixes
that completed with a confirmed coinjoin transaction matching any of the
provided hashes.  This may be used later by wallet to remove mixes that
include transaction hashes in the merkle tree, while dcrd can just provide the
mined transactions themselves and remove anything that double spends a PR
UTXO.