### PR TITLE
blockchain/standalone: Prepare v2.2.2

### DIFF
--- a/blockchain/standalone/go.mod
+++ b/blockchain/standalone/go.mod
@@ -3,12 +3,12 @@ module github.com/decred/dcrd/blockchain/standalone/v2
 go 1.17
 
 require (
-	github.com/decred/dcrd/chaincfg/chainhash v1.0.4
-	github.com/decred/dcrd/wire v1.7.0
+	github.com/decred/dcrd/chaincfg/chainhash v1.0.5
+	github.com/decred/dcrd/wire v1.7.1
 )
 
 require (
-	github.com/decred/dcrd/crypto/blake256 v1.0.1 // indirect
+	github.com/decred/dcrd/crypto/blake256 v1.1.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	lukechampine.com/blake3 v1.3.0 // indirect
 )

--- a/blockchain/standalone/go.sum
+++ b/blockchain/standalone/go.sum
@@ -1,11 +1,11 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/decred/dcrd/chaincfg/chainhash v1.0.4 h1:zRCv6tdncLfLTKYqu7hrXvs7hW+8FO/NvwoFvGsrluU=
-github.com/decred/dcrd/chaincfg/chainhash v1.0.4/go.mod h1:hA86XxlBWwHivMvxzXTSD0ZCG/LoYsFdWnCekkTMCqY=
-github.com/decred/dcrd/crypto/blake256 v1.0.1 h1:7PltbUIQB7u/FfZ39+DGa/ShuMyJ5ilcvdfma9wOH6Y=
-github.com/decred/dcrd/crypto/blake256 v1.0.1/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
-github.com/decred/dcrd/wire v1.7.0 h1:5JHiDjEQeS4XUl4PfnTZYLwAD/E/+LwBmPRec/fP76o=
-github.com/decred/dcrd/wire v1.7.0/go.mod h1:lAqrzV0SU4kyV6INLEJgDtUjJaTaVKrbF4LHtaYl+zU=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.5 h1:GwzXLsZoemdDxFdtj3GdW25Z+NXdN6nD3OjVtA+UwiE=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.5/go.mod h1:vCqZMGtKbyxJkdcVzP3Ryc9IvaspVUb7hO6t+rjxmcs=
+github.com/decred/dcrd/crypto/blake256 v1.1.0 h1:zPMNGQCm0g4QTY27fOCorQW7EryeQ/U0x++OzVrdms8=
+github.com/decred/dcrd/crypto/blake256 v1.1.0/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
+github.com/decred/dcrd/wire v1.7.1 h1:kDuHBiY1Qv9rBxYKgC2RgyPy7IOA2WRf00jqHwpr16I=
+github.com/decred/dcrd/wire v1.7.1/go.mod h1:eP9XRsMloy+phlntkTAaAm611JgLv8NqY1YJoRxkNKU=
 github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 lukechampine.com/blake3 v1.3.0 h1:sJ3XhFINmHSrYCgl958hscfIa3bw8x4DqMP3u1YvoYE=

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.2.0
 	github.com/decred/dcrd/rpcclient/v8 v8.0.1
 	github.com/decred/dcrd/txscript/v4 v4.1.1
-	github.com/decred/dcrd/wire v1.7.0
+	github.com/decred/dcrd/wire v1.7.1
 	github.com/decred/dcrtest/dcrdtest v1.0.1-0.20240404170936-a2529e936df1
 	github.com/decred/go-socks v1.1.0
 	github.com/decred/slog v1.2.0


### PR DESCRIPTION
This updates the `blockchain/standalone` module dependencies and serves as a base for `blockchain/standalone/v2.2.2`.

The updated direct dependencies in this commit are as follows:

- github.com/decred/dcrd/chaincfg/chainhash@v1.0.5
- github.com/decred/dcrd/wire@v1.7.1

The updated indirect dependencies in this commit are as follows:

- github.com/decred/dcrd/crypto/blake256@v1.1.0

The full list of updated direct and indirect dependencies since the previous `blockchain/standalone/v2.2.1` release are the same as above.

Finally, all modules in the repository are tidied to ensure they are updated to use the latest versions hoisted forward as a result.