### PR TITLE
netsync: Mark blocks as known via headers.

### DIFF
--- a/internal/netsync/manager.go
+++ b/internal/netsync/manager.go
@@ -1614,7 +1614,8 @@ func (m *SyncManager) OnHeaders(peer *Peer, headersMsg *wire.MsgHeaders) {
 	_, prevBestHeaderHeight := chain.BestHeader()
 
 	// Process all of the received headers.
-	for _, header := range headers {
+	for i, header := range headers {
+		headerHash := &headerHashes[i]
 		err := chain.ProcessBlockHeader(header)
 		if err != nil {
 			// Update the sync height when the sync peer fails to process any
@@ -1637,10 +1638,10 @@ func (m *SyncManager) OnHeaders(peer *Peer, headersMsg *wire.MsgHeaders) {
 			var rErr blockchain.RuleError
 			if errors.As(err, &rErr) {
 				log.Debugf("Rejected block header %s from peer %s: %v -- "+
-					"disconnecting", header.BlockHash(), peer, err)
+					"disconnecting", headerHash, peer, err)
 			} else {
 				log.Errorf("Failed to process block header %s from peer %s: %v"+
-					" -- disconnecting", header.BlockHash(), peer, err)
+					" -- disconnecting", headerHash, peer, err)
 			}
 			if errors.Is(err, database.ErrCorruption) {
 				log.Errorf("Criticial failure: %v", err)
@@ -1649,6 +1650,12 @@ func (m *SyncManager) OnHeaders(peer *Peer, headersMsg *wire.MsgHeaders) {
 			peer.Disconnect()
 			return
 		}
+
+		// Add the block to the cache of known inventory for the peer.  This
+		// helps avoid sending blocks to the peer that it is already known to
+		// have.
+		invVect := wire.NewInvVect(wire.InvTypeBlock, headerHash)
+		peer.AddKnownInventory(invVect)
 	}
 
 	// All of the headers were either accepted or already known valid at this


### PR DESCRIPTION
Currently, the known blocks for each peer are only updated when receiving and sending `inv` announcements for blocks and when receiving the blocks themselves.  That historically covered all relevant cases since syncing was purely done via `getblocks` and the resulting `inv` announcements.

However, block announcements are now done via header announcements instead and that path does not currently add the associated block as known inventory when it sees the header.  This ultimately leads to some unnecessary extra work that gets thrown away.

This resolves that issue by updating the logic that processes announced headers to add the associated block to the known inventory accordingly.