### PR TITLE
secp256k1: Add additional field64 benchmarks.

### DIFF
--- a/dcrec/secp256k1/field64_bench_test.go
+++ b/dcrec/secp256k1/field64_bench_test.go
@@ -35,6 +35,19 @@ func BenchmarkField64Add(b *testing.B) {
 	}
 }
 
+// BenchmarkFieldMulInt benchmarks multiplying an unsigned 256-bit big-endian
+// integer by small integers with [FieldVal64.MulInt].
+func BenchmarkField64MulInt(b *testing.B) {
+	fHex := "16fb970147a9acc73654d4be233cc48b875ce20a2122d24f073d29bd28805aca"
+	f := mustFieldVal64(fHex)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		f.MulInt(2)
+	}
+}
+
 // BenchmarkField64Mul benchmarks multiplying two unsigned 256-bit big-endian
 // integers modulo the field prime with [FieldVal64].
 func BenchmarkField64Mul(b *testing.B) {

--- a/dcrec/secp256k1/field64_bench_test.go
+++ b/dcrec/secp256k1/field64_bench_test.go
@@ -4,7 +4,9 @@
 
 package secp256k1
 
-import "testing"
+import (
+	"testing"
+)
 
 // BenchmarkField64Negate benchmarks calculating the additive inverse of an
 // unsigned 256-bit big-endian integer modulo the field prime with [FieldVal64].
@@ -32,6 +34,58 @@ func BenchmarkField64Add(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		var sum FieldVal64
 		sum.Add2(a, c)
+	}
+}
+
+// BenchmarkField64MulBy2 benchmarks multiplying an unsigned 256-bit big-endian
+// integer by 2 with [FieldVal64.MulBy2].
+func BenchmarkField64MulBy2(b *testing.B) {
+	fHex := "16fb970147a9acc73654d4be233cc48b875ce20a2122d24f073d29bd28805aca"
+	f := mustFieldVal64(fHex)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		f.MulBy2()
+	}
+}
+
+// BenchmarkField64MulBy3 benchmarks multiplying an unsigned 256-bit big-endian
+// integer by 3 with [FieldVal64.MulBy3].
+func BenchmarkField64MulBy3(b *testing.B) {
+	fHex := "16fb970147a9acc73654d4be233cc48b875ce20a2122d24f073d29bd28805aca"
+	f := mustFieldVal64(fHex)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		f.MulBy3()
+	}
+}
+
+// BenchmarkField64MulBy4 benchmarks multiplying an unsigned 256-bit big-endian
+// integer by 4 with [FieldVal64.MulBy4].
+func BenchmarkField64MulBy4(b *testing.B) {
+	fHex := "16fb970147a9acc73654d4be233cc48b875ce20a2122d24f073d29bd28805aca"
+	f := mustFieldVal64(fHex)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		f.MulBy4()
+	}
+}
+
+// BenchmarkField64MulBy8 benchmarks multiplying an unsigned 256-bit big-endian
+// integer by 8 with [FieldVal64.MulBy8].
+func BenchmarkField64MulBy8(b *testing.B) {
+	fHex := "16fb970147a9acc73654d4be233cc48b875ce20a2122d24f073d29bd28805aca"
+	f := mustFieldVal64(fHex)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		f.MulBy8()
 	}
 }
 

--- a/dcrec/secp256k1/field64_bench_test.go
+++ b/dcrec/secp256k1/field64_bench_test.go
@@ -6,6 +6,32 @@ package secp256k1
 
 import "testing"
 
+// BenchmarkField64Add benchmarks adding two field values.
+func BenchmarkField64Add(b *testing.B) {
+	a := mustFieldVal64("d2e670a19c6d753d1a6d8b20bd045df8a08fb162cf508956c31268c6d81ffdab")
+	c := mustFieldVal64("16fb970147a9acc73654d4be233cc48b875ce20a2122d24f073d29bd28805aca")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var sum FieldVal64
+		sum.Add2(a, c)
+	}
+}
+
+// BenchmarkField64Mul benchmarks multiplying two field values.
+func BenchmarkField64Mul(b *testing.B) {
+	a := mustFieldVal64("d2e670a19c6d753d1a6d8b20bd045df8a08fb162cf508956c31268c6d81ffdab")
+	c := mustFieldVal64("16fb970147a9acc73654d4be233cc48b875ce20a2122d24f073d29bd28805aca")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var prod FieldVal64
+		prod.Mul2(a, c)
+	}
+}
+
 // BenchmarkField64Sqrt benchmarks calculating the square root of an unsigned
 // 256-bit big-endian integer modulo the field prime with the FieldVal64 type.
 func BenchmarkField64Sqrt(b *testing.B) {
@@ -18,6 +44,18 @@ func BenchmarkField64Sqrt(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		var result FieldVal64
 		_ = result.SquareRootVal(f)
+	}
+}
+
+// BenchmarkField64Square benchmarks squaring a field value.
+func BenchmarkField64Square(b *testing.B) {
+	a := mustFieldVal64("16fb970147a9acc73654d4be233cc48b875ce20a2122d24f073d29bd28805aca")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var sq FieldVal64
+		sq.SquareVal(a)
 	}
 }
 
