### PR TITLE
mixing: Reduce slot reservation mix pads allocs.

### DIFF
--- a/mixing/dcnet.go
+++ b/mixing/dcnet.go
@@ -17,7 +17,7 @@ import (
 func SRMixPads(kp [][]byte, my uint32) []*big.Int {
 	h := blake256.New()
 	scratch := make([]byte, 8)
-
+	digest := make([]byte, blake256.Size)
 	pads := make([]*big.Int, len(kp))
 	partialPad := new(big.Int)
 	for j := uint32(0); j < uint32(len(kp)); j++ {
@@ -30,7 +30,7 @@ func SRMixPads(kp [][]byte, my uint32) []*big.Int {
 			h.Reset()
 			h.Write(kp[i])
 			h.Write(scratch)
-			digest := h.Sum(nil)
+			digest = h.Sum(digest[:0])
 			partialPad.SetBytes(digest)
 			if my > i {
 				pads[j].Add(pads[j], partialPad)


### PR DESCRIPTION
This significantly reduces the number of allocations needed to create a vector of exponential DC-net pads by reusing a digest slice prior to converting the result to a big integer.

Specifically, it reduces the allocations for the digest calculation from quadratic in the number of participants to a single alloc.  The big integers themselves are still predominantly linear in the number of participants, however, they are not entirely linear because the big ints involve multiple allocations as the numbers grow larger prior to the modular reduction.

For a concrete example, with 15 participants, the total number of overall allocations with this change is reduced from 257 down to 47.