### PR TITLE
mining: Use synctest to speed up test execution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/decred/dcrd
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1

--- a/internal/mining/bgblktmplgenerator_test.go
+++ b/internal/mining/bgblktmplgenerator_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 The Decred developers
+// Copyright (c) 2020-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -6,35 +6,32 @@ package mining
 
 import (
 	"testing"
-	"time"
+	"testing/synctest"
 )
 
 // TestWaitGroup ensures the API for the local waitGroup implementation behaves
 // correctly.
 func TestWaitGroup(t *testing.T) {
-	// goWait is a helper that calls wg.Wait() on a gorutine and closes the
+	// goWait is a helper that calls wg.Wait() on a goroutine and closes the
 	// returned chan once Wait() returns.
 	goWait := func(wg *waitGroup) chan struct{} {
 		c := make(chan struct{})
-		started := make(chan struct{})
 		go func() {
-			close(started)
 			wg.Wait()
 			close(c)
 		}()
-
-		// Allow Wait() to be called.
-		<-started
 		return c
 	}
 
-	// waitReturned returns true if the passed channel created by goWait is
-	// closed before a timeout.
+	// waitReturned returns true if the passed channel is closed. It calls
+	// synctest.Wait() before checking the status of the channel to ensure the
+	// tests are not subject to race conditions.
 	waitReturned := func(c chan struct{}) bool {
+		synctest.Wait()
 		select {
 		case <-c:
 			return true
-		case <-time.After(time.Second):
+		default:
 			return false
 		}
 	}
@@ -93,10 +90,8 @@ func TestWaitGroup(t *testing.T) {
 
 			// No chan should be signalled yet.
 			for i := 0; i < nb; i++ {
-				select {
-				case <-chans[i]:
+				if waitReturned(chans[i]) {
 					t.Fatalf("unexpected Wait() return")
-				default:
 				}
 			}
 
@@ -151,6 +146,6 @@ func TestWaitGroup(t *testing.T) {
 	}}
 
 	for _, tc := range tests {
-		t.Run(tc.name, tc.test)
+		synctest.Test(t, tc.test)
 	}
 }


### PR DESCRIPTION
This bumps the go version to 1.25 in order to use testing/synctest to rewrite the waitGroup tests in the internal/mining module. This removes the need to do time.After and dramatically speeds up test execution.

On my system with a i7-10750H CPU this reduces the total runtime for the mining package tests from ~2.00s to ~0.02s.