### PR TITLE
connmgr: Add inbound rate limiting and anti-flood.

### DIFF
--- a/internal/connmgr/README.md
+++ b/internal/connmgr/README.md
@@ -13,7 +13,8 @@ logic.
 
 It handles all general connection lifecycle concerns such as accepting inbound
 connections, automatically maintaining a set number of outbound connections,
-maintaining persistent connections, enforcing limits, and preventing duplicates.
+maintaining persistent connections, preventing duplicates, and enforcing
+multiple layers of connection limits and anti-abuse protections.
 
 The design has a strong emphasis on reliability, readability, and efficiency under high connection load while also aiming to provide an ergonomic API.
 
@@ -23,6 +24,12 @@ The following is a brief overview of the key features:
 - Inbound listening
   - Accepts inbound connections on provided `Listeners`
   - Uses connection shedding for rejected inbound connections
+  - Provides token bucket rate limiting on a per network group basis
+  - Anti-flood protection
+    - Detects floods based on allowed connection attempts
+    - Dynamically coarsens network group rate limiting during flooding
+    - Probabilistically drops connections when flooding is active via an S-curve
+    - Rate limits logging of dropped connections
 - Automatic outbound maintenance
   - Maintains up to `TargetOutbound` normal outbound connections via a provided
     address source (`GetNewAddress`)

--- a/internal/connmgr/connmanager.go
+++ b/internal/connmgr/connmanager.go
@@ -100,6 +100,29 @@ const (
 	// per minute to be logged with periodic bursts up to 4.
 	dropLogRateLimit  = float64(1) / 60
 	dropLogBurstLimit = 4
+
+	// floodLow is the number of allowed connection attempts in the last minute
+	// to consider active low-intensity connection flooding.  ~5 average
+	// attempts per second.
+	//
+	// floodHighFactor is the multiple of [floodLow] that sets the width of the
+	// ramp above [floodLow] over which the drop probability scales.  The
+	// maximum drop probability is reached at floodLow*(1+floodHighFactor)
+	// allowed attempts in the last minute (1200 with the current values).
+	floodLow        = 5 * 60
+	floodHighFactor = 3
+
+	// These values tune how often connections are probabilistically dropped
+	// during active flooding.  A quadratic rational S-curve is used.  See
+	// [inboundRateLimiter.ShouldDropProbabilistic].
+	//
+	// floodMinDropProb and floodMaxDropProb are the minimum and maximum
+	// probability with which to drop connections during active flooding.
+	//
+	// floodRamp is the normalized intensity to start rapid growth.
+	floodMinDropProb = 0.2
+	floodMaxDropProb = 0.85
+	floodRamp        = 0.1
 )
 
 // ConnectionType specifies the different types of supported connections.
