### PR TITLE
addrmgr: Use atomic types.

### DIFF
--- a/addrmgr/go.mod
+++ b/addrmgr/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrd/addrmgr/v3
 
-go 1.18
+go 1.19
 
 require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.5


### PR DESCRIPTION
Use atomic types introduced in .19, which necessitates bumping go version in go.mod to 1.19.