### PR TITLE
addrmgr: Allow filtering by type, and remove DNS.

### DIFF
--- a/addrmgr/addrmanager.go
+++ b/addrmgr/addrmanager.go
@@ -704,7 +704,9 @@ func (a *AddrManager) AddressCache() []*NetAddress {
 	// Adjust length, we only deal with high quality addresses now.
 	addrLen = len(allAddr)
 
-	numAddresses := addrLen * getKnownAddressPercentage / 100
+	// Calculate the number of addresses to be shared: a small subset of all
+	// known addresses.  If available, always return at least one address.
+	numAddresses := ((addrLen * getKnownAddressPercentage) + 99) / 100
 	if numAddresses > getKnownAddressLimit {
 		numAddresses = getKnownAddressLimit
 	}

--- a/addrmgr/netaddress_test.go
+++ b/addrmgr/netaddress_test.go
@@ -244,7 +244,7 @@ func TestNewNetAddressFromParams(t *testing.T) {
 // TestNewNetAddressFromString verifies that the newNetAddressFromString
 // constructor correctly creates a network address with expected field values.
 func TestNewNetAddressFromString(t *testing.T) {
-	amgr := New("TestNewNetAddressFromString", nil)
+	amgr := New("TestNewNetAddressFromString")
 	tests := []struct {
 		name          string
 		addrString    string

--- a/addrmgr/network.go
+++ b/addrmgr/network.go
@@ -107,6 +107,12 @@ const (
 	// TorV2Address       NetAddressType = 3  // No longer supported
 )
 
+// NetAddressTypeFilter represents a function that returns whether a particular
+// network address type matches a filter.  Internally, it is used to ensure that
+// only addresses that pass the filter's constraints are returned by the address
+// manager.
+type NetAddressTypeFilter func(NetAddressType) bool
+
 // isRFC1918 returns whether or not the passed address is part of the IPv4
 // private network address space as defined by RFC1918 (10.0.0.0/8,
 // 172.16.0.0/12, or 192.168.0.0/16).

--- a/config.go
+++ b/config.go
@@ -1372,7 +1372,7 @@ func dcrdDial(ctx context.Context, network, addr string) (net.Conn, error) {
 	return cfg.dial(ctx, network, addr)
 }
 
-// dcrdLookup returns the correct DNS lookup function to use depending on the
+// dcrdLookup invokes the correct DNS lookup function to use depending on the
 // passed host and configuration options.  For example, .onion addresses will be
 // resolved using the onion specific proxy if one was specified, but will
 // otherwise treat the normal proxy as tor unless --noonion was specified in

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2024 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"reflect"
+	"testing"
+
+	"github.com/decred/dcrd/addrmgr/v3"
+	"github.com/decred/dcrd/wire"
+)
+
+// TestHostToNetAddress ensures that hostToNetAddress behaves as expected
+// given valid and invalid host name arguments.
+func TestHostToNetAddress(t *testing.T) {
+	// Define a hostname that will cause a lookup to be performed using the
+	// lookupFunc provided to the address manager instance for each test.
+	const hostnameForLookup = "hostname.test"
+	const services = wire.SFNodeNetwork
+
+	tests := []struct {
+		name       string
+		host       string
+		port       uint16
+		lookupFunc func(host string) ([]net.IP, error)
+		wantErr    bool
+		want       *addrmgr.NetAddress
+	}{{
+		// 	name:       "valid onion address",
+		// 	host:       "a5ccbdkubbr2jlcp.onion",
+		// 	port:       8333,
+		// 	lookupFunc: nil,
+		// 	wantErr:    false,
+		// 	want: NewNetAddressFromIPPort(
+		// 		net.ParseIP("fd87:d87e:eb43:744:208d:5408:63a4:ac4f"), 8333,
+		// 		services),
+		// }, {
+		// 	name:       "invalid onion address",
+		// 	host:       "0000000000000000.onion",
+		// 	port:       8333,
+		// 	lookupFunc: nil,
+		// 	wantErr:    true,
+		// 	want:       nil,
+		// }, {
+		name: "unresolvable host name",
+		host: hostnameForLookup,
+		port: 8333,
+		lookupFunc: func(host string) ([]net.IP, error) {
+			return nil, fmt.Errorf("unresolvable host %v", host)
+		},
+		wantErr: true,
+		want:    nil,
+	}, {
+		name: "not resolved host name",
+		host: hostnameForLookup,
+		port: 8333,
+		lookupFunc: func(host string) ([]net.IP, error) {
+			return nil, nil
+		},
+		wantErr: true,
+		want:    nil,
+	}, {
+		name: "resolved host name",
+		host: hostnameForLookup,
+		port: 8333,
+		lookupFunc: func(host string) ([]net.IP, error) {
+			return []net.IP{net.ParseIP("127.0.0.1")}, nil
+		},
+		wantErr: false,
+		want: addrmgr.NewNetAddressFromIPPort(net.ParseIP("127.0.0.1"), 8333,
+			services),
+	}, {
+		name:       "valid IPv4 address",
+		host:       "12.1.2.3",
+		port:       8333,
+		lookupFunc: nil,
+		wantErr:    false,
+		want: addrmgr.NewNetAddressFromIPPort(net.ParseIP("12.1.2.3"), 8333,
+			services),
+	}, {
+		name:       "valid IPv6 address",
+		host:       "2003::1",
+		port:       8333,
+		lookupFunc: nil,
+		wantErr:    false,
+		want: addrmgr.NewNetAddressFromIPPort(net.ParseIP("2003::1"), 8333,
+			services),
+	}}
+
+	for _, test := range tests {
+		result, err := hostToNetAddress(test.host, test.port, services, test.lookupFunc)
+		if test.wantErr == true && err == nil {
+			t.Errorf("%q: expected error but one was not returned", test.name)
+		}
+		if !reflect.DeepEqual(result, test.want) {
+			t.Errorf("%q: unexpected result - got %v, want %v", test.name,
+				result, test.want)
+		}
+	}
+}


### PR DESCRIPTION
Similar to #3406, this work heavily references the work started in #2627, with the ultimate goal of adding support for TorV3 and other network address types.

The first commit fixes a minor bug where, if a node is asked to share addresses, but it only knows a very tiny number of addresses (less than five), it wouldn't share any. This isn't considered good behavior. I found this bug while trying to write tests for the second commit, where I added the ability to ask for addresses that match a certain filter.  The bugfix is to always share at least one address (of the specified type) if any are known.

The second commit adds the ability to filter net addresses by specific address types. Eventually, this can be changed based on wire protocol versions which support different address types.

The third commit removes DNS from the address manager. With this proposed plan, the address manager will only be responsible for storing and managing addresses, encoded so that they're serialized compactly. The responsibility of dialing DNS has been moved to `server.go`.