### PR TITLE
mixclient: Dont append to slice with non-zero length.

### DIFF
--- a/mixing/mixclient/blame.go
+++ b/mixing/mixclient/blame.go
@@ -82,7 +82,7 @@ func (c *Client) blame(ctx context.Context, sesRun *sessionRun) (err error) {
 	rcv.Sid = sesRun.sid
 	rcv.RSs = make([]*wire.MsgMixSecrets, 0, 1)
 	_ = mp.Receive(ctx, rcv)
-	rsHashes := make([]chainhash.Hash, len(rcv.RSs))
+	rsHashes := make([]chainhash.Hash, 0, len(rcv.RSs))
 	for _, rs := range rcv.RSs {
 		rsHashes = append(rsHashes, rs.Hash())
 	}


### PR DESCRIPTION
Immediately appending to a slice initialized with a non-zero length will lead to a slice which is twice as large as intended, with the initial half of the entries being left at their zero value.

This is fixed by initializing the slice with **capacity** instead of length.