### PR TITLE
Fix the system exited due to null data error

### DIFF
--- a/mixing/mixclient/client.go
+++ b/mixing/mixclient/client.go
@@ -848,6 +848,9 @@ func (c *Client) pairSession(ctx context.Context, ps *pairedSessions, prs []*wir
 				localPeerCount++
 			} else {
 				p = newRemotePeer(pr)
+				rs := wire.NewMsgMixSecrets(*p.id, currentRun.sid, currentRun.run,
+					[32]byte{}, [][]byte{}, nil)
+				p.rs = rs
 			}
 			p.myVk = uint32(i)
 			p.myStart = m


### PR DESCRIPTION
Issue: #3355 
My solution is simply to add a setting to avoid the value being null and exited when used later