### PR TITLE
docker: Update image to golang:1.23.3-alpine3.20.

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -3,13 +3,13 @@
 ###############
 
 # Basic Go environment with git, SSL CA certs, and upx.
-# The image below is golang:1.23.2-alpine3.20 (linux/amd64)
+# The image below is golang:1.23.3-alpine3.20 (linux/amd64)
 # It's pulled by the digest (immutable id) to avoid supply-chain attacks.
 # Maintainer Note:
 #    To update to a new digest, you must first manually pull the new image:
 #    `docker pull golang:<new version>`
 #    Docker will print the digest of the new image after the pull has finished.
-FROM golang@sha256:9dd2625a1ff2859b8d8b01d8f7822c0f528942fe56cfe7a1e7c38d3b8d72d679 AS builder
+FROM golang@sha256:09742590377387b931261cbeb72ce56da1b0d750a27379f7385245b2b058b63a AS builder
 RUN apk add --no-cache git ca-certificates upx
 
 # Empty directory to be copied into place in the production image since it will


### PR DESCRIPTION
This updates the docker image to golang:1.23.3-alpine3.20.

To confirm the new digest:

```
$ docker pull golang:1.23.3-alpine3.20
1.23.3-alpine3.20: Pulling from library/golang
...
Digest: sha256:09742590377387b931261cbeb72ce56da1b0d750a27379f7385245b2b058b63a
...
```