### PR TITLE
connmgr: Support whitelisting.

### DIFF
--- a/internal/connmgr/README.md
+++ b/internal/connmgr/README.md
@@ -33,6 +33,8 @@ The following is a brief overview of the key features:
   - Supports manual connection establishment via `Connect`
 - Duplicate address prevention
   - Rejects duplicate connections to and from the same address (host:port)
+- Whitelist support
+  - CIDR-based whitelists that allow bypassing certain limits and restrictions
 - Rich managed connections via `Conn`
   - Connection types for differentiated handling
   - Automatic cleanup on connection close

--- a/internal/connmgr/connmanager.go
+++ b/internal/connmgr/connmanager.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -260,6 +261,10 @@ type Config struct {
 	// DialTimeout specifies the amount of time to wait for a connection to
 	// complete before giving up.
 	DialTimeout time.Duration
+
+	// Whitelists specifies CIDR address prefixes to whitelist.  Whitelisted
+	// addresses are exempt from banning and certain connection limits.
+	Whitelists []netip.Prefix
 }
 
 // ConnManager provides a manager to handle network connections.
@@ -315,6 +320,22 @@ type ConnManager struct {
 	// (host:port).  It is kept in sync with the persistent, pending, and active
 	// maps and is primarily used to efficiently reject duplicate connections.
 	connIDByAddr map[string]uint64
+}
+
+// IsWhitelisted returns whether the IP address is included in the whitelisted
+// networks and IPs.
+func (cm *ConnManager) IsWhitelisted(addr *addrmgr.NetAddress) bool {
+	if len(cm.cfg.Whitelists) == 0 {
+		return false
+	}
+
+	ip, _ := netip.AddrFromSlice(addr.IP)
+	for _, prefix := range cm.cfg.Whitelists {
+		if prefix.Contains(ip) {
+			return true
+		}
+	}
+	return false
 }
 
 // checkShutdown returns [ErrShutdown] when the connection manager quit channel

--- a/internal/connmgr/connmanager_test.go
+++ b/internal/connmgr/connmanager_test.go
@@ -219,6 +219,93 @@ func TestNewConfig(t *testing.T) {
 	})
 }
 
