### PR TITLE
mixclient: Suppress ERR log for no active local peers

### DIFF
--- a/mixing/mixclient/client.go
+++ b/mixing/mixclient/client.go
@@ -1184,6 +1184,9 @@ func (c *Client) pairSession(ctx context.Context, ps *pairedSessions, prs []*wir
 			// err = nil would be an ineffectual assignment here;
 			// blamed is non-nil and the following if block will
 			// always be entered.
+
+		case errors.Is(err, errNoActiveLocalPeers):
+			return
 		}
 
 		if blamed != nil || errors.As(err, &blamed) {


### PR DESCRIPTION
The mixing client behavior is now correct but can create logs at ERR level for a normal and properly handled situation.  Detect and return early without logging these errors below.