### PR TITLE
mixclient: Wait for runs to finish before closing client 

### DIFF
--- a/mixing/mixclient/errors.go
+++ b/mixing/mixclient/errors.go
@@ -10,6 +10,8 @@ var (
 	ErrTooFewPeers = errors.New("not enough peers required to mix")
 
 	ErrUnknownPRs = errors.New("unable to participate in reformed session referencing unknown PRs")
+
+	ErrStopping = errors.New("mixing client is stopping")
 )
 
 // testPeerBlamedError describes the error condition of a misbehaving peer


### PR DESCRIPTION
This improves mix reliability in case a wallet is shut down while in the
middle of a mix run.

Requires additional wallet changes to properly order the shutdown of mixclient
and the RPC/SPV syncers.

Rebased over #3463.