### PR TITLE
wire: Rename assertion and remove return.

### DIFF
--- a/wire/common_test.go
+++ b/wire/common_test.go
@@ -1002,14 +1002,14 @@ func varBytesLen(l uint32) uint32 {
 	return uint32(VarIntSerializeSize(uint64(l))) + l
 }
 
-// expectedSerializationEqual compares serialized bytes to the expected
+// assertSerializationEqual compares serialized bytes to the expected
 // sequence of bytes.  When got and expected are not equal, the test t will be
 // errored with descriptive messages of how the two encodings are different.
-// Returns true if the serializations are equal, and false if the test
-// errors.
-func expectedSerializationEqual(t *testing.T, got, expected []byte) bool {
+func assertSerializationEqual(t *testing.T, got, expected []byte) {
+	t.Helper()
+
 	if bytes.Equal(got, expected) {
-		return true
+		return
 	}
 
 	t.Errorf("encoded message differs from expected serialization")
@@ -1031,5 +1031,4 @@ func expectedSerializationEqual(t *testing.T, got, expected []byte) bool {
 		t.Errorf("serialization prematurely ends at index %d, missing bytes [%x]",
 			len(got), expected[len(got):])
 	}
-	return false
 }

--- a/wire/msgmixciphertexts_test.go
+++ b/wire/msgmixciphertexts_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 The Decred developers
+// Copyright (c) 2023-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -68,7 +68,7 @@ func TestMsgMixCiphertextsWire(t *testing.T) {
 	expected = append(expected, repeat(0x8a, 32)...)
 	expected = append(expected, repeat(0x8b, 32)...)
 
-	expectedSerializationEqual(t, buf.Bytes(), expected)
+	assertSerializationEqual(t, buf.Bytes(), expected)
 
 	decodedCT := new(MsgMixCiphertexts)
 	err = decodedCT.BtcDecode(bytes.NewReader(buf.Bytes()), pver)

--- a/wire/msgmixconfirm_test.go
+++ b/wire/msgmixconfirm_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 The Decred developers
+// Copyright (c) 2023-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -67,7 +67,7 @@ func TestMsgMixConfirmWire(t *testing.T) {
 	expected = append(expected, repeat(0x86, 32)...)
 	expected = append(expected, repeat(0x87, 32)...)
 
-	expectedSerializationEqual(t, buf.Bytes(), expected)
+	assertSerializationEqual(t, buf.Bytes(), expected)
 
 	decodedCM := new(MsgMixConfirm)
 	err = decodedCM.BtcDecode(bytes.NewReader(buf.Bytes()), pver)

--- a/wire/msgmixdcnet_test.go
+++ b/wire/msgmixdcnet_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 The Decred developers
+// Copyright (c) 2023-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -92,7 +92,7 @@ func TestMsgMixDCNetWire(t *testing.T) {
 	expected = append(expected, repeat(0x96, 32)...)
 	expected = append(expected, repeat(0x97, 32)...)
 
-	expectedSerializationEqual(t, buf.Bytes(), expected)
+	assertSerializationEqual(t, buf.Bytes(), expected)
 
 	decodedDC := new(MsgMixDCNet)
 	err = decodedDC.BtcDecode(bytes.NewReader(buf.Bytes()), pver)

--- a/wire/msgmixfactoredpoly_test.go
+++ b/wire/msgmixfactoredpoly_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 The Decred developers
+// Copyright (c) 2024-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -76,7 +76,7 @@ func TestMsgMixFactoredPoly(t *testing.T) {
 	expected = append(expected, repeat(0x8A, 32)...)
 	expected = append(expected, repeat(0x8B, 32)...)
 
-	expectedSerializationEqual(t, buf.Bytes(), expected)
+	assertSerializationEqual(t, buf.Bytes(), expected)
 
 	decodedFP := new(MsgMixFactoredPoly)
 	err = decodedFP.BtcDecode(bytes.NewReader(buf.Bytes()), pver)

--- a/wire/msgmixkeyexchange_test.go
+++ b/wire/msgmixkeyexchange_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 The Decred developers
+// Copyright (c) 2023-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -68,7 +68,7 @@ func TestMsgMixKeyExchangeWire(t *testing.T) {
 	expected = append(expected, repeat(0x8a, 32)...)
 	expected = append(expected, repeat(0x8b, 32)...)
 
-	expectedSerializationEqual(t, buf.Bytes(), expected)
+	assertSerializationEqual(t, buf.Bytes(), expected)
 
 	decodedKE := new(MsgMixKeyExchange)
 	err = decodedKE.BtcDecode(bytes.NewReader(buf.Bytes()), pver)

--- a/wire/msgmixpairreq_test.go
+++ b/wire/msgmixpairreq_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 The Decred developers
+// Copyright (c) 2023-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -164,7 +164,7 @@ func TestMsgMixPairReqWire(t *testing.T) {
 	expected = append(expected, 0x95) // Flags
 	expected = append(expected, 0x96) // Pairing flags
 
-	expectedSerializationEqual(t, buf.Bytes(), expected)
+	assertSerializationEqual(t, buf.Bytes(), expected)
 
 	decodedPR := new(MsgMixPairReq)
 	err = decodedPR.BtcDecode(bytes.NewReader(buf.Bytes()), pver)

--- a/wire/msgmixsecrets_test.go
+++ b/wire/msgmixsecrets_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 The Decred developers
+// Copyright (c) 2023-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -87,7 +87,7 @@ func TestMsgMixSecretsWire(t *testing.T) {
 	expected = append(expected, repeat(0x8f, 32)...)
 	expected = append(expected, repeat(0x90, 32)...)
 
-	expectedSerializationEqual(t, buf.Bytes(), expected)
+	assertSerializationEqual(t, buf.Bytes(), expected)
 
 	decodedRS := new(MsgMixSecrets)
 	err = decodedRS.BtcDecode(bytes.NewReader(buf.Bytes()), pver)

--- a/wire/msgmixslotreserve_test.go
+++ b/wire/msgmixslotreserve_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 The Decred developers
+// Copyright (c) 2023-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -104,7 +104,7 @@ func TestMsgMixSlotReserveWire(t *testing.T) {
 	expected = append(expected, repeat(0x96, 32)...)
 	expected = append(expected, repeat(0x97, 32)...)
 
-	expectedSerializationEqual(t, buf.Bytes(), expected)
+	assertSerializationEqual(t, buf.Bytes(), expected)
 
 	decodedSR := new(MsgMixSlotReserve)
 	err = decodedSR.BtcDecode(bytes.NewReader(buf.Bytes()), pver)


### PR DESCRIPTION
Rename expectedSerializationEqual so it has the "assert" prefix, a common naming pattern in this repo. Tag it with t.Helper() so test failures arising from this func have more helpful error messages. Also remove the bool returned by the func because it was unused/unnecessary.