### PR TITLE
multi: Use builtin min and max.

### DIFF
--- a/internal/blockchain/common_test.go
+++ b/internal/blockchain/common_test.go
@@ -1150,15 +1150,6 @@ func (g *chaingenHarness) ReconsiderBlockAndExpectTip(blockName string, wantErr 
 	g.ExpectTip(tipName)
 }
 
-// minUint32 is a helper function to return the minimum of two uint32s.
-// This avoids a math import and the need to cast to floats.
-func minUint32(a, b uint32) uint32 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // generateToHeight generates enough blocks in the generator associated with the
 // harness to reach the provided height assuming the blocks up to and including
 // the provided from height have already been generated.  It also purchases the
@@ -1211,7 +1202,7 @@ func (g *chaingenHarness) generateToHeight(fromHeight, toHeight uint32, buyTicke
 	//
 	//   genesis -> bfb -> bm2 -> bm3 -> ... -> bm#
 	alreadyAsserted := tipHeight >= coinbaseMaturity+1
-	targetHeight := minUint32(coinbaseMaturity+1, toHeight)
+	targetHeight := min(coinbaseMaturity+1, toHeight)
 	for ; tipHeight < targetHeight; tipHeight++ {
 		blockName := fmt.Sprintf("bm%d", tipHeight-intermediateHeight)
 		g.NextBlock(blockName, nil, nil)
@@ -1232,7 +1223,7 @@ func (g *chaingenHarness) generateToHeight(fromHeight, toHeight uint32, buyTicke
 	//   ... -> bm# ... -> bse18 -> bse19 -> ... -> bse#
 	var ticketsPurchased uint32
 	alreadyAsserted = tipHeight >= stakeEnabledHeight
-	targetHeight = minUint32(stakeEnabledHeight, toHeight)
+	targetHeight = min(stakeEnabledHeight, toHeight)
 	for ; tipHeight < targetHeight; tipHeight++ {
 		var ticketOuts []chaingen.SpendableOut
 		if buyTicketsPerBlock > 0 {
@@ -1259,7 +1250,7 @@ func (g *chaingenHarness) generateToHeight(fromHeight, toHeight uint32, buyTicke
 		var ticketOuts []chaingen.SpendableOut
 		// Only purchase tickets until the target ticket pool size is reached.
 		ticketsNeeded := targetPoolSize - ticketsPurchased
-		ticketsNeeded = minUint32(ticketsNeeded, buyTicketsPerBlock)
+		ticketsNeeded = min(ticketsNeeded, buyTicketsPerBlock)
 		if ticketsNeeded > 0 {
 			outs := g.OldestCoinbaseOuts()
 			ticketOuts = outs[1 : ticketsNeeded+1]

--- a/internal/mining/policy.go
+++ b/internal/mining/policy.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2016 The btcsuite developers
-// Copyright (c) 2016-2022 The Decred developers
+// Copyright (c) 2016-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -40,15 +40,6 @@ type Policy struct {
 	//
 	// This function must be safe for concurrent access.
 	StandardVerifyFlags func() (txscript.ScriptFlags, error)
-}
-
-// minInt is a helper function to return the minimum of two ints.  This avoids
-// a math import and the need to cast to floats.
-func minInt(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
 }
 
 // calcInputValueAge is a helper function used to calculate the input age of
@@ -113,7 +104,7 @@ func CalcPriority(tx *wire.MsgTx, prioInputs PriorityInputser, nextBlockHeight i
 	overhead := 0
 	for _, txIn := range tx.TxIn {
 		// Max inputs + size can't possibly overflow here.
-		overhead += 58 + minInt(110, len(txIn.SignatureScript))
+		overhead += 58 + min(110, len(txIn.SignatureScript))
 	}
 
 	serializedTxSize := tx.SerializeSize()

--- a/internal/rpcserver/rpcserver.go
+++ b/internal/rpcserver/rpcserver.go
@@ -4001,30 +4001,12 @@ func handleGetWorkRequest(ctx context.Context, s *Server) (any, error) {
 	return reply, nil
 }
 
-// minInt is a helper function to return the minimum of two ints.  This avoids
-// the need to cast to floats.
-func minInt(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-// maxInt is a helper function to return the maximum of two ints.  This avoids
-// the need to cast to floats.
-func maxInt(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 // handleGetWorkSubmission is a helper for handleGetWork which deals with
 // the calling submitting work to be verified and processed.
 func handleGetWorkSubmission(_ context.Context, s *Server, hexData string) (any, error) {
 	// Ensure the provided data is sane.
-	minDataLen := minInt(getworkDataLenBlake256, getworkDataLenBlake3)
-	maxDataLen := maxInt(getworkDataLenBlake256, getworkDataLenBlake3)
+	minDataLen := min(getworkDataLenBlake256, getworkDataLenBlake3)
+	maxDataLen := max(getworkDataLenBlake256, getworkDataLenBlake3)
 	paddedHexDataLen := len(hexData) + len(hexData)%2
 	if paddedHexDataLen < minDataLen*2 || paddedHexDataLen > maxDataLen*2 {
 		if minDataLen == maxDataLen {
@@ -4613,8 +4595,8 @@ func handleSubmitBlock(_ context.Context, s *Server, cmd any) (any, error) {
 	return nil, nil
 }
 
-// min gets the minimum amount from a slice of amounts.
-func min(s []dcrutil.Amount) dcrutil.Amount {
+// minAmount gets the minimum amount from a slice of amounts.
+func minAmount(s []dcrutil.Amount) dcrutil.Amount {
 	if len(s) == 0 {
 		return 0
 	}
@@ -4630,7 +4612,7 @@ func min(s []dcrutil.Amount) dcrutil.Amount {
 }
 
 // max gets the maximum amount from a slice of amounts.
-func max(s []dcrutil.Amount) dcrutil.Amount {
+func maxAmount(s []dcrutil.Amount) dcrutil.Amount {
 	max := dcrutil.Amount(0)
 	for i := range s {
 		if s[i] > max {
@@ -4708,8 +4690,8 @@ func feeInfoForMempool(s *Server, txType stake.TxType) *types.FeeInfoMempool {
 
 	return &types.FeeInfoMempool{
 		Number: uint32(len(ticketFees)),
-		Min:    min(ticketFees).ToCoin(),
-		Max:    max(ticketFees).ToCoin(),
+		Min:    minAmount(ticketFees).ToCoin(),
+		Max:    maxAmount(ticketFees).ToCoin(),
 		Mean:   mean(ticketFees).ToCoin(),
 		Median: median(ticketFees).ToCoin(),
 		StdDev: stdDev(ticketFees).ToCoin(),
@@ -4776,8 +4758,8 @@ func ticketFeeInfoForBlock(s *Server, height int64, txType stake.TxType) (*types
 	return &types.FeeInfoBlock{
 		Height: uint32(height),
 		Number: uint32(txNum),
-		Min:    min(txFees).ToCoin(),
-		Max:    max(txFees).ToCoin(),
+		Min:    minAmount(txFees).ToCoin(),
+		Max:    maxAmount(txFees).ToCoin(),
 		Mean:   mean(txFees).ToCoin(),
 		Median: median(txFees).ToCoin(),
 		StdDev: stdDev(txFees).ToCoin(),
@@ -4823,8 +4805,8 @@ func ticketFeeInfoForRange(s *Server, start int64, end int64, txType stake.TxTyp
 		StartHeight: uint32(start),
 		EndHeight:   uint32(end),
 		Number:      uint32(len(txFees)),
-		Min:         min(txFees).ToCoin(),
-		Max:         max(txFees).ToCoin(),
+		Min:         minAmount(txFees).ToCoin(),
+		Max:         maxAmount(txFees).ToCoin(),
 		Mean:        mean(txFees).ToCoin(),
 		Median:      median(txFees).ToCoin(),
 		StdDev:      stdDev(txFees).ToCoin(),


### PR DESCRIPTION
min and max functions were added to the builtin package in go 1.21 so don't need to be re-implemented.
