### PR TITLE
main: Add .gitattributes.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+# Normalize line endings of text files to LF regardless of OS or git settings
+*.conf          text
+*.dockerignore  text
+.gitattributes  text
+.gitignore      text
+*.go            text
+*.gv            text
+*.json          text
+*.md            text
+*.mediawiki     text
+*.mod           text
+*.py            text
+*.service       text
+*.sh            text
+*.sum           text
+*.svg           text
+*.xml           text
+*.yml           text


### PR DESCRIPTION
This change ensures that devs using Windows:
1) Will avoid accidentally pushing modified files with CRLF line endings (i.e. this repo will maintain a consistent use of LF line endings)
2) Won't see files as modified in git due to line ending changes
3) Can still use CRLF in their working trees

By default, git doesn't perform any line ending normalization. Therefore, Windows devs will use CRLF line endings, and Unix/Mac devs will use LF. If a file is saved on Windows, line endings will be replaced with CRLF, even if nothing else changed in the file. This is difficult to detect, other than git showing that the file has been modified, and a warning:

> warning: in the working copy of '<file>', LF will be replaced by CRLF the next time Git touches it

It's possible for Windows developers to configure their local git to use CRLF in the working tree and only commit files with LF line endings, but this requires all Windows developers to modify their git config. With this new `.gitattributes` file and the line, no configuration is needed from developers.