### PR TITLE
blockchain: Reduce size of UTXOCache in tests.

### DIFF
--- a/internal/blockchain/common_test.go
+++ b/internal/blockchain/common_test.go
@@ -150,7 +150,7 @@ func chainSetup(t testing.TB, params *chaincfg.Params) (*BlockChain, error) {
 					// tests.
 					return nil
 				},
-				MaxSize: 100 * 1024 * 1024, // 100 MiB
+				MaxSize: 100 * 1024, // 100 KiB
 			}),
 		})
 


### PR DESCRIPTION
On my system with a i7-10750H CPU this reduces the total runtime for the blockchain package tests from ~28.0s to ~6.1s.

Being honest I'm not 100% sure why this works, I just noticed on a profile that a huge amount of time was spent in `UtxoCache.flush` and so fiddled with the param to see what would change.