### PR TITLE
chaincfg: Introduce max treasury spend agenda.

### DIFF
--- a/blockchain/fullblocktests/params.go
+++ b/blockchain/fullblocktests/params.go
@@ -70,6 +70,11 @@ const (
 	// block reward subsidy split to 1% PoW, 89% PoS, and 10% Treasury as
 	// defined in DCP0012.
 	voteIDChangeSubsidySplitR2 = "changesubsidysplitr2"
+
+	// voteIDMaxTreasurySpend is the vote ID for the agenda that changes the
+	// maximum expenditure policy of the treasury account to be limited to 4% of
+	// the total available treasury per month as defined in DCP0013.
+	voteIDMaxTreasurySpend = "maxtreasuryspend"
 )
 
 // newHashFromStr converts the passed big-endian hex string into a
@@ -530,6 +535,34 @@ var regNetParams = &chaincfg.Params{
 					Id:          "yes",
 					Description: "change to the new consensus rules",
 					Bits:        0x0040, // Bit 6
+					IsAbstain:   false,
+					IsNo:        false,
+				}},
+			},
+			StartTime:  0,             // Always available for vote
+			ExpireTime: math.MaxInt64, // Never expires
+		}},
+		12: {{
+			Vote: chaincfg.Vote{
+				Id:          voteIDMaxTreasurySpend,
+				Description: "Change maximum treasury expenditure policy as defined in DCP0013",
+				Mask:        0x0006, // Bits 1 and 2
+				Choices: []chaincfg.Choice{{
+					Id:          "abstain",
+					Description: "abstain voting for change",
+					Bits:        0x0000,
+					IsAbstain:   true,
+					IsNo:        false,
+				}, {
+					Id:          "no",
+					Description: "keep the existing consensus rules",
+					Bits:        0x0002, // Bit 1
+					IsAbstain:   false,
+					IsNo:        true,
+				}, {
+					Id:          "yes",
+					Description: "change to the new consensus rules",
+					Bits:        0x0004, // Bit 2
 					IsAbstain:   false,
 					IsNo:        false,
 				}},

--- a/chaincfg/mainnetparams.go
+++ b/chaincfg/mainnetparams.go
@@ -483,6 +483,34 @@ func MainNetParams() *Params {
 				StartTime:  1682294400, // Apr 24th, 2023
 				ExpireTime: 1745452800, // Apr 24th, 2025
 			}},
+			11: {{
+				Vote: Vote{
+					Id:          VoteIDMaxTreasurySpend,
+					Description: "Change maximum treasury expenditure policy as defined in DCP0013",
+					Mask:        0x0006, // Bits 1 and 2
+					Choices: []Choice{{
+						Id:          "abstain",
+						Description: "abstain voting for change",
+						Bits:        0x0000,
+						IsAbstain:   true,
+						IsNo:        false,
+					}, {
+						Id:          "no",
+						Description: "keep the existing consensus rules",
+						Bits:        0x0002, // Bit 1
+						IsAbstain:   false,
+						IsNo:        true,
+					}, {
+						Id:          "yes",
+						Description: "change to the new consensus rules",
+						Bits:        0x0004, // Bit 2
+						IsAbstain:   false,
+						IsNo:        false,
+					}},
+				},
+				StartTime:  1762992000, // Nov 13th, 2025
+				ExpireTime: 1826064000, // Nov 13th, 2027
+			}},
 		},
 
 		// Enforce current block version once majority of the network has

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2016 The btcsuite developers
-// Copyright (c) 2015-2023 The Decred developers
+// Copyright (c) 2015-2025 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -173,6 +173,11 @@ const (
 	// block reward subsidy split to 1% PoW, 89% PoS, and 10% Treasury as
 	// defined in DCP0012.
 	VoteIDChangeSubsidySplitR2 = "changesubsidysplitr2"
+
+	// VoteIDMaxTreasurySpend is the vote ID for the agenda that changes the
+	// maximum expenditure policy of the treasury account to be limited to 4% of
+	// the total available treasury per month as defined in DCP0013.
+	VoteIDMaxTreasurySpend = "maxtreasuryspend"
 )
 
 // ConsensusDeployment defines details related to a specific consensus rule
