### PR TITLE
secp256k1: Minor cleanup.

### DIFF
--- a/dcrec/secp256k1/curve.go
+++ b/dcrec/secp256k1/curve.go
@@ -823,7 +823,7 @@ func splitK(k *ModNScalar) (ModNScalar, ModNScalar) {
 	//
 	// Finally, consider the vector u:
 	//
-	// u  = <k, 0> - v
+	// u = <k, 0> - v
 	//
 	// It follows that f(u) = k and thus the two components of vector u satisfy
 	// the required equation:
@@ -891,10 +891,10 @@ func splitK(k *ModNScalar) (ModNScalar, ModNScalar) {
 	//    Therefore, the computation of va can be avoided to save two
 	//    field multiplications and a field addition.
 	//
-	// 2) Since k1 = k - k2*λ = k + k2*(-λ), an additional field negation is
+	// 2) Since k1 ≡ k - k2*λ ≡ k + k2*(-λ), an additional field negation is
 	//    saved by storing and using the negative version of λ.
 	//
-	// 3) Since k2 = -vb = -(c1*b1 + c2*b2) = c1*(-b1) + c2*(-b2), one more
+	// 3) Since k2 ≡ -vb ≡ -(c1*b1 + c2*b2) ≡ c1*(-b1) + c2*(-b2), one more
 	//    field negation is saved by storing and using the negative versions of
 	//    b1 and b2.
 	//

--- a/dcrec/secp256k1/ellipticadaptor.go
+++ b/dcrec/secp256k1/ellipticadaptor.go
@@ -153,17 +153,17 @@ func moduloReduce(k []byte) []byte {
 	return k
 }
 
-// ScalarMult returns k*(Bx, By) where k is a big endian integer.
+// ScalarMult returns k*(bx, by) where k is a big endian integer.
 //
 // This is part of the elliptic.Curve interface implementation.
-func (curve *KoblitzCurve) ScalarMult(Bx, By *big.Int, k []byte) (*big.Int, *big.Int) {
+func (curve *KoblitzCurve) ScalarMult(bx, by *big.Int, k []byte) (*big.Int, *big.Int) {
 	// Convert the affine coordinates from big integers to Jacobian points,
 	// do the multiplication in Jacobian projective space, and convert the
 	// Jacobian point back to affine big.Ints.
 	var kModN ModNScalar
 	kModN.SetByteSlice(moduloReduce(k))
 	var point, result JacobianPoint
-	bigAffineToJacobian(Bx, By, &point)
+	bigAffineToJacobian(bx, by, &point)
 	ScalarMultNonConst(&kModN, &point, &result)
 	return jacobianToBigAffine(&result)
 }

--- a/dcrec/secp256k1/field.go
+++ b/dcrec/secp256k1/field.go
@@ -364,26 +364,26 @@ func (f *FieldVal) Normalize() *FieldVal {
 	// additional carry to bit 256 (bit 22 of the high order word).
 	t9 := f.n[9]
 	m := t9 >> fieldMSBBits
-	t9 = t9 & fieldMSBMask
+	t9 &= fieldMSBMask
 	t0 := f.n[0] + m*977
 	t1 := (t0 >> fieldBase) + f.n[1] + (m << 6)
-	t0 = t0 & fieldBaseMask
+	t0 &= fieldBaseMask
 	t2 := (t1 >> fieldBase) + f.n[2]
-	t1 = t1 & fieldBaseMask
+	t1 &= fieldBaseMask
 	t3 := (t2 >> fieldBase) + f.n[3]
-	t2 = t2 & fieldBaseMask
+	t2 &= fieldBaseMask
 	t4 := (t3 >> fieldBase) + f.n[4]
-	t3 = t3 & fieldBaseMask
+	t3 &= fieldBaseMask
 	t5 := (t4 >> fieldBase) + f.n[5]
-	t4 = t4 & fieldBaseMask
+	t4 &= fieldBaseMask
 	t6 := (t5 >> fieldBase) + f.n[6]
-	t5 = t5 & fieldBaseMask
+	t5 &= fieldBaseMask
 	t7 := (t6 >> fieldBase) + f.n[7]
-	t6 = t6 & fieldBaseMask
+	t6 &= fieldBaseMask
 	t8 := (t7 >> fieldBase) + f.n[8]
-	t7 = t7 & fieldBaseMask
+	t7 &= fieldBaseMask
 	t9 = (t8 >> fieldBase) + t9
-	t8 = t8 & fieldBaseMask
+	t8 &= fieldBaseMask
 
 	// At this point, the magnitude is guaranteed to be one, however, the
 	// value could still be greater than the prime if there was either a
@@ -398,26 +398,26 @@ func (f *FieldVal) Normalize() *FieldVal {
 	m &= constantTimeEq(t8&t7&t6&t5&t4&t3&t2, fieldBaseMask)
 	m &= constantTimeGreater(t1+64+((t0+977)>>fieldBase), fieldBaseMask)
 	m |= t9 >> fieldMSBBits
-	t0 = t0 + m*977
+	t0 += m * 977
 	t1 = (t0 >> fieldBase) + t1 + (m << 6)
-	t0 = t0 & fieldBaseMask
+	t0 &= fieldBaseMask
 	t2 = (t1 >> fieldBase) + t2
-	t1 = t1 & fieldBaseMask
+	t1 &= fieldBaseMask
 	t3 = (t2 >> fieldBase) + t3
-	t2 = t2 & fieldBaseMask
+	t2 &= fieldBaseMask
 	t4 = (t3 >> fieldBase) + t4
-	t3 = t3 & fieldBaseMask
+	t3 &= fieldBaseMask
 	t5 = (t4 >> fieldBase) + t5
-	t4 = t4 & fieldBaseMask
+	t4 &= fieldBaseMask
 	t6 = (t5 >> fieldBase) + t6
-	t5 = t5 & fieldBaseMask
+	t5 &= fieldBaseMask
 	t7 = (t6 >> fieldBase) + t7
-	t6 = t6 & fieldBaseMask
+	t6 &= fieldBaseMask
 	t8 = (t7 >> fieldBase) + t8
-	t7 = t7 & fieldBaseMask
+	t7 &= fieldBaseMask
 	t9 = (t8 >> fieldBase) + t9
-	t8 = t8 & fieldBaseMask
-	t9 = t9 & fieldMSBMask // Remove potential multiple of 2^256.
+	t8 &= fieldBaseMask
+	t9 &= fieldMSBMask // Remove potential multiple of 2^256.
 
 	// Finally, set the normalized and reduced words.
 	f.n[0] = t0
@@ -1058,7 +1058,7 @@ func (f *FieldVal) Mul2(val *FieldVal, val2 *FieldVal) *FieldVal {
 	t8 = m & fieldBaseMask
 	m = (m >> fieldBase) + t9 + t18*1024 + t19*68719492368
 	t9 = m & fieldMSBMask
-	m = m >> fieldMSBBits
+	m >>= fieldMSBBits
 
 	// At this point, if the magnitude is greater than 0, the overall value
 	// is greater than the max possible 256-bit value.  In particular, it is
@@ -1465,7 +1465,7 @@ func (f *FieldVal) SquareVal(val *FieldVal) *FieldVal {
 	t8 = m & fieldBaseMask
 	m = (m >> fieldBase) + t9 + t18*1024 + t19*68719492368
 	t9 = m & fieldMSBMask
-	m = m >> fieldMSBBits
+	m >>= fieldMSBBits
 
 	// At this point, if the magnitude is greater than 0, the overall value
 	// is greater than the max possible 256-bit value.  In particular, it is

--- a/dcrec/secp256k1/field_bench_test.go
+++ b/dcrec/secp256k1/field_bench_test.go
@@ -26,7 +26,7 @@ func BenchmarkFieldNormalize(b *testing.B) {
 }
 
 // BenchmarkFieldSqrt benchmarks calculating the square root of an unsigned
-// 256-bit big-endian integer modulo the field prime  with the specialized type.
+// 256-bit big-endian integer modulo the field prime with the specialized type.
 func BenchmarkFieldSqrt(b *testing.B) {
 	// The function is constant time so any value is fine.
 	valHex := "16fb970147a9acc73654d4be233cc48b875ce20a2122d24f073d29bd28805aca"
@@ -43,7 +43,6 @@ func BenchmarkFieldSqrt(b *testing.B) {
 // BenchmarkBigSqrt benchmarks calculating the square root of an unsigned
 // 256-bit big-endian integer modulo the field prime with stdlib big integers.
 func BenchmarkBigSqrt(b *testing.B) {
-	// The function is constant time so any value is fine.
 	valHex := "16fb970147a9acc73654d4be233cc48b875ce20a2122d24f073d29bd28805aca"
 	val, ok := new(big.Int).SetString(valHex, 16)
 	if !ok {

--- a/dcrec/secp256k1/field_test.go
+++ b/dcrec/secp256k1/field_test.go
@@ -528,7 +528,7 @@ func TestFieldIsOne(t *testing.T) {
 // TestFieldStringer ensures the stringer returns the appropriate hex string.
 func TestFieldStringer(t *testing.T) {
 	tests := []struct {
-		name     string //test description
+		name     string // test description
 		in       string // hex encoded test value
 		expected string // expected result
 	}{{

--- a/dcrec/secp256k1/modnscalar.go
+++ b/dcrec/secp256k1/modnscalar.go
@@ -67,10 +67,10 @@ const (
 	orderComplementWordOne   uint32 = ^orderWordOne
 	orderComplementWordTwo   uint32 = ^orderWordTwo
 	orderComplementWordThree uint32 = ^orderWordThree
-	//orderComplementWordFour  uint32 = ^orderWordFour  // unused
-	//orderComplementWordFive  uint32 = ^orderWordFive  // unused
-	//orderComplementWordSix   uint32 = ^orderWordSix   // unused
-	//orderComplementWordSeven uint32 = ^orderWordSeven // unused
+	// orderComplementWordFour  uint32 = ^orderWordFour  // unused
+	// orderComplementWordFive  uint32 = ^orderWordFive  // unused
+	// orderComplementWordSix   uint32 = ^orderWordSix   // unused
+	// orderComplementWordSeven uint32 = ^orderWordSeven // unused
 
 	// These fields provide convenient access to each of the words of the
 	// secp256k1 curve group order N / 2 to improve code readability and avoid
@@ -663,7 +663,7 @@ func (s *ModNScalar) reduce512(t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11,
 	//
 	// Technically the max possible value here is (N-1)^2 since the two scalars
 	// being multiplied are always mod N.  Nevertheless, it is safer to consider
-	// it to be (2^256-1)^2 = 2^512 - 2^256 + 1 since it is the product of two
+	// it to be (2^256-1)^2 = 2^512 - 2^257 + 1 since it is the product of two
 	// 256-bit values.
 	//
 	// The algorithm is to reduce the result modulo the prime by subtracting

--- a/dcrec/secp256k1/nonce.go
+++ b/dcrec/secp256k1/nonce.go
@@ -181,7 +181,7 @@ func NonceRFC6979(privKey []byte, hash []byte, extra []byte, version []byte, ext
 	// with potential additional data as described by section 3.6 of the RFC.
 	hasher := newHMACSHA256(k)
 	hasher.Write(oneInitializer)
-	hasher.Write(singleZero[:])
+	hasher.Write(singleZero)
 	hasher.Write(key)
 	k = hasher.Sum()
 
@@ -200,8 +200,8 @@ func NonceRFC6979(privKey []byte, hash []byte, extra []byte, version []byte, ext
 	// with potential additional data as described by section 3.6 of the RFC.
 	hasher.Reset()
 	hasher.Write(v)
-	hasher.Write(singleOne[:])
-	hasher.Write(key[:])
+	hasher.Write(singleOne)
+	hasher.Write(key)
 	k = hasher.Sum()
 
 	// Step G.
@@ -252,7 +252,7 @@ func NonceRFC6979(privKey []byte, hash []byte, extra []byte, version []byte, ext
 		// K = HMAC_K(V || 0x00)
 		hasher.Reset()
 		hasher.Write(v)
-		hasher.Write(singleZero[:])
+		hasher.Write(singleZero)
 		k = hasher.Sum()
 
 		// V = HMAC_K(V)

--- a/dcrec/secp256k1/nonce_test.go
+++ b/dcrec/secp256k1/nonce_test.go
@@ -150,7 +150,7 @@ func TestNonceRFC6979(t *testing.T) {
 		wantNonce := hexToBytes(test.expected)
 
 		// Ensure deterministically generated nonce is the expected value.
-		gotNonce := NonceRFC6979(privKey, hash[:], extraData, version,
+		gotNonce := NonceRFC6979(privKey, hash, extraData, version,
 			test.iterations)
 		gotNonceBytes := gotNonce.Bytes()
 		if !bytes.Equal(gotNonceBytes[:], wantNonce) {

--- a/dcrec/secp256k1/schnorr/signature.go
+++ b/dcrec/secp256k1/schnorr/signature.go
@@ -166,7 +166,7 @@ func schnorrVerify(sig *Signature, hash []byte, pubKey *secp256k1.PublicKey) err
 	// e = BLAKE-256(r || m) (Ensure r is padded to 32 bytes)
 	var commitmentInput [scalarSize * 2]byte
 	sig.r.PutBytesUnchecked(commitmentInput[0:scalarSize])
-	copy(commitmentInput[scalarSize:], hash[:])
+	copy(commitmentInput[scalarSize:], hash)
 	commitment := blake256.Sum256(commitmentInput[:])
 
 	// Step 6.
@@ -293,7 +293,7 @@ func schnorrSign(privKey, nonce *secp256k1.ModNScalar, hash []byte) (*Signature,
 	// e = BLAKE-256(r || m) (Ensure r is padded to 32 bytes)
 	var commitmentInput [scalarSize * 2]byte
 	r.PutBytesUnchecked(commitmentInput[0:scalarSize])
-	copy(commitmentInput[scalarSize:], hash[:])
+	copy(commitmentInput[scalarSize:], hash)
 	commitment := blake256.Sum256(commitmentInput[:])
 
 	// Step 8.

--- a/dcrec/secp256k1/schnorr/signature_test.go
+++ b/dcrec/secp256k1/schnorr/signature_test.go
@@ -382,7 +382,7 @@ func TestSchnorrSignAndVerifyRandom(t *testing.T) {
 		randByte = rng.Intn(len(badHash))
 		randBit = rng.Intn(7)
 		badHash[randByte] ^= 1 << randBit
-		if sig.Verify(badHash[:], pubKey) {
+		if sig.Verify(badHash, pubKey) {
 			t.Fatalf("verified signature for bad hash\nsig: %x\nhash: %x\n"+
 				"pubkey: %x", sig.Serialize(), badHash,
 				pubKey.SerializeCompressed())


### PR DESCRIPTION
This cleans up and corrects some comments in the `secp256k1` module and also addresses some linter complaints.