### PR TITLE
secp256k1: Use full field range in rand tests.

### DIFF
--- a/dcrec/secp256k1/field64_test.go
+++ b/dcrec/secp256k1/field64_test.go
@@ -72,7 +72,7 @@ func randIntAndFieldVal64(t *testing.T, rng *rand.Rand) (*big.Int, *FieldVal64) 
 	}
 
 	bigIntVal := new(big.Int).SetBytes(buf[:])
-	bigIntVal.Mod(bigIntVal, curveParams.N)
+	bigIntVal.Mod(bigIntVal, curveParams.P)
 	var fv FieldVal64
 	fv.SetBytes(&buf)
 	return bigIntVal, &fv

--- a/dcrec/secp256k1/field_bench_test.go
+++ b/dcrec/secp256k1/field_bench_test.go
@@ -67,7 +67,7 @@ func BenchmarkBigIntAddModP(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		result := new(big.Int).Add(v1, v2)
-		result.Mod(result, curveParams.N)
+		result.Mod(result, curveParams.P)
 	}
 }
 

--- a/dcrec/secp256k1/field_test.go
+++ b/dcrec/secp256k1/field_test.go
@@ -56,7 +56,7 @@ func randIntAndFieldVal(t *testing.T, rng *rand.Rand) (*big.Int, *FieldVal) {
 
 	// Create and return both a big integer and a field value.
 	bigIntVal := new(big.Int).SetBytes(buf[:])
-	bigIntVal.Mod(bigIntVal, curveParams.N)
+	bigIntVal.Mod(bigIntVal, curveParams.P)
 	var fv FieldVal
 	fv.SetBytes(&buf)
 	return bigIntVal, &fv


### PR DESCRIPTION
This updates a few of the tests to use the entire range of the field for random values in tests as opposed to limiting them to the curve order subset.