### PR TITLE
mixpool: Cache recently removed msgs.

### DIFF
--- a/mixing/go.mod
+++ b/mixing/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.4
 	github.com/decred/dcrd/chaincfg/v3 v3.2.1
+	github.com/decred/dcrd/container/lru v1.0.0
 	github.com/decred/dcrd/crypto/blake256 v1.0.1
 	github.com/decred/dcrd/crypto/rand v1.0.0
 	github.com/decred/dcrd/dcrec v1.0.1

--- a/mixing/go.sum
+++ b/mixing/go.sum
@@ -14,6 +14,8 @@ github.com/decred/dcrd/chaincfg/chainhash v1.0.4 h1:zRCv6tdncLfLTKYqu7hrXvs7hW+8
 github.com/decred/dcrd/chaincfg/chainhash v1.0.4/go.mod h1:hA86XxlBWwHivMvxzXTSD0ZCG/LoYsFdWnCekkTMCqY=
 github.com/decred/dcrd/chaincfg/v3 v3.2.1 h1:x9zKJaU24WAKbxAR1UyFKHlM3oJgP0H9LodokM4X5lM=
 github.com/decred/dcrd/chaincfg/v3 v3.2.1/go.mod h1:SDCWDtY7BLj0leXc9FuoA1YjSVKyCIBVAyxwZn6+sXc=
+github.com/decred/dcrd/container/lru v1.0.0 h1:7foQymtbu18aQWYiY9RnNIeE+kvpiN+fiBQ3+viyJjI=
+github.com/decred/dcrd/container/lru v1.0.0/go.mod h1:vlPwj0l+IzAHhQSsbgQnJgO5Cte78+yI065V+Mc5PRQ=
 github.com/decred/dcrd/crypto/blake256 v1.0.1 h1:7PltbUIQB7u/FfZ39+DGa/ShuMyJ5ilcvdfma9wOH6Y=
 github.com/decred/dcrd/crypto/blake256 v1.0.1/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
 github.com/decred/dcrd/crypto/rand v1.0.0 h1:Ah9Asl36OZt09sGSMbJZuL1HfwGdlC38q/ZUeLDVKRg=

--- a/mixing/mixpool/log.go
+++ b/mixing/mixpool/log.go
@@ -20,3 +20,12 @@ var log = slog.Disabled
 func UseLogger(logger slog.Logger) {
 	log = logger
 }
+
+// pickNoun returns the singular or plural form of a noun depending on the count
+// n.
+func pickNoun[T ~uint32 | ~uint64](n T, singular, plural string) string {
+	if n == 1 {
+		return singular
+	}
+	return plural
+}

--- a/server.go
+++ b/server.go
@@ -788,11 +788,10 @@ func (sp *serverPeer) handleServeGetData(invVects []*wire.InvVect,
 
 		case wire.InvTypeMix:
 			mixHash := &iv.Hash
-			msg, err := sp.server.mixMsgPool.Message(mixHash)
-			if err != nil {
-				peerLog.Debugf("Unable to fetch mix message %v ",
-					"from the mix pool for %v: %v", mixHash,
-					sp, err)
+			msg, ok := sp.server.mixMsgPool.RecentMessage(mixHash)
+			if !ok {
+				peerLog.Debugf("Unable to fetch mix message %v from the mix "+
+					"pool for peer %s", mixHash, sp)
 				break
 			}
 			dataMsg = msg


### PR DESCRIPTION
**This requires #3360 and is rebased on #3362**.

This adds a cache to house mix messages that have recently been removed from the mixpool.  It makes use of the new `container/lru` module to handle automatic expiration of entries and maximum entry limiting.

The rationale for this change is that it is considered misbehavior to advertise a mix message and then claim it is not found when the corresponding request arrives.  Maintaining a separate cache of mix messages recently removed from the mixpool for a short period of time significantly increases the probability they are available to serve when a request for the advertisement arrives independent of the current status of the mixpool.
