### PR TITLE
docker: Update image to golang:1.25.3-alpine3.22.

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -3,13 +3,13 @@
 ###############
 
 # Basic Go environment with git, SSL CA certs, and upx.
-# The image below is golang:1.25.0-alpine3.22 (linux/amd64)
+# The image below is golang:1.25.3-alpine3.22 (linux/amd64)
 # It's pulled by the digest (immutable id) to avoid supply-chain attacks.
 # Maintainer Note:
 #    To update to a new digest, you must first manually pull the new image:
 #    `docker pull golang:<new version>`
 #    Docker will print the digest of the new image after the pull has finished.
-FROM golang@sha256:f18a072054848d87a8077455f0ac8a25886f2397f88bfdd222d6fafbb5bba440 AS builder
+FROM golang@sha256:aee43c3ccbf24fdffb7295693b6e33b21e01baec1b2a55acc351fde345e9ec34 AS builder
 RUN apk add --no-cache git ca-certificates upx
 
 # Empty directory to be copied into place in the production image since it will


### PR DESCRIPTION
This updates the docker image to golang:1.25.3-alpine3.22.

To confirm the new digest:

```
$ docker pull golang:1.25.3-alpine3.22
1.25.3-alpine3.22: Pulling from library/golang
...
Digest: sha256:aee43c3ccbf24fdffb7295693b6e33b21e01baec1b2a55acc351fde345e9ec34
...
```

Alternatively, the index digest may be confirmed directly from the [multi-platform image](https://hub.docker.com/layers/library/golang/1.25.3-alpine3.22/images/sha256-c3dc5d5e8cf34ccb2172fb8d1aa399aa13cd8b60d27bba891d18e3b436a0c5f6) for golang:1.25.3-alpine3.22 on docker hub.