### PR TITLE
blockchain: Consolidate not in main chain err fmt.

### DIFF
--- a/internal/blockchain/chain.go
+++ b/internal/blockchain/chain.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2024 The Decred developers
+// Copyright (c) 2015-2025 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -487,8 +487,7 @@ func (b *BlockChain) lookupRecentBlock(hash *chainhash.Hash) (*dcrutil.Block, bo
 func (b *BlockChain) fetchMainChainBlockByNode(node *blockNode) (*dcrutil.Block, error) {
 	// Ensure the block is in the main chain.
 	if !b.bestChain.Contains(node) {
-		str := fmt.Sprintf("block %s is not in the main chain", node.hash)
-		return nil, errNotInMainChain(str)
+		return nil, errNotInMainChainByHash(node.hash)
 	}
 
 	// Attempt to load the block from the recent block cache.
@@ -1687,8 +1686,7 @@ func (b *BlockChain) HeaderByHash(hash *chainhash.Hash) (wire.BlockHeader, error
 func (b *BlockChain) HeaderByHeight(height int64) (wire.BlockHeader, error) {
 	node := b.bestChain.NodeByHeight(height)
 	if node == nil {
-		str := fmt.Sprintf("no block at height %d exists", height)
-		return wire.BlockHeader{}, errNotInMainChain(str)
+		return wire.BlockHeader{}, errNotInMainChainByHeight(height)
 	}
 
 	return node.Header(), nil
@@ -1716,8 +1714,7 @@ func (b *BlockChain) BlockByHeight(height int64) (*dcrutil.Block, error) {
 	// Lookup the block height in the best chain.
 	node := b.bestChain.NodeByHeight(height)
 	if node == nil {
-		str := fmt.Sprintf("no block at height %d exists", height)
-		return nil, errNotInMainChain(str)
+		return nil, errNotInMainChainByHeight(height)
 	}
 
 	// Return the block from either cache or the database.  Note that this is
@@ -1755,8 +1752,7 @@ func (b *BlockChain) MedianTimeByHash(hash *chainhash.Hash) (time.Time, error) {
 func (b *BlockChain) BlockHeightByHash(hash *chainhash.Hash) (int64, error) {
 	node := b.index.LookupNode(hash)
 	if node == nil || !b.bestChain.Contains(node) {
-		str := fmt.Sprintf("block %s is not in the main chain", hash)
-		return 0, errNotInMainChain(str)
+		return 0, errNotInMainChainByHash(*hash)
 	}
 
 	return node.height, nil
@@ -1769,8 +1765,7 @@ func (b *BlockChain) BlockHeightByHash(hash *chainhash.Hash) (int64, error) {
 func (b *BlockChain) BlockHashByHeight(height int64) (*chainhash.Hash, error) {
 	node := b.bestChain.NodeByHeight(height)
 	if node == nil {
-		str := fmt.Sprintf("no block at height %d exists", height)
-		return nil, errNotInMainChain(str)
+		return nil, errNotInMainChainByHeight(height)
 	}
 
 	return &node.hash, nil

--- a/internal/blockchain/chainio.go
+++ b/internal/blockchain/chainio.go
@@ -110,13 +110,24 @@ var (
 	treasuryTSpendBucketName = []byte("tspend")
 )
 
-// errNotInMainChain signifies that a block hash or height that is not in the
-// main chain was requested.
-type errNotInMainChain string
+// errNotInMainChainByHeight signifies a requested block height is not in the
+// main chain.
+type errNotInMainChainByHeight int64
 
 // Error implements the error interface.
-func (e errNotInMainChain) Error() string {
-	return string(e)
+func (e errNotInMainChainByHeight) Error() string {
+	return fmt.Sprintf("no block at height %d exists", int64(e))
+}
+
+// errNotInMainChainByHash signifies a block hash that is not in the main chain
+// was requested.  This also applies to the case when a requested block hash
+// does not exist at all since it most definitely is not in the main chain in
+// that case either.
+type errNotInMainChainByHash chainhash.Hash
+
+// Error implements the error interface.
+func (e errNotInMainChainByHash) Error() string {
+	return fmt.Sprintf("block %s is not in the main chain", chainhash.Hash(e))
 }
 
 // errDeserialize signifies that a problem was encountered when deserializing

--- a/internal/blockchain/chainio_test.go
+++ b/internal/blockchain/chainio_test.go
@@ -59,32 +59,26 @@ func hexToExtraData(s string) [32]byte {
 	return extraData
 }
 
-// isNotInMainChainErr returns whether or not the passed error is an
-// errNotInMainChain error.
-func isNotInMainChainErr(err error) bool {
-	var e errNotInMainChain
-	return errors.As(err, &e)
-}
-
-// TestErrNotInMainChain ensures the functions related to errNotInMainChain work
-// as expected.
+// TestErrNotInMainChain ensures the stringized output for the
+// [errNotInMainChainByHeight] and [errNotInMainChainByHash] errors works as
+// expected.
 func TestErrNotInMainChain(t *testing.T) {
-	const errStr = "no block at height 1 exists"
-	err := error(errNotInMainChain(errStr))
-
-	// Ensure the stringized output for the error is as expected.
-	if err.Error() != errStr {
-		t.Fatalf("errNotInMainChain returned unexpected error string - "+
-			"got %q, want %q", err, errStr)
+	// Ensure the stringized output for the by height error is as expected.
+	err1 := errNotInMainChainByHeight(1)
+	const err1Str = "no block at height 1 exists"
+	if err1.Error() != err1Str {
+		t.Fatalf("errNotInMainChainByHeight returned unexpected error string - "+
+			"got %q, want %q", err1, err1Str)
 	}
 
-	// Ensure error is detected as the correct type.
-	if !isNotInMainChainErr(err) {
-		t.Fatalf("isNotInMainChainErr did not detect as expected type")
-	}
-	err = errors.New("something else")
-	if isNotInMainChainErr(err) {
-		t.Fatalf("isNotInMainChainErr detected incorrect type")
+	// Ensure the stringized output for the by hash error is as expected.
+	const hashStr = "5ef2bb79795d7503c0ccc5cb6e0d4731992fc8c8c5b332c1c0e2c687d864c666"
+	hash := *mustParseHash(hashStr)
+	err2 := errNotInMainChainByHash(hash)
+	const err2Str = "block " + hashStr + " is not in the main chain"
+	if err2.Error() != err2Str {
+		t.Fatalf("errNotInMainChainByHash returned unexpected error string - "+
+			"got %q, want %q", err2, err2Str)
 	}
 }
 

--- a/internal/blockchain/validate_test.go
+++ b/internal/blockchain/validate_test.go
@@ -115,8 +115,7 @@ func TestBlockchainSpendJournal(t *testing.T) {
 		for i := int64(2); i <= chain.bestChain.Tip().height; i++ {
 			node := chain.bestChain.NodeByHeight(i)
 			if node == nil {
-				str := fmt.Sprintf("no block at height %d exists", i)
-				return errNotInMainChain(str)
+				return errNotInMainChainByHeight(i)
 			}
 			block, err := dbFetchBlockByNode(dbTx, node)
 			if err != nil {


### PR DESCRIPTION
This consolidates the error formatting logic for the various cases when a block that is not in the main chain is requested either by height or hash.

Rather than having a single generic error string that represents the various cases and repeatedly formatting the errors at each call site, this introduces two individual errors of the appropriate types and moves the error formatting onto the types.

It also updates the tests to remove `isNotInMainChainErr` which is a holdover that is no longer needed due to previous changes, as well as to ensure the new formatted error strings are the expected output.