### PR TITLE
secp256k1: Reduce allocations.

### DIFF
--- a/dcrec/secp256k1/modnscalar.go
+++ b/dcrec/secp256k1/modnscalar.go
@@ -7,6 +7,7 @@ package secp256k1
 import (
 	"encoding/hex"
 	"math/big"
+	"sync"
 )
 
 // References:
@@ -1059,6 +1060,29 @@ func (s *ModNScalar) Negate() *ModNScalar {
 	return s.NegateVal(s)
 }
 
+// intPool is used to reduce allocations of [big.Int] limbs while calculating
+// inverse modulo on [ModNScalar].
+type intPool struct {
+	pool sync.Pool
+}
+
+func (i *intPool) put(v *big.Int) {
+	v.SetInt64(0)
+	i.pool.Put(v)
+}
+
+func (i *intPool) get() *big.Int {
+	return i.pool.Get().(*big.Int)
+}
+
+var intP = intPool{
+	pool: sync.Pool{
+		New: func() interface{} {
+			return new(big.Int)
+		},
+	},
+}
+
 // InverseValNonConst finds the modular multiplicative inverse of the passed
 // scalar and stores result in s in *non-constant* time.
 //
@@ -1068,9 +1092,18 @@ func (s *ModNScalar) InverseValNonConst(val *ModNScalar) *ModNScalar {
 	// This is making use of big integers for now.  Ideally it will be replaced
 	// with an implementation that does not depend on big integers.
 	valBytes := val.Bytes()
-	bigVal := new(big.Int).SetBytes(valBytes[:])
+
+	// Reuse [big.Int] to avoid limb allocation.
+	bigVal := intP.get().SetBytes(valBytes[:])
 	bigVal.ModInverse(bigVal, curveParams.N)
-	s.SetByteSlice(bigVal.Bytes())
+	var bigBytes [32]byte
+	bigVal.FillBytes(bigBytes[:])
+	s.SetBytes(&bigBytes)
+
+	// Cleanup.
+	zeroArray32(&bigBytes)
+	intP.put(bigVal)
+
 	return s
 }
 

--- a/dcrec/secp256k1/pubkey.go
+++ b/dcrec/secp256k1/pubkey.go
@@ -85,6 +85,89 @@ func NewPublicKey(x, y *FieldVal) *PublicKey {
 	return &pubKey
 }
 
+func (p *PublicKey) parse(serialized []byte) error {
+	var x, y FieldVal
+	switch len(serialized) {
+	case PubKeyBytesLenUncompressed:
+		// Reject unsupported public key formats for the given length.
+		format := serialized[0]
+		switch format {
+		case PubKeyFormatUncompressed:
+		case PubKeyFormatHybridEven, PubKeyFormatHybridOdd:
+		default:
+			str := fmt.Sprintf("invalid public key: unsupported format: %x",
+				format)
+			return makeError(ErrPubKeyInvalidFormat, str)
+		}
+
+		// Parse the x and y coordinates while ensuring that they are in the
+		// allowed range.
+		if overflow := x.SetByteSlice(serialized[1:33]); overflow {
+			str := "invalid public key: x >= field prime"
+			return makeError(ErrPubKeyXTooBig, str)
+		}
+		if overflow := y.SetByteSlice(serialized[33:]); overflow {
+			str := "invalid public key: y >= field prime"
+			return makeError(ErrPubKeyYTooBig, str)
+		}
+
+		// Ensure the oddness of the y coordinate matches the specified format
+		// for hybrid public keys.
+		if format == PubKeyFormatHybridEven || format == PubKeyFormatHybridOdd {
+			wantOddY := format == PubKeyFormatHybridOdd
+			if y.IsOdd() != wantOddY {
+				str := fmt.Sprintf("invalid public key: y oddness does not "+
+					"match specified value of %v", wantOddY)
+				return makeError(ErrPubKeyMismatchedOddness, str)
+			}
+		}
+
+		// Reject public keys that are not on the secp256k1 curve.
+		if !isOnCurve(&x, &y) {
+			str := fmt.Sprintf("invalid public key: [%v,%v] not on secp256k1 "+
+				"curve", x, y)
+			return makeError(ErrPubKeyNotOnCurve, str)
+		}
+
+	case PubKeyBytesLenCompressed:
+		// Reject unsupported public key formats for the given length.
+		format := serialized[0]
+		switch format {
+		case PubKeyFormatCompressedEven, PubKeyFormatCompressedOdd:
+		default:
+			str := fmt.Sprintf("invalid public key: unsupported format: %x",
+				format)
+			return makeError(ErrPubKeyInvalidFormat, str)
+		}
+
+		// Parse the x coordinate while ensuring that it is in the allowed
+		// range.
+		if overflow := x.SetByteSlice(serialized[1:33]); overflow {
+			str := "invalid public key: x >= field prime"
+			return makeError(ErrPubKeyXTooBig, str)
+		}
+
+		// Attempt to calculate the y coordinate for the given x coordinate such
+		// that the result pair is a point on the secp256k1 curve and the
+		// solution with desired oddness is chosen.
+		wantOddY := format == PubKeyFormatCompressedOdd
+		if !DecompressY(&x, wantOddY, &y) {
+			str := fmt.Sprintf("invalid public key: x coordinate %v is not on "+
+				"the secp256k1 curve", x)
+			return makeError(ErrPubKeyNotOnCurve, str)
+		}
+
+	default:
+		str := fmt.Sprintf("malformed public key: invalid length: %d",
+			len(serialized))
+		return makeError(ErrPubKeyInvalidLen, str)
+	}
+
+	p.x.Set(&x)
+	p.y.Set(&y)
+	return nil
+}
+
 // ParsePubKey parses a secp256k1 public key encoded according to the format
 // specified by ANSI X9.62-1998, which means it is also compatible with the
 // SEC (Standards for Efficient Cryptography) specification which is a subset of
