### PR TITLE
connmgr: Implement exponential backoff with jitter.

### DIFF
--- a/internal/connmgr/README.md
+++ b/internal/connmgr/README.md
@@ -28,7 +28,7 @@ The following is a brief overview of the key features:
     address source (`GetNewAddress`)
 - Persistent connections
   - Maintains up to `MaxPersistent` addresses that are automatically retried
-    with exponential backoff on disconnect
+    with exponential backoff and jitter on disconnect
 - Manual connections
   - Supports manual connection establishment via `Connect`
 - Connection limits

--- a/internal/connmgr/connmanager.go
+++ b/internal/connmgr/connmanager.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"net/netip"
 	"strconv"
@@ -329,6 +330,11 @@ type ConnManager struct {
 	// maxRetryDuration is the maximum duration a persistent connection retry
 	// backoff is allowed to grow to.
 	maxRetryDuration time.Duration
+
+	// maxRetryScalingBits is the maximum number of bits the exponential backoff
+	// scaling factor can occupy such that multiplying by [Config.RetryDuration]
+	// is guaranteed not to overflow.
+	maxRetryScalingBits uint8
 
 	// runPersistentChan is used to signal the persistent connections handler to
 	// launch a goroutine that attempts to always maintain an established
@@ -1289,6 +1295,30 @@ func (cm *ConnManager) FindPersistentAddrID(addr net.Addr) (uint64, bool) {
 	return id, ok
 }
 
+// backoffWithJitter returns an exponential backoff delay with additional jitter
+// for the given number of retries.
+func (cm *ConnManager) backoffWithJitter(retries uint32) time.Duration {
+	if retries == 0 {
+		return 0
+	}
+
+	// Calculate an exponential backoff capped to prevent overflow and clamped
+	// to the max retry duration.
+	shift := min(retries-1, uint32(cm.maxRetryScalingBits))
+	factor := uint64(1) << shift
+
+	baseRetryDuration := cm.cfg.RetryDuration
+	backoff := min(baseRetryDuration*time.Duration(factor), cm.maxRetryDuration)
+	if backoff == 0 {
+		return 0
+	}
+
+	// Apply 50% jitter.
+	halfBackoff := backoff / 2
+	jitter := time.Duration(cm.csprng.Uint64N(uint64(halfBackoff)))
+	return halfBackoff + jitter
+}
+
 // runPersistent attempts to maintain a persistent connection to the provided
 // address until the passed context is canceled.
 //
@@ -1341,10 +1371,9 @@ func (cm *ConnManager) runPersistent(ctx context.Context, connID uint64, addr *a
 				if retryCount < maxUint32 {
 					retryCount++
 				}
-				retryWait := time.Duration(retryCount) * cm.cfg.RetryDuration
-				retryWait = min(retryWait, cm.maxRetryDuration)
+				retryWait := cm.backoffWithJitter(retryCount)
 				log.Debugf("Retrying connection to %v in %v (retries %d)", addr,
-					retryWait, retryCount)
+					retryWait.Truncate(time.Microsecond), retryCount)
 				retryAfter = time.After(retryWait)
 				continue
 			}
@@ -1619,11 +1648,13 @@ func New(cfg *Config) (*ConnManager, error) {
 		cfg.TargetOutbound = defaultTargetOutbound
 	}
 	cfg.TargetOutbound = min(cfg.TargetOutbound, cfg.MaxNormalConns)
