### PR TITLE
multi: Implement DCP0013 max treasury spend vote.

### DIFF
--- a/internal/blockchain/validate.go
+++ b/internal/blockchain/validate.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2023 The Decred developers
+// Copyright (c) 2015-2025 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -1011,7 +1011,7 @@ func isDCP0005Violation(network wire.CurrencyNet, header *wire.BlockHeader, bloc
 func (b *BlockChain) isOldBlockVersionByMajority(header *wire.BlockHeader, blockHash *chainhash.Hash, prevNode *blockNode) bool {
 	// Note that the latest block version for all networks other than the main
 	// network is one higher.
-	latestBlockVersion := int32(10)
+	latestBlockVersion := int32(11)
 	if b.chainParams.Net != wire.MainNet {
 		latestBlockVersion++
 	}

--- a/internal/mining/mining.go
+++ b/internal/mining/mining.go
@@ -265,11 +265,11 @@ const (
 	// will require changes to the generated block.  Using the wire constant
 	// for generated block version could allow creation of invalid blocks
 	// for the updated version.
-	generatedBlockVersion = 10
+	generatedBlockVersion = 11
 
 	// generatedBlockVersionTest is the version of the block being generated
 	// for networks other than the main network.
-	generatedBlockVersionTest = 11
+	generatedBlockVersionTest = 12
 
 	// blockHeaderOverhead is the max number of bytes it takes to serialize
 	// a block header and max possible transaction count.


### PR DESCRIPTION
**This requires #3548**.

---

This implements the agenda for voting on the max treasury expenditure policy update defined in [DCP0013](https://github.com/decred/dcps/blob/master/dcp-0013/dcp-0013.mediawiki) along with consensus tests.

In particular, once the vote has passed and is active, the treasury expenditure policy will allow a max of 4% of the balance to be spent per policy window with a minimum floor imposed.

The following is an overview of the changes:

- Generate new version blocks and reject old version blocks after a super majority has been reached
  - New block version on mainnet is version 11
  - New block version on testnet is version 12
- Introduce a convenience function for determining if the vote passed and is now active
- Modify the treasury expenditure policy to enforce the new semantics in accordance with the state of the vote
- Add tests for determining if the agenda is active for both mainnet and the regression test network
- Add tests to ensure proper behavior for the modified policy once the agenda is active as follows:
  - Treasury spends that spend more than 4% of treasury balance when it is more than the minimum floor are rejected
  - Treasury spends that spend exactly 4% of treasury balance when it is more than the minimum floor are accepted
  - The maximum expenditure amount for the policy window is the same regardless of where the treasury spends happen in the policy window
  - Repeat all of the above cases when the treasury balance is low enough that the minimum floor is in effect