### PR TITLE
secp256k1: Prepare v4.4.0.

### DIFF
--- a/dcrec/secp256k1/field_test.go
+++ b/dcrec/secp256k1/field_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2022 The Decred developers
-// Copyright (c) 2013-2022 Dave Collins
+// Copyright (c) 2015-2024 The Decred developers
+// Copyright (c) 2013-2024 Dave Collins
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/dcrec/secp256k1/go.mod
+++ b/dcrec/secp256k1/go.mod
@@ -2,4 +2,4 @@ module github.com/decred/dcrd/dcrec/secp256k1/v4
 
 go 1.17
 
-require github.com/decred/dcrd/crypto/blake256 v1.0.1
+require github.com/decred/dcrd/crypto/blake256 v1.1.0

--- a/dcrec/secp256k1/go.sum
+++ b/dcrec/secp256k1/go.sum
@@ -1,2 +1,2 @@
-github.com/decred/dcrd/crypto/blake256 v1.0.1 h1:7PltbUIQB7u/FfZ39+DGa/ShuMyJ5ilcvdfma9wOH6Y=
-github.com/decred/dcrd/crypto/blake256 v1.0.1/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
+github.com/decred/dcrd/crypto/blake256 v1.1.0 h1:zPMNGQCm0g4QTY27fOCorQW7EryeQ/U0x++OzVrdms8=
+github.com/decred/dcrd/crypto/blake256 v1.1.0/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=

--- a/dcrec/secp256k1/modnscalar.go
+++ b/dcrec/secp256k1/modnscalar.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 The Decred developers
+// Copyright (c) 2020-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/dcrec/secp256k1/modnscalar_bench_test.go
+++ b/dcrec/secp256k1/modnscalar_bench_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 The Decred developers
+// Copyright (c) 2020-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/dcrec/secp256k1/nonce.go
+++ b/dcrec/secp256k1/nonce.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/dcrec/secp256k1/nonce_test.go
+++ b/dcrec/secp256k1/nonce_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/dcrec/secp256k1/privkey.go
+++ b/dcrec/secp256k1/privkey.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2023 The Decred developers
+// Copyright (c) 2015-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 


### PR DESCRIPTION
This updates the `secp256k1` module dependencies, copyright year in the files modified since the previous release, and serves as a base for `dcrec/secp256k1/v4.4.0`.

The updated direct dependencies are as follows:

- github.com/decred/dcrd/crypto/blake256@v1.1.0

As compared to v4.3.0, this release includes the following notable changes:

- Provides a new exported method on `JacobianPoint` named `EquivalentNonConst` for efficiently determining if two Jacobian points represent the same affine point without needing to convert the points to affine
- Provides new exported methods for obtaining the `R` and `S` components of Schnorr signatures
- Optimized field inversion that results in about a 9% speedup which translates to about 3% faster public key derivation, 1% faster Schnorr signature verification, and 1.5% faster public key recovery from compact signatures
- The `DecompressY` method now returns normalized values
- Faster `blake256` hashing for Schnorr signing and verification
- Includes additional quality assurance tests for the new methods
- Includes benchmarks for the new methods where appropriate
- Documentation updates
