### PR TITLE
netsync: Remove spent PRs from tip block txns.

### DIFF
--- a/internal/netsync/manager.go
+++ b/internal/netsync/manager.go
@@ -1051,17 +1051,10 @@ func (m *SyncManager) handleBlockMsg(bmsg *blockMsg) {
 		m.rejectedTxns.Reset()
 
 		// Remove expired pair requests and completed mixes from
-		// mixpool.  The transactions from the previous block are used
-		// to remove spent PRs to avoid a logic race where a mined
-		// block immediately removes messages still propagating the
-		// network.
-		prevBlock, err := chain.BlockByHash(&header.PrevBlock)
-		if err == nil {
-			prev := prevBlock.MsgBlock()
-			m.cfg.MixPool.RemoveSpentPRs(prev.Transactions)
-			m.cfg.MixPool.RemoveSpentPRs(prev.STransactions)
-			m.cfg.MixPool.ExpireMessagesInBackground(prev.Header.Height)
-		}
+		// mixpool.
+		m.cfg.MixPool.RemoveSpentPRs(msgBlock.Transactions)
+		m.cfg.MixPool.RemoveSpentPRs(msgBlock.STransactions)
+		m.cfg.MixPool.ExpireMessagesInBackground(header.Height)
 	}
 
 	// Update the latest block height for the peer to avoid stale heights when


### PR DESCRIPTION
**This requires #3366**.

Now that recently removed mix messages are independently cached for a short period, this reverts the change that only removed spent pair requests from previous block transactions to make it track the current best tip again.

For reference, the change was originally made to avoid immediately removing mixpool messages that are still propagating the network when a block was quickly mined which includes transactions created from those very same mix messages.

However, as noted when the change was made, while it was a quick way to address the stated scenario, it doesn't deal with large reorgs nicely.

The new method is much more robust and works under all scenarios, so it is preferable for the mixpool to track the current tip.
