### PR TITLE
mixclient: Reduce test peers from 10 to 5.

### DIFF
--- a/mixing/mixclient/client_test.go
+++ b/mixing/mixclient/client_test.go
@@ -287,11 +287,6 @@ func testDisruption(t *testing.T, misbehavingID *identity, h hook, f hookFunc) {
 		{cj: NewCoinJoin(w.gen, nil, mixValue, testStartingHeight+10, 1)},
 		{cj: NewCoinJoin(w.gen, nil, mixValue, testStartingHeight+10, 1)},
 		{cj: NewCoinJoin(w.gen, nil, mixValue, testStartingHeight+10, 1)},
-		{cj: NewCoinJoin(w.gen, nil, mixValue, testStartingHeight+10, 1)},
-		{cj: NewCoinJoin(w.gen, nil, mixValue, testStartingHeight+10, 1)},
-		{cj: NewCoinJoin(w.gen, nil, mixValue, testStartingHeight+10, 1)},
-		{cj: NewCoinJoin(w.gen, nil, mixValue, testStartingHeight+10, 1)},
-		{cj: NewCoinJoin(w.gen, nil, mixValue, testStartingHeight+10, 1)},
 	}
 	inputTx := wire.NewMsgTx()
 	for range peers {


### PR DESCRIPTION
This reduces the amount of CPU intensive cryptography executed by tests without changing the validity or coverage of the tests.

On my system with a i7-10750H CPU this reduces the runtime of each invocation of testDisruption by around 2 seconds.