### PR TITLE
mixpool: Only ban full nodes for bad UTXO sigs

### DIFF
--- a/server.go
+++ b/server.go
@@ -1734,7 +1734,7 @@ func (sp *serverPeer) onMixMessage(msg mixing.Message) {
 			nil, nil, nil, mixHashes)
 		return
 	}
-	if mixpool.IsBannable(err) {
+	if mixpool.IsBannable(err, sp.Services()) {
 		reason := fmt.Sprintf("sent malformed mix message: %s", err)
 		sp.server.BanPeer(sp, reason)
 	}


### PR DESCRIPTION
If an invalid UTXO signature in a pair request message is received from any
node besides a full node, reject the message but do not ban for the error.
However, full nodes are required to check this before relaying.  Ban any
self-reporting full node that still sends these invalid messages.

Because the banning logic is currently isolated to the mixpool package and
mixpool is unaware of the capabilities of the peer that provided the message,
give IsBannable an additional service flags argument.  This changes the
semantics of the bannable errors to only be bannable when all of the required
service flags are described.