### PR TITLE
wire: Pass pointers by interface to writeElement

### DIFF
--- a/wire/bench_test.go
+++ b/wire/bench_test.go
@@ -665,3 +665,14 @@ func BenchmarkHashH(b *testing.B) {
 		_ = chainhash.HashH(txBytes)
 	}
 }
+
+// BenchmarkWriteMessageN benchmarks the genesis coinbase serialization
+// using the WriteMessageN function.
+func BenchmarkWriteMessageN(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err := WriteMessageN(io.Discard, &genesisCoinbaseTx, ProtocolVersion, MainNet)
+		if err != nil {
+			b.Fatalf("WriteMessageN: unexpected error: %v", err)
+		}
+	}
+}

--- a/wire/blockheader.go
+++ b/wire/blockheader.go
@@ -222,9 +222,9 @@ func readBlockHeader(r io.Reader, pver uint32, bh *BlockHeader) error {
 // opposed to encoding for the wire.
 func writeBlockHeader(w io.Writer, pver uint32, bh *BlockHeader) error {
 	sec := uint32(bh.Timestamp.Unix())
-	return writeElements(w, bh.Version, &bh.PrevBlock, &bh.MerkleRoot,
-		&bh.StakeRoot, bh.VoteBits, bh.FinalState, bh.Voters,
-		bh.FreshStake, bh.Revocations, bh.PoolSize, bh.Bits, bh.SBits,
-		bh.Height, bh.Size, sec, bh.Nonce, bh.ExtraData,
-		bh.StakeVersion)
+	return writeElements(w, &bh.Version, &bh.PrevBlock, &bh.MerkleRoot,
+		&bh.StakeRoot, &bh.VoteBits, &bh.FinalState, &bh.Voters,
+		&bh.FreshStake, &bh.Revocations, &bh.PoolSize, &bh.Bits, &bh.SBits,
+		&bh.Height, &bh.Size, &sec, &bh.Nonce, &bh.ExtraData,
+		&bh.StakeVersion)
 }

--- a/wire/common.go
+++ b/wire/common.go
@@ -417,51 +417,51 @@ func writeElement(w io.Writer, element interface{}) error {
 	// Attempt to write the element based on the concrete type via fast
 	// type assertions first.
 	switch e := element.(type) {
-	case uint8:
-		err := binarySerializer.PutUint8(w, e)
+	case *uint8:
+		err := binarySerializer.PutUint8(w, *e)
 		if err != nil {
 			return err
 		}
 		return nil
 
-	case uint16:
-		err := binarySerializer.PutUint16(w, littleEndian, e)
+	case *uint16:
+		err := binarySerializer.PutUint16(w, littleEndian, *e)
 		if err != nil {
 			return err
 		}
 		return nil
 
-	case int32:
-		err := binarySerializer.PutUint32(w, littleEndian, uint32(e))
+	case *int32:
+		err := binarySerializer.PutUint32(w, littleEndian, uint32(*e))
 		if err != nil {
 			return err
 		}
 		return nil
 
-	case uint32:
-		err := binarySerializer.PutUint32(w, littleEndian, e)
+	case *uint32:
+		err := binarySerializer.PutUint32(w, littleEndian, *e)
 		if err != nil {
 			return err
 		}
 		return nil
 
-	case int64:
-		err := binarySerializer.PutUint64(w, littleEndian, uint64(e))
+	case *int64:
+		err := binarySerializer.PutUint64(w, littleEndian, uint64(*e))
 		if err != nil {
 			return err
 		}
 		return nil
 
-	case uint64:
-		err := binarySerializer.PutUint64(w, littleEndian, e)
+	case *uint64:
+		err := binarySerializer.PutUint64(w, littleEndian, *e)
 		if err != nil {
 			return err
 		}
 		return nil
 
-	case bool:
+	case *bool:
 		var err error
-		if e {
+		if *e {
 			err = binarySerializer.PutUint8(w, 0x01)
 		} else {
 			err = binarySerializer.PutUint8(w, 0x00)
@@ -472,7 +472,15 @@ func writeElement(w io.Writer, element interface{}) error {
 		return nil
 
 	// Message header checksum.
-	case [4]byte:
+	case *[4]byte:
+		_, err := w.Write(e[:])
+		if err != nil {
+			return err
+		}
+		return nil
+
+	// Block header final state.
+	case *[6]byte:
 		_, err := w.Write(e[:])
 		if err != nil {
 			return err
@@ -480,7 +488,7 @@ func writeElement(w io.Writer, element interface{}) error {
 		return nil
 
 	// Message header command.
-	case [CommandSize]uint8:
+	case *[CommandSize]uint8:
 		_, err := w.Write(e[:])
 		if err != nil {
 			return err
@@ -488,7 +496,7 @@ func writeElement(w io.Writer, element interface{}) error {
 		return nil
 
 	// IP address.
-	case [16]byte:
+	case *[16]byte:
 		_, err := w.Write(e[:])
 		if err != nil {
 			return err
@@ -549,29 +557,29 @@ func writeElement(w io.Writer, element interface{}) error {
 		}
 		return nil
 
-	case ServiceFlag:
-		err := binarySerializer.PutUint64(w, littleEndian, uint64(e))
+	case *ServiceFlag:
+		err := binarySerializer.PutUint64(w, littleEndian, uint64(*e))
 		if err != nil {
 			return err
 		}
 		return nil
 
-	case InvType:
-		err := binarySerializer.PutUint32(w, littleEndian, uint32(e))
+	case *InvType:
+		err := binarySerializer.PutUint32(w, littleEndian, uint32(*e))
 		if err != nil {
 			return err
 		}
 		return nil
 
-	case CurrencyNet:
-		err := binarySerializer.PutUint32(w, littleEndian, uint32(e))
+	case *CurrencyNet:
+		err := binarySerializer.PutUint32(w, littleEndian, uint32(*e))
 		if err != nil {
 			return err
 		}
 		return nil
 
-	case RejectCode:
-		err := binarySerializer.PutUint8(w, uint8(e))
+	case *RejectCode:
+		err := binarySerializer.PutUint8(w, uint8(*e))
 		if err != nil {
 			return err
 		}

--- a/wire/common_test.go
+++ b/wire/common_test.go
@@ -52,6 +52,38 @@ func (r *fakeRandReader) Read(p []byte) (int, error) {
 	return n, r.err
 }
 
+func newInt32(v int32) *int32 {
+	return &v
+}
+
+func newUint32(v uint32) *uint32 {
+	return &v
+}
+
+func newInt64(v int64) *int64 {
+	return &v
+}
+
+func newUint64(v uint64) *uint64 {
+	return &v
+}
+
+func newBool(v bool) *bool {
+	return &v
+}
+
+func newServiceFlag(v ServiceFlag) *ServiceFlag {
+	return &v
+}
+
+func newInvType(v InvType) *InvType {
+	return &v
+}
+
+func newCurrencyNet(v CurrencyNet) *CurrencyNet {
+	return &v
+}
+
 // TestElementWire tests wire encode and decode for various element types.  This
 // is mainly to test the "fast" paths in readElement and writeElement which use
 // type assertions to avoid reflection when possible.
@@ -62,30 +94,30 @@ func TestElementWire(t *testing.T) {
 		in  interface{} // Value to encode
 		buf []byte      // Wire encoding
 	}{
-		{int32(1), []byte{0x01, 0x00, 0x00, 0x00}},
-		{uint32(256), []byte{0x00, 0x01, 0x00, 0x00}},
+		{newInt32(1), []byte{0x01, 0x00, 0x00, 0x00}},
+		{newUint32(256), []byte{0x00, 0x01, 0x00, 0x00}},
 		{
-			int64(65536),
+			newInt64(65536),
 			[]byte{0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00},
 		},
 		{
-			uint64(4294967296),
+			newUint64(4294967296),
 			[]byte{0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00},
 		},
 		{
-			true,
+			newBool(true),
 			[]byte{0x01},
 		},
 		{
-			false,
+			newBool(false),
 			[]byte{0x00},
 		},
 		{
-			[4]byte{0x01, 0x02, 0x03, 0x04},
+			&[4]byte{0x01, 0x02, 0x03, 0x04},
 			[]byte{0x01, 0x02, 0x03, 0x04},
 		},
 		{
-			[CommandSize]byte{
+			&[CommandSize]byte{
 				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
 				0x09, 0x0a, 0x0b, 0x0c,
 			},
@@ -95,7 +127,7 @@ func TestElementWire(t *testing.T) {
 			},
 		},
 		{
-			[16]byte{
+			&[16]byte{
 				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
 				0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
 			},
@@ -119,15 +151,15 @@ func TestElementWire(t *testing.T) {
 			},
 		},
 		{
-			SFNodeNetwork,
+			newServiceFlag(SFNodeNetwork),
 			[]byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 		},
 		{
-			InvTypeTx,
+			newInvType(InvTypeTx),
 			[]byte{0x01, 0x00, 0x00, 0x00},
 		},
 		{
-			MainNet,
+			newCurrencyNet(MainNet),
 			[]byte{0xf9, 0x00, 0xb4, 0xd9},
 		},
 		// Type not supported by the "fast" path and requires reflection.
@@ -184,20 +216,20 @@ func TestElementWireErrors(t *testing.T) {
 		writeErr error       // Expected write error
 		readErr  error       // Expected read error
 	}{
-		{int32(1), 0, io.ErrShortWrite, io.EOF},
-		{uint32(256), 0, io.ErrShortWrite, io.EOF},
-		{int64(65536), 0, io.ErrShortWrite, io.EOF},
-		{true, 0, io.ErrShortWrite, io.EOF},
-		{[4]byte{0x01, 0x02, 0x03, 0x04}, 0, io.ErrShortWrite, io.EOF},
+		{newInt32(1), 0, io.ErrShortWrite, io.EOF},
+		{newUint32(256), 0, io.ErrShortWrite, io.EOF},
+		{newInt64(65536), 0, io.ErrShortWrite, io.EOF},
+		{newBool(true), 0, io.ErrShortWrite, io.EOF},
+		{&[4]byte{0x01, 0x02, 0x03, 0x04}, 0, io.ErrShortWrite, io.EOF},
 		{
-			[CommandSize]byte{
+			&[CommandSize]byte{
 				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
 				0x09, 0x0a, 0x0b, 0x0c,
 			},
 			0, io.ErrShortWrite, io.EOF,
 		},
 		{
-			[16]byte{
+			&[16]byte{
 				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
 				0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
 			},
@@ -212,9 +244,9 @@ func TestElementWireErrors(t *testing.T) {
 			}),
 			0, io.ErrShortWrite, io.EOF,
 		},
-		{SFNodeNetwork, 0, io.ErrShortWrite, io.EOF},
-		{InvTypeTx, 0, io.ErrShortWrite, io.EOF},
-		{MainNet, 0, io.ErrShortWrite, io.EOF},
+		{newServiceFlag(SFNodeNetwork), 0, io.ErrShortWrite, io.EOF},
+		{newInvType(InvTypeTx), 0, io.ErrShortWrite, io.EOF},
+		{newCurrencyNet(MainNet), 0, io.ErrShortWrite, io.EOF},
 	}
 
 	t.Logf("Running %d tests", len(tests))

--- a/wire/invvect.go
+++ b/wire/invvect.go
@@ -75,5 +75,5 @@ func readInvVect(r io.Reader, pver uint32, iv *InvVect) error {
 
 // writeInvVect serializes an InvVect to w depending on the protocol version.
 func writeInvVect(w io.Writer, pver uint32, iv *InvVect) error {
-	return writeElements(w, iv.Type, &iv.Hash)
+	return writeElements(w, &iv.Type, &iv.Hash)
 }

--- a/wire/msgcfilterv2.go
+++ b/wire/msgcfilterv2.go
@@ -115,7 +115,7 @@ func (msg *MsgCFilterV2) BtcEncode(w io.Writer, pver uint32) error {
 		return err
 	}
 
-	err = writeElement(w, msg.ProofIndex)
+	err = writeElement(w, &msg.ProofIndex)
 	if err != nil {
 		return err
 	}
@@ -125,8 +125,8 @@ func (msg *MsgCFilterV2) BtcEncode(w io.Writer, pver uint32) error {
 		return err
 	}
 
-	for _, hash := range msg.ProofHashes {
-		err := writeElement(w, hash)
+	for i := range msg.ProofHashes {
+		err := writeElement(w, &msg.ProofHashes[i])
 		if err != nil {
 			return err
 		}

--- a/wire/msgfeefilter.go
+++ b/wire/msgfeefilter.go
@@ -43,7 +43,7 @@ func (msg *MsgFeeFilter) BtcEncode(w io.Writer, pver uint32) error {
 		return messageError(op, ErrMsgInvalidForPVer, msg)
 	}
 
-	return writeElement(w, msg.MinFee)
+	return writeElement(w, &msg.MinFee)
 }
 
 // Command returns the protocol command string for the message.  This is part

--- a/wire/msggetblocks.go
+++ b/wire/msggetblocks.go
@@ -97,7 +97,7 @@ func (msg *MsgGetBlocks) BtcEncode(w io.Writer, pver uint32) error {
 		return messageError(op, ErrTooManyLocators, msg)
 	}
 
-	err := writeElement(w, msg.ProtocolVersion)
+	err := writeElement(w, &msg.ProtocolVersion)
 	if err != nil {
 		return err
 	}

--- a/wire/msggetcfsv2.go
+++ b/wire/msggetcfsv2.go
@@ -47,7 +47,7 @@ func (msg *MsgGetCFsV2) BtcEncode(w io.Writer, pver uint32) error {
 		return messageError(op, ErrMsgInvalidForPVer, msg)
 	}
 
-	return writeElements(w, &msg.StartHash, msg.EndHash)
+	return writeElements(w, &msg.StartHash, &msg.EndHash)
 }
 
 // Command returns the protocol command string for the message.  This is part

--- a/wire/msggetheaders.go
+++ b/wire/msggetheaders.go
@@ -96,7 +96,7 @@ func (msg *MsgGetHeaders) BtcEncode(w io.Writer, pver uint32) error {
 		return messageError(op, ErrTooManyLocators, msg)
 	}
 
-	err := writeElement(w, msg.ProtocolVersion)
+	err := writeElement(w, &msg.ProtocolVersion)
 	if err != nil {
 		return err
 	}

--- a/wire/msgminingstate.go
+++ b/wire/msgminingstate.go
@@ -123,12 +123,12 @@ func (msg *MsgMiningState) BtcDecode(r io.Reader, pver uint32) error {
 // This is part of the Message interface implementation.
 func (msg *MsgMiningState) BtcEncode(w io.Writer, pver uint32) error {
 	const op = "MsgMiningState.BtcEncode"
-	err := writeElement(w, msg.Version)
+	err := writeElement(w, &msg.Version)
 	if err != nil {
 		return err
 	}
 
-	err = writeElement(w, msg.Height)
+	err = writeElement(w, &msg.Height)
 	if err != nil {
 		return err
 	}

--- a/wire/msgmixciphertexts.go
+++ b/wire/msgmixciphertexts.go
@@ -148,7 +148,7 @@ func (msg *MsgMixCiphertexts) writeMessageNoSignature(op string, w io.Writer, pv
 		return messageError(op, ErrTooManyPrevMixMsgs, msg)
 	}
 
-	err := writeElements(w, &msg.Identity, &msg.SessionID, msg.Run)
+	err := writeElements(w, &msg.Identity, &msg.SessionID, &msg.Run)
 	if err != nil {
 		return err
 	}

--- a/wire/msgmixconfirm.go
+++ b/wire/msgmixconfirm.go
@@ -140,7 +140,7 @@ func (msg *MsgMixConfirm) writeMessageNoSignature(op string, w io.Writer, pver u
 		return messageError(op, ErrTooManyPrevMixMsgs, msg)
 	}
 
-	err := writeElements(w, &msg.Identity, &msg.SessionID, msg.Run)
+	err := writeElements(w, &msg.Identity, &msg.SessionID, &msg.Run)
 	if err != nil {
 		return err
 	}

--- a/wire/msgmixdcnet.go
+++ b/wire/msgmixdcnet.go
@@ -146,7 +146,7 @@ func (msg *MsgMixDCNet) writeMessageNoSignature(op string, w io.Writer, pver uin
 		return messageError(op, ErrTooManyPrevMixMsgs, msg)
 	}
 
-	err := writeElements(w, &msg.Identity, &msg.SessionID, msg.Run)
+	err := writeElements(w, &msg.Identity, &msg.SessionID, &msg.Run)
 	if err != nil {
 		return err
 	}

--- a/wire/msgmixfactoredpoly.go
+++ b/wire/msgmixfactoredpoly.go
@@ -163,7 +163,7 @@ func (msg *MsgMixFactoredPoly) writeMessageNoSignature(op string, w io.Writer, p
 		return messageError(op, ErrTooManyPrevMixMsgs, msg)
 	}
 
-	err := writeElements(w, &msg.Identity, &msg.SessionID, msg.Run)
+	err := writeElements(w, &msg.Identity, &msg.SessionID, &msg.Run)
 	if err != nil {
 		return err
 	}

--- a/wire/msgmixkeyexchange.go
+++ b/wire/msgmixkeyexchange.go
@@ -148,8 +148,8 @@ func (msg *MsgMixKeyExchange) writeMessageNoSignature(op string, w io.Writer, pv
 		return messageError(op, ErrTooManyPrevMixMsgs, msg)
 	}
 
-	err := writeElements(w, &msg.Identity, &msg.SessionID, msg.Epoch,
-		msg.Run, &msg.Pos, &msg.ECDH, &msg.PQPK, &msg.Commitment)
+	err := writeElements(w, &msg.Identity, &msg.SessionID, &msg.Epoch,
+		&msg.Run, &msg.Pos, &msg.ECDH, &msg.PQPK, &msg.Commitment)
 	if err != nil {
 		return err
 	}

--- a/wire/msgmixpairreq.go
+++ b/wire/msgmixpairreq.go
@@ -89,7 +89,7 @@ func (msg *MsgMixPairReq) Pairing() ([]byte, error) {
 		1 // Pairing flags
 	w := bytes.NewBuffer(make([]byte, 0, bufLen))
 
-	err := writeElement(w, msg.MixAmount)
+	err := writeElement(w, &msg.MixAmount)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (msg *MsgMixPairReq) Pairing() ([]byte, error) {
 		return nil, err
 	}
 
-	err = writeElements(w, msg.TxVersion, msg.LockTime, msg.PairingFlags)
+	err = writeElements(w, &msg.TxVersion, &msg.LockTime, &msg.PairingFlags)
 	if err != nil {
 		return nil, err
 	}
@@ -294,7 +294,7 @@ func (msg *MsgMixPairReq) writeMessageNoSignature(op string, w io.Writer, pver u
 		return messageError(op, ErrTooManyMixPairReqUTXOs, msg)
 	}
 
-	err := writeElements(w, &msg.Identity, msg.Expiry, msg.MixAmount)
+	err := writeElements(w, &msg.Identity, &msg.Expiry, &msg.MixAmount)
 	if err != nil {
 		return err
 	}
@@ -304,8 +304,8 @@ func (msg *MsgMixPairReq) writeMessageNoSignature(op string, w io.Writer, pver u
 		return err
 	}
 
-	err = writeElements(w, msg.TxVersion, msg.LockTime, msg.MessageCount,
-		msg.InputValue)
+	err = writeElements(w, &msg.TxVersion, &msg.LockTime, &msg.MessageCount,
+		&msg.InputValue)
 	if err != nil {
 		return err
 	}
@@ -352,7 +352,7 @@ func (msg *MsgMixPairReq) writeMessageNoSignature(op string, w io.Writer, pver u
 			return err
 		}
 
-		err = writeElement(w, utxo.Opcode)
+		err = writeElement(w, &utxo.Opcode)
 		if err != nil {
 			return err
 		}
@@ -362,7 +362,7 @@ func (msg *MsgMixPairReq) writeMessageNoSignature(op string, w io.Writer, pver u
 	if msg.Change != nil {
 		hasChange = 1
 	}
-	err = writeElement(w, hasChange)
+	err = writeElement(w, &hasChange)
 	if err != nil {
 		return err
 	}
@@ -373,7 +373,7 @@ func (msg *MsgMixPairReq) writeMessageNoSignature(op string, w io.Writer, pver u
 		}
 	}
 
-	err = writeElements(w, msg.Flags, msg.PairingFlags)
+	err = writeElements(w, &msg.Flags, &msg.PairingFlags)
 	if err != nil {
 		return err
 	}

--- a/wire/msgmixsecrets.go
+++ b/wire/msgmixsecrets.go
@@ -239,7 +239,7 @@ func (msg *MsgMixSecrets) writeMessageNoSignature(op string, w io.Writer, pver u
 		return messageError(op, ErrTooManyPrevMixMsgs, msg)
 	}
 
-	err := writeElements(w, &msg.Identity, &msg.SessionID, msg.Run, &msg.Seed)
+	err := writeElements(w, &msg.Identity, &msg.SessionID, &msg.Run, &msg.Seed)
 	if err != nil {
 		return err
 	}

--- a/wire/msgmixslotreserve.go
+++ b/wire/msgmixslotreserve.go
@@ -177,7 +177,7 @@ func (msg *MsgMixSlotReserve) WriteHash(h hash.Hash) {
 func (msg *MsgMixSlotReserve) writeMessageNoSignature(op string, w io.Writer, pver uint32) error {
 	_, hashing := w.(hash.Hash)
 
-	err := writeElements(w, &msg.Identity, &msg.SessionID, msg.Run)
+	err := writeElements(w, &msg.Identity, &msg.SessionID, &msg.Run)
 	if err != nil {
 		return err
 	}

--- a/wire/msgping.go
+++ b/wire/msgping.go
@@ -36,7 +36,7 @@ func (msg *MsgPing) BtcDecode(r io.Reader, pver uint32) error {
 // BtcEncode encodes the receiver to w using the Decred protocol encoding.
 // This is part of the Message interface implementation.
 func (msg *MsgPing) BtcEncode(w io.Writer, pver uint32) error {
-	err := writeElement(w, msg.Nonce)
+	err := writeElement(w, &msg.Nonce)
 	return err
 }
 

--- a/wire/msgpong.go
+++ b/wire/msgpong.go
@@ -29,7 +29,7 @@ func (msg *MsgPong) BtcDecode(r io.Reader, pver uint32) error {
 // BtcEncode encodes the receiver to w using the Decred protocol encoding.
 // This is part of the Message interface implementation.
 func (msg *MsgPong) BtcEncode(w io.Writer, pver uint32) error {
-	return writeElement(w, msg.Nonce)
+	return writeElement(w, &msg.Nonce)
 }
 
 // Command returns the protocol command string for the message.  This is part

--- a/wire/msgreject.go
+++ b/wire/msgreject.go
@@ -169,7 +169,7 @@ func (msg *MsgReject) BtcEncode(w io.Writer, pver uint32) error {
 	}
 
 	// Code indicating why the command was rejected.
-	err = writeElement(w, msg.Code)
+	err = writeElement(w, &msg.Code)
 	if err != nil {
 		return err
 	}

--- a/wire/msgversion.go
+++ b/wire/msgversion.go
@@ -157,8 +157,13 @@ func (msg *MsgVersion) BtcEncode(w io.Writer, pver uint32) error {
 		return err
 	}
 
-	err = writeElements(w, msg.ProtocolVersion, msg.Services,
-		msg.Timestamp.Unix())
+	var elems struct {
+		ts      int64
+		relayTx bool
+	}
+	elems.ts = msg.Timestamp.Unix()
+
+	err = writeElements(w, &msg.ProtocolVersion, &msg.Services, &elems.ts)
 	if err != nil {
 		return err
 	}
@@ -173,7 +178,7 @@ func (msg *MsgVersion) BtcEncode(w io.Writer, pver uint32) error {
 		return err
 	}
 
-	err = writeElement(w, msg.Nonce)
+	err = writeElement(w, &msg.Nonce)
 	if err != nil {
 		return err
 	}
@@ -183,12 +188,13 @@ func (msg *MsgVersion) BtcEncode(w io.Writer, pver uint32) error {
 		return err
 	}
 
-	err = writeElement(w, msg.LastBlock)
+	err = writeElement(w, &msg.LastBlock)
 	if err != nil {
 		return err
 	}
 
-	return writeElement(w, !msg.DisableRelayTx)
+	elems.relayTx = !msg.DisableRelayTx
+	return writeElement(w, &elems.relayTx)
 }
 
 // Command returns the protocol command string for the message.  This is part


### PR DESCRIPTION
For at least the past 5 years, due to garbage collector design, Go has not optimized small non-pointer types to fit inside interface headers, and instead always uses a pointer to data, if the type is not already a pointer.  This means that writeElement, which was written before this time to avoid unnecessary heap allocations, was now causing heap allocations for each special cased non-pointer type.

This commit rewrites writeElement to only special case pointers to types, and to pass all elements by pointer.