@@ -561,7 +584,7 @@ type ConnManager struct {
 	outboundGroups *outboundGroupInfo
 
 	// inboundLimiter tracks information about inbound connections and provides
-	// per group rate limiting.
+	// per group rate limiting with anti-flood protection.
 	inboundLimiter *inboundRateLimiter
 
 	// ******************************************************************
@@ -1262,7 +1285,8 @@ type inboundGroupKey struct {
 	hash1 uint64
 }
 
-// inboundRateLimiter houses state related to rate limiting inbound connections.
+// inboundRateLimiter houses state related to rate limiting inbound connections
+// and flood detection.
 type inboundRateLimiter struct {
 	// burstLimit is the max burst size for the group rate limiters.  It is set
 	// to [groupBurstLimit] by default.
@@ -1279,6 +1303,27 @@ type inboundRateLimiter struct {
 	// on how groups are determined.
 	groupMtx      sync.Mutex
 	groupLimiters *lru.Map[inboundGroupKey, *ratelimit.Limiter]
+
+	// These fields are protected by the flood mutex.
+	//
+	// attempts houses a sliding window of the number of allowed connections per
+	// second over the previous minute as a ring buffer.
+	//
+	// attemptsStart is the current unix time for the head of the ring buffer.
+	//
+	// totalAttempts is the sum of all attempts in the window.
+	floodMtx      sync.RWMutex
+	attempts      [60]uint32
+	attemptsStart int64
+	totalAttempts uint64
+
+	// flooding tracks whether or not flooding mode is active.  It is an atomic
+	// so that it is independently safe to read concurrently without any
+	// additional mutex.
+	//
+	// Nevertheless, it is only modified under [floodMtx] since it depends on
+	// [totalAttempts].
+	flooding atomic.Bool
 
 	// These fields are protected by the log mutex.
 	//
@@ -1311,28 +1356,39 @@ func newInboundRateLimiter(csprng csprng) *inboundRateLimiter {
 // This should not be confused with the outbound group key.  They are not the
 // same and serve different purposes.
 //
-// The group for IPv4 is the entire address (/32 prefix) and the typical
-// residential block for IPv6 (/64 prefix).
+// By default, the group for IPv4 is the entire address (/32 prefix) and the
+// typical residential block for IPv6 (/64 prefix).  When flooding is detected,
+// the groups are coarsened to /24 for IPv4 and /56 for IPv6 in order to
+// increase the cost of prefix spraying.
 //
-// For IPv4, that has the effect of rate limiting individual addresses.
+// For IPv4, that has the effect of rate limiting individual addresses during
+// normal conditions and dynamically adjusting to rate limit the blocks of IPv4s
+// that are the easiest for the same attacker to control as a single entity.
 //
-// For IPv6, it has the effect of rate limiting all addresses in the typical
-// residential blocks assigned by ISPs as a single entity since they are the
-// easiest for the same attacker to control.
+// Similarly, for IPv6, it has the effect of rate limiting all addresses in the
+// typical residential blocks assigned by ISPs as a single entity and
+// dynamically adjusting to encompass the full range typically assigned by an
+// ISP since they are the easiest for the same attacker to control.
 //
 // This function is safe for concurrent access.
 func (l *inboundRateLimiter) GroupKey(addr *addrmgr.NetAddress) inboundGroupKey {
 	var preimage []byte
 	switch addr.Type {
 	case addrmgr.IPv4Address:
-		const bits = 32
+		bits := 32
+		if l.flooding.Load() {
+			bits = 24
+		}
 		ip, _ := netip.AddrFromSlice(addr.IP)
 		prefix, _ := ip.Prefix(bits)
 		prefixBytes := prefix.Addr().As4()
 		preimage = prefixBytes[:]
 
 	case addrmgr.IPv6Address:
-		const bits = 64
+		bits := 64
+		if l.flooding.Load() {
+			bits = 56
+		}
 		ip, _ := netip.AddrFromSlice(addr.IP)
 		prefix, _ := ip.Prefix(bits)
 		prefixBytes := prefix.Addr().As16()
@@ -1355,15 +1411,82 @@ func (l *inboundRateLimiter) GroupKey(addr *addrmgr.NetAddress) inboundGroupKey 
 	return inboundGroupKey{h0, h1}
 }
 
+// recordAttempt updates the flood state to decay stale data and records
+// attempts that were not rate limited by prefix.
+//
+// The flood detection scheme is a simple sliding window over the prior minute
+// implemented as an efficient ring buffer.
+func (l *inboundRateLimiter) recordAttempt(rateLimited bool) {
+	// buckets is the number of one second buckets in the sliding window.
+	const buckets = 60
+
+	now := time.Now()
+	nowUnix := now.Unix()
+	idx := nowUnix % buckets
+
+	l.floodMtx.Lock()
+	defer l.floodMtx.Unlock()
+
+	// Advance the sliding window to the current time.  This approach is
+	// extremely efficient and still provides excellent properties such as
+	// deterministic behavior, good burst detection, and reasonable reaction
+	// time.
+	//
+	// This entire section only runs a max of once per second.
+	//
+	// In other words, in a real flooding scenario where this might be called
+	// hundreds or thousands of times per second, it is effectively a noop.
+	//
+	// On the other end of the spectrum, when more than 1 min has elapsed since
+	// the last update, it reduces to a tiny memcpy to zero the array.
+	//
+	// Otherwise, it is somewhere between clearing 1 to 59 buckets which only
+	// involves very cheap calculations.
+	if l.attemptsStart != nowUnix {
+		numExpired := nowUnix - l.attemptsStart
+		if numExpired >= buckets {
+			for i := range l.attempts {
+				l.attempts[i] = 0
+			}
+			l.totalAttempts = 0
+		} else if numExpired > 0 {
+			tail := l.attemptsStart + 1
+			for i := range numExpired {
+				oldIdx := (tail + i) % buckets
+				l.totalAttempts -= uint64(l.attempts[oldIdx])
+				l.attempts[oldIdx] = 0
+			}
+		}
+		l.attemptsStart = nowUnix
+	}
+
+	// Record allowed attempts.
+	if !rateLimited {
+		l.attempts[idx]++
+		l.totalAttempts++
+	}
+
+	// Activate flooding mode if there have been enough recent allowed attempts
+	// in the last minute.  Deactivate otherwise.
+	l.flooding.Store(l.totalAttempts > floodLow)
+}
+
 // Allow updates the limiter state for the given address and returns whether an
 // inbound connection from it is permitted at the current time.
 //
-// It enforces a per group (prefix based) rate limit.  The connection is allowed
-// when that rate limit has not been exceeded.
+// This is the first line of defense against inbound attacks.
+//
+// It enforces a per group (prefix based) rate limit that is dynamically
+// adjusted depending on whether flooding is detected.  The connection is
+// allowed when that rate limit has not been exceeded.
+//
+// It also records allowed attempts for flood detection and updates the flood
+// state when needed.
 //
 // Care must be taken when modifying this method.  It is in the critical hot
 // path for every inbound connection and must remain fast and tightly control
-// memory usage in order to remain resilient under sustained misbehavior.
+// memory usage in order to remain resilient under sustained misbehavior and
+// flooding.
 //
 // This function is safe for concurrent access.
 func (l *inboundRateLimiter) Allow(addr *addrmgr.NetAddress) bool {
@@ -1375,7 +1498,7 @@ func (l *inboundRateLimiter) Allow(addr *addrmgr.NetAddress) bool {
 	//
 	// Adding a new entry may evict another limiter when at max capacity.  In
 	// practice, that case is only realistically possible to hit when under
-	// a heavy DDoS attack.
+	// a heavy DDoS attack.  The anti-flooding measures help combat that.
 	groupKey := l.GroupKey(addr)
 	l.groupMtx.Lock()
 	limiter, ok := l.groupLimiters.Get(groupKey)
@@ -1386,7 +1509,55 @@ func (l *inboundRateLimiter) Allow(addr *addrmgr.NetAddress) bool {
 	l.groupMtx.Unlock()
 	allowed := limiter.Allow()
 
+	// Tally attempts that were not rate limited and periodically update the
+	// state related to detecting active flooding.
+	l.recordAttempt(!allowed)
+
 	return allowed
+}
+
+// ShouldDropProbabilistic returns whether or not a connection should be
+// probabilistically dropped.
+//
+// No probabilistic dropping is applied unless active flooding is detected and
+// the probability of dropping a connection is increased according to the
+// intensity of flooding per an S-curve.
+//
+// This acts as a second layer of defense against any inbound attackers that
+// make it through the initial rate limiting.
+//
+// This function is safe for concurrent access.
+func (l *inboundRateLimiter) ShouldDropProbabilistic(csprng csprng) bool {
+	// Don't probabilistically drop anything unless flooding has been detected.
+	if !l.flooding.Load() {
+		return false
+	}
+
+	l.floodMtx.RLock()
+	totalAttempts := l.totalAttempts
+	l.floodMtx.RUnlock()
+
+	// Scale the probability of dropping a connection in accordance with the
+	// intensity of flooding using a smooth quadratic rational S-curve between
+	// the min and max drop probability.
+	//
+	// This provides a smooth non-linear curve to apply increasing backpressure
+	// as flooding intensifies.
+	//
+	// The equation is:
+	//
+	// P(x) = minP + (1+r)*(maxP-minP)*x^2 / (r+x^2)
+	//
+	// Where x is the normalized flood intensity in the range [0, 1] and r is
+	// normalized intensity to start rapid growth.
+	const factor = (1 + floodRamp) * (floodMaxDropProb - floodMinDropProb)
+	const rampWidth = floodLow * floodHighFactor
+	norm := float64(max(totalAttempts, floodLow)-floodLow) / float64(rampWidth)
+	norm = min(norm, 1.0)
+	nSquared := norm * norm
+	prob := floodMinDropProb + factor*nSquared/(floodRamp+nSquared)
+
+	return csprng.Float64() < prob
 }
 
 // LogDrops consolidates the logic for logging dropped connections with
@@ -1473,12 +1644,22 @@ func (cm *ConnManager) listenHandler(ctx context.Context, listener net.Listener)
 		isWhitelisted := cm.IsWhitelisted(rAddr)
 		isLoopback := net.IP(rAddr.IP).IsLoopback()
 
-		// Apply rate limiting for inbound connections that are not whitelisted
-		// or originating from a loopback address.
-		if !isWhitelisted && !isLoopback && !cm.inboundLimiter.Allow(rAddr) {
-			cm.inboundLimiter.LogDrops(rAddr, "rate limited")
-			netConn.Close()
-			continue
+		// Apply rate limiting and anti-flooding measures for inbound
+		// connections that are not whitelisted or originating from a loopback
+		// address.
+		if !isWhitelisted && !isLoopback {
+			if !cm.inboundLimiter.Allow(rAddr) {
+				cm.inboundLimiter.LogDrops(rAddr, "rate limited")
+				netConn.Close()
+				continue
+			}
+
+			if cm.inboundLimiter.ShouldDropProbabilistic(cm.csprng) {
+				cm.inboundLimiter.LogDrops(rAddr, "probabilistically blocked "+
+					"during flood")
+				netConn.Close()
+				continue
+			}
 		}
 
 		// Reject connections with the same host:port as any existing pending,

--- a/internal/connmgr/connmanager.go
+++ b/internal/connmgr/connmanager.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/dchest/siphash"
 	"github.com/decred/dcrd/addrmgr/v4"
+	"github.com/decred/dcrd/container/lru"
+	"github.com/decred/dcrd/internal/ratelimit"
 )
 
 const (
@@ -63,6 +65,41 @@ const (
 	// defaultTargetOutbound is the default number of outbound connections to
 	// maintain.
 	defaultTargetOutbound = 8
+
+	// *********************************************************************
+	// Constants related to rate limiting inbound connections and associated
+	// logging.
+	// *********************************************************************
+
+	// maxGroupLimiters specifies the maximum number of inbound group limiters
+	// to cache and is set to target a reasonable balance between memory usage
+	// and the number of addresses/network groups simultaneously subject to
+	// direct rate limiting.
+	//
+	// maxPerGroupTTL is the time to keep each inbound rate limiter in the cache
+	// without access before they expire.
+	//
+	// These values result in ~2 MiB memory usage including overhead for normal
+	// operation and a temporary maximum of ~6.5 MiB under sustained worst case
+	// attack scenarios.
+	maxGroupLimiters = 10000
+	maxPerGroupTTL   = 20 * time.Minute
+
+	// groupRateLimit and groupBurstLimit control the inbound rate limiting per
+	// network group.
+	//
+	// These values result in rate limiting each group to an average of one
+	// connection per five seconds with periodic bursts up to 3.
+	groupRateLimit  = 0.2
+	groupBurstLimit = 3
+
+	// dropLogRateLimit and dropLogBurstLimit define how often dropped
+	// connections are allowed to be logged before suppression.
+	//
+	// These values result in only allowing an average of 1 dropped connection
+	// per minute to be logged with periodic bursts up to 4.
+	dropLogRateLimit  = float64(1) / 60
+	dropLogBurstLimit = 4
 )
 
 // ConnectionType specifies the different types of supported connections.
@@ -522,6 +559,10 @@ type ConnManager struct {
 	// groups such that it is extremely difficult for attackers to gain control
 	// of addresses that are a part of a lot of different groups.
 	outboundGroups *outboundGroupInfo
+
+	// inboundLimiter tracks information about inbound connections and provides
+	// per group rate limiting.
+	inboundLimiter *inboundRateLimiter
 
 	// ******************************************************************
 	// The fields below this point are protected by the connection mutex.
@@ -1214,6 +1255,186 @@ func inboundStdlibNetAddrToAddrMgrAddr(addr net.Addr) (*addrmgr.NetAddress, erro
 	return stdlibNetAddrToAddrMgrNetAddr(addr)
 }
 
+// inboundGroupKey represents an inbound network group to use when rate
+// limiting addresses.  See [inboundRateLimiter.GroupKey].
+type inboundGroupKey struct {
+	hash0 uint64
+	hash1 uint64
+}
+
+// inboundRateLimiter houses state related to rate limiting inbound connections.
+type inboundRateLimiter struct {
+	// burstLimit is the max burst size for the group rate limiters.  It is set
+	// to [groupBurstLimit] by default.
+	burstLimit uint32
+
+	// key is a unique cryptographically random seed used when determining
+	// inbound network group keys.  It ensures different connection manager
+	// instances produce distinct mappings that are unpredictable to external
+	// observers.
+	key [2]uint64
+
+	// groupLimiters provides distinct rate limiters per inbound group up to the
+	// max capacity of the LRU.  See [inboundRateLimiter.GroupKey] for details
+	// on how groups are determined.
+	groupMtx      sync.Mutex
+	groupLimiters *lru.Map[inboundGroupKey, *ratelimit.Limiter]
+
+	// These fields are protected by the log mutex.
+	//
+	// logLimiter provides rate limiting for logging of dropped inbound
+	// connections.  It is used in conjunction with [droppedLogs], so even
+	// though it has its own mutex, it typically will also need to be protected
+	// by the embedded mutex.
+	//
+	// droppedLogs tallies the number of dropped inbound connections during log
+	// suppression due to exceeding the logging rate.
+	logMtx      sync.Mutex
+	logLimiter  *ratelimit.Limiter
+	droppedLogs uint64
+}
+
+// newInboundRateLimiter returns an initialized inboundRateLimiter instance.
+func newInboundRateLimiter(csprng csprng) *inboundRateLimiter {
+	newGroupLims := lru.NewMapWithDefaultTTL[inboundGroupKey, *ratelimit.Limiter]
+	return &inboundRateLimiter{
+		key:           [2]uint64{csprng.Uint64(), csprng.Uint64()},
+		burstLimit:    groupBurstLimit,
+		groupLimiters: newGroupLims(maxGroupLimiters, maxPerGroupTTL),
+		logLimiter:    ratelimit.New(dropLogRateLimit, dropLogBurstLimit),
+	}
+}
+
+// GroupKey returns a key that represents an inbound network group to use when
+// rate limiting the provided address.
+//
+// This should not be confused with the outbound group key.  They are not the
+// same and serve different purposes.
+//
+// The group for IPv4 is the entire address (/32 prefix) and the typical
+// residential block for IPv6 (/64 prefix).
+//
+// For IPv4, that has the effect of rate limiting individual addresses.
+//
+// For IPv6, it has the effect of rate limiting all addresses in the typical
+// residential blocks assigned by ISPs as a single entity since they are the
+// easiest for the same attacker to control.
+//
+// This function is safe for concurrent access.
+func (l *inboundRateLimiter) GroupKey(addr *addrmgr.NetAddress) inboundGroupKey {
+	var preimage []byte
+	switch addr.Type {
+	case addrmgr.IPv4Address:
+		const bits = 32
+		ip, _ := netip.AddrFromSlice(addr.IP)
+		prefix, _ := ip.Prefix(bits)
+		prefixBytes := prefix.Addr().As4()
+		preimage = prefixBytes[:]
+
+	case addrmgr.IPv6Address:
+		const bits = 64
+		ip, _ := netip.AddrFromSlice(addr.IP)
+		prefix, _ := ip.Prefix(bits)
+		prefixBytes := prefix.Addr().As16()
+		preimage = prefixBytes[:]
+
+	case addrmgr.TorV3Address:
+		// Remote addresses for inbound connections are never Tor addresses, but
+		// be safe and treat them all as a single group anyway.
+		preimage = []byte("tor")
+
+	case addrmgr.UnknownAddressType:
+		fallthrough
+	default:
+		// Group all unknown or future address types together for safety, but
+		// this should never be hit in practice.
+		preimage = []byte("unknown")
+	}
+
+	h0, h1 := siphash.Hash128(l.key[0], l.key[1], preimage)
+	return inboundGroupKey{h0, h1}
+}
+
+// Allow updates the limiter state for the given address and returns whether an
+// inbound connection from it is permitted at the current time.
+//
+// It enforces a per group (prefix based) rate limit.  The connection is allowed
+// when that rate limit has not been exceeded.
+//
+// Care must be taken when modifying this method.  It is in the critical hot
+// path for every inbound connection and must remain fast and tightly control
+// memory usage in order to remain resilient under sustained misbehavior.
+//
+// This function is safe for concurrent access.
+func (l *inboundRateLimiter) Allow(addr *addrmgr.NetAddress) bool {
+	// Rate limit the inbound group.
+	//
+	// Either get an existing rate limiter or create a new one when one does not
+	// already exist.  Then put the limiter into the LRU cache unconditionally
+	// so its TTL is updated.
+	//
+	// Adding a new entry may evict another limiter when at max capacity.  In
+	// practice, that case is only realistically possible to hit when under
+	// a heavy DDoS attack.
+	groupKey := l.GroupKey(addr)
+	l.groupMtx.Lock()
+	limiter, ok := l.groupLimiters.Get(groupKey)
+	if !ok {
+		limiter = ratelimit.New(groupRateLimit, l.burstLimit)
+	}
+	l.groupLimiters.Put(groupKey, limiter)
+	l.groupMtx.Unlock()
+	allowed := limiter.Allow()
+
+	return allowed
+}
+
+// LogDrops consolidates the logic for logging dropped connections with
+// throttling.
+//
+// This function is safe for concurrent access.
+func (l *inboundRateLimiter) LogDrops(addr *addrmgr.NetAddress, reason string) {
+	l.logMtx.Lock()
+	defer l.logMtx.Unlock()
+
+	// Only log a few dropped connections individually with a periodic summary
+	// once the rate is exceeded to prevent flooding spam.
+	if !l.logLimiter.Allow() {
+		// Report how long no further dropped connections will be logged when
+		// suppression starts.
+		if l.droppedLogs == 0 {
+			nextAllowed := l.logLimiter.UntilNextAllowed()
+			log.Debugf("Dropped connection from %v: %v -- suppressing drop "+
+				"logs for %v", addr, reason, nextAllowed.Round(time.Second))
+
+			// Report a summary of the total number of suppressed connection
+			// drops once messages are allowed again.  The callback is always
+			// scheduled so the suppression state is reset even when debug
+			// logging is disabled.
+			time.AfterFunc(nextAllowed, func() {
+				l.logMtx.Lock()
+				defer l.logMtx.Unlock()
+
+				// Reset suppression state.
+				dropped := l.droppedLogs
+				l.droppedLogs = 0
+
+				// The initial message that triggered suppression was already
+				// logged, so adjust accordingly.
+				if dropped > 1 {
+					dropped--
+					log.Debugf("Dropped %d %s while suppressed", dropped,
+						pickNoun(dropped, "connection", "connections"))
+				}
+			})
+		}
+
+		l.droppedLogs++
+		return
+	}
+	log.Debugf("Dropped connection from %v: %v", addr, reason)
+}
+
 // listenHandler accepts incoming connections on a given listener.  It must be
 // run as a goroutine.
 func (cm *ConnManager) listenHandler(ctx context.Context, listener net.Listener) {
@@ -1250,6 +1471,15 @@ func (cm *ConnManager) listenHandler(ctx context.Context, listener net.Listener)
 			continue
 		}
 		isWhitelisted := cm.IsWhitelisted(rAddr)
+		isLoopback := net.IP(rAddr.IP).IsLoopback()
+
+		// Apply rate limiting for inbound connections that are not whitelisted
+		// or originating from a loopback address.
+		if !isWhitelisted && !isLoopback && !cm.inboundLimiter.Allow(rAddr) {
+			cm.inboundLimiter.LogDrops(rAddr, "rate limited")
+			netConn.Close()
+			continue
+		}
 
 		// Reject connections with the same host:port as any existing pending,
 		// established, or persistent connections.  Note that this does NOT
@@ -1262,7 +1492,7 @@ func (cm *ConnManager) listenHandler(ctx context.Context, listener net.Listener)
 		cm.connMtx.Lock()
 		if err := cm.rejectDuplicateAddr(rAddr); err != nil {
 			cm.connMtx.Unlock()
-			log.Debugf("Dropped connection from %v: %v", rAddr, err)
+			cm.inboundLimiter.LogDrops(rAddr, err.Error())
 			netConn.Close()
 			continue
 		}
@@ -1271,7 +1501,7 @@ func (cm *ConnManager) listenHandler(ctx context.Context, listener net.Listener)
 		// Limit the max number of connections per host unless exempt.
 		releaseHostPermit, err := cm.maybeReserveHostPermit(rAddr)
 		if err != nil {
-			log.Debugf("Dropped connection from %v: %v", rAddr, err)
+			cm.inboundLimiter.LogDrops(rAddr, err.Error())
 			netConn.Close()
 			continue
 		}
@@ -1292,10 +1522,10 @@ func (cm *ConnManager) listenHandler(ctx context.Context, listener net.Listener)
 			}
 			if !acquired {
 				releaseHostPermit()
-				maxAllowed := cm.cfg.MaxNormalConns
-				log.Debugf("Dropped connection from %v: a maximum of %d %s is "+
-					"allowed", rAddr, maxAllowed, pickNoun(maxAllowed,
-					"connection", "connections"))
+				maxConns := cm.cfg.MaxNormalConns
+				reason := fmt.Sprintf("a maximum of %d %s is allowed", maxConns,
+					pickNoun(maxConns, "connection", "connections"))
+				cm.inboundLimiter.LogDrops(rAddr, reason)
 				netConn.Close()
 				continue
 			}
@@ -1902,6 +2132,7 @@ func New(cfg *Config) (*ConnManager, error) {
 		totalNormalConnsSem: makeSemaphore(cfg.MaxNormalConns),
 		activeOutboundsSem:  makeSemaphore(cfg.TargetOutbound),
 		outboundGroups:      newOutboundGroupInfo(csprng),
+		inboundLimiter:      newInboundRateLimiter(csprng),
 		persistent:          make(map[uint64]*persistentEntry, MaxPersistent),
 		pending:             make(map[uint64]*pendingConnInfo),
 		active:              make(map[uint64]*Conn, cfg.TargetOutbound),

--- a/internal/connmgr/connmanager_test.go
+++ b/internal/connmgr/connmanager_test.go
@@ -300,6 +300,8 @@ func newTestConnManager(t *testing.T, cfg *Config) *ConnManager {
 	cm.csprng = mrand.New(src) // nolint:gosec
 	cm.outboundGroups.key[0] = cm.csprng.Uint64()
 	cm.outboundGroups.key[1] = cm.csprng.Uint64()
+	cm.inboundLimiter.key[0] = cm.csprng.Uint64()
+	cm.inboundLimiter.key[1] = cm.csprng.Uint64()
 	return cm
 }
 
@@ -1749,6 +1751,7 @@ func TestRejectDuplicateConns(t *testing.T) {
 			disconnected <- conn
 		},
 	})
+	cm.inboundLimiter.burstLimit = 4
 	ctx, _, _ := runConnMgrAsync(t, cm)
 
 	// Dial a manual connection and wait for it to become pending.

--- a/internal/connmgr/connmanager_test.go
+++ b/internal/connmgr/connmanager_test.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"math"
 	mrand "math/rand/v2"
 	"net"
 	"net/netip"
@@ -133,6 +134,7 @@ func mustParseAddrPort(addr string) *addrmgr.NetAddress {
 // addrGenerator houses state for an address generator used to simplify tests.
 type addrGenerator struct {
 	mtx                     sync.Mutex
+	inboundGroupPrefixBits  uint
 	outboundGroupPrefixBits uint
 	addr                    netip.Addr
 	port                    uint16
@@ -143,6 +145,7 @@ type addrGenerator struct {
 func newAddrGenerator(baseAddrPort string) *addrGenerator {
 	addrPort := netip.MustParseAddrPort(baseAddrPort)
 	return &addrGenerator{
+		inboundGroupPrefixBits:  32,
 		outboundGroupPrefixBits: 16,
 		addr:                    addrPort.Addr(),
 		port:                    addrPort.Port(),
@@ -220,6 +223,17 @@ func (g *addrGenerator) nextPrefix(prefixBits uint) *addrmgr.NetAddress {
 	return addrmgr.NewNetAddressFromIPPort(g.addr.AsSlice(), g.port, 0)
 }
 
+// NextInboundGroup advances the generator to the next inbound group IP and
+// returns the result.  It skips all addresses of the form "x.x.x.0".
+//
+// An inbound group is determined by a certain number of prefix bits.
+func (g *addrGenerator) NextInboundGroup() *addrmgr.NetAddress {
+	g.mtx.Lock()
+	defer g.mtx.Unlock()
+
+	return g.nextPrefix(g.inboundGroupPrefixBits)
+}
+
 // NextOutboundGroup advances the generator to the next outbound group IP and
 // returns the result.  It skips all addresses of the form "x.x.x.0".
 //
@@ -235,7 +249,7 @@ func (g *addrGenerator) NextOutboundGroup() *addrmgr.NetAddress {
 // starting base address and port useful throughout the tests.  The base address
 // is a normal routable IPv4 address.
 func defaultAddrGenerator() *addrGenerator {
-	return newAddrGenerator(fmt.Sprintf("12.0.0.0:%d", defaultTestP2PPort))
+	return newAddrGenerator(fmt.Sprintf("12.1.1.0:%d", defaultTestP2PPort))
 }
 
 // defaultTestAddr returns a default address to use throughout the tests.  It is
@@ -2273,4 +2287,74 @@ func TestOutboundGroups(t *testing.T) {
 		t.Fatalf("unexpected number of outbound groups -- got %d, want %d",
 			len(groups), targetOutbound)
 	}
+}
+
+// TestInboundRateLimiting ensures the connection manager rate limits inbound
+// connections as expected.  It includes tests for normal rate limiting and
+// bursts.
+func TestInboundRateLimiting(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		inboundConns := make(chan *Conn)
+		listener := defaultMockListener()
+		cm := newTestConnManager(t, &Config{
+			Listeners:       []net.Listener{listener},
+			MaxConnsPerHost: 100,
+			OnAccept: func(conn *Conn) {
+				inboundConns <- conn
+			},
+			Dial: mockDialer,
+		})
+		runConnMgrAsync(t, cm)
+
+		// Ensure exactly the max allowed burst of inbound connections from the
+		// same address are accepted.
+		addrGen := defaultAddrGenerator()
+		addrGen.Next()
+		for range groupBurstLimit {
+			go listener.Connect(addrGen.NextPort())
+			assertConnReceived(t, inboundConns, 0, ConnTypeInbound).Close()
+		}
+		assertConnManagerInternalState(t, cm)
+
+		// Ensure connections from the same address are now rate limited.
+		for range 3 {
+			go listener.Connect(addrGen.NextPort())
+		}
+		assertNoConnReceived(t, inboundConns)
+		assertConnManagerInternalState(t, cm)
+
+		// Wait just long enough for the next connection to be allowed and
+		// ensure it is.
+		perConnSecs := time.Duration(math.Ceil(1/groupRateLimit)) * time.Second
+		time.Sleep(perConnSecs - connTestNonReceiveTimeout)
+		go listener.Connect(addrGen.NextPort())
+		assertConnReceived(t, inboundConns, 0, ConnTypeInbound).Close()
+		assertConnManagerInternalState(t, cm)
+
+		// Wait just long enough to reset the burst tokens and ensure another
+		// burst of inbound connections from the same address are accepted.
+		time.Sleep(groupBurstLimit * perConnSecs)
+		for range groupBurstLimit {
+			go listener.Connect(addrGen.NextPort())
+			assertConnReceived(t, inboundConns, 0, ConnTypeInbound).Close()
+		}
+		assertConnManagerInternalState(t, cm)
+
+		// Ensure the next inbound group is not rate limited and independently
+		// allows the max allowed burst.
+		addrGen.NextInboundGroup()
+		for range groupBurstLimit {
+			go listener.Connect(addrGen.NextPort())
+			assertConnReceived(t, inboundConns, 0, ConnTypeInbound).Close()
+		}
+		assertConnManagerInternalState(t, cm)
+
+		// Ensure connections from the same address in the new inbound group are
+		// now rate limited.
+		for range 3 {
+			go listener.Connect(addrGen.NextPort())
+		}
+		assertNoConnReceived(t, inboundConns)
+		assertConnManagerInternalState(t, cm)
+	})
 }

--- a/internal/connmgr/connmanager_test.go
+++ b/internal/connmgr/connmanager_test.go
@@ -223,6 +223,19 @@ func (g *addrGenerator) nextPrefix(prefixBits uint) *addrmgr.NetAddress {
 	return addrmgr.NewNetAddressFromIPPort(g.addr.AsSlice(), g.port, 0)
 }
 
+// SetFlooded sets the address generator to use inbound prefix groups per the
+// given flooded state.
+func (g *addrGenerator) SetFlooded(active bool) {
+	g.mtx.Lock()
+	defer g.mtx.Unlock()
+
+	bits := uint(32)
+	if active {
+		bits = 24
+	}
+	g.inboundGroupPrefixBits = bits
+}
+
 // NextInboundGroup advances the generator to the next inbound group IP and
 // returns the result.  It skips all addresses of the form "x.x.x.0".
 //
@@ -438,6 +451,33 @@ func assertInternalOutboundGroupState(t *testing.T, cm *ConnManager) {
 	}
 }
 
+// assertInternalRateLimiterState ensures the internal rate limiting and
+// flooding state of the passed connection manager instance is coherent.
+func assertInternalRateLimiterState(t *testing.T, cm *ConnManager) {
+	t.Helper()
+
+	l := cm.inboundLimiter
+	l.floodMtx.Lock()
+	defer l.floodMtx.Unlock()
+
+	// Assert the total attempts count matches the value obtained from manually
+	// tallying it.
+	var totalAttempts uint64
+	for _, attempts := range l.attempts {
+		totalAttempts += uint64(attempts)
+	}
+	if l.totalAttempts != totalAttempts {
+		t.Fatalf("mismatched total attempts count: %d != %d", l.totalAttempts,
+			totalAttempts)
+	}
+
+	// Assert the flooding flag status is correct.
+	flooding := l.totalAttempts > floodLow
+	if got := l.flooding.Load(); got != flooding {
+		t.Fatalf("mismatched flooding flag: %v != %v", got, flooding)
+	}
+}
+
 // assertConnManagerInternalState ensures the internal state of the passed
 // connection manager instance is coherent.
 func assertConnManagerInternalState(t *testing.T, cm *ConnManager) {
@@ -446,6 +486,7 @@ func assertConnManagerInternalState(t *testing.T, cm *ConnManager) {
 	assertInternalConnState(t, cm)
 	assertInternalPerHostState(t, cm)
 	assertInternalOutboundGroupState(t, cm)
+	assertInternalRateLimiterState(t, cm)
 }
 
 // assertConnManagerCleanShutdown ensures the internal state of the passed
@@ -705,6 +746,16 @@ func assertNoConnReceived(t *testing.T, ch <-chan *Conn) {
 	t.Helper()
 
 	assertNoConnReceivedTimeout(t, ch, connTestNonReceiveTimeout)
+}
+
+// assertFlooded ensures the flooding status of the connection manager is the
+// given value.
+func assertFlooded(t *testing.T, cm *ConnManager, want bool) {
+	t.Helper()
+
+	if got := cm.inboundLimiter.flooding.Load(); got != want {
+		t.Fatalf("flooding status %v is not %v", got, want)
+	}
 }
 
 // TestConnectMode tests that the connection manager works in the connect mode.
@@ -2290,8 +2341,8 @@ func TestOutboundGroups(t *testing.T) {
 }
 
 // TestInboundRateLimiting ensures the connection manager rate limits inbound
-// connections as expected.  It includes tests for normal rate limiting and
-// bursts.
+// connections behavior as expected.  It includes tests for normal rate
+// limiting, bursts, flooding, and flood recovery.
 func TestInboundRateLimiting(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		inboundConns := make(chan *Conn)
@@ -2356,5 +2407,84 @@ func TestInboundRateLimiting(t *testing.T) {
 		}
 		assertNoConnReceived(t, inboundConns)
 		assertConnManagerInternalState(t, cm)
+
+		// Make exactly enough allowed connections to reach one prior to the low
+		// intensity flood cutover.  Ensure all connections are accepted and
+		// flooding is not detected.
+		//
+		// Wait long enough to reset the flood state first to simplify the
+		// calcs.
+		//
+		// Then, advance time such that the connections fill up the entire
+		// sliding window used to track allowed connections for flood detection.
+		time.Sleep(60 * time.Second)
+		for i := range floodLow {
+			if i%groupBurstLimit == 0 {
+				addrGen.NextInboundGroup()
+			}
+			go listener.Connect(addrGen.NextPort())
+			assertConnReceived(t, inboundConns, 0, ConnTypeInbound).Close()
+			time.Sleep(60 * time.Second / (floodLow + 1))
+		}
+		assertConnManagerInternalState(t, cm)
+		assertFlooded(t, cm, false)
+
+		// Ensure the next connection activates flooding mode.
+		//
+		// The current inbound group might be rate limited depending on the
+		// actual values above and flooding mode will have coarsened it, so use
+		// an address from the next inbound group with the coarsened prefix.
+		//
+		// The connection may be probabilistically dropped due to flooding, so
+		// it may or may not be accepted.
+		addrGen.SetFlooded(true)
+		go listener.Connect(addrGen.NextInboundGroup())
+		select {
+		case conn := <-inboundConns:
+			assertConnType(t, conn, ConnTypeInbound)
+			conn.Close()
+		case <-time.After(connTestNonReceiveTimeout):
+		}
+		assertConnManagerInternalState(t, cm)
+		assertFlooded(t, cm, true)
+
+		// Make enough connections from the same address to hit the group burst
+		// limit.
+		//
+		// The connections may be probabilistically dropped due to flooding, so
+		// they may or may not be accepted.
+		for range groupBurstLimit {
+			go listener.Connect(addrGen.NextPort())
+			select {
+			case conn := <-inboundConns:
+				assertConnType(t, conn, ConnTypeInbound)
+				conn.Close()
+			case <-time.After(connTestNonReceiveTimeout):
+			}
+		}
+		assertConnManagerInternalState(t, cm)
+		assertFlooded(t, cm, true)
+
+		// Ensure the next few addresses in the same inbound group are now rate
+		// limited.  Use a value high enough to ensure they aren't just being
+		// dropped probabilistically.
+		for range int(math.Ceil(groupBurstLimit/(1-floodMaxDropProb))) * 2 {
+			go listener.Connect(addrGen.Next())
+		}
+		assertNoConnReceived(t, inboundConns)
+		assertConnManagerInternalState(t, cm)
+
+		// Ensure flood mode is deactivated once flooding subsides.
+		//
+		// Wait for an entire window to pass with no connections and then ensure
+		// the same address can connect up to the burst limit again.
+		time.Sleep(time.Minute)
+		addrGen.SetFlooded(false)
+		for range groupBurstLimit {
+			go listener.Connect(addrGen.NextPort())
+			assertConnReceived(t, inboundConns, 0, ConnTypeInbound).Close()
+		}
+		assertConnManagerInternalState(t, cm)
+		assertFlooded(t, cm, false)
 	})
 }

--- a/internal/connmgr/csprng.go
+++ b/internal/connmgr/csprng.go
@@ -16,6 +16,7 @@ import (
 type csprng interface {
 	Uint64() uint64
 	Uint64N(n uint64) uint64
+	Float64() float64
 }
 
 // lockingPRNG wraps an instance of [rand.PRNG] with a mutex so it can be used
@@ -39,6 +40,14 @@ func (p *lockingPRNG) Uint64N(n uint64) uint64 {
 	defer p.Unlock()
 
 	return p.prng.Uint64N(n)
+}
+
+// Float64 returns a random float64 in the half-open interval [0.0,1.0).
+func (p *lockingPRNG) Float64() float64 {
+	p.Lock()
+	defer p.Unlock()
+
+	return float64(p.prng.Uint64N(1<<53)) / (1 << 53)
 }
 
 // Read fills s with len(s) of cryptographically-secure random bytes.  It never

--- a/internal/ratelimit/README.md
+++ b/internal/ratelimit/README.md
@@ -1,0 +1,70 @@
+ratelimit
+=========
+
+[![Build Status](https://github.com/decred/dcrd/workflows/Build%20and%20Test/badge.svg)](https://github.com/decred/dcrd/actions)
+[![ISC License](https://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![Doc](https://img.shields.io/badge/doc-reference-blue.svg)](https://pkg.go.dev/github.com/decred/dcrd/internal/ratelimit)
+
+## Overview
+
+Package `ratelimit` implements a simple concurrent safe token bucket rate
+limiter.
+
+It is ideal for traffic shaping, rate limiting API calls, and controlling
+resource usage while supporting controlled bursts of activity.
+
+Since rate limiting is often in the hot path and exposed to extreme conditions,
+the package is designed to be highly efficient, use minimal memory, and support
+high concurrency.
+
+The API is currently primarily aimed at serving use cases where the intention is
+to drop events that exceed the rate limit.  However, it also provides the minimal
+information needed for callers to manually implement blocking behavior until the
+next event is allowed if desired.
+
+Comprehensive tests are included to ensure proper functionality.
+
+All dcrd code in the main module is expected to use this package over
+golang.org/x/time/rate.  This package is more efficient, tailored specifically
+to the needs of dcrd, and it avoids an extra dependency on the x packages that
+have a release policy that conflicts with dcrd's release policy.
+
+## Creating a Rate Limiter
+
+Use `New` to create a limiter with a desired rate (events per second) and
+burst size.
+
+For example, a rate of 10.5 with a burst size of 30 would allow an average of
+10.5 events per second with periodic bursts of up to 30 events.
+
+In order to rate limit events to every `x` seconds (versus `x` events per
+second), specify the rate scaled by `1/x` and scale the rate accordingly for
+other time units.
+
+For example, to specify a rate of 15 events per minute, the rate would be 0.25
+`(15/60)` and 450 events every 2 hours would be 0.0625 (`450/(2*3600)`).
+
+## Using the Limiter
+
+Call `Allow` to determine whether an event is permitted at the current time.  It
+returns `true` when an event may proceed and automatically consumes a token.
+
+For use cases where blocking until the next event is allowed is preferred
+instead of merely dropping events, use `UntilNextAllowed` to determine how long
+to wait.
+
+## Querying State
+
+The current number of tokens in the bucket can be obtained with `Tokens` and the
+fixed maximum burst size is available via `Burst`.
+
+## Examples
+
+* [Basic Limiter Usage](https://pkg.go.dev/github.com/decred/dcrd/internal/ratelimit#example-Limiter.Allow)
+  Demonstrates creating and using a rate limiter that allows up to 10 events
+  per second with periodic bursts of up to 25 events.
+
+## License
+
+Package ratelimit is licensed under the [copyfree](http://copyfree.org) ISC
+License.

--- a/internal/ratelimit/example_test.go
+++ b/internal/ratelimit/example_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package ratelimit_test
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/decred/dcrd/internal/ratelimit"
+)
+
+// This example demonstrates creating and using a rate limiter that allows 10
+// events per second with periodic bursts of up to 25 events.
+func ExampleLimiter_Allow() {
+	const eventsPerSec = 10
+	const burstTokens = 25
+	limiter := ratelimit.New(eventsPerSec, burstTokens)
+
+	// Simulate a burst of events.  Ordinarily the if statement would be in
+	// response to events that are externally generated, but the events are
+	// simulated here with a loop for the purposes of the example.
+	var numAllowed, numDropped uint64
+	for range burstTokens + 10 {
+		if limiter.Allow() {
+			// Ordinarily this would process the allowed event.
+			numAllowed++
+		} else {
+			numDropped++
+		}
+	}
+	fmt.Printf("num events allowed: %v\n", numAllowed)
+	fmt.Printf("num events dropped: %v\n", numDropped)
+
+	// There will be no more tokens available since another event will not be
+	// allowed for another 100 milliseconds (minus however long has already
+	// elapsed since the final allowed event and reaching this point) given the
+	// rate is 10 per second and the burst size has been exhausted.
+	fmt.Printf("num tokens remaining: %v\n", math.Floor(limiter.Tokens()))
+	const msPerEvent = time.Duration(float64(1000)/eventsPerSec) * time.Millisecond
+	time.Sleep(msPerEvent)
+	isAllowed := limiter.UntilNextAllowed() == 0
+	fmt.Printf("event allowed after %v: %v\n", msPerEvent, isAllowed)
+
+	// Output:
+	// num events allowed: 25
+	// num events dropped: 10
+	// num tokens remaining: 0
+	// event allowed after 100ms: true
+}

--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -1,0 +1,196 @@
+// Copyright (c) 2026 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+// Package ratelimit implements a simple concurrent safe token bucket rate
+// limiter.
+package ratelimit
+
+import (
+	"math"
+	"sync"
+	"time"
+)
+
+// Forever represents an infinite duration.
+const Forever time.Duration = math.MaxInt64
+
+// Limiter provides a simple token bucket rate limiter for controlling the
+// frequency of permitted events.  The token bucket algorithm used by this
+// implementation works by starting with a fixed number of tokens specified by
+// the burst size and refills the tokens at the specified rate.  Events are
+// allowed so long as there is at least one token in the bucket at the time of
+// the event.  It is ideal for use in traffic shaping and traffic policing.
+//
+// The limiter is primarily aimed at serving use cases where the intention is to
+// drop events that exceed the rate limit by only processing events when
+// [Limiter.Allow] reports true and dropping them otherwise.
+//
+// The current number of tokens in the bucket can be obtained with
+// [Limiter.Tokens] and the fixed burst size is available via [Limiter.Burst].
+//
+// Callers that wish to block until the next event is allowed instead of merely
+// dropping events that exceed the rate can make use of
+// [Limiter.UntilNextAllowed] to determine how long they need to wait.
+//
+// [New] must be used to create a usable limiter since the zero value of this
+// struct is not valid.
+type Limiter struct {
+	// These fields do not require a mutex since they are set at initialization
+	// time and never modified after.
+	nowFn func() time.Time
+
+	// These fields are protected by the embedded mutex.
+	//
+	// rate is the number of events to allow per second.
+	//
+	// burst is the maximum amount of tokens to permit for handling rapid
+	// bursts of events.
+	//
+	// tokens is the number of remaining tokens in the bucket.  More events are
+	// permitted while it is greater than 0.
+	//
+	// updated is the last time tokens was updated.
+	mtx     sync.Mutex
+	rate    float64
+	burst   float64
+	tokens  float64
+	updated time.Time
+}
+
+// New returns a token bucket rate limiter that allows events up to the provided
+// rate, in number of events per second, while also allowing bursts up to the
+// provided burst size.
+//
+// For example a rate of 10.5 with a burst size of 30 would allow an average of
+// 10.5 events per second with periodic bursts of up to 30 events.
+//
+// In order to rate limit events to every X seconds (versus X events per
+// second), specify the rate scaled by 1/X.
+//
+// Scale the rate accordingly for other time units.
+//
+// For example, to specify a rate of 15 events per minute, the rate would be
+// 0.25 (15/60) and 450 events every 2 hours would be 450/(2*3600) = 0.0625.
+func New(rate float64, burst uint32) *Limiter {
+	return &Limiter{
+		nowFn:  time.Now,
+		rate:   rate,
+		burst:  float64(burst),
+		tokens: float64(burst),
+	}
+}
+
+// Burst returns the burst size specified when the limiter was created.
+//
+// This function is safe for concurrent access.
+func (l *Limiter) Burst() uint32 {
+	l.mtx.Lock()
+	burst := uint32(l.burst)
+	l.mtx.Unlock()
+	return burst
+}
+
+// durationToTokens returns the number of tokens that would refill during the
+// provided duration at the given rate.
+func durationToTokens(d time.Duration, rate float64) float64 {
+	if rate <= 0 {
+		return 0
+	}
+	return d.Seconds() * rate
+}
+
+// tokensAt returns the number of available tokens at the provided time.  Times
+// prior to the last time the limiter was updated will return the current number
+// of tokens in the bucket.
+//
+// This function MUST be called with the embedded mutex held (for reads).
+func (l *Limiter) tokensAt(t time.Time) float64 {
+	updated := l.updated
+	if t.Before(updated) {
+		updated = t
+	}
+	elapsed := t.Sub(updated)
+	delta := durationToTokens(elapsed, l.rate)
+	numTokens := l.tokens + delta
+	if numTokens > l.burst {
+		numTokens = l.burst
+	}
+	return numTokens
+}
+
+// Tokens returns the number of available tokens at the current time.
+//
+// This function is safe for concurrent access.
+func (l *Limiter) Tokens() float64 {
+	l.mtx.Lock()
+	tokens := l.tokensAt(l.nowFn())
+	l.mtx.Unlock()
+	return tokens
+}
+
+// Allow returns true when an event is allowed to happen at the current time
+// and, when it returns true, the state is updated to consume a token.
+//
+// Callers will typically want to process the event normally when true is
+// returned and drop it otherwise.
+//
+// This function is safe for concurrent access.
+func (l *Limiter) Allow() bool {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+
+	now := l.nowFn()
+	tokens := l.tokensAt(now)
+	tokens--
+
+	if tokens >= 0 && tokens <= l.burst {
+		l.updated = now
+		l.tokens = tokens
+		return true
+	}
+	return false
+}
+
+// tokensToDuration returns the duration the provided number of tokens would
+// take to refill at the given rate.
+//
+// This function is safe for concurrent access.
+func tokensToDuration(tokens float64, rate float64) time.Duration {
+	if rate <= 0 {
+		return Forever
+	}
+	duration := (tokens / rate) * float64(time.Second)
+	if uint64(duration) >= math.MaxInt64 {
+		return Forever
+	}
+	return time.Duration(duration)
+}
+
+// UntilNextAllowed returns the duration that must elapse until the next event
+// is allowed.  [Forever] is returned when no more events will ever be allowed,
+// such as when there is a negative rate or a burst size of 0.
+//
+// This function is safe for concurrent access.
+func (l *Limiter) UntilNextAllowed() time.Duration {
+	// Events are never allowed with a burst size of 0.
+	l.mtx.Lock()
+	if l.burst == 0 {
+		l.mtx.Unlock()
+		return Forever
+	}
+	tokens := l.tokensAt(l.nowFn())
+	rate := l.rate
+	l.mtx.Unlock()
+
+	// The next event is not allowed until there is at least one token, so
+	// determine how much is needed to reach one.
+	needed := 1 - tokens
+	if needed <= 0 {
+		// There is already one or more tokens available.
+		return 0
+	}
+
+	// Convert the needed tokens into a duration based on the rate.
+	return tokensToDuration(needed, rate)
+}

--- a/internal/ratelimit/ratelimit_test.go
+++ b/internal/ratelimit/ratelimit_test.go
@@ -1,0 +1,240 @@
+// Copyright (c) 2026 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package ratelimit
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// TestLimiter ensures functionality related to [Limiter.Allow] works as
+// intended such as the token regeneration rate, burst handling, allowed
+// reporting and time until next allowed.  It also includes tests for some
+// corner cases such as negative rates and backwards time jumps.
+func TestLimiter(t *testing.T) {
+	t.Parallel()
+
+	// Create a mock time to control testing.
+	startTime := time.Now()
+	mockNow := startTime
+	mockNowFn := func() time.Time { return mockNow }
+
+	// asSec returns the provided number of seconds as a duration.
+	asSec := func(secs int) time.Duration {
+		return time.Second * time.Duration(secs)
+	}
+
+	// asMs returns the provided number of milliseconds as a duration.
+	asMs := func(millis int) time.Duration {
+		return time.Millisecond * time.Duration(millis)
+	}
+
+	type perLimiterTest struct {
+		off     time.Duration // offset from start time to test
+		tokens  float64       // expected number of tokens at time
+		next    time.Duration // expected duration until next event is allowed
+		allowed bool          // expected allow value at time to test
+	}
+
+	tests := []struct {
+		name            string           // test description
+		rate            float64          // rate to use
+		burst           uint32           // burst size to use
+		perLimiterTests []perLimiterTest // tests to run against limiter
+	}{{
+		// Test burst capacity and regen rate with 1 event per sec and burst
+		// size 5.
+		name:  "1/s, burst 5",
+		rate:  1.0,
+		burst: 5,
+		perLimiterTests: []perLimiterTest{
+			// Bucket starts full and allows up to burst rate.
+			{off: 0, tokens: 5, next: 0, allowed: true},
+			{off: 0, tokens: 4, next: 0, allowed: true},
+			{off: 0, tokens: 3, next: 0, allowed: true},
+			{off: 0, tokens: 2, next: 0, allowed: true},
+			{off: 0, tokens: 1, next: 0, allowed: true},
+			// Tokens exhausted.
+			{off: 0, tokens: 0, next: asSec(1), allowed: false},
+			// Bucket refills at 1 per sec.
+			{off: asSec(1), tokens: 1, next: 0, allowed: true},
+			{off: asSec(2), tokens: 1, next: 0, allowed: true},
+			{off: asSec(2), tokens: 0, next: asSec(1), allowed: false},
+			// Back to full.
+			{off: asSec(7), tokens: 5, next: 0, allowed: true},
+			// Doesn't fill back up more than burst.
+			{off: asSec(9), tokens: 5, next: 0, allowed: true},
+		},
+	}, {
+		// Test burst capacity and regen rate with 1 event per sec and burst
+		// size 1.
+		name:  "1/s, burst 1",
+		rate:  1.0,
+		burst: 1,
+		perLimiterTests: []perLimiterTest{
+			// Bucket starts full and allows up to burst rate.
+			{off: 0, tokens: 1, next: 0, allowed: true},
+			// Tokens exhausted.
+			{off: 0, tokens: 0, next: asSec(1), allowed: false},
+			// Bucket refills at 1 per sec.
+			{off: asSec(1), tokens: 1, next: 0, allowed: true},
+			{off: asSec(2), tokens: 1, next: 0, allowed: true},
+			{off: asSec(2), tokens: 0, next: asSec(1), allowed: false},
+			// Back to full.
+			{off: asSec(3), tokens: 1, next: 0, allowed: true},
+			// Doesn't fill back up more than burst.
+			{off: asSec(5), tokens: 1, next: 0, allowed: true},
+		},
+	}, {
+		// Test backwards time jumps and regen rate with 100 events per sec and
+		// burst size 6.  Thus the refill rate is 1 event per 10ms.
+		name:  "100/s, burst 6",
+		rate:  100.0,
+		burst: 6,
+		perLimiterTests: []perLimiterTest{
+			// Start one second in the future, back one second to the starting
+			// time and consume all tokens.
+			{off: asSec(1), tokens: 6, next: 0, allowed: true},
+			{off: 0, tokens: 5, next: 0, allowed: true},
+			{off: 0, tokens: 4, next: 0, allowed: true},
+			{off: 0, tokens: 3, next: 0, allowed: true},
+			{off: 0, tokens: 2, next: 0, allowed: true},
+			{off: 0, tokens: 1, next: 0, allowed: true},
+			// Tokens exhausted.
+			{off: 0, tokens: 0, next: asMs(10), allowed: false},
+			{off: 0, tokens: 0, next: asMs(10), allowed: false},
+			// Bucket refills at 1 per 10ms.
+			{off: asMs(10), tokens: 1, next: 0, allowed: true},
+			{off: asMs(10), tokens: 0, next: asMs(10), allowed: false},
+			{off: asMs(20), tokens: 1, next: 0, allowed: true},
+			// Back to full.
+			{off: asMs(80), tokens: 6, next: 0, allowed: true},
+			// Doesn't fill back up more than burst.
+			{off: asMs(100), tokens: 6, next: 0, allowed: true},
+		},
+	}, {
+		// Test burst capacity with 1 event per 10 secs and burst size 10.
+		name:  "1 per 10s, burst 10",
+		rate:  0.1,
+		burst: 10,
+		perLimiterTests: []perLimiterTest{
+			{off: 0, tokens: 10, next: 0, allowed: true},
+			{off: 0, tokens: 9, next: 0, allowed: true},
+			{off: 0, tokens: 8, next: 0, allowed: true},
+			{off: 0, tokens: 7, next: 0, allowed: true},
+			{off: 0, tokens: 6, next: 0, allowed: true},
+			{off: 0, tokens: 5, next: 0, allowed: true},
+			{off: 0, tokens: 4, next: 0, allowed: true},
+			{off: 0, tokens: 3, next: 0, allowed: true},
+			{off: 0, tokens: 2, next: 0, allowed: true},
+			{off: 0, tokens: 1, next: 0, allowed: true},
+			// Tokens exhausted.
+			{off: 0, tokens: 0, next: asSec(10), allowed: false},
+			{off: 0, tokens: 0, next: asSec(10), allowed: false},
+			// Bucket refills at 1 per 10sec.
+			{off: asSec(1), tokens: 0.1, next: asSec(9), allowed: false},
+			{off: asSec(5), tokens: 0.5, next: asSec(5), allowed: false},
+			{off: asSec(10), tokens: 1, next: 0, allowed: true},
+			{off: asSec(10), tokens: 0, next: asSec(10), allowed: false},
+			// Back to full.
+			{off: asSec(110), tokens: 10, next: 0, allowed: true},
+			// Doesn't fill back up more than burst.
+			{off: asSec(130), tokens: 10, next: 0, allowed: true},
+		},
+	}, {
+		// Test negative rates do not regenerate tokens.
+		name:  "negative rate, burst 3",
+		rate:  -1.0,
+		burst: 3,
+		perLimiterTests: []perLimiterTest{
+			{off: 0, tokens: 3, next: 0, allowed: true},
+			{off: 0, tokens: 2, next: 0, allowed: true},
+			{off: 0, tokens: 1, next: 0, allowed: true},
+			// Tokens exhausted and do not regenerate.
+			{off: 0, tokens: 0, next: Forever, allowed: false},
+			{off: 0, tokens: 0, next: Forever, allowed: false},
+		},
+	}, {
+		// Test burst size of 0 never allows any events.
+		name:  "1/s, burst 0",
+		rate:  1.0,
+		burst: 0,
+		perLimiterTests: []perLimiterTest{
+			{off: 0, tokens: 0, next: Forever, allowed: false},
+			{off: 0, tokens: 0, next: Forever, allowed: false},
+		},
+	}}
+
+	for _, test := range tests {
+		// Create limiter with the rate and burst values specified by the test.
+		// Also override the now function so the cur time can be manipulated.
+		limiter := New(test.rate, test.burst)
+		limiter.nowFn = mockNowFn
+
+		// Ensure burst rate is returned properly.
+		if gotBurst := limiter.Burst(); gotBurst != test.burst {
+			t.Errorf("%q: mismatched burst -- got %v, want %v", test.name,
+				gotBurst, test.burst)
+		}
+
+		for i, plTest := range test.perLimiterTests {
+			// Ensure the expected number of tokens are reported.
+			mockNow = startTime.Add(plTest.off)
+			gotTokens := limiter.Tokens()
+			if gotTokens != plTest.tokens {
+				t.Errorf("%q-%d: mismatched tokens -- got %v, want %v",
+					test.name, i, gotTokens, plTest.tokens)
+				continue
+			}
+
+			// Ensure the expected duration until the next allowed event is
+			// reported.
+			gotNextAllowed := limiter.UntilNextAllowed()
+			if gotNextAllowed != plTest.next {
+				t.Errorf("%q-%d: mismatched next allowed -- got %v, want %v",
+					test.name, i, gotNextAllowed, plTest.next)
+				continue
+			}
+
+			// Ensure the expected allowed status is reported.
+			gotAllowed := limiter.Allow()
+			if gotAllowed != plTest.allowed {
+				t.Errorf("%q-%d: mismatched allowed -- got %v, want %v",
+					test.name, i, gotAllowed, plTest.allowed)
+				continue
+			}
+		}
+	}
+}
+
+// TestLimiterMaxDuration ensures any calculated durations that would exceed the
+// max allowed value by [time.Duration] are clamped to [Forever].
+func TestLimiterMaxDuration(t *testing.T) {
+	// Create a mock time to control testing.
+	mockNow := time.Now()
+	mockNowFn := func() time.Time { return mockNow }
+
+	// Since [time.Duration] is an int64 and is in nanoseconds, the maximum
+	// duration that can be represented is 9223372036854775807 nanoseconds.
+	//
+	// Calculate the equivalent rate such that the time until the next allowed
+	// event would exceed that and ensure it is properly clamped to [Forever].
+	limiter := New(float64(time.Second)/float64(math.MaxInt64), 1)
+	limiter.nowFn = mockNowFn
+	if !limiter.Allow() {
+		t.Fatalf("burst size of 1 should allow the event")
+	}
+	if gotDuration := limiter.UntilNextAllowed(); gotDuration != Forever {
+		t.Fatalf("unexpected duration -- got %v, want %v", gotDuration, Forever)
+	}
+
+	// Ensure [Forever] is no longer returned once the duration no longer
+	// exceeds the max after it previously did.
+	mockNow = mockNow.Add(time.Millisecond)
+	if gotDuration := limiter.UntilNextAllowed(); gotDuration == Forever {
+		t.Fatalf("unexpected duration -- got %v, want < %v", gotDuration, Forever)
+	}
+}


### PR DESCRIPTION
~~**This requires #3701**.~~

The current code leans heavily on sysadmins to provide traffic shaping via their OS firewalls.  While the OS is typically an ideal place to implement the vast majority of such policies, most users are not sysadmins and are very unlikely to have strong knowledge of what constitute good traffic patterns and general connection needs of the network.

Allowing `dcrd` to handle the vast majority of it with a reasonable default configuration will alleviate the need of any additional OS-level configuration for the vast majority of users and cases.  It also means that `dcrd` can make more intelligent decisions to dynamically adjust behavior based on prevailing network conditions since it is aware of the protocol.

Finally, implementing it here does not prevent more sophisticated sysadmins from enforcing additional policies and QoS with their OS firewalls.

With that in mind, this adds fairly sophisticated inbound connection rate limiting and anti-flooding measures to the connection manager.

As a first layer of defense, it implements token bucket rate limiting on a per network group basis.  In order to ensure memory remains tightly controlled, an LRU with a 20 minute TTL that enforces a max of 10000 independent rate limiters is used.  Each network group is rate limited to an average of 1 connection per 5 seconds and allows periodic controlled bursts up to 3.

In normal operation, for IPv4, the network group is set to individual IPv4s.  For IPv6, it is set to the /64 prefix that is typically assigned by residential ISPs.  In other words, it has the effect of treating all IPv6s in the typical block residential users are assigned as a single entity since they are the easiest for the same attacker to control.

Further, the connection manager is given a unique per-instance cryptographic key for calculating the inbound group keys.  
This has the effect of making the mapping unpredictable to external observers which in turn protects against deliberately targeting specific cache entries or coordinating network-wide cache eviction strategies across nodes.

Per-group rate limiting is great first line of defense, however, it is not able to effectively handle prefix spraying by more sophisticated attackers who control large numbers of prefixes because the number of simultaneously tracked rate limiters necessarily must remain bounded to prevent unchecked memory growth.

This makes such attacks significantly more difficult by implementing anti-flood measures which detect sustained distributed connection pressure and dynamically adjust the limiting to actively combat it.

The detection uses an extremely efficient O(1) sliding window approach that tracks allowed connections over the past minute via a ring buffer.

Once flooding is detected, the prefixes for both IPv4 and IPv6 are coarsened to treat larger blocks of addresses that attackers are most likely to control as a single entity thereby reducing the pressure on the cache.  IPv4 is modified to /24 and IPv6 to /56.

Second, probabilistic connection dropping that uses a quadratic rational S-curve to dynamically increase the drop probability according to the observed intensity of the flood is activated.

This approach was chosen because it ultimately still allows honest peers to periodically establish connections even in the face of a sustained DDoS attack rather than completely starving new inbound connections as more naive approaches do.

It also introduces rate limiting on the logging of dropped connections to ensure the drop logging does not become its own DoS vector.  The logging now includes a summary of the number of dropped connections if any were suppressed due to the rate limiting.

Finally, great care was taken to ensure all limiting mechanisms are suitable for the inbound connection hot path.  The implementation uses constant-time operations with tightly bounded memory usage which ensures it is able to continue operating predictably even during sustained attack conditions.

It is implemented via a series of commits to ease the review process.  See the individual commit descriptions for details.

---

The following graph shows the S-curve used for probabilistic dropping:

<img width="400" height="400" alt="probabilistic_conn_drop_s_curve" src="https://github.com/user-attachments/assets/9d0f2209-b064-4987-be04-ea6a0b954c82" />
