### PR TITLE
blockchain: Correct expected pre SVH upper bound.

### DIFF
--- a/internal/blockchain/validate.go
+++ b/internal/blockchain/validate.go
@@ -3897,14 +3897,12 @@ func (b *BlockChain) checkTransactionsAndConnect(inputFees dcrutil.Amount,
 			voteSubsidy := b.subsidyCache.CalcStakeVoteSubsidyV3(node.height-1,
 				subsidySplitVariant)
 			expAtomOut = voteSubsidy * int64(node.voters)
-		} else {
-			expAtomOut = totalFees
 		}
 
 		if totalAtomOutStake > expAtomOut {
-			str := fmt.Sprintf("stakebase transactions for block "+
-				"pays %v which is more than expected value "+
-				"of %v", totalAtomOutStake, expAtomOut)
+			str := fmt.Sprintf("stakebase transactions for block pays %v "+
+				"which is more than expected value of %v", totalAtomOutStake,
+				expAtomOut)
 			return ruleError(ErrBadStakebaseValue, str)
 		}
 	}

--- a/internal/blockchain/validate.go
+++ b/internal/blockchain/validate.go
@@ -3905,14 +3905,12 @@ func (b *BlockChain) checkTransactionsAndConnect(inputFees dcrutil.Amount,
 			voteSubsidy := b.subsidyCache.CalcStakeVoteSubsidyV3(node.height-1,
 				subsidySplitVariant)
 			expAtomOut = voteSubsidy * int64(node.voters)
-		} else {
-			expAtomOut = totalFees
 		}
 
 		if totalAtomOutStake > expAtomOut {
-			str := fmt.Sprintf("stakebase transactions for block "+
-				"pays %v which is more than expected value "+
-				"of %v", totalAtomOutStake, expAtomOut)
+			str := fmt.Sprintf("stakebase transactions for block pays %v "+
+				"which is more than expected value of %v", totalAtomOutStake,
+				expAtomOut)
 			return ruleError(ErrBadStakebaseValue, str)
 		}
 	}


### PR DESCRIPTION
This removes an incorrect else branch that sets the upper bound for the stake tree prior to stake validation height to the total fees.  It looks like the branch was incorrectly copied from the original code it was extending at the time.

Note that despite being incorrect, the existing code has no adverse effects in practice because votes are not permitted prior to stake validation height which means the sum of stakebases (aka the subsidy votes generate) will necessarily always be 0.