### PR TITLE
[release-v2.1] server: Revert Don't consider services before handshake.

### DIFF
--- a/server.go
+++ b/server.go
@@ -676,9 +676,6 @@ type serverPeer struct {
 	isWhitelisted bool
 	quit          chan struct{}
 
-	handshakeDone          chan struct{}
-	closeHandshakeDoneOnce sync.Once
-
 	// syncMgrPeer houses the network sync manager peer instance that wraps the
 	// underlying peer similar to the way this server peer itself wraps it.
 	syncMgrPeer *netsync.Peer
@@ -734,7 +731,6 @@ func newServerPeer(s *server, isPersistent bool) *serverPeer {
 		persistent:     isPersistent,
 		knownAddresses: apbf.NewFilter(maxKnownAddrsPerPeer, knownAddrsFPRate),
 		quit:           make(chan struct{}),
-		handshakeDone:  make(chan struct{}),
 		getDataQueue:   make(chan []*wire.InvVect, maxConcurrentGetDataReqs),
 	}
 }
@@ -928,9 +924,6 @@ func (sp *serverPeer) Run() {
 		sp.serveGetData()
 		wg.Done()
 	}()
-
-	// Add valid peer to the server.
-	sp.server.AddPeer(sp)
 
 	// Wait for the peer to disconnect and notify the net sync manager and
 	// server accordingly.
@@ -1201,13 +1194,15 @@ func (sp *serverPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) {
 	// Add the remote peer time as a sample for creating an offset against
 	// the local clock to keep the network time in sync.
 	sp.server.timeSource.AddTimeSample(sp.Addr(), msg.Timestamp)
+
+	// Add valid peer to the server.
+	sp.server.AddPeer(sp)
 }
 
 // OnVerAck is invoked when a peer receives a verack wire message.  It creates
 // and sends a sendheaders message to request all block annoucements are made
 // via full headers instead of the inv message.
 func (sp *serverPeer) OnVerAck(_ *peer.Peer, msg *wire.MsgVerAck) {
-	sp.closeHandshakeDoneOnce.Do(func() { close(sp.handshakeDone) })
 	sp.QueueMessage(wire.NewMsgSendHeaders(), nil)
 }
 
@@ -2332,14 +2327,8 @@ func (s *server) inboundPeerConnected(conn net.Conn) {
 	sp := newServerPeer(s, false)
 	sp.isWhitelisted = isWhitelisted(conn.RemoteAddr())
 	sp.Peer = peer.NewInboundPeer(newPeerConfig(sp))
-	sp.AssociateConnection(conn)
-	select {
-	case <-sp.handshakeDone:
-	case <-time.After(30 * time.Second):
-		srvrLog.Debugf("Handshake timeout for inbound peer %s", conn.RemoteAddr())
-		return
-	}
 	sp.syncMgrPeer = netsync.NewPeer(sp.Peer)
+	sp.AssociateConnection(conn)
 	go sp.Run()
 }
 
@@ -2357,17 +2346,10 @@ func (s *server) outboundPeerConnected(c *connmgr.ConnReq, conn net.Conn) {
 		return
 	}
 	sp.Peer = p
+	sp.syncMgrPeer = netsync.NewPeer(sp.Peer)
 	sp.connReq.Store(c)
 	sp.isWhitelisted = isWhitelisted(conn.RemoteAddr())
 	sp.AssociateConnection(conn)
-	select {
-	case <-sp.handshakeDone:
-	case <-time.After(30 * time.Second):
-		srvrLog.Debugf("Handshake timeout from outbound peer %s", c.Addr)
-		s.connManager.Disconnect(c.ID())
-		return
-	}
-	sp.syncMgrPeer = netsync.NewPeer(sp.Peer)
 	go sp.Run()
 }
 


### PR DESCRIPTION
This reverts commit 664d136e45d29cf734c620e1c8b91f7797b57d1d.

The changes in the `peer` module that required the changes in the reverted commit are not included in the `release-v2.1` branch and therefore the commit should not have been backported.

The commit being reverted introduced a bug unique to the release-v2.1 branch whereby the goroutines to process incoming messages are spawned before the `sp.syncMgrPeer` field has been set which can result in either a data race or `nil` dereference when the `syncMgrPeer` is read by the callback methods.

This does not apply to the master branch since it no longer runs inbound message processing until after both the handshake has completed and the `syncMgrPeer` field has been set.

As of reverting the offending commit, the behavior on the `release-v2.1` branch now matches the same behavior in previous releases.