### PR TITLE
[release-v2.1] main: Use backported mixing updates.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/decred/dcrd/dcrutil/v4 v4.0.3
 	github.com/decred/dcrd/gcs/v4 v4.1.1
 	github.com/decred/dcrd/math/uint256 v1.0.2
-	github.com/decred/dcrd/mixing v0.7.2
+	github.com/decred/dcrd/mixing v0.7.3
 	github.com/decred/dcrd/peer/v3 v3.2.0
 	github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.4.0
 	github.com/decred/dcrd/rpcclient/v8 v8.1.0

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/decred/dcrd/hdkeychain/v3 v3.1.3 h1:Kn2wfj5cOR6pQO/WrYOMT1KK12IgWFEeQ
 github.com/decred/dcrd/hdkeychain/v3 v3.1.3/go.mod h1:mDAuGaH6InRD+hKVeVJsjLD/ih1mD3aCKURNHS8Tq2s=
 github.com/decred/dcrd/math/uint256 v1.0.2 h1:o8peafL5QmuXGTergI3YDpDU0eq5Z0pQi88B8ym4PRA=
 github.com/decred/dcrd/math/uint256 v1.0.2/go.mod h1:7M/y9wJJvlyNG/f/X6mxxhxo9dgloZHFiOfbiscl75A=
-github.com/decred/dcrd/mixing v0.7.2 h1:lfCjkn9N7KuANNJkBdTJTrkIbzzklsf8yGBQ8trVTpk=
-github.com/decred/dcrd/mixing v0.7.2/go.mod h1:riSgG1GpWXl8LVuBvo8WXuFgcBj01ZGpTAxT/4PrtU0=
+github.com/decred/dcrd/mixing v0.7.3 h1:zrMPKvR3GP2stDiqT9tiv0e8GGnFpgl1EClNRew7FFk=
+github.com/decred/dcrd/mixing v0.7.3/go.mod h1:riSgG1GpWXl8LVuBvo8WXuFgcBj01ZGpTAxT/4PrtU0=
 github.com/decred/dcrd/peer/v3 v3.2.0 h1:6PxoGcsyjV3me/WLjIZdmWs4Pma5jYGi40CmzNCzeNY=
 github.com/decred/dcrd/peer/v3 v3.2.0/go.mod h1:OUFvMboEQvnq4V8CRw2RUn/fFls0rpVuDN0QT0zq8RA=
 github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.4.0 h1:BBVaYemabsFsaqNVlCmacoZlSsLDqwHYIs8ty6fg59Q=

--- a/mixing/mixpool/observer.go
+++ b/mixing/mixpool/observer.go
@@ -155,6 +155,7 @@ func (o *Observer) checkPrevEpoch(cancelledCtx context.Context, prevEpoch uint64
 	prByKE := make(map[chainhash.Hash]*wire.MsgMixPairReq)
 	timedOut := make(map[string]map[idPubKey]struct{})
 	active := o.mixpool.activeInEpoch(prevEpoch)
+	sizeLimited := make(map[idPubKey]string)
 	for _, a := range active {
 		pairing, err := a.pr.Pairing()
 		if err != nil {
@@ -173,7 +174,7 @@ func (o *Observer) checkPrevEpoch(cancelledCtx context.Context, prevEpoch uint64
 	r := &Received{
 		ReceiveAll: true,
 	}
-	for _, ses := range pairings {
+	for pairing, ses := range pairings {
 		for sid, sesKEs := range ses {
 			// Sessions formed with fewer than the
 			// required minimum peer count can't be used
@@ -206,7 +207,16 @@ func (o *Observer) checkPrevEpoch(cancelledCtx context.Context, prevEpoch uint64
 			// When no ciphertext messages were received, a
 			// session was not formed, and timeout can not be
 			// observed.
+			//
+			// As this occurs when sessions exceeding the mix
+			// limits are recreated, mark all peers in this
+			// session as potentially limited, so they can be
+			// removed from the active map later.
 			if len(r.CTs) == 0 {
+				for _, ke := range sesKEs {
+					sizeLimited[ke.Identity] = pairing
+				}
+
 				continue
 			}
 
@@ -217,10 +227,6 @@ func (o *Observer) checkPrevEpoch(cancelledCtx context.Context, prevEpoch uint64
 				continue
 			}
 
-			pairing, err := prByKE[sesKEs[0].Hash()].Pairing()
-			if err != nil {
-				return err
-			}
 			if len(r.CMs) == len(sesKEs) {
 				completed[sid] = sesKEs
 				continue
@@ -264,11 +270,11 @@ func (o *Observer) checkPrevEpoch(cancelledCtx context.Context, prevEpoch uint64
 					delete(ids, cm.Identity)
 				}
 			}
-			if _, ok := timedOut[string(pairing)]; !ok {
-				timedOut[string(pairing)] = make(map[idPubKey]struct{})
+			if _, ok := timedOut[pairing]; !ok {
+				timedOut[pairing] = make(map[idPubKey]struct{})
 			}
 			for id := range ids {
-				timedOut[string(pairing)][id] = struct{}{}
+				timedOut[pairing][id] = struct{}{}
 			}
 		}
 	}
@@ -313,6 +319,19 @@ func (o *Observer) checkPrevEpoch(cancelledCtx context.Context, prevEpoch uint64
 			}
 			delete(active, id)
 		}
+	}
+
+	// Modify the active map by removing identities that were in abandoned
+	// sessions exceeding the mix limits.  If any of these peers also
+	// timed out in another session, do not exclude them from the
+	// misbehaving peer set.
+	for id, pairing := range sizeLimited {
+		if timedOutIDs, ok := timedOut[pairing]; ok {
+			if _, ok := timedOutIDs[id]; ok {
+				continue
+			}
+		}
+		delete(active, id)
 	}
 
 	o.updateStrikes(prevEpoch, active, prByKE, completed)


### PR DESCRIPTION
This updates the 2.1 release branch to use the latest version of the `mixing` module which includes an update to ensure coins that are excluded from mixes due to overall session limits of a single mix being exceeded are not greylisted.

In particular, the following updated module version is used:

- github.com/decred/dcrd/mixing@v0.7.3

Note that it also cherry picks all of the commits included in updates to the `mixing` module to ensure they are also included in the release branch even though it is not strictly necessary since `go.mod` has been updated to require the new release and thus will pull in the new code. However, from past experience, not having code backported to modules available in the release branch too leads to headaches for devs building from source in their local workspace with overrides such as those in `go.work`.

The following PRs are included:

- #3673