### PR TITLE
[release-v2.0] main: Use backported peer updates.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/decred/dcrd/lru v1.1.2
 	github.com/decred/dcrd/math/uint256 v1.0.2
 	github.com/decred/dcrd/mixing v0.2.0
-	github.com/decred/dcrd/peer/v3 v3.1.0
+	github.com/decred/dcrd/peer/v3 v3.1.1
 	github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.3.0
 	github.com/decred/dcrd/rpcclient/v8 v8.0.1
 	github.com/decred/dcrd/txscript/v4 v4.1.1

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/decred/dcrd/math/uint256 v1.0.2 h1:o8peafL5QmuXGTergI3YDpDU0eq5Z0pQi8
 github.com/decred/dcrd/math/uint256 v1.0.2/go.mod h1:7M/y9wJJvlyNG/f/X6mxxhxo9dgloZHFiOfbiscl75A=
 github.com/decred/dcrd/mixing v0.2.0 h1:6aQiJuyu3D4OduSRPLta6GX6FZEi4XCxuQVNt26H0rY=
 github.com/decred/dcrd/mixing v0.2.0/go.mod h1:W3K7yJKmoI03G2U5Yw+HSRNe6lLBegi63ZR6fFLnM9c=
-github.com/decred/dcrd/peer/v3 v3.1.0 h1:20bdEHVJjcOrhVNNdVuQEhWffU0k9SCtlwzBz7XhCxk=
-github.com/decred/dcrd/peer/v3 v3.1.0/go.mod h1:6htwUvneZt44SMIQjHClliBmlDgMIH4rHxYSmkUo+FU=
+github.com/decred/dcrd/peer/v3 v3.1.1 h1:yBUnhcJQGPXWp4izdpV0bDz+N1eEoz+75V51TxcDqkQ=
+github.com/decred/dcrd/peer/v3 v3.1.1/go.mod h1:viGm1O62juvbV6uXQpKKKiEkwR5C7GRSAdb7HijnICY=
 github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.3.0 h1:l0DnCcILTNrpy8APF3FLN312ChpkQaAuW30aC/RgBaw=
 github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.3.0/go.mod h1:j+kkRPXPJB5S9VFOsx8SQLcU7PTFkPKRc1aCHN4ENzA=
 github.com/decred/dcrd/rpcclient/v8 v8.0.1 h1:hd81e4w1KSqvPcozJlnz6XJfWKDNuahgooH/N5E8vOU=

--- a/peer/go.mod
+++ b/peer/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.4
+	github.com/decred/dcrd/crypto/blake256 v1.0.1
 	github.com/decred/dcrd/lru v1.1.2
 	github.com/decred/dcrd/txscript/v4 v4.1.1
 	github.com/decred/dcrd/wire v1.7.0
@@ -15,7 +16,6 @@ require (
 require (
 	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 // indirect
 	github.com/dchest/siphash v1.2.3 // indirect
-	github.com/decred/dcrd/crypto/blake256 v1.0.1 // indirect
 	github.com/decred/dcrd/crypto/ripemd160 v1.0.2 // indirect
 	github.com/decred/dcrd/dcrec v1.0.1 // indirect
 	github.com/decred/dcrd/dcrec/edwards/v2 v2.0.3 // indirect


### PR DESCRIPTION
This updates the 2.0 release branch to use the latest version of the `peer` module which includes updates to immediately hash mix messages when they are read from the wire and to include mix message summaries in the debug logging output.

In particular, the following updated module version is used:

- github.com/decred/dcrd/peer/v3@v3.1.1

Note that it also cherry picks all of the commits included in updates to the `peer/v3` module to ensure they are also included in the release branch even though it is not strictly necessary since `go.mod` has been updated to require the new `peer/v3.1.1` release and thus will pull in the new code.  However, from past experience, not having code backported to modules available in the release branch too leads to headaches for devs building from source in their local workspace with overrides such as those in `go.work`.