### PR TITLE
standalone: Reject bad input values in tx sanity.

### DIFF
--- a/blockchain/standalone/error.go
+++ b/blockchain/standalone/error.go
@@ -49,6 +49,11 @@ const (
 	// invalid in some way such as being out of range.
 	ErrBadTxOutValue = ErrorKind("ErrBadTxOutValue")
 
+	// ErrFraudAmountIn indicates a fraud proof witness amount (aka the input
+	// value) for a transaction is invalid in some way such as being out of
+	// range.
+	ErrFraudAmountIn = ErrorKind("ErrFraudAmountIn")
+
 	// ErrDuplicateTxInputs indicates a transaction references the same
 	// input more than once.
 	ErrDuplicateTxInputs = ErrorKind("ErrDuplicateTxInputs")

--- a/blockchain/standalone/error_test.go
+++ b/blockchain/standalone/error_test.go
@@ -23,6 +23,7 @@ func TestErrorKindStringer(t *testing.T) {
 		{ErrNoTxOutputs, "ErrNoTxOutputs"},
 		{ErrTxTooBig, "ErrTxTooBig"},
 		{ErrBadTxOutValue, "ErrBadTxOutValue"},
+		{ErrFraudAmountIn, "ErrFraudAmountIn"},
 		{ErrDuplicateTxInputs, "ErrDuplicateTxInputs"},
 	}
 

--- a/blockchain/standalone/tx.go
+++ b/blockchain/standalone/tx.go
@@ -199,6 +199,22 @@ func CheckTransactionSanity(tx *wire.MsgTx, maxTxSize uint64) error {
 		}
 	}
 
+	// Input values in the fraud proof must either be in the valid range or the
+	// special sentinel value that signals it needs to be filled in later.
+	for _, txIn := range tx.TxIn {
+		atoms := txIn.ValueIn
+		if atoms < 0 && atoms != wire.NullValueIn {
+			str := fmt.Sprintf("transaction input value has negative value of "+
+				"%v", atoms)
+			return ruleError(ErrFraudAmountIn, str)
+		}
+		if atoms > maxAtoms {
+			str := fmt.Sprintf("transaction input value %v is higher than max "+
+				"allowed value of %v", atoms, maxAtoms)
+			return ruleError(ErrFraudAmountIn, str)
+		}
+	}
+
 	// Check for duplicate transaction inputs.
 	existingTxOut := make(map[wire.OutPoint]struct{})
 	for _, txIn := range tx.TxIn {

--- a/blockchain/standalone/tx_test.go
+++ b/blockchain/standalone/tx_test.go
@@ -370,6 +370,29 @@ func TestCheckTransactionSanity(t *testing.T) {
 		}(),
 		err: ErrBadTxOutValue,
 	}, {
+		name: "transaction with input value == wire.NullValueIn (ok)",
+		tx: func() *wire.MsgTx {
+			tx := baseTx.Copy()
+			tx.TxIn[0].ValueIn = wire.NullValueIn
+			return tx
+		}(),
+	}, {
+		name: "transaction with negative input value",
+		tx: func() *wire.MsgTx {
+			tx := baseTx.Copy()
+			tx.TxIn[0].ValueIn = -2
+			return tx
+		}(),
+		err: ErrFraudAmountIn,
+	}, {
+		name: "transaction with single input value > max per tx",
+		tx: func() *wire.MsgTx {
+			tx := baseTx.Copy()
+			tx.TxIn[0].ValueIn = maxAtoms + 1
+			return tx
+		}(),
+		err: ErrFraudAmountIn,
+	}, {
 		name: "transaction spending duplicate input",
 		tx: func() *wire.MsgTx {
 			tx := baseTx.Copy()

--- a/internal/blockchain/validate.go
+++ b/internal/blockchain/validate.go
@@ -663,10 +663,10 @@ func CheckProofOfStake(block *dcrutil.Block, posLimit int64) error {
 }
 
 // standaloneToChainRuleError attempts to convert the passed error from a
-// standalone.RuleError to a blockchain.RuleError with the equivalent error
-// kind.  The error is simply passed through without modification if it is
-// not a standalone.RuleError, not one of the specifically recognized
-// error kinds, or nil.
+// [standalone.RuleError] to a [RuleError] with the equivalent error kind.  The
+// error is simply passed through without modification if it is not a
+// [standalone.RuleError], not one of the specifically recognized error kinds,
+// or nil.
 func standaloneToChainRuleError(err error) error {
 	// Convert standalone package rule errors to blockchain rule errors.
 	switch {
@@ -682,6 +682,8 @@ func standaloneToChainRuleError(err error) error {
 		return ruleError(ErrTxTooBig, err.Error())
 	case errors.Is(err, standalone.ErrBadTxOutValue):
 		return ruleError(ErrBadTxOutValue, err.Error())
+	case errors.Is(err, standalone.ErrFraudAmountIn):
+		return ruleError(ErrFraudAmountIn, err.Error())
 	case errors.Is(err, standalone.ErrDuplicateTxInputs):
 		return ruleError(ErrDuplicateTxInputs, err.Error())
 	}


### PR DESCRIPTION
Transactions with input values that are negative or greater than the max supply ultimately will always eventually end up invalid by checks performed much later in the validation process.  Moreover, the aforementioned conditions are entirely context free.

Given that, it is much more efficient and robust to simply reject any transactions that violate them as early as possible in the validation process.

The context-free transaction sanity checks are the ideal location since they are among the earliest validation checks that are performed.

However, unconfirmed transactions are allowed to leave the input value set to the special sentinel value of -1 (`wire.NullValueIn`) that signals the actual value will be filled in later.  The sanity checks take place before that information is available to populate, so that case needs to be exempted and left for the later checks to reject as they already do now.

With that in mind, this modifies `CheckTransactionSanity` to reject transactions that violate those conditions accordingly.

It also adds `ErrFraudAmountIn` to uniquely identify when checks fail validation for that reason.

Finally, it modifies the rule error conversion in the internal `blockchain` code to recognize and convert the new error.

Additional tests are included in a second commit to test the new checks work as expected.
