### PR TITLE
secp256k1: Add formal functional field redux proof.

### DIFF
--- a/dcrec/secp256k1/field64.go
+++ b/dcrec/secp256k1/field64.go
@@ -857,9 +857,9 @@ func field64Square512(t *[8]uint64, a *[4]uint64) {
 // field64Reduce512 reduces a 512-bit little-endian limb array modulo p in
 // constant time and stores the result in r.
 func field64Reduce512(r *[4]uint64, x *[8]uint64) {
-	// The intermediate bounds and carry assumptions used by this algorithm have
-	// been formally verified.  The verification artifacts are available in
-	// internal/proofs.
+	// This algorithm has been formally verified, including its intermediate
+	// bounds, carry assumptions, and functional correctness.  The verification
+	// artifacts are available in internal/proofs.
 
 	// Per [HAC] section 14.3.4: Reduction method of moduli of special form,
 	// when the modulus is of the special form m = b^t - c, highly efficient

--- a/dcrec/secp256k1/field64.go
+++ b/dcrec/secp256k1/field64.go
@@ -799,9 +799,10 @@ func field64Square512(t *[8]uint64, a *[4]uint64) {
 	// The p5 carry is safe to discard because p5 + h13 + c ≤ 2^64 - 1 (where c
 	// is the carry from p4 + l13).
 	//
-	// A full proof involves case work that is omitted here, but the key point
-	// is that the only way the final add could have a carry is if all 3 of the
-	// following conditions were simultaneously true:
+	// A full proof involves case analysis that is omitted here since the
+	// impossibility of the carry is formally proven in internal/proofs, but the
+	// key point is that the only way the final add could have a carry is if all
+	// 3 of the following conditions were simultaneously true:
 	//
 	// 1) p5_old = 1 (the carry from the earlier chain, so ≤ 1)
 	// 2) h13 = 2^64 - 2 (h13 ≤ 2^64 - 2 as proven previously)
@@ -891,14 +892,15 @@ func field64Reduce512(r *[4]uint64, x *[8]uint64) {
 
 	h, t0 = bits.Mul64(x[4], field64PrimeComplement)
 
-	// Note that since hi is the upper 64 bits of the product of two uint64s:
-	//   h3 ≤ floor((2^64-1)^2 / 2^64) = 2^64 - 2
+	// Note that since hi is the upper 64 bits of the product of a uint64 with
+	// c and c < 2^33:
+	//   hi ≤ floor((2^64-1)(2^33 - 1) / 2^64) = 2^33 - 2
 	//
-	// Then, because c ≤ 1, a loose bound is:
-	//   p4 ≤ h3 + 1 = 2^64 - 1 < 2^64
+	// Then, because carry ≤ 1, a loose bound for h is:
+	//   h ≤ hi + 1 = 2^33 - 1 < 2^64
 	//
 	// Therefore, it is safe to discard the carry and the same applies to the
-	// next two limbs.
+	// next two limbs (second h and first t4).
 	hi, lo = bits.Mul64(x[5], field64PrimeComplement)
 	t1, carry = bits.Add64(lo, h, 0)
 	h, _ = bits.Add64(hi, 0, carry)
@@ -911,6 +913,9 @@ func field64Reduce512(r *[4]uint64, x *[8]uint64) {
 	t3, carry = bits.Add64(lo, h, 0)
 	t4, _ = bits.Add64(hi, 0, carry)
 
+	// The carryless add into t4 below is safe because, per the bound above,
+	// t4 ≤ 2^33 - 1 and carry ≤ 1, so:
+	//  t4 ≤ (2^33 - 1) + 1 = 2^33 < 2^64
 	t0, carry = bits.Add64(t0, x[0], 0)
 	t1, carry = bits.Add64(t1, x[1], carry)
 	t2, carry = bits.Add64(t2, x[2], carry)

--- a/dcrec/secp256k1/internal/proofs/field_4x64_reduce_prover.py
+++ b/dcrec/secp256k1/internal/proofs/field_4x64_reduce_prover.py
@@ -92,24 +92,18 @@ r3 = If(borrow == ONE, t3, s3)
 # -------
 
 # Discarded carries are never set.
-for idx, discarded in enumerate(discards):
-    s = Solver()
-    s.add(discarded != ZERO)
-    check(s, f"discarded carry {idx} != 0")
+prove_no_discarded_carries(discards)
 
 # Top limb never exceeds the field complement after first reduction.
-s = Solver()
-s.add(UGT(t4_saved, field64PrimeComplement))
-check(s, "top limb after 1st reduction > complement")
+#
+# Since the complement is 33 bits, this proves the value does not exceed
+# 256 + 33 = 289 bits after the first reduction.
+prove(ULE(t4_saved, field64PrimeComplement), "top limb after 1st reduction > complement")
 
 # Value after second reduction is less than twice the prime (t < 2p).
-s = Solver()
 t = Concat(t4, t3, t2, t1, t0)
-s.add(UGE(t, twicePrime))
-check(s, "value after 2nd reduction >= 2p")
+prove(ULT(t, twicePrime), "value after 2nd reduction >= 2p")
 
 # Fully reduced result is less than the prime (r < p).
-s = Solver()
 r = Concat(r3, r2, r1, r0)
-s.add(UGE(r, field64Prime))
-check(s, "fully reduced result >= prime")
+prove(ULT(r, field64Prime), "fully reduced result >= prime")

--- a/dcrec/secp256k1/internal/proofs/field_4x64_reduce_prover.py
+++ b/dcrec/secp256k1/internal/proofs/field_4x64_reduce_prover.py
@@ -9,21 +9,20 @@ from z3_proof_helpers import *
 # Inputs.
 # -------
 
-x0 = BitVec('x0', 64)
-x1 = BitVec('x1', 64)
-x2 = BitVec('x2', 64)
-x3 = BitVec('x3', 64)
-x4 = BitVec('x4', 64)
-x5 = BitVec('x5', 64)
-x6 = BitVec('x6', 64)
-x7 = BitVec('x7', 64)
+x = BitVecs('x0 x1 x2 x3 x4 x5 x6 x7', 64)
 
+# NOTE: The code in this section reuses the variable names from the Go code
+# being proven for easy cross referencing.  However, the comments refer to them
+# by shorter mathematical variables for clarity.
+
+# Define P.
 field64Prime0 = BitVecVal(0xfffffffefffffc2f, 64)
 field64Prime1 = BitVecVal(0xffffffffffffffff, 64)
 field64Prime2 = BitVecVal(0xffffffffffffffff, 64)
 field64Prime3 = BitVecVal(0xffffffffffffffff, 64)
 field64Prime = Concat(field64Prime3, field64Prime2, field64Prime1, field64Prime0)
 
+# Define 2P.
 twicePrime0 = BitVecVal(0xfffffffdfffff85e, 64)
 twicePrime1 = BitVecVal(0xffffffffffffffff, 64)
 twicePrime2 = BitVecVal(0xffffffffffffffff, 64)
@@ -31,6 +30,7 @@ twicePrime3 = BitVecVal(0xffffffffffffffff, 64)
 twicePrime4 = ONE
 twicePrime = Concat(twicePrime4, twicePrime3, twicePrime2, twicePrime1, twicePrime0)
 
+# Define c = 2**256 - P.
 field64PrimeComplement = BitVecVal(2**32+977, 64)
 
 # ---------------
@@ -40,33 +40,34 @@ field64PrimeComplement = BitVecVal(2**32+977, 64)
 discards = []
 
 # first reduction: 512 bits -> 289 bits.
-h, t0 = mul64(x4, field64PrimeComplement)
+h, t0 = mul64(x[4], field64PrimeComplement)
 
-hi, lo = mul64(x5, field64PrimeComplement)
+hi, lo = mul64(x[5], field64PrimeComplement)
 t1, carry = add64(lo, h, ZERO)
 h, discarded = add64(hi, ZERO, carry)
 discards.append(discarded)
 
-hi, lo = mul64(x6, field64PrimeComplement)
+hi, lo = mul64(x[6], field64PrimeComplement)
 t2, carry = add64(lo, h, ZERO)
 h, discarded = add64(hi, ZERO, carry)
 discards.append(discarded)
 
-hi, lo = mul64(x7, field64PrimeComplement)
+hi, lo = mul64(x[7], field64PrimeComplement)
 t3, carry = add64(lo, h, ZERO)
 t4, discarded = add64(hi, ZERO, carry)
 discards.append(discarded)
 
-t0, carry = add64(t0, x0, ZERO)
-t1, carry = add64(t1, x1, carry)
-t2, carry = add64(t2, x2, carry)
-t3, carry = add64(t3, x3, carry)
-t4 += carry
+t0, carry = add64(t0, x[0], ZERO)
+t1, carry = add64(t1, x[1], carry)
+t2, carry = add64(t2, x[2], carry)
+t3, carry = add64(t3, x[3], carry)
+t4, discarded = add64(t4, ZERO, carry)
+discards.append(discarded)
 
 # Save for analysis.
 t4_saved = t4
 
-# second reduction: 289 bits -> t < 2p
+# second reduction: 289 bits -> t < 2P
 h, t4 = mul64(t4, field64PrimeComplement)
 
 t0, carry = add64(t0, t4, ZERO)
@@ -76,7 +77,7 @@ t3, carry = add64(t3, ZERO, carry)
 
 t4 = carry
 
-# final reduction: t < 2p -> t < p
+# final reduction: t < 2P -> t < P
 s0, borrow = sub64(t0, field64Prime0, ZERO)
 s1, borrow = sub64(t1, field64Prime1, borrow)
 s2, borrow = sub64(t2, field64Prime2, borrow)
@@ -100,10 +101,10 @@ prove_no_discarded_carries(discards)
 # 256 + 33 = 289 bits after the first reduction.
 prove(ULE(t4_saved, field64PrimeComplement), "top limb after 1st reduction > complement")
 
-# Value after second reduction is less than twice the prime (t < 2p).
+# Value after second reduction is less than twice the prime (t < 2P).
 t = Concat(t4, t3, t2, t1, t0)
-prove(ULT(t, twicePrime), "value after 2nd reduction >= 2p")
+prove(ULT(t, twicePrime), "value after 2nd reduction >= 2P")
 
-# Fully reduced result is less than the prime (r < p).
+# Fully reduced result is less than the prime (r < P).
 r = Concat(r3, r2, r1, r0)
-prove(ULT(r, field64Prime), "fully reduced result >= prime")
+prove(ULT(r, field64Prime), "fully reduced result >= P")

--- a/dcrec/secp256k1/internal/proofs/field_4x64_reduce_prover.py
+++ b/dcrec/secp256k1/internal/proofs/field_4x64_reduce_prover.py
@@ -33,6 +33,28 @@ twicePrime = Concat(twicePrime4, twicePrime3, twicePrime2, twicePrime1, twicePri
 # Define c = 2**256 - P.
 field64PrimeComplement = BitVecVal(2**32+977, 64)
 
+# --------------------------------------------------------------------------
+# Prove the constant definitions satisfy the required identities before
+# trusting anything that uses them.
+# --------------------------------------------------------------------------
+
+# Prove twicePrime = 2P.
+field64Prime320 = ZeroExt(64, field64Prime)
+prove(twicePrime == field64Prime320 << 1, "twicePrime != 2P")
+
+# --------------------------------------------------------------------------
+# Lemma R-identity: P + c == 2**256
+#
+# This lemma justifies replacing factors of 2**256 modulo P by c:
+#
+# P + c ≡ 2**256 (mod P)
+# => 0 + c ≡ 2**256 (mod P)
+# => c ≡ 2**256 (mod P)
+# --------------------------------------------------------------------------
+field64PrimeComplement320 = ZeroExt(256, field64PrimeComplement)
+prove(field64Prime320+field64PrimeComplement320 == BitVecVal(1, 320)<<256,
+   "Lemma R-identity: P+c != 2**256")
+
 # ---------------
 # Model the code.
 # ---------------
@@ -108,3 +130,216 @@ prove(ULT(t, twicePrime), "value after 2nd reduction >= 2P")
 # Fully reduced result is less than the prime (r < P).
 r = Concat(r3, r2, r1, r0)
 prove(ULT(r, field64Prime), "fully reduced result >= P")
+
+# -----------------------------------------------------------------------------
+# Prove functional congruence: r ≡ x (mod P).
+#
+# The checks above establish bounds and the safety of discarded carries,
+# self-consistency of the constants, and the reduction identity (lemma
+# R-identity).
+#
+# The following lemmas establish the arithmetic identity of each transformation
+# stage.  Together with the previously proven bounds and reduction identity,
+# they imply the overall congruence r ≡ x (mod P).
+#
+# A direct assertion such as t == x_lo + (x >> 256)*c is intractable because
+# it introduces a monolithic 256x256 multiplier that appears nowhere in the
+# modeled code, so the SMT solver is forced into bit-level equivalence
+# checking between two structurally unrelated multiplier circuits.
+#
+# Instead, because every accumulation block in the implementation is a fixed
+# carry-propagation network over the *outputs* of bits.Mul64, whether or not
+# those 128-bit inputs are actually products is irrelevant to the network.  Each
+# block satisfies its per-block identity for ALL 128-bit values.  So each block
+# identity is proven here as a universal lemma over unconstrained variables,
+# which contains no multipliers at all and reduces to adder-network equivalence
+# that the solver dispatches quickly.
+#
+# The Go function, field64Reduce512, computes r in three stages:
+#
+# 1) First reduction: Fold the high 256 bits of x (x4..x7) into the low 256 bits
+#    (x0..x3).  This produces t_1 = x_lo + x_hi*c which fits in 289 bits (5
+#    64-bit limbs with the 5th limb small).
+# 2) Second reduction: Fold t_1's 5th limb back in the same way.  This produces
+#    t_2 = t_1_lo + t_1_hi*c, where t_2 < 2P.
+# 3) Final reduction: One conditional subtraction of P which is valid because
+#    t_2 < 2p.
+#
+# The lemmas below chain together to prove r ≡ t2 ≡ t1 ≡ x (mod P) and 0 ≤ r <
+# P which is exactly the definition of x ≡ r (mod P).
+def prove_functional_congruence_lemmas():
+    """
+    Prove r == x (mod P) for field64Reduce512.
+
+    x is the 512-bit input (8 limbs x0..x7) and r is the fully-reduced 256-bit
+    output (4 limbs).
+    """
+
+    # Use a wide enough congruence width that nothing in a 512-bit input ever
+    # wraps around.  This is comfortably wider than the largest quantity
+    # of x_hi*c < 2**289.
+    CONGRUENCE_WIDTH = 512
+
+    def cwidth(v):
+        """Zero-extend v to CONGRUENCE_WIDTH bits."""
+        return ZeroExt(CONGRUENCE_WIDTH - v.size(), v)
+
+    def pack(*limbs):
+        """
+        Concatenate the provided big-endian 64-bit limbs into a single
+        CONGRUENCE_WIDTH-bit value:
+
+        limb0*2**(64*num_limbs) + limb1*2**(64*(num_limbs-1)) + ...
+        """
+        return cwidth(Concat(*limbs))
+
+    def pack_limbs(limbs):
+        """
+        Concatenate the provided iterable little-endian 64-bit limbs into a
+        single CONGRUENCE_WIDTH-bit value:
+
+        limbs[0] + limbs[1]*2**64 + limbs[2]*2**128 + ...
+        """
+        return cwidth(Concat(*reversed(limbs)))
+
+    # Universal lemma variables shared by R-open, R-interior, and R-second.
+    #
+    # prod models the 128-bit product returned by bits.Mul64(_, c) at some point
+    # in the real code.  It is NOT tied to any specific x[j] or t4.
+    #
+    # hi and lo are its two halves.
+    prod = BitVec("prod", 128)
+    hi, lo = split128(prod)
+
+    # -------------------------------------------------------------------------
+    # Lemma R-open: The opening block of the first reduction (the x4 line).
+    #
+    #   h, t0 = bits.Mul64(x[4], c)
+    #
+    # No addition happens on this line at all.  It just splits the product.
+    #
+    # This lemma is really just confirming that packing lo and hi back together
+    # recreates the original product, which sounds trivial, but it matters
+    # because it's the base case that R-interior's telescoping argument (below)
+    # builds on.
+    #
+    # It establishes that after processing x4, the running total (h, t0) exactly
+    # equals x4*c with nothing lost.
+    # -------------------------------------------------------------------------
+    prove(pack(hi,lo) == cwidth(prod), "R-open: (h,t0) != x4*c")
+
+    # -------------------------------------------------------------------------
+    # Lemma R-interior: The shape shared by the x5, x6, and x7 blocks.
+    #
+    # The x7 block simply names its final output t4 instead of h.
+    #
+    #   hi, lo = bits.Mul64(x[j], c)
+    #   t_j, carry = bits.Add64(lo, h, 0)
+    #   h, _ = bits.Add64(hi, 0, carry)
+    #
+    # h_in models the incoming running-total limb carried forward from the
+    # previous block (R-open's h, or a previous R-interior's h_out).
+    #
+    # One carry is discarded and assumed zero.  This fact is proven above by the
+    # discard checks for the real x5/x6/x7 blocks, so this does not smuggle in a
+    # new assumption.
+    # -------------------------------------------------------------------------
+    h_in = BitVec("h_in", 64)
+    t_j, carry = add64(lo, h_in, ZERO)
+    h_out, discarded = add64(hi, ZERO, carry)
+    prove(
+        pack(h_out, t_j) == cwidth(h_in) + cwidth(prod),
+        "R-interior: (t_j,h_out) != h_in + xj*c",
+        assumptions=[discarded == ZERO],
+    )
+
+    # -------------------------------------------------------------------------
+    # Lemma R-tail: Fold x0..x3 into running total after the four blocks above.
+    #
+    #   t0, carry = bits.Add64(t0, x[0], 0)
+    #   t1, carry = bits.Add64(t1, x[1], carry)
+    #   t2, carry = bits.Add64(t2, x[2], carry)
+    #   t3, carry = bits.Add64(t3, x[3], carry)
+    #   t4 += carry
+    #
+    # b0..b4 model the incoming running total in t0..t4.
+    #
+    # The final line is modeled here as add64 with its own carry-out assumed
+    # zero.  This fact is proven above by the discard checks for the real total,
+    # so this does not smuggle in a new assumption.
+    # -------------------------------------------------------------------------
+    b = BitVecs("b0 b1 b2 b3 b4", 64)
+    v = [None]*5
+    v[0], carry = add64(b[0], x[0], ZERO)
+    v[1], carry = add64(b[1], x[1], carry)
+    v[2], carry = add64(b[2], x[2], carry)
+    v[3], carry = add64(b[3], x[3], carry)
+    v[4], discarded = add64(b[4], ZERO, carry)
+    prove(
+        pack_limbs(v) == pack_limbs(b) + pack_limbs(x[:4]),
+        "R-tail: post-fold total != state + x_lo",
+        assumptions=[discarded == ZERO],
+    )
+
+    # -------------------------------------------------------------------------
+    # Lemma R-second: The second reduction.
+    #
+    #   h, t4 = bits.Mul64(t4, c)
+    #   t0, carry = bits.Add64(t0, t4, 0)
+    #   t1, carry = bits.Add64(t1, h, carry)
+    #   t2, carry = bits.Add64(t2, 0, carry)
+    #   t3, carry = bits.Add64(t3, 0, carry)
+    #   t4 = carry
+    #
+    # prod is reused here for t4_old*c since it's still just a free 128-bit
+    # variable and nothing ties it to being x4*c specifically.
+    #
+    # d0..d3 model t0..t3 going into this stage.
+    #
+    # No carries are discarded and the final carry becomes the new t4, so no
+    # assumption is needed.
+    # -------------------------------------------------------------------------
+    d = BitVecs("d0 d1 d2 d3", 64)
+    w = [None] * 5
+    w[0], carry = add64(d[0], lo, ZERO)
+    w[1], carry = add64(d[1], hi, carry)
+    w[2], carry = add64(d[2], ZERO, carry)
+    w[3], carry = add64(d[3], ZERO, carry)
+    w[4] = carry
+    prove(
+        pack_limbs(w) == pack_limbs(d) + cwidth(prod),
+        "R-second: 2nd reduction != state + t4*c",
+    )
+
+    # -------------------------------------------------------------------------
+    # Lemma R-final: The conditional-subtraction final reduction.
+    #
+    #   s0, borrow = bits.Sub64(t0, p0, 0)
+    #   ...
+    #   _, borrow = bits.Sub64(t4, 0, borrow)
+    #   r[i] = constantTimeSelect64(borrow, t[i], s[i])
+    #
+    # z0..z4 model t0..t4 going into this stage.
+    #
+    # This is only valid because t < 2P as otherwise t - P could still exceed P
+    # and the 4-limb result wouldn't represent it.  This fact is proven above
+    # for the real total, so this does not smuggle in a new assumption.
+    # -------------------------------------------------------------------------
+    p = cwidth(field64Prime)
+    twop = cwidth(twicePrime)
+    z = BitVecs("z0 z1 z2 z3 z4", 64)
+    s = [None]*4
+    s[0], borrow = sub64(z[0], field64Prime0, ZERO)
+    s[1], borrow = sub64(z[1], field64Prime1, borrow)
+    s[2], borrow = sub64(z[2], field64Prime2, borrow)
+    s[3], borrow = sub64(z[3], field64Prime3, borrow)
+    _, borrow = sub64(z[4], ZERO, borrow)
+    t = pack_limbs(z)
+    r = If(borrow == ONE, t, pack_limbs(s))
+    prove(
+        r == If(ULT(t, p), t, t - p),
+        "R-final: conditional-subtract result != t mod P",
+        assumptions=[ULT(t, twop)],
+    )
+
+prove_functional_congruence_lemmas()

--- a/dcrec/secp256k1/internal/proofs/mul512_4x64_prover.py
+++ b/dcrec/secp256k1/internal/proofs/mul512_4x64_prover.py
@@ -9,14 +9,8 @@ from z3_proof_helpers import *
 # Inputs.
 # -------
 
-a0 = BitVec('a0', 64)
-a1 = BitVec('a1', 64)
-a2 = BitVec('a2', 64)
-a3 = BitVec('a3', 64)
-b0 = BitVec('b0', 64)
-b1 = BitVec('b1', 64)
-b2 = BitVec('b2', 64)
-b3 = BitVec('b3', 64)
+a0, a1, a2, a3 = BitVecs('a0 a1 a2 a3', 64)
+b0, b1, b2, b3 = BitVecs('b0 b1 b2 b3', 64)
 
 # ---------------
 # Model the code.

--- a/dcrec/secp256k1/internal/proofs/mul512_4x64_prover.py
+++ b/dcrec/secp256k1/internal/proofs/mul512_4x64_prover.py
@@ -99,27 +99,13 @@ q4_saved_3 = q4
 # -------
 
 # Discarded carries are never set.
-for idx, discarded in enumerate(discards):
-    s = Solver()
-    s.add(discarded != ZERO)
-    check(s, f"discarded carry {idx} != 0")
+prove_no_discarded_carries(discards)
 
-# Top limb after row 0 is max 2**64 - 2 (p4 ≤ 2**64 - 2).
-s = Solver()
-s.add(UGT(p4_saved_0, (1<<64) - 2))
-check(s, "top limb after row 0 > 2**64-2")
-
-# Limb 5 after row 1 is max 2**64 - 2 (q4 ≤ 2**64 - 2).
-s = Solver()
-s.add(UGT(q4_saved_1, (1<<64) - 2))
-check(s, "limb 5 after row 1 > 2**64-2")
-
-# Limb 5 after row 2 is max 2**64 - 2 (q4 ≤ 2**64 - 2).
-s = Solver()
-s.add(UGT(q4_saved_2, (1<<64) - 2))
-check(s, "limb 5 after row 2 > 2**64-2")
-
-# Limb 5 after row 3 is max 2**64 - 2 (q4 ≤ 2**64 - 2).
-s = Solver()
-s.add(UGT(q4_saved_3, (1<<64) - 2))
-check(s, "limb 5 after row 3 > 2**64-2")
+# Top limb of each of the four rows is max 2**64 - 2.
+#
+# For row 0, that corresponds to: (p4 ≤ 2**64 - 2)
+# For rows 1-3, it corresponds to: (q4 ≤ 2**64 - 2)
+prove(ULE(p4_saved_0, (1<<64) - 2), "top limb after row 0 > 2**64-2")
+prove(ULE(q4_saved_1, (1<<64) - 2), "limb 5 after row 1 > 2**64-2")
+prove(ULE(q4_saved_2, (1<<64) - 2), "limb 5 after row 2 > 2**64-2")
+prove(ULE(q4_saved_3, (1<<64) - 2), "limb 5 after row 3 > 2**64-2")

--- a/dcrec/secp256k1/internal/proofs/square512_4x64_prover.py
+++ b/dcrec/secp256k1/internal/proofs/square512_4x64_prover.py
@@ -9,10 +9,7 @@ from z3_proof_helpers import *
 # Inputs.
 # -------
 
-a0 = BitVec('a0', 64)
-a1 = BitVec('a1', 64)
-a2 = BitVec('a2', 64)
-a3 = BitVec('a3', 64)
+a0, a1, a2, a3 = BitVecs('a0 a1 a2 a3', 64)
 
 # ---------------
 # Model the code.

--- a/dcrec/secp256k1/internal/proofs/square512_4x64_prover.py
+++ b/dcrec/secp256k1/internal/proofs/square512_4x64_prover.py
@@ -13,7 +13,6 @@ a0 = BitVec('a0', 64)
 a1 = BitVec('a1', 64)
 a2 = BitVec('a2', 64)
 a3 = BitVec('a3', 64)
-a_full = Concat(a3, a2, a1, a0)
 
 # ---------------
 # Model the code.
@@ -73,7 +72,4 @@ discards.append(discarded)
 # -------
 
 # Discarded carries are never set.
-for idx, discarded in enumerate(discards):
-    s = Solver()
-    s.add(discarded != ZERO)
-    check(s, f"discarded carry {idx} != 0")
+prove_no_discarded_carries(discards)

--- a/dcrec/secp256k1/internal/proofs/z3_proof_helpers.py
+++ b/dcrec/secp256k1/internal/proofs/z3_proof_helpers.py
@@ -66,6 +66,11 @@ def sub64(x, y, bin):
                 ONE, ZERO)
     return lo, borrow
 
+def split128(product):
+    """Return (high, low) 64-bit halves from a 128-bit value."""
+    assert product.size() == 128
+    return Extract(127, 64, product), Extract(63, 0, product)
+
 def check(s, reason):
     """Fail unless the proof succeeds."""
     result = s.check()

--- a/dcrec/secp256k1/internal/proofs/z3_proof_helpers.py
+++ b/dcrec/secp256k1/internal/proofs/z3_proof_helpers.py
@@ -85,7 +85,7 @@ def prove(proposition, reason, assumptions=()):
 
     The assumptions encode additional assumptions proven elsewhere.
     """
-    s = Solver()
+    s = SolverFor("QF_BV")
     for a in assumptions:
         s.add(a)
     s.add(Not(proposition))

--- a/dcrec/secp256k1/internal/proofs/z3_proof_helpers.py
+++ b/dcrec/secp256k1/internal/proofs/z3_proof_helpers.py
@@ -30,7 +30,12 @@ def add64(x, y, cin):
     Return (sum, carry) exactly like bits.Add64.
 
     x,y : 64-bit bitvectors
-    cin : 0/1 as a 64-bit bitvector
+    cin : 0 or 1 as a 64-bit bitvector
+
+    Note:
+        Although cin is a 64-bit bitvector, it should semantically represent a
+        single carry bit (0 or 1).  Z3 handles arbitrary values correctly
+        (extracting only bit 0), but callers should maintain this invariant.
     """
     assert x.size() == 64
     assert y.size() == 64
@@ -45,7 +50,12 @@ def sub64(x, y, bin):
     Return (difference, borrow) exactly like bits.Sub64.
 
     x,y : 64-bit bitvectors
-    bin : 0/1 as a 64-bit bitvector
+    bin : 0 or 1 as a 64-bit bitvector
+
+    Note:
+        Although bin is a 64-bit bitvector, it should semantically represent a
+        single borrow bit (0 or 1).  Z3 handles arbitrary values correctly
+        (extracting only bit 0), but callers should maintain this invariant.
     """
     assert x.size() == 64
     assert y.size() == 64
@@ -57,14 +67,34 @@ def sub64(x, y, bin):
     return lo, borrow
 
 def check(s, reason):
-    check_result = s.check()
-    print(f"{reason}: {check_result}")
+    """Fail unless the proof succeeds."""
+    result = s.check()
+    if result != unsat:
+        m = s.model() if result == sat else None
+        details = ""
+        if m is not None:
+            details = "\n  " + ", ".join(
+                f"{d.name()}=0x{m[d].as_long():016x}" for d in m.decls()
+            )
+        raise AssertionError(f"{reason}: {result}{details}")
+    print(f"{reason}: {result}")
 
-    if check_result == sat:
-        m = s.model()
+def prove(proposition, reason, assumptions=()):
+    """
+    Prove the proposition is valid by showing its negation is unsatisfiable.
 
-        for v in [x0,x1,x2,x3,x4,x5,x6,x7]:
-            if m[v] != None:
-                print(f"{v} = 0x{m[v].as_long():016x}")
-            else:
-                print(f"{v} = {m[v]}")
+    The assumptions encode additional assumptions proven elsewhere.
+    """
+    s = Solver()
+    for a in assumptions:
+        s.add(a)
+    s.add(Not(proposition))
+    check(s, reason)
+
+def prove_no_discarded_carries(discards):
+    """
+    Prove every carry in discards is always zero.  This is to say, discarding it
+    never loses information.
+    """
+    for idx, discarded in enumerate(discards):
+        prove(discarded == ZERO, f"discarded carry {idx} != 0")


### PR DESCRIPTION
The existing formal proof for the 4x64 field reduction establishes the intermediate bounds and verifies that no carries are discarded.

This extends it to include a full end-to-end functional correctness proof that shows the implementation computes the correct reduction modulo the field prime for all 512-bit inputs.

It also contains several commits leading up to the main one to perform a bit of light cleanup to correct and tighten some comments, significantly improve the readability for all of the proofs by introducing new helpers and compacting them, ensure any proof failures throw an assertion, and use an explicit solver to avoid unnecessary overhead.

Prover output:
```
$ python field_4x64_reduce_prover.py 
twicePrime != 2P: unsat
Lemma 1: P+c != 2**256: unsat
discarded carry 0 != 0: unsat
discarded carry 1 != 0: unsat
discarded carry 2 != 0: unsat
discarded carry 3 != 0: unsat
top limb after 1st reduction > complement: unsat
value after 2nd reduction >= 2P: unsat
fully reduced result >= P: unsat
R-open: (h,t0) != x4*c: unsat
R-interior: (t_j,h_out) != h_in + xj*c: unsat
R-tail: post-fold total != state + x_lo: unsat
R-second: 2nd reduction != state + t4*c: unsat
R-final: conditional-subtract result != t mod P: unsat
```
