### PR TITLE
netsync: Name received msg handlers with On, not Queue

### DIFF
--- a/internal/netsync/manager.go
+++ b/internal/netsync/manager.go
@@ -1706,9 +1706,9 @@ func (m *SyncManager) PeerConnected(peer *Peer) {
 	}
 }
 
-// QueueTx adds the passed transaction message and peer to the event handling
+// OnTx adds the passed transaction message and peer to the event handling
 // queue.
-func (m *SyncManager) QueueTx(tx *dcrutil.Tx, peer *Peer, done chan struct{}) {
+func (m *SyncManager) OnTx(tx *dcrutil.Tx, peer *Peer, done chan struct{}) {
 	select {
 	case m.msgChan <- &txMsg{tx: tx, peer: peer, reply: done}:
 	case <-m.quit:
@@ -1716,9 +1716,9 @@ func (m *SyncManager) QueueTx(tx *dcrutil.Tx, peer *Peer, done chan struct{}) {
 	}
 }
 
-// QueueBlock adds the passed block message and peer to the event handling
+// OnBlock adds the passed block message and peer to the event handling
 // queue.
-func (m *SyncManager) QueueBlock(block *dcrutil.Block, peer *Peer, done chan struct{}) {
+func (m *SyncManager) OnBlock(block *dcrutil.Block, peer *Peer, done chan struct{}) {
 	select {
 	case m.msgChan <- &blockMsg{block: block, peer: peer, reply: done}:
 	case <-m.quit:
@@ -1726,35 +1726,35 @@ func (m *SyncManager) QueueBlock(block *dcrutil.Block, peer *Peer, done chan str
 	}
 }
 
-// QueueInv adds the passed inv message and peer to the event handling queue.
-func (m *SyncManager) QueueInv(inv *wire.MsgInv, peer *Peer) {
+// OnInv adds the passed inv message and peer to the event handling queue.
+func (m *SyncManager) OnInv(inv *wire.MsgInv, peer *Peer) {
 	select {
 	case m.msgChan <- &invMsg{inv: inv, peer: peer}:
 	case <-m.quit:
 	}
 }
 
-// QueueHeaders adds the passed headers message and peer to the event handling
+// OnHeaders adds the passed headers message and peer to the event handling
 // queue.
-func (m *SyncManager) QueueHeaders(headers *wire.MsgHeaders, peer *Peer) {
+func (m *SyncManager) OnHeaders(headers *wire.MsgHeaders, peer *Peer) {
 	select {
 	case m.msgChan <- &headersMsg{headers: headers, peer: peer}:
 	case <-m.quit:
 	}
 }
 
-// QueueMixMsg adds the passed mixing message and peer to the event handling
+// OnMixMsg adds the passed mixing message and peer to the event handling
 // queue.
-func (m *SyncManager) QueueMixMsg(msg mixing.Message, peer *Peer, done chan error) {
+func (m *SyncManager) OnMixMsg(msg mixing.Message, peer *Peer, done chan error) {
 	select {
 	case m.msgChan <- &mixMsg{msg: msg, peer: peer, reply: done}:
 	case <-m.quit:
 	}
 }
 
-// QueueNotFound adds the passed notfound message and peer to the event handling
+// OnNotFound adds the passed notfound message and peer to the event handling
 // queue.
-func (m *SyncManager) QueueNotFound(notFound *wire.MsgNotFound, peer *Peer) {
+func (m *SyncManager) OnNotFound(notFound *wire.MsgNotFound, peer *Peer) {
 	select {
 	case m.msgChan <- &notFoundMsg{notFound: notFound, peer: peer}:
 	case <-m.quit:

--- a/server.go
+++ b/server.go
@@ -1469,7 +1469,7 @@ func (sp *serverPeer) OnTx(_ *peer.Peer, msg *wire.MsgTx) {
 	// processed and known good or bad.  This helps prevent a malicious peer
 	// from queuing up a bunch of bad transactions before disconnecting (or
 	// being disconnected) and wasting memory.
-	sp.server.syncManager.QueueTx(tx, sp.syncMgrPeer, sp.txProcessed)
+	sp.server.syncManager.OnTx(tx, sp.syncMgrPeer, sp.txProcessed)
 	<-sp.txProcessed
 }
 
@@ -1492,7 +1492,7 @@ func (sp *serverPeer) OnBlock(_ *peer.Peer, msg *wire.MsgBlock, buf []byte) {
 	// depended on by at least the block acceptance test tool as the reference
 	// implementation processes blocks in the same thread and therefore blocks
 	// further messages until the network block has been fully processed.
-	sp.server.syncManager.QueueBlock(block, sp.syncMgrPeer, sp.blockProcessed)
+	sp.server.syncManager.OnBlock(block, sp.syncMgrPeer, sp.blockProcessed)
 	<-sp.blockProcessed
 }
 
@@ -1509,7 +1509,7 @@ func (sp *serverPeer) OnInv(_ *peer.Peer, msg *wire.MsgInv) {
 	}
 
 	if !cfg.BlocksOnly {
-		sp.server.syncManager.QueueInv(msg, sp.syncMgrPeer)
+		sp.server.syncManager.OnInv(msg, sp.syncMgrPeer)
 		return
 	}
 
@@ -1528,13 +1528,13 @@ func (sp *serverPeer) OnInv(_ *peer.Peer, msg *wire.MsgInv) {
 		return
 	}
 
-	sp.server.syncManager.QueueInv(msg, sp.syncMgrPeer)
+	sp.server.syncManager.OnInv(msg, sp.syncMgrPeer)
 }
 
 // OnHeaders is invoked when a peer receives a headers wire message.  The
 // message is passed down to the net sync manager.
 func (sp *serverPeer) OnHeaders(_ *peer.Peer, msg *wire.MsgHeaders) {
-	sp.server.syncManager.QueueHeaders(msg, sp.syncMgrPeer)
+	sp.server.syncManager.OnHeaders(msg, sp.syncMgrPeer)
 }
 
 // OnGetData is invoked when a peer receives a getdata wire message and is used
@@ -1835,7 +1835,7 @@ func (sp *serverPeer) onMixMessage(msg mixing.Message) {
 
 	// Queue the message to be handled by the net sync manager
 	// XXX: add ban score increases for non-instaban errors?
-	sp.server.syncManager.QueueMixMsg(msg, sp.syncMgrPeer, sp.mixMsgProcessed)
+	sp.server.syncManager.OnMixMsg(msg, sp.syncMgrPeer, sp.mixMsgProcessed)
 	err := <-sp.mixMsgProcessed
 	var missingOwnPRErr *mixpool.MissingOwnPRError
 	if errors.As(err, &missingOwnPRErr) {
@@ -1957,7 +1957,7 @@ func (sp *serverPeer) OnNotFound(_ *peer.Peer, msg *wire.MsgNotFound) {
 			return
 		}
 	}
-	sp.server.syncManager.QueueNotFound(msg, sp.syncMgrPeer)
+	sp.server.syncManager.OnNotFound(msg, sp.syncMgrPeer)
 }
 
 // attemptDcrdDial is a wrapper function around dcrdDial which adds and marks


### PR DESCRIPTION
This matches the naming used by the public peer package and (because it implements the peer interface) the server peer.

More importantly, the "Queue" naming is already used by the server/peer package to push outgoing messages to peers (e.g. QueueMessage and QueueInventory), and it seemed unnecessarily complex to need to distinguish the different uses cases of the same names when working on server and netsync simultaneously.