### PR TITLE
docker: Update image to golang:1.26.2-alpine3.23.

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -3,13 +3,13 @@
 ###############
 
 # Basic Go environment with git, SSL CA certs, and upx.
-# The image below is golang:1.26.0-alpine3.23 (linux/amd64)
+# The image below is golang:1.26.2-alpine3.23 (linux/amd64)
 # It's pulled by the digest (immutable id) to avoid supply-chain attacks.
 # Maintainer Note:
 #    To update to a new digest, you must first manually pull the new image:
 #    `docker pull golang:<new version>`
 #    Docker will print the digest of the new image after the pull has finished.
-FROM golang@sha256:d4c4845f5d60c6a974c6000ce58ae079328d03ab7f721a0734277e69905473e5 AS builder
+FROM golang@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS builder
 RUN apk add --no-cache git ca-certificates upx
 
 # Empty directory to be copied into place in the production image since it will


### PR DESCRIPTION
This updates the docker image to `golang:1.26.2-alpine3.23`.

To confirm the new digest:

```
$ docker pull golang:1.26.2-alpine3.23
1.26.2-alpine3.23: Pulling from library/golang
...
Digest: sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1
...
```

Alternatively, the index digest may be confirmed directly from the [multi-platform image](https://hub.docker.com/layers/library/golang/1.26.2-alpine3.23/images/sha256-dcd42605f7f4432904156be77580f9c2ea1d48a6db4ce818b52f9db72cfcb3e7) for `golang:1.26.2-alpine3.23` on docker hub.