### PR TITLE
blockchain:  Early null revocation input check.

### DIFF
--- a/internal/blockchain/validate.go
+++ b/internal/blockchain/validate.go
@@ -434,7 +434,6 @@ func checkTransactionContext(tx *wire.MsgTx, params *chaincfg.Params, flags Agen
 		isCoinBase = standalone.IsCoinBaseTx(tx, isTreasuryEnabled)
 	}
 
-	// Take action on type.
 	switch {
 	case isVote:
 		// Check script length of stake base signature.
@@ -454,10 +453,10 @@ func checkTransactionContext(tx *wire.MsgTx, params *chaincfg.Params, flags Agen
 			return ruleError(ErrBadStakebaseScrVal, str)
 		}
 
-		// The ticket reference hash in an SSGen tx must not be null.
+		// The referenced ticket in a vote must not be null.
 		ticketHash := &tx.TxIn[1].PreviousOutPoint
 		if isNullOutpoint(ticketHash) {
-			str := "vote ticket input refers to previous output that is null"
+			const str = "vote ticket input refers to null previous output"
 			return ruleError(ErrBadTxInput, str)
 		}
 
@@ -470,6 +469,13 @@ func checkTransactionContext(tx *wire.MsgTx, params *chaincfg.Params, flags Agen
 			str := fmt.Sprintf("revocation transaction version is %d instead "+
 				"of %d", tx.Version, stake.TxVersionAutoRevocations)
 			return ruleError(ErrInvalidRevocationTxVersion, str)
+		}
+
+		// The referenced ticket in a revocation must not be null.
+		ticketHash := &tx.TxIn[0].PreviousOutPoint
+		if isNullOutpoint(ticketHash) {
+			const str = "revocation ticket input refers to null previous output"
+			return ruleError(ErrBadTxInput, str)
 		}
 
 	case isCoinBase:


### PR DESCRIPTION
The early null output check for the ticket input of revocations was inadvertently removed when the automatic revocations agenda was introduced.  This restores that check.

Not doing the early check doesn't cause any real issue because later checks will fail on attempting to lookup a null output anyway, but it is always ideal to fail as early as possible to avoid additional unnecessary work.