+// TestIsWhitelisted ensures [ConnManager.IsWhitelisted] works as expected.
+func TestIsWhitelisted(t *testing.T) {
+	type perManagerTest struct {
+		addr        string // address to test against whitelist
+		whitelisted bool   // expected whitelisted result
+	}
+
+	tests := []struct {
+		name            string           // test description
+		prefixes        []netip.Prefix   // CIDR prefixes to whitelist
+		perManagerTests []perManagerTest // tests to run against the prefixes
+	}{{
+		name:     "no whitelisted entries",
+		prefixes: nil,
+		perManagerTests: []perManagerTest{
+			{"1.2.3.4:18555", false},
+			{"127.0.0.1:18555", false},
+		},
+	}, {
+		name: "single /32 IPv4 entry",
+		prefixes: []netip.Prefix{
+			netip.MustParsePrefix("1.2.3.4/32"),
+		},
+		perManagerTests: []perManagerTest{
+			{"1.2.3.4:18555", true},
+			{"1.2.3.4:9108", true},
+			{"[::1.2.3.4]:18555", false}, // IPv4 in IPv6
+			{"1.2.3.5:18555", false},
+		},
+	}, {
+		name: "single /128 IPv6 entry",
+		prefixes: []netip.Prefix{
+			netip.MustParsePrefix("::1.2.3.4/128"),
+		},
+		perManagerTests: []perManagerTest{
+			{"[::1.2.3.4]:18555", true},
+			{"[::1.2.3.4]:9108", true},
+			{"1.2.3.4:18555", false}, // IPv4 doesn't match IPv4 in IPv6
+			{"[::1.2.3.5]:9108", false},
+		},
+	}, {
+		name: "mixed IPv4 and IPv6 with different prefix lengths",
+		prefixes: []netip.Prefix{
+			netip.MustParsePrefix("12.13.14.0/24"),
+			netip.MustParsePrefix("20.21.22.23/8"),
+			netip.MustParsePrefix("fe80::/64"),
+		},
+		perManagerTests: []perManagerTest{
+			{"12.13.14.1:18555", true},
+			{"12.13.14.255:18555", true},
+			{"12.13.15.0:18555", false},
+			{"20.0.0.0:18555", true},
+			{"20.0.0.0:9108", true},
+			{"20.255.255.255:18555", true},
+			{"20.255.255.255:9108", true},
+			{"21.0.0.0:18555", false},
+			{"[fe80::1]:18555", true},
+			{"[fe80::1]:9108", true},
+			{"[fe80::ffff:ffff:ffff:ffff]:18555", true},
+			{"[fe80::ffff:ffff:ffff:ffff]:1234", true},
+			{"[fe80::1:ffff:ffff:ffff:ffff]:18555", false},
+		},
+	}}
+
+	for _, test := range tests {
+		// Parse the whitelist entries for the test.
+		cmgr := newTestConnManager(t, &Config{
+			Dial:       mockDialer,
+			Whitelists: test.prefixes,
+		})
+
+		for _, pmTest := range test.perManagerTests {
+			mAddr := mockAddr{"tcp", pmTest.addr}
+			addr, err := stdlibNetAddrToAddrMgrNetAddr(mAddr)
+			if err != nil {
+				t.Fatalf("%q-%q: failed to parse address: %v", test.name,
+					pmTest.addr, err)
+			}
+			if got := cmgr.IsWhitelisted(addr); got != pmTest.whitelisted {
+				t.Errorf("%q-%q: mismatched result -- got %v, want %v",
+					test.name, pmTest.addr, got, pmTest.whitelisted)
+				continue
+			}
+		}
+	}
+}
+
 // assertConnID ensures the provided connection has the given ID.
 func assertConnID(t *testing.T, conn *Conn, wantID uint64) {
 	t.Helper()

--- a/server.go
+++ b/server.go
@@ -513,6 +513,7 @@ func newServerPeer(s *server, conn *connmgr.Conn, remoteAddr *addrmgr.NetAddress
 		conn:           conn,
 		remoteAddr:     remoteAddr,
 		persistent:     s.connManager.IsPersistent(conn.ID()),
+		isWhitelisted:  s.connManager.IsWhitelisted(remoteAddr),
 		knownAddresses: apbf.NewFilter(maxKnownAddrsPerPeer, knownAddrsFPRate),
 		quit:           make(chan struct{}),
 		getDataQueue:   make(chan []*wire.InvVect, maxConcurrentGetDataReqs),
@@ -2289,7 +2290,6 @@ func (s *server) inboundPeerConnected(ctx context.Context, conn *connmgr.Conn) {
 
 	sp := newServerPeer(s, conn, remoteNetAddr)
 	sp.Peer = peer.NewInboundPeer(newPeerConfig(sp), conn)
-	sp.isWhitelisted = isWhitelisted(remoteNetAddr)
 	if err := sp.Handshake(ctx, sp.OnVersion); err != nil {
 		srvrLog.Debugf("Failed handshake for inbound peer %s: %v",
 			remoteNetAddr, err)
@@ -2323,7 +2323,6 @@ func (s *server) outboundPeerConnected(ctx context.Context, conn *connmgr.Conn) 
 
 	sp := newServerPeer(s, conn, remoteNetAddr)
 	sp.Peer = peer.NewOutboundPeer(newPeerConfig(sp), conn.RemoteAddr(), conn)
-	sp.isWhitelisted = isWhitelisted(remoteNetAddr)
 	if err := sp.Handshake(ctx, sp.OnVersion); err != nil {
 		srvrLog.Debugf("Failed handshake for outbound peer %s: %v",
 			conn.RemoteAddr(), err)
@@ -4367,6 +4366,7 @@ func newServer(ctx context.Context, profiler *profileServer,
 			s.outboundPeerConnected(ctx, conn)
 		},
 		GetNewAddress: newAddressFunc,
+		Whitelists:    cfg.whitelists,
 	})
 	if err != nil {
 		return nil, err
@@ -4630,20 +4630,4 @@ func addLocalAddress(addrMgr *addrmgr.AddrManager, addr string, services wire.Se
 	}
 
 	return nil
-}
-
-// isWhitelisted returns whether the IP address is included in the whitelisted
-// networks and IPs.
-func isWhitelisted(addr *addrmgr.NetAddress) bool {
-	if len(cfg.whitelists) == 0 {
-		return false
-	}
-
-	ip, _ := netip.AddrFromSlice(addr.IP)
-	for _, prefix := range cfg.whitelists {
-		if prefix.Contains(ip) {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
~~**This requires #3695**.~~

Currently the whitelisting logic happens in the server which makes it inaccessible to the connection manager.

In order to pave the way for supporting various connection-related logic that currently happens in the server, but ideally should be happening in the connection manager, this adds basic support for whitelisting CIDR prefixes to the connection manager.

The connection manager config struct now accepts a slice of prefixes and a new method named `IsWhitelisted` is added.

In a separate commit, it modifies the server to pass in the parsed whitelist entries to the connection manager config and the relevant code to make use of the new method it exposes.

Finally, it removes the no longer used local `isWhitelisted` method.