### PR TITLE
multi: Update outdated IBD refs to inital chain sync.

### DIFF
--- a/docs/json_rpc_api.mediawiki
+++ b/docs/json_rpc_api.mediawiki
@@ -1081,7 +1081,7 @@ of the best block.
 : <code>difficultyratio</code>: <code>(numeric)</code> The current proof-of-work difficulty as a multiple of the minimum difficulty.
 : <code>verificationprogress</code>: <code>(numeric)</code> The chain verification progress estimate.
 : <code>chainwork</code>: <code>(string)</code> Hex encoded total work done for the chain.
-: <code>initialblockdownload</code>: <code>(boolean)</code> Best guess of whether this node is in the initial block download mode used to catch up the chain when it is far behind.
+: <code>initialblockdownload</code>: <code>(boolean)</code> Best guess of whether this node is in the initial chain sync mode used to catch up the chain when it is far behind.
 : <code>maxblocksize</code>: <code>(numeric)</code> The maximum allowed block size.
 : <code>deployments</code>: <code>(json array of objects)</code> Network consensus deployments.
 : <code>status</code>: <code>(string)</code> The deployment agenda's current status.

--- a/internal/blockchain/utxocache.go
+++ b/internal/blockchain/utxocache.go
@@ -53,7 +53,7 @@ const (
 	// periodicFlushInterval is the amount of time to wait before a periodic
 	// flush is required.
 	//
-	// The cache is flushed periodically during initial block download to avoid
+	// The cache is flushed periodically during the initial chain sync to avoid
 	// requiring a flush that would take a significant amount of time on
 	// shutdown (or, in the case of an unclean shutdown, a significant amount of
 	// time to initialize the cache when restarted).
@@ -113,7 +113,7 @@ type UtxoCacher interface {
 // UtxoCache is an unspent transaction output cache that sits on top of the
 // utxo set backend and provides significant runtime performance benefits at
 // the cost of some additional memory usage.  It drastically reduces the amount
-// of reading and writing to disk, especially during initial block download when
+// of reading and writing to disk, especially during the initial chain sync when
 // a very large number of blocks are being processed in quick succession.
 //
 // The UtxoCache is a read-through cache.  All utxo reads go through the cache.
@@ -162,7 +162,7 @@ type UtxoCache struct {
 
 	// lastFlushTime is the last time that the cache was flushed to the backend.
 	// It is used to determine when to periodically flush the cache to the
-	// backend during initial block download even if the cache isn't full to
+	// backend during the initial chain sync even if the cache isn't full to
 	// minimize the amount of progress lost if an unclean shutdown occurs.
 	lastFlushTime time.Time
 
@@ -1041,9 +1041,9 @@ func (c *UtxoCache) Initialize(ctx context.Context, b *BlockChain) error {
 }
 
 // ShutdownUtxoCache flushes the utxo cache to the backend on shutdown.  Since
-// the cache is flushed periodically during initial block download and flushed
-// after every block is connected after initial block download is complete,
-// this flush that occurs during shutdown should finish relatively quickly.
+// the cache is flushed periodically during the initial chain sync and flushed
+// after every block is connected after the initial chain sync is complete, this
+// flush that occurs during shutdown should finish relatively quickly.
 //
 // Note that if an unclean shutdown occurs, the cache will still be initialized
 // properly when restarted as during initialization it will replay blocks to

--- a/internal/netsync/README.md
+++ b/internal/netsync/README.md
@@ -10,10 +10,10 @@ Package netsync implements a concurrency safe block syncing protocol.
 ## Overview
 
 The provided implementation of SyncManager communicates with connected peers to
-perform an initial block download, keep the chain in sync, and announce new
-blocks connected to the chain. Currently the sync manager selects a single sync
-peer that it downloads all blocks from until it is up to date with the longest
-chain the sync peer is aware of.
+perform an initial chain sync, keep the chain in sync, and announce new blocks
+connected to the chain. Currently the sync manager selects a single sync peer
+that it downloads all blocks from until it is up to date with the longest chain
+the sync peer is aware of.
 
 ## License
 

--- a/internal/netsync/doc.go
+++ b/internal/netsync/doc.go
@@ -6,9 +6,9 @@
 Package netsync implements a concurrency safe block syncing protocol.
 
 The provided implementation of SyncManager communicates with connected peers to
-perform an initial block download, keep the chain in sync, and announce new
-blocks connected to the chain.  Currently the sync manager selects a single sync
-peer that it downloads all blocks from until it is up to date with the longest
-chain the sync peer is aware of.
+perform an initial chain sync, keep the chain in sync, and announce new blocks
+connected to the chain.  Currently the sync manager selects a single sync peer
+that it downloads all blocks from until it is up to date with the longest chain
+the sync peer is aware of.
 */
 package netsync

--- a/internal/rpcserver/rpcserverhelp.go
+++ b/internal/rpcserver/rpcserverhelp.go
@@ -246,7 +246,7 @@ var helpDescsEnUS = map[string]string{
 	"getblockchaininforesult-difficultyratio":      "The current proof-of-work difficulty as a multiple of the minimum difficulty.",
 	"getblockchaininforesult-verificationprogress": "The chain verification progress estimate.",
 	"getblockchaininforesult-chainwork":            "Hex encoded total work done for the chain.",
-	"getblockchaininforesult-initialblockdownload": "Best guess of whether this node is in the initial block download mode used to catch up the chain when it is far behind",
+	"getblockchaininforesult-initialblockdownload": "Best guess of whether this node is in the initial chain sync mode used to catch up the chain when it is far behind",
 	"getblockchaininforesult-maxblocksize":         "The maximum allowed block size.",
 	"getblockchaininforesult-deployments":          "Network consensus deployments.",
 	"getblockchaininforesult-deployments--desc":    "Consensus deployment agendas.",

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1094,10 +1094,10 @@ func (p *Peer) shouldHandleReadError(err error) bool {
 func (p *Peer) maybeAddDeadline(pendingResponses map[string]time.Time, msgCmd string) {
 	// Setup a deadline for each message being sent that expects a response.
 	//
-	// NOTE: Pings are intentionally ignored here since they are typically
-	// sent asynchronously and as a result of a long backlog of messages,
-	// such as is typical in the case of initial block download, the
-	// response won't be received in time.
+	// NOTE: Pings are intentionally ignored here since they are typically sent
+	// asynchronously and as a result of a long backlog of messages, such as is
+	// typical in the case of the initial chain sync, the response won't be
+	// received in time.
 	//
 	// Also, getheaders is intentionally ignored since there is no guaranteed
 	// response if the remote peer does not have any headers for the locator.


### PR DESCRIPTION
Historically, initial block download consisted of downloading all blocks one-by-one in a linear fashion and only storing them once they had been fully verified, so the terminology of initial block download accurately described the process.

However, the logic related to initial chain syncing was changed long ago to a much more efficient and robust approach based on downloading the headers first and then using those to guide the sync process.

This updates the remaining references in the code to more accurately refer to the initial chain sync process/mode accordingly.

The following is an overview of the changes:

- Updates the help text for the `initialblockdownload` field of the `getblockchaininfo` RPC to refer to the initial chain sync mode
  - NOTE: The RPC field name was not updated to avoid breaking the API
- Updates several comments in `peer`, `blockchain`, and `netsync`
- Updates the JSON-RPC API docs description to match



    