### PR TITLE
rand: Use stdlib crypto/rand.Read on Linux 6.11 + Go 1.24

### DIFF
--- a/crypto/rand/prng_linux.go
+++ b/crypto/rand/prng_linux.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2024 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+//go:build linux && go1.24
+
+package rand
+
+import (
+	"bytes"
+	"strconv"
+
+	"golang.org/x/sys/unix"
+)
+
+func init() {
+	var utsname unix.Utsname
+	err := unix.Uname(&utsname)
+	if err != nil {
+		return
+	}
+	if usesVDSO(utsname.Release[:]) {
+		readCryptoRand = true
+		globalMutex = nil
+	}
+}
+
+func usesVDSO(kernelVersion []byte) bool {
+	var v = kernelVersion
+
+	dot := bytes.IndexByte(v, '.')
+	if dot == -1 {
+		return false
+	}
+	maj, err := strconv.Atoi(string(v[:dot]))
+	if err != nil {
+		return false
+	}
+	v = v[dot+1:]
+	dot = bytes.IndexByte(v, '.')
+	if dot == -1 {
+		return false
+	}
+	min, err := strconv.Atoi(string(v[:dot]))
+	if err != nil {
+		return false
+	}
+
+	// crypto/rand is implemented by the vDSO on Linux >= 6.11.
+	return maj >= 7 || (maj == 6 && min >= 11)
+}


### PR DESCRIPTION
On Go 1.24 and Linux >=6.11, the standard library crypto/rand.Read method will read cryptographically secure bytes using the getrandom vDSO.  This avoids a context switch to kernel for a getrandom(2) system call and is much faster on small reads than both the previous stdlib crypto/rand reader, and our custom implemented userspace PRNG.  It also avoids the need to provide (additional) locking to the dcrd's package global userspace PRNG.

```
goos: linux
goarch: amd64
pkg: github.com/decred/dcrd/crypto/rand
cpu: Intel(R) Core(TM) i7-14700K
                     │    old.txt    │               new.txt               │
                     │    sec/op     │   sec/op     vs base                │
DcrdRead/4b-20          37.29n ±  2%   34.09n ± 3%   -8.58% (p=0.000 n=10)
DcrdRead/8b-20          41.80n ±  2%   40.41n ± 2%   -3.34% (p=0.000 n=10)
DcrdRead/32b-20         69.45n ±  1%   77.14n ± 2%  +11.07% (p=0.000 n=10)
DcrdRead/512b-20        538.9n ±  2%   674.9n ± 2%  +25.24% (p=0.000 n=10)
DcrdRead/1KiB-20        1.038µ ±  2%   1.308µ ± 1%  +26.01% (p=0.000 n=10)
DcrdRead/4KiB-20        4.069µ ±  2%   5.091µ ± 2%  +25.10% (p=0.000 n=10)
StdlibRead/4b-20       254.25n ±  1%   22.71n ± 2%  -91.07% (p=0.000 n=10)
StdlibRead/8b-20       253.80n ±  1%   29.28n ± 2%  -88.46% (p=0.000 n=10)
StdlibRead/32b-20      253.15n ±  2%   67.43n ± 1%  -73.36% (p=0.000 n=10)
StdlibRead/512b-20      990.3n ±  2%   682.4n ± 2%  -31.09% (p=0.000 n=10)
StdlibRead/1KiB-20      1.717µ ±  4%   1.288µ ± 2%  -24.93% (p=0.000 n=10)
StdlibRead/4KiB-20      6.167µ ±  1%   5.069µ ± 2%  -17.81% (p=0.000 n=10)
DcrdReadPRNG/4b-20      28.86n ±  2%   23.34n ± 2%  -19.12% (p=0.000 n=10)
DcrdReadPRNG/8b-20      33.69n ±  1%   30.17n ± 2%  -10.46% (p=0.000 n=10)
DcrdReadPRNG/32b-20     61.36n ±  1%   68.57n ± 1%  +11.75% (p=0.001 n=10)
DcrdReadPRNG/512b-20    531.4n ±  2%   671.1n ± 2%  +26.30% (p=0.000 n=10)
DcrdReadPRNG/1KiB-20    1.033µ ±  2%   1.312µ ± 1%  +26.96% (p=0.000 n=10)
DcrdReadPRNG/4KiB-20    3.976µ ±  2%   5.086µ ± 2%  +27.90% (p=0.000 n=10)
Int32N-20               46.53n ±  2%   40.80n ± 2%  -12.33% (p=0.000 n=10)
Uint32N-20              46.55n ±  2%   41.51n ± 2%  -10.81% (p=0.000 n=10)
Int64N-20               45.35n ±  2%   41.42n ± 2%   -8.65% (p=0.000 n=10)
Uint64N-20              45.37n ±  3%   41.36n ± 2%   -8.82% (p=0.000 n=10)
Duration-20             46.96n ± 10%   43.34n ± 5%   -7.70% (p=0.002 n=10)
ShuffleSlice-20         38.29n ±  2%   31.05n ± 2%  -18.91% (p=0.000 n=10)
geomean                 208.2n         160.1n       -23.10%
```
