### PR TITLE
peer/uprng: Remove unneeded carry add.

### DIFF
--- a/peer/internal/uprng/uprng.go
+++ b/peer/internal/uprng/uprng.go
@@ -51,8 +51,7 @@ func (n *nonce) inc() {
 	var carry uint32
 	n0, carry = bits.Add32(n0, 1, carry)
 	n1, carry = bits.Add32(n1, 0, carry)
-	n2, carry = bits.Add32(n2, 0, carry)
-	n0, _ = bits.Add32(n0, 0, carry)
+	n2, _ = bits.Add32(n2, 0, carry)
 
 	binary.LittleEndian.PutUint32(n[0:4], n0)
 	binary.LittleEndian.PutUint32(n[4:8], n1)


### PR DESCRIPTION
This removes an unnecessary and technically incorrect carry add on the nonce increment.  While there really isn't a security concern since the wraparound will never actually be hit in practice given it's working modulo 2^96 and only incremented once on each reseed, removing it to have the correct wraparound behavior also has the benefit of one less addition on every invocation.