+	retryDurationBits := uint8(math.Ceil(math.Log2(float64(cfg.RetryDuration))))
 	cm := ConnManager{
 		cfg:                 *cfg, // Copy so caller can't mutate
 		quit:                make(chan struct{}),
 		csprng:              globalRand,
 		maxRetryDuration:    defaultMaxRetryDuration,
+		maxRetryScalingBits: 63 - retryDurationBits,
 		runPersistentChan:   make(chan *persistentEntry, MaxPersistent),
 		totalNormalConnsSem: makeSemaphore(cfg.MaxNormalConns),
 		activeOutboundsSem:  makeSemaphore(cfg.TargetOutbound),

--- a/internal/connmgr/connmanager.go
+++ b/internal/connmgr/connmanager.go
@@ -319,6 +319,13 @@ type ConnManager struct {
 	// creating time and treated as immutable after that.
 	cfg Config
 
+	// csprng provides a cryptographically secure pseudorandom number generator.
+	//
+	// All code in the connection manager that relies on random values is
+	// expected to make use of this so that tests can replace the real
+	// implementation with a deterministic PRNG for reproducibility.
+	csprng csprng
+
 	// maxRetryDuration is the maximum duration a persistent connection retry
 	// backoff is allowed to grow to.
 	maxRetryDuration time.Duration
@@ -348,7 +355,10 @@ type ConnManager struct {
 	perHostCountsMtx sync.Mutex
 	perHostCounts    map[string]uint32
 
-	// The fields below this point are all protected by the connection mutex.
+	// ******************************************************************
+	// The fields below this point are protected by the connection mutex.
+	// ******************************************************************
+
 	connMtx sync.Mutex
 
 	// persistent tracks all registered persistent connection entries.
@@ -1612,6 +1622,7 @@ func New(cfg *Config) (*ConnManager, error) {
 	cm := ConnManager{
 		cfg:                 *cfg, // Copy so caller can't mutate
 		quit:                make(chan struct{}),
+		csprng:              globalRand,
 		maxRetryDuration:    defaultMaxRetryDuration,
 		runPersistentChan:   make(chan *persistentEntry, MaxPersistent),
 		totalNormalConnsSem: makeSemaphore(cfg.MaxNormalConns),

--- a/internal/connmgr/connmanager_test.go
+++ b/internal/connmgr/connmanager_test.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/decred/dcrd/addrmgr/v4"
@@ -1000,56 +1001,61 @@ func TestMaxPersistent(t *testing.T) {
 	assertConnManagerInternalState(t, cm)
 }
 
-// TestMaxRetryDuration tests the maximum retry duration.
-//
-// We have a timed dialer which initially returns err but after RetryDuration
-// hits maxRetryDuration returns a mock conn.
+// TestMaxRetryDuration ensures the maximum retry duration is respected.
 func TestMaxRetryDuration(t *testing.T) {
 	t.Parallel()
-
-	// This test relies on the current value of the max retry duration defined
-	// in the tests, so assert it.
-	if defaultTestMaxRetryDuration != 2*time.Millisecond {
-		t.Fatalf("max retry duration of %v is not the required value for test",
-			defaultTestMaxRetryDuration)
-	}
-
-	networkUp := make(chan struct{})
-	timedDialer := func(ctx context.Context, network, addr string) (net.Conn, error) {
-		select {
-		case <-networkUp:
-			return mockDialer(ctx, network, addr)
-		default:
-			return nil, errors.New("network down")
+	synctest.Test(t, func(t *testing.T) {
+		networkUp := make(chan struct{})
+		timedDialer := func(ctx context.Context, network, addr string) (net.Conn, error) {
+			select {
+			case <-networkUp:
+				return mockDialer(ctx, network, addr)
+			default:
+				return nil, errors.New("network down")
+			}
 		}
-	}
 
-	connected := make(chan *Conn)
-	cm := newTestConnManager(t, &Config{
-		RetryDuration:  time.Millisecond,
-		TargetOutbound: 1,
-		Dial:           timedDialer,
-		OnConnection: func(conn *Conn) {
-			connected <- conn
-		},
+		connected := make(chan *Conn)
+		cm := newTestConnManager(t, &Config{
+			RetryDuration: time.Second,
+			Dial:          timedDialer,
+			OnConnection: func(conn *Conn) {
+				connected <- conn
+			},
+		})
+		cm.maxRetryDuration = 2 * time.Second
+		runConnMgrAsync(t, cm)
+
+		connID, err := cm.AddPersistent(mustParseAddrPort("127.0.0.1:18555"))
+		if err != nil {
+			t.Fatalf("failed to add persistent connection: %v", err)
+		}
+
+		// Approximate sequence of events.  The exact number of retries will
+		// vary due to jitter.
+		//
+		// The test is stable regardless since it expects a connection within
+		// one max retry duration of the network being brought up and, as shown
+		// below, the retry duration without the max imposed would be far
+		// greater and not arrive in time.
+		//
+		//  0s: initial attempt (retry in ~1s)
+		// ~1s: retry 1 (retry in ~2s) - max retry duration reached
+		// ~3s: retry 2 (retry in ~2s, w/o max would be in ~3s => next at ~6s)
+		// ~5s: retry 3 (retry in ~2s, w/o max would be in ~4s => next at ~10s)
+		// ~7s: retry 4 (retry in ~2s, w/o max would be in ~5s => next at ~15s)
+		// ~9s: retry 5 (retry in ~2s, w/o max would be in ~6s => next at ~21s)
+		// ~11s: retry 6 (retry in ~2s, w/o max would be in ~7s => next at ~28s)
+		// ~12s: timedDialer returns [mockDialer]
+		// ~13s: retry 7 succeeds
+		networkUpTimeout := 6 * cm.maxRetryDuration
+		time.AfterFunc(networkUpTimeout, func() {
+			close(networkUp)
+		})
+		timeout := networkUpTimeout + cm.maxRetryDuration
+		assertConnReceivedTimeout(t, connected, timeout, connID, ConnTypeManual)
+		assertConnManagerInternalState(t, cm)
 	})
-	runConnMgrAsync(t, cm)
-
-	connID, err := cm.AddPersistent(mustParseAddrPort("127.0.0.1:18555"))
-	if err != nil {
-		t.Fatalf("failed to add persistent connection: %v", err)
-	}
-
-	// retry in 1ms
-	// retry in 2ms - max retry duration reached
-	// retry in 2ms - timedDialer returns [mockDialer]
-	const networkUpTimeout = 5 * time.Millisecond
-	time.AfterFunc(networkUpTimeout, func() {
-		close(networkUp)
-	})
-	const timeout = connTestReceiveTimeout + networkUpTimeout
-	assertConnReceivedTimeout(t, connected, timeout, connID, ConnTypeManual)
-	assertConnManagerInternalState(t, cm)
 }
 
 // TestNetworkFailure tests that the connection manager handles a network

--- a/internal/connmgr/connmanager_test.go
+++ b/internal/connmgr/connmanager_test.go
@@ -7,11 +7,18 @@ package connmgr
 
 import (
 	"context"
+	"encoding/binary"
+	"encoding/hex"
 	"errors"
+	"flag"
 	"fmt"
+	mrand "math/rand/v2"
 	"net"
 	"net/netip"
+	"os"
 	"reflect"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -20,6 +27,82 @@ import (
 
 	"github.com/decred/dcrd/addrmgr/v4"
 )
+
+// prngSeed is populated when the tests are initialized either by the -seed
+// parameter if specified or a source of cryptographic randomness otherwise.
+var prngSeed [32]byte
+
+// prngIteration is incremented each time a new test prng seed is requested so
+// that each iteration when testing with -count > 1 gets a unique sequence of
+// reproducible values.  It can be overridden via the -seed parameter when the
+// tests are initialized for easy reproducibility of test failures.
+var prngIteration atomic.Uint32
+
+func TestMain(m *testing.M) {
+	seedFlag := flag.String("seed", "", "use deterministic PRNG seed")
+	flag.Parse()
+	if *seedFlag != "" {
+		parts := strings.Split(*seedFlag, "/")
+		if len(parts) == 0 || len(parts) > 2 {
+			fmt.Fprintln(os.Stderr, "invalid -seed: format must be "+
+				"<32 byte hex seed> or <32 byte hex seed>/<iteration>")
+			os.Exit(1)
+		}
+		b, err := hex.DecodeString(parts[0])
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "invalid -seed hex:", err)
+			os.Exit(1)
+		}
+		if len(b) != 32 {
+			fmt.Fprintln(os.Stderr, "invalid -seed: must be 32 bytes")
+			os.Exit(1)
+		}
+		copy(prngSeed[:], b)
+		if len(parts) > 1 {
+			iteration, err := strconv.ParseUint(parts[1], 10, 32)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "invalid -seed iteration:", err)
+				os.Exit(1)
+			}
+			prngIteration.Store(uint32(iteration))
+		}
+	} else {
+		globalRand.Read(prngSeed[:])
+	}
+	os.Exit(m.Run())
+}
+
+// newTestPRNGSeed returns a seed to use for the deterministic test prng for the
+// given iteration based on the global [prngSeed] variable which is populated in
+// [TestMain].
+func newTestPRNGSeed(t testing.TB) [32]byte {
+	t.Helper()
+
+	// Generate a new determinstic seed based on the test iteration count and
+	// global [prngSeed] variable which can be set with flags in [TestMain].
+	iteration := prngIteration.Add(1) - 1
+	t.Cleanup(func() {
+		t.Helper()
+		if t.Failed() {
+			runFlags := fmt.Sprintf("-run=%s", t.Name())
+			if _, ok := t.(*testing.B); ok {
+				runFlags = fmt.Sprintf("-run=^$ -bench=%s", t.Name())
+			}
+			t.Logf("Reproduce with: go test %s -seed=%x/%d -count=1", runFlags,
+				prngSeed, iteration)
+		}
+	})
+
+	// Increment the test seed by the iteration count so each test iteration has
+	// a unique seed derived from the overall test seed.
+	//
+	// This is hacky and not cryptographically sound, but it's is only used for
+	// tests, so it doesn't need to be.
+	seed := prngSeed
+	be := binary.BigEndian
+	be.PutUint32(seed[28:], be.Uint32(seed[28:])+iteration)
+	return seed
+}
 
 const (
 	// defaultTestMaxRetryDuration is the default max duration a connection
@@ -88,6 +171,9 @@ func newTestConnManager(t *testing.T, cfg *Config) *ConnManager {
 		t.Fatalf("New: unexpected error: %v", err)
 	}
 	cm.maxRetryDuration = defaultTestMaxRetryDuration
+	seed := newTestPRNGSeed(t)
+	src := mrand.NewChaCha8(seed)
+	cm.csprng = mrand.New(src) // nolint:gosec
 	return cm
 }
 

--- a/internal/connmgr/connmanager_test.go
+++ b/internal/connmgr/connmanager_test.go
@@ -1127,11 +1127,11 @@ func TestMaxRetryDuration(t *testing.T) {
 		//
 		//  0s: initial attempt (retry in ~1s)
 		// ~1s: retry 1 (retry in ~2s) - max retry duration reached
-		// ~3s: retry 2 (retry in ~2s, w/o max would be in ~3s => next at ~6s)
-		// ~5s: retry 3 (retry in ~2s, w/o max would be in ~4s => next at ~10s)
-		// ~7s: retry 4 (retry in ~2s, w/o max would be in ~5s => next at ~15s)
-		// ~9s: retry 5 (retry in ~2s, w/o max would be in ~6s => next at ~21s)
-		// ~11s: retry 6 (retry in ~2s, w/o max would be in ~7s => next at ~28s)
+		// ~3s: retry 2 (retry in ~2s, w/o max would be in ~4s => next at ~7s)
+		// ~5s: retry 3 (retry in ~2s, w/o max would be in ~8s => next at ~15s)
+		// ~7s: retry 4 (retry in ~2s, w/o max would be in ~16s => next at ~33s)
+		// ~9s: retry 5 (retry in ~2s, w/o max would be in ~32s => next at ~65s)
+		// ~11s: retry 6 (retry in ~2s, w/o max would be in ~64s => next at ~129s)
 		// ~12s: timedDialer returns [mockDialer]
 		// ~13s: retry 7 succeeds
 		networkUpTimeout := 6 * cm.maxRetryDuration

--- a/internal/connmgr/csprng.go
+++ b/internal/connmgr/csprng.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package connmgr
+
+import (
+	"sync"
+
+	"github.com/decred/dcrd/crypto/rand"
+)
+
+// csprng provides an interface for the CSPRNG methods the connection manager
+// uses.  This primarily exists so tests can replace the real implementation
+// with a deterministic PRNG for reproducibility.
+type csprng interface {
+	Uint64N(n uint64) uint64
+}
+
+// lockingPRNG wraps an instance of [rand.PRNG] with a mutex so it can be used
+// concurrently.
+type lockingPRNG struct {
+	prng *rand.PRNG
+	sync.Mutex
+}
+
+// Uint64 returns a uniform random uint64.
+func (p *lockingPRNG) Uint64() uint64 {
+	p.Lock()
+	defer p.Unlock()
+
+	return p.prng.Uint64()
+}
+
+// Uint64N returns a random uint64 in range [0,n) without modulo bias.
+func (p *lockingPRNG) Uint64N(n uint64) uint64 {
+	p.Lock()
+	defer p.Unlock()
+
+	return p.prng.Uint64N(n)
+}
+
+// Read fills s with len(s) of cryptographically-secure random bytes.  It never
+// errors.
+func (p *lockingPRNG) Read(s []byte) {
+	p.Lock()
+	defer p.Unlock()
+
+	_, _ = p.prng.Read(s)
+}
+
+// globalRand is set at init time so any failure to seed, which should never
+// happen in practice, will cause a panic at startup instead of runtime.
+var globalRand *lockingPRNG
+
+func init() {
+	p, err := rand.NewPRNG()
+	if err != nil {
+		panic(err)
+	}
+	globalRand = &lockingPRNG{prng: p}
+}


### PR DESCRIPTION
**This requires #3699**.

The current code uses a simple deterministic linear backoff with a maximum capacity.  While it works well enough, it has a big downside in  that all of the attempts will tend to coalesce over time.  This is especially true during a network outage since all connections will drop at the same time.

Also, exponential backoffs are preferred over linear to reduce the retry frequency more quickly and give the remote more time to come back online.

This addresses both of those points by changing the linear backoff for persistent peers to use an exponential backoff with jitter instead.

Due to the introduction of nondeterministic behavior, and considering there are various other aspects of the connection manager that would benefit from making use of randomness, this also includes a separate commit to introduce full infrastructure and support for deterministic reproducibility when running the tests.

See the individual commit descriptions for more details.