### PR TITLE
docker: Update image to golang:1.25.0-alpine3.22.

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -3,13 +3,13 @@
 ###############
 
 # Basic Go environment with git, SSL CA certs, and upx.
-# The image below is golang:1.24.5-alpine3.22 (linux/amd64)
+# The image below is golang:1.25.0-alpine3.22 (linux/amd64)
 # It's pulled by the digest (immutable id) to avoid supply-chain attacks.
 # Maintainer Note:
 #    To update to a new digest, you must first manually pull the new image:
 #    `docker pull golang:<new version>`
 #    Docker will print the digest of the new image after the pull has finished.
-FROM golang@sha256:ddf52008bce1be455fe2b22d780b6693259aaf97b16383b6372f4b22dd33ad66 AS builder
+FROM golang@sha256:f18a072054848d87a8077455f0ac8a25886f2397f88bfdd222d6fafbb5bba440 AS builder
 RUN apk add --no-cache git ca-certificates upx
 
 # Empty directory to be copied into place in the production image since it will


### PR DESCRIPTION
This updates the docker image to golang:1.25.0-alpine3.22.

To confirm the new digest:

```
$ docker pull golang:1.25.0-alpine3.22
1.25.0-alpine3.22: Pulling from library/golang
...
Digest: sha256:f18a072054848d87a8077455f0ac8a25886f2397f88bfdd222d6fafbb5bba440
...
```

Alternatively, the index digest may be confirmed directly from the [multi-platform image](https://hub.docker.com/layers/library/golang/1.25.0-alpine3.22/images/sha256-68fc16b7551a4cf71251f343a47ff766ec4fa7c02fbdeb4c5ed2a14c2c23ea08) for `golang:1.25.0-alpine3.22` on docker hub.