### PR TITLE
stake: Minor improvements in IsTreasuryX tests.

### DIFF
--- a/blockchain/stake/treasury.go
+++ b/blockchain/stake/treasury.go
@@ -72,8 +72,7 @@ func CheckTAdd(tx *wire.MsgTx) error {
 
 	// All output scripts must be version 0 and non-empty.
 	const consensusScriptVer = 0
-	for txOutIdx := range tx.TxOut {
-		txOut := tx.TxOut[txOutIdx]
+	for txOutIdx, txOut := range tx.TxOut {
 		if txOut.Version != consensusScriptVer {
 			str := fmt.Sprintf("treasury add transaction output %d script "+
 				"version is %d instead of %d", txOutIdx, txOut.Version,

--- a/blockchain/stake/treasury_test.go
+++ b/blockchain/stake/treasury_test.go
@@ -80,7 +80,7 @@ func treasurySpendSignature(sig, pubKey []byte) []byte {
 }
 
 // fakeTreasurySpendSignature returns a signature script that is valid enough to
-// pass all checks, but would fail if actually checked.  This identification
+// pass all checks, but would fail if actually checked.  The identification
 // funcs in this package do not verify signatures, so valid signatures are not
 // required for the tests.
 func fakeTreasurySpendSignature() []byte {
@@ -183,7 +183,7 @@ func TestTreasuryIsFunctions(t *testing.T) {
 	tests := []struct {
 		name          string      // test description
 		tx            *wire.MsgTx // transaction to test
-		treasuryAdd   bool        // expected check is treasury add
+		treasuryAdd   bool        // expected is treasury add
 		treasuryBase  bool        // expected is treasury base
 		treasurySpend bool        // expected is treasury spend
 	}{{


### PR DESCRIPTION
I was late to the party reviewing [these recent changes](https://github.com/decred/dcrd/pull/3680) but I've taken a look anyway and here are a few minor things I noticed could be improved.

Using t.Run takes advantage of go tooling to prefix test error messages with the test name, rather than having to manually constructing the strings.
