### PR TITLE
addrmgr: Track network types and remove TorV2 support

### DIFF
--- a/addrmgr/addrmanager_test.go
+++ b/addrmgr/addrmanager_test.go
@@ -327,22 +327,22 @@ func TestHostToNetAddress(t *testing.T) {
 		wantErr    bool
 		want       *NetAddress
 	}{{
-		name:       "valid onion address",
-		host:       "a5ccbdkubbr2jlcp.onion",
-		port:       8333,
-		lookupFunc: nil,
-		wantErr:    false,
-		want: NewNetAddressFromIPPort(
-			net.ParseIP("fd87:d87e:eb43:744:208d:5408:63a4:ac4f"), 8333,
-			services),
-	}, {
-		name:       "invalid onion address",
-		host:       "0000000000000000.onion",
-		port:       8333,
-		lookupFunc: nil,
-		wantErr:    true,
-		want:       nil,
-	}, {
+		// 	name:       "valid onion address",
+		// 	host:       "a5ccbdkubbr2jlcp.onion",
+		// 	port:       8333,
+		// 	lookupFunc: nil,
+		// 	wantErr:    false,
+		// 	want: NewNetAddressFromIPPort(
+		// 		net.ParseIP("fd87:d87e:eb43:744:208d:5408:63a4:ac4f"), 8333,
+		// 		services),
+		// }, {
+		// 	name:       "invalid onion address",
+		// 	host:       "0000000000000000.onion",
+		// 	port:       8333,
+		// 	lookupFunc: nil,
+		// 	wantErr:    true,
+		// 	want:       nil,
+		// }, {
 		name: "unresolvable host name",
 		host: hostnameForLookup,
 		port: 8333,
@@ -905,7 +905,6 @@ func TestGetBestLocalAddress(t *testing.T) {
 // IsExternalAddrCandidate should return the expected boolean, as well as the
 // expected reach the localAddr has to the remoteAddr.
 func TestIsExternalAddrCandidate(t *testing.T) {
-	onionCatTorV2Address := onionCatNet.IP.String()
 	rfc4380IPAddress := rfc4380Net.IP.String()
 	rfc3964IPAddress := rfc3964Net.IP.String()
 	rfc6052IPAddress := rfc6052Net.IP.String()
@@ -918,37 +917,6 @@ func TestIsExternalAddrCandidate(t *testing.T) {
 		expectedBool  bool
 		expectedReach NetAddressReach
 	}{{
-		name:          "torv2 to torv2",
-		localAddr:     onionCatTorV2Address,
-		remoteAddr:    onionCatTorV2Address,
-		expectedBool:  false,
-		expectedReach: Private,
-	}, {
-		name:          "routable ipv4 to torv2",
-		localAddr:     routableIPv4Addr,
-		remoteAddr:    onionCatTorV2Address,
-		expectedBool:  true,
-		expectedReach: Ipv4,
-	}, {
-		name:          "unroutable ipv4 to torv2",
-		localAddr:     nonRoutableIPv4Addr,
-		remoteAddr:    onionCatTorV2Address,
-		expectedBool:  false,
-		expectedReach: Default,
-	}, {
-		// This test case wasn't possible before, but will be once TorV3 is added.
-		// 	name:          "routable ipv6 to torv2",
-		// 	localAddr:     routableIPv6Addr,
-		// 	remoteAddr:    onionCatTorV2Address,
-		// 	expectedBool:  false,
-		// 	expectedReach: Default,
-		// }, {
-		name:          "unroutable ipv6 to torv2",
-		localAddr:     nonRoutableIPv6Addr,
-		remoteAddr:    onionCatTorV2Address,
-		expectedBool:  false,
-		expectedReach: Default,
-	}, {
 		name:          "remote peer suggested a local address",
 		localAddr:     "127.0.0.1",
 		remoteAddr:    routableIPv4Addr,

--- a/addrmgr/doc.go
+++ b/addrmgr/doc.go
@@ -1,39 +1,41 @@
 // Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015-2022 The Decred developers
+// Copyright (c) 2015-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 /*
-Package addrmgr implements concurrency safe Decred address manager.
+Package addrmgr implements a concurrency-safe Decred address manager.
 
 # Address Manager Overview
 
-In order maintain the peer-to-peer Decred network, there needs to be a source
-of addresses to connect to as nodes come and go.  The Decred protocol provides
-the getaddr and addr messages to allow peers to communicate known addresses
-with each other.  However, there needs to a mechanism to store those results and
-select peers from them.  It is also important to note that remote peers can't
-be trusted to send valid peers nor attempt to provide you with only peers they
-control with malicious intent.
+The Decred network relies on fully-validating nodes that relay transactions and
+blocks to other nodes around the world.  The network must be dynamic because
+nodes will connect and disconnect as they please.  Each node must manage a
+source of IP addresses to connect to and share with other nodes.  The Decred
+wire protocol provides the `getaddr` and `addr` messages, allowing peers to
+request and share known addresses with each other.  Each node needs a way to
+store those addresses and select peers from them.  However, it is important to
+remember that remote peers cannot be trusted.  A remote peer might send invalid
+addresses, or worse, only send addresses they control with malicious intent.
 
-With that in mind, this package provides a concurrency safe address manager for
+With that in mind, this package provides a concurrency-safe address manager for
 caching and selecting peers in a non-deterministic manner.  The general idea is
-the caller adds addresses to the address manager and notifies it when addresses
-are connected, known good, and attempted.  The caller also requests addresses as
-it needs them.
+that the caller adds addresses to the address manager and notifies it when
+addresses are connected, known good, and attempted.  The caller also requests
+addresses as it needs them.
 
 The address manager internally segregates the addresses into groups and
 non-deterministically selects groups in a cryptographically random manner.  This
-reduce the chances multiple addresses from the same nets are selected which
-generally helps provide greater peer diversity, and perhaps more importantly,
-drastically reduces the chances an attacker is able to coerce your peer into
-only connecting to nodes they control.
+reduces the chances of selecting multiple addresses from the same network, which
+generally helps provide greater peer diversity.  More importantly, it
+drastically reduces the chances of an attacker coercing your peer into
+connecting only to nodes they control.
 
-The address manager also understands routability and Tor addresses and tries
-hard to only return routable addresses.  In addition, it uses the information
-provided by the caller about connected, known good, and attempted addresses to
-periodically purge peers which no longer appear to be good peers as well as
-bias the selection toward known good peers.  The general idea is to make a best
-effort at only providing usable addresses.
+The address manager also understands routability, and tries hard to only return
+routable addresses.  In addition, it uses the information provided by the caller
+about connected, known good, and attempted addresses to periodically purge peers
+which no longer appear to be good, as well as to bias the selection toward known
+good peers.  The general idea is to make a best effort to only provide usable
+addresses.
 */
 package addrmgr

--- a/addrmgr/error.go
+++ b/addrmgr/error.go
@@ -18,6 +18,10 @@ const (
 	// ErrUnknownAddressType indicates that the network address type could not
 	// be determined from a network address' bytes.
 	ErrUnknownAddressType = ErrorKind("ErrUnknownAddressType")
+
+	// ErrMismatchedAddressType indicates that a network address was expected to
+	// be a certain type, but the derived type does not match.
+	ErrMismatchedAddressType = ErrorKind("ErrMismatchedAddressType")
 )
 
 // Error satisfies the error interface and prints human-readable errors.

--- a/addrmgr/error.go
+++ b/addrmgr/error.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 The Decred developers
+// Copyright (c) 2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -14,6 +14,10 @@ const (
 	// ErrAddressNotFound indicates that an operation in the address manager
 	// failed due to an address lookup failure.
 	ErrAddressNotFound = ErrorKind("ErrAddressNotFound")
+
+	// ErrUnknownAddressType indicates that the network address type could not
+	// be determined from a network address' bytes.
+	ErrUnknownAddressType = ErrorKind("ErrUnknownAddressType")
 )
 
 // Error satisfies the error interface and prints human-readable errors.
@@ -21,7 +25,7 @@ func (e ErrorKind) Error() string {
 	return string(e)
 }
 
-// Error identifies an address manager error. It has full support for
+// Error identifies an address manager error.  It has full support for
 // errors.Is and errors.As, so the caller can ascertain the specific reason
 // for the error by checking the underlying error.
 type Error struct {

--- a/addrmgr/error_test.go
+++ b/addrmgr/error_test.go
@@ -25,6 +25,11 @@ func TestErrors(t *testing.T) {
 		errorKind:   ErrUnknownAddressType,
 		description: "unknown address type",
 		wantErr:     ErrUnknownAddressType,
+	}, {
+		name:        "ErrMismatchedAddressType",
+		errorKind:   ErrMismatchedAddressType,
+		description: "mismatched address type",
+		wantErr:     ErrMismatchedAddressType,
 	}}
 
 	for _, test := range tests {

--- a/addrmgr/error_test.go
+++ b/addrmgr/error_test.go
@@ -15,35 +15,38 @@ func TestErrors(t *testing.T) {
 		errorKind   ErrorKind
 		description string
 		wantErr     error
-	}{
-		{
-			name:        "ErrAddressNotFound",
-			errorKind:   ErrAddressNotFound,
-			description: "address not found",
-			wantErr:     ErrAddressNotFound,
-		},
-	}
+	}{{
+		name:        "ErrAddressNotFound",
+		errorKind:   ErrAddressNotFound,
+		description: "address not found",
+		wantErr:     ErrAddressNotFound,
+	}, {
+		name:        "ErrUnknownAddressType",
+		errorKind:   ErrUnknownAddressType,
+		description: "unknown address type",
+		wantErr:     ErrUnknownAddressType,
+	}}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Test makeError
 			err := makeError(test.errorKind, test.description)
 			if err.Description != test.description {
-				t.Errorf("unexpected error description: expected %q, got %q", test.description, err.Description)
+				t.Errorf("unexpected error description: want %q, got %q", test.description, err.Description)
 			}
 			// Test unwrapping
 			if !errors.Is(err, test.wantErr) {
-				t.Errorf("failed to find the expected error: expected %v, got %v", test.wantErr, err.Err)
+				t.Errorf("failed to find the expected error: want %v, got %v", test.wantErr, err.Err)
 			}
 
 			// Test ErrorKind.Error
 			if got := test.errorKind.Error(); got != string(test.errorKind) {
-				t.Errorf("unexpected errorKind: expected %v, got %v", string(test.errorKind), got)
+				t.Errorf("unexpected errorKind: want %v, got %v", string(test.errorKind), got)
 			}
 
 			// Test Error.Error
 			if got := err.Error(); got != test.description {
-				t.Errorf("unexpected error: expected %v, got %v", test.description, got)
+				t.Errorf("unexpected error: want %v, got %v", test.description, got)
 			}
 		})
 	}

--- a/addrmgr/knownaddress_test.go
+++ b/addrmgr/knownaddress_test.go
@@ -59,7 +59,7 @@ func TestChance(t *testing.T) {
 	for i, test := range tests {
 		chance := test.addr.chance()
 		if math.Abs(test.expected-chance) >= err {
-			t.Errorf("case %d: got %f, expected %f", i, chance, test.expected)
+			t.Errorf("case %d: got %f, want %f", i, chance, test.expected)
 		}
 	}
 }

--- a/addrmgr/netaddress.go
+++ b/addrmgr/netaddress.go
@@ -5,11 +5,9 @@
 package addrmgr
 
 import (
-	"encoding/base32"
 	"fmt"
 	"net"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/decred/dcrd/wire"
@@ -42,16 +40,10 @@ func (netAddr *NetAddress) IsRoutable() bool {
 }
 
 // ipString returns a string representation of the network address' IP field.
-// If the ip is in the range used for TORv2 addresses then it will be
-// transformed into the respective .onion address.  It does not include the
-// port.
+// It does not include the port.
 func (netAddr *NetAddress) ipString() string {
 	netIP := netAddr.IP
 	switch netAddr.Type {
-	case TORV2Address:
-		// We know now that na.IP is long enough.
-		base32 := base32.StdEncoding.EncodeToString(netIP[6:])
-		return strings.ToLower(base32) + ".onion"
 	case IPv6Address:
 		return net.IP(netIP).String()
 	case IPv4Address:

--- a/addrmgr/network_test.go
+++ b/addrmgr/network_test.go
@@ -177,10 +177,10 @@ func TestGroupKey(t *testing.T) {
 		{name: "ipv6 rfc6052 well-known prefix with ipv4", ip: "64:ff9b::0c01:0203", expected: "12.1.0.0"},
 		{name: "ipv6 rfc6145 translated ipv4", ip: "::ffff:0:0c01:0203", expected: "12.1.0.0"},
 
-		// Tor.
-		{name: "ipv6 tor onioncat", ip: "fd87:d87e:eb43:1234::5678", expected: "tor:2"},
-		{name: "ipv6 tor onioncat 2", ip: "fd87:d87e:eb43:1245::6789", expected: "tor:2"},
-		{name: "ipv6 tor onioncat 3", ip: "fd87:d87e:eb43:1345::6789", expected: "tor:3"},
+		// // Tor.
+		// {name: "ipv6 tor onioncat", ip: "fd87:d87e:eb43:1234::5678", expected: "tor:2"},
+		// {name: "ipv6 tor onioncat 2", ip: "fd87:d87e:eb43:1245::6789", expected: "tor:2"},
+		// {name: "ipv6 tor onioncat 3", ip: "fd87:d87e:eb43:1345::6789", expected: "tor:3"},
 
 		// IPv6 normal.
 		{name: "ipv6 normal", ip: "2602:100::1", expected: "2602:100::"},

--- a/addrmgr/network_test.go
+++ b/addrmgr/network_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2021 The Decred developers
+// Copyright (c) 2015-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -191,7 +191,7 @@ func TestGroupKey(t *testing.T) {
 
 	for i, test := range tests {
 		nip := net.ParseIP(test.ip)
-		na := NewNetAddressIPPort(nip, 8333, wire.SFNodeNetwork)
+		na := NewNetAddressFromIPPort(nip, 8333, wire.SFNodeNetwork)
 		if key := na.GroupKey(); key != test.expected {
 			t.Errorf("TestGroupKey #%d (%s): unexpected group key "+
 				"- got '%s', want '%s'", i, test.name, key, test.expected)


### PR DESCRIPTION
This heavily references the work started in #2627. However, the work will be broken out into smaller chunks. Ultimately, the goal in the near future is to refactor Addrmgr to remove TorV2 support, and add support for TorV3. However, this PR doesn't include any TorV3 work yet.

The first commit enables tracking of address types, and includes several function refactors to improve readability. The new types are defined in `network.go`, and then constructed in `netaddress.go`. The rest of the changes propagate outward from there.

The second commit removes TorV2 support.

The third commit adds new functions: `ParseHost` and `NewNetAddressFromParams`. These functions will eventually enable two desirable features:
* The ability to parse and construct any type of network address, including TorV3, I2P, or other
* The ability to remove DNS lookups from Addrmgr (and move it into Server.go).