### PR TITLE
[release-v2.0] main: Use backported mixing updates.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/decred/dcrd/gcs/v4 v4.1.0
 	github.com/decred/dcrd/lru v1.1.2
 	github.com/decred/dcrd/math/uint256 v1.0.2
-	github.com/decred/dcrd/mixing v0.2.0
+	github.com/decred/dcrd/mixing v0.3.0
 	github.com/decred/dcrd/peer/v3 v3.1.1
 	github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.3.0
 	github.com/decred/dcrd/rpcclient/v8 v8.0.1

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/decred/dcrd/lru v1.1.2 h1:KdCzlkxppuoIDGEvCGah1fZRicrDH36IipvlB1ROkFY
 github.com/decred/dcrd/lru v1.1.2/go.mod h1:gEdCVgXs1/YoBvFWt7Scgknbhwik3FgVSzlnCcXL2N8=
 github.com/decred/dcrd/math/uint256 v1.0.2 h1:o8peafL5QmuXGTergI3YDpDU0eq5Z0pQi88B8ym4PRA=
 github.com/decred/dcrd/math/uint256 v1.0.2/go.mod h1:7M/y9wJJvlyNG/f/X6mxxhxo9dgloZHFiOfbiscl75A=
-github.com/decred/dcrd/mixing v0.2.0 h1:6aQiJuyu3D4OduSRPLta6GX6FZEi4XCxuQVNt26H0rY=
-github.com/decred/dcrd/mixing v0.2.0/go.mod h1:W3K7yJKmoI03G2U5Yw+HSRNe6lLBegi63ZR6fFLnM9c=
+github.com/decred/dcrd/mixing v0.3.0 h1:eUHpTdwTqXUllnn1ZYLfxucW/2UOkMmx4CyztipTJ9g=
+github.com/decred/dcrd/mixing v0.3.0/go.mod h1:W3K7yJKmoI03G2U5Yw+HSRNe6lLBegi63ZR6fFLnM9c=
 github.com/decred/dcrd/peer/v3 v3.1.1 h1:yBUnhcJQGPXWp4izdpV0bDz+N1eEoz+75V51TxcDqkQ=
 github.com/decred/dcrd/peer/v3 v3.1.1/go.mod h1:viGm1O62juvbV6uXQpKKKiEkwR5C7GRSAdb7HijnICY=
 github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.3.0 h1:l0DnCcILTNrpy8APF3FLN312ChpkQaAuW30aC/RgBaw=

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -627,18 +627,11 @@ type TxMempooler interface {
 // The interface contract requires that all of these methods are safe for
 // concurrent access.
 type MixPooler interface {
-	// MixPRs returns all MixPR messages with hashes matching the query.
-	// Unknown messages are ignored.
-	//
-	// If query is nil, all PRs are returned.
-	MixPRs(query []chainhash.Hash) []*wire.MsgMixPairReq
+	// MixPRs returns all MixPR messages.
+	MixPRs() []*wire.MsgMixPairReq
 
 	// Message searches the mixing pool for a message by its hash.
 	Message(query *chainhash.Hash) (mixing.Message, error)
-
-	// RemoveConfirmedRuns removes all messages including pair requests
-	// from runs which ended in each peer sending a confirm mix message.
-	RemoveConfirmedRuns()
 }
 
 // TxIndexer provides an interface for retrieving details for a given

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -2608,8 +2608,7 @@ func handleGetMixMessage(_ context.Context, s *Server, cmd interface{}) (interfa
 func handleGetMixPairRequests(_ context.Context, s *Server, _ interface{}) (interface{}, error) {
 	mp := s.cfg.MixPooler
 
-	mp.RemoveConfirmedRuns() // XXX: a bit hacky to do this here
-	prs := mp.MixPRs(nil)
+	prs := mp.MixPRs()
 
 	buf := new(strings.Builder)
 	res := make([]string, 0, len(prs))

--- a/mixing/mixclient/blame.go
+++ b/mixing/mixclient/blame.go
@@ -48,7 +48,7 @@ func (e blamedIdentities) String() string {
 }
 
 func (c *Client) blame(ctx context.Context, sesRun *sessionRun) (err error) {
-	c.logf("Blaming for sid=%x run=%d", sesRun.sid[:], sesRun.run)
+	c.logf("Blaming for sid=%x", sesRun.sid[:])
 
 	mp := c.mixpool
 	prs := sesRun.prs
@@ -79,7 +79,6 @@ func (c *Client) blame(ctx context.Context, sesRun *sessionRun) (err error) {
 
 	// Receive currently-revealed secrets
 	rcv := new(mixpool.Received)
-	rcv.Run = sesRun.run
 	rcv.Sid = sesRun.sid
 	rcv.RSs = make([]*wire.MsgMixSecrets, 0, len(sesRun.prs))
 	_ = mp.Receive(ctx, 0, rcv)
@@ -193,7 +192,7 @@ KELoop:
 
 		// Recover or initialize PRNG from seed and the last run that
 		// caused secrets to be generated.
-		p.prng = chacha20prng.New(p.rs.Seed[:], sesRun.prngRun)
+		p.prng = chacha20prng.New(p.rs.Seed[:], 0)
 
 		// Recover derived key exchange from PRNG.
 		p.kx, err = mixing.NewKX(p.prng)
@@ -320,7 +319,7 @@ SRLoop:
 			revealed.Ciphertexts = append(revealed.Ciphertexts, ct[p.myVk])
 		}
 		sharedSecrets, err := p.kx.SharedSecrets(revealed,
-			sesRun.sid[:], sesRun.run, sesRun.mcounts)
+			sesRun.sid[:], 0, sesRun.mcounts)
 		var decapErr *mixing.DecapsulateError
 		if errors.As(err, &decapErr) {
 			submittingID := p.id

--- a/mixing/mixclient/client.go
+++ b/mixing/mixclient/client.go
@@ -917,7 +917,7 @@ func (c *Client) pairSession(ctx context.Context, ps *pairedSessions, prs []*wir
 			}
 		}
 		if blamed != nil || errors.As(err, &blamed) {
-			sesLog.logf("Identified %d blamed peers", len(blamed))
+			sesLog.logf("Identified %d blamed peers %x", len(blamed), []identity(blamed))
 
 			// Blamed peers were identified, either during the run
 			// in a way that all participants could have observed,

--- a/mixing/mixclient/client.go
+++ b/mixing/mixclient/client.go
@@ -886,10 +886,8 @@ func (c *Client) pairSession(ctx context.Context, ps *pairedSessions, prs []*wir
 
 			rerun = &sessionRun{
 				sid:       sizeLimitedErr.sid,
-				run:       0,
 				prs:       sizeLimitedErr.prs,
 				freshGen:  false,
-				prngRun:   0,
 				deadlines: d,
 			}
 			continue
@@ -1140,14 +1138,14 @@ func (c *Client) run(ctx context.Context, ps *pairedSessions, madePairing *bool)
 		}
 	}
 
-	// Before confirming the pairing in run-0, check all of the
-	// agreed-upon PRs that they will not result in a coinjoin transaction
-	// that exceeds the standard size limits.
+	// Before confirming the pairing, check all of the agreed-upon PRs
+	// that they will not result in a coinjoin transaction that exceeds
+	// the standard size limits.
 	//
 	// PRs are randomly ordered in each epoch based on the session ID, so
 	// they can be iterated in order to discover any PR that would
 	// increase the final coinjoin size above the limits.
-	if run == 0 {
+	if !*madePairing {
 		var sizeExcluded []*wire.MsgMixPairReq
 		var cjSize coinjoinSize
 		for _, pr := range sesRun.prs {

--- a/mixing/mixclient/client.go
+++ b/mixing/mixclient/client.go
@@ -538,7 +538,7 @@ func (c *Client) removeUnresponsiveDuringEpoch(prs []*wire.MsgMixPairReq, prevEp
 }
 
 func (c *Client) epochTicker(ctx context.Context) error {
-	prevPRs := c.mixpool.MixPRs(nil)
+	prevPRs := c.mixpool.MixPRs()
 
 	// Wait for the next epoch + the KE timeout + extra duration for local
 	// clock differences, then remove any previous pair requests that are

--- a/mixing/mixclient/client.go
+++ b/mixing/mixclient/client.go
@@ -237,14 +237,10 @@ type pairedSessions struct {
 
 type sessionRun struct {
 	sid  [32]byte
-	run  uint32
 	mtot uint32
 
 	// Whether this run must generate fresh KX keys, SR/DC messages.
-	// prngRun records the run (used as PRNG nonce) for the last run where
-	// a new PRNG and keys were generated.
 	freshGen bool
-	prngRun  uint32
 
 	deadlines
 
@@ -578,7 +574,7 @@ func (c *Client) epochTicker(ctx context.Context) error {
 		// results in "expired PR" errors.
 		// Ideally, we would behave like dcrd and only remove sessions that have
 		// mined mix transactions or are otherwise double spent in a block.
-		c.mixpool.RemoveConfirmedRuns()
+		c.mixpool.RemoveConfirmedSessions()
 		c.expireMessages()
 
 		for _, p := range c.pairings {
@@ -768,7 +764,7 @@ func (c *Client) pairSession(ctx context.Context, ps *pairedSessions, prs []*wir
 				time.Sleep(10 * time.Second)
 				c.logf("sid=%x removing mixed session completed with transaction %v",
 					mixedSession.sid[:], mixedSession.cj.txHash)
-				c.mixpool.RemoveSession(mixedSession.sid, true)
+				c.mixpool.RemoveSession(mixedSession.sid)
 			}()
 		}
 		if len(unmixedPeers) == 0 {
@@ -822,10 +818,8 @@ func (c *Client) pairSession(ctx context.Context, ps *pairedSessions, prs []*wir
 
 			sesRun := sessionRun{
 				sid:       sid,
-				run:       0,
 				prs:       prs,
 				freshGen:  true,
-				prngRun:   0,
 				deadlines: d,
 				mcounts:   make([]uint32, 0, len(prs)),
 			}
@@ -865,12 +859,8 @@ func (c *Client) pairSession(ctx context.Context, ps *pairedSessions, prs []*wir
 		}
 		currentRun.mtot = m
 
-		action := "created"
-		if currentRun.run != 0 {
-			action = "rerunning"
-		}
-		sesLog.logf("%s session for pairid=%x from %d total %d local PRs %s",
-			action, ps.pairing, len(prHashes), localPeerCount, prHashes)
+		sesLog.logf("created session for pairid=%x from %d total %d local PRs %s",
+			ps.pairing, len(prHashes), localPeerCount, prHashes)
 
 		if localPeerCount == 0 {
 			sesLog.logf("no more local peers")
@@ -926,10 +916,8 @@ func (c *Client) pairSession(ctx context.Context, ps *pairedSessions, prs []*wir
 
 			rerun = &sessionRun{
 				sid:       altses.sid,
-				run:       0,
 				prs:       altses.prs,
 				freshGen:  false,
-				prngRun:   0,
 				deadlines: d,
 			}
 			continue
@@ -979,7 +967,6 @@ func (c *Client) run(ctx context.Context, ps *pairedSessions, madePairing *bool)
 
 	mp := c.wallet.Mixpool()
 	sesRun := &ps.runs[len(ps.runs)-1]
-	run := sesRun.run
 	prs := sesRun.prs
 
 	d := &sesRun.deadlines
@@ -1007,7 +994,7 @@ func (c *Client) run(ctx context.Context, ps *pairedSessions, madePairing *bool)
 			if err != nil {
 				return err
 			}
-			p.prng = chacha20prng.New(p.prngSeed[:], sesRun.prngRun)
+			p.prng = chacha20prng.New(p.prngSeed[:], 0)
 
 			// Generate fresh keys from this run's PRNG
 			p.kx, err = mixing.NewKX(p.prng)
@@ -1049,14 +1036,14 @@ func (c *Client) run(ctx context.Context, ps *pairedSessions, madePairing *bool)
 		for i := range p.srMsg {
 			srMsgBytes[i] = p.srMsg[i].Bytes()
 		}
-		rs := wire.NewMsgMixSecrets(*p.id, sesRun.sid, run,
+		rs := wire.NewMsgMixSecrets(*p.id, sesRun.sid, 0,
 			*p.prngSeed, srMsgBytes, p.dcMsg)
 		c.blake256HasherMu.Lock()
 		commitment := rs.Commitment(c.blake256Hasher)
 		c.blake256HasherMu.Unlock()
 		ecdhPub := *(*[33]byte)(p.kx.ECDHPublicKey.SerializeCompressed())
 		pqPub := *p.kx.PQPublicKey
-		ke := wire.NewMsgMixKeyExchange(*p.id, sesRun.sid, unixEpoch, run,
+		ke := wire.NewMsgMixKeyExchange(*p.id, sesRun.sid, unixEpoch, 0,
 			uint32(identityIndices[*p.id]), ecdhPub, pqPub, commitment,
 			seenPRs)
 
@@ -1104,21 +1091,20 @@ func (c *Client) run(ctx context.Context, ps *pairedSessions, madePairing *bool)
 	var kes []*wire.MsgMixKeyExchange
 	recvKEs := func(sesRun *sessionRun) (kes []*wire.MsgMixKeyExchange, err error) {
 		rcv := new(mixpool.Received)
-		rcv.Run = sesRun.run
 		rcv.Sid = sesRun.sid
 		rcv.KEs = make([]*wire.MsgMixKeyExchange, 0, len(sesRun.prs))
 		ctx, cancel := context.WithDeadline(ctx, d.recvKE)
 		defer cancel()
 		err = mp.Receive(ctx, len(sesRun.prs), rcv)
 		if ctx.Err() != nil {
-			err = fmt.Errorf("session %x run-%d KE receive context cancelled: %w",
-				sesRun.sid[:], sesRun.run, ctx.Err())
+			err = fmt.Errorf("session %x KE receive context cancelled: %w",
+				sesRun.sid[:], ctx.Err())
 		}
 		return rcv.KEs, err
 	}
 
 	switch {
-	case run == 0:
+	case !*madePairing:
 		// Receive KEs for the last attempted session.  Local
 		// peers may have been modified (new keys generated, and myVk
 		// indexes changed) if this is a recreated session, and we
@@ -1148,7 +1134,6 @@ func (c *Client) run(ctx context.Context, ps *pairedSessions, madePairing *bool)
 		return c.alternateSession(ps.pairing, sesRun.prs, d)
 
 	default:
-		// Receive KEs only for the agreed-upon session.
 		kes, err = recvKEs(sesRun)
 		if err != nil {
 			return err
@@ -1206,7 +1191,7 @@ func (c *Client) run(ctx context.Context, ps *pairedSessions, madePairing *bool)
 	}
 
 	// Remove paired local peers from waiting pairing.
-	if run == 0 {
+	if !*madePairing {
 		c.mu.Lock()
 		if waiting := c.pairings[string(ps.pairing)]; waiting != nil {
 			for id := range ps.localPeers {
@@ -1218,10 +1203,8 @@ func (c *Client) run(ctx context.Context, ps *pairedSessions, madePairing *bool)
 		}
 		c.mu.Unlock()
 
-		if !*madePairing {
-			c.pairingWG.Done()
-			*madePairing = true
-		}
+		*madePairing = true
+		c.pairingWG.Done()
 	}
 
 	sort.Slice(kes, func(i, j int) bool {
@@ -1271,7 +1254,7 @@ func (c *Client) run(ctx context.Context, ps *pairedSessions, madePairing *bool)
 		}
 
 		// Send ciphertext messages
-		ct := wire.NewMsgMixCiphertexts(*p.id, sesRun.sid, run, pqct, seenKEs)
+		ct := wire.NewMsgMixCiphertexts(*p.id, sesRun.sid, 0, pqct, seenKEs)
 		p.ct = ct
 		c.testHook(hookBeforePeerCTPublish, sesRun, p)
 		return p.signAndSubmit(ct)
@@ -1280,7 +1263,6 @@ func (c *Client) run(ctx context.Context, ps *pairedSessions, madePairing *bool)
 	// Receive all ciphertext messages
 	rcv := new(mixpool.Received)
 	rcv.Sid = sesRun.sid
-	rcv.Run = run
 	rcv.KEs = nil
 	rcv.CTs = make([]*wire.MsgMixCiphertexts, 0, len(prs))
 	rcvCtx, rcvCtxCancel := context.WithDeadline(ctx, d.recvCT)
@@ -1332,7 +1314,7 @@ func (c *Client) run(ctx context.Context, ps *pairedSessions, madePairing *bool)
 		}
 
 		// Derive shared secret keys
-		shared, err := p.kx.SharedSecrets(revealed, sesRun.sid[:], run, sesRun.mcounts)
+		shared, err := p.kx.SharedSecrets(revealed, sesRun.sid[:], 0, sesRun.mcounts)
 		if err != nil {
 			p.triggeredBlame = true
 			return errTriggeredBlame
@@ -1350,7 +1332,7 @@ func (c *Client) run(ctx context.Context, ps *pairedSessions, madePairing *bool)
 
 		// Broadcast message commitment and exponential DC-mix vectors for slot
 		// reservations.
-		sr := wire.NewMsgMixSlotReserve(*p.id, sesRun.sid, run, srMixBytes, seenCTs)
+		sr := wire.NewMsgMixSlotReserve(*p.id, sesRun.sid, 0, srMixBytes, seenCTs)
 		p.sr = sr
 		c.testHook(hookBeforePeerSRPublish, sesRun, p)
 		return p.signAndSubmit(sr)
@@ -1432,7 +1414,7 @@ func (c *Client) run(ctx context.Context, ps *pairedSessions, madePairing *bool)
 		}
 
 		// Broadcast XOR DC-net vectors.
-		dc := wire.NewMsgMixDCNet(*p.id, sesRun.sid, run, p.dcNet, seenSRs)
+		dc := wire.NewMsgMixDCNet(*p.id, sesRun.sid, 0, p.dcNet, seenSRs)
 		p.dc = dc
 		c.testHook(hookBeforePeerDCPublish, sesRun, p)
 		return p.signAndSubmit(dc)
@@ -1512,7 +1494,7 @@ func (c *Client) run(ctx context.Context, ps *pairedSessions, madePairing *bool)
 		}
 
 		// Broadcast partially signed mix tx
-		cm := wire.NewMsgMixConfirm(*p.id, sesRun.sid, run,
+		cm := wire.NewMsgMixConfirm(*p.id, sesRun.sid, 0,
 			p.coinjoin.Tx().Copy(), seenDCs)
 		p.cm = cm
 		return p.signAndSubmit(cm)
@@ -1622,7 +1604,7 @@ func (c *Client) roots(ctx context.Context, seenSRs []chainhash.Hash,
 		}
 		err = c.forLocalPeers(ctx, sesRun, func(p *peer) error {
 			fp := wire.NewMsgMixFactoredPoly(*p.id, sesRun.sid,
-				sesRun.run, rootBytes, seenSRs)
+				0, rootBytes, seenSRs)
 			return p.signAndSubmit(fp)
 		})
 		return roots, err
@@ -1635,7 +1617,6 @@ func (c *Client) roots(ctx context.Context, seenSRs []chainhash.Hash,
 	expectedMessages := 1
 	rcv := &mixpool.Received{
 		Sid: sesRun.sid,
-		Run: sesRun.run,
 		FPs: make([]*wire.MsgMixFactoredPoly, 0, sesRun.mtot),
 	}
 	roots := make([]*big.Int, 0, len(a)-1)
@@ -2001,20 +1982,16 @@ func excludeBlamed(prevRun *sessionRun, blamed blamedIdentities, revealedSecrets
 	d := prevRun.deadlines
 	d.restart()
 
+	unixEpoch := prevRun.epoch.Unix()
+	sid := mixing.SortPRsForSession(prs, uint64(unixEpoch))
+
 	// mtot, peers, mcounts are all recalculated from the prs before
 	// calling run()
 	nextRun := &sessionRun{
-		sid:       prevRun.sid,
-		run:       prevRun.run + 1,
+		sid:       sid,
+		freshGen:  revealedSecrets,
 		prs:       prs,
 		deadlines: d,
-	}
-	if revealedSecrets {
-		nextRun.freshGen = true
-		nextRun.prngRun = nextRun.run
-	} else {
-		nextRun.freshGen = false
-		nextRun.prngRun = prevRun.prngRun
 	}
 	return nextRun
 }

--- a/mixing/mixclient/client.go
+++ b/mixing/mixclient/client.go
@@ -1897,7 +1897,7 @@ func excludeBlamed(prevRun *sessionRun, blamed blamedIdentities, revealedSecrets
 		blamedMap[id] = struct{}{}
 	}
 
-	prs := prevRun.prs[:0]
+	prs := make([]*wire.MsgMixPairReq, 0, len(prevRun.prs)-1)
 	for _, p := range prevRun.peers {
 		if _, ok := blamedMap[*p.id]; ok {
 			// Should never happen except during tests.

--- a/mixing/mixclient/client.go
+++ b/mixing/mixclient/client.go
@@ -39,9 +39,11 @@ const MinPeers = 4
 
 const pairingFlags byte = 0
 
-// ErrExpired indicates that a dicemix session failed to complete due to the
+// expiredPRErr indicates that a dicemix session failed to complete due to the
 // submitted pair request expiring.
-var ErrExpired = errors.New("mixing pair request expired")
+func expiredPRErr(pr *wire.MsgMixPairReq) error {
+	return fmt.Errorf("mixing pair request %v by %x expired", pr.Hash(), pr.Pub())
+}
 
 var (
 	errOnlyKEsBroadcasted = errors.New("session ended without mix occurring")
@@ -717,7 +719,7 @@ func (c *Client) expireMessages() {
 				// blocked, we have already served this peer
 				// or sent another error.
 				select {
-				case p.res <- ErrExpired:
+				case p.res <- expiredPRErr(p.pr):
 				default:
 				}
 

--- a/mixing/mixclient/client_test.go
+++ b/mixing/mixclient/client_test.go
@@ -238,7 +238,7 @@ func TestHonest(t *testing.T) {
 			select {
 			case <-ctx.Done():
 				return
-			case <-time.After(200 * time.Millisecond):
+			case <-time.After(500 * time.Millisecond):
 			}
 		}
 	}()
@@ -367,7 +367,7 @@ func testDisruption(t *testing.T, misbehavingID *identity, h hook, f hookFunc) {
 			select {
 			case <-ctx.Done():
 				return
-			case <-time.After(200 * time.Millisecond):
+			case <-time.After(1000 * time.Millisecond):
 			}
 		}
 	}()
@@ -395,7 +395,7 @@ func testDisruption(t *testing.T, misbehavingID *identity, h hook, f hookFunc) {
 func TestCTDisruption(t *testing.T) {
 	var misbehavingID identity
 	testDisruption(t, &misbehavingID, hookBeforePeerCTPublish, func(c *Client, s *sessionRun, p *peer) {
-		if s.run != 0 || p.myVk != 0 {
+		if p.myVk != 0 {
 			return
 		}
 		if misbehavingID != [33]byte{} {
@@ -410,7 +410,10 @@ func TestCTDisruption(t *testing.T) {
 func TestCTLength(t *testing.T) {
 	var misbehavingID identity
 	testDisruption(t, &misbehavingID, hookBeforePeerCTPublish, func(c *Client, s *sessionRun, p *peer) {
-		if s.run != 0 || p.myVk != 0 {
+		if p.myVk != 0 {
+			return
+		}
+		if misbehavingID != [33]byte{} {
 			return
 		}
 		t.Logf("malicious peer %x: sending too few ciphertexts", p.id[:])
@@ -418,8 +421,12 @@ func TestCTLength(t *testing.T) {
 		p.ct.Ciphertexts = p.ct.Ciphertexts[:len(p.ct.Ciphertexts)-1]
 	})
 
+	misbehavingID = identity{}
 	testDisruption(t, &misbehavingID, hookBeforePeerCTPublish, func(c *Client, s *sessionRun, p *peer) {
-		if s.run != 0 || p.myVk != 0 {
+		if p.myVk != 0 {
+			return
+		}
+		if misbehavingID != [33]byte{} {
 			return
 		}
 		t.Logf("malicious peer %x: sending too many ciphertexts", p.id[:])
@@ -431,7 +438,10 @@ func TestCTLength(t *testing.T) {
 func TestSRDisruption(t *testing.T) {
 	var misbehavingID identity
 	testDisruption(t, &misbehavingID, hookBeforePeerSRPublish, func(c *Client, s *sessionRun, p *peer) {
-		if s.run != 0 || p.myVk != 0 {
+		if p.myVk != 0 {
+			return
+		}
+		if misbehavingID != [33]byte{} {
 			return
 		}
 		t.Logf("malicious peer %x: flipping SR bit", p.id[:])
@@ -443,7 +453,10 @@ func TestSRDisruption(t *testing.T) {
 func TestDCDisruption(t *testing.T) {
 	var misbehavingID identity
 	testDisruption(t, &misbehavingID, hookBeforePeerDCPublish, func(c *Client, s *sessionRun, p *peer) {
-		if s.run != 0 || p.myVk != 0 {
+		if p.myVk != 0 {
+			return
+		}
+		if misbehavingID != [33]byte{} {
 			return
 		}
 		t.Logf("malicious peer %x: flipping DC bit", p.id[:])

--- a/mixing/mixpool/errors.go
+++ b/mixing/mixpool/errors.go
@@ -121,3 +121,7 @@ type MissingOwnPRError struct {
 func (e *MissingOwnPRError) Error() string {
 	return "KE identity's own PR is missing from mixpool"
 }
+
+var (
+	errMessageNotFound = errors.New("message not found")
+)

--- a/mixing/mixpool/mixpool.go
+++ b/mixing/mixpool/mixpool.go
@@ -75,7 +75,6 @@ type entry struct {
 	recvTime time.Time
 	msg      mixing.Message
 	msgtype  msgtype
-	run      uint32
 }
 
 type orphan struct {
@@ -1482,7 +1481,6 @@ func (p *Pool) acceptEntry(msg mixing.Message, msgtype msgtype, hash *chainhash.
 		recvTime: time.Now(),
 		msg:      msg,
 		msgtype:  msgtype,
-		run:      run,
 	}
 	p.pool[*hash] = e
 	p.messagesByIdentity[*id] = append(p.messagesByIdentity[*id], *hash)

--- a/mixing/mixpool/mixpool.go
+++ b/mixing/mixpool/mixpool.go
@@ -511,9 +511,14 @@ func (p *Pool) removeSession(sid [32]byte, txHash *chainhash.Hash, success bool)
 	}
 
 	delete(p.sessions, sid)
-	for _, r := range ses.runs {
+	for i, r := range ses.runs {
 		for hash := range r.hashes {
-			delete(p.pool, hash)
+			e, ok := p.pool[hash]
+			if ok {
+				log.Debugf("Removing session %x run %d %T %v by %x",
+					sid[:], i, e.msg, hash, e.msg.Pub())
+				delete(p.pool, hash)
+			}
 		}
 	}
 

--- a/mixing/mixpool/mixpool.go
+++ b/mixing/mixpool/mixpool.go
@@ -837,7 +837,6 @@ var zeroHash chainhash.Hash
 // All newly accepted messages, including any orphan key exchange messages
 // that were processed after processing missing pair requests, are returned.
 func (p *Pool) AcceptMessage(msg mixing.Message) (accepted []mixing.Message, err error) {
-	hash := msg.Hash()
 	defer func() {
 		if err == nil && len(accepted) == 0 {
 			// Duplicate message; don't log it again.
@@ -847,6 +846,7 @@ func (p *Pool) AcceptMessage(msg mixing.Message) (accepted []mixing.Message, err
 			return
 		}
 		if err != nil {
+			hash := msg.Hash()
 			switch msg.(type) {
 			case *wire.MsgMixPairReq:
 				log.Debugf("Rejected message %T %v by %x: %v",
@@ -858,6 +858,7 @@ func (p *Pool) AcceptMessage(msg mixing.Message) (accepted []mixing.Message, err
 			return
 		}
 		for _, msg := range accepted {
+			hash := msg.Hash()
 			switch msg.(type) {
 			case *wire.MsgMixPairReq:
 				log.Debugf("Accepted message %T %v by %x", msg, hash, msg.Pub())
@@ -868,6 +869,7 @@ func (p *Pool) AcceptMessage(msg mixing.Message) (accepted []mixing.Message, err
 		}
 	}()
 
+	hash := msg.Hash()
 	if hash == zeroHash {
 		return nil, fmt.Errorf("message of type %T has not been hashed", msg)
 	}

--- a/mixing/mixpool/mixpool.go
+++ b/mixing/mixpool/mixpool.go
@@ -220,7 +220,7 @@ func (p *Pool) Message(query *chainhash.Hash) (mixing.Message, error) {
 		return pr, nil
 	}
 	if !ok || e.msg == nil {
-		return nil, fmt.Errorf("message not found")
+		return nil, errMessageNotFound
 	}
 	return e.msg, nil
 }

--- a/server.go
+++ b/server.go
@@ -1713,7 +1713,7 @@ func (sp *serverPeer) onMixMessage(msg mixing.Message) {
 			nil, nil, nil, mixHashes)
 		return
 	}
-	if mixpool.IsBannable(err) {
+	if mixpool.IsBannable(err, sp.Services()) {
 		reason := fmt.Sprintf("sent malformed mix message: %s", err)
 		sp.server.BanPeer(sp, reason)
 	}


### PR DESCRIPTION
This updates the 2.0 release branch to use the latest version of the `mixing` module which includes updates to respect maximum standard transaction size limits and improvements to the blame assignment and resulting rerun process.

In particular, the following updated module version is used:

- github.com/decred/dcrd/mixing@v0.3.0

Note that it also cherry picks all of the commits included in updates to the `mixing` module to ensure they are also included in the release branch even though it is not strictly necessary since `go.mod` has been updated to require the new release and thus will pull in the new code. However, from past experience, not having code backported to modules available in the release branch too leads to headaches for devs building from source in their local workspace with overrides such as those in `go.work`.