### PR TITLE
blockchain/standalone: Prepare v2.3.0

### DIFF
--- a/blockchain/standalone/error.go
+++ b/blockchain/standalone/error.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023 The Decred developers
+// Copyright (c) 2019-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/blockchain/standalone/error_test.go
+++ b/blockchain/standalone/error_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022 The Decred developers
+// Copyright (c) 2019-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/blockchain/standalone/go.mod
+++ b/blockchain/standalone/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.5
-	github.com/decred/dcrd/wire v1.7.1
+	github.com/decred/dcrd/wire v1.7.5
 )
 
 require (

--- a/blockchain/standalone/go.sum
+++ b/blockchain/standalone/go.sum
@@ -4,8 +4,8 @@ github.com/decred/dcrd/chaincfg/chainhash v1.0.5 h1:GwzXLsZoemdDxFdtj3GdW25Z+NXd
 github.com/decred/dcrd/chaincfg/chainhash v1.0.5/go.mod h1:vCqZMGtKbyxJkdcVzP3Ryc9IvaspVUb7hO6t+rjxmcs=
 github.com/decred/dcrd/crypto/blake256 v1.1.0 h1:zPMNGQCm0g4QTY27fOCorQW7EryeQ/U0x++OzVrdms8=
 github.com/decred/dcrd/crypto/blake256 v1.1.0/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
-github.com/decred/dcrd/wire v1.7.1 h1:kDuHBiY1Qv9rBxYKgC2RgyPy7IOA2WRf00jqHwpr16I=
-github.com/decred/dcrd/wire v1.7.1/go.mod h1:eP9XRsMloy+phlntkTAaAm611JgLv8NqY1YJoRxkNKU=
+github.com/decred/dcrd/wire v1.7.5 h1:fRaaB5CrwYWGI3YVv50XHm54lsU1TB40WnnIJ4W6aGM=
+github.com/decred/dcrd/wire v1.7.5/go.mod h1:NZK8QD5W2ObX6p+Q0TUzYNpQtk4Ov3pBIvc6ZUK88FU=
 github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 lukechampine.com/blake3 v1.3.0 h1:sJ3XhFINmHSrYCgl958hscfIa3bw8x4DqMP3u1YvoYE=

--- a/blockchain/standalone/tx.go
+++ b/blockchain/standalone/tx.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2022 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/blockchain/standalone/tx_test.go
+++ b/blockchain/standalone/tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023 The Decred developers
+// Copyright (c) 2019-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/mixing/go.mod
+++ b/mixing/go.mod
@@ -33,4 +33,5 @@ require (
 )
 
 retract v0.7.0 // Build broken for 32-bit targets
+
 retract v0.7.1 // Incorrect check for P2SH scripts


### PR DESCRIPTION
This updates the `blockchain/standalone` module dependencies, the copyright year in the files modifies since the previous release, and serves as a base for `blockchain/standalone/v2.3.0`.

The updated direct dependencies in this commit are as follows:

- github.com/decred/dcrd/wire@v1.7.5

The full list of updated direct and indirect dependencies since the previous `blockchain/standalone/v2.2.2` release are the same as above.

Finally, all modules in the repository are tidied to ensure they are updated to use the latest versions hoisted forward as a result.
