### PR TITLE
netsync: Rework external request from peer.

### DIFF
--- a/server.go
+++ b/server.go
@@ -1343,11 +1343,8 @@ func (sp *serverPeer) OnMiningState(_ *peer.Peer, msg *wire.MsgMiningState) {
 		}
 	}
 
-	err := sp.server.syncManager.RequestFromPeer(sp.syncMgrPeer, blockHashes,
+	sp.server.syncManager.RequestFromPeer(sp.syncMgrPeer, blockHashes,
 		voteHashes, nil)
-	if err != nil {
-		peerLog.Warnf("couldn't handle mining state message: %v", err)
-	}
 }
 
 // OnGetInitState is invoked when a peer receives a getinitstate wire message.
@@ -1429,11 +1426,8 @@ func (sp *serverPeer) OnGetInitState(_ *peer.Peer, msg *wire.MsgGetInitState) {
 // OnInitState is invoked when a peer receives a initstate wire message.  It
 // requests the data advertised in the message from the peer.
 func (sp *serverPeer) OnInitState(_ *peer.Peer, msg *wire.MsgInitState) {
-	err := sp.server.syncManager.RequestFromPeer(sp.syncMgrPeer,
-		msg.BlockHashes, msg.VoteHashes, msg.TSpendHashes)
-	if err != nil {
-		peerLog.Warnf("couldn't handle init state message: %v", err)
-	}
+	sp.server.syncManager.RequestFromPeer(sp.syncMgrPeer, msg.BlockHashes,
+		msg.VoteHashes, msg.TSpendHashes)
 }
 
 // OnTx is invoked when a peer receives a tx wire message.  It blocks until the


### PR DESCRIPTION
**This requires #3499**.

This reworks the logic that allows code external to the sync manager to request blocks, votes, and treasury spend transactions to both simplify and optimize it.  The method now makes use of the same logic the sync manager itself uses when requesting data and no longer potentially returns an error.

Of particular note is that it now uses the same much more efficient code path that the sync manager itself uses to determine if a transaction is needed as opposed to the rather expensive legacy utxo-based query approach.

Finally, this also modifies the logic to potentially make more than one request if needed since it is technically more accurate and avoids any possibility of error even though the current request sizes are nowhere near the limits.