### PR TITLE
server: Use modern net/netip for whitelists.

### DIFF
--- a/config.go
+++ b/config.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -225,7 +226,7 @@ type config struct {
 	dial          func(context.Context, string, string) (net.Conn, error)
 	miningAddrs   []stdaddr.Address
 	minRelayTxFee dcrutil.Amount
-	whitelists    []*net.IPNet
+	whitelists    []netip.Prefix
 	ipv4NetInfo   types.NetworksResult
 	ipv6NetInfo   types.NetworksResult
 	onionNetInfo  types.NetworksResult
@@ -966,31 +967,24 @@ func loadConfig(appName string) (*config, []string, error) {
 
 	// Validate any given whitelisted IP addresses and networks.
 	if len(cfg.Whitelists) > 0 {
-		var ip net.IP
-		cfg.whitelists = make([]*net.IPNet, 0, len(cfg.Whitelists))
-
+		cfg.whitelists = make([]netip.Prefix, 0, len(cfg.Whitelists))
 		for _, addr := range cfg.Whitelists {
-			_, ipnet, err := net.ParseCIDR(addr)
+			prefix, err := netip.ParsePrefix(addr)
 			if err != nil {
-				ip = net.ParseIP(addr)
-				if ip == nil {
-					str := "%s: the whitelist value of '%s' is invalid"
+				ip, err := netip.ParseAddr(addr)
+				if err != nil {
+					str := "%s: invalid whitelist value %q"
 					err = fmt.Errorf(str, funcName, addr)
 					return nil, nil, err
 				}
-				var bits int
-				if ip.To4() == nil {
-					// IPv6
+				bits := 32
+				if ip.Is6() {
 					bits = 128
-				} else {
-					bits = 32
 				}
-				ipnet = &net.IPNet{
-					IP:   ip,
-					Mask: net.CIDRMask(bits, bits),
-				}
+				prefix = netip.PrefixFrom(ip, bits)
 			}
-			cfg.whitelists = append(cfg.whitelists, ipnet)
+			prefix = prefix.Masked()
+			cfg.whitelists = append(cfg.whitelists, prefix)
 		}
 	}
 

--- a/server.go
+++ b/server.go
@@ -4694,9 +4694,9 @@ func isWhitelisted(addr *addrmgr.NetAddress) bool {
 		return false
 	}
 
-	ip := net.IP(addr.IP)
-	for _, ipnet := range cfg.whitelists {
-		if ipnet.Contains(ip) {
+	ip, _ := netip.AddrFromSlice(addr.IP)
+	for _, prefix := range cfg.whitelists {
+		if prefix.Contains(ip) {
 			return true
 		}
 	}


### PR DESCRIPTION
~~**This requires #3638**~~.

This updates the code that parses and handles whitelisted addresses to use the more efficient and modern `net/netip` stdlib package.