### PR TITLE
docker: Update image to golang:1.25.4-alpine3.22.

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -3,13 +3,13 @@
 ###############
 
 # Basic Go environment with git, SSL CA certs, and upx.
-# The image below is golang:1.25.3-alpine3.22 (linux/amd64)
+# The image below is golang:1.25.4-alpine3.22 (linux/amd64)
 # It's pulled by the digest (immutable id) to avoid supply-chain attacks.
 # Maintainer Note:
 #    To update to a new digest, you must first manually pull the new image:
 #    `docker pull golang:<new version>`
 #    Docker will print the digest of the new image after the pull has finished.
-FROM golang@sha256:aee43c3ccbf24fdffb7295693b6e33b21e01baec1b2a55acc351fde345e9ec34 AS builder
+FROM golang@sha256:d3f0cf7723f3429e3f9ed846243970b20a2de7bae6a5b66fc5914e228d831bbb AS builder
 RUN apk add --no-cache git ca-certificates upx
 
 # Empty directory to be copied into place in the production image since it will


### PR DESCRIPTION
This updates the docker image to golang:1.25.4-alpine3.22.

To confirm the new digest:

```
$ docker pull golang:1.25.4-alpine3.22
1.25.4-alpine3.22: Pulling from library/golang
...
Digest: sha256:d3f0cf7723f3429e3f9ed846243970b20a2de7bae6a5b66fc5914e228d831bbb
...
```

Alternatively, the index digest may be confirmed directly from the [multi-platform image](https://hub.docker.com/layers/library/golang/1.25.4-alpine3.22/images/sha256-96f36e77302b6982abdd9849dff329feef03b0f2520c24dc2352fc4b33ed776d) for golang:1.25.4-alpine3.22 on docker hub.