### PR TITLE
main: Add .editorconfig.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# top-most EditorConfig file
+root = true
+
+[*.{go,gv,s}]
+indent_style = tab
+indent_size = 4
+charset = utf-8
+
+[*.py]
+indent_style = space
+indent_size = 4
+charset = utf-8
+
+[*.{js,json,sh,xml,yml}]
+indent_style = space
+indent_size = 2
+charset = utf-8


### PR DESCRIPTION
This adds a .editorconfig file that specifies the canonical indentation style and charset for various file types in the repository.

The vast majority of the files in the repository are Go code which is required to use gofmt and thus almost all of the formatting is handled by that.  However, additionally specifying a canonical indentation style helps keep wrapping consistent among developers.

I am fully aware that some developers feel strongly about specific amounts of indentation and canonical values are not going to please everyone.  It is possible to override these settings for developers that feel super strongly about it so long as the final code they commit is consistent with them.

In any case, it is important to have a canonical standard to help prevent developers, often inadvertently, rewrapping each others code due to differing values.  It's the same reason that gofmt, and variants in other modern languages that have followed suit, are so great.