### PR TITLE
docs: Remove Go report card badge from README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ dcrd
 [![Build Status](https://github.com/decred/dcrd/workflows/Build%20and%20Test/badge.svg)](https://github.com/decred/dcrd/actions)
 [![ISC License](https://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
 [![Doc](https://img.shields.io/badge/doc-reference-blue.svg)](https://pkg.go.dev/github.com/decred/dcrd)
-[![Go Report Card](https://goreportcard.com/badge/github.com/decred/dcrd)](https://goreportcard.com/report/github.com/decred/dcrd)
 
 ## Decred Overview
 


### PR DESCRIPTION
This removes the Go report card badge from the `README.md` since the service is no longer available.