### PR TITLE
mixclient: Remove submit queue channel

### DIFF
--- a/mixing/mixclient/client.go
+++ b/mixing/mixclient/client.go
@@ -744,8 +744,11 @@ func (c *Client) Dicemix(ctx context.Context, cj *CoinJoin) error {
 		c.pairings[string(pairingID)] = pairing
 	}
 	pairing.localPeers[*p.id] = p
+	c.mu.Unlock()
+
 	err = p.submit(pr)
 	if err != nil {
+		c.mu.Lock()
 		delete(pairing.localPeers, *p.id)
 		if len(pairing.localPeers) == 0 {
 			delete(c.pairings, string(pairingID))
@@ -753,7 +756,6 @@ func (c *Client) Dicemix(ctx context.Context, cj *CoinJoin) error {
 		c.mu.Unlock()
 		return err
 	}
-	c.mu.Unlock()
 
 	select {
 	case res := <-p.res:


### PR DESCRIPTION
The submit queue channel was not actually increasing any performance. (*peer).submit() would synchronously wait for all error results, and the call to (*Wallet).SubmitMixMessage was already synchronized by the mixpool mutex.

Furthermore, this also fixes a deadlock that was observed after a mixing wallet with the RPC syncer mode reconnected to a restarted dcrd.  Pair request messages were being submitted onto the channel with the client mutex held in (*Client).Dicemix.  However, handleSubmitQueue had already exited and the client had not yet been restarted after dcrd reconnect, and was unable to be started due to the locked mutex.