### PR TITLE
chaincfg: Update assume valid for release.

### DIFF
--- a/chaincfg/mainnetparams.go
+++ b/chaincfg/mainnetparams.go
@@ -133,9 +133,9 @@ func MainNetParams() *Params {
 		// forks rejection checkpoint.  This is intended to be updated
 		// periodically with new releases.
 		//
-		// Block f04628f2fe7fd0d33055dc326936a6af3772ec5226525bc8fca50631f3081faa
-		// Height: 865184
-		AssumeValid: *newHashFromStr("f04628f2fe7fd0d33055dc326936a6af3772ec5226525bc8fca50631f3081faa"),
+		// Block 458d6a8e11c916d4149ca8bc5c7aaaaf16cc61971b0c20764c07edf85df44eb6
+		// Height: 1026597
+		AssumeValid: *newHashFromStr("458d6a8e11c916d4149ca8bc5c7aaaaf16cc61971b0c20764c07edf85df44eb6"),
 
 		// MinKnownChainWork is the minimum amount of known total work for the
 		// chain at a given point in time.  This is intended to be updated

--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -131,9 +131,9 @@ func TestNet3Params() *Params {
 		// forks rejection checkpoint.  This is intended to be updated
 		// periodically with new releases.
 		//
-		// Block 88d61d7609c06c8e171f050789f6649d21525a144b820026f7b396476a05a44b
-		// Height: 1377455
-		AssumeValid: *newHashFromStr("88d61d7609c06c8e171f050789f6649d21525a144b820026f7b396476a05a44b"),
+		// Block e5d29f04aa33d19dfe4935ca2e70d8f640a7263b653f57ce600b6829d6f2cf48
+		// Height: 1780540
+		AssumeValid: *newHashFromStr("e5d29f04aa33d19dfe4935ca2e70d8f640a7263b653f57ce600b6829d6f2cf48"),
 
 		// MinKnownChainWork is the minimum amount of known total work for the
 		// chain at a given point in time.  This is intended to be updated


### PR DESCRIPTION
This updates the assumed valid block for the main and test networks as follows:

> mainnet: 458d6a8e11c916d4149ca8bc5c7aaaaf16cc61971b0c20764c07edf85df44eb6
> testnet: e5d29f04aa33d19dfe4935ca2e70d8f640a7263b653f57ce600b6829d6f2cf48

Reviewers should verify that:

- The mainnet block is at least 4032 blocks behind the current tip
- The testnet block is at least 10080 blocks behind the current tip
- The block hashes and heights match their local instances

The following commands may be used to verify the hashes:
```
$ dcrctl getblockhash 1026597
458d6a8e11c916d4149ca8bc5c7aaaaf16cc61971b0c20764c07edf85df44eb6
$ dcrctl --testnet getblockhash 1780540
e5d29f04aa33d19dfe4935ca2e70d8f640a7263b653f57ce600b6829d6f2cf48
```