### PR TITLE
build: Use golangci action and make parallel.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,6 +4,19 @@ permissions:
   contents: read
 
 jobs:
+  resolve-modules:
+    name: Resolve Go modules
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Check out source
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - id: set-matrix
+        run: |
+          echo "Resolving modules in $(pwd)" && \
+          MODPATHS=$(find . -mindepth 2 -type f -name go.mod -printf '{"workdir":"%h"},') && \
+          echo "matrix={\"include\":[${MODPATHS%,}]}" >> $GITHUB_OUTPUT
   build:
     name: Go CI
     runs-on: ubuntu-latest
@@ -17,20 +30,30 @@ jobs:
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version: ${{ matrix.go }}
-      - name: Use lint cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: |
-            ~/.cache/golangci-lint
-          key: go-lint-${{ matrix.go }}-${{ hashFiles('./go.sum') }}
-          restore-keys: go-lint-${{ matrix.go }}
       - name: Stablilize testdata timestamps
         run: |
           bash ./.github/stablilize_testdata_timestamps.sh "${{ github.workspace }}"
-      - name: Install Linters
-        run: "go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.6.1"
       - name: Build
         run: go build ./...
       - name: Test
         run: |
           sh ./run_tests.sh
+  lint:
+    name: Lint
+    needs: resolve-modules
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.resolve-modules.outputs.matrix ) }}
+    steps:
+      - name: Check out source
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Set up Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version: "1.24"
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@0a35821d5c230e903fcfe077583637dea1b27b47 # v9.0.0
+        with:
+          install-mode: "goinstall"
+          version: e3b3bac5dd24906c205db9224fde52efd4d238cf # v2.6.1
+          working-directory: ${{ matrix.workdir }}

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -3,8 +3,10 @@
 set -ex
 
 # This script runs the tests for all packages in all Go modules in the
-# repository and then runs the linters for all Go modules in the repository by
-# invoking the separate linter script.
+# repository.
+#
+# It also runs the linters for all Go modules in the repository by invoking the
+# separate linter script when not running as a GitHub action.
 
 go version
 
@@ -28,8 +30,8 @@ for module in $MODULES; do
   )
 done
 
-# run linters on all modules
-. ./lint.sh
+# run linters on all modules when not running as a GitHub action
+[ -z "$GITHUB_ACTIONS" ] && source ./lint.sh
 
 echo "------------------------------------------"
 echo "Tests completed successfully!"


### PR DESCRIPTION
This updates the GitHub workflow to use the official `golangci-lint` action which has additional caching logic and also creates GitHub annotations for any issues which makes it easier to identify issues versus needing to dig through build logs.

It also arranges for the linters to run as a separate job which executes in parallel to the go build and tests.

Since the repository has multiple modules and `golangci-lint` does not support running all modules in the repository directly, this uses a separate job to resolve the modules dynamically and then feeds those into the separate linter job as a matrix of modules (work directories) so the linters run on all modules in the repo.

In order to avoid running the linters as a part of the normal test job while still allowing developers to invoke all of the tests and linters via the `run_tests.sh` script, it is updated to only conditionally invoke the separate `lint.sh` script when not running as a GitHub action.

Finally, it pins the dependencies for both the action itself as well as the `golangci-lint` version by using their respective hashes.