@@ -106,85 +189,12 @@ func NewPublicKey(x, y *FieldVal) *PublicKey {
 // NOTE: The hybrid format makes little sense in practice an therefore this
 // package will not produce public keys serialized in this format.  However,
 // this function will properly parse them since they exist in the wild.
-func ParsePubKey(serialized []byte) (key *PublicKey, err error) {
-	var x, y FieldVal
-	switch len(serialized) {
-	case PubKeyBytesLenUncompressed:
-		// Reject unsupported public key formats for the given length.
-		format := serialized[0]
-		switch format {
-		case PubKeyFormatUncompressed:
-		case PubKeyFormatHybridEven, PubKeyFormatHybridOdd:
-		default:
-			str := fmt.Sprintf("invalid public key: unsupported format: %x",
-				format)
-			return nil, makeError(ErrPubKeyInvalidFormat, str)
-		}
-
-		// Parse the x and y coordinates while ensuring that they are in the
-		// allowed range.
-		if overflow := x.SetByteSlice(serialized[1:33]); overflow {
-			str := "invalid public key: x >= field prime"
-			return nil, makeError(ErrPubKeyXTooBig, str)
-		}
-		if overflow := y.SetByteSlice(serialized[33:]); overflow {
-			str := "invalid public key: y >= field prime"
-			return nil, makeError(ErrPubKeyYTooBig, str)
-		}
-
-		// Ensure the oddness of the y coordinate matches the specified format
-		// for hybrid public keys.
-		if format == PubKeyFormatHybridEven || format == PubKeyFormatHybridOdd {
-			wantOddY := format == PubKeyFormatHybridOdd
-			if y.IsOdd() != wantOddY {
-				str := fmt.Sprintf("invalid public key: y oddness does not "+
-					"match specified value of %v", wantOddY)
-				return nil, makeError(ErrPubKeyMismatchedOddness, str)
-			}
-		}
-
-		// Reject public keys that are not on the secp256k1 curve.
-		if !isOnCurve(&x, &y) {
-			str := fmt.Sprintf("invalid public key: [%v,%v] not on secp256k1 "+
-				"curve", x, y)
-			return nil, makeError(ErrPubKeyNotOnCurve, str)
-		}
-
-	case PubKeyBytesLenCompressed:
-		// Reject unsupported public key formats for the given length.
-		format := serialized[0]
-		switch format {
-		case PubKeyFormatCompressedEven, PubKeyFormatCompressedOdd:
-		default:
-			str := fmt.Sprintf("invalid public key: unsupported format: %x",
-				format)
-			return nil, makeError(ErrPubKeyInvalidFormat, str)
-		}
-
-		// Parse the x coordinate while ensuring that it is in the allowed
-		// range.
-		if overflow := x.SetByteSlice(serialized[1:33]); overflow {
-			str := "invalid public key: x >= field prime"
-			return nil, makeError(ErrPubKeyXTooBig, str)
-		}
-
-		// Attempt to calculate the y coordinate for the given x coordinate such
-		// that the result pair is a point on the secp256k1 curve and the
-		// solution with desired oddness is chosen.
-		wantOddY := format == PubKeyFormatCompressedOdd
-		if !DecompressY(&x, wantOddY, &y) {
-			str := fmt.Sprintf("invalid public key: x coordinate %v is not on "+
-				"the secp256k1 curve", x)
-			return nil, makeError(ErrPubKeyNotOnCurve, str)
-		}
-
-	default:
-		str := fmt.Sprintf("malformed public key: invalid length: %d",
-			len(serialized))
-		return nil, makeError(ErrPubKeyInvalidLen, str)
+func ParsePubKey(serialized []byte) (*PublicKey, error) {
+	var key PublicKey
+	if err := key.parse(serialized); err != nil {
+		return nil, err
 	}
-
-	return NewPublicKey(&x, &y), nil
+	return &key, nil
 }
 
 // SerializeUncompressed serializes a public key in the 65-byte uncompressed


### PR DESCRIPTION
With the support of [vinteum](https://vinteum.org) I'm working in performance optimizations on btcd. This PR addresses reduction of allocations for modulo inverse calculations and also public key parsing, as stated in the benchmarks below.

Reduce modulo inverse allocations:

```
goos: linux
goarch: amd64
pkg: github.com/decred/dcrd/dcrec/secp256k1/v4
cpu: Intel(R) Core(TM) i5-10310U CPU @ 1.70GHz
                    │ /tmp/modinversebefore │    /tmp/modinverseafter     │
                    │        sec/op         │   sec/op     vs base        │
ModNScalarInverse-8             444.4n ± 0%   370.3n ± 0%  -16.66% (n=60)

                    │ /tmp/modinversebefore │    /tmp/modinverseafter    │
                    │         B/op          │   B/op     vs base         │
ModNScalarInverse-8              96.00 ± 0%   0.00 ± 0%  -100.00% (n=60)

                    │ /tmp/modinversebefore │    /tmp/modinverseafter     │
                    │       allocs/op       │ allocs/op   vs base         │
ModNScalarInverse-8              2.000 ± 0%   0.000 ± 0%  -100.00% (n=60)
```

Reduce pubkey parse allocations

```
goos: linux
goarch: amd64
pkg: github.com/decred/dcrd/dcrec/secp256k1/v4
cpu: Intel(R) Core(TM) i5-10310U CPU @ 1.70GHz
                          │ /tmp/parsepubbefore │         /tmp/parsepubafter          │
                          │       sec/op        │   sec/op     vs base                │
ParsePubKeyCompressed-8             11.06µ ± 0%   11.06µ ± 0%        ~ (p=0.803 n=60)
ParsePubKeyUncompressed-8           238.3n ± 1%   208.5n ± 0%  -12.52% (n=60)
geomean                             1.623µ        1.519µ        -6.46%

                          │ /tmp/parsepubbefore │       /tmp/parsepubafter       │
                          │        B/op         │   B/op     vs base             │
ParsePubKeyCompressed-8              80.00 ± 0%   0.00 ± 0%  -100.00% (n=60)
ParsePubKeyUncompressed-8            80.00 ± 0%   0.00 ± 0%  -100.00% (n=60)
geomean                              80.00                   ?               ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean

                          │ /tmp/parsepubbefore │       /tmp/parsepubafter        │
                          │      allocs/op      │ allocs/op   vs base             │
ParsePubKeyCompressed-8              1.000 ± 0%   0.000 ± 0%  -100.00% (n=60)
ParsePubKeyUncompressed-8            1.000 ± 0%   0.000 ± 0%  -100.00% (n=60)
geomean                              1.000                    ?               ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean
```

The only observation is that `big.Int.ModInverse` also allocates in the master branch of the Go stdlib, but I have a open PR zeroing these allocations, and I'm currently using the [patch](https://github.com/golang/go/pull/79708), for this reason there's even less allocations in the benchmarks above.