### PR TITLE
chaincfg: Update min known chain work for release.

### DIFF
--- a/chaincfg/mainnetparams.go
+++ b/chaincfg/mainnetparams.go
@@ -141,9 +141,9 @@ func MainNetParams() *Params {
 		// chain at a given point in time.  This is intended to be updated
 		// periodically with new releases.
 		//
-		// Block bf7f2d914bea1b97f5db0cd914f0ff6ca7f8675e1c4d0984776a74de48948568
-		// Height: 869216
-		MinKnownChainWork: hexToBigInt("000000000000000000000000000000000000000000243845fb2fb3d8f20ddfeb"),
+		// Block 48681f17d2c8fc545f9a1d2e9ee9946e9b33d3923ed1ab6180f04a641c26302a
+		// Height: 1030629
+		MinKnownChainWork: hexToBigInt("000000000000000000000000000000000000000000243868232c14b8224643b6"),
 
 		// The miner confirmation window is defined as:
 		//   target proof of work timespan / target proof of work spacing

--- a/chaincfg/testnetparams.go
+++ b/chaincfg/testnetparams.go
@@ -139,9 +139,9 @@ func TestNet3Params() *Params {
 		// chain at a given point in time.  This is intended to be updated
 		// periodically with new releases.
 		//
-		// Block 50f244d269a61de438a9075f7f5477a785f3f2060d2c7127f000093176a386fa
-		// Height: 1387535
-		MinKnownChainWork: hexToBigInt("000000000000000000000000000000000000000000000000f376ddb1ab3a5a2e"),
+		// Block dc499445d16fb002e3f62388276bbf6669b9ac721d99069a77314490c4abb5a2
+		// Height: 1790621
+		MinKnownChainWork: hexToBigInt("000000000000000000000000000000000000000000000000f377240e146195df"),
 
 		// Consensus rule change deployments.
 		//


### PR DESCRIPTION
This updates the minimum known chain work values for the main and test networks as follows:

> mainnet: 0x000000000000000000000000000000000000000000243868232c14b8224643b6
> testnet: 0x000000000000000000000000000000000000000000000000f377240e146195df

The following commands may be used to verify:
```
$ dcrctl getblockhash 1030629 | dcrctl getblockheader - | jq -r .chainwork
000000000000000000000000000000000000000000243868232c14b8224643b6
$ dcrctl --testnet getblockhash 1790621 | dcrctl --testnet getblockheader - | jq -r .chainwork
000000000000000000000000000000000000000000000000f377240e146195df
```