### PR TITLE
main: Increase runtime GC memlimit params.

### DIFF
--- a/dcrd.go
+++ b/dcrd.go
@@ -75,16 +75,14 @@ func dcrdMain() error {
 	// limits the garbage collector from excessively overallocating during
 	// bursts.  It does this by tweaking the soft memory limit.
 	//
-	// A soft upper memory limit is imposed that leaves plenty of headroom
-	// for the minimum recommended value and the target GC percentage is
-	// left at the default value to significantly reduce the number of GC
-	// cycles thereby reducing the amount of CPU time spent doing garbage
-	// collection.
+	// A soft upper memory limit is imposed that leaves plenty of headroom for
+	// the minimum recommended value and the target GC percentage is left at the
+	// default value to significantly reduce the number of GC cycles thereby
+	// reducing the amount of CPU time spent doing garbage collection.
 	//
-	// A limit of 1.5 GiB is used as a baseline, with an increase to the
-	// limit when the UTXO cache max size has been increased over the
-	// default.
-	const memLimitBase = (15 * (1 << 30)) / 10 // 1.5 GiB
+	// A limit of 1.8 GiB is used as a baseline, with an increase to the limit
+	// when the UTXO cache max size has been increased over the default.
+	const memLimitBase = (18 * (1 << 30)) / 10 // 1.8 GiB
 	softMemLimit := int64(memLimitBase)
 	if cfg.UtxoCacheMaxSize > defaultUtxoCacheMaxSize {
 		extra := int64(cfg.UtxoCacheMaxSize) - defaultUtxoCacheMaxSize


### PR DESCRIPTION
The current soft upper memory limit was calculated based on the main network and prior to the addition of the mixing pool.

As can be expected, the mixing pool requires extra memory which implies the soft memory limit should be raised to account for it.

This hasn't been an issue on the main network because the limit was intentionally set to include an additional overhead buffer to help future proof it which has been large enough to handle the additional memory requirements.

However, the test network also requires additional memory due to having a significantly longer chain.  The combination of those two factors comes very close to exhausting that additional overhead buffer and therefore can lead to excessive CPU utilization on the test network as the GC no longer has much working room to efficiently perform its job.

In order to address the aforementioned, this bumps the soft upper memory limit from 1.5 GiB to 1.8 GiB which accounts for both sources of increased memory usage along with a good overhead buffer on par with the original value prior to the additional memory requirements.

Note that the overall minimum recommended memory in the README does not need to be increased since the new limit is still 10% under the recommendation.