### PR TITLE
mixclient: Fix test timeouts

### DIFF
--- a/mixing/mixclient/client.go
+++ b/mixing/mixclient/client.go
@@ -643,7 +643,7 @@ func (c *Client) waitForEpoch(ctx context.Context) (time.Time, error) {
 		if !timer.Stop() {
 			<-timer.C
 		}
-		return epoch, nil
+		return time.Now(), nil
 	case <-timer.C:
 		return epoch, nil
 	}


### PR DESCRIPTION
Tests were timing out due to mixpool checks that require KEs to not be received too early for their stated epochs.  To speed tests up, the mixclient's internal epoch ticker is manually ticked by the testing code, but this was causing test runs where KE messages were being rejected by mixpool, with the tests never completing and eventually timing out.

Using the current time as the epoch whenever the internal epoch ticker is manually ticked by tests resolves the issue and allows all tests to pass.

Timeouts spotted by @jholdstock.