### PR TITLE
[release-v2.0] main: Use backported peer updates.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/decred/dcrd/connmgr/v3 v3.1.2
 	github.com/decred/dcrd/container/apbf v1.0.1
 	github.com/decred/dcrd/container/lru v1.0.0
-	github.com/decred/dcrd/crypto/blake256 v1.0.1
+	github.com/decred/dcrd/crypto/blake256 v1.1.0
 	github.com/decred/dcrd/crypto/ripemd160 v1.0.2
 	github.com/decred/dcrd/database/v3 v3.0.2
 	github.com/decred/dcrd/dcrec v1.0.1
@@ -27,7 +27,7 @@ require (
 	github.com/decred/dcrd/lru v1.1.2
 	github.com/decred/dcrd/math/uint256 v1.0.2
 	github.com/decred/dcrd/mixing v0.4.1
-	github.com/decred/dcrd/peer/v3 v3.1.2
+	github.com/decred/dcrd/peer/v3 v3.1.3
 	github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.3.0
 	github.com/decred/dcrd/rpcclient/v8 v8.0.1
 	github.com/decred/dcrd/txscript/v4 v4.1.1

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/decred/dcrd/container/apbf v1.0.1 h1:oepQzRtLADudsrx0AmmowoU1kambozIN
 github.com/decred/dcrd/container/apbf v1.0.1/go.mod h1:paQplssZMsRhwOUcP6LDNDypyb7lwsFHrUKUkAPFWtQ=
 github.com/decred/dcrd/container/lru v1.0.0 h1:7foQymtbu18aQWYiY9RnNIeE+kvpiN+fiBQ3+viyJjI=
 github.com/decred/dcrd/container/lru v1.0.0/go.mod h1:vlPwj0l+IzAHhQSsbgQnJgO5Cte78+yI065V+Mc5PRQ=
-github.com/decred/dcrd/crypto/blake256 v1.0.1 h1:7PltbUIQB7u/FfZ39+DGa/ShuMyJ5ilcvdfma9wOH6Y=
-github.com/decred/dcrd/crypto/blake256 v1.0.1/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
+github.com/decred/dcrd/crypto/blake256 v1.1.0 h1:zPMNGQCm0g4QTY27fOCorQW7EryeQ/U0x++OzVrdms8=
+github.com/decred/dcrd/crypto/blake256 v1.1.0/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
 github.com/decred/dcrd/crypto/rand v1.0.0 h1:Ah9Asl36OZt09sGSMbJZuL1HfwGdlC38q/ZUeLDVKRg=
 github.com/decred/dcrd/crypto/rand v1.0.0/go.mod h1:coa7BbxSTiKH6esi257plGfMFYuGL4MTbQlLYnOdzpE=
 github.com/decred/dcrd/crypto/ripemd160 v1.0.2 h1:TvGTmUBHDU75OHro9ojPLK+Yv7gDl2hnUvRocRCjsys=
@@ -60,8 +60,8 @@ github.com/decred/dcrd/math/uint256 v1.0.2 h1:o8peafL5QmuXGTergI3YDpDU0eq5Z0pQi8
 github.com/decred/dcrd/math/uint256 v1.0.2/go.mod h1:7M/y9wJJvlyNG/f/X6mxxhxo9dgloZHFiOfbiscl75A=
 github.com/decred/dcrd/mixing v0.4.1 h1:W8ZCzhmNyzG1xjJMA3L6FOElmp98Ttnk3dDUxD6irAE=
 github.com/decred/dcrd/mixing v0.4.1/go.mod h1:ySvVwTZyVz5YvevA6YjPrB6pJEwTm7IkHohTfaiHh2c=
-github.com/decred/dcrd/peer/v3 v3.1.2 h1:Qe7SpqDtfM0HARmDYwr4WjUu16X6HQ7ZWNnHqE1swiw=
-github.com/decred/dcrd/peer/v3 v3.1.2/go.mod h1:M9FxNkHuEBtsRW5gwzIH4cJTWk5xSkxy9zG+TEL1N2Y=
+github.com/decred/dcrd/peer/v3 v3.1.3 h1:MmIVuP82VdBTqSqqz6+m8YFpsV7C7KT/jTzngleepyY=
+github.com/decred/dcrd/peer/v3 v3.1.3/go.mod h1:Uj2o/et9DswIv173UTIiQwZ3jb57vcjss8yAkUHAvcY=
 github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.3.0 h1:l0DnCcILTNrpy8APF3FLN312ChpkQaAuW30aC/RgBaw=
 github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.3.0/go.mod h1:j+kkRPXPJB5S9VFOsx8SQLcU7PTFkPKRc1aCHN4ENzA=
 github.com/decred/dcrd/rpcclient/v8 v8.0.1 h1:hd81e4w1KSqvPcozJlnz6XJfWKDNuahgooH/N5E8vOU=

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1128,6 +1128,7 @@ func (p *Peer) maybeAddDeadline(pendingResponses map[string]time.Time, msgCmd st
 		pendingResponses[wire.CmdMixCiphertexts] = deadline
 		pendingResponses[wire.CmdMixSlotReserve] = deadline
 		pendingResponses[wire.CmdMixDCNet] = deadline
+		pendingResponses[wire.CmdMixFactoredPoly] = deadline
 		pendingResponses[wire.CmdMixConfirm] = deadline
 		pendingResponses[wire.CmdMixSecrets] = deadline
 		pendingResponses[wire.CmdNotFound] = deadline
@@ -1203,6 +1204,8 @@ out:
 					fallthrough
 				case wire.CmdMixDCNet:
 					fallthrough
+				case wire.CmdMixFactoredPoly:
+					fallthrough
 				case wire.CmdMixConfirm:
 					fallthrough
 				case wire.CmdMixSecrets:
@@ -1215,6 +1218,7 @@ out:
 					delete(pendingResponses, wire.CmdMixCiphertexts)
 					delete(pendingResponses, wire.CmdMixSlotReserve)
 					delete(pendingResponses, wire.CmdMixDCNet)
+					delete(pendingResponses, wire.CmdMixFactoredPoly)
 					delete(pendingResponses, wire.CmdMixConfirm)
 					delete(pendingResponses, wire.CmdMixSecrets)
 					delete(pendingResponses, wire.CmdNotFound)


### PR DESCRIPTION
This updates the 2.0 release branch to use the latest version of the `peer` module which includes updates to ensure peers are not incorrectly disconnected in some cases when serving factored poly data.

In particular, the following updated module version is used:

    - github.com/decred/dcrd/peer/v3@v3.1.3

Note that it also cherry picks all of the commits included in updates to the `peer` module to ensure they are also included in the release branch even though it is not strictly necessary since `go.mod` has been updated to require the new release and thus will pull in the new code. However, from past experience, not having code backported to modules available in the release branch too leads to headaches for devs building from source in their local workspace with overrides such as those in `go.work`.

The following PRs are included:

- #3446
