### PR TITLE
docker: Update image to golang:1.24.2-alpine3.21.

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -3,13 +3,13 @@
 ###############
 
 # Basic Go environment with git, SSL CA certs, and upx.
-# The image below is golang:1.24.1-alpine3.21 (linux/amd64)
+# The image below is golang:1.24.2-alpine3.21 (linux/amd64)
 # It's pulled by the digest (immutable id) to avoid supply-chain attacks.
 # Maintainer Note:
 #    To update to a new digest, you must first manually pull the new image:
 #    `docker pull golang:<new version>`
 #    Docker will print the digest of the new image after the pull has finished.
-FROM golang@sha256:43c094ad24b6ac0546c62193baeb3e6e49ce14d3250845d166c77c25f64b0386 AS builder
+FROM golang@sha256:7772cb5322baa875edd74705556d08f0eeca7b9c4b5367754ce3f2f00041ccee AS builder
 RUN apk add --no-cache git ca-certificates upx
 
 # Empty directory to be copied into place in the production image since it will


### PR DESCRIPTION
This updates the docker image to golang:1.24.2-alpine3.21.

To confirm the new digest:

```
$ docker pull golang:1.24.2-alpine3.21
1.24.2-alpine3.21: Pulling from library/golang
...
Digest: sha256:7772cb5322baa875edd74705556d08f0eeca7b9c4b5367754ce3f2f00041ccee
...
```

Alternatively, the index digest may be confirmed directly on from the [multi-platform image](https://hub.docker.com/layers/library/golang/1.24.2-alpine3.21/images/sha256-e0dafc77c7d66b0a051b882b32b2cf12e3d3a29ec11fdb9415ae74fa296c88c4) for `golang:1.24.2-alpine3.21` on docker hub.