### PR TITLE
build: Update to latest actions and linter.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           bash ./.github/stablilize_testdata_timestamps.sh "${{ github.workspace }}"
       - name: Install Linters
-        run: "go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0"
+        run: "go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.6.1"
       - name: Build
         run: go build ./...
       - name: Test


### PR DESCRIPTION
**This requires #3540**.

This consists of a couple of commits to update the CI to the latest linter and action versions.

In particular:

- build: Update to latest action versions.
  - actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
  - actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
- build: Update golangci-lint to v2.6.1