### PR TITLE
server: Initial state protocol banning.

### DIFF
--- a/server.go
+++ b/server.go
@@ -692,6 +692,15 @@ type serverPeer struct {
 	getMiningStateSent bool
 	initStateSent      bool
 
+	// initStateReceived tracks whether or not the peer has already received an
+	// initstate or miningstate message.  It is used to prevent more than one
+	// per connection.
+	//
+	// It is only accessed directly in callbacks which run in the same peer
+	// input handler goroutine and thus does not need to be protected for
+	// concurrent access.
+	initStateReceived bool
+
 	// peerNa is network address of the peer connected to.
 	peerNa atomic.Pointer[wire.NetAddress]
 
@@ -1366,8 +1375,11 @@ func (sp *serverPeer) OnGetMiningState(_ *peer.Peer, msg *wire.MsgGetMiningState
 		return
 	}
 
+	// Ban peers sending more than one request for an initial state message.
 	if sp.getMiningStateSent {
-		peerLog.Tracef("Ignoring getminingstate from %v - already sent", sp)
+		reason := fmt.Sprintf("send more than one %s", msg.Command())
+		sp.server.BanPeer(sp, reason)
+		sp.Disconnect()
 		return
 	}
 	sp.getMiningStateSent = true
@@ -1439,6 +1451,15 @@ func (sp *serverPeer) OnMiningState(_ *peer.Peer, msg *wire.MsgMiningState) {
 		return
 	}
 
+	// Ban peers sending more than one initial state message.
+	if sp.initStateReceived {
+		const reason = "sent more than one initial state message (miningstate)"
+		sp.server.BanPeer(sp, reason)
+		sp.Disconnect()
+		return
+	}
+	sp.initStateReceived = true
+
 	var blockHashes, voteHashes []chainhash.Hash
 	if len(msg.BlockHashes) > 0 {
 		blockHashes = make([]chainhash.Hash, 0, len(msg.BlockHashes))
@@ -1460,8 +1481,11 @@ func (sp *serverPeer) OnMiningState(_ *peer.Peer, msg *wire.MsgMiningState) {
 // OnGetInitState is invoked when a peer receives a getinitstate wire message.
 // It sends the available requested info to the remote peer.
 func (sp *serverPeer) OnGetInitState(_ *peer.Peer, msg *wire.MsgGetInitState) {
+	// Ban peers sending more than one request for an initial state message.
 	if sp.initStateSent {
-		peerLog.Tracef("Ignoring getinitstate from %v - already sent", sp)
+		reason := fmt.Sprintf("sent more than one %s", msg.Command())
+		sp.server.BanPeer(sp, reason)
+		sp.Disconnect()
 		return
 	}
 	sp.initStateSent = true
@@ -1536,6 +1560,15 @@ func (sp *serverPeer) OnGetInitState(_ *peer.Peer, msg *wire.MsgGetInitState) {
 // OnInitState is invoked when a peer receives a initstate wire message.  It
 // requests the data advertised in the message from the peer.
 func (sp *serverPeer) OnInitState(_ *peer.Peer, msg *wire.MsgInitState) {
+	// Ban peers sending more than one initial state message.
+	if sp.initStateReceived {
+		const reason = "sent more than one initial state message (initstate)"
+		sp.server.BanPeer(sp, reason)
+		sp.Disconnect()
+		return
+	}
+	sp.initStateReceived = true
+
 	sp.server.syncManager.RequestFromPeer(sp.syncMgrPeer, msg.BlockHashes,
 		msg.VoteHashes, msg.TSpendHashes)
 }

--- a/server.go
+++ b/server.go
@@ -1355,6 +1355,17 @@ func (sp *serverPeer) pushMiningStateMsg(height uint32, blockHashes []chainhash.
 // It constructs a list of the current best blocks and votes that should be
 // mined on and pushes a miningstate wire message back to the requesting peer.
 func (sp *serverPeer) OnGetMiningState(_ *peer.Peer, msg *wire.MsgGetMiningState) {
+	// Ban peers attempting to request the initial state via miningstate once
+	// the protocol version is high enough that the peer is knowingly violating
+	// the protocol.
+	if sp.ProtocolVersion() >= wire.InitStateVersion {
+		reason := fmt.Sprintf("sent %s request with protocol version %d >= %d",
+			msg.Command(), sp.ProtocolVersion(), wire.InitStateVersion)
+		sp.server.BanPeer(sp, reason)
+		sp.Disconnect()
+		return
+	}
+
 	if sp.getMiningStateSent {
 		peerLog.Tracef("Ignoring getminingstate from %v - already sent", sp)
 		return
@@ -1417,6 +1428,17 @@ func (sp *serverPeer) OnGetMiningState(_ *peer.Peer, msg *wire.MsgGetMiningState
 // OnMiningState is invoked when a peer receives a miningstate wire message.  It
 // requests the data advertised in the message from the peer.
 func (sp *serverPeer) OnMiningState(_ *peer.Peer, msg *wire.MsgMiningState) {
+	// Ban peers attempting to send the initial state via miningstate once
+	// the protocol version is high enough that the peer is knowingly violating
+	// the protocol.
+	if sp.ProtocolVersion() >= wire.InitStateVersion {
+		reason := fmt.Sprintf("sent %s with protocol version %d >= %d",
+			msg.Command(), sp.ProtocolVersion(), wire.InitStateVersion)
+		sp.server.BanPeer(sp, reason)
+		sp.Disconnect()
+		return
+	}
+
 	var blockHashes, voteHashes []chainhash.Hash
 	if len(msg.BlockHashes) > 0 {
 		blockHashes = make([]chainhash.Hash, 0, len(msg.BlockHashes))

--- a/server.go
+++ b/server.go
@@ -472,6 +472,15 @@ type serverPeer struct {
 	getMiningStateSent bool
 	initStateSent      bool
 
+	// initStateReceived tracks whether or not the peer has already received an
+	// initstate or miningstate message.  It is used to prevent more than one
+	// per connection.
+	//
+	// It is only accessed directly in callbacks which run in the same peer
+	// input handler goroutine and thus does not need to be protected for
+	// concurrent access.
+	initStateReceived bool
+
 	// reportedLocalAddr is network address the remote peer reported for the
 	// connection.  In other words, what it believes to be the external address
 	// of the server.
@@ -1149,8 +1158,11 @@ func (sp *serverPeer) OnGetMiningState(_ *peer.Peer, msg *wire.MsgGetMiningState
 		return
 	}
 
+	// Ban peers sending more than one request for an initial state message.
 	if sp.getMiningStateSent {
-		peerLog.Tracef("Ignoring getminingstate from %v - already sent", sp)
+		reason := fmt.Sprintf("sent more than one %s", msg.Command())
+		sp.server.BanPeer(sp, reason)
+		sp.Disconnect()
 		return
 	}
 	sp.getMiningStateSent = true
@@ -1222,6 +1234,15 @@ func (sp *serverPeer) OnMiningState(_ *peer.Peer, msg *wire.MsgMiningState) {
 		return
 	}
 
+	// Ban peers sending more than one initial state message.
+	if sp.initStateReceived {
+		const reason = "sent more than one initial state message (miningstate)"
+		sp.server.BanPeer(sp, reason)
+		sp.Disconnect()
+		return
+	}
+	sp.initStateReceived = true
+
 	var blockHashes, voteHashes []chainhash.Hash
 	if len(msg.BlockHashes) > 0 {
 		blockHashes = make([]chainhash.Hash, 0, len(msg.BlockHashes))
@@ -1243,8 +1264,11 @@ func (sp *serverPeer) OnMiningState(_ *peer.Peer, msg *wire.MsgMiningState) {
 // OnGetInitState is invoked when a peer receives a getinitstate wire message.
 // It sends the available requested info to the remote peer.
 func (sp *serverPeer) OnGetInitState(_ *peer.Peer, msg *wire.MsgGetInitState) {
+	// Ban peers sending more than one request for an initial state message.
 	if sp.initStateSent {
-		peerLog.Tracef("Ignoring getinitstate from %v - already sent", sp)
+		reason := fmt.Sprintf("sent more than one %s", msg.Command())
+		sp.server.BanPeer(sp, reason)
+		sp.Disconnect()
 		return
 	}
 	sp.initStateSent = true
@@ -1319,6 +1343,15 @@ func (sp *serverPeer) OnGetInitState(_ *peer.Peer, msg *wire.MsgGetInitState) {
 // OnInitState is invoked when a peer receives a initstate wire message.  It
 // requests the data advertised in the message from the peer.
 func (sp *serverPeer) OnInitState(_ *peer.Peer, msg *wire.MsgInitState) {
+	// Ban peers sending more than one initial state message.
+	if sp.initStateReceived {
+		const reason = "sent more than one initial state message (initstate)"
+		sp.server.BanPeer(sp, reason)
+		sp.Disconnect()
+		return
+	}
+	sp.initStateReceived = true
+
 	sp.server.syncManager.RequestFromPeer(sp.syncMgrPeer, msg.BlockHashes,
 		msg.VoteHashes, msg.TSpendHashes)
 }

--- a/server.go
+++ b/server.go
@@ -1133,10 +1133,22 @@ func (sp *serverPeer) pushMiningStateMsg(height uint32, blockHashes []chainhash.
 	return nil
 }
 
-// OnGetMiningState is invoked when a peer receives a getminings wire message.
-// It constructs a list of the current best blocks and votes that should be
-// mined on and pushes a miningstate wire message back to the requesting peer.
+// OnGetMiningState is invoked when a peer receives a getminings (aka
+// getminingstate) wire message.  It constructs a list of the current best
+// blocks and votes that should be mined on and pushes a miningstate wire
+// message back to the requesting peer.
 func (sp *serverPeer) OnGetMiningState(_ *peer.Peer, msg *wire.MsgGetMiningState) {
+	// Ban peers attempting to request the initial state via miningstate once
+	// the protocol version is high enough that the peer is knowingly violating
+	// the protocol.
+	if sp.ProtocolVersion() >= wire.InitStateVersion {
+		reason := fmt.Sprintf("sent %s request with protocol version %d >= %d",
+			msg.Command(), sp.ProtocolVersion(), wire.InitStateVersion)
+		sp.server.BanPeer(sp, reason)
+		sp.Disconnect()
+		return
+	}
+
 	if sp.getMiningStateSent {
 		peerLog.Tracef("Ignoring getminingstate from %v - already sent", sp)
 		return
@@ -1199,6 +1211,17 @@ func (sp *serverPeer) OnGetMiningState(_ *peer.Peer, msg *wire.MsgGetMiningState
 // OnMiningState is invoked when a peer receives a miningstate wire message.  It
 // requests the data advertised in the message from the peer.
 func (sp *serverPeer) OnMiningState(_ *peer.Peer, msg *wire.MsgMiningState) {
+	// Ban peers attempting to send the initial state via miningstate once
+	// the protocol version is high enough that the peer is knowingly violating
+	// the protocol.
+	if sp.ProtocolVersion() >= wire.InitStateVersion {
+		reason := fmt.Sprintf("sent %s with protocol version %d >= %d",
+			msg.Command(), sp.ProtocolVersion(), wire.InitStateVersion)
+		sp.server.BanPeer(sp, reason)
+		sp.Disconnect()
+		return
+	}
+
 	var blockHashes, voteHashes []chainhash.Hash
 	if len(msg.BlockHashes) > 0 {
 		blockHashes = make([]chainhash.Hash, 0, len(msg.BlockHashes))


### PR DESCRIPTION
The required method for requesting and sending the initial state was changed to `getinitstate` and `initstate` in protocol version 8.  However, that wasn't strictly enforced at the time to ensure any straggling implementations had a chance to catch up.

Now that there have been multiple protocol versions since that time and new consensus changes that would fork any old nodes from the network anyway, this adds hard enforcement of that rule.

Further, the expected protocol for the initial state messages in general is that only a single request and response will be sent per connection.  All honest peers on the network follow this rule, however it is not strictly enforced.

This adds logic to strictly enforce those rules by banning any peers that violate them.