### PR TITLE
secp256k1: Add field64 proofs.

### DIFF
--- a/dcrec/secp256k1/field64.go
+++ b/dcrec/secp256k1/field64.go
@@ -651,6 +651,10 @@ func (f *FieldVal64) SquareVal(val *FieldVal64) *FieldVal64 {
 // field64Mul512 sets t = x * y as an unreduced 512-bit product via a row-by-row
 // schoolbook multiply.
 func field64Mul512(t *[8]uint64, x, y *[4]uint64) {
+	// The intermediate bounds and carry assumptions used by this algorithm have
+	// been formally verified.  The verification artifacts are available in
+	// internal/proofs.
+
 	a0, a1, a2, a3 := x[0], x[1], x[2], x[3]
 	b0, b1, b2, b3 := y[0], y[1], y[2], y[3]
 
@@ -760,6 +764,10 @@ func field64Mul512(t *[8]uint64, x, y *[4]uint64) {
 
 // field64Square512 sets t = a^2 as an unreduced 512-bit product.
 func field64Square512(t *[8]uint64, a *[4]uint64) {
+	// The intermediate bounds and carry assumptions used by this algorithm have
+	// been formally verified.  The verification artifacts are available in
+	// internal/proofs.
+
 	a0, a1, a2, a3 := a[0], a[1], a[2], a[3]
 
 	var c uint64
@@ -845,6 +853,10 @@ func field64Square512(t *[8]uint64, a *[4]uint64) {
 // field64Reduce512 reduces a 512-bit little-endian limb array modulo p in
 // constant time and stores the result in r.
 func field64Reduce512(r *[4]uint64, x *[8]uint64) {
+	// The intermediate bounds and carry assumptions used by this algorithm have
+	// been formally verified.  The verification artifacts are available in
+	// internal/proofs.
+
 	// Per [HAC] section 14.3.4: Reduction method of moduli of special form,
 	// when the modulus is of the special form m = b^t - c, highly efficient
 	// reduction can be achieved.  While [HAC] only presents the algorithm and

--- a/dcrec/secp256k1/internal/proofs/README.md
+++ b/dcrec/secp256k1/internal/proofs/README.md
@@ -1,0 +1,47 @@
+proofs
+======
+
+## Overview
+
+This consists of formal verification artifacts used to help establish the
+correctness of the security-critical arithmetic implementations.
+
+The current proofs formally verify properties of the optimized field arithmetic
+implementations using [z3](https://github.com/Z3Prover/z3):
+
+- Correctness of multi-precision multiplication
+- Bounds on intermediate values
+- Safety of intentionally discarded carries
+- Correctness of modular reduction steps
+
+The proofs are not required when building or using the package.  They are
+provided to document important correctness properties and make it possible to
+independently verify correctness claims documented throughout the optimized
+implementations.
+
+The proofs use SMT-based verification to model the underlying fixed-width
+integer operations and mechanically verify those properties.
+
+These artifacts are only intended to complement, rather than replace,
+traditional testing and code review.  They provide additional assurance that the
+optimized implementations preserve the required arithmetic invariants.
+
+## Contents
+
+### secp256k1 Arithmetic Proofs
+
+- [Helpers for z3 proofs](z3_proof_helpers.py)
+  Provides common helpers used in several of the proofs.  It is not intended to
+  be run directly.
+
+- [512-bit Multiplication with 64-bit Limbs](mul512_4x64_prover.py)
+  Provides formal verification of the multiplication of two 256-bit values to
+  produce a full 512-bit unreduced product using saturated 64-bit limbs.
+
+- [512-bit Squaring with 64-bit Limbs](square512_4x64_prover.py)
+  Provides formal verification of the squaring of a 256-bit value to produce a
+  full 512-bit unreduced result using saturated 64-bit limbs.
+
+- [Field Modular Reduction](field_4x64_reduce_prover.py)
+  Provides formal verification of the reduction of a 512-bit value represented
+  using saturated 64-bit limbs modulo the secp256k1 prime.

--- a/dcrec/secp256k1/internal/proofs/field_4x64_reduce_prover.py
+++ b/dcrec/secp256k1/internal/proofs/field_4x64_reduce_prover.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026 The Decred developers
+# Copyright (c) 2026 Dave Collins
+# Use of this source code is governed by an ISC
+# license that can be found in the LICENSE file.
+
+from z3_proof_helpers import *
+
+# -------
+# Inputs.
+# -------
+
+x0 = BitVec('x0', 64)
+x1 = BitVec('x1', 64)
+x2 = BitVec('x2', 64)
+x3 = BitVec('x3', 64)
+x4 = BitVec('x4', 64)
+x5 = BitVec('x5', 64)
+x6 = BitVec('x6', 64)
+x7 = BitVec('x7', 64)
+
+field64Prime0 = BitVecVal(0xfffffffefffffc2f, 64)
+field64Prime1 = BitVecVal(0xffffffffffffffff, 64)
+field64Prime2 = BitVecVal(0xffffffffffffffff, 64)
+field64Prime3 = BitVecVal(0xffffffffffffffff, 64)
+field64Prime = Concat(field64Prime3, field64Prime2, field64Prime1, field64Prime0)
+
+twicePrime0 = BitVecVal(0xfffffffdfffff85e, 64)
+twicePrime1 = BitVecVal(0xffffffffffffffff, 64)
+twicePrime2 = BitVecVal(0xffffffffffffffff, 64)
+twicePrime3 = BitVecVal(0xffffffffffffffff, 64)
+twicePrime4 = ONE
+twicePrime = Concat(twicePrime4, twicePrime3, twicePrime2, twicePrime1, twicePrime0)
+
+field64PrimeComplement = BitVecVal(2**32+977, 64)
+
+# ---------------
+# Model the code.
+# ---------------
+
+discards = []
+
+# first reduction: 512 bits -> 289 bits.
+h, t0 = mul64(x4, field64PrimeComplement)
+
+hi, lo = mul64(x5, field64PrimeComplement)
+t1, carry = add64(lo, h, ZERO)
+h, discarded = add64(hi, ZERO, carry)
+discards.append(discarded)
+
+hi, lo = mul64(x6, field64PrimeComplement)
+t2, carry = add64(lo, h, ZERO)
+h, discarded = add64(hi, ZERO, carry)
+discards.append(discarded)
+
+hi, lo = mul64(x7, field64PrimeComplement)
+t3, carry = add64(lo, h, ZERO)
+t4, discarded = add64(hi, ZERO, carry)
+discards.append(discarded)
+
+t0, carry = add64(t0, x0, ZERO)
+t1, carry = add64(t1, x1, carry)
+t2, carry = add64(t2, x2, carry)
+t3, carry = add64(t3, x3, carry)
+t4 += carry
+
+# Save for analysis.
+t4_saved = t4
+
+# second reduction: 289 bits -> t < 2p
+h, t4 = mul64(t4, field64PrimeComplement)
+
+t0, carry = add64(t0, t4, ZERO)
+t1, carry = add64(t1, h, carry)
+t2, carry = add64(t2, ZERO, carry)
+t3, carry = add64(t3, ZERO, carry)
+
+t4 = carry
+
+# final reduction: t < 2p -> t < p
+s0, borrow = sub64(t0, field64Prime0, ZERO)
+s1, borrow = sub64(t1, field64Prime1, borrow)
+s2, borrow = sub64(t2, field64Prime2, borrow)
+s3, borrow = sub64(t3, field64Prime3, borrow)
+_, borrow = sub64(t4, ZERO, borrow)
+r0 = If(borrow == ONE, t0, s0)
+r1 = If(borrow == ONE, t1, s1)
+r2 = If(borrow == ONE, t2, s2)
+r3 = If(borrow == ONE, t3, s3)
+
+# ------
+# Proofs.
+# -------
+
+# Discarded carries are never set.
+for idx, discarded in enumerate(discards):
+    s = Solver()
+    s.add(discarded != ZERO)
+    check(s, f"discarded carry {idx} != 0")
+
+# Top limb never exceeds the field complement after first reduction.
+s = Solver()
+s.add(UGT(t4_saved, field64PrimeComplement))
+check(s, "top limb after 1st reduction > complement")
+
+# Value after second reduction is less than twice the prime (t < 2p).
+s = Solver()
+t = Concat(t4, t3, t2, t1, t0)
+s.add(UGE(t, twicePrime))
+check(s, "value after 2nd reduction >= 2p")
+
+# Fully reduced result is less than the prime (r < p).
+s = Solver()
+r = Concat(r3, r2, r1, r0)
+s.add(UGE(r, field64Prime))
+check(s, "fully reduced result >= prime")

--- a/dcrec/secp256k1/internal/proofs/mul512_4x64_prover.py
+++ b/dcrec/secp256k1/internal/proofs/mul512_4x64_prover.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2026 The Decred developers
+# Copyright (c) 2026 Dave Collins
+# Use of this source code is governed by an ISC
+# license that can be found in the LICENSE file.
+
+from z3_proof_helpers import *
+
+# -------
+# Inputs.
+# -------
+
+a0 = BitVec('a0', 64)
+a1 = BitVec('a1', 64)
+a2 = BitVec('a2', 64)
+a3 = BitVec('a3', 64)
+b0 = BitVec('b0', 64)
+b1 = BitVec('b1', 64)
+b2 = BitVec('b2', 64)
+b3 = BitVec('b3', 64)
+
+# ---------------
+# Model the code.
+# ---------------
+
+discards = []
+
+# Row 0: p0..p4 = a * b0.
+h0, p0 = mul64(a0, b0)
+h1, p1 = mul64(a1, b0)
+h2, p2 = mul64(a2, b0)
+h3, p3 = mul64(a3, b0)
+p1, c = add64(p1, h0, ZERO)
+p2, c = add64(p2, h1, c)
+p3, c = add64(p3, h2, c)
+p4, discarded = add64(h3, ZERO, c)
+discards.append(discarded)
+
+p4_saved_0 = p4
+
+# Row 1: p1..p5 += a * b1.
+h0, q0 = mul64(a0, b1)
+h1, q1 = mul64(a1, b1)
+h2, q2 = mul64(a2, b1)
+h3, q3 = mul64(a3, b1)
+q1, c = add64(q1, h0, ZERO)
+q2, c = add64(q2, h1, c)
+q3, c = add64(q3, h2, c)
+q4, discarded = add64(h3, ZERO, c)
+discards.append(discarded)
+p1, c = add64(p1, q0, ZERO)
+p2, c = add64(p2, q1, c)
+p3, c = add64(p3, q2, c)
+p4, c = add64(p4, q3, c)
+p5, discarded = add64(q4, ZERO, c)
+discards.append(discarded)
+
+q4_saved_1 = q4
+
+# Row 2: p2..p6 += a * b2.
+h0, q0 = mul64(a0, b2)
+h1, q1 = mul64(a1, b2)
+h2, q2 = mul64(a2, b2)
+h3, q3 = mul64(a3, b2)
+q1, c = add64(q1, h0, ZERO)
+q2, c = add64(q2, h1, c)
+q3, c = add64(q3, h2, c)
+q4, discarded = add64(h3, ZERO, c)
+discards.append(discarded)
+p2, c = add64(p2, q0, ZERO)
+p3, c = add64(p3, q1, c)
+p4, c = add64(p4, q2, c)
+p5, c = add64(p5, q3, c)
+p6, discarded = add64(q4, ZERO, c)
+discards.append(discarded)
+
+q4_saved_2 = q4
+
+# Row 3: p3..p7 += a * b3.
+h0, q0 = mul64(a0, b3)
+h1, q1 = mul64(a1, b3)
+h2, q2 = mul64(a2, b3)
+h3, q3 = mul64(a3, b3)
+q1, c = add64(q1, h0, ZERO)
+q2, c = add64(q2, h1, c)
+q3, c = add64(q3, h2, c)
+q4, discarded = add64(h3, ZERO, c)
+discards.append(discarded)
+p3, c = add64(p3, q0, ZERO)
+p4, c = add64(p4, q1, c)
+p5, c = add64(p5, q2, c)
+p6, c = add64(p6, q3, c)
+p7, discarded = add64(q4, ZERO, c)
+discards.append(discarded)
+
+q4_saved_3 = q4
+
+# ------
+# Proofs.
+# -------
+
+# Discarded carries are never set.
+for idx, discarded in enumerate(discards):
+    s = Solver()
+    s.add(discarded != ZERO)
+    check(s, f"discarded carry {idx} != 0")
+
+# Top limb after row 0 is max 2**64 - 2 (p4 ≤ 2**64 - 2).
+s = Solver()
+s.add(UGT(p4_saved_0, (1<<64) - 2))
+check(s, "top limb after row 0 > 2**64-2")
+
+# Limb 5 after row 1 is max 2**64 - 2 (q4 ≤ 2**64 - 2).
+s = Solver()
+s.add(UGT(q4_saved_1, (1<<64) - 2))
+check(s, "limb 5 after row 1 > 2**64-2")
+
+# Limb 5 after row 2 is max 2**64 - 2 (q4 ≤ 2**64 - 2).
+s = Solver()
+s.add(UGT(q4_saved_2, (1<<64) - 2))
+check(s, "limb 5 after row 2 > 2**64-2")
+
+# Limb 5 after row 3 is max 2**64 - 2 (q4 ≤ 2**64 - 2).
+s = Solver()
+s.add(UGT(q4_saved_3, (1<<64) - 2))
+check(s, "limb 5 after row 3 > 2**64-2")

--- a/dcrec/secp256k1/internal/proofs/square512_4x64_prover.py
+++ b/dcrec/secp256k1/internal/proofs/square512_4x64_prover.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2026 The Decred developers
+# Copyright (c) 2026 Dave Collins
+# Use of this source code is governed by an ISC
+# license that can be found in the LICENSE file.
+
+from z3_proof_helpers import *
+
+# -------
+# Inputs.
+# -------
+
+a0 = BitVec('a0', 64)
+a1 = BitVec('a1', 64)
+a2 = BitVec('a2', 64)
+a3 = BitVec('a3', 64)
+a_full = Concat(a3, a2, a1, a0)
+
+# ---------------
+# Model the code.
+# ---------------
+
+discards = []
+
+# Off-diagonal upper-triangle products.
+p2, p1 = mul64(a0, a1)
+h02, l02 = mul64(a0, a2)
+h03, l03 = mul64(a0, a3)
+p2, c = add64(p2, l02, ZERO)
+p3, c = add64(h02, l03, c)
+p4, discarded = add64(h03, ZERO, c)
+discards.append(discarded)
+
+h12, l12 = mul64(a1, a2)
+p3, c = add64(p3, l12, ZERO)
+p4, c = add64(p4, h12, c)
+p5 = c
+
+h13, l13 = mul64(a1, a3)
+p4, c = add64(p4, l13, ZERO)
+p5, discarded = add64(p5, h13, c)
+discards.append(discarded)
+
+h23, l23 = mul64(a2, a3)
+p5, c = add64(p5, l23, ZERO)
+p6, discarded = add64(h23, ZERO, c)
+discards.append(discarded)
+
+# Double p1..p6, capturing the top carry into p7.
+p1, c = add64(p1, p1, ZERO)
+p2, c = add64(p2, p2, c)
+p3, c = add64(p3, p3, c)
+p4, c = add64(p4, p4, c)
+p5, c = add64(p5, p5, c)
+p6, c = add64(p6, p6, c)
+p7 = c
+
+# Add the diagonal squares a[i]^2 at columns 0,2,4,6 in one carry chain.
+h0, p0 = mul64(a0, a0)
+h1, l1 = mul64(a1, a1)
+h2, l2 = mul64(a2, a2)
+h3, l3 = mul64(a3, a3)
+p1, c = add64(p1, h0, ZERO)
+p2, c = add64(p2, l1, c)
+p3, c = add64(p3, h1, c)
+p4, c = add64(p4, l2, c)
+p5, c = add64(p5, h2, c)
+p6, c = add64(p6, l3, c)
+p7, discarded = add64(p7, h3, c)
+discards.append(discarded)
+
+# ------
+# Proofs.
+# -------
+
+# Discarded carries are never set.
+for idx, discarded in enumerate(discards):
+    s = Solver()
+    s.add(discarded != ZERO)
+    check(s, f"discarded carry {idx} != 0")

--- a/dcrec/secp256k1/internal/proofs/z3_proof_helpers.py
+++ b/dcrec/secp256k1/internal/proofs/z3_proof_helpers.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026 The Decred developers
+# Copyright (c) 2026 Dave Collins
+# Use of this source code is governed by an ISC
+# license that can be found in the LICENSE file.
+
+from z3 import *
+
+# -------
+# Inputs.
+# -------
+
+ZERO = BitVecVal(0, 64)
+ONE  = BitVecVal(1, 64)
+
+# --------
+# Helpers.
+# --------
+
+def mul64(x, y):
+    """Return (hi, lo) exactly like bits.Mul64."""
+    assert x.size() == 64
+    assert y.size() == 64
+    p = ZeroExt(64, x) * ZeroExt(64, y)
+    lo = Extract(63, 0, p)
+    hi = Extract(127, 64, p)
+    return hi, lo
+
+def add64(x, y, cin):
+    """
+    Return (sum, carry) exactly like bits.Add64.
+
+    x,y : 64-bit bitvectors
+    cin : 0/1 as a 64-bit bitvector
+    """
+    assert x.size() == 64
+    assert y.size() == 64
+    assert cin.size() == 64
+    s = ZeroExt(1, x) + ZeroExt(1, y) + ZeroExt(1, cin)
+    lo = Extract(63, 0, s)
+    carry = ZeroExt(63, Extract(64, 64, s))
+    return lo, carry
+
+def sub64(x, y, bin):
+    """
+    Return (difference, borrow) exactly like bits.Sub64.
+
+    x,y : 64-bit bitvectors
+    bin : 0/1 as a 64-bit bitvector
+    """
+    assert x.size() == 64
+    assert y.size() == 64
+    assert bin.size() == 64
+    d = ZeroExt(1, x) - ZeroExt(1, y) - ZeroExt(1, bin)
+    lo = Extract(63, 0, d)
+    borrow = If(ULT(ZeroExt(1, x), ZeroExt(1, y) + ZeroExt(1, bin)),
+                ONE, ZERO)
+    return lo, borrow
+
+def check(s, reason):
+    check_result = s.check()
+    print(f"{reason}: {check_result}")
+
+    if check_result == sat:
+        m = s.model()
+
+        for v in [x0,x1,x2,x3,x4,x5,x6,x7]:
+            if m[v] != None:
+                print(f"{v} = 0x{m[v].as_long():016x}")
+            else:
+                print(f"{v} = {m[v]}")


### PR DESCRIPTION
This adds formal verification proofs of the arithmetic in the new field64 implementation using the Z3 theorem prover along with a new directory to house all such proofs and an associated README.md to describe its contents.

It includes formal proofs for the following:

- 512-bit multiplication with saturated 64-bit limbs
- 512-bit squaring with saturated 64-bit limbs
- 512-bit modular reduction over the field prime saturated 64-bit limbs

---

Theorem prover output:

```
$ python internal/proofs/mul512_4x64_prover.py
discarded carry 0 != 0: unsat
discarded carry 1 != 0: unsat
discarded carry 2 != 0: unsat
discarded carry 3 != 0: unsat
discarded carry 4 != 0: unsat
discarded carry 5 != 0: unsat
discarded carry 6 != 0: unsat
top limb after row 0 > 2**64-2: unsat
limb 5 after row 1 > 2**64-2: unsat
limb 5 after row 2 > 2**64-2: unsat
limb 5 after row 3 > 2**64-2: unsat

$ python internal/proofs/square512_4x64_prover.py
discarded carry 0 != 0: unsat
discarded carry 1 != 0: unsat
discarded carry 2 != 0: unsat
discarded carry 3 != 0: unsat

$ python internal/proofs/field_4x64_reduce_prover.py
discarded carry 0 != 0: unsat
discarded carry 1 != 0: unsat
discarded carry 2 != 0: unsat
top limb after 1st reduction > complement: unsat
value after 2nd reduction >= 2p: unsat
fully reduced result >= prime: unsat
```