### PR TITLE
chaincfg: Add dcr-seed.jz.bz mainnet seeder.

### DIFF
--- a/chaincfg/mainnetparams.go
+++ b/chaincfg/mainnetparams.go
@@ -605,6 +605,7 @@ func MainNetParams() *Params {
 			"mainnet-seed-1.decred.org",
 			"mainnet-seed-2.decred.org",
 			"mainnet-seed.jholdstock.uk",
+			"dcr-seed.jz.bz",
 		},
 	}
 }


### PR DESCRIPTION
This adds dcr-seed.jz.bz to the mainnet HTTPS seeders list. It's running the official dcrseeder and is currently serving addresses at https://dcr-seed.jz.bz/api/addrs.