### PR TITLE
docker: Update image to golang:1.23.4-alpine3.21.

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -3,13 +3,13 @@
 ###############
 
 # Basic Go environment with git, SSL CA certs, and upx.
-# The image below is golang:1.23.3-alpine3.20 (linux/amd64)
+# The image below is golang:1.23.4-alpine3.21 (linux/amd64)
 # It's pulled by the digest (immutable id) to avoid supply-chain attacks.
 # Maintainer Note:
 #    To update to a new digest, you must first manually pull the new image:
 #    `docker pull golang:<new version>`
 #    Docker will print the digest of the new image after the pull has finished.
-FROM golang@sha256:09742590377387b931261cbeb72ce56da1b0d750a27379f7385245b2b058b63a AS builder
+FROM golang@sha256:6c5c9590f169f77c8046e45c611d3b28fe477789acd8d3762d23d4744de69812 AS builder
 RUN apk add --no-cache git ca-certificates upx
 
 # Empty directory to be copied into place in the production image since it will


### PR DESCRIPTION
This updates the docker image to golang:1.23.4-alpine3.21.

To confirm the new digest:

```
$ docker pull golang:1.23.4-alpine3.21
1.23.4-alpine3.21: Pulling from library/golang
...
Digest: sha256:6c5c9590f169f77c8046e45c611d3b28fe477789acd8d3762d23d4744de69812
...
```