@@ -599,15 +604,20 @@ type Params struct {
 	// that define a single "expenditure window".
 	TreasuryExpenditureWindow uint64
 
-	// TreasuryExpenditurePolicy is the number of previous
-	// TreasuryExpenditureWindows that defines how far back to calculate
-	// the average expenditure of the treasury for an expenditure policy
-	// check.
+	// TreasuryExpenditurePolicy defines the number of previous expenditure
+	// windows to use when calculating the average expenditure of the treasury
+	// for an expenditure policy check.
+	//
+	// NOTE: This only applies to the treasury expenditure policy introduced by
+	// DCP0006.  Later iterations of the policy do not make use of it.
 	TreasuryExpenditurePolicy uint64
 
 	// TreasuryExpenditureBootstrap is the value to use as previous average
-	// expenditure when there are no treasury spends inside the entire
-	// window defined by TreasuryExpenditurePolicy.
+	// expenditure when there are no treasury spends inside the entire window
+	// defined by TreasuryExpenditurePolicy.
+	//
+	// NOTE: This only applies to the treasury expenditure policy introduced by
+	// DCP0006.  Later iterations of the policy do not make use of it.
 	TreasuryExpenditureBootstrap uint64
 
 	// seeders defines a list of seeders for the network that are used

--- a/chaincfg/regnetparams.go
+++ b/chaincfg/regnetparams.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2023 The Decred developers
+// Copyright (c) 2018-2025 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -473,6 +473,34 @@ func RegNetParams() *Params {
 						Id:          "yes",
 						Description: "change to the new consensus rules",
 						Bits:        0x0040, // Bit 6
+						IsAbstain:   false,
+						IsNo:        false,
+					}},
+				},
+				StartTime:  0,             // Always available for vote
+				ExpireTime: math.MaxInt64, // Never expires
+			}},
+			12: {{
+				Vote: Vote{
+					Id:          VoteIDMaxTreasurySpend,
+					Description: "Change maximum treasury expenditure policy as defined in DCP0013",
+					Mask:        0x0006, // Bits 1 and 2
+					Choices: []Choice{{
+						Id:          "abstain",
+						Description: "abstain voting for change",
+						Bits:        0x0000,
+						IsAbstain:   true,
+						IsNo:        false,
+					}, {
+						Id:          "no",
+						Description: "keep the existing consensus rules",
+						Bits:        0x0002, // Bit 1
+						IsAbstain:   false,
+						IsNo:        true,
+					}, {
+						Id:          "yes",
+						Description: "change to the new consensus rules",
+						Bits:        0x0004, // Bit 2
 						IsAbstain:   false,
 						IsNo:        false,
 					}},

--- a/chaincfg/simnetparams.go
+++ b/chaincfg/simnetparams.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2016 The btcsuite developers
-// Copyright (c) 2015-2023 The Decred developers
+// Copyright (c) 2015-2025 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -484,6 +484,35 @@ func SimNetParams() *Params {
 						Id:          "yes",
 						Description: "change to the new consensus rules",
 						Bits:        0x0040, // Bit 6
+						IsAbstain:   false,
+						IsNo:        false,
+					}},
+				},
+				ForcedChoiceID: "yes",
+				StartTime:      0,             // Always available for vote
+				ExpireTime:     math.MaxInt64, // Never expires
+			}},
+			12: {{
+				Vote: Vote{
+					Id:          VoteIDMaxTreasurySpend,
+					Description: "Change maximum treasury expenditure policy as defined in DCP0013",
+					Mask:        0x0006, // Bits 1 and 2
+					Choices: []Choice{{
+						Id:          "abstain",
+						Description: "abstain voting for change",
+						Bits:        0x0000,
+						IsAbstain:   true,
+						IsNo:        false,
+					}, {
+						Id:          "no",
+						Description: "keep the existing consensus rules",
+						Bits:        0x0002, // Bit 1
+						IsAbstain:   false,
+						IsNo:        true,
+					}, {
+						Id:          "yes",
+						Description: "change to the new consensus rules",
+						Bits:        0x0004, // Bit 2
 						IsAbstain:   false,
 						IsNo:        false,
 					}},

--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -458,6 +458,34 @@ func TestNet3Params() *Params {
 				StartTime:  1682294400, // Apr 24th, 2023
 				ExpireTime: 1745452800, // Apr 24th, 2025
 			}},
+			12: {{
+				Vote: Vote{
+					Id:          VoteIDMaxTreasurySpend,
+					Description: "Change maximum treasury expenditure policy as defined in DCP0013",
+					Mask:        0x0006, // Bits 1 and 2
+					Choices: []Choice{{
+						Id:          "abstain",
+						Description: "abstain voting for change",
+						Bits:        0x0000,
+						IsAbstain:   true,
+						IsNo:        false,
+					}, {
+						Id:          "no",
+						Description: "keep the existing consensus rules",
+						Bits:        0x0002, // Bit 1
+						IsAbstain:   false,
+						IsNo:        true,
+					}, {
+						Id:          "yes",
+						Description: "change to the new consensus rules",
+						Bits:        0x0004, // Bit 2
+						IsAbstain:   false,
+						IsNo:        false,
+					}},
+				},
+				StartTime:  1762992000, // Nov 13th, 2025
+				ExpireTime: 1826064000, // Nov 13th, 2027
+			}},
 		},
 
 		// Enforce current block version once majority of the network has


### PR DESCRIPTION
This adds a new definition for the upcoming agenda vote to change the treasury spend limits to 4% of the total available treasury per expenditure window as defined in DCP0013.

It does not include any code to make decisions based on the status of the agenda or bump block versions.  It only adds the definition for the agenda.