### PR TITLE
gencerts: Uncapitalize -S description

### DIFF
--- a/cmd/gencerts/gencerts.go
+++ b/cmd/gencerts/gencerts.go
@@ -42,7 +42,7 @@ type config struct {
 	CAKey string   `short:"K" description:"key of CA certificate"`
 	Hosts []string `short:"H" description:"hostname or IP certificate is valid for; may be specified multiple times"`
 	Local bool     `short:"L" description:"append localhost, 127.0.0.1, and ::1 to hosts if not already specified"`
-	Signs bool     `short:"S" description:"Allow certificate to sign leaf certificates"`
+	Signs bool     `short:"S" description:"allow certificate to sign leaf certificates"`
 	Org   string   `short:"o" description:"organization"`
 	Algo  string   `short:"a" description:"key algorithm (one of: P-256, P-384, P-521, Ed25519, RSA4096)"`
 	Years int      `short:"y" description:"years certificate is valid for"`


### PR DESCRIPTION
Keep consistency with all of the other descriptions.