### PR TITLE
mixclient: Avoid nil deref on errored run

### DIFF
--- a/mixing/mixclient/client.go
+++ b/mixing/mixclient/client.go
@@ -1375,7 +1375,7 @@ func (c *Client) run(ctx context.Context, ps *pairedSessions) (sesRun *sessionRu
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return sesRun, err
 	}
 	sesRun.freshGen = false
 	err = c.sendLocalPeerMsgs(ctx, ps.deadlines.recvKE, sesRun, msgKE)


### PR DESCRIPTION
When an unactionable error is returned by run(), the logger variable of the current session is used to log the error, automatically providing additional context to the log message regarding the session run which errored.  However, there was still one return statement which returned a nil run state, which could lead to a panic.