### PR TITLE
chaincfg: Remove dcrdata.org seeders.

### DIFF
--- a/chaincfg/mainnetparams.go
+++ b/chaincfg/mainnetparams.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2016 The btcsuite developers
-// Copyright (c) 2015-2024 The Decred developers
+// Copyright (c) 2015-2025 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -576,7 +576,6 @@ func MainNetParams() *Params {
 		seeders: []string{
 			"mainnet-seed-1.decred.org",
 			"mainnet-seed-2.decred.org",
-			"mainnet-seed.dcrdata.org",
 			"mainnet-seed.jholdstock.uk",
 		},
 	}

--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2016 The btcsuite developers
-// Copyright (c) 2015-2024 The Decred developers
+// Copyright (c) 2015-2025 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -547,7 +547,6 @@ func TestNet3Params() *Params {
 		seeders: []string{
 			"testnet-seed-1.decred.org",
 			"testnet-seed-2.decred.org",
-			"testnet-seed.dcrdata.org",
 			"testnet-seed.jholdstock.uk",
 		},
 	}


### PR DESCRIPTION
dcrseeder no longer seems to be hosted on this domain

FYI @chappjc 