### PR TITLE
dcrjson: Prepare v4.2.0

### DIFF
--- a/dcrjson/go.mod
+++ b/dcrjson/go.mod
@@ -2,6 +2,6 @@ module github.com/decred/dcrd/dcrjson/v4
 
 go 1.17
 
-require github.com/decred/dcrd/chaincfg/chainhash v1.0.4
+require github.com/decred/dcrd/chaincfg/chainhash v1.0.5
 
-require github.com/decred/dcrd/crypto/blake256 v1.0.1 // indirect
+require github.com/decred/dcrd/crypto/blake256 v1.1.0 // indirect

--- a/dcrjson/go.sum
+++ b/dcrjson/go.sum
@@ -1,4 +1,4 @@
-github.com/decred/dcrd/chaincfg/chainhash v1.0.4 h1:zRCv6tdncLfLTKYqu7hrXvs7hW+8FO/NvwoFvGsrluU=
-github.com/decred/dcrd/chaincfg/chainhash v1.0.4/go.mod h1:hA86XxlBWwHivMvxzXTSD0ZCG/LoYsFdWnCekkTMCqY=
-github.com/decred/dcrd/crypto/blake256 v1.0.1 h1:7PltbUIQB7u/FfZ39+DGa/ShuMyJ5ilcvdfma9wOH6Y=
-github.com/decred/dcrd/crypto/blake256 v1.0.1/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.5 h1:GwzXLsZoemdDxFdtj3GdW25Z+NXdN6nD3OjVtA+UwiE=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.5/go.mod h1:vCqZMGtKbyxJkdcVzP3Ryc9IvaspVUb7hO6t+rjxmcs=
+github.com/decred/dcrd/crypto/blake256 v1.1.0 h1:zPMNGQCm0g4QTY27fOCorQW7EryeQ/U0x++OzVrdms8=
+github.com/decred/dcrd/crypto/blake256 v1.1.0/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/decred/dcrd/blockchain/standalone/v2 v2.2.1
 	github.com/decred/dcrd/blockchain/v5 v5.0.1
 	github.com/decred/dcrd/certgen v1.1.3
-	github.com/decred/dcrd/chaincfg/chainhash v1.0.4
+	github.com/decred/dcrd/chaincfg/chainhash v1.0.5
 	github.com/decred/dcrd/chaincfg/v3 v3.2.1
 	github.com/decred/dcrd/connmgr/v3 v3.1.2
 	github.com/decred/dcrd/container/apbf v1.0.1


### PR DESCRIPTION
This updates the `dcrjson` module dependencies and serves as a base for `dcrjson/v4.2.0`.

The updated direct dependencies in this commit are as follows:

- github.com/decred/dcrd/chaincfg/chainhash@v1.0.5

The updated indirect dependencies in this commit are as follows:

- github.com/decred/dcrd/crypto/blake256@v1.1.0

The full list of updated direct and indirect dependencies since the previous `dcrjson/v4.1.0` release are the same as above.

Finally, all modules in the repository that depend on the module are tidied to ensure they are updated to use the latest versions hoisted forward as a result.