### PR TITLE
blockchain: Fix return amts test for Go 1.23+.

### DIFF
--- a/internal/blockchain/validate_test.go
+++ b/internal/blockchain/validate_test.go
@@ -1342,7 +1342,8 @@ func TestCalcTicketReturnAmounts(t *testing.T) {
 		"958002e000000000000000000000000000000000000000007000000")
 
 	// Default ticket commitment script hex for tests.
-	p2pkhCommitScriptHex := "ba76a914097e847d49c6806f6933e806a350f43b97ac70d088ac"
+	p2pkhCommitScriptHex := "6a1e4cab672d1d6db7605d428119ecf2e74edb533606958e" +
+		"0a87030000000058"
 
 	// createTestTicketOuts is a helper function that creates mock minimal outputs
 	// for a ticket with the given contribution amounts.  Note that this only


### PR DESCRIPTION
This updates the test for ticket return calculation amounts to work properly with Go 1.23+.

Specifically, it updates the default ticket commitment script that is used when creating the mock minimal ouputs that the tests then modify to be an actual commitment script.  Note that this is solely a test issue.

It appears that an invalid mock ticket commitment script was specified when the test was created, but since the tests only deal with the return amounts which are explicitly modified in the mock script to the values the test data requires, it did not previously matter.

However, the code that updates the mock script for the tests inadvertently relied on undocumented behavior in `hex.DecodeString` returning a slice with a larger capacity which allowed the slice to be extended when setting the appropriate amounts.  However, that is no longer the case as of Go 1.23+ which uncovered the otherwise invalid script.