### PR TITLE
[release-v2.0] main: Use backported mixing updates.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/decred/dcrd/gcs/v4 v4.1.0
 	github.com/decred/dcrd/lru v1.1.2
 	github.com/decred/dcrd/math/uint256 v1.0.2
-	github.com/decred/dcrd/mixing v0.4.1
+	github.com/decred/dcrd/mixing v0.4.2
 	github.com/decred/dcrd/peer/v3 v3.1.3
 	github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.3.0
 	github.com/decred/dcrd/rpcclient/v8 v8.0.1

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 )
 
 require (
-	decred.org/cspp/v2 v2.2.0 // indirect
+	decred.org/cspp/v2 v2.3.0 // indirect
 	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 // indirect
 	github.com/companyzero/sntrup4591761 v0.0.0-20220309191932-9e0f3af2f07a // indirect
 	github.com/dchest/siphash v1.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/decred/dcrd/lru v1.1.2 h1:KdCzlkxppuoIDGEvCGah1fZRicrDH36IipvlB1ROkFY
 github.com/decred/dcrd/lru v1.1.2/go.mod h1:gEdCVgXs1/YoBvFWt7Scgknbhwik3FgVSzlnCcXL2N8=
 github.com/decred/dcrd/math/uint256 v1.0.2 h1:o8peafL5QmuXGTergI3YDpDU0eq5Z0pQi88B8ym4PRA=
 github.com/decred/dcrd/math/uint256 v1.0.2/go.mod h1:7M/y9wJJvlyNG/f/X6mxxhxo9dgloZHFiOfbiscl75A=
-github.com/decred/dcrd/mixing v0.4.1 h1:W8ZCzhmNyzG1xjJMA3L6FOElmp98Ttnk3dDUxD6irAE=
-github.com/decred/dcrd/mixing v0.4.1/go.mod h1:ySvVwTZyVz5YvevA6YjPrB6pJEwTm7IkHohTfaiHh2c=
+github.com/decred/dcrd/mixing v0.4.2 h1:mpt2pNIFTI6L1hXrieAWJTQJv5t9WzHcNnhI+tnAG90=
+github.com/decred/dcrd/mixing v0.4.2/go.mod h1:VF87lOn41kitgWVOwmXoB4qMYF7+bxItZXyw4JfW3EQ=
 github.com/decred/dcrd/peer/v3 v3.1.3 h1:MmIVuP82VdBTqSqqz6+m8YFpsV7C7KT/jTzngleepyY=
 github.com/decred/dcrd/peer/v3 v3.1.3/go.mod h1:Uj2o/et9DswIv173UTIiQwZ3jb57vcjss8yAkUHAvcY=
 github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.3.0 h1:l0DnCcILTNrpy8APF3FLN312ChpkQaAuW30aC/RgBaw=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-decred.org/cspp/v2 v2.2.0 h1:VSOUC1w0Wo+QOGS0r1XO6TLnO16X67KuvpDmRRYyr08=
-decred.org/cspp/v2 v2.2.0/go.mod h1:9nO3bfvCheOPIFZw5f6sRQ42CjBFB5RKSaJ9Iq6G4MA=
+decred.org/cspp/v2 v2.3.0 h1:GC8emJnLbOVAkgBTHK/1wy6o/m0AVsN1r4m1ZnZZWjo=
+decred.org/cspp/v2 v2.3.0/go.mod h1:9nO3bfvCheOPIFZw5f6sRQ42CjBFB5RKSaJ9Iq6G4MA=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
 github.com/companyzero/sntrup4591761 v0.0.0-20220309191932-9e0f3af2f07a h1:clYxJ3Os0EQUKDDVU8M0oipllX0EkuFNBfhVQuIfyF0=

--- a/mixing/go.mod
+++ b/mixing/go.mod
@@ -3,7 +3,7 @@ module github.com/decred/dcrd/mixing
 go 1.18
 
 require (
-	decred.org/cspp/v2 v2.2.0
+	decred.org/cspp/v2 v2.3.0
 	github.com/companyzero/sntrup4591761 v0.0.0-20220309191932-9e0f3af2f07a
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.4

--- a/mixing/go.sum
+++ b/mixing/go.sum
@@ -1,5 +1,5 @@
-decred.org/cspp/v2 v2.2.0 h1:VSOUC1w0Wo+QOGS0r1XO6TLnO16X67KuvpDmRRYyr08=
-decred.org/cspp/v2 v2.2.0/go.mod h1:9nO3bfvCheOPIFZw5f6sRQ42CjBFB5RKSaJ9Iq6G4MA=
+decred.org/cspp/v2 v2.3.0 h1:GC8emJnLbOVAkgBTHK/1wy6o/m0AVsN1r4m1ZnZZWjo=
+decred.org/cspp/v2 v2.3.0/go.mod h1:9nO3bfvCheOPIFZw5f6sRQ42CjBFB5RKSaJ9Iq6G4MA=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
 github.com/companyzero/sntrup4591761 v0.0.0-20220309191932-9e0f3af2f07a h1:clYxJ3Os0EQUKDDVU8M0oipllX0EkuFNBfhVQuIfyF0=

--- a/mixing/mixclient/client.go
+++ b/mixing/mixclient/client.go
@@ -516,11 +516,11 @@ func (c *Client) prDelay(ctx context.Context, p *peer) error {
 	sendBefore := epoch.Add(-timeoutDuration - maxJitter)
 	sendAfter := epoch.Add(timeoutDuration)
 	var wait time.Duration
-	if now.After(sendBefore) {
+	if !now.Before(sendBefore) {
 		wait = sendAfter.Sub(now)
 		sendBefore = sendBefore.Add(c.epoch)
 	}
-	wait += p.msgJitter() + rand.Duration(time.Until(sendBefore))
+	wait += p.msgJitter() + rand.Duration(sendBefore.Sub(now))
 	timer := time.NewTimer(wait)
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
This updates the 2.0 release branch to use the latest version of the `mixing` module which includes various fixes to make decentralized mixing more robust against misbehaving peers.  All participants will need to update to the latest version to achieve the maximum anonymity set.

In particular, the following updated module version is used:

    - github.com/decred/dcrd/mixing@v0.4.2

Note that it also cherry picks all of the commits included in updates to the `mixing` module to ensure they are also included in the release branch even though it is not strictly necessary since `go.mod` has been updated to require the new release and thus will pull in the new code. However, from past experience, not having code backported to modules available in the release branch too leads to headaches for devs building from source in their local workspace with overrides such as those in `go.work`.

The following PRs are included:

- #3448
- #3451
- #3453
- #3454