### PR TITLE
multi: Remove old format build tags.

### DIFF
--- a/certgen/certgen_ed25519.go
+++ b/certgen/certgen_ed25519.go
@@ -1,10 +1,9 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015-2024 The Decred developers
+// Copyright (c) 2015-2025 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 //go:build go1.13
-// +build go1.13
 
 package certgen
 

--- a/certgen/net.go
+++ b/certgen/net.go
@@ -1,10 +1,9 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2017 The Decred developers
+// Copyright (c) 2015-2025 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 //go:build !appengine
-// +build !appengine
 
 package certgen
 

--- a/certgen/net_noop.go
+++ b/certgen/net_noop.go
@@ -1,10 +1,9 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2017 The Decred developers
+// Copyright (c) 2015-2025 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 //go:build appengine
-// +build appengine
 
 package certgen
 

--- a/chaincfg/generatesubsidytables.go
+++ b/chaincfg/generatesubsidytables.go
@@ -1,9 +1,8 @@
-// Copyright (c) 2019-2020 The Decred developers
+// Copyright (c) 2019-2025 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/chaincfg/subsidydefinitions.go
+++ b/chaincfg/subsidydefinitions.go
@@ -1,9 +1,8 @@
-// Copyright (c) 2019 The Decred developers
+// Copyright (c) 2019-2025 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 //go:build subsidydefs
-// +build subsidydefs
 
 package chaincfg
 

--- a/container/apbf/generateapbftable.go
+++ b/container/apbf/generateapbftable.go
@@ -1,9 +1,8 @@
-// Copyright (c) 2021 The Decred developers
+// Copyright (c) 2021-2025 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/dcrec/secp256k1/genprecomps.go
+++ b/dcrec/secp256k1/genprecomps.go
@@ -1,5 +1,5 @@
 // Copyright 2015 The btcsuite developers
-// Copyright (c) 2015-2022 The Decred developers
+// Copyright (c) 2015-2025 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -7,7 +7,6 @@
 // It is called by go generate and used to automatically generate pre-computed
 // tables used to accelerate operations.
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/require.go
+++ b/require.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 The Decred developers
+// Copyright (c) 2019-2025 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -8,7 +8,6 @@
 // binary.
 
 //go:build require
-// +build require
 
 package main
 


### PR DESCRIPTION
Since all of the modules with build tags require Go 1.17 as a minimum, remove the obsolete old format build tags.

This will be required to prevent newer versions of `govet` from complaining about the use of the obsolete format.