### PR TITLE
mixclient: Don't exit blame assignment for no local peers

### DIFF
--- a/mixing/mixclient/client.go
+++ b/mixing/mixclient/client.go
@@ -600,7 +600,7 @@ func (c *Client) sendLocalPeerMsgs(ctx context.Context, deadline time.Time, s *s
 			msgs = append(msgs, msg)
 		}
 	}
-	if len(msgs) == 0 {
+	if len(msgs) == 0 && msgMask != 0 {
 		return errNoActiveLocalPeers
 	}
 	sort.SliceStable(msgs, func(i, j int) bool {


### PR DESCRIPTION
When blame assignment first runs, if there no peers belonging to the client that triggered blame, blame assignment would exit early with errNoLocalPeers due to sendLocalPeerMsgs not sending any revealed secrets.  Fix this by not erroring as long as the message mask is 0 (which is only used by the first message publish during blame assignment).

Spotted by the TestXXDisruption family of tests timing out due to one of the two clients spun up by the test not managing the peer which first reported the blame.