### PR TITLE
peer: Use dcrd crypto/rand for self detect nonce.

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -2058,10 +2058,7 @@ func (p *Peer) localVersionMsg() (*wire.MsgVersion, error) {
 	// Generate a unique nonce for this peer so self connections can be
 	// detected.  This is accomplished by adding it to a size-limited map of
 	// recently seen nonces.
-	nonce, err := wire.RandomUint64()
-	if err != nil {
-		return nil, err
-	}
+	nonce := rand.Uint64()
 	sentNonces.Put(nonce)
 
 	// Version message.


### PR DESCRIPTION
Use the newer, more efficient, and error-free `crypto/rand` module for generating the nonce used to detect self connections instead of the older `wire` method.