### PR TITLE
wire: Clarify some payload size names.

### DIFF
--- a/wire/blockheader.go
+++ b/wire/blockheader.go
@@ -15,7 +15,8 @@ import (
 	"lukechampine.com/blake3"
 )
 
-// MaxBlockHeaderPayload is the maximum number of bytes a block header can be.
+// MaxBlockHeaderPayload is the number of bytes a serialized block header is.
+// Every field is fixed width, so this is the exact size, not an upper bound.
 // Version 4 bytes + PrevBlock 32 bytes + MerkleRoot 32 bytes + StakeRoot 32
 // bytes + VoteBits 2 bytes + FinalState 6 bytes + Voters 2 bytes + FreshStake 1
 // byte + Revocations 1 bytes + PoolSize 4 bytes + Bits 4 bytes + SBits 8 bytes

--- a/wire/invvect.go
+++ b/wire/invvect.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2024 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -17,7 +17,9 @@ const (
 	// single Decred inv message.
 	MaxInvPerMsg = 50000
 
-	// Maximum payload size for an inventory vector.
+	// maxInvVectPayload is the serialized size of an inventory vector: a 4-byte
+	// type followed by a fixed-size hash.  Both fields are fixed width, so this
+	// is the exact payload size, not an upper bound.
 	maxInvVectPayload = 4 + chainhash.HashSize
 )
 

--- a/wire/msgcfheaders.go
+++ b/wire/msgcfheaders.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	// MaxCFHeaderPayload is the maximum byte size of a committed
-	// filter header.
+	// MaxCFHeaderPayload is the serialized byte size of a committed filter
+	// header.  A header is a single fixed-size hash, so this is the exact
+	// size, not an upper bound.
 	MaxCFHeaderPayload = chainhash.HashSize
 
 	// MaxCFHeadersPerMsg is the maximum number of committed filter headers


### PR DESCRIPTION
Some of the constants in the package are misleadingly prefixed "max" despite describing the exact size of a field rather than the upper bound.

maxInvVectPayload is renamed to clear this up, but MaxCFHeaderPayload and MaxBlockHeaderPayload are exported so these just have their comments updated to avoid a module major version bump.