### PR TITLE
build: Rework lint script to use go.mod files.

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -9,18 +9,15 @@ set -ex
 go version
 
 # loop all modules
-ROOTPKG=$(go list)
-ROOTPKGPATTERN=$(echo $ROOTPKG | sed 's,\\,\\\\,g' | sed 's,/,\\/,g')
-MODPATHS=$(go list -m all | grep "^$ROOTPKGPATTERN" | cut -d' ' -f1)
-for module in $MODPATHS; do
-  echo "==> lint ${module}"
-
-  # determine module directory
-  MODNAME=$(echo $module | sed -E -e "s/^$ROOTPKGPATTERN//" \
-    -e 's,^/,,' -e 's,/v[0-9]+$,,')
+MODULES=$(find . -name go.mod -not -path "./playground/*")
+for module in $MODULES; do
+  # determine module name/directory
+  MODNAME=$(echo $module | sed -E -e 's,/go\.mod$,,' -e 's,^./,,')
   if [ -z "$MODNAME" ]; then
     MODNAME=.
   fi
+
+  echo "==> lint ${MODNAME}"
 
   # run commands in the module directory as a subshell
   (


### PR DESCRIPTION
This reworks the logic in the lint script for determining which modules to lint to use the existence of a `go.mod` file instead of attempting to use the result of `go list`.

The existing logic is to pick the dependencies out of output of `go list` which have the main module as a prefix.  However, that is error prone because `go list` also reports indirect dependencies which may themselves depend on older versions of modules that are no longer in the repo, but naturally have the prefix that is being filtered.

Searching for the `go.mod` files in the repo is a simpler approach that isn't prone to the aforementioned issue while still dynamically finding all modules in the repo.