### PR TITLE
secp256k1: Field64 API parity.

### DIFF
--- a/dcrec/secp256k1/field64.go
+++ b/dcrec/secp256k1/field64.go
@@ -166,6 +166,9 @@ func (f *FieldVal64) SetByteSlice(b []byte) bool {
 	return result != 0
 }
 
+// Normalize is a no-op.  It is provided to keep API parity with [FieldVal].
+func (f *FieldVal64) Normalize() {}
+
 // PutBytesUnchecked unpacks the field value to a 32-byte big-endian value
 // directly into the passed byte slice in constant time.  The target slice must
 // have at least 32 bytes available or it will panic.
@@ -279,11 +282,11 @@ func (f *FieldVal64) Equals(val *FieldVal64) bool {
 }
 
 // NegateVal negates the passed value and stores the result in f in constant
-// time.
+// time.  The ignored parameter exists to keep API parity with [FieldVal].
 //
 // The field value is returned to support chaining.  This enables syntax like:
 // f.NegateVal(f2).AddInt(1) so that f = -f2 + 1.
-func (f *FieldVal64) NegateVal(val *FieldVal64) *FieldVal64 {
+func (f *FieldVal64) NegateVal(val *FieldVal64, _ uint32) *FieldVal64 {
 	// Since the value is already in the range 0 ≤ val < p, where p is the
 	// secp256k1 prime, negation modulo p is just p - val.  This implies that
 	// the result will always be in the desired range with the sole exception of
@@ -322,12 +325,12 @@ func (f *FieldVal64) NegateVal(val *FieldVal64) *FieldVal64 {
 }
 
 // Negate negates the field value in constant time.  The existing field value is
-// modified.
+// modified.  The ignored parameter exists to keep API parity with [FieldVal].
 //
 // The field value is returned to support chaining.  This enables syntax like:
 // f.Negate().AddInt(1) so that f = -f + 1.
-func (f *FieldVal64) Negate() *FieldVal64 {
-	return f.NegateVal(f)
+func (f *FieldVal64) Negate(_ uint32) *FieldVal64 {
+	return f.NegateVal(f, 0)
 }
 
 // AddInt adds the passed integer to the existing field value and stores the

--- a/dcrec/secp256k1/field64_bench_test.go
+++ b/dcrec/secp256k1/field64_bench_test.go
@@ -19,7 +19,7 @@ func BenchmarkField64Negate(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		var result FieldVal64
-		_ = result.NegateVal(f)
+		_ = result.NegateVal(f, 0)
 	}
 }
 

--- a/dcrec/secp256k1/field64_test.go
+++ b/dcrec/secp256k1/field64_test.go
@@ -606,7 +606,7 @@ func TestField64Negate(t *testing.T) {
 		expected := mustFieldVal64(test.expected)
 
 		// Ensure negating another value produces the expected result.
-		result := new(FieldVal64).NegateVal(f)
+		result := new(FieldVal64).NegateVal(f, 0)
 		if !result.Equals(expected) {
 			t.Errorf("%s: unexpected result -- got: %x, want: %x", test.name,
 				result.Bytes(), expected.Bytes())
@@ -614,7 +614,7 @@ func TestField64Negate(t *testing.T) {
 		}
 
 		// Ensure self negating also produces the expected result.
-		result2 := f.Negate()
+		result2 := f.Negate(0)
 		if !result2.Equals(expected) {
 			t.Errorf("%s: unexpected result -- got: %x, want: %x", test.name,
 				result2.Bytes(), expected.Bytes())


### PR DESCRIPTION
This modifies the new FieldVal64 type have API parity with the existing FieldVal type with the goal of ultimately allowing the backend to be dynamically replaced.