### PR TITLE
blockchain/stake: Local consts for req script vers.

### DIFF
--- a/blockchain/stake/staketx.go
+++ b/blockchain/stake/staketx.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2024 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 //
@@ -38,9 +38,6 @@ const (
 )
 
 const (
-	// consensusVersion = txscript.consensusVersion
-	consensusVersion = 0
-
 	// TxVersionAutoRevocations is the revocation transaction version that enables
 	// automatic ticket revocations.
 	TxVersionAutoRevocations uint16 = 2
@@ -734,9 +731,10 @@ func CheckSStx(tx *wire.MsgTx) error {
 		return stakeRuleError(ErrSStxNoOutputs, str)
 	}
 
-	// Check to make sure that all output scripts are the consensus version.
+	// All output scripts must be version 0.
+	const consensusScriptVer = 0
 	for idx, txOut := range tx.TxOut {
-		if txOut.Version != consensusVersion {
+		if txOut.Version != consensusScriptVer {
 			str := fmt.Sprintf("invalid script version found in "+
 				"txOut idx %v", idx)
 			return stakeRuleError(ErrSStxInvalidOutputs, str)
@@ -1037,9 +1035,10 @@ func CheckSSGenVotes(tx *wire.MsgTx) ([]TreasuryVoteTuple, error) {
 		}
 	}
 
-	// Check to make sure that all output scripts are the consensus version.
+	// All output scripts must be version 0.
+	const consensusScriptVer = 0
 	for _, txOut := range tx.TxOut {
-		if txOut.Version != consensusVersion {
+		if txOut.Version != consensusScriptVer {
 			str := "invalid script version found in txOut"
 			return nil, stakeRuleError(ErrSSGenBadGenOuts, str)
 		}
@@ -1209,9 +1208,10 @@ func CheckSSRtx(tx *wire.MsgTx) error {
 		return stakeRuleError(ErrSSRtxNoOutputs, str)
 	}
 
-	// Check to make sure that all output scripts are the consensus version.
+	// All output scripts must be version 0.
+	const consensusScriptVer = 0
 	for _, txOut := range tx.TxOut {
-		if txOut.Version != consensusVersion {
+		if txOut.Version != consensusScriptVer {
 			str := "invalid script version found in txOut"
 			return stakeRuleError(ErrSSRtxBadOuts, str)
 		}
@@ -1381,9 +1381,10 @@ func CreateRevocationFromTicket(ticketHash *chainhash.Hash,
 	txIn := wire.NewTxIn(prevOut, ticketSubmissionAmount, nil)
 	revocationTx.AddTxIn(txIn)
 
-	// Check to make sure that all scripts are the consensus version.
+	// All output scripts must be version 0.
+	const consensusScriptVer = 0
 	for i, ticketMinOut := range ticketMinOuts {
-		if ticketMinOut.Version != consensusVersion {
+		if ticketMinOut.Version != consensusScriptVer {
 			str := fmt.Sprintf("invalid script version found in ticket minimal "+
 				"outputs idx %d", i)
 			return nil, stakeRuleError(ErrSStxInvalidOutputs, str)

--- a/blockchain/stake/treasury.go
+++ b/blockchain/stake/treasury.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 The Decred developers
+// Copyright (c) 2020-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -56,9 +56,10 @@ func checkTAdd(mtx *wire.MsgTx) error {
 				len(mtx.TxIn), len(mtx.TxOut)))
 	}
 
-	// Verify all TxOut script versions and lengths.
+	// All output scripts must be version 0 and non-empty.
+	const consensusScriptVer = 0
 	for k := range mtx.TxOut {
-		if mtx.TxOut[k].Version != consensusVersion {
+		if mtx.TxOut[k].Version != consensusScriptVer {
 			return stakeRuleError(ErrTAddInvalidVersion,
 				fmt.Sprintf("invalid script version found "+
 					"in TADD TxOut: %v", k))
@@ -131,15 +132,14 @@ func CheckTSpend(mtx *wire.MsgTx) ([]byte, []byte, error) {
 				"out: %v", len(mtx.TxIn), len(mtx.TxOut)))
 	}
 
-	// Check to make sure that all output scripts are the consensus version.
+	// All output scripts must be version 0 and non-empty.
+	const consensusScriptVer = 0
 	for k, txOut := range mtx.TxOut {
-		if txOut.Version != consensusVersion {
+		if txOut.Version != consensusScriptVer {
 			return nil, nil, stakeRuleError(ErrTSpendInvalidVersion,
 				fmt.Sprintf("invalid script version found in "+
 					"TxOut: %v", k))
 		}
-
-		// Make sure there is a script.
 		if len(txOut.PkScript) == 0 {
 			return nil, nil, stakeRuleError(ErrTSpendInvalidScriptLength,
 				fmt.Sprintf("invalid TxOut script length %v: "+
@@ -227,9 +227,10 @@ func checkTreasuryBase(mtx *wire.MsgTx) error {
 			"treasurybase input 0 contains a script")
 	}
 
-	// Verify all TxOut script versions.
+	// All output scripts must be version 0.
+	const consensusScriptVer = 0
 	for k := range mtx.TxOut {
-		if mtx.TxOut[k].Version != consensusVersion {
+		if mtx.TxOut[k].Version != consensusScriptVer {
 			return stakeRuleError(ErrTreasuryBaseInvalidVersion,
 				fmt.Sprintf("invalid script version found in "+
 					"treasurybase: output %v", k))


### PR DESCRIPTION
The current code uses a single global constant for the consensus script version.  This does not cause any issue at the moment since everything requires version 0 and version 0 is the only supported script version anyway.

However, it is highly misleading and quite brittle.  It implies that the constant could be bumped to a new version, but that is not the case at all.  For example, if the value were to change to, say, version 1, it would break consensus because it would make all historical stake transactions invalid.

In practice, supporting a new script version means each individual supported stake transaction type needs to be carefully analyzed and updated to support both the old version for historical transactions as well as the new version.  Moreover, that support would need to be dependent on the state of a consensus vote.

This modifies each instance that checks the required script version to use a local constant instead to help make it clear that every individual case can be different and requires individual analysis and support in the event of any new supported script versions.