### PR TITLE
docs: Update for rpc/jsonrpc/types v5 module.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -175,7 +175,7 @@ The following versioned modules are provided by dcrd repository:
   a robust and easy to use Websocket-enabled Decred JSON-RPC client
 * [dcrjson/v4](https://github.com/decred/dcrd/tree/master/dcrjson) - Provides
   infrastructure for working with Decred JSON-RPC APIs
-* [rpc/jsonrpc/types/v4](https://github.com/decred/dcrd/tree/master/rpc/jsonrpc/types) -
+* [rpc/jsonrpc/types/v5](https://github.com/decred/dcrd/tree/master/rpc/jsonrpc/types) -
   Provides concrete types via dcrjson for the chain server JSON-RPC commands,
   return values, and notifications
 * [wire](https://github.com/decred/dcrd/tree/master/wire) - Implements the

--- a/docs/assets/module_hierarchy.gv
+++ b/docs/assets/module_hierarchy.gv
@@ -9,7 +9,7 @@ digraph {
 	bech32 [label="bech32" fillcolor=antiquewhite3]
 	chainhash [label="chaincfg/chainhash" fillcolor=aquamarine]
 	dcrjson [label="dcrjson/v4" fillcolor=indianred]
-	types [label="rpc/jsonrpc/types/v4" fillcolor=tomato]
+	types [label="rpc/jsonrpc/types/v5" fillcolor=tomato]
 	wire [label="wire" fillcolor=coral]
 	chaincfg [label="chaincfg/v3" fillcolor=cadetblue]
 	dcrec [label="dcrec" fillcolor=mediumpurple]

--- a/docs/assets/module_hierarchy.svg
+++ b/docs/assets/module_hierarchy.svg
@@ -127,7 +127,7 @@
 <g id="node8" class="node">
 <title>types</title>
 <path fill="tomato" stroke="black" d="M702.78,-468C702.78,-468 596.88,-468 596.88,-468 590.88,-468 584.88,-462 584.88,-456 584.88,-456 584.88,-444 584.88,-444 584.88,-438 590.88,-432 596.88,-432 596.88,-432 702.78,-432 702.78,-432 708.78,-432 714.78,-438 714.78,-444 714.78,-444 714.78,-456 714.78,-456 714.78,-462 708.78,-468 702.78,-468"/>
-<text text-anchor="middle" x="649.83" y="-444.57" font-family="Times New Roman,serif" font-size="14.00">rpc/jsonrpc/types/v4</text>
+<text text-anchor="middle" x="649.83" y="-444.57" font-family="Times New Roman,serif" font-size="14.00">rpc/jsonrpc/types/v5</text>
 </g>
 <!-- dcrjson&#45;&gt;types -->
 <g id="edge23" class="edge">

--- a/rpc/jsonrpc/types/README.md
+++ b/rpc/jsonrpc/types/README.md
@@ -3,7 +3,7 @@ jsonrpc/types
 
 [![Build Status](https://github.com/decred/dcrd/workflows/Build%20and%20Test/badge.svg)](https://github.com/decred/dcrd/actions)
 [![ISC License](https://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![Doc](https://img.shields.io/badge/doc-reference-blue.svg)](https://pkg.go.dev/github.com/decred/dcrd/rpc/jsonrpc/types/v4)
+[![Doc](https://img.shields.io/badge/doc-reference-blue.svg)](https://pkg.go.dev/github.com/decred/dcrd/rpc/jsonrpc/types/v5)
 
 Package types implements concrete types for marshalling to and from the dcrd
 JSON-RPC commands, return values, and notifications.  A comprehensive suite of
@@ -17,7 +17,7 @@ projects needing to marshal to and from dcrd JSON-RPC requests and responses.
 
 ## Installation and Updating
 
-This package is part of the `github.com/decred/dcrd/rpc/jsonrpc/types/v2`
+This package is part of the `github.com/decred/dcrd/rpc/jsonrpc/types/v5`
 module.  Use the standard go tooling for working with modules to incorporate it.
 
 ## License


### PR DESCRIPTION
This updates the module README.md file, module hierarchy graphviz, and module hierarchy diagram to reflect the new module version.