@@ -48,43 +86,5 @@ func BenchmarkField64IsGtOrEqPrimeMinusOrder(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = f.IsGtOrEqPrimeMinusOrder()
-	}
-}
-
-// BenchmarkField64Add benchmarks adding two field values.
-func BenchmarkField64Add(b *testing.B) {
-	a := mustFieldVal64("d2e670a19c6d753d1a6d8b20bd045df8a08fb162cf508956c31268c6d81ffdab")
-	c := mustFieldVal64("16fb970147a9acc73654d4be233cc48b875ce20a2122d24f073d29bd28805aca")
-
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		var sum FieldVal64
-		sum.Add2(a, c)
-	}
-}
-
-// BenchmarkField64Mul benchmarks multiplying two field values.
-func BenchmarkField64Mul(b *testing.B) {
-	a := mustFieldVal64("d2e670a19c6d753d1a6d8b20bd045df8a08fb162cf508956c31268c6d81ffdab")
-	c := mustFieldVal64("16fb970147a9acc73654d4be233cc48b875ce20a2122d24f073d29bd28805aca")
-
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		var prod FieldVal64
-		prod.Mul2(a, c)
-	}
-}
-
-// BenchmarkField64Square benchmarks squaring a field value.
-func BenchmarkField64Square(b *testing.B) {
-	a := mustFieldVal64("16fb970147a9acc73654d4be233cc48b875ce20a2122d24f073d29bd28805aca")
-
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		var sq FieldVal64
-		sq.SquareVal(a)
 	}
 }

--- a/dcrec/secp256k1/field64_bench_test.go
+++ b/dcrec/secp256k1/field64_bench_test.go
@@ -6,6 +6,21 @@ package secp256k1
 
 import "testing"
 
+// BenchmarkField64Negate benchmarks calculating the additive inverse of an
+// unsigned 256-bit big-endian integer modulo the field prime with [FieldVal64].
+func BenchmarkField64Negate(b *testing.B) {
+	// The function is constant time so any value is fine.
+	valHex := "16fb970147a9acc73654d4be233cc48b875ce20a2122d24f073d29bd28805aca"
+	f := mustFieldVal64(valHex)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var result FieldVal64
+		_ = result.NegateVal(f)
+	}
+}
+
 // BenchmarkField64Add benchmarks adding two unsigned 256-bit big-endian
 // integers modulo the field prime with [FieldVal64].
 func BenchmarkField64Add(b *testing.B) {

--- a/dcrec/secp256k1/field64_bench_test.go
+++ b/dcrec/secp256k1/field64_bench_test.go
@@ -6,7 +6,8 @@ package secp256k1
 
 import "testing"
 
-// BenchmarkField64Add benchmarks adding two field values.
+// BenchmarkField64Add benchmarks adding two unsigned 256-bit big-endian
+// integers modulo the field prime with [FieldVal64].
 func BenchmarkField64Add(b *testing.B) {
 	a := mustFieldVal64("d2e670a19c6d753d1a6d8b20bd045df8a08fb162cf508956c31268c6d81ffdab")
 	c := mustFieldVal64("16fb970147a9acc73654d4be233cc48b875ce20a2122d24f073d29bd28805aca")
@@ -19,7 +20,8 @@ func BenchmarkField64Add(b *testing.B) {
 	}
 }
 
-// BenchmarkField64Mul benchmarks multiplying two field values.
+// BenchmarkField64Mul benchmarks multiplying two unsigned 256-bit big-endian
+// integers modulo the field prime with [FieldVal64].
 func BenchmarkField64Mul(b *testing.B) {
 	a := mustFieldVal64("d2e670a19c6d753d1a6d8b20bd045df8a08fb162cf508956c31268c6d81ffdab")
 	c := mustFieldVal64("16fb970147a9acc73654d4be233cc48b875ce20a2122d24f073d29bd28805aca")
@@ -47,7 +49,8 @@ func BenchmarkField64Sqrt(b *testing.B) {
 	}
 }
 
-// BenchmarkField64Square benchmarks squaring a field value.
+// BenchmarkField64Square benchmarks squaring a 256-bit big-endian integer
+// modulo the field prime with [FieldVal64].
 func BenchmarkField64Square(b *testing.B) {
 	a := mustFieldVal64("16fb970147a9acc73654d4be233cc48b875ce20a2122d24f073d29bd28805aca")
 
@@ -60,8 +63,8 @@ func BenchmarkField64Square(b *testing.B) {
 }
 
 // BenchmarkField64Inverse benchmarks calculating the multiplicative inverse of
-// an unsigned 256-bit big-endian integer modulo the field prime with the
-// FieldVal64 type.
+// an unsigned 256-bit big-endian integer modulo the field prime with
+// [FieldVal64].
 func BenchmarkField64Inverse(b *testing.B) {
 	// The function is constant time so any value is fine.
 	valHex := "16fb970147a9acc73654d4be233cc48b875ce20a2122d24f073d29bd28805aca"
@@ -74,9 +77,9 @@ func BenchmarkField64Inverse(b *testing.B) {
 	}
 }
 
-// BenchmarkField64IsGtOrEqPrimeMinusOrder benchmarks determining whether a value
-// is greater than or equal to the field prime minus the group order with the
-// FieldVal64 type.
+// BenchmarkField64IsGtOrEqPrimeMinusOrder benchmarks determining whether a
+// value is greater than or equal to the field prime minus the group order with
+// [FieldVal64].
 func BenchmarkField64IsGtOrEqPrimeMinusOrder(b *testing.B) {
 	// The function is constant time so any value is fine.
 	valHex := "16fb970147a9acc73654d4be233cc48b875ce20a2122d24f073d29bd28805aca"


### PR DESCRIPTION
~~**This requires #3713**.~~

This adds some additional benchmarks for the new `FieldVal64` type and performs a bit of light cleanup while here.