### PR TITLE
chaincfg/chainhash: Prepare v1.0.5.

### DIFF
--- a/chaincfg/chainhash/go.mod
+++ b/chaincfg/chainhash/go.mod
@@ -2,4 +2,4 @@ module github.com/decred/dcrd/chaincfg/chainhash
 
 go 1.17
 
-require github.com/decred/dcrd/crypto/blake256 v1.0.1
+require github.com/decred/dcrd/crypto/blake256 v1.1.0

--- a/chaincfg/chainhash/go.sum
+++ b/chaincfg/chainhash/go.sum
@@ -1,2 +1,2 @@
-github.com/decred/dcrd/crypto/blake256 v1.0.1 h1:7PltbUIQB7u/FfZ39+DGa/ShuMyJ5ilcvdfma9wOH6Y=
-github.com/decred/dcrd/crypto/blake256 v1.0.1/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
+github.com/decred/dcrd/crypto/blake256 v1.1.0 h1:zPMNGQCm0g4QTY27fOCorQW7EryeQ/U0x++OzVrdms8=
+github.com/decred/dcrd/crypto/blake256 v1.1.0/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=


### PR DESCRIPTION
This updates the `chaincfg/chainhash` module to use the latest `blake256` module dependency and serves as a base for `chaincfg/chainhash/v1.0.5`.

The updated direct dependencies in this commit are as follows:

- github.com/decred/dcrd/crypto/blake256@v1.1.0

The full list of updated direct dependencies since the previous `chaincfg/chainhash/v1.0.4` release are the same as above.