### PR TITLE
build: Ensure root directory is linted.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
         id: resolve_module_dirs
         run: |
           echo "Resolving modules in $(pwd)" && \
-          MODPATHS=$(find . -mindepth 2 -type f -name go.mod -printf '"%h",') && \
+          MODPATHS=$(find . -type f -name go.mod -printf '"%h",') && \
           echo "module_dirs=[${MODPATHS%,}]" >> $GITHUB_OUTPUT
   build:
     name: Go CI


### PR DESCRIPTION
**Rebased on #3542** 

Mostly just refactoring, but a big change here to ensure the root directory is not missed when running linters.