### PR TITLE
connmgr: Limit total overall normal connections.

### DIFF
--- a/internal/connmgr/README.md
+++ b/internal/connmgr/README.md
@@ -31,6 +31,8 @@ The following is a brief overview of the key features:
     with exponential backoff on disconnect
 - Manual connections
   - Supports manual connection establishment via `Connect`
+- Connection limits
+  - Limits total normal (non-persistent) connections to `MaxNormalConns`
 - Duplicate address prevention
   - Rejects duplicate connections to and from the same address (host:port)
 - Whitelist support

--- a/internal/connmgr/connmanager.go
+++ b/internal/connmgr/connmanager.go
@@ -44,6 +44,10 @@ const (
 	// base times the number of retries that have been done.
 	defaultMaxRetryDuration = time.Minute * 5
 
+	// defaultMaxNormalConns is the default maximum number of normal inbound,
+	// outbound, and pending connections to permit.
+	defaultMaxNormalConns = 125
+
 	// defaultTargetOutbound is the default number of outbound connections to
 	// maintain.
 	defaultTargetOutbound = 8
@@ -233,11 +237,25 @@ type Config struct {
 	// connections in that case.
 	OnAccept func(*Conn)
 
+	// MaxNormalConns is the maximum number of normal inbound, outbound, and
+	// pending connections to permit.  Defaults to 125.
+	//
+	// Persistent connections do not count against this limit.  They have their
+	// own maximum defined by [MaxPersistent].
+	//
+	// Whitelisted connections and some connections with special permissions are
+	// also exempt.  As a result, the total number of connections may exceed
+	// this value.
+	MaxNormalConns uint32
+
 	// TargetOutbound is the number of outbound network connections to maintain
 	// automatically.  Defaults to 8.
 	//
 	// Persistent connections do not count against this value.  They have their
 	// own maximum limit defined by [MaxPersistent].
+	//
+	// This will be forced to the smaller of the specified value (or its default
+	// value when unspecified) and [Config.MaxNormalConns].
 	TargetOutbound uint32
 
 	// RetryDuration is the duration to wait before retrying connection
@@ -290,10 +308,16 @@ type ConnManager struct {
 	// It is a buffered channel with size [MaxPersistent].
 	runPersistentChan chan *persistentEntry
 
-	// outboundSem limits the number of active outbound connections.  It does
-	// not apply to persistent connections which are separately limited to
-	// [MaxPersistent].
-	activeOutboundsSem semaphore
+	// These semaphores are used to enforce max limits on the number of
+	// connections of different kinds.  They do not apply to persistent
+	// connections which are separately limited to [MaxPersistent].
+	//
+	// totalNormalConnsSem limits the total overall number of normal inbound,
+	// outbound, and pending connections.
+	//
+	// outboundSem limits the number of active outbound connections.
+	totalNormalConnsSem semaphore
+	activeOutboundsSem  semaphore
 
 	// The fields below this point are all protected by the connection mutex.
 	connMtx sync.Mutex
@@ -694,9 +718,13 @@ func (cm *ConnManager) dial(ctx context.Context, addr net.Addr, connType Connect
 // the connection manager.
 //
 // Attempts to dial addresses that already have an established, pending, or
-// persistent connection will return an error as described below.
+// persistent connection or would exceed max allowed limits will return an error
+// as described below.
 //
-// The connection will have type [ConnTypeManual].
+// The connection will have type [ConnTypeManual] and the following connection
+// limits are enforced:
+//
+//   - Total normal connections ([Config.MaxNormalConns])
 //
 // Note that the context parameter to this function and the lifecycle context
 // may be independent.
@@ -710,6 +738,8 @@ func (cm *ConnManager) dial(ctx context.Context, addr net.Addr, connType Connect
 //     to the address
 //   - [ErrAlreadyConnected] when there is already an established connection to
 //     the address
+//   - [ErrMaxNormalConns] when there are already the maximum allowed number of
+//     normal connections (inbound, outbound, and pending)
 //   - [ErrShutdown] when the connection manager is shutting down
 //   - [context.Canceled] or [context.DeadlineExceeded] depending on the
 //     provided context or when the dialer fails to establish a connection
@@ -717,7 +747,21 @@ func (cm *ConnManager) dial(ctx context.Context, addr net.Addr, connType Connect
 //
 // This function is safe for concurrent access.
 func (cm *ConnManager) Connect(ctx context.Context, addr net.Addr) (*Conn, error) {
-	conn, err := cm.dial(ctx, addr, ConnTypeManual, nil, nil)
+	acquired, err := cm.totalNormalConnsSem.TryAcquire(ctx)
+	if err != nil {
+		if sErr := cm.checkShutdown(); sErr != nil {
+			return nil, sErr
+		}
+		return nil, err
+	}
+	if !acquired {
+		maxAllowed := cm.cfg.MaxNormalConns
+		str := fmt.Sprintf("a maximum of %d %s is allowed", maxAllowed,
+			pickNoun(maxAllowed, "connection", "connections"))
+		return nil, MakeError(ErrMaxNormalConns, str)
+	}
+	onClose := cm.totalNormalConnsSem.Release
+	conn, err := cm.dial(ctx, addr, ConnTypeManual, onClose, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -847,6 +891,18 @@ func (cm *ConnManager) listenHandler(ctx context.Context, listener net.Listener)
 	defer log.Tracef("Listener handler done for %s", listener.Addr())
 
 	for ctx.Err() == nil {
+		// The following is intentionally implementing active connection
+		// shedding by accepting connections and then immediately disconnecting
+		// them after the [net.Listener.Accept] call if any policies are
+		// violated.
+		//
+		// Reversing it and blocking until a permit is available and only then
+		// calling Accept would cause the connections to build up in the kernel.
+		// Then, since the kernel will still create the 3-way handshake, clients
+		// would connect and hang until their own timeouts are hit, and,
+		// eventually, the entire service could appear entirely down if the SYN
+		// queue were to fill.  It also would not allow implementing better
+		// additional policies.
 		netConn, err := listener.Accept()
 		if err != nil {
 			// Only log the error if not forcibly shutting down.
@@ -881,7 +937,29 @@ func (cm *ConnManager) listenHandler(ctx context.Context, listener net.Listener)
 		}
 		cm.connMtx.Unlock()
 
-		go func(netConn net.Conn) {
+		// Require a permit to allow the inbound connection unless the address
+		// has special permissions (e.g. whitelisted).
+		//
+		// Attempt to acquire a permit via a non-blocking call and immediately
+		// disconnect if unsuccessful so that all blocking happens on
+		// [net.Listener.Accept] for the reasons described above.
+		requirePermit := !cm.IsWhitelisted(rAddr)
+		if requirePermit {
+			acquired, err := cm.totalNormalConnsSem.TryAcquire(ctx)
+			if err != nil {
+				netConn.Close()
+				continue
+			}
+			if !acquired {
+				maxAllowed := cm.cfg.MaxNormalConns
+				log.Debugf("Dropped connection from %v: a maximum of %d %s is "+
+					"allowed", rAddr, maxAllowed, pickNoun(maxAllowed,
+					"connection", "connections"))
+				netConn.Close()
+				continue
+			}
+		}
+		go func(netConn net.Conn, requirePermit bool) {
 			// Create a new connection instance with the next globally unique
 			// connection ID, add an entry to the map that tracks all active
 			// connections, and invoke the configured accept callback with it.
@@ -897,6 +975,9 @@ func (cm *ConnManager) listenHandler(ctx context.Context, listener net.Listener)
 				cm.connMtx.Unlock()
 				log.Debugf("Disconnected from %v (id: %d, type: %v)", rAddr, id,
 					connType)
+				if requirePermit {
+					cm.totalNormalConnsSem.Release()
+				}
 			}
 			conn = newConn(cm, netConn, id, connType, rAddr, onClose)
 			cm.connMtx.Lock()
@@ -905,7 +986,7 @@ func (cm *ConnManager) listenHandler(ctx context.Context, listener net.Listener)
 			log.Debugf("Accepted connection from %v (id: %d, type: %v)", rAddr,
 				id, connType)
 			cm.cfg.OnAccept(conn)
-		}(netConn)
+		}(netConn, requirePermit)
 	}
 }
 
@@ -1147,16 +1228,28 @@ func (cm *ConnManager) targetOutboundHandler(ctx context.Context) {
 			return
 		}
 
+		// Wait for a permit to make another overall connection.  This limits
+		// the total number of normal connections while the previous limits the
+		// total number of automatic outbound connections.
+		if !cm.totalNormalConnsSem.Acquire(ctx) {
+			cm.activeOutboundsSem.Release()
+			return
+		}
+
 		addr, err := cm.cfg.GetNewAddress()
 		if err != nil {
 			failedAttempts.Add(1)
 			log.Debugf("Failed to get address for outbound connection: %v", err)
+			cm.totalNormalConnsSem.Release()
 			cm.activeOutboundsSem.Release()
 			continue
 		}
 
 		go func(addr net.Addr) {
-			onClose := cm.activeOutboundsSem.Release
+			onClose := func() {
+				cm.totalNormalConnsSem.Release()
+				cm.activeOutboundsSem.Release()
+			}
 			conn, err := cm.dial(ctx, addr, ConnTypeOutbound, onClose, nil)
 			if err != nil {
 				failedAttempts.Add(1)
@@ -1252,23 +1345,28 @@ func New(cfg *Config) (*ConnManager, error) {
 	if cfg.Dial == nil {
 		return nil, MakeError(ErrDialNil, "dial cannot be nil")
 	}
-	// Default to sane values
+	// Default to sane values.
 	if cfg.RetryDuration <= 0 {
 		cfg.RetryDuration = defaultRetryDuration
+	}
+	if cfg.MaxNormalConns == 0 {
+		cfg.MaxNormalConns = defaultMaxNormalConns
 	}
 	if cfg.TargetOutbound == 0 {
 		cfg.TargetOutbound = defaultTargetOutbound
 	}
+	cfg.TargetOutbound = min(cfg.TargetOutbound, cfg.MaxNormalConns)
 	cm := ConnManager{
-		cfg:                *cfg, // Copy so caller can't mutate
-		quit:               make(chan struct{}),
-		maxRetryDuration:   defaultMaxRetryDuration,
-		runPersistentChan:  make(chan *persistentEntry, MaxPersistent),
-		activeOutboundsSem: makeSemaphore(cfg.TargetOutbound),
-		persistent:         make(map[uint64]*persistentEntry, MaxPersistent),
-		pending:            make(map[uint64]*pendingConnInfo),
-		active:             make(map[uint64]*Conn, cfg.TargetOutbound),
-		connIDByAddr:       make(map[string]uint64),
+		cfg:                 *cfg, // Copy so caller can't mutate
+		quit:                make(chan struct{}),
+		maxRetryDuration:    defaultMaxRetryDuration,
+		runPersistentChan:   make(chan *persistentEntry, MaxPersistent),
+		totalNormalConnsSem: makeSemaphore(cfg.MaxNormalConns),
+		activeOutboundsSem:  makeSemaphore(cfg.TargetOutbound),
+		persistent:          make(map[uint64]*persistentEntry, MaxPersistent),
+		pending:             make(map[uint64]*pendingConnInfo),
+		active:              make(map[uint64]*Conn, cfg.TargetOutbound),
+		connIDByAddr:        make(map[string]uint64),
 	}
 	return &cm, nil
 }

--- a/internal/connmgr/connmanager_test.go
+++ b/internal/connmgr/connmanager_test.go
@@ -1710,3 +1710,177 @@ func TestRejectDuplicateConns(t *testing.T) {
 	wg.Wait()
 	assertConnManagerCleanShutdown(t, cmgr)
 }
+
+// TestMaxNormalConns ensures the connection manager limits the total number of
+// normal connections to [Config.MaxNormalConns] including automatic outbound,
+// manual outbound, and inbound connections.  It also ensures that it is not
+// applied to persistent connections.
+func TestMaxNormalConns(t *testing.T) {
+	t.Parallel()
+
+	// nextAddr is a convenience func to return a new unique address with every
+	// invocation.
+	var numAddrs atomic.Uint32
+	nextAddr := func() net.Addr {
+		addrStr := fmt.Sprintf("10.0.0.%d:18555", numAddrs.Add(1))
+		return mustParseAddrPort(addrStr)
+	}
+
+	// Create an address that will be whitelisted.
+	whitelistedIP := netip.MustParseAddr("220.0.0.1")
+	whitelistedAddr := mustParseAddrPort(whitelistedIP.String() + ":1024")
+
+	// Constants for the number of various normal connection types to test
+	// overall max normal connection limits.
+	const (
+		targetOutbound = 3
+		targetManual   = 4
+		targetInbound  = 5
+		maxNormalConns = targetOutbound + targetManual + targetInbound
+	)
+	connected := make(chan *Conn)
+	disconnected := make(chan *Conn)
+	inboundConns := make(chan *Conn)
+	listener := newMockListener("127.0.0.1:9108")
+	var pauseTargetOutbound atomic.Bool
+	var totalPausedAddrs atomic.Uint32
+	hitMaxFailedAttempts := make(chan struct{})
+	cmgr := newTestConnManager(t, &Config{
+		Listeners:      []net.Listener{listener},
+		MaxNormalConns: maxNormalConns,
+		TargetOutbound: targetOutbound,
+		RetryDuration:  50 * time.Millisecond,
+		Dial:           mockDialer,
+		Whitelists:     []netip.Prefix{netip.PrefixFrom(whitelistedIP, 32)},
+		OnAccept: func(conn *Conn) {
+			inboundConns <- conn
+		},
+		GetNewAddress: func() (net.Addr, error) {
+			if pauseTargetOutbound.Load() {
+				total := totalPausedAddrs.Add(1)
+				if total == maxFailedAttempts {
+					hitMaxFailedAttempts <- struct{}{}
+				}
+				return nil, errors.New("network down")
+			}
+			return nextAddr(), nil
+		},
+		OnConnection: func(conn *Conn) {
+			connected <- conn
+		},
+		OnDisconnection: func(conn *Conn) {
+			disconnected <- conn
+		},
+	})
+	cmgr.maxRetryDuration = cmgr.cfg.RetryDuration
+	ctx, shutdown, wg := runConnMgrAsync(context.Background(), cmgr)
+
+	// Wait for the expected number of target outbound conns to be established.
+	outbounds := make([]*Conn, 0, targetOutbound)
+	for len(outbounds) < targetOutbound {
+		conn := assertConnReceived(t, connected, 0, ConnTypeOutbound)
+		outbounds = append(outbounds, conn)
+	}
+	assertConnManagerInternalState(t, cmgr)
+
+	// Establish target number of inbounds to the listener and wait for them to
+	// be established.
+	go func() {
+		for range targetInbound {
+			listener.Connect(nextAddr())
+		}
+	}()
+	inbounds := make([]*Conn, 0, targetInbound)
+	for len(inbounds) < targetInbound {
+		conn := assertConnReceived(t, inboundConns, 0, ConnTypeInbound)
+		inbounds = append(inbounds, conn)
+	}
+	assertConnManagerInternalState(t, cmgr)
+
+	// Establish target number of manual connections and wait for them to be
+	// established.
+	go func() {
+		for range targetManual {
+			go cmgr.Connect(ctx, nextAddr())
+		}
+	}()
+	manualConns := make([]*Conn, 0, targetManual+1)
+	for len(manualConns) < targetManual {
+		conn := assertConnReceived(t, connected, 0, ConnTypeManual)
+		manualConns = append(manualConns, conn)
+	}
+	assertConnManagerInternalState(t, cmgr)
+
+	// Ensure manual connections that would exceed the max allowed normal
+	// connections are rejected.
+	_, err := cmgr.Connect(ctx, nextAddr())
+	if !errors.Is(err, ErrMaxNormalConns) {
+		t.Fatalf("did not reject manual connection at max allowed, err: %v", err)
+	}
+	assertConnManagerInternalState(t, cmgr)
+
+	// Ensure inbound connections that would exceed the max allowed normal
+	// connections are rejected.
+	go listener.Connect(nextAddr())
+	assertNoConnReceived(t, inboundConns)
+	assertConnManagerInternalState(t, cmgr)
+
+	// Ensure inbound connections from whitelisted addresses are exempt from the
+	// max allowed normal connections by establishing one while at the limit.
+	go listener.Connect(whitelistedAddr)
+	conn := assertConnReceived(t, inboundConns, 0, ConnTypeInbound)
+	assertConnManagerInternalState(t, cmgr)
+
+	// Ensure closing the whitelisted connection does not release a permit it
+	// never acquired by asserting inbound connections that would exceed the max
+	// allowed normal connections are still rejected after the close.
+	conn.Close()
+	assertConnReceived(t, disconnected, conn.ID(), ConnTypeInbound)
+	go listener.Connect(nextAddr())
+	assertNoConnReceived(t, inboundConns)
+	assertConnManagerInternalState(t, cmgr)
+
+	// Pause the target outbound dials and remove one of the target outbound
+	// connections to make room for another manual connection.  Then wait for
+	// the max failures to be hit so attempts are paused for a retry timeout.
+	pauseTargetOutbound.Store(true)
+	outboundConn := outbounds[0]
+	outboundConn.Close()
+	assertConnReceived(t, disconnected, outboundConn.ID(), ConnTypeOutbound)
+	select {
+	case <-hitMaxFailedAttempts:
+		time.Sleep(connTestReceiveTimeout)
+	case <-time.After(maxFailedAttempts * connTestReceiveTimeout):
+		t.Fatal("did not reach max failed attempts before timeout")
+	}
+	assertConnManagerInternalState(t, cmgr)
+
+	// Establish another manual connection to take the place of the target
+	// outbound connection that was just closed and wait for it to be
+	// established.
+	go cmgr.Connect(ctx, nextAddr())
+	assertConnReceived(t, connected, 0, ConnTypeManual)
+	assertConnManagerInternalState(t, cmgr)
+
+	// Unpause the target outbound dials and ensure no additional automatic
+	// outbound connections are made despite being under the target outbound due
+	// to max total conns.
+	pauseTargetOutbound.Store(false)
+	assertNoConnReceivedTimeout(t, connected, connTestNonReceiveTimeout+
+		cmgr.cfg.RetryDuration)
+	assertConnManagerInternalState(t, cmgr)
+
+	// Ensure persistent connections are not subject to the max total normal
+	// connections by adding one and waiting for it to be established.
+	connID, err := cmgr.AddPersistent(nextAddr())
+	if err != nil {
+		t.Fatalf("failed to add persistent connection: %v", err)
+	}
+	assertConnReceived(t, connected, connID, ConnTypeManual)
+	assertConnManagerInternalState(t, cmgr)
+
+	// Ensure clean shutdown of connection manager.
+	shutdown()
+	wg.Wait()
+	assertConnManagerCleanShutdown(t, cmgr)
+}

--- a/internal/connmgr/error.go
+++ b/internal/connmgr/error.go
@@ -22,6 +22,10 @@ const (
 	// already has an established connection.
 	ErrAlreadyConnected = ErrorKind("ErrAlreadyConnected")
 
+	// ErrMaxNormalConns indicates a connection attempt (inbound or outbound)
+	// would exceed the maximum allowed number of normal connections.
+	ErrMaxNormalConns = ErrorKind("ErrMaxNormalConns")
+
 	// ErrMaxPersistent indicates an attempt to add more than the maximum
 	// allowed number of persistent connections.
 	ErrMaxPersistent = ErrorKind("ErrMaxPersistent")

--- a/internal/connmgr/error_test.go
+++ b/internal/connmgr/error_test.go
@@ -19,6 +19,7 @@ func TestErrorKindStringer(t *testing.T) {
 		{ErrDialNil, "ErrDialNil"},
 		{ErrAlreadyPending, "ErrAlreadyPending"},
 		{ErrAlreadyConnected, "ErrAlreadyConnected"},
+		{ErrMaxNormalConns, "ErrMaxNormalConns"},
 		{ErrMaxPersistent, "ErrMaxPersistent"},
 		{ErrDuplicatePersistent, "ErrDuplicatePersistent"},
 		{ErrNotFound, "ErrNotFound"},

--- a/internal/connmgr/log.go
+++ b/internal/connmgr/log.go
@@ -19,3 +19,12 @@ var log = slog.Disabled
 func UseLogger(logger slog.Logger) {
 	log = logger
 }
+
+// pickNoun returns the singular or plural form of a noun depending on the count
+// n.
+func pickNoun[T ~uint32 | ~uint64](n T, singular, plural string) string {
+	if n == 1 {
+		return singular
+	}
+	return plural
+}

--- a/internal/connmgr/semaphore.go
+++ b/internal/connmgr/semaphore.go
@@ -27,6 +27,27 @@ func (s semaphore) Acquire(ctx context.Context) bool {
 	return true
 }
 
+// TryAcquire attempts to acquire the semaphore without blocking when there are
+// no resources immediately available.
+//
+// It returns true with a nil error on success.  It returns false with a nil
+// error when the semaphore is at capacity and no permit is available.
+//
+// Finally, it returns false with the error associated with the context
+// immediately when the context is already canceled or timed out at the time of
+// the call.  It does not attempt to acquire the semaphore in that case.
+func (s semaphore) TryAcquire(ctx context.Context) (bool, error) {
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+	select {
+	case s <- struct{}{}:
+		return true, nil
+	default:
+	}
+	return false, nil
+}
+
 // Release release the semaphore.
 func (s semaphore) Release() {
 	select {

--- a/internal/connmgr/semaphore_test.go
+++ b/internal/connmgr/semaphore_test.go
@@ -6,6 +6,7 @@ package connmgr
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 )
@@ -21,10 +22,24 @@ func TestSemaphore(t *testing.T) {
 		return sem.Acquire(ctx)
 	}
 
+	// Create a closure that tries to acquire a semaphore via the nonblocking
+	// method with a timeout.
+	timedTryAcquire := func(sem semaphore, timeout time.Duration) (bool, error) {
+		ctx, cancel := context.WithTimeout(ctx, timeout)
+		if timeout == 0 {
+			cancel()
+		} else {
+			defer cancel()
+		}
+		return sem.TryAcquire(ctx)
+	}
+
 	// perSemTest describes a test to run against the same semaphore.
 	type perSemTest struct {
 		name        string // test description
 		numAcquires uint32 // num to acquire
+		numTries    uint32 // num to try to acquire via nonblocking method
+		cancelTry   bool   // whether or not to cancel nonblocking try
 		numReleases uint32 // num to release
 	}
 
@@ -69,6 +84,45 @@ func TestSemaphore(t *testing.T) {
 			numReleases: 5,
 		}},
 		want: []bool{true, true, true, true, true, true, true, false},
+	}, {
+		name: "nonblocking tryacquire and blocking acquire mixed",
+		cap:  3,
+		perSemTests: []perSemTest{{
+			name:        "cap 3 (0 acquired): try 1, release 2",
+			numTries:    1,
+			numReleases: 2,
+		}, {
+			name:        "cap 3 (0 acquired): acquire 2, try 1, release 1",
+			numAcquires: 2,
+			numTries:    1,
+			numReleases: 1,
+		}, {
+			name:        "cap 3 (2 acquired): acquire 1, try 2, release 3",
+			numAcquires: 1,
+			numTries:    2,
+			numReleases: 3,
+		}},
+		want: []bool{true, true, true, true, true, false, false},
+	}, {
+		name: "nonblocking tryacquire with canceled context",
+		cap:  1,
+		perSemTests: []perSemTest{{
+			name:        "cap 1 (0 acquired): try 1 (canceled), release 0",
+			numTries:    1,
+			cancelTry:   true,
+			numReleases: 0,
+		}, {
+			name:        "cap 1 (0 acquired): acquire 1, try 1, release 1",
+			numAcquires: 1,
+			numTries:    1,
+			numReleases: 1,
+		}, {
+			name:        "cap 1 (0 acquired): try 2, release 1",
+			numAcquires: 0,
+			numTries:    2,
+			numReleases: 1,
+		}},
+		want: []bool{false, true, false, true, false},
 	}}
 
 	for _, test := range tests {
@@ -77,12 +131,29 @@ func TestSemaphore(t *testing.T) {
 		sem := makeSemaphore(test.cap)
 		results := make([]bool, 0, len(test.want))
 
-		// Perform each sequence of acquires and releases as specified by the
-		// per semaphore tests.
+		// Perform each sequence of acquires, try acquires, and releases as
+		// specified by the per semaphore tests.
 		for _, psTest := range test.perSemTests {
 			const timeout = 10 * time.Millisecond
 			for range psTest.numAcquires {
 				results = append(results, timedAcquire(sem, timeout))
+			}
+			for range psTest.numTries {
+				// Override timeout with a duration 0 and expected error when
+				// the flag to force the context for the try acquire to be
+				// canceled is specified.
+				var wantErr error
+				tryTimeout := timeout
+				if psTest.cancelTry {
+					tryTimeout = 0
+					wantErr = context.DeadlineExceeded
+				}
+				acquired, err := timedTryAcquire(sem, tryTimeout)
+				if !errors.Is(err, wantErr) {
+					t.Fatalf("%q: unexpected try acquire error: got %v, want %v",
+						psTest.name, err, wantErr)
+				}
+				results = append(results, acquired)
 			}
 			for range psTest.numReleases {
 				sem.Release()

--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -130,14 +130,6 @@ func (cm *rpcConnManager) Connect(ctx context.Context, addr string, permanent bo
 		return err
 	}
 
-	// Limit max number of total peers.
-	cm.server.peerState.Lock()
-	count := cm.server.peerState.count()
-	cm.server.peerState.Unlock()
-	if count >= cfg.MaxPeers {
-		return errors.New("max peers reached")
-	}
-
 	// Attempt to add a persistent peer when requested.
 	connManager := cm.server.connManager
 	if permanent {

--- a/server.go
+++ b/server.go
@@ -2703,17 +2703,6 @@ func (s *server) handleAddPeer(sp *serverPeer) bool {
 		return false
 	}
 
-	// Limit max number of total peers.  However, allow whitelisted inbound
-	// peers regardless.
-	if state.count()+1 > cfg.MaxPeers && !isInboundWhitelisted {
-		srvrLog.Infof("Max peers reached [%d] - disconnecting peer %s",
-			cfg.MaxPeers, sp)
-		sp.Disconnect()
-		// TODO: how to handle permanent peers here?
-		// they should be rescheduled.
-		return false
-	}
-
 	// Add the new peer.
 	if sp.Inbound() {
 		state.inboundPeers[sp.ID()] = sp
@@ -4359,6 +4348,7 @@ func newServer(ctx context.Context, profiler *profileServer,
 			s.inboundPeerConnected(ctx, conn)
 		},
 		RetryDuration:  connectionRetryInterval,
+		MaxNormalConns: uint32(cfg.MaxPeers),
 		TargetOutbound: s.targetOutbound,
 		Dial:           s.attemptDcrdDial,
 		DialTimeout:    cfg.DialTimeout,


### PR DESCRIPTION
**This requires ~~#3695~~ and #3696**.

The current overall total connection limits are enforced by the server rather than the connection manager.  This is not ideal for many reasons, but one of the most important consequences is that it makes DoS attacks easier.  Another example of some less than ideal behavior that it allows is that some rare combinations of events can lead to temporary extra connection churn.

It is much more robust and natural to perform the limiting in the connection manager itself via semaphores.  That approach not only significantly hardens the server against DoS attacks and solves various edge cases present in the current code, it also paves the way for even more advanced features such as traffic shaping in the future.

To that end, this adds semaphore-based limiting for the total overall number of normal connections to the connection manager and removes the relevant current limiting for it from the server.

Normal connections are the automatic outbound, manual outbound, and inbound connections.  Persistent connections, on the other hand, are not subject to the limit since they have their own limiting.  This is consistent with them not being subject to the automatic target outbound limit either.

It also adds tests to ensure that the new max normal connection limiting properly enforces the limit including automatic outbound, manual outbound, and inbound connections and that it is not applied to persistent connections.
