### PR TITLE
multi: Use blake256.NewHasher256 instead of New

### DIFF
--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -6247,7 +6247,7 @@ func New(config *Config) (*Server, error) {
 		workState:              newWorkState(),
 		helpCacher:             newHelpCacher(),
 		requestProcessShutdown: make(chan struct{}),
-		blake256Hasher:         blake256.New(),
+		blake256Hasher:         blake256.NewHasher256(),
 	}
 	key := make([]byte, 32)
 	rand.Read(key)

--- a/internal/rpcserver/rpcserverhandlers_test.go
+++ b/internal/rpcserver/rpcserverhandlers_test.go
@@ -8402,7 +8402,7 @@ func testRPCServerHandler(t *testing.T, tests []rpcTest) {
 				ntfnMgr:        new(testNtfnManager),
 				workState:      workState,
 				helpCacher:     helpCacher,
-				blake256Hasher: blake256.New(),
+				blake256Hasher: blake256.NewHasher256(),
 			}
 			result, err := test.handler(ctx, testServer, test.cmd)
 			if test.wantErr {

--- a/mixing/mixpool/mixpool_test.go
+++ b/mixing/mixpool/mixpool_test.go
@@ -215,7 +215,7 @@ func TestAccept(t *testing.T) {
 	}
 	identity := *(*[33]byte)(identityPub.SerializeCompressed())
 
-	h := blake256.New()
+	h := blake256.NewHasher256()
 
 	var (
 		expires      uint32 = 1010

--- a/mixing/mixpool/orphans_test.go
+++ b/mixing/mixpool/orphans_test.go
@@ -47,7 +47,7 @@ func TestOrphans(t *testing.T) {
 	}
 	id := *(*[33]byte)(pub.SerializeCompressed())
 
-	h := blake256.New()
+	h := blake256.NewHasher256()
 
 	pr := &wire.MsgMixPairReq{
 		Identity: id,

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -2343,7 +2343,7 @@ func newPeerBase(cfgOrig *Config, conn net.Conn, inbound bool) *Peer {
 	}
 
 	p := Peer{
-		blake256Hasher: blake256.New(),
+		blake256Hasher: blake256.NewHasher256(),
 		conn:           conn,
 		inbound:        inbound,
 		knownInventory: lru.NewSetWithDefaultTTL[wire.InvVect](


### PR DESCRIPTION
Callers should prefer NewHasher256 over New since it returns a concrete type that has more functionality and allows avoiding additional allocations.
