### PR TITLE
multi: Replace reflect.Ptr with reflect.Pointer.

### DIFF
--- a/dcrjson/cmdinfo.go
+++ b/dcrjson/cmdinfo.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2015 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -138,7 +138,7 @@ func fieldUsage(structField reflect.StructField, defaultVal *reflect.Value) stri
 
 	// Indirect the pointer if needed.
 	fieldType := structField.Type
-	if fieldType.Kind() == reflect.Ptr {
+	if fieldType.Kind() == reflect.Pointer {
 		fieldType = fieldType.Elem()
 	}
 
@@ -189,7 +189,7 @@ func methodUsageText(rtp reflect.Type, defaults map[int]reflect.Value, method in
 	for i := 0; i < numFields; i++ {
 		rtf := rt.Field(i)
 		var isOptional bool
-		if kind := rtf.Type.Kind(); kind == reflect.Ptr {
+		if kind := rtf.Type.Kind(); kind == reflect.Pointer {
 			isOptional = true
 		}
 

--- a/dcrjson/cmdparse.go
+++ b/dcrjson/cmdparse.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015-2022 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -21,7 +21,7 @@ func makeParams(rt reflect.Type, rv reflect.Value) []interface{} {
 	for i := 0; i < numFields; i++ {
 		rtf := rt.Field(i)
 		rvf := rv.Field(i)
-		if rtf.Type.Kind() == reflect.Ptr {
+		if rtf.Type.Kind() == reflect.Pointer {
 			if rvf.IsNil() {
 				break
 			}
@@ -223,7 +223,7 @@ func typesMaybeCompatible(dest reflect.Type, src reflect.Type) bool {
 // pointers along with how many indirections were necessary.
 func baseType(arg reflect.Type) (reflect.Type, int) {
 	var numIndirects int
-	for arg.Kind() == reflect.Ptr {
+	for arg.Kind() == reflect.Pointer {
 		arg = arg.Elem()
 		numIndirects++
 	}
@@ -285,7 +285,7 @@ func assignField(paramNum int, fieldName string, dest reflect.Value, src reflect
 	}
 
 	// Indirect through to the base source value.
-	for src.Kind() == reflect.Ptr {
+	for src.Kind() == reflect.Pointer {
 		src = src.Elem()
 	}
 

--- a/dcrjson/cmdparse_test.go
+++ b/dcrjson/cmdparse_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -177,7 +177,7 @@ func TestAssignField(t *testing.T) {
 
 		// Indirect through to the base types to ensure their values
 		// are the same.
-		for dst.Kind() == reflect.Ptr {
+		for dst.Kind() == reflect.Pointer {
 			dst = dst.Elem()
 		}
 		if !reflect.DeepEqual(dst.Interface(), test.expected) {

--- a/dcrjson/go.mod
+++ b/dcrjson/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrd/dcrjson/v4
 
-go 1.17
+go 1.18
 
 require github.com/decred/dcrd/chaincfg/chainhash v1.0.5
 

--- a/dcrjson/help.go
+++ b/dcrjson/help.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2015 The btcsuite developers
-// Copyright (c) 2015-2022 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -101,7 +101,7 @@ func resultStructHelp(xT descLookupFunc, rt reflect.Type, indentLevel int) []str
 
 		// Deference pointer if needed.
 		rtfType := rtf.Type
-		if rtfType.Kind() == reflect.Ptr {
+		if rtfType.Kind() == reflect.Pointer {
 			rtfType = rtf.Type.Elem()
 		}
 
@@ -143,7 +143,7 @@ func resultStructHelp(xT descLookupFunc, rt reflect.Type, indentLevel int) []str
 // differently.
 func reflectTypeToJSONExample(xT descLookupFunc, rt reflect.Type, indentLevel int, fieldDescKey string) ([]string, bool) {
 	// Indirect pointer if needed.
-	if rt.Kind() == reflect.Ptr {
+	if rt.Kind() == reflect.Pointer {
 		rt = rt.Elem()
 	}
 	kind := rt.Kind()
@@ -287,7 +287,7 @@ func argTypeHelp(xT descLookupFunc, structField reflect.StructField, defaultVal 
 	// Indirect the pointer if needed and track if it's an optional field.
 	fieldType := structField.Type
 	var isOptional bool
-	if fieldType.Kind() == reflect.Ptr {
+	if fieldType.Kind() == reflect.Pointer {
 		fieldType = fieldType.Elem()
 		isOptional = true
 	}
@@ -354,7 +354,7 @@ func argHelp(xT descLookupFunc, rtp reflect.Type, defaults map[int]reflect.Value
 		// For types which require a JSON object, or an array of JSON
 		// objects, generate the full syntax for the argument.
 		fieldType := rtf.Type
-		if fieldType.Kind() == reflect.Ptr {
+		if fieldType.Kind() == reflect.Pointer {
 			fieldType = fieldType.Elem()
 		}
 		kind := fieldType.Kind()
@@ -524,7 +524,7 @@ func GenerateHelp(method interface{}, descs map[string]string, resultTypes ...in
 		}
 
 		rtp := reflect.TypeOf(resultType)
-		if rtp.Kind() != reflect.Ptr {
+		if rtp.Kind() != reflect.Pointer {
 			str := fmt.Sprintf("result #%d (%v) is not a pointer",
 				i, rtp.Kind())
 			return "", makeError(ErrInvalidType, str)

--- a/dcrjson/register.go
+++ b/dcrjson/register.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The btcsuite developers
-// Copyright (c) 2015-2019 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -95,7 +95,7 @@ var (
 // indirecting through all pointers.
 func baseKindString(rt reflect.Type) string {
 	numIndirects := 0
-	for rt.Kind() == reflect.Ptr {
+	for rt.Kind() == reflect.Pointer {
 		numIndirects++
 		rt = rt.Elem()
 	}
@@ -116,7 +116,7 @@ func isAcceptableKind(kind reflect.Kind) bool {
 		fallthrough
 	case reflect.Func:
 		fallthrough
-	case reflect.Ptr:
+	case reflect.Pointer:
 		fallthrough
 	case reflect.Interface:
 		return false
@@ -188,7 +188,7 @@ func Register(method interface{}, params interface{}, flags UsageFlag) error {
 		return makeError(ErrInvalidUsageFlags, str)
 	}
 
-	if rtp.Kind() != reflect.Ptr {
+	if rtp.Kind() != reflect.Pointer {
 		str := fmt.Sprintf("type must be *struct not '%s (%s)'", rtp,
 			rtp.Kind())
 		return makeError(ErrInvalidType, str)
@@ -222,7 +222,7 @@ func Register(method interface{}, params interface{}, flags UsageFlag) error {
 		// if the field is optional based on it being a pointer.
 		var isOptional bool
 		switch kind := rtf.Type.Kind(); kind {
-		case reflect.Ptr:
+		case reflect.Pointer:
 			isOptional = true
 			kind = rtf.Type.Elem().Kind()
 			fallthrough

--- a/wire/common_test.go
+++ b/wire/common_test.go
@@ -166,7 +166,7 @@ func TestElementWire(t *testing.T) {
 		// Read from wire format.
 		rbuf := bytes.NewReader(test.buf)
 		val := test.in
-		if reflect.ValueOf(test.in).Kind() != reflect.Ptr {
+		if reflect.ValueOf(test.in).Kind() != reflect.Pointer {
 			val = reflect.New(reflect.TypeOf(test.in)).Interface()
 		}
 		err = readElement(rbuf, val)
@@ -175,7 +175,7 @@ func TestElementWire(t *testing.T) {
 			continue
 		}
 		ival := val
-		if reflect.ValueOf(test.in).Kind() != reflect.Ptr {
+		if reflect.ValueOf(test.in).Kind() != reflect.Pointer {
 			ival = reflect.Indirect(reflect.ValueOf(val)).Interface()
 		}
 		if !reflect.DeepEqual(ival, test.in) {
@@ -187,7 +187,7 @@ func TestElementWire(t *testing.T) {
 		// Read from wire format again, but this time with a one byte reader.
 		obr := iotest.OneByteReader(bytes.NewReader(test.buf))
 		val = test.in
-		if reflect.ValueOf(test.in).Kind() != reflect.Ptr {
+		if reflect.ValueOf(test.in).Kind() != reflect.Pointer {
 			val = reflect.New(reflect.TypeOf(test.in)).Interface()
 		}
 		err = readElement(obr, val)
@@ -196,7 +196,7 @@ func TestElementWire(t *testing.T) {
 			continue
 		}
 		ival = val
-		if reflect.ValueOf(test.in).Kind() != reflect.Ptr {
+		if reflect.ValueOf(test.in).Kind() != reflect.Pointer {
 			ival = reflect.Indirect(reflect.ValueOf(val)).Interface()
 		}
 		if !reflect.DeepEqual(ival, test.in) {
@@ -263,7 +263,7 @@ func TestElementWireErrors(t *testing.T) {
 		// Decode from wire format.
 		r := newFixedReader(test.max, nil)
 		val := test.in
-		if reflect.ValueOf(test.in).Kind() != reflect.Ptr {
+		if reflect.ValueOf(test.in).Kind() != reflect.Pointer {
 			val = reflect.New(reflect.TypeOf(test.in)).Interface()
 		}
 		err = readElement(r, val)

--- a/wire/go.mod
+++ b/wire/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrd/wire
 
-go 1.17
+go 1.18
 
 require (
 	github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
Opening this PR because updating the linter to 2.12 throws an error about using the old name, I think because of [this](https://cs.opensource.google/go/go/+/refs/tags/go1.25.0:src/reflect/type.go;l=312) and  [this](https://go.dev/blog/inliner). 

The conversation about updating `go.mod` version has already been had in #3053 and #3054 (and many times in other places), but I'm opening this PR anyway so it can be merged at some point in the future when the update to >=1.18 eventually does happen.