### PR TITLE
addrmgr: Prepare v3.

### DIFF
--- a/addrmgr/go.mod
+++ b/addrmgr/go.mod
@@ -1,4 +1,4 @@
-module github.com/decred/dcrd/addrmgr/v2
+module github.com/decred/dcrd/addrmgr/v3
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/base58 v1.0.5
-	github.com/decred/dcrd/addrmgr/v2 v2.0.3
+	github.com/decred/dcrd/addrmgr/v3 v3.0.0
 	github.com/decred/dcrd/bech32 v1.1.4
 	github.com/decred/dcrd/blockchain/stake/v5 v5.0.1
 	github.com/decred/dcrd/blockchain/standalone/v2 v2.2.1
@@ -60,7 +60,7 @@ require (
 )
 
 replace (
-	github.com/decred/dcrd/addrmgr/v2 => ./addrmgr
+	github.com/decred/dcrd/addrmgr/v3 => ./addrmgr
 	github.com/decred/dcrd/bech32 => ./bech32
 	github.com/decred/dcrd/blockchain/stake/v5 => ./blockchain/stake
 	github.com/decred/dcrd/blockchain/standalone/v2 => ./blockchain/standalone

--- a/internal/rpcserver/interface.go
+++ b/internal/rpcserver/interface.go
@@ -9,7 +9,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/decred/dcrd/addrmgr/v2"
+	"github.com/decred/dcrd/addrmgr/v3"
 	"github.com/decred/dcrd/blockchain/stake/v5"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil/v4"

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/decred/dcrd/addrmgr/v2"
+	"github.com/decred/dcrd/addrmgr/v3"
 	"github.com/decred/dcrd/blockchain/stake/v5"
 	"github.com/decred/dcrd/blockchain/standalone/v2"
 	"github.com/decred/dcrd/chaincfg/chainhash"

--- a/log.go
+++ b/log.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/decred/dcrd/addrmgr/v2"
+	"github.com/decred/dcrd/addrmgr/v3"
 	"github.com/decred/dcrd/blockchain/stake/v5"
 	"github.com/decred/dcrd/connmgr/v3"
 	"github.com/decred/dcrd/database/v3"

--- a/server.go
+++ b/server.go
@@ -24,7 +24,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/decred/dcrd/addrmgr/v2"
+	"github.com/decred/dcrd/addrmgr/v3"
 	"github.com/decred/dcrd/blockchain/stake/v5"
 	"github.com/decred/dcrd/blockchain/standalone/v2"
 	"github.com/decred/dcrd/certgen"


### PR DESCRIPTION
Upcoming changes to the addrmgr module will include breaking changes to the public API. Therefore, this commit follows the process for introducing major API changes, which consists of:

- Bump the major version in the go.mod of the addrmgr module
- Update all imports in the repo to use the new major version as necessary
- Tidy all modules in the repository to ensure they are updated to use the latest versions