### PR TITLE
connmgr: Misc test cleanup and modernization.

### DIFF
--- a/internal/connmgr/connmanager_test.go
+++ b/internal/connmgr/connmanager_test.go
@@ -82,12 +82,12 @@ func newTestConnManager(t *testing.T, cfg *Config) *ConnManager {
 	if cfg.MaxConnsPerHost == 0 {
 		cfg.MaxConnsPerHost = 5
 	}
-	cmgr, err := New(cfg)
+	cm, err := New(cfg)
 	if err != nil {
 		t.Fatalf("New: unexpected error: %v", err)
 	}
-	cmgr.maxRetryDuration = defaultTestMaxRetryDuration
-	return cmgr
+	cm.maxRetryDuration = defaultTestMaxRetryDuration
+	return cm
 }
 
 // assertInternalConnState ensures the internal connection state of the passed
@@ -318,7 +318,7 @@ func TestIsWhitelisted(t *testing.T) {
 
 	for _, test := range tests {
 		// Parse the whitelist entries for the test.
-		cmgr := newTestConnManager(t, &Config{
+		cm := newTestConnManager(t, &Config{
 			Dial:       mockDialer,
 			Whitelists: test.prefixes,
 		})
@@ -330,7 +330,7 @@ func TestIsWhitelisted(t *testing.T) {
 				t.Fatalf("%q-%q: failed to parse address: %v", test.name,
 					pmTest.addr, err)
 			}
-			if got := cmgr.IsWhitelisted(addr); got != pmTest.whitelisted {
+			if got := cm.IsWhitelisted(addr); got != pmTest.whitelisted {
 				t.Errorf("%q-%q: mismatched result -- got %v, want %v",
 					test.name, pmTest.addr, got, pmTest.whitelisted)
 				continue
@@ -454,22 +454,22 @@ func TestConnectMode(t *testing.T) {
 	t.Parallel()
 
 	connected := make(chan *Conn)
-	cmgr := newTestConnManager(t, &Config{
+	cm := newTestConnManager(t, &Config{
 		TargetOutbound: 2,
 		Dial:           mockDialer,
 		OnConnection: func(conn *Conn) {
 			connected <- conn
 		},
 	})
-	ctx, _, _ := runConnMgrAsync(t, context.Background(), cmgr)
+	ctx, _, _ := runConnMgrAsync(t, context.Background(), cm)
 
 	addr := mustParseAddrPort("127.0.0.1:18555")
-	go cmgr.Connect(ctx, addr)
+	go cm.Connect(ctx, addr)
 
 	// Ensure that only a single connection is received.
 	assertConnReceived(t, connected, 0, ConnTypeManual)
 	assertNoConnReceived(t, connected)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 }
 
 // TestDisconnect ensures that [ConnManager.Disconnect] properly disconnects
@@ -502,7 +502,7 @@ func TestDisconnect(t *testing.T) {
 		}
 		return conn, err
 	}
-	cmgr := newTestConnManager(t, &Config{
+	cm := newTestConnManager(t, &Config{
 		Dial: pendingDialer,
 		OnConnection: func(conn *Conn) {
 			connected <- conn
@@ -511,14 +511,14 @@ func TestDisconnect(t *testing.T) {
 			disconnected <- conn
 		},
 	})
-	ctx, _, _ := runConnMgrAsync(t, context.Background(), cmgr)
+	ctx, _, _ := runConnMgrAsync(t, context.Background(), cm)
 
 	// Attempt a connection to a localhost IP.
 	notifyDialed.Store(true)
 	waitForPending.Store(true)
 	notifyCanceled.Store(true)
 	addr := mustParseAddrPort("127.0.0.1:18555")
-	go cmgr.Connect(ctx, addr)
+	go cm.Connect(ctx, addr)
 
 	// Wait for the connection manager to attempt to dial and ensure the
 	// connection is marked as pending while the dialer is blocked.
@@ -527,15 +527,15 @@ func TestDisconnect(t *testing.T) {
 	case <-time.After(time.Millisecond * 5):
 		t.Fatal("timeout waiting for dial")
 	}
-	assertPendingAddr(t, cmgr, addr)
-	assertConnManagerInternalState(t, cmgr)
+	assertPendingAddr(t, cm, addr)
+	assertConnManagerInternalState(t, cm)
 
 	// Disconnect the connection attempt while it's still pending.
-	connID, _ := pendingAddrConnID(cmgr, addr)
-	if err := cmgr.Disconnect(connID); err != nil {
+	connID, _ := pendingAddrConnID(cm, addr)
+	if err := cm.Disconnect(connID); err != nil {
 		t.Fatalf("unexpected disconnect err: %v", err)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Allow the dialer to proceed with the disconnected connection attempt and
 	// then wait for the dialer to signal the context associated with the dial
@@ -550,37 +550,37 @@ func TestDisconnect(t *testing.T) {
 	case <-time.After(time.Millisecond * 5):
 		t.Fatal("timeout waiting for cancel")
 	}
-	if _, ok := pendingAddrConnID(cmgr, addr); ok {
+	if _, ok := pendingAddrConnID(cm, addr); ok {
 		t.Fatalf("connection %s is still pending", addr)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Start a connection attempt and wait for it to be established.
 	notifyDialed.Store(false)
 	waitForPending.Store(false)
 	notifyCanceled.Store(false)
-	go cmgr.Connect(ctx, addr)
+	go cm.Connect(ctx, addr)
 	conn := assertConnReceived(t, connected, 0, ConnTypeManual)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Disconnect the established connection and wait for the disconnect
 	// notification to ensure it is disconnected as intended.
 	connID = conn.ID()
-	if err := cmgr.Disconnect(connID); err != nil {
+	if err := cm.Disconnect(connID); err != nil {
 		t.Fatalf("unexpected disconnect err: %v", err)
 	}
 	assertConnReceived(t, disconnected, connID, ConnTypeManual)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Add a persistent connection back to the same address.
 	notifyDialed.Store(true)
 	waitForPending.Store(true)
 	notifyCanceled.Store(true)
-	connID, err := cmgr.AddPersistent(addr)
+	connID, err := cm.AddPersistent(addr)
 	if err != nil {
 		t.Fatalf("failed to add persistent connection: %v", err)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Wait for the connection manager to attempt to dial and ensure the
 	// connection is marked as pending while the dialer is blocked.
@@ -589,14 +589,14 @@ func TestDisconnect(t *testing.T) {
 	case <-time.After(time.Millisecond * 5):
 		t.Fatal("timeout waiting for dial")
 	}
-	assertPendingAddr(t, cmgr, addr)
-	assertConnManagerInternalState(t, cmgr)
+	assertPendingAddr(t, cm, addr)
+	assertConnManagerInternalState(t, cm)
 
 	// Disconnect the persistent connection attempt while it's still pending.
-	if err := cmgr.Disconnect(connID); err != nil {
+	if err := cm.Disconnect(connID); err != nil {
 		t.Fatalf("unexpected disconnect err: %v", err)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Allow the dialer to proceed with the disconnected persistent connection
 	// attempt and then wait for the dialer to signal the context associated
@@ -618,15 +618,15 @@ func TestDisconnect(t *testing.T) {
 
 	// Wait for the retry to be established.
 	assertConnReceived(t, connected, connID, ConnTypeManual)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Disconnect the established persistent connection and wait for the
 	// disconnect notification to ensure it is disconnected as intended.
-	if err := cmgr.Disconnect(connID); err != nil {
+	if err := cm.Disconnect(connID); err != nil {
 		t.Fatalf("unexpected disconnect err: %v", err)
 	}
 	assertConnReceived(t, disconnected, connID, ConnTypeManual)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 }
 
 // TestRemove ensures that [ConnManager.Remove] properly removes pending and
@@ -660,7 +660,7 @@ func TestRemove(t *testing.T) {
 		}
 		return conn, err
 	}
-	cmgr := newTestConnManager(t, &Config{
+	cm := newTestConnManager(t, &Config{
 		Dial: pendingDialer,
 		OnConnection: func(conn *Conn) {
 			connected <- conn
@@ -669,10 +669,10 @@ func TestRemove(t *testing.T) {
 			disconnected <- conn
 		},
 	})
-	ctx, _, _ := runConnMgrAsync(t, context.Background(), cmgr)
+	ctx, _, _ := runConnMgrAsync(t, context.Background(), cm)
 
 	// Ensure removing an ID that doesn't exist returns the expected error.
-	if err := cmgr.Remove(^uint64(0)); !errors.Is(err, ErrNotFound) {
+	if err := cm.Remove(^uint64(0)); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("mismatched remove error: got %v, want %v", err, ErrNotFound)
 	}
 
@@ -681,7 +681,7 @@ func TestRemove(t *testing.T) {
 	waitForPending.Store(true)
 	notifyCanceled.Store(true)
 	addr := mustParseAddrPort("127.0.0.1:18555")
-	go cmgr.Connect(ctx, addr)
+	go cm.Connect(ctx, addr)
 
 	// Wait for the connection manager to attempt to dial and ensure the
 	// connection is marked as pending while the dialer is blocked.
@@ -690,12 +690,12 @@ func TestRemove(t *testing.T) {
 	case <-time.After(time.Millisecond * 5):
 		t.Fatal("timeout waiting for dial")
 	}
-	assertPendingAddr(t, cmgr, addr)
-	assertConnManagerInternalState(t, cmgr)
+	assertPendingAddr(t, cm, addr)
+	assertConnManagerInternalState(t, cm)
 
 	// Remove the connection attempt while it's still pending.
-	connID, _ := pendingAddrConnID(cmgr, addr)
-	if err := cmgr.Remove(connID); err != nil {
+	connID, _ := pendingAddrConnID(cm, addr)
+	if err := cm.Remove(connID); err != nil {
 		t.Fatalf("unexpected remove err: %v", err)
 	}
 
@@ -712,37 +712,37 @@ func TestRemove(t *testing.T) {
 	case <-time.After(time.Millisecond * 5):
 		t.Fatal("timeout waiting for cancel")
 	}
-	if _, ok := pendingAddrConnID(cmgr, addr); ok {
+	if _, ok := pendingAddrConnID(cm, addr); ok {
 		t.Fatalf("connection %s is still pending", addr)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Start a connection attempt and wait for it to be established.
 	notifyDialed.Store(false)
 	waitForPending.Store(false)
 	notifyCanceled.Store(false)
-	go cmgr.Connect(ctx, addr)
+	go cm.Connect(ctx, addr)
 	conn := assertConnReceived(t, connected, 0, ConnTypeManual)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Remove the established connection and wait for the disconnect
 	// notification to ensure it is disconnected as intended.
 	connID = conn.ID()
-	if err := cmgr.Remove(connID); err != nil {
+	if err := cm.Remove(connID); err != nil {
 		t.Fatalf("unexpected disconnect err: %v", err)
 	}
 	assertConnReceived(t, disconnected, connID, ConnTypeManual)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Add a persistent connection back to the same address.
 	notifyDialed.Store(true)
 	waitForPending.Store(true)
 	notifyCanceled.Store(true)
-	connID, err := cmgr.AddPersistent(addr)
+	connID, err := cm.AddPersistent(addr)
 	if err != nil {
 		t.Fatalf("failed to add persistent connection: %v", err)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Wait for the connection manager to attempt to dial and ensure the
 	// connection is marked as pending while the dialer is blocked.
@@ -751,13 +751,13 @@ func TestRemove(t *testing.T) {
 	case <-time.After(time.Millisecond * 5):
 		t.Fatal("timeout waiting for dial")
 	}
-	assertPendingAddr(t, cmgr, addr)
+	assertPendingAddr(t, cm, addr)
 
 	// Remove the persistent connection attempt while it's still pending.
-	if err := cmgr.Remove(connID); err != nil {
+	if err := cm.Remove(connID); err != nil {
 		t.Fatalf("unexpected disconnect err: %v", err)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Allow the dialer to proceed with the removed persistent connection
 	// attempt and then wait for the dialer to signal the context associated
@@ -776,29 +776,29 @@ func TestRemove(t *testing.T) {
 	case <-time.After(time.Millisecond * 5):
 		t.Fatal("timeout waiting for cancel")
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Add a persistent connection back to the same address and wait for it to
 	// be established.
 	notifyDialed.Store(false)
 	waitForPending.Store(false)
 	notifyCanceled.Store(false)
-	connID, err = cmgr.AddPersistent(addr)
+	connID, err = cm.AddPersistent(addr)
 	if err != nil {
 		t.Fatalf("failed to add persistent connection: %v", err)
 	}
 	conn2 := assertConnReceived(t, connected, connID, ConnTypeManual)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Remove the established persistent connection and wait for the disconnect
 	// notification to ensure it is disconnected as intended.  Also, ensure the
 	// persistent connection entry is removed.
 	connID = conn2.ID()
-	if err := cmgr.Remove(connID); err != nil {
+	if err := cm.Remove(connID); err != nil {
 		t.Fatalf("unexpected disconnect err: %v", err)
 	}
 	assertConnReceived(t, disconnected, connID, ConnTypeManual)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 }
 
 // TestTargetOutbound tests the target number of outbound connections
@@ -810,7 +810,7 @@ func TestTargetOutbound(t *testing.T) {
 	const targetOutbound = 10
 	var nextAddr atomic.Uint32
 	connected := make(chan *Conn)
-	cmgr := newTestConnManager(t, &Config{
+	cm := newTestConnManager(t, &Config{
 		TargetOutbound: targetOutbound,
 		Dial:           mockDialer,
 		GetNewAddress: func() (*addrmgr.NetAddress, error) {
@@ -821,7 +821,7 @@ func TestTargetOutbound(t *testing.T) {
 			connected <- conn
 		},
 	})
-	runConnMgrAsync(t, context.Background(), cmgr)
+	runConnMgrAsync(t, context.Background(), cm)
 
 	// Ensure only the expected number of target outbound conns are established
 	// and no more.
@@ -829,7 +829,7 @@ func TestTargetOutbound(t *testing.T) {
 		assertConnReceived(t, connected, 0, ConnTypeOutbound)
 	}
 	assertNoConnReceived(t, connected)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 }
 
 // TestDoubleClose ensures closing a connection multiple times is a noop after
@@ -838,7 +838,7 @@ func TestDoubleClose(t *testing.T) {
 	t.Parallel()
 
 	connected := make(chan *Conn)
-	cmgr := newTestConnManager(t, &Config{
+	cm := newTestConnManager(t, &Config{
 		TargetOutbound: 1,
 		Dial:           mockDialer,
 		GetNewAddress: func() (*addrmgr.NetAddress, error) {
@@ -848,11 +848,11 @@ func TestDoubleClose(t *testing.T) {
 			connected <- conn
 		},
 	})
-	runConnMgrAsync(t, context.Background(), cmgr)
+	runConnMgrAsync(t, context.Background(), cm)
 
 	// Wait for the connection to be established.
 	conn := assertConnReceived(t, connected, 0, ConnTypeOutbound)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Override the close func to cleanly detect closes.
 	var numClosed uint32
@@ -869,7 +869,7 @@ func TestDoubleClose(t *testing.T) {
 	if numClosed != 1 {
 		t.Fatal("connection closed more than once")
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 }
 
 // TestRetryPersistent tests that persistent connections are retried.
@@ -878,7 +878,7 @@ func TestRetryPersistent(t *testing.T) {
 
 	connected := make(chan *Conn)
 	disconnected := make(chan *Conn)
-	cmgr := newTestConnManager(t, &Config{
+	cm := newTestConnManager(t, &Config{
 		RetryDuration: time.Millisecond,
 		Dial:          mockDialer,
 		OnConnection: func(conn *Conn) {
@@ -888,14 +888,14 @@ func TestRetryPersistent(t *testing.T) {
 			disconnected <- conn
 		},
 	})
-	runConnMgrAsync(t, context.Background(), cmgr)
+	runConnMgrAsync(t, context.Background(), cm)
 
 	addr := mustParseAddrPort("127.0.0.1:18555")
-	connID, err := cmgr.AddPersistent(addr)
+	connID, err := cm.AddPersistent(addr)
 	if err != nil {
 		t.Fatalf("failed to add persistent connection: %v", err)
 	}
-	if !cmgr.IsPersistent(connID) {
+	if !cm.IsPersistent(connID) {
 		t.Fatal("IsPersistent did not reported true for persistent conn")
 	}
 
@@ -905,16 +905,16 @@ func TestRetryPersistent(t *testing.T) {
 	conn.Close()
 	assertConnReceived(t, disconnected, connID, ConnTypeManual)
 	assertConnReceived(t, connected, connID, ConnTypeManual)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Remove the persistent connection, wait for it to disconnect, and ensure
 	// it is actually removed.
-	if err := cmgr.Remove(connID); err != nil {
+	if err := cm.Remove(connID); err != nil {
 		t.Fatalf("failed to remove persistent connection: %v", err)
 	}
 	assertConnReceived(t, disconnected, connID, ConnTypeManual)
-	assertRemovedPersistent(t, cmgr, addr)
-	assertConnManagerInternalState(t, cmgr)
+	assertRemovedPersistent(t, cm, addr)
+	assertConnManagerInternalState(t, cm)
 }
 
 // TestMaxPersistent ensures [ConnManager.AddPersistent] limits the maximum
@@ -925,7 +925,7 @@ func TestMaxPersistent(t *testing.T) {
 
 	connected := make(chan *Conn)
 	disconnected := make(chan *Conn)
-	cmgr := newTestConnManager(t, &Config{
+	cm := newTestConnManager(t, &Config{
 		Dial: mockDialer,
 		OnConnection: func(conn *Conn) {
 			connected <- conn
@@ -934,7 +934,7 @@ func TestMaxPersistent(t *testing.T) {
 			disconnected <- conn
 		},
 	})
-	runConnMgrAsync(t, context.Background(), cmgr)
+	runConnMgrAsync(t, context.Background(), cm)
 
 	var numAddrs uint32
 	nextAddr := func() *addrmgr.NetAddress {
@@ -948,7 +948,7 @@ func TestMaxPersistent(t *testing.T) {
 	addrs := make([]*addrmgr.NetAddress, 0, MaxPersistent)
 	for range MaxPersistent {
 		addr := nextAddr()
-		connID, err := cmgr.AddPersistent(addr)
+		connID, err := cm.AddPersistent(addr)
 		if err != nil {
 			t.Fatalf("failed to add persistent connection %v: %v", addr, err)
 		}
@@ -957,45 +957,45 @@ func TestMaxPersistent(t *testing.T) {
 
 		// Wait for the connection.
 		assertConnReceived(t, connected, connID, ConnTypeManual)
-		assertConnManagerInternalState(t, cmgr)
+		assertConnManagerInternalState(t, cm)
 	}
 
 	// Attempting to add more than the max allowed number of persistent conns
 	// should be rejected.
-	_, err := cmgr.AddPersistent(nextAddr())
+	_, err := cm.AddPersistent(nextAddr())
 	if !errors.Is(err, ErrMaxPersistent) {
 		t.Fatalf("did not reject > max persistent, err: %v", err)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Ensure disconnecting the persistent conn does not incorrectly decrement
 	// the count.
 	connID, addr := connIDs[0], addrs[0]
-	if err := cmgr.Disconnect(connID); err != nil {
+	if err := cm.Disconnect(connID); err != nil {
 		t.Fatalf("failed to disconnect persistent conn %v: %v", addr, err)
 	}
-	_, err = cmgr.AddPersistent(nextAddr())
+	_, err = cm.AddPersistent(nextAddr())
 	if !errors.Is(err, ErrMaxPersistent) {
 		t.Fatalf("did not reject max persistent after dc, err: %v", err)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Remove the first persistent connection, wait for it to disconnect, and
 	// ensure it is actually removed.
-	if err := cmgr.Remove(connID); err != nil {
+	if err := cm.Remove(connID); err != nil {
 		t.Fatalf("failed to remove persistent conn %v: %v", addr, err)
 	}
 	assertConnReceived(t, disconnected, connID, ConnTypeManual)
-	assertRemovedPersistent(t, cmgr, addr)
-	assertConnManagerInternalState(t, cmgr)
+	assertRemovedPersistent(t, cm, addr)
+	assertConnManagerInternalState(t, cm)
 
 	// A new persistent conn should now be allowed.
 	addr = nextAddr()
-	_, err = cmgr.AddPersistent(addr)
+	_, err = cm.AddPersistent(addr)
 	if err != nil {
 		t.Fatalf("failed to add persistent connection %v: %v", addr, err)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 }
 
 // TestMaxRetryDuration tests the maximum retry duration.
@@ -1023,7 +1023,7 @@ func TestMaxRetryDuration(t *testing.T) {
 	}
 
 	connected := make(chan *Conn)
-	cmgr := newTestConnManager(t, &Config{
+	cm := newTestConnManager(t, &Config{
 		RetryDuration:  time.Millisecond,
 		TargetOutbound: 1,
 		Dial:           timedDialer,
@@ -1031,9 +1031,9 @@ func TestMaxRetryDuration(t *testing.T) {
 			connected <- conn
 		},
 	})
-	runConnMgrAsync(t, context.Background(), cmgr)
+	runConnMgrAsync(t, context.Background(), cm)
 
-	connID, err := cmgr.AddPersistent(mustParseAddrPort("127.0.0.1:18555"))
+	connID, err := cm.AddPersistent(mustParseAddrPort("127.0.0.1:18555"))
 	if err != nil {
 		t.Fatalf("failed to add persistent connection: %v", err)
 	}
@@ -1047,7 +1047,7 @@ func TestMaxRetryDuration(t *testing.T) {
 	})
 	const timeout = connTestReceiveTimeout + networkUpTimeout
 	assertConnReceivedTimeout(t, connected, timeout, connID, ConnTypeManual)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 }
 
 // TestNetworkFailure tests that the connection manager handles a network
@@ -1070,7 +1070,7 @@ func TestNetworkFailure(t *testing.T) {
 		return nil, errors.New("network down")
 	}
 	var nextAddr atomic.Uint32
-	cmgr := newTestConnManager(t, &Config{
+	cm := newTestConnManager(t, &Config{
 		TargetOutbound: targetOutbound,
 		RetryDuration:  retryTimeout,
 		Dial:           errDialer,
@@ -1083,7 +1083,7 @@ func TestNetworkFailure(t *testing.T) {
 				conn.RemoteAddr())
 		},
 	})
-	_, shutdown, wg := runConnMgrAsync(t, context.Background(), cmgr)
+	_, shutdown, wg := runConnMgrAsync(t, context.Background(), cm)
 
 	// Shutdown the connection manager after the max failed attempts is reached
 	// and an additional retry duration has passed and then wait for the
@@ -1130,22 +1130,22 @@ func TestMultipleFailedConns(t *testing.T) {
 		}
 		return nil, errors.New("network down")
 	}
-	cmgr := newTestConnManager(t, &Config{
+	cm := newTestConnManager(t, &Config{
 		RetryDuration: maxRetryDuration,
 		Dial:          errDialer,
 	})
-	cmgr.maxRetryDuration = maxRetryDuration
-	runConnMgrAsync(t, context.Background(), cmgr)
+	cm.maxRetryDuration = maxRetryDuration
+	runConnMgrAsync(t, context.Background(), cm)
 
 	// Establish several connection requests to localhost IPs.
 	for i := range targetFailed {
 		addr := mustParseAddrPort(fmt.Sprintf("127.0.0.%d:18555", i+1))
-		_, err := cmgr.AddPersistent(addr)
+		_, err := cm.AddPersistent(addr)
 		if err != nil {
 			t.Fatalf("unexpected add err: %v", err)
 		}
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Wait for the target number of dials and ensure they happen simultaneously
 	// by checking it happens before the retry timeout.
@@ -1154,14 +1154,14 @@ func TestMultipleFailedConns(t *testing.T) {
 	case <-time.After(20 * time.Millisecond):
 		t.Fatal("did not reach target number of dials before timeout")
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Ensure that the connection manager still responds to requests while the
 	// failed connections are still retrying.
 	disconnected := make(chan struct{})
 	go func() {
 		const badID = ^uint64(0)
-		cmgr.Disconnect(badID)
+		cm.Disconnect(badID)
 		close(disconnected)
 	}()
 	select {
@@ -1169,7 +1169,7 @@ func TestMultipleFailedConns(t *testing.T) {
 	case <-time.After(20 * time.Millisecond):
 		t.Fatal("timeout servicing connmgr requests")
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 }
 
 // TestShutdownFailedConns tests that failed connections are ignored after
@@ -1184,20 +1184,20 @@ func TestShutdownFailedConns(t *testing.T) {
 		closeOnce.Do(func() { close(dialed) })
 		return nil, errors.New("network down")
 	}
-	cmgr := newTestConnManager(t, &Config{
+	cm := newTestConnManager(t, &Config{
 		RetryDuration: retryTimeout,
 		Dial:          waitDialer,
 	})
-	cmgr.maxRetryDuration = retryTimeout
-	runConnMgrAsync(t, context.Background(), cmgr)
+	cm.maxRetryDuration = retryTimeout
+	runConnMgrAsync(t, context.Background(), cm)
 
 	// Add a persistent connection.
 	addr := mustParseAddrPort("127.0.0.1:18555")
-	_, err := cmgr.AddPersistent(addr)
+	_, err := cm.AddPersistent(addr)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Shutdown the connection manager during the retry timeout after a failed
 	// dial attempt.
@@ -1224,15 +1224,15 @@ func TestRemovePendingConnection(t *testing.T) {
 		close(canceled)
 		return nil, errors.New("error")
 	}
-	cmgr := newTestConnManager(t, &Config{
+	cm := newTestConnManager(t, &Config{
 		Dial: indefiniteDialer,
 	})
-	ctx, _, _ := runConnMgrAsync(t, context.Background(), cmgr)
+	ctx, _, _ := runConnMgrAsync(t, context.Background(), cm)
 
 	// Establish a connection request to a localhost IP.
 	addr := mustParseAddrPort("127.0.0.1:18555")
-	go cmgr.Connect(ctx, addr)
-	assertConnManagerInternalState(t, cmgr)
+	go cm.Connect(ctx, addr)
+	assertConnManagerInternalState(t, cm)
 
 	// Wait for the connection manager to attempt to dial and ensure the
 	// connection is marked as pending while the dialer is blocked.
@@ -1241,15 +1241,15 @@ func TestRemovePendingConnection(t *testing.T) {
 	case <-time.After(time.Millisecond * 20):
 		t.Fatal("timeout waiting for dial")
 	}
-	assertPendingAddr(t, cmgr, addr)
-	assertConnManagerInternalState(t, cmgr)
+	assertPendingAddr(t, cm, addr)
+	assertConnManagerInternalState(t, cm)
 
 	// Cancel the connection attempt while it's still pending.
-	connID, _ := pendingAddrConnID(cmgr, addr)
-	if err := cmgr.Remove(connID); err != nil {
+	connID, _ := pendingAddrConnID(cm, addr)
+	if err := cm.Remove(connID); err != nil {
 		t.Fatalf("unexpected remove err: %v", err)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Wait for the dialer to signal the context associated with the dial was
 	// canceled and ensure the internal pending state is removed.
@@ -1258,10 +1258,10 @@ func TestRemovePendingConnection(t *testing.T) {
 	case <-time.After(time.Millisecond * 20):
 		t.Fatal("timeout waiting for cancel")
 	}
-	if _, ok := pendingAddrConnID(cmgr, addr); ok {
+	if _, ok := pendingAddrConnID(cm, addr); ok {
 		t.Fatalf("connection %s is still pending", addr)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 }
 
 // TestCancelIgnoreDelayedConnection tests that a canceled pending persistent
@@ -1293,22 +1293,22 @@ func TestCancelIgnoreDelayedConnection(t *testing.T) {
 	}
 
 	connected := make(chan *Conn)
-	cmgr := newTestConnManager(t, &Config{
+	cm := newTestConnManager(t, &Config{
 		Dial:          failingDialer,
 		RetryDuration: retryTimeout,
 		OnConnection: func(conn *Conn) {
 			connected <- conn
 		},
 	})
-	runConnMgrAsync(t, context.Background(), cmgr)
+	runConnMgrAsync(t, context.Background(), cm)
 
 	// Establish a persistent connection to a localhost IP.
 	addr := mustParseAddrPort("127.0.0.1:18555")
-	connID, err := cmgr.AddPersistent(addr)
+	connID, err := cm.AddPersistent(addr)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Wait for the retry and ensure the connection is pending.
 	select {
@@ -1316,12 +1316,12 @@ func TestCancelIgnoreDelayedConnection(t *testing.T) {
 	case <-time.After(20 * time.Millisecond):
 		t.Fatalf("did not get retry before timeout")
 	}
-	assertPendingAddr(t, cmgr, addr)
-	assertConnManagerInternalState(t, cmgr)
+	assertPendingAddr(t, cm, addr)
+	assertConnManagerInternalState(t, cm)
 
 	// Remove the connection and then immediately allow the next connection to
 	// succeed.
-	if err := cmgr.Remove(connID); err != nil {
+	if err := cm.Remove(connID); err != nil {
 		t.Fatalf("unexpected remove err: %v", err)
 	}
 	close(connect)
@@ -1331,7 +1331,7 @@ func TestCancelIgnoreDelayedConnection(t *testing.T) {
 	// timeout window to ensure the connection manager's backoff is allowed to
 	// properly elapse.
 	assertNoConnReceivedTimeout(t, connected, 5*retryTimeout)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 }
 
 // TestDialTimeout ensure [Config.Timeout] works as intended by creating a
@@ -1354,16 +1354,16 @@ func TestDialTimeout(t *testing.T) {
 
 		return mockDialer(ctx, network, addr)
 	}
-	cmgr := newTestConnManager(t, &Config{
+	cm := newTestConnManager(t, &Config{
 		Dial:        timeoutDialer,
 		DialTimeout: dialTimeout,
 	})
-	ctx, _, _ := runConnMgrAsync(t, context.Background(), cmgr)
+	ctx, _, _ := runConnMgrAsync(t, context.Background(), cm)
 
 	// Establish a connection to a localhost IP.
 	addr := mustParseAddrPort("127.0.0.1:18555")
-	go cmgr.Connect(ctx, addr)
-	assertConnManagerInternalState(t, cmgr)
+	go cm.Connect(ctx, addr)
+	assertConnManagerInternalState(t, cm)
 
 	// Wait to receive the signal that the dialer context was cancelled, which
 	// means the dial timeout was hit.
@@ -1372,7 +1372,7 @@ func TestDialTimeout(t *testing.T) {
 	case <-time.After(dialTimeout * 10):
 		t.Fatal("timeout waiting for dial cancellation")
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 }
 
 // TestConnectContext ensures the [ConnManager.Connect] method works as intended
@@ -1388,10 +1388,10 @@ func TestConnectContext(t *testing.T) {
 		<-ctx.Done()
 		return nil, ctx.Err()
 	}
-	cmgr := newTestConnManager(t, &Config{
+	cm := newTestConnManager(t, &Config{
 		Dial: indefiniteDialer,
 	})
-	ctx, _, _ := runConnMgrAsync(t, context.Background(), cmgr)
+	ctx, _, _ := runConnMgrAsync(t, context.Background(), cm)
 
 	// Establish a connection request to a localhost IP with a separate context
 	// that can be canceled.
@@ -1399,7 +1399,7 @@ func TestConnectContext(t *testing.T) {
 	connectCtx, cancelConnect := context.WithCancel(ctx)
 	connectErr := make(chan error, 1)
 	go func() {
-		_, err := cmgr.Connect(connectCtx, addr)
+		_, err := cm.Connect(connectCtx, addr)
 		connectErr <- err
 	}()
 
@@ -1411,8 +1411,8 @@ func TestConnectContext(t *testing.T) {
 	case <-time.After(time.Millisecond * 20):
 		t.Fatal("timeout waiting for dial")
 	}
-	assertPendingAddr(t, cmgr, addr)
-	assertConnManagerInternalState(t, cmgr)
+	assertPendingAddr(t, cm, addr)
+	assertConnManagerInternalState(t, cm)
 
 	// Cancel the connection context, wait for the error from connect, and
 	// ensure it is the expected error.
@@ -1426,7 +1426,7 @@ func TestConnectContext(t *testing.T) {
 	case <-time.After(10 * time.Millisecond):
 		t.Fatal("timeout waiting for dial cancellation")
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 }
 
 // TestListeners ensures providing listeners to the connection manager along
@@ -1440,14 +1440,14 @@ func TestListeners(t *testing.T) {
 	listener1 := newMockListener("127.0.0.1:9108")
 	listener2 := newMockListener("127.0.0.1:9208")
 	listeners := []net.Listener{listener1, listener2}
-	cmgr := newTestConnManager(t, &Config{
+	cm := newTestConnManager(t, &Config{
 		Listeners: listeners,
 		OnAccept: func(conn *Conn) {
 			receivedConns <- conn
 		},
 		Dial: mockDialer,
 	})
-	runConnMgrAsync(t, context.Background(), cmgr)
+	runConnMgrAsync(t, context.Background(), cm)
 
 	// Fake a couple of mock connections to each of the listeners.
 	go func() {
@@ -1463,7 +1463,7 @@ func TestListeners(t *testing.T) {
 	for range expectedNumConns {
 		assertConnReceived(t, receivedConns, 0, ConnTypeInbound)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 }
 
 // TestRejectDuplicateConns ensures duplicate addresses are rejected.  This
@@ -1488,7 +1488,7 @@ func TestRejectDuplicateConns(t *testing.T) {
 		<-pending
 		return mockDialer(ctx, network, addr)
 	}
-	cmgr := newTestConnManager(t, &Config{
+	cm := newTestConnManager(t, &Config{
 		Listeners: []net.Listener{listener},
 		OnAccept: func(conn *Conn) {
 			inboundConns <- conn
@@ -1501,108 +1501,108 @@ func TestRejectDuplicateConns(t *testing.T) {
 			disconnected <- conn
 		},
 	})
-	ctx, _, _ := runConnMgrAsync(t, context.Background(), cmgr)
+	ctx, _, _ := runConnMgrAsync(t, context.Background(), cm)
 
 	// Dial a manual connection and wait for it to become pending.
 	addr := mustParseAddrPort("127.0.0.1:18555")
-	go cmgr.Connect(ctx, addr)
+	go cm.Connect(ctx, addr)
 	select {
 	case <-dialed:
 	case <-time.After(time.Millisecond * 5):
 		t.Fatal("did not receive pending dial before timeout")
 	}
-	assertPendingAddr(t, cmgr, addr)
-	assertConnManagerInternalState(t, cmgr)
+	assertPendingAddr(t, cm, addr)
+	assertConnManagerInternalState(t, cm)
 
 	// Duplicate connect to the pending address should be rejected.
-	if _, err := cmgr.Connect(ctx, addr); !errors.Is(err, ErrAlreadyPending) {
+	if _, err := cm.Connect(ctx, addr); !errors.Is(err, ErrAlreadyPending) {
 		t.Fatalf("did not reject duplicate pending connection, err: %v", err)
 	}
 
 	// Inbound attempts from the pending outbound address should be rejected.
 	go listener.Connect(addr)
 	assertNoConnReceived(t, inboundConns)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Allow the pending connection to complete.
 	close(pending)
 	conn := assertConnReceived(t, connected, 0, ConnTypeManual)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Duplicate connect to the established address should be rejected.
-	if _, err := cmgr.Connect(ctx, addr); !errors.Is(err, ErrAlreadyConnected) {
+	if _, err := cm.Connect(ctx, addr); !errors.Is(err, ErrAlreadyConnected) {
 		t.Fatalf("did not reject duplicate active connection, err: %v", err)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Inbound attempts from the established outbound address should be
 	// rejected.
 	go listener.Connect(addr)
 	assertNoConnReceived(t, inboundConns)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Close the connection and wait for the disconnect.
 	conn.Close()
 	assertConnReceived(t, disconnected, conn.ID(), ConnTypeManual)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Add a persistent connection back to the same address and wait for it to
 	// connect since there are no longer any connections to the address.
-	connID, err := cmgr.AddPersistent(addr)
+	connID, err := cm.AddPersistent(addr)
 	if err != nil {
 		t.Fatalf("failed to add persistent connection: %v", err)
 	}
 	assertConnReceived(t, connected, connID, ConnTypeManual)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Duplicate persistent connection attempts should be rejected.
-	_, err = cmgr.AddPersistent(addr)
+	_, err = cm.AddPersistent(addr)
 	if !errors.Is(err, ErrDuplicatePersistent) {
 		t.Fatalf("did not reject duplicate persistent connection, err: %v", err)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Manual connection attempts to persistent connection should be rejected.
-	_, err = cmgr.Connect(ctx, addr)
+	_, err = cm.Connect(ctx, addr)
 	if !errors.Is(err, ErrDuplicatePersistent) {
 		t.Fatalf("did not reject manual connection to persistent, err: %v", err)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Inbound atempts from the persistent address should be rejected.
 	go listener.Connect(addr)
 	assertNoConnReceived(t, inboundConns)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Remove the persistent connection, wait for it to disconnect, and ensure
 	// it is actually removed.
-	if err := cmgr.Remove(connID); err != nil {
+	if err := cm.Remove(connID); err != nil {
 		t.Fatalf("failed to remove persistent connection: %v", err)
 	}
 	assertConnReceived(t, disconnected, connID, ConnTypeManual)
-	assertRemovedPersistent(t, cmgr, addr)
-	assertConnManagerInternalState(t, cmgr)
+	assertRemovedPersistent(t, cm, addr)
+	assertConnManagerInternalState(t, cm)
 
 	// Inbound connections from the same address should now succeed.
 	go listener.Connect(addr)
 	assertConnReceived(t, inboundConns, 0, ConnTypeInbound)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Manual connection attempts to the inbound address should be rejected.
-	if _, err := cmgr.Connect(ctx, addr); !errors.Is(err, ErrAlreadyConnected) {
+	if _, err := cm.Connect(ctx, addr); !errors.Is(err, ErrAlreadyConnected) {
 		t.Fatalf("did not reject outbound for existing inbound conn, err: %v",
 			err)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Attempts to add a persistent connection to an existing inbound should be
 	// rejected.
-	_, err = cmgr.AddPersistent(addr)
+	_, err = cm.AddPersistent(addr)
 	if !errors.Is(err, ErrAlreadyConnected) {
 		t.Fatalf("did not reject persistent conn for existing inbound conn: %v",
 			err)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 }
 
 // TestMaxNormalConns ensures the connection manager limits the total number of
@@ -1639,7 +1639,7 @@ func TestMaxNormalConns(t *testing.T) {
 	var pauseTargetOutbound atomic.Bool
 	var totalPausedAddrs atomic.Uint32
 	hitMaxFailedAttempts := make(chan struct{})
-	cmgr := newTestConnManager(t, &Config{
+	cm := newTestConnManager(t, &Config{
 		Listeners:      []net.Listener{listener},
 		MaxNormalConns: maxNormalConns,
 		TargetOutbound: targetOutbound,
@@ -1666,8 +1666,8 @@ func TestMaxNormalConns(t *testing.T) {
 			disconnected <- conn
 		},
 	})
-	cmgr.maxRetryDuration = cmgr.cfg.RetryDuration
-	ctx, _, _ := runConnMgrAsync(t, context.Background(), cmgr)
+	cm.maxRetryDuration = cm.cfg.RetryDuration
+	ctx, _, _ := runConnMgrAsync(t, context.Background(), cm)
 
 	// Wait for the expected number of target outbound conns to be established.
 	outbounds := make([]*Conn, 0, targetOutbound)
@@ -1675,7 +1675,7 @@ func TestMaxNormalConns(t *testing.T) {
 		conn := assertConnReceived(t, connected, 0, ConnTypeOutbound)
 		outbounds = append(outbounds, conn)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Establish target number of inbounds to the listener and wait for them to
 	// be established.
@@ -1689,13 +1689,13 @@ func TestMaxNormalConns(t *testing.T) {
 		conn := assertConnReceived(t, inboundConns, 0, ConnTypeInbound)
 		inbounds = append(inbounds, conn)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Establish target number of manual connections and wait for them to be
 	// established.
 	go func() {
 		for range targetManual {
-			go cmgr.Connect(ctx, nextAddr())
+			go cm.Connect(ctx, nextAddr())
 		}
 	}()
 	manualConns := make([]*Conn, 0, targetManual+1)
@@ -1703,27 +1703,27 @@ func TestMaxNormalConns(t *testing.T) {
 		conn := assertConnReceived(t, connected, 0, ConnTypeManual)
 		manualConns = append(manualConns, conn)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Ensure manual connections that would exceed the max allowed normal
 	// connections are rejected.
-	_, err := cmgr.Connect(ctx, nextAddr())
+	_, err := cm.Connect(ctx, nextAddr())
 	if !errors.Is(err, ErrMaxNormalConns) {
 		t.Fatalf("did not reject manual connection at max allowed, err: %v", err)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Ensure inbound connections that would exceed the max allowed normal
 	// connections are rejected.
 	go listener.Connect(nextAddr())
 	assertNoConnReceived(t, inboundConns)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Ensure inbound connections from whitelisted addresses are exempt from the
 	// max allowed normal connections by establishing one while at the limit.
 	go listener.Connect(whitelistedAddr)
 	conn := assertConnReceived(t, inboundConns, 0, ConnTypeInbound)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Ensure closing the whitelisted connection does not release a permit it
 	// never acquired by asserting inbound connections that would exceed the max
@@ -1732,7 +1732,7 @@ func TestMaxNormalConns(t *testing.T) {
 	assertConnReceived(t, disconnected, conn.ID(), ConnTypeInbound)
 	go listener.Connect(nextAddr())
 	assertNoConnReceived(t, inboundConns)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Pause the target outbound dials and remove one of the target outbound
 	// connections to make room for another manual connection.  Then wait for
@@ -1747,31 +1747,31 @@ func TestMaxNormalConns(t *testing.T) {
 	case <-time.After(maxFailedAttempts * connTestReceiveTimeout):
 		t.Fatal("did not reach max failed attempts before timeout")
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Establish another manual connection to take the place of the target
 	// outbound connection that was just closed and wait for it to be
 	// established.
-	go cmgr.Connect(ctx, nextAddr())
+	go cm.Connect(ctx, nextAddr())
 	assertConnReceived(t, connected, 0, ConnTypeManual)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Unpause the target outbound dials and ensure no additional automatic
 	// outbound connections are made despite being under the target outbound due
 	// to max total conns.
 	pauseTargetOutbound.Store(false)
 	assertNoConnReceivedTimeout(t, connected, connTestNonReceiveTimeout+
-		cmgr.cfg.RetryDuration)
-	assertConnManagerInternalState(t, cmgr)
+		cm.cfg.RetryDuration)
+	assertConnManagerInternalState(t, cm)
 
 	// Ensure persistent connections are not subject to the max total normal
 	// connections by adding one and waiting for it to be established.
-	connID, err := cmgr.AddPersistent(nextAddr())
+	connID, err := cm.AddPersistent(nextAddr())
 	if err != nil {
 		t.Fatalf("failed to add persistent connection: %v", err)
 	}
 	assertConnReceived(t, connected, connID, ConnTypeManual)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 }
 
 // TestMaxConnsPerHost ensures the connection manager limits the total number of
@@ -1806,7 +1806,7 @@ func TestMaxConnsPerHost(t *testing.T) {
 	var pauseTargetOutbound atomic.Bool
 	var totalPausedAddrs atomic.Uint32
 	hitMaxFailedAttempts := make(chan struct{})
-	cmgr := newTestConnManager(t, &Config{
+	cm := newTestConnManager(t, &Config{
 		Listeners:       []net.Listener{listener},
 		MaxNormalConns:  30, // High enough to not interfere with per-host tests.
 		MaxConnsPerHost: maxConnsPerHost,
@@ -1834,8 +1834,8 @@ func TestMaxConnsPerHost(t *testing.T) {
 			disconnected <- conn
 		},
 	})
-	cmgr.maxRetryDuration = cmgr.cfg.RetryDuration
-	ctx, _, _ := runConnMgrAsync(t, context.Background(), cmgr)
+	cm.maxRetryDuration = cm.cfg.RetryDuration
+	ctx, _, _ := runConnMgrAsync(t, context.Background(), cm)
 
 	// Wait for the maximum allowed non-whitelisted per-host automatic outbound
 	// conns.
@@ -1844,27 +1844,27 @@ func TestMaxConnsPerHost(t *testing.T) {
 		conn := assertConnReceived(t, connected, 0, ConnTypeOutbound)
 		outboundConns = append(outboundConns, conn)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Ensure non-whitelisted manual connections that would exceed the max
 	// allowed per-host connections are rejected.
-	_, err := cmgr.Connect(ctx, nextSameHost())
+	_, err := cm.Connect(ctx, nextSameHost())
 	if !errors.Is(err, ErrMaxConnsPerHost) {
 		t.Fatalf("did not reject manual connection at per-host limit, err: %v",
 			err)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Ensure non-whitelisted inbound connections that would exceed the max
 	// allowed per-host connections are rejected.
 	go listener.Connect(nextSameHost())
 	assertNoConnReceived(t, inboundConns)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Ensure whitelisted manual connections are allowed to exceed the per-host
 	// limit.
 	for range maxConnsPerHost + 1 {
-		go cmgr.Connect(ctx, nextSameWhitelistedHost())
+		go cm.Connect(ctx, nextSameWhitelistedHost())
 		assertConnReceived(t, connected, 0, ConnTypeManual)
 	}
 
@@ -1872,16 +1872,16 @@ func TestMaxConnsPerHost(t *testing.T) {
 	// limit.
 	go listener.Connect(nextSameWhitelistedHost())
 	assertConnReceived(t, inboundConns, 0, ConnTypeInbound)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Ensure whitelisted persistent connections are allowed to exceed the
 	// per-host limit.
-	connID, err := cmgr.AddPersistent(nextSameWhitelistedHost())
+	connID, err := cm.AddPersistent(nextSameWhitelistedHost())
 	if err != nil {
 		t.Fatalf("failed to add persistent connection: %v", err)
 	}
 	assertConnReceived(t, connected, connID, ConnTypeManual)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Pause the target outbound dials and remove one of the target outbound
 	// connections to make room for another manual connection with the same
@@ -1900,30 +1900,30 @@ func TestMaxConnsPerHost(t *testing.T) {
 
 	// Ensure a new non-whitelisted manual connection to the same host now
 	// succeeds.
-	go cmgr.Connect(ctx, nextSameHost())
+	go cm.Connect(ctx, nextSameHost())
 	assertConnReceived(t, connected, 0, ConnTypeManual)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Unpause the target outbound dials and ensure no additional automatic
 	// outbound connections to the same host are made despite being under the
 	// target outbound.
-	noConnWaitTimeout := connTestReceiveTimeout + cmgr.cfg.RetryDuration
+	noConnWaitTimeout := connTestReceiveTimeout + cm.cfg.RetryDuration
 	pauseTargetOutbound.Store(false)
 	assertNoConnReceivedTimeout(t, connected, noConnWaitTimeout)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Ensure persistent connections for a host that already has all available
 	// host slots used by non-persistent conns can still be added but their
 	// connection attempts fail while there are no slots available.
 	//
 	// Then remove it to avoid interfering with the following tests.
-	connID, err = cmgr.AddPersistent(nextSameHost())
+	connID, err = cm.AddPersistent(nextSameHost())
 	if err != nil {
 		t.Fatalf("failed to add persistent connection: %v", err)
 	}
 	assertNoConnReceived(t, connected)
-	assertConnManagerInternalState(t, cmgr)
-	if err := cmgr.Remove(connID); err != nil {
+	assertConnManagerInternalState(t, cm)
+	if err := cm.Remove(connID); err != nil {
 		t.Fatalf("unexpected remove err: %v", err)
 	}
 
@@ -1939,14 +1939,14 @@ func TestMaxConnsPerHost(t *testing.T) {
 	// Ensure persistent connections can achieve the per-host limit.
 	persistentConns := make([]*Conn, 0, maxConnsPerHost)
 	for len(persistentConns) < maxConnsPerHost {
-		connID, err := cmgr.AddPersistent(nextSameHost2())
+		connID, err := cm.AddPersistent(nextSameHost2())
 		if err != nil {
 			t.Fatalf("failed to add persistent connection: %v", err)
 		}
 		conn := assertConnReceived(t, connected, connID, ConnTypeManual)
 		persistentConns = append(persistentConns, conn)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Ensure persistent connection reconnects are allowed at the per-host
 	// limit.  Wait for the disconnect first and then for the reconnect to be
@@ -1955,17 +1955,17 @@ func TestMaxConnsPerHost(t *testing.T) {
 	connID = persistentConn.ID()
 	persistentConn.Close()
 	assertConnReceived(t, disconnected, connID, ConnTypeManual)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 	timeout := retryTimeout + connTestReceiveTimeout
 	assertConnReceivedTimeout(t, connected, timeout, connID, ConnTypeManual)
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 
 	// Ensure persistent connection registrations are limited to the max
 	// per-host connections by attempting to add one and confirming it is
 	// rejected.
-	_, err = cmgr.AddPersistent(nextSameHost2())
+	_, err = cm.AddPersistent(nextSameHost2())
 	if !errors.Is(err, ErrMaxPersistentPerHost) {
 		t.Fatalf("did not reject > max persistent per host, err: %v", err)
 	}
-	assertConnManagerInternalState(t, cmgr)
+	assertConnManagerInternalState(t, cm)
 }

--- a/internal/connmgr/connmanager_test.go
+++ b/internal/connmgr/connmanager_test.go
@@ -859,7 +859,9 @@ func TestDoubleClose(t *testing.T) {
 	origOnClose := conn.onClose
 	conn.onClose = func() {
 		numClosed++
-		origOnClose()
+		if numClosed == 1 {
+			origOnClose()
+		}
 	}
 
 	// Close the connection multiple times and make sure it only happens once.

--- a/internal/connmgr/connmanager_test.go
+++ b/internal/connmgr/connmanager_test.go
@@ -1345,12 +1345,10 @@ func TestDialTimeout(t *testing.T) {
 	// Create a connection manager instance with a dialer that blocks for three
 	// times the configured dial timeout before connecting.
 	const dialTimeout = time.Millisecond * 20
-	cancelled := make(chan struct{})
 	timeoutDialer := func(ctx context.Context, network, addr string) (net.Conn, error) {
 		select {
 		case <-time.After(dialTimeout * 3):
 		case <-ctx.Done():
-			close(cancelled)
 			return nil, ctx.Err()
 		}
 
@@ -1362,15 +1360,21 @@ func TestDialTimeout(t *testing.T) {
 	})
 	ctx, _, _ := runConnMgrAsync(t, cm)
 
-	// Establish a connection to a localhost IP.
-	addr := mustParseAddrPort("127.0.0.1:18555")
-	go cm.Connect(ctx, addr)
+	connectErr := make(chan error, 1)
+	go func() {
+		addr := mustParseAddrPort("127.0.0.1:18555")
+		_, err := cm.Connect(ctx, addr)
+		connectErr <- err
+	}()
 	assertConnManagerInternalState(t, cm)
 
-	// Wait to receive the signal that the dialer context was cancelled, which
-	// means the dial timeout was hit.
+	// Wait for the error from connect and ensure it is the expected deadline
+	// exceeded (aka dial timeout) error.
 	select {
-	case <-cancelled:
+	case err := <-connectErr:
+		if wantErr := context.DeadlineExceeded; !errors.Is(err, wantErr) {
+			t.Fatalf("unexpected connect err: got %v, want %v", err, wantErr)
+		}
 	case <-time.After(dialTimeout * 10):
 		t.Fatal("timeout waiting for dial cancellation")
 	}

--- a/internal/connmgr/connmanager_test.go
+++ b/internal/connmgr/connmanager_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"net/netip"
 	"reflect"
@@ -56,56 +55,6 @@ func runConnMgrAsync(ctx context.Context, cmgr *ConnManager) (context.Context, c
 		wg.Done()
 	}()
 	return ctx, cancel, &wg
-}
-
-// mockAddr mocks a network address.
-type mockAddr struct {
-	net, address string
-}
-
-func (m mockAddr) Network() string { return m.net }
-func (m mockAddr) String() string  { return m.address }
-
-// mockConn mocks a network connection by implementing the net.Conn interface.
-type mockConn struct {
-	io.Reader
-	io.Writer
-	io.Closer
-
-	// local network, address for the connection.
-	lnet, laddr string
-
-	// remote network, address for the connection.
-	rAddr net.Addr
-}
-
-// LocalAddr returns the local address for the connection.
-func (c mockConn) LocalAddr() net.Addr {
-	return &mockAddr{c.lnet, c.laddr}
-}
-
-// RemoteAddr returns the remote address for the connection.
-func (c mockConn) RemoteAddr() net.Addr {
-	return &mockAddr{c.rAddr.Network(), c.rAddr.String()}
-}
-
-// Close handles closing the connection.
-func (c mockConn) Close() error {
-	return nil
-}
-
-func (c mockConn) SetDeadline(t time.Time) error      { return nil }
-func (c mockConn) SetReadDeadline(t time.Time) error  { return nil }
-func (c mockConn) SetWriteDeadline(t time.Time) error { return nil }
-
-// mockDialer mocks the net.Dial interface by returning a mock connection to
-// the given address.
-func mockDialer(ctx context.Context, network, addr string) (net.Conn, error) {
-	r, w := io.Pipe()
-	c := &mockConn{rAddr: &mockAddr{network, addr}}
-	c.Reader = r
-	c.Writer = w
-	return c, ctx.Err()
 }
 
 // newTestConnManager returns a new connection manager with the provided
@@ -1531,62 +1480,6 @@ func TestConnectContext(t *testing.T) {
 	shutdown()
 	wg.Wait()
 	assertConnManagerCleanShutdown(t, cmgr)
-}
-
-// mockListener implements the net.Listener interface and is used to test
-// code that deals with net.Listeners without having to actually make any real
-// connections.
-type mockListener struct {
-	localAddr   string
-	provideConn chan net.Conn
-}
-
-// Accept returns a mock connection when it receives a signal via the Connect
-// function.
-//
-// This is part of the net.Listener interface.
-func (m *mockListener) Accept() (net.Conn, error) {
-	for conn := range m.provideConn {
-		return conn, nil
-	}
-	return nil, errors.New("network connection closed")
-}
-
-// Close closes the mock listener which will cause any blocked Accept
-// operations to be unblocked and return errors.
-//
-// This is part of the net.Listener interface.
-func (m *mockListener) Close() error {
-	close(m.provideConn)
-	return nil
-}
-
-// Addr returns the address the mock listener was configured with.
-//
-// This is part of the net.Listener interface.
-func (m *mockListener) Addr() net.Addr {
-	return &mockAddr{"tcp", m.localAddr}
-}
-
-// Connect fakes a connection to the mock listener from the provided remote
-// address.  It will cause the Accept function to return a mock connection
-// configured with the provided remote address and the local address for the
-// mock listener.
-func (m *mockListener) Connect(addr net.Addr) {
-	m.provideConn <- &mockConn{
-		laddr: m.localAddr,
-		lnet:  "tcp",
-		rAddr: addr,
-	}
-}
-
-// newMockListener returns a new mock listener for the provided local address
-// and port.  No ports are actually opened.
-func newMockListener(localAddr string) *mockListener {
-	return &mockListener{
-		localAddr:   localAddr,
-		provideConn: make(chan net.Conn),
-	}
 }
 
 // TestListeners ensures providing listeners to the connection manager along

--- a/internal/connmgr/connmanager_test.go
+++ b/internal/connmgr/connmanager_test.go
@@ -50,10 +50,10 @@ func mustParseAddrPort(addr string) *addrmgr.NetAddress {
 //
 // It also registers a test cleanup func that waits for shutdown and asserts the
 // internal state of the connection manager is empty as expected.
-func runConnMgrAsync(t *testing.T, ctx context.Context, cm *ConnManager) (context.Context, context.CancelFunc, *sync.WaitGroup) {
+func runConnMgrAsync(t *testing.T, cm *ConnManager) (context.Context, context.CancelFunc, *sync.WaitGroup) {
 	t.Helper()
 
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(t.Context())
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -461,7 +461,7 @@ func TestConnectMode(t *testing.T) {
 			connected <- conn
 		},
 	})
-	ctx, _, _ := runConnMgrAsync(t, context.Background(), cm)
+	ctx, _, _ := runConnMgrAsync(t, cm)
 
 	addr := mustParseAddrPort("127.0.0.1:18555")
 	go cm.Connect(ctx, addr)
@@ -511,7 +511,7 @@ func TestDisconnect(t *testing.T) {
 			disconnected <- conn
 		},
 	})
-	ctx, _, _ := runConnMgrAsync(t, context.Background(), cm)
+	ctx, _, _ := runConnMgrAsync(t, cm)
 
 	// Attempt a connection to a localhost IP.
 	notifyDialed.Store(true)
@@ -669,7 +669,7 @@ func TestRemove(t *testing.T) {
 			disconnected <- conn
 		},
 	})
-	ctx, _, _ := runConnMgrAsync(t, context.Background(), cm)
+	ctx, _, _ := runConnMgrAsync(t, cm)
 
 	// Ensure removing an ID that doesn't exist returns the expected error.
 	if err := cm.Remove(^uint64(0)); !errors.Is(err, ErrNotFound) {
@@ -821,7 +821,7 @@ func TestTargetOutbound(t *testing.T) {
 			connected <- conn
 		},
 	})
-	runConnMgrAsync(t, context.Background(), cm)
+	runConnMgrAsync(t, cm)
 
 	// Ensure only the expected number of target outbound conns are established
 	// and no more.
@@ -848,7 +848,7 @@ func TestDoubleClose(t *testing.T) {
 			connected <- conn
 		},
 	})
-	runConnMgrAsync(t, context.Background(), cm)
+	runConnMgrAsync(t, cm)
 
 	// Wait for the connection to be established.
 	conn := assertConnReceived(t, connected, 0, ConnTypeOutbound)
@@ -888,7 +888,7 @@ func TestRetryPersistent(t *testing.T) {
 			disconnected <- conn
 		},
 	})
-	runConnMgrAsync(t, context.Background(), cm)
+	runConnMgrAsync(t, cm)
 
 	addr := mustParseAddrPort("127.0.0.1:18555")
 	connID, err := cm.AddPersistent(addr)
@@ -934,7 +934,7 @@ func TestMaxPersistent(t *testing.T) {
 			disconnected <- conn
 		},
 	})
-	runConnMgrAsync(t, context.Background(), cm)
+	runConnMgrAsync(t, cm)
 
 	var numAddrs uint32
 	nextAddr := func() *addrmgr.NetAddress {
@@ -1031,7 +1031,7 @@ func TestMaxRetryDuration(t *testing.T) {
 			connected <- conn
 		},
 	})
-	runConnMgrAsync(t, context.Background(), cm)
+	runConnMgrAsync(t, cm)
 
 	connID, err := cm.AddPersistent(mustParseAddrPort("127.0.0.1:18555"))
 	if err != nil {
@@ -1083,7 +1083,7 @@ func TestNetworkFailure(t *testing.T) {
 				conn.RemoteAddr())
 		},
 	})
-	_, shutdown, wg := runConnMgrAsync(t, context.Background(), cm)
+	_, shutdown, wg := runConnMgrAsync(t, cm)
 
 	// Shutdown the connection manager after the max failed attempts is reached
 	// and an additional retry duration has passed and then wait for the
@@ -1135,7 +1135,7 @@ func TestMultipleFailedConns(t *testing.T) {
 		Dial:          errDialer,
 	})
 	cm.maxRetryDuration = maxRetryDuration
-	runConnMgrAsync(t, context.Background(), cm)
+	runConnMgrAsync(t, cm)
 
 	// Establish several connection requests to localhost IPs.
 	for i := range targetFailed {
@@ -1189,7 +1189,7 @@ func TestShutdownFailedConns(t *testing.T) {
 		Dial:          waitDialer,
 	})
 	cm.maxRetryDuration = retryTimeout
-	runConnMgrAsync(t, context.Background(), cm)
+	runConnMgrAsync(t, cm)
 
 	// Add a persistent connection.
 	addr := mustParseAddrPort("127.0.0.1:18555")
@@ -1227,7 +1227,7 @@ func TestRemovePendingConnection(t *testing.T) {
 	cm := newTestConnManager(t, &Config{
 		Dial: indefiniteDialer,
 	})
-	ctx, _, _ := runConnMgrAsync(t, context.Background(), cm)
+	ctx, _, _ := runConnMgrAsync(t, cm)
 
 	// Establish a connection request to a localhost IP.
 	addr := mustParseAddrPort("127.0.0.1:18555")
@@ -1300,7 +1300,7 @@ func TestCancelIgnoreDelayedConnection(t *testing.T) {
 			connected <- conn
 		},
 	})
-	runConnMgrAsync(t, context.Background(), cm)
+	runConnMgrAsync(t, cm)
 
 	// Establish a persistent connection to a localhost IP.
 	addr := mustParseAddrPort("127.0.0.1:18555")
@@ -1358,7 +1358,7 @@ func TestDialTimeout(t *testing.T) {
 		Dial:        timeoutDialer,
 		DialTimeout: dialTimeout,
 	})
-	ctx, _, _ := runConnMgrAsync(t, context.Background(), cm)
+	ctx, _, _ := runConnMgrAsync(t, cm)
 
 	// Establish a connection to a localhost IP.
 	addr := mustParseAddrPort("127.0.0.1:18555")
@@ -1391,7 +1391,7 @@ func TestConnectContext(t *testing.T) {
 	cm := newTestConnManager(t, &Config{
 		Dial: indefiniteDialer,
 	})
-	ctx, _, _ := runConnMgrAsync(t, context.Background(), cm)
+	ctx, _, _ := runConnMgrAsync(t, cm)
 
 	// Establish a connection request to a localhost IP with a separate context
 	// that can be canceled.
@@ -1447,7 +1447,7 @@ func TestListeners(t *testing.T) {
 		},
 		Dial: mockDialer,
 	})
-	runConnMgrAsync(t, context.Background(), cm)
+	runConnMgrAsync(t, cm)
 
 	// Fake a couple of mock connections to each of the listeners.
 	go func() {
@@ -1501,7 +1501,7 @@ func TestRejectDuplicateConns(t *testing.T) {
 			disconnected <- conn
 		},
 	})
-	ctx, _, _ := runConnMgrAsync(t, context.Background(), cm)
+	ctx, _, _ := runConnMgrAsync(t, cm)
 
 	// Dial a manual connection and wait for it to become pending.
 	addr := mustParseAddrPort("127.0.0.1:18555")
@@ -1667,7 +1667,7 @@ func TestMaxNormalConns(t *testing.T) {
 		},
 	})
 	cm.maxRetryDuration = cm.cfg.RetryDuration
-	ctx, _, _ := runConnMgrAsync(t, context.Background(), cm)
+	ctx, _, _ := runConnMgrAsync(t, cm)
 
 	// Wait for the expected number of target outbound conns to be established.
 	outbounds := make([]*Conn, 0, targetOutbound)
@@ -1835,7 +1835,7 @@ func TestMaxConnsPerHost(t *testing.T) {
 		},
 	})
 	cm.maxRetryDuration = cm.cfg.RetryDuration
-	ctx, _, _ := runConnMgrAsync(t, context.Background(), cm)
+	ctx, _, _ := runConnMgrAsync(t, cm)
 
 	// Wait for the maximum allowed non-whitelisted per-host automatic outbound
 	// conns.

--- a/internal/connmgr/connmanager_test.go
+++ b/internal/connmgr/connmanager_test.go
@@ -43,17 +43,31 @@ func mustParseAddrPort(addr string) *addrmgr.NetAddress {
 		addrPort.Port(), 0)
 }
 
-// runConnMgrAsync invokes the Run method on the passed connection manager in a
-// separate goroutine and returns a cancelable context and wait group the caller
-// can use to shutdown the connection manager and wait for clean shutdown.
-func runConnMgrAsync(ctx context.Context, cmgr *ConnManager) (context.Context, context.CancelFunc, *sync.WaitGroup) {
+// runConnMgrAsync invokes [ConnManager.Run] on the passed connection manager in
+// a separate goroutine and returns a cancelable context and wait group the
+// caller can use to shutdown the connection manager and wait for clean
+// shutdown.
+//
+// It also registers a test cleanup func that waits for shutdown and asserts the
+// internal state of the connection manager is empty as expected.
+func runConnMgrAsync(t *testing.T, ctx context.Context, cm *ConnManager) (context.Context, context.CancelFunc, *sync.WaitGroup) {
+	t.Helper()
+
 	ctx, cancel := context.WithCancel(ctx)
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		cmgr.Run(ctx)
+		cm.Run(ctx)
 		wg.Done()
 	}()
+	t.Cleanup(func() {
+		t.Helper()
+
+		cancel()
+		wg.Wait()
+		assertConnManagerCleanShutdown(t, cm)
+	})
+
 	return ctx, cancel, &wg
 }
 
@@ -96,6 +110,11 @@ func assertInternalConnState(t *testing.T, cm *ConnManager) {
 
 	// Assert the pending and active maps are mutually exclusive for both conn
 	// IDs and addrs.
+	//
+	// Also build maps of the following data in the pending, active, and
+	// persistent maps:
+	//
+	//   - addrs to conn IDs
 	connIDByAddr := make(map[string]uint64)
 	for id, info := range cm.pending {
 		if _, ok := cm.active[id]; ok {
@@ -442,7 +461,7 @@ func TestConnectMode(t *testing.T) {
 			connected <- conn
 		},
 	})
-	ctx, shutdown, wg := runConnMgrAsync(context.Background(), cmgr)
+	ctx, _, _ := runConnMgrAsync(t, context.Background(), cmgr)
 
 	addr := mustParseAddrPort("127.0.0.1:18555")
 	go cmgr.Connect(ctx, addr)
@@ -451,11 +470,6 @@ func TestConnectMode(t *testing.T) {
 	assertConnReceived(t, connected, 0, ConnTypeManual)
 	assertNoConnReceived(t, connected)
 	assertConnManagerInternalState(t, cmgr)
-
-	// Ensure clean shutdown of connection manager.
-	shutdown()
-	wg.Wait()
-	assertConnManagerCleanShutdown(t, cmgr)
 }
 
 // TestDisconnect ensures that [ConnManager.Disconnect] properly disconnects
@@ -497,7 +511,7 @@ func TestDisconnect(t *testing.T) {
 			disconnected <- conn
 		},
 	})
-	ctx, shutdown, wg := runConnMgrAsync(context.Background(), cmgr)
+	ctx, _, _ := runConnMgrAsync(t, context.Background(), cmgr)
 
 	// Attempt a connection to a localhost IP.
 	notifyDialed.Store(true)
@@ -613,11 +627,6 @@ func TestDisconnect(t *testing.T) {
 	}
 	assertConnReceived(t, disconnected, connID, ConnTypeManual)
 	assertConnManagerInternalState(t, cmgr)
-
-	// Ensure clean shutdown of connection manager.
-	shutdown()
-	wg.Wait()
-	assertConnManagerCleanShutdown(t, cmgr)
 }
 
 // TestRemove ensures that [ConnManager.Remove] properly removes pending and
@@ -660,7 +669,7 @@ func TestRemove(t *testing.T) {
 			disconnected <- conn
 		},
 	})
-	ctx, shutdown, wg := runConnMgrAsync(context.Background(), cmgr)
+	ctx, _, _ := runConnMgrAsync(t, context.Background(), cmgr)
 
 	// Ensure removing an ID that doesn't exist returns the expected error.
 	if err := cmgr.Remove(^uint64(0)); !errors.Is(err, ErrNotFound) {
@@ -790,11 +799,6 @@ func TestRemove(t *testing.T) {
 	}
 	assertConnReceived(t, disconnected, connID, ConnTypeManual)
 	assertConnManagerInternalState(t, cmgr)
-
-	// Ensure clean shutdown of connection manager.
-	shutdown()
-	wg.Wait()
-	assertConnManagerCleanShutdown(t, cmgr)
 }
 
 // TestTargetOutbound tests the target number of outbound connections
@@ -817,7 +821,7 @@ func TestTargetOutbound(t *testing.T) {
 			connected <- conn
 		},
 	})
-	_, shutdown, wg := runConnMgrAsync(context.Background(), cmgr)
+	runConnMgrAsync(t, context.Background(), cmgr)
 
 	// Ensure only the expected number of target outbound conns are established
 	// and no more.
@@ -826,11 +830,6 @@ func TestTargetOutbound(t *testing.T) {
 	}
 	assertNoConnReceived(t, connected)
 	assertConnManagerInternalState(t, cmgr)
-
-	// Ensure clean shutdown of connection manager.
-	shutdown()
-	wg.Wait()
-	assertConnManagerCleanShutdown(t, cmgr)
 }
 
 // TestDoubleClose ensures closing a connection multiple times is a noop after
@@ -849,7 +848,7 @@ func TestDoubleClose(t *testing.T) {
 			connected <- conn
 		},
 	})
-	_, shutdown, wg := runConnMgrAsync(context.Background(), cmgr)
+	runConnMgrAsync(t, context.Background(), cmgr)
 
 	// Wait for the connection to be established.
 	conn := assertConnReceived(t, connected, 0, ConnTypeOutbound)
@@ -871,11 +870,6 @@ func TestDoubleClose(t *testing.T) {
 		t.Fatal("connection closed more than once")
 	}
 	assertConnManagerInternalState(t, cmgr)
-
-	// Ensure clean shutdown of connection manager.
-	shutdown()
-	wg.Wait()
-	assertConnManagerCleanShutdown(t, cmgr)
 }
 
 // TestRetryPersistent tests that persistent connections are retried.
@@ -894,7 +888,7 @@ func TestRetryPersistent(t *testing.T) {
 			disconnected <- conn
 		},
 	})
-	_, shutdown, wg := runConnMgrAsync(context.Background(), cmgr)
+	runConnMgrAsync(t, context.Background(), cmgr)
 
 	addr := mustParseAddrPort("127.0.0.1:18555")
 	connID, err := cmgr.AddPersistent(addr)
@@ -921,11 +915,6 @@ func TestRetryPersistent(t *testing.T) {
 	assertConnReceived(t, disconnected, connID, ConnTypeManual)
 	assertRemovedPersistent(t, cmgr, addr)
 	assertConnManagerInternalState(t, cmgr)
-
-	// Ensure clean shutdown of connection manager.
-	shutdown()
-	wg.Wait()
-	assertConnManagerCleanShutdown(t, cmgr)
 }
 
 // TestMaxPersistent ensures [ConnManager.AddPersistent] limits the maximum
@@ -945,7 +934,7 @@ func TestMaxPersistent(t *testing.T) {
 			disconnected <- conn
 		},
 	})
-	_, shutdown, wg := runConnMgrAsync(context.Background(), cmgr)
+	runConnMgrAsync(t, context.Background(), cmgr)
 
 	var numAddrs uint32
 	nextAddr := func() *addrmgr.NetAddress {
@@ -1007,11 +996,6 @@ func TestMaxPersistent(t *testing.T) {
 		t.Fatalf("failed to add persistent connection %v: %v", addr, err)
 	}
 	assertConnManagerInternalState(t, cmgr)
-
-	// Ensure clean shutdown of connection manager.
-	shutdown()
-	wg.Wait()
-	assertConnManagerCleanShutdown(t, cmgr)
 }
 
 // TestMaxRetryDuration tests the maximum retry duration.
@@ -1047,7 +1031,7 @@ func TestMaxRetryDuration(t *testing.T) {
 			connected <- conn
 		},
 	})
-	_, shutdown, wg := runConnMgrAsync(context.Background(), cmgr)
+	runConnMgrAsync(t, context.Background(), cmgr)
 
 	connID, err := cmgr.AddPersistent(mustParseAddrPort("127.0.0.1:18555"))
 	if err != nil {
@@ -1064,11 +1048,6 @@ func TestMaxRetryDuration(t *testing.T) {
 	const timeout = connTestReceiveTimeout + networkUpTimeout
 	assertConnReceivedTimeout(t, connected, timeout, connID, ConnTypeManual)
 	assertConnManagerInternalState(t, cmgr)
-
-	// Ensure clean shutdown of connection manager.
-	shutdown()
-	wg.Wait()
-	assertConnManagerCleanShutdown(t, cmgr)
 }
 
 // TestNetworkFailure tests that the connection manager handles a network
@@ -1104,7 +1083,7 @@ func TestNetworkFailure(t *testing.T) {
 				conn.RemoteAddr())
 		},
 	})
-	_, shutdown, wg := runConnMgrAsync(context.Background(), cmgr)
+	_, shutdown, wg := runConnMgrAsync(t, context.Background(), cmgr)
 
 	// Shutdown the connection manager after the max failed attempts is reached
 	// and an additional retry duration has passed and then wait for the
@@ -1128,8 +1107,6 @@ func TestNetworkFailure(t *testing.T) {
 		t.Fatalf("unexpected number of dials - got %v, want <= %v", gotDials,
 			wantMaxDials)
 	}
-
-	assertConnManagerCleanShutdown(t, cmgr)
 }
 
 // TestMultipleFailedConns ensures that the connection manager remains
@@ -1158,7 +1135,7 @@ func TestMultipleFailedConns(t *testing.T) {
 		Dial:          errDialer,
 	})
 	cmgr.maxRetryDuration = maxRetryDuration
-	_, shutdown, wg := runConnMgrAsync(context.Background(), cmgr)
+	runConnMgrAsync(t, context.Background(), cmgr)
 
 	// Establish several connection requests to localhost IPs.
 	for i := range targetFailed {
@@ -1193,11 +1170,6 @@ func TestMultipleFailedConns(t *testing.T) {
 		t.Fatal("timeout servicing connmgr requests")
 	}
 	assertConnManagerInternalState(t, cmgr)
-
-	// Ensure clean shutdown of connection manager.
-	shutdown()
-	wg.Wait()
-	assertConnManagerCleanShutdown(t, cmgr)
 }
 
 // TestShutdownFailedConns tests that failed connections are ignored after
@@ -1217,7 +1189,7 @@ func TestShutdownFailedConns(t *testing.T) {
 		Dial:          waitDialer,
 	})
 	cmgr.maxRetryDuration = retryTimeout
-	_, shutdown, wg := runConnMgrAsync(context.Background(), cmgr)
+	runConnMgrAsync(t, context.Background(), cmgr)
 
 	// Add a persistent connection.
 	addr := mustParseAddrPort("127.0.0.1:18555")
@@ -1235,11 +1207,6 @@ func TestShutdownFailedConns(t *testing.T) {
 		t.Fatal("timeout waiting for dial")
 	}
 	time.Sleep(connTestNonReceiveTimeout)
-	shutdown()
-
-	// Ensure clean shutdown of connection manager.
-	wg.Wait()
-	assertConnManagerCleanShutdown(t, cmgr)
 }
 
 // TestRemovePendingConnection ensures that removing a pending outbound
@@ -1260,7 +1227,7 @@ func TestRemovePendingConnection(t *testing.T) {
 	cmgr := newTestConnManager(t, &Config{
 		Dial: indefiniteDialer,
 	})
-	ctx, shutdown, wg := runConnMgrAsync(context.Background(), cmgr)
+	ctx, _, _ := runConnMgrAsync(t, context.Background(), cmgr)
 
 	// Establish a connection request to a localhost IP.
 	addr := mustParseAddrPort("127.0.0.1:18555")
@@ -1295,11 +1262,6 @@ func TestRemovePendingConnection(t *testing.T) {
 		t.Fatalf("connection %s is still pending", addr)
 	}
 	assertConnManagerInternalState(t, cmgr)
-
-	// Ensure clean shutdown of connection manager.
-	shutdown()
-	wg.Wait()
-	assertConnManagerCleanShutdown(t, cmgr)
 }
 
 // TestCancelIgnoreDelayedConnection tests that a canceled pending persistent
@@ -1338,7 +1300,7 @@ func TestCancelIgnoreDelayedConnection(t *testing.T) {
 			connected <- conn
 		},
 	})
-	_, shutdown, wg := runConnMgrAsync(context.Background(), cmgr)
+	runConnMgrAsync(t, context.Background(), cmgr)
 
 	// Establish a persistent connection to a localhost IP.
 	addr := mustParseAddrPort("127.0.0.1:18555")
@@ -1370,11 +1332,6 @@ func TestCancelIgnoreDelayedConnection(t *testing.T) {
 	// properly elapse.
 	assertNoConnReceivedTimeout(t, connected, 5*retryTimeout)
 	assertConnManagerInternalState(t, cmgr)
-
-	// Ensure clean shutdown of connection manager.
-	shutdown()
-	wg.Wait()
-	assertConnManagerCleanShutdown(t, cmgr)
 }
 
 // TestDialTimeout ensure [Config.Timeout] works as intended by creating a
@@ -1401,7 +1358,7 @@ func TestDialTimeout(t *testing.T) {
 		Dial:        timeoutDialer,
 		DialTimeout: dialTimeout,
 	})
-	ctx, shutdown, wg := runConnMgrAsync(context.Background(), cmgr)
+	ctx, _, _ := runConnMgrAsync(t, context.Background(), cmgr)
 
 	// Establish a connection to a localhost IP.
 	addr := mustParseAddrPort("127.0.0.1:18555")
@@ -1416,11 +1373,6 @@ func TestDialTimeout(t *testing.T) {
 		t.Fatal("timeout waiting for dial cancellation")
 	}
 	assertConnManagerInternalState(t, cmgr)
-
-	// Ensure clean shutdown of connection manager.
-	shutdown()
-	wg.Wait()
-	assertConnManagerCleanShutdown(t, cmgr)
 }
 
 // TestConnectContext ensures the [ConnManager.Connect] method works as intended
@@ -1439,7 +1391,7 @@ func TestConnectContext(t *testing.T) {
 	cmgr := newTestConnManager(t, &Config{
 		Dial: indefiniteDialer,
 	})
-	ctx, shutdown, wg := runConnMgrAsync(context.Background(), cmgr)
+	ctx, _, _ := runConnMgrAsync(t, context.Background(), cmgr)
 
 	// Establish a connection request to a localhost IP with a separate context
 	// that can be canceled.
@@ -1475,11 +1427,6 @@ func TestConnectContext(t *testing.T) {
 		t.Fatal("timeout waiting for dial cancellation")
 	}
 	assertConnManagerInternalState(t, cmgr)
-
-	// Ensure clean shutdown of connection manager.
-	shutdown()
-	wg.Wait()
-	assertConnManagerCleanShutdown(t, cmgr)
 }
 
 // TestListeners ensures providing listeners to the connection manager along
@@ -1500,7 +1447,7 @@ func TestListeners(t *testing.T) {
 		},
 		Dial: mockDialer,
 	})
-	_, shutdown, wg := runConnMgrAsync(context.Background(), cmgr)
+	runConnMgrAsync(t, context.Background(), cmgr)
 
 	// Fake a couple of mock connections to each of the listeners.
 	go func() {
@@ -1517,11 +1464,6 @@ func TestListeners(t *testing.T) {
 		assertConnReceived(t, receivedConns, 0, ConnTypeInbound)
 	}
 	assertConnManagerInternalState(t, cmgr)
-
-	// Ensure clean shutdown of connection manager.
-	shutdown()
-	wg.Wait()
-	assertConnManagerCleanShutdown(t, cmgr)
 }
 
 // TestRejectDuplicateConns ensures duplicate addresses are rejected.  This
@@ -1559,7 +1501,7 @@ func TestRejectDuplicateConns(t *testing.T) {
 			disconnected <- conn
 		},
 	})
-	ctx, shutdown, wg := runConnMgrAsync(context.Background(), cmgr)
+	ctx, _, _ := runConnMgrAsync(t, context.Background(), cmgr)
 
 	// Dial a manual connection and wait for it to become pending.
 	addr := mustParseAddrPort("127.0.0.1:18555")
@@ -1661,11 +1603,6 @@ func TestRejectDuplicateConns(t *testing.T) {
 			err)
 	}
 	assertConnManagerInternalState(t, cmgr)
-
-	// Ensure clean shutdown of connection manager.
-	shutdown()
-	wg.Wait()
-	assertConnManagerCleanShutdown(t, cmgr)
 }
 
 // TestMaxNormalConns ensures the connection manager limits the total number of
@@ -1730,7 +1667,7 @@ func TestMaxNormalConns(t *testing.T) {
 		},
 	})
 	cmgr.maxRetryDuration = cmgr.cfg.RetryDuration
-	ctx, shutdown, wg := runConnMgrAsync(context.Background(), cmgr)
+	ctx, _, _ := runConnMgrAsync(t, context.Background(), cmgr)
 
 	// Wait for the expected number of target outbound conns to be established.
 	outbounds := make([]*Conn, 0, targetOutbound)
@@ -1835,11 +1772,6 @@ func TestMaxNormalConns(t *testing.T) {
 	}
 	assertConnReceived(t, connected, connID, ConnTypeManual)
 	assertConnManagerInternalState(t, cmgr)
-
-	// Ensure clean shutdown of connection manager.
-	shutdown()
-	wg.Wait()
-	assertConnManagerCleanShutdown(t, cmgr)
 }
 
 // TestMaxConnsPerHost ensures the connection manager limits the total number of
@@ -1903,7 +1835,7 @@ func TestMaxConnsPerHost(t *testing.T) {
 		},
 	})
 	cmgr.maxRetryDuration = cmgr.cfg.RetryDuration
-	ctx, shutdown, wg := runConnMgrAsync(context.Background(), cmgr)
+	ctx, _, _ := runConnMgrAsync(t, context.Background(), cmgr)
 
 	// Wait for the maximum allowed non-whitelisted per-host automatic outbound
 	// conns.
@@ -2036,9 +1968,4 @@ func TestMaxConnsPerHost(t *testing.T) {
 		t.Fatalf("did not reject > max persistent per host, err: %v", err)
 	}
 	assertConnManagerInternalState(t, cmgr)
-
-	// Ensure clean shutdown of connection manager.
-	shutdown()
-	wg.Wait()
-	assertConnManagerCleanShutdown(t, cmgr)
 }

--- a/internal/connmgr/mockconn_test.go
+++ b/internal/connmgr/mockconn_test.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2016 The btcsuite developers
+// Copyright (c) 2019-2026 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package connmgr
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"time"
+)
+
+// mockAddr mocks a network address.
+type mockAddr struct {
+	net, address string
+}
+
+func (m mockAddr) Network() string { return m.net }
+func (m mockAddr) String() string  { return m.address }
+
+// mockConn mocks a network connection by implementing the net.Conn interface.
+type mockConn struct {
+	io.Reader
+	io.Writer
+	io.Closer
+
+	// local network, address for the connection.
+	lnet, laddr string
+
+	// remote network, address for the connection.
+	rAddr net.Addr
+}
+
+// LocalAddr returns the local address for the connection.
+func (c mockConn) LocalAddr() net.Addr {
+	return &mockAddr{c.lnet, c.laddr}
+}
+
+// RemoteAddr returns the remote address for the connection.
+func (c mockConn) RemoteAddr() net.Addr {
+	return &mockAddr{c.rAddr.Network(), c.rAddr.String()}
+}
+
+// Close handles closing the connection.
+func (c mockConn) Close() error {
+	return nil
+}
+
+func (c mockConn) SetDeadline(t time.Time) error      { return nil }
+func (c mockConn) SetReadDeadline(t time.Time) error  { return nil }
+func (c mockConn) SetWriteDeadline(t time.Time) error { return nil }
+
+// mockDialer mocks the net.Dial interface by returning a mock connection to
+// the given address.
+func mockDialer(ctx context.Context, network, addr string) (net.Conn, error) {
+	r, w := io.Pipe()
+	c := &mockConn{rAddr: &mockAddr{network, addr}}
+	c.Reader = r
+	c.Writer = w
+	return c, ctx.Err()
+}
+
+// mockListener implements the net.Listener interface and is used to test
+// code that deals with net.Listeners without having to actually make any real
+// connections.
+type mockListener struct {
+	localAddr   string
+	provideConn chan net.Conn
+}
+
+// Accept returns a mock connection when it receives a signal via the Connect
+// function.
+//
+// This is part of the net.Listener interface.
+func (m *mockListener) Accept() (net.Conn, error) {
+	for conn := range m.provideConn {
+		return conn, nil
+	}
+	return nil, errors.New("network connection closed")
+}
+
+// Close closes the mock listener which will cause any blocked Accept
+// operations to be unblocked and return errors.
+//
+// This is part of the net.Listener interface.
+func (m *mockListener) Close() error {
+	close(m.provideConn)
+	return nil
+}
+
+// Addr returns the address the mock listener was configured with.
+//
+// This is part of the net.Listener interface.
+func (m *mockListener) Addr() net.Addr {
+	return &mockAddr{"tcp", m.localAddr}
+}
+
+// Connect fakes a connection to the mock listener from the provided remote
+// address.  It will cause the Accept function to return a mock connection
+// configured with the provided remote address and the local address for the
+// mock listener.
+func (m *mockListener) Connect(addr net.Addr) {
+	m.provideConn <- &mockConn{
+		laddr: m.localAddr,
+		lnet:  "tcp",
+		rAddr: addr,
+	}
+}
+
+// newMockListener returns a new mock listener for the provided local address
+// and port.  No ports are actually opened.
+func newMockListener(localAddr string) *mockListener {
+	return &mockListener{
+		localAddr:   localAddr,
+		provideConn: make(chan net.Conn),
+	}
+}


### PR DESCRIPTION
**This requires #3698**.

This consists of a few commits to modernize and do some light cleanup the connection manager tests.

- Separate code related to mock addresses, connections, and listeners to its own file
- Use `t.Cleanup` to wait for clean shutdown and assert final state correctness
- Make variable names in tests consistent with the implementation code
- Only close once in double close tests
- Use error return from `Connect` for dial timeout detection