### PR TITLE
blockchain: Allow trsy spends of maturing funds.

### DIFF
--- a/internal/blockchain/treasury_test.go
+++ b/internal/blockchain/treasury_test.go
@@ -943,7 +943,7 @@ func TestTSpendEmptyTreasury(t *testing.T) {
 	}
 
 	tspendAmount := dcrutil.Amount(devsub*(tvi*mul-uint64(params.CoinbaseMaturity)+
-		uint64(start-nextBlockHeight)) + 1) // One atom too many
+		uint64(start-nextBlockHeight)+1) + 1) // One atom too many
 	const tspendFee = 0
 	tspend := g.CreateTreasuryTSpend(privKey, []chaingen.AddressAmountTuple{
 		{Amount: tspendAmount - tspendFee}}, tspendFee, expiry)
@@ -970,8 +970,8 @@ func TestTSpendEmptyTreasury(t *testing.T) {
 	// ---------------------------------------------------------------------
 	// Generate a TVI worth of rewards and try to spend more.
 	//
-	//   ... -> b0 ... -> b7
-	//                 \-> btoomuch0
+	//   ... -> b#
+	//            \-> btoomuch0
 	// ---------------------------------------------------------------------
 
 	voteCount := params.TicketsPerBlock
@@ -987,8 +987,9 @@ func TestTSpendEmptyTreasury(t *testing.T) {
 		outs = g.OldestCoinbaseOuts()
 	}
 
-	// Ensure treasury balance is 1 atom less than calculated amount.
-	g.ExpectTreasuryBalance(int64(tspendAmount-tspendFee) - 1)
+	// Ensure treasury balance for the next block is 1 atom less than calculated
+	// amount.
+	g.ExpectTreasuryBalance(int64(tspendAmount-tspendFee-devsub) - 1)
 
 	// Try spending 1 atom more than treasury balance.
 	name := "btoomuch0"


### PR DESCRIPTION
**This is rebased on #3517**.

The existing treasury spending rules artificially increase the maturity by one more block than expected since they do not allow spending funds that are maturing in the same block that includes a treasury spend transaction.

This behavior technically does not match the specification already voted in by the stakeholders by the original decentralized treasury proposal, however, thankfully it does not actually currently matter because the existing max expenditure policy prevents the necessary preconditions for the extra maturity case to be hit.

Nevertheless, the existing policy will eventually need to change one way or another, as was noted in the original treasury proposal, and at that point it would otherwise be possible to hit the case in question if it is not corrected.

Thus, this updates the treasury spending rules to match the expected behavior by allowing funds that are maturing in the same block that includes a treasury spend.

Note that while this is technically a consensus change there is no risk of forking nodes form the network because, as previously mentioned, it is not possible to hit the condition under the current expenditure policy and changing the expenditure policy requires a consensus vote. So, either the current policy stays in place where it doesn't apply, or a new policy is voted in where it applies and that necessarily requires all nodes to upgrade anyway.
