### PR TITLE
secp256k1/schnorr: Expose signature r and s.

### DIFF
--- a/dcrec/secp256k1/schnorr/signature.go
+++ b/dcrec/secp256k1/schnorr/signature.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2022 The Decred developers
+// Copyright (c) 2015-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -47,6 +47,16 @@ func NewSignature(r *secp256k1.FieldVal, s *secp256k1.ModNScalar) *Signature {
 	sig.r.Set(r).Normalize()
 	sig.s.Set(s)
 	return &sig
+}
+
+// R returns the r value of the signature.
+func (sig *Signature) R() secp256k1.FieldVal {
+	return sig.r
+}
+
+// S returns the s value of the signature.
+func (sig *Signature) S() secp256k1.ModNScalar {
+	return sig.s
 }
 
 // Serialize returns the Schnorr signature in the more strict format.

--- a/dcrec/secp256k1/schnorr/signature_test.go
+++ b/dcrec/secp256k1/schnorr/signature_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -261,6 +261,8 @@ func TestSchnorrSignAndVerify(t *testing.T) {
 		hash := hexToBytes(test.hash)
 		nonce := hexToModNScalar(test.nonce)
 		wantSig := hexToBytes(test.expected)
+		wantSigR := hexToFieldVal(test.expected[:64])
+		wantSigS := hexToModNScalar(test.expected[64:])
 
 		// Ensure the test data is sane by comparing the provided hashed message
 		// and nonce, in the case rfc6979 was used, to their calculated values.
@@ -299,6 +301,22 @@ func TestSchnorrSignAndVerify(t *testing.T) {
 		if !bytes.Equal(gotSigBytes, wantSig) {
 			t.Errorf("%s: unexpected signature -- got %x, want %x", test.name,
 				gotSigBytes, wantSig)
+			continue
+		}
+
+		// Ensure the R method returns the expected value.
+		gotSigR := gotSig.R()
+		if !gotSigR.Equals(wantSigR) {
+			t.Errorf("%s: unexpected R value -- got %064x, want %064x",
+				test.name, gotSigR.Bytes(), wantSigR.Bytes())
+			continue
+		}
+
+		// Ensure the S method returns the expected value.
+		gotSigS := gotSig.S()
+		if !gotSigS.Equals(wantSigS) {
+			t.Errorf("%s: unexpected S value -- got %064x, want %064x",
+				test.name, gotSigS.Bytes(), wantSigS.Bytes())
 			continue
 		}
 


### PR DESCRIPTION
This exposes the `R` and `S` values of Schnorr signatures in the same way they are exposed for ECDSA signatures.

The `R` and `S` values are useful for various computations and currently there is currently no easy and efficient way for external consumers to get the values.

It also adds some additional checks to the sign and verify tests to ensure the new methods return the expected values.