### PR TITLE
multi: Build and doco updates for Go 1.23.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,13 +12,13 @@ jobs:
         go: ["1.21", "1.22"]
     steps:
       - name: Check out source
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b #v4.1.4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Set up Go
-        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 #v5.0.1
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version: ${{ matrix.go }}
       - name: Use lint cache
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: |
             ~/.cache/golangci-lint

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           bash ./.github/stablilize_testdata_timestamps.sh "${{ github.workspace }}"
       - name: Install Linters
-        run: "go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.58.1"
+        run: "go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1"
       - name: Build
         run: go build ./...
       - name: Test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.21", "1.22"]
+        go: ["1.22", "1.23"]
     steps:
       - name: Check out source
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ https://decred.org/downloads/
 
 <details><summary><b>Install Dependencies</b></summary>
 
-- **Go 1.21 or 1.22**
+- **Go 1.22 or 1.23**
 
   Installation instructions can be found here: https://golang.org/doc/install.
   Ensure Go was installed properly and is a supported version:


### PR DESCRIPTION
This consists of several commits to update the CI and documentation for Go 1.23. It also takes the opportunity to bump to the latest linter and action versions.

In particular:

- build: Update to latest action versions.
  - actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
  - actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 #v5.0.2
  - actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
- build: Update golangci-lint to v1.60.1.
- build: Test against Go 1.23 and remove Go 1.21 accordingly.
- docs: Update README.md to required Go 1.22/1.23.
