### PR TITLE
wire: Add tests for MsgGetMiningState.

### DIFF
--- a/wire/msggetaddr_test.go
+++ b/wire/msggetaddr_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2019 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -47,7 +47,7 @@ func TestGetAddr(t *testing.T) {
 // protocol versions.
 func TestGetAddrWire(t *testing.T) {
 	msgGetAddr := NewMsgGetAddr()
-	msgGetAddrEncoded := []byte{}
+	var msgGetAddrEncoded []byte
 
 	tests := []struct {
 		in   *MsgGetAddr // Message to encode

--- a/wire/msggetcftypes_test.go
+++ b/wire/msggetcftypes_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 The Decred developers
+// Copyright (c) 2019-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -63,7 +63,7 @@ func TestGetCFTypes(t *testing.T) {
 // protocol versions.
 func TestGetCFTypesWire(t *testing.T) {
 	msgGetCFTypes := NewMsgGetCFTypes()
-	msgGetCFTypesEncoded := []byte{}
+	var msgGetCFTypesEncoded []byte
 
 	tests := []struct {
 		in   *MsgGetCFTypes // Message to encode

--- a/wire/msggetminingstate_test.go
+++ b/wire/msggetminingstate_test.go
@@ -1,5 +1,4 @@
-// Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2026 The Decred developers
+// Copyright (c) 2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -13,19 +12,19 @@ import (
 	"github.com/davecgh/go-spew/spew"
 )
 
-// TestVerAck tests the MsgVerAck API.
-func TestVerAck(t *testing.T) {
+// TestGetMiningState tests the MsgGetMiningState API.
+func TestGetMiningState(t *testing.T) {
 	pver := ProtocolVersion
 
 	// Ensure the command is expected value.
-	wantCmd := "verack"
-	msg := NewMsgVerAck()
+	wantCmd := "getminings"
+	msg := NewMsgGetMiningState()
 	if cmd := msg.Command(); cmd != wantCmd {
-		t.Errorf("NewMsgVerAck: wrong command - got %v want %v",
+		t.Errorf("NewMsgGetMiningState: wrong command - got %v want %v",
 			cmd, wantCmd)
 	}
 
-	// Ensure max payload is expected value.
+	// Ensure max payload is expected value for latest protocol version.
 	wantPayload := uint32(0)
 	maxPayload := msg.MaxPayloadLength(pver)
 	if maxPayload != wantPayload {
@@ -42,23 +41,23 @@ func TestVerAck(t *testing.T) {
 	}
 }
 
-// TestVerAckWire tests the MsgVerAck wire encode and decode for various
-// protocol versions.
-func TestVerAckWire(t *testing.T) {
-	msgVerAck := NewMsgVerAck()
-	var msgVerAckEncoded []byte
+// TestGetMiningStateWire tests the MsgGetMiningState wire encode and decode for
+// various protocol versions.
+func TestGetMiningStateWire(t *testing.T) {
+	msgGetMiningState := NewMsgGetMiningState()
+	var msgGetMiningStateEncoded []byte
 
 	tests := []struct {
-		in   *MsgVerAck // Message to encode
-		out  *MsgVerAck // Expected decoded message
-		buf  []byte     // Wire encoding
-		pver uint32     // Protocol version for wire encoding
+		in   *MsgGetMiningState // Message to encode
+		out  *MsgGetMiningState // Expected decoded message
+		buf  []byte             // Wire encoding
+		pver uint32             // Protocol version for wire encoding
 	}{
 		// Latest protocol version.
 		{
-			msgVerAck,
-			msgVerAck,
-			msgVerAckEncoded,
+			msgGetMiningState,
+			msgGetMiningState,
+			msgGetMiningStateEncoded,
 			ProtocolVersion,
 		},
 	}
@@ -79,7 +78,7 @@ func TestVerAckWire(t *testing.T) {
 		}
 
 		// Decode the message from wire format.
-		var msg MsgVerAck
+		var msg MsgGetMiningState
 		rbuf := bytes.NewReader(test.buf)
 		err = msg.BtcDecode(rbuf, test.pver)
 		if err != nil {

--- a/wire/msgsendheaders_test.go
+++ b/wire/msgsendheaders_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2016 The btcsuite developers
-// Copyright (c) 2019 The Decred developers
+// Copyright (c) 2019-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -129,7 +129,7 @@ func TestSendHeadersCrossProtocol(t *testing.T) {
 // various protocol versions.
 func TestSendHeadersWire(t *testing.T) {
 	msgSendHeaders := NewMsgSendHeaders()
-	msgSendHeadersEncoded := []byte{}
+	var msgSendHeadersEncoded []byte
 
 	tests := []struct {
 		in   *MsgSendHeaders // Message to encode


### PR DESCRIPTION
MsgGetMiningState is the only non-mixing wire message which did not have an accompanying test file. The tests added in this commit copy from the existing tests for message types with no message body.