### PR TITLE
wire: Add SerializeSize to Message interface

### DIFF
--- a/wire/fakemessage_test.go
+++ b/wire/fakemessage_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -53,4 +53,10 @@ func (msg *fakeMessage) MaxPayloadLength(pver uint32) uint32 {
 	}
 
 	return lenp
+}
+
+// SerializeSize returns the length of the payload field of the fake message.
+// It satisfies the Message interface.
+func (msg *fakeMessage) SerializeSize() int {
+	return len(msg.payload)
 }

--- a/wire/message.go
+++ b/wire/message.go
@@ -100,6 +100,7 @@ type Message interface {
 	BtcEncode(io.Writer, uint32) error
 	Command() string
 	MaxPayloadLength(uint32) uint32
+	SerializeSize() int
 }
 
 // makeEmptyMessage creates a message of the appropriate concrete type based

--- a/wire/msgaddr.go
+++ b/wire/msgaddr.go
@@ -141,7 +141,20 @@ func (msg *MsgAddr) MaxPayloadLength(pver uint32) uint32 {
 	// Num addresses (size of varInt for max address per message) + max allowed
 	// addresses * max address size.
 	return uint32(VarIntSerializeSize(MaxAddrPerMsg)) +
-		(MaxAddrPerMsg * maxNetAddressPayload(pver))
+		(MaxAddrPerMsg * maxNetAddressPayload)
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgAddr) SerializeSize() int {
+	// Num addresses (varInt) + total size of the addresses.  Each network
+	// address in an addr message is serialized with a timestamp.
+	n := VarIntSerializeSize(uint64(len(msg.AddrList)))
+	for _, na := range msg.AddrList {
+		const includeTimestamp = true
+		n += na.SerializeSize(includeTimestamp)
+	}
+	return n
 }
 
 // NewMsgAddr returns a new bitcoin addr message that conforms to the

--- a/wire/msgaddr_test.go
+++ b/wire/msgaddr_test.go
@@ -166,6 +166,14 @@ func TestAddrWire(t *testing.T) {
 			continue
 		}
 
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
+		}
+
 		// Decode the message from wire format.
 		var msg MsgAddr
 		rbuf := bytes.NewReader(test.buf)

--- a/wire/msgaddrv2.go
+++ b/wire/msgaddrv2.go
@@ -223,20 +223,10 @@ func (msg *MsgAddrV2) Command() string {
 	return CmdAddrV2
 }
 
-// maxNetAddressPayloadV2 returns the max payload size for a network address
-// based on the protocol version.
-func maxNetAddressPayloadV2() uint32 {
-	const (
-		timestampSize   = 8
-		servicesSize    = 8
-		addressTypeSize = 1
-		portSize        = 2
-	)
-
-	const maxAddressSize = 32 // TorV3 is a 32-byte pubkey
-	return timestampSize + servicesSize + addressTypeSize + maxAddressSize +
-		portSize
-}
+// maxNetAddressPayloadV2 returns the max payload size for a NetAddressV2.
+// Timestamp 8 bytes + services 8 bytes + address type 1 byte +
+// TorV3 address 32 bytes + port 2 bytes.
+const maxNetAddressPayloadV2 = 51
 
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
@@ -245,7 +235,18 @@ func (msg *MsgAddrV2) MaxPayloadLength(pver uint32) uint32 {
 		return 0
 	}
 	return uint32(VarIntSerializeSize(MaxAddrPerV2Msg)) +
-		(MaxAddrPerV2Msg * maxNetAddressPayloadV2())
+		(MaxAddrPerV2Msg * maxNetAddressPayloadV2)
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgAddrV2) SerializeSize() int {
+	// Num addresses (varInt) + total size of the addresses.
+	n := VarIntSerializeSize(uint64(len(msg.AddrList)))
+	for i := range msg.AddrList {
+		n += msg.AddrList[i].SerializeSize()
+	}
+	return n
 }
 
 // NewMsgAddrV2 returns a new wire addrv2 message that conforms to the

--- a/wire/msgaddrv2_test.go
+++ b/wire/msgaddrv2_test.go
@@ -196,6 +196,14 @@ func TestAddrV2Wire(t *testing.T) {
 			continue
 		}
 
+		// Ensure the serialize size is the actual encoded size.
+		sz := subject.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
+		}
+
 		// Decode the message from the wire format and ensure it deserializes
 		// correctly.
 		var msg MsgAddrV2

--- a/wire/msgblock.go
+++ b/wire/msgblock.go
@@ -311,7 +311,7 @@ func (msg *MsgBlock) Bytes() ([]byte, error) {
 }
 
 // SerializeSize returns the number of bytes it would take to serialize the
-// block.
+// block.  This is part of the Message interface implementation.
 func (msg *MsgBlock) SerializeSize() int {
 	// Check to make sure that all transactions have the correct
 	// type and version to be included in a block.

--- a/wire/msgcfheaders.go
+++ b/wire/msgcfheaders.go
@@ -176,6 +176,16 @@ func (msg *MsgCFHeaders) MaxPayloadLength(pver uint32) uint32 {
 		(MaxCFHeaderPayload * MaxCFHeadersPerMsg)
 }
 
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgCFHeaders) SerializeSize() int {
+	// Stop hash + filter type 1 byte + num headers (varInt) + (header hash
+	// size * num headers).
+	return chainhash.HashSize + 1 +
+		VarIntSerializeSize(uint64(len(msg.HeaderHashes))) +
+		len(msg.HeaderHashes)*MaxCFHeaderPayload
+}
+
 // NewMsgCFHeaders returns a new cfheaders message that conforms to the Message
 // interface. See MsgCFHeaders for details.
 //

--- a/wire/msgcfheaders_test.go
+++ b/wire/msgcfheaders_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 The Decred developers
+// Copyright (c) 2019-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -176,6 +176,14 @@ func TestCFHeadersWire(t *testing.T) {
 			t.Errorf("BtcEncode #%d\n got: %s want: %s", i,
 				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
 			continue
+		}
+
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
 		}
 
 		// Decode the message from wire format.

--- a/wire/msgcfilter.go
+++ b/wire/msgcfilter.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2017 The btcsuite developers
 // Copyright (c) 2017 The Lightning Network Developers
-// Copyright (c) 2018-2024 The Decred developers
+// Copyright (c) 2018-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -114,6 +114,14 @@ func (msg *MsgCFilter) Command() string {
 func (msg *MsgCFilter) MaxPayloadLength(pver uint32) uint32 {
 	return uint32(VarIntSerializeSize(MaxCFilterDataSize)) +
 		MaxCFilterDataSize + chainhash.HashSize + 1
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgCFilter) SerializeSize() int {
+	// Block hash + filter type 1 byte + filter data (varInt + data).
+	return chainhash.HashSize + 1 +
+		VarIntSerializeSize(uint64(len(msg.Data))) + len(msg.Data)
 }
 
 // NewMsgCFilter returns a new cfilter message that conforms to the Message

--- a/wire/msgcfilter_test.go
+++ b/wire/msgcfilter_test.go
@@ -137,6 +137,14 @@ func TestCFilterWire(t *testing.T) {
 			continue
 		}
 
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
+		}
+
 		// Decode the message from wire format.
 		var msg MsgCFilter
 		rbuf := bytes.NewReader(test.buf)

--- a/wire/msgcfiltersv2.go
+++ b/wire/msgcfiltersv2.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 The Decred developers
+// Copyright (c) 2024-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -154,6 +154,17 @@ func (msg *MsgCFiltersV2) MaxPayloadLength(pver uint32) uint32 {
 			MaxCFilterDataSize+4+
 			uint32(VarIntSerializeSize(MaxHeaderProofHashes))+
 			(MaxHeaderProofHashes*chainhash.HashSize))*uint32(MaxCFiltersV2PerBatch)
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgCFiltersV2) SerializeSize() int {
+	// Num cfilters (varInt) + total size of the individual cfilter messages.
+	n := VarIntSerializeSize(uint64(len(msg.CFilters)))
+	for i := range msg.CFilters {
+		n += msg.CFilters[i].SerializeSize()
+	}
+	return n
 }
 
 // NewMsgCFiltersV2 returns a new cfiltersv2 message that conforms to the

--- a/wire/msgcfiltersv2_test.go
+++ b/wire/msgcfiltersv2_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 The Decred developers
+// Copyright (c) 2024-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -186,6 +186,14 @@ func TestCFiltersV2Wire(t *testing.T) {
 			t.Errorf("BtcEncode #%d\n got: %s want: %s", i,
 				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
 			continue
+		}
+
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
 		}
 
 		// Decode the message from wire format.

--- a/wire/msgcfilterv2.go
+++ b/wire/msgcfilterv2.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 The Decred developers
+// Copyright (c) 2024-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -151,6 +151,17 @@ func (msg *MsgCFilterV2) MaxPayloadLength(pver uint32) uint32 {
 		MaxCFilterDataSize + 4 +
 		uint32(VarIntSerializeSize(MaxHeaderProofHashes)) +
 		(MaxHeaderProofHashes * chainhash.HashSize)
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgCFilterV2) SerializeSize() int {
+	// Block hash + filter data (varInt + data) + proof index 4 bytes +
+	// num proof hashes (varInt) + proof hashes.
+	return chainhash.HashSize +
+		VarIntSerializeSize(uint64(len(msg.Data))) + len(msg.Data) + 4 +
+		VarIntSerializeSize(uint64(len(msg.ProofHashes))) +
+		len(msg.ProofHashes)*chainhash.HashSize
 }
 
 // NewMsgCFilterV2 returns a new cfilterv2 message that conforms to the Message

--- a/wire/msgcfilterv2_test.go
+++ b/wire/msgcfilterv2_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 The Decred developers
+// Copyright (c) 2019-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -193,6 +193,14 @@ func TestCFilterV2Wire(t *testing.T) {
 			t.Errorf("BtcEncode #%d\n got: %s want: %s", i,
 				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
 			continue
+		}
+
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
 		}
 
 		// Decode the message from wire format.

--- a/wire/msgcftypes.go
+++ b/wire/msgcftypes.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2017 The btcsuite developers
 // Copyright (c) 2017 The Lightning Network Developers
-// Copyright (c) 2018-2024 The Decred developers
+// Copyright (c) 2018-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -128,6 +128,14 @@ func (msg *MsgCFTypes) MaxPayloadLength(pver uint32) uint32 {
 	// 3 bytes for filter count, 1 byte up to 256 bytes filter types.
 	return uint32(VarIntSerializeSize(MaxFilterTypesPerMsg)) +
 		MaxFilterTypesPerMsg
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgCFTypes) SerializeSize() int {
+	// Num filter types (varInt) + 1 byte per filter type.
+	return VarIntSerializeSize(uint64(len(msg.SupportedFilters))) +
+		len(msg.SupportedFilters)
 }
 
 // NewMsgCFTypes returns a new cftypes message that conforms to the Message

--- a/wire/msgcftypes_test.go
+++ b/wire/msgcftypes_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 The Decred developers
+// Copyright (c) 2019-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -147,6 +147,14 @@ func TestCFTypesWire(t *testing.T) {
 			t.Errorf("BtcEncode #%d\n got: %s want: %s", i,
 				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
 			continue
+		}
+
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
 		}
 
 		// Decode the message from wire format.

--- a/wire/msgfeefilter.go
+++ b/wire/msgfeefilter.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2016 The btcsuite developers
-// Copyright (c) 2017-2020 The Decred developers
+// Copyright (c) 2017-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -55,6 +55,13 @@ func (msg *MsgFeeFilter) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgFeeFilter) MaxPayloadLength(pver uint32) uint32 {
+	// 8 bytes min fee.
+	return 8
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgFeeFilter) SerializeSize() int {
 	// 8 bytes min fee.
 	return 8
 }

--- a/wire/msgfeefilter_test.go
+++ b/wire/msgfeefilter_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2017-2020 The Decred developers
+// Copyright (c) 2017-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -109,6 +109,14 @@ func TestFeeFilterWire(t *testing.T) {
 			t.Errorf("BtcEncode #%d\n got: %s want: %s", i,
 				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
 			continue
+		}
+
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
 		}
 
 		// Decode the message from wire format.

--- a/wire/msggetaddr.go
+++ b/wire/msggetaddr.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -38,6 +38,13 @@ func (msg *MsgGetAddr) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgGetAddr) MaxPayloadLength(pver uint32) uint32 {
+	return 0
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgGetAddr) SerializeSize() int {
+	// Empty message.
 	return 0
 }
 

--- a/wire/msggetaddr_test.go
+++ b/wire/msggetaddr_test.go
@@ -79,6 +79,14 @@ func TestGetAddrWire(t *testing.T) {
 			continue
 		}
 
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
+		}
+
 		// Decode the message from wire format.
 		var msg MsgGetAddr
 		rbuf := bytes.NewReader(test.buf)

--- a/wire/msggetblocks.go
+++ b/wire/msggetblocks.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -130,6 +130,15 @@ func (msg *MsgGetBlocks) MaxPayloadLength(pver uint32) uint32 {
 	// locator hashes + hash stop.
 	return 4 + uint32(VarIntSerializeSize(MaxBlockLocatorsPerMsg)) +
 		(MaxBlockLocatorsPerMsg * chainhash.HashSize) + chainhash.HashSize
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgGetBlocks) SerializeSize() int {
+	// Protocol version 4 bytes + num hashes (varInt) + block locator hashes +
+	// hash stop.
+	return 4 + VarIntSerializeSize(uint64(len(msg.BlockLocatorHashes))) +
+		len(msg.BlockLocatorHashes)*chainhash.HashSize + chainhash.HashSize
 }
 
 // NewMsgGetBlocks returns a new Decred getblocks message that conforms to the

--- a/wire/msggetblocks_test.go
+++ b/wire/msggetblocks_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -186,6 +186,14 @@ func TestGetBlocksWire(t *testing.T) {
 			t.Errorf("BtcEncode #%d\n got: %s want: %s", i,
 				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
 			continue
+		}
+
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
 		}
 
 		// Decode the message from wire format.

--- a/wire/msggetcfheaders.go
+++ b/wire/msggetcfheaders.go
@@ -133,6 +133,15 @@ func (msg *MsgGetCFHeaders) MaxPayloadLength(pver uint32) uint32 {
 		(MaxBlockLocatorsPerMsg * chainhash.HashSize) + chainhash.HashSize + 1
 }
 
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgGetCFHeaders) SerializeSize() int {
+	// Num block locator hashes (varInt) + block locator hashes + hash stop +
+	// filter type 1 byte.
+	return VarIntSerializeSize(uint64(len(msg.BlockLocatorHashes))) +
+		len(msg.BlockLocatorHashes)*chainhash.HashSize + chainhash.HashSize + 1
+}
+
 // NewMsgGetCFHeaders returns a new getcfheader message that conforms to the
 // Message interface using the passed parameters and defaults for the remaining
 // fields.

--- a/wire/msggetcfheaders_test.go
+++ b/wire/msggetcfheaders_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 The Decred developers
+// Copyright (c) 2019-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -196,6 +196,14 @@ func TestGetCFHeadersWire(t *testing.T) {
 			t.Errorf("BtcEncode #%d\n got: %s want: %s", i,
 				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
 			continue
+		}
+
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
 		}
 
 		// Decode the message from wire format.

--- a/wire/msggetcfilter.go
+++ b/wire/msggetcfilter.go
@@ -70,6 +70,13 @@ func (msg *MsgGetCFilter) MaxPayloadLength(pver uint32) uint32 {
 	return chainhash.HashSize + 1
 }
 
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgGetCFilter) SerializeSize() int {
+	// Block hash + filter type.
+	return chainhash.HashSize + 1
+}
+
 // NewMsgGetCFilter returns a new getcfilter message that conforms to the
 // Message interface using the passed parameters and defaults for the remaining
 // fields.

--- a/wire/msggetcfilter_test.go
+++ b/wire/msggetcfilter_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 The Decred developers
+// Copyright (c) 2019-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -139,6 +139,14 @@ func TestGetCFilterWire(t *testing.T) {
 			t.Errorf("BtcEncode #%d\n got: %s want: %s", i,
 				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
 			continue
+		}
+
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
 		}
 
 		// Decode the message from wire format.

--- a/wire/msggetcfilterv2.go
+++ b/wire/msggetcfilterv2.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 The Decred developers
+// Copyright (c) 2024-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -56,6 +56,13 @@ func (msg *MsgGetCFilterV2) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgGetCFilterV2) MaxPayloadLength(pver uint32) uint32 {
+	// Block hash.
+	return chainhash.HashSize
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgGetCFilterV2) SerializeSize() int {
 	// Block hash.
 	return chainhash.HashSize
 }

--- a/wire/msggetcfilterv2_test.go
+++ b/wire/msggetcfilterv2_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 The Decred developers
+// Copyright (c) 2019-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -156,6 +156,14 @@ func TestGetCFilterV2Wire(t *testing.T) {
 			t.Errorf("BtcEncode #%d\n got: %s want: %s", i,
 				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
 			continue
+		}
+
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
 		}
 
 		// Decode the message from wire format.

--- a/wire/msggetcfsv2.go
+++ b/wire/msggetcfsv2.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 The Decred developers
+// Copyright (c) 2024-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -60,6 +60,13 @@ func (msg *MsgGetCFsV2) Command() string {
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgGetCFsV2) MaxPayloadLength(pver uint32) uint32 {
 	// Block hash.
+	return chainhash.HashSize * 2
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgGetCFsV2) SerializeSize() int {
+	// Start hash + end hash.
 	return chainhash.HashSize * 2
 }
 

--- a/wire/msggetcfsv2_test.go
+++ b/wire/msggetcfsv2_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 The Decred developers
+// Copyright (c) 2024-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -168,6 +168,14 @@ func TestGetCFiltersV2Wire(t *testing.T) {
 			t.Errorf("BtcEncode #%d\n got: %s want: %s", i,
 				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
 			continue
+		}
+
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
 		}
 
 		// Decode the message from wire format.

--- a/wire/msggetcftypes.go
+++ b/wire/msggetcftypes.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2017 The btcsuite developers
 // Copyright (c) 2017 The Lightning Network Developers
-// Copyright (c) 2018-2024 The Decred developers
+// Copyright (c) 2018-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -52,6 +52,13 @@ func (msg *MsgGetCFTypes) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgGetCFTypes) MaxPayloadLength(pver uint32) uint32 {
+	// Empty message.
+	return 0
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgGetCFTypes) SerializeSize() int {
 	// Empty message.
 	return 0
 }

--- a/wire/msggetcftypes_test.go
+++ b/wire/msggetcftypes_test.go
@@ -103,6 +103,14 @@ func TestGetCFTypesWire(t *testing.T) {
 			continue
 		}
 
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
+		}
+
 		// Decode the message from wire format.
 		var msg MsgGetCFTypes
 		rbuf := bytes.NewReader(test.buf)

--- a/wire/msggetdata.go
+++ b/wire/msggetdata.go
@@ -108,6 +108,14 @@ func (msg *MsgGetData) MaxPayloadLength(pver uint32) uint32 {
 		(MaxInvPerMsg * maxInvVectPayload)
 }
 
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgGetData) SerializeSize() int {
+	// Num inventory vectors (varInt) + total size of the inventory vectors.
+	return VarIntSerializeSize(uint64(len(msg.InvList))) +
+		len(msg.InvList)*maxInvVectPayload
+}
+
 // NewMsgGetData returns a new Decred getdata message that conforms to the
 // Message interface.  See MsgGetData for details.
 func NewMsgGetData() *MsgGetData {

--- a/wire/msggetdata_test.go
+++ b/wire/msggetdata_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -157,6 +157,14 @@ func TestGetDataWire(t *testing.T) {
 			t.Errorf("BtcEncode #%d\n got: %s want: %s", i,
 				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
 			continue
+		}
+
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
 		}
 
 		// Decode the message from wire format.

--- a/wire/msggetheaders.go
+++ b/wire/msggetheaders.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -129,6 +129,15 @@ func (msg *MsgGetHeaders) MaxPayloadLength(pver uint32) uint32 {
 	// block locators + hash stop.
 	return 4 + uint32(VarIntSerializeSize(MaxBlockLocatorsPerMsg)) +
 		(MaxBlockLocatorsPerMsg * chainhash.HashSize) + chainhash.HashSize
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgGetHeaders) SerializeSize() int {
+	// Protocol version 4 bytes + num block locator hashes (varInt) + block
+	// locator hashes + hash stop.
+	return 4 + VarIntSerializeSize(uint64(len(msg.BlockLocatorHashes))) +
+		len(msg.BlockLocatorHashes)*chainhash.HashSize + chainhash.HashSize
 }
 
 // NewMsgGetHeaders returns a new Decred getheaders message that conforms to

--- a/wire/msggetheaders_test.go
+++ b/wire/msggetheaders_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -176,6 +176,14 @@ func TestGetHeadersWire(t *testing.T) {
 			t.Errorf("BtcEncode #%d\n got: %s want: %s", i,
 				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
 			continue
+		}
+
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
 		}
 
 		// Decode the message from wire format.

--- a/wire/msggetinitstate.go
+++ b/wire/msggetinitstate.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 The decred developers
+// Copyright (c) 2020-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -175,6 +175,18 @@ func (msg *MsgGetInitState) MaxPayloadLength(pver uint32) uint32 {
 		MaxInitStateTypeLen
 	return uint32(VarIntSerializeSize(MaxInitStateTypes) +
 		MaxInitStateTypes*maxLenType)
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgGetInitState) SerializeSize() int {
+	// Num types (varInt) + for each type its serialized length (varInt +
+	// string).
+	n := VarIntSerializeSize(uint64(len(msg.Types)))
+	for _, typ := range msg.Types {
+		n += VarIntSerializeSize(uint64(len(typ))) + len(typ)
+	}
+	return n
 }
 
 // NewMsgGetInitState returns a new Decred getinitialstate message that

--- a/wire/msggetinitstate_test.go
+++ b/wire/msggetinitstate_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Decred developers
+// Copyright (c) 2020-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -125,6 +125,14 @@ func TestGetInitStateWire(t *testing.T) {
 			t.Errorf("BtcEncode #%d - got %s, want: %s", i,
 				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
 			continue
+		}
+
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
 		}
 
 		// Decode the message from wire format.

--- a/wire/msggetminingstate.go
+++ b/wire/msggetminingstate.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -35,6 +35,13 @@ func (msg *MsgGetMiningState) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgGetMiningState) MaxPayloadLength(pver uint32) uint32 {
+	return 0
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgGetMiningState) SerializeSize() int {
+	// Empty message.
 	return 0
 }
 

--- a/wire/msggetminingstate_test.go
+++ b/wire/msggetminingstate_test.go
@@ -77,6 +77,14 @@ func TestGetMiningStateWire(t *testing.T) {
 			continue
 		}
 
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
+		}
+
 		// Decode the message from wire format.
 		var msg MsgGetMiningState
 		rbuf := bytes.NewReader(test.buf)

--- a/wire/msgheaders.go
+++ b/wire/msgheaders.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -130,6 +130,15 @@ func (msg *MsgHeaders) MaxPayloadLength(pver uint32) uint32 {
 	// 1 byte for the number of transactions which is always 0).
 	return uint32(VarIntSerializeSize(MaxBlockHeadersPerMsg)) +
 		((MaxBlockHeaderPayload + 1) * MaxBlockHeadersPerMsg)
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgHeaders) SerializeSize() int {
+	// Num headers (varInt) + for each header the block header bytes plus
+	// 1 byte for the number of transactions which is always 0.
+	return VarIntSerializeSize(uint64(len(msg.Headers))) +
+		len(msg.Headers)*(blockHeaderLen+1)
 }
 
 // NewMsgHeaders returns a new Decred headers message that conforms to the

--- a/wire/msgheaders_test.go
+++ b/wire/msgheaders_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -171,6 +171,14 @@ func TestHeadersWire(t *testing.T) {
 			t.Errorf("BtcEncode #%d\n got: %s want: %s", i,
 				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
 			continue
+		}
+
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
 		}
 
 		// Decode the message from wire format.

--- a/wire/msginitstate.go
+++ b/wire/msginitstate.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 The Decred developers
+// Copyright (c) 2020-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -239,6 +239,19 @@ func (msg *MsgInitState) MaxPayloadLength(pver uint32) uint32 {
 		(MaxISVotesAtHeadPerMsg * chainhash.HashSize) +
 		uint32(VarIntSerializeSize(MaxISTSpendsAtHeadPerMsg)) +
 		(MaxISTSpendsAtHeadPerMsg * chainhash.HashSize)
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgInitState) SerializeSize() int {
+	// Num block hashes (varInt) + block hashes + num vote hashes (varInt) +
+	// vote hashes + num tspend hashes (varInt) + tspend hashes.
+	return VarIntSerializeSize(uint64(len(msg.BlockHashes))) +
+		len(msg.BlockHashes)*chainhash.HashSize +
+		VarIntSerializeSize(uint64(len(msg.VoteHashes))) +
+		len(msg.VoteHashes)*chainhash.HashSize +
+		VarIntSerializeSize(uint64(len(msg.TSpendHashes))) +
+		len(msg.TSpendHashes)*chainhash.HashSize
 }
 
 // NewMsgInitState returns a new Decred initstate message that conforms to the

--- a/wire/msginitstate_test.go
+++ b/wire/msginitstate_test.go
@@ -218,6 +218,14 @@ func TestInitStateWire(t *testing.T) {
 			continue
 		}
 
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
+		}
+
 		// Decode the message from wire format.
 		var msg MsgInitState
 		rbuf := bytes.NewReader(test.buf)

--- a/wire/msginv.go
+++ b/wire/msginv.go
@@ -116,6 +116,14 @@ func (msg *MsgInv) MaxPayloadLength(pver uint32) uint32 {
 		maxInvVectPayload)
 }
 
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgInv) SerializeSize() int {
+	// Num inventory vectors (varInt) + total size of the inventory vectors.
+	return VarIntSerializeSize(uint64(len(msg.InvList))) +
+		len(msg.InvList)*maxInvVectPayload
+}
+
 // NewMsgInv returns a new Decred inv message that conforms to the Message
 // interface.  See MsgInv for details.
 func NewMsgInv() *MsgInv {

--- a/wire/msginv_test.go
+++ b/wire/msginv_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -157,6 +157,14 @@ func TestInvWire(t *testing.T) {
 			t.Errorf("BtcEncode #%d\n got: %s want: %s", i,
 				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
 			continue
+		}
+
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
 		}
 
 		// Decode the message from wire format.

--- a/wire/msgmempool.go
+++ b/wire/msgmempool.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -38,6 +38,13 @@ func (msg *MsgMemPool) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgMemPool) MaxPayloadLength(pver uint32) uint32 {
+	return 0
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgMemPool) SerializeSize() int {
+	// Empty message.
 	return 0
 }
 

--- a/wire/msgmempool_test.go
+++ b/wire/msgmempool_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2019 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -42,6 +42,13 @@ func TestMemPool(t *testing.T) {
 	err := msg.BtcEncode(&buf, pver)
 	if err != nil {
 		t.Errorf("encode of MsgMemPool failed %v err <%v>", msg, err)
+	}
+
+	// Ensure the serialize size is the actual encoded size.
+	sz := msg.SerializeSize()
+	actualSz := len(buf.Bytes())
+	if sz != actualSz {
+		t.Errorf("Wrong serialize size - got: %d want: %d", sz, actualSz)
 	}
 
 	// Test decode with latest protocol version.

--- a/wire/msgminingstate.go
+++ b/wire/msgminingstate.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -191,6 +191,17 @@ func (msg *MsgMiningState) MaxPayloadLength(pver uint32) uint32 {
 		(MaxMSBlocksAtHeadPerMsg * chainhash.HashSize) +
 		uint32(VarIntSerializeSize(MaxMSVotesAtHeadPerMsg)) +
 		(MaxMSVotesAtHeadPerMsg * chainhash.HashSize)
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgMiningState) SerializeSize() int {
+	// Protocol version 4 bytes + height 4 bytes + num block hashes (varInt) +
+	// block hashes + num vote hashes (varInt) + vote hashes.
+	return 4 + 4 + VarIntSerializeSize(uint64(len(msg.BlockHashes))) +
+		len(msg.BlockHashes)*chainhash.HashSize +
+		VarIntSerializeSize(uint64(len(msg.VoteHashes))) +
+		len(msg.VoteHashes)*chainhash.HashSize
 }
 
 // NewMsgMiningState returns a new Decred miningstate message that conforms to

--- a/wire/msgminingstate_test.go
+++ b/wire/msgminingstate_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2025 The Decred developers
+// Copyright (c) 2019-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -141,6 +141,14 @@ func TestMiningStateWire(t *testing.T) {
 			t.Errorf("BtcEncode #%d\n got: %s want: %s", i,
 				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
 			continue
+		}
+
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
 		}
 
 		// Decode the message from wire format.

--- a/wire/msgmixciphertexts.go
+++ b/wire/msgmixciphertexts.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 The Decred developers
+// Copyright (c) 2023-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -196,6 +196,20 @@ func (msg *MsgMixCiphertexts) MaxPayloadLength(pver uint32) uint32 {
 
 	// See tests for this calculation.
 	return 552584
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgMixCiphertexts) SerializeSize() int {
+	// Signature 64 bytes + identity 33 bytes + session id 32 bytes +
+	// run 4 bytes.
+	const fixedSize = 64 + 33 + 32 + 4
+
+	// Fixed fields + count (varInt) + ciphertexts (1047 bytes each) +
+	// seen key exchange hashes.
+	return fixedSize + VarIntSerializeSize(uint64(len(msg.Ciphertexts))) +
+		len(msg.Ciphertexts)*1047 +
+		len(msg.SeenKeyExchanges)*chainhash.HashSize
 }
 
 // Pub returns the message sender's public key identity.

--- a/wire/msgmixciphertexts_test.go
+++ b/wire/msgmixciphertexts_test.go
@@ -70,6 +70,13 @@ func TestMsgMixCiphertextsWire(t *testing.T) {
 
 	assertSerializationEqual(t, buf.Bytes(), expected)
 
+	// Ensure the serialize size is the actual encoded size.
+	sz := ct.SerializeSize()
+	actualSz := len(buf.Bytes())
+	if sz != actualSz {
+		t.Errorf("Wrong serialize size - got: %d want: %d", sz, actualSz)
+	}
+
 	decodedCT := new(MsgMixCiphertexts)
 	err = decodedCT.BtcDecode(bytes.NewReader(buf.Bytes()), pver)
 	if err != nil {

--- a/wire/msgmixconfirm.go
+++ b/wire/msgmixconfirm.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 The Decred developers
+// Copyright (c) 2023-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -187,6 +187,20 @@ func (msg *MsgMixConfirm) MaxPayloadLength(pver uint32) uint32 {
 
 	// See tests for this calculation.
 	return 1016520
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgMixConfirm) SerializeSize() int {
+	// Signature 64 bytes + identity 33 bytes + session id 32 bytes +
+	// run 4 bytes.
+	const fixedSize = 64 + 33 + 32 + 4
+
+	// Fixed fields + mix transaction + num seen DC-net messages (varInt) +
+	// seen DC-net hashes.
+	return fixedSize + msg.Mix.SerializeSize() +
+		VarIntSerializeSize(uint64(len(msg.SeenDCNets))) +
+		len(msg.SeenDCNets)*chainhash.HashSize
 }
 
 // Pub returns the message sender's public key identity.

--- a/wire/msgmixconfirm_test.go
+++ b/wire/msgmixconfirm_test.go
@@ -69,6 +69,13 @@ func TestMsgMixConfirmWire(t *testing.T) {
 
 	assertSerializationEqual(t, buf.Bytes(), expected)
 
+	// Ensure the serialize size is the actual encoded size.
+	sz := cm.SerializeSize()
+	actualSz := len(buf.Bytes())
+	if sz != actualSz {
+		t.Errorf("Wrong serialize size - got: %d want: %d", sz, actualSz)
+	}
+
 	decodedCM := new(MsgMixConfirm)
 	err = decodedCM.BtcDecode(bytes.NewReader(buf.Bytes()), pver)
 	if err != nil {

--- a/wire/msgmixdcnet.go
+++ b/wire/msgmixdcnet.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 The Decred developers
+// Copyright (c) 2023-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -267,6 +267,32 @@ func (msg *MsgMixDCNet) MaxPayloadLength(pver uint32) uint32 {
 
 	// See tests for this calculation.
 	return 20988047
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgMixDCNet) SerializeSize() int {
+	// Signature 64 bytes + identity 33 bytes + session id 32 bytes +
+	// run 4 bytes.
+	const fixedSize = 64 + 33 + 32 + 4
+
+	// Fixed fields + DC-net mix vectors, which are serialized as the number of
+	// vectors (varInt) and, when non-empty, the vector length and message size
+	// varInts plus the fixed-size messages themselves.
+	n := fixedSize + VarIntSerializeSize(uint64(len(msg.DCNet)))
+	if len(msg.DCNet) > 0 {
+		n += VarIntSerializeSize(uint64(len(msg.DCNet[0]))) +
+			VarIntSerializeSize(MixMsgSize)
+		for i := range msg.DCNet {
+			n += len(msg.DCNet[i]) * MixMsgSize
+		}
+	}
+
+	// Num seen slot reserve messages (varInt) + seen slot reserve hashes.
+	n += VarIntSerializeSize(uint64(len(msg.SeenSlotReserves))) +
+		len(msg.SeenSlotReserves)*chainhash.HashSize
+
+	return n
 }
 
 // Pub returns the message sender's public key identity.

--- a/wire/msgmixdcnet_test.go
+++ b/wire/msgmixdcnet_test.go
@@ -94,6 +94,13 @@ func TestMsgMixDCNetWire(t *testing.T) {
 
 	assertSerializationEqual(t, buf.Bytes(), expected)
 
+	// Ensure the serialize size is the actual encoded size.
+	sz := dc.SerializeSize()
+	actualSz := len(buf.Bytes())
+	if sz != actualSz {
+		t.Errorf("Wrong serialize size - got: %d want: %d", sz, actualSz)
+	}
+
 	decodedDC := new(MsgMixDCNet)
 	err = decodedDC.BtcDecode(bytes.NewReader(buf.Bytes()), pver)
 	if err != nil {

--- a/wire/msgmixfactoredpoly.go
+++ b/wire/msgmixfactoredpoly.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 The Decred developers
+// Copyright (c) 2024-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -216,6 +216,27 @@ func (msg *MsgMixFactoredPoly) MaxPayloadLength(pver uint32) uint32 {
 
 	// See tests for this calculation.
 	return 49291
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgMixFactoredPoly) SerializeSize() int {
+	// Signature 64 bytes + identity 33 bytes + session id 32 bytes +
+	// run 4 bytes.
+	const fixedSize = 64 + 33 + 32 + 4
+
+	// Fixed fields + num roots (varInt) + roots (each a varInt-prefixed byte
+	// slice).
+	n := fixedSize + VarIntSerializeSize(uint64(len(msg.Roots)))
+	for _, root := range msg.Roots {
+		n += VarIntSerializeSize(uint64(len(root))) + len(root)
+	}
+
+	// Num seen slot reserve messages (varInt) + seen slot reserve hashes.
+	n += VarIntSerializeSize(uint64(len(msg.SeenSlotReserves))) +
+		len(msg.SeenSlotReserves)*chainhash.HashSize
+
+	return n
 }
 
 // Pub returns the message sender's public key identity.

--- a/wire/msgmixfactoredpoly_test.go
+++ b/wire/msgmixfactoredpoly_test.go
@@ -78,6 +78,13 @@ func TestMsgMixFactoredPoly(t *testing.T) {
 
 	assertSerializationEqual(t, buf.Bytes(), expected)
 
+	// Ensure the serialize size is the actual encoded size.
+	sz := fp.SerializeSize()
+	actualSz := len(buf.Bytes())
+	if sz != actualSz {
+		t.Errorf("Wrong serialize size - got: %d want: %d", sz, actualSz)
+	}
+
 	decodedFP := new(MsgMixFactoredPoly)
 	err = decodedFP.BtcDecode(bytes.NewReader(buf.Bytes()), pver)
 	if err != nil {

--- a/wire/msgmixkeyexchange.go
+++ b/wire/msgmixkeyexchange.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 The Decred developers
+// Copyright (c) 2023-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -191,6 +191,19 @@ func (msg *MsgMixKeyExchange) MaxPayloadLength(pver uint32) uint32 {
 
 	// See tests for this calculation.
 	return 17815
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgMixKeyExchange) SerializeSize() int {
+	// Signature 64 bytes + identity 33 bytes + session id 32 bytes +
+	// epoch 8 bytes + run 4 bytes + pos 4 bytes + ECDH public key 33 bytes +
+	// PQ public key 1218 bytes + commitment 32 bytes.
+	const fixedSize = 64 + 33 + 32 + 8 + 4 + 4 + 33 + 1218 + 32
+
+	// Fixed fields + num seen PRs (varInt) + seen PR hashes.
+	return fixedSize + VarIntSerializeSize(uint64(len(msg.SeenPRs))) +
+		len(msg.SeenPRs)*chainhash.HashSize
 }
 
 // Pub returns the message sender's public key identity.

--- a/wire/msgmixkeyexchange_test.go
+++ b/wire/msgmixkeyexchange_test.go
@@ -70,6 +70,13 @@ func TestMsgMixKeyExchangeWire(t *testing.T) {
 
 	assertSerializationEqual(t, buf.Bytes(), expected)
 
+	// Ensure the serialize size is the actual encoded size.
+	sz := ke.SerializeSize()
+	actualSz := len(buf.Bytes())
+	if sz != actualSz {
+		t.Errorf("Wrong serialize size - got: %d want: %d", sz, actualSz)
+	}
+
 	decodedKE := new(MsgMixKeyExchange)
 	err = decodedKE.BtcDecode(bytes.NewReader(buf.Bytes()), pver)
 	if err != nil {

--- a/wire/msgmixpairreq.go
+++ b/wire/msgmixpairreq.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 The Decred developers
+// Copyright (c) 2023-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -404,6 +404,47 @@ func (msg *MsgMixPairReq) MaxPayloadLength(pver uint32) uint32 {
 
 	// See tests for this calculation.
 	return 8476848
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgMixPairReq) SerializeSize() int {
+	// Signature 64 bytes + identity 33 bytes + expiry 4 bytes +
+	// mix amount 8 bytes.
+	n := 64 + 33 + 4 + 8
+
+	// Script class (varInt + string).
+	n += VarIntSerializeSize(uint64(len(msg.ScriptClass))) + len(msg.ScriptClass)
+
+	// Tx version 2 bytes + lock time 4 bytes + message count 4 bytes +
+	// input value 8 bytes.
+	n += 2 + 4 + 4 + 8
+
+	// Num UTXOs (varInt) + each UTXO.
+	n += VarIntSerializeSize(uint64(len(msg.UTXOs)))
+	for i := range msg.UTXOs {
+		utxo := &msg.UTXOs[i]
+
+		// Outpoint (hash 32 bytes + index 4 bytes + tree 1 byte) + script
+		// (varInt + bytes) + pubkey (varInt + bytes) + signature (varInt +
+		// bytes) + opcode 1 byte.
+		n += 37 +
+			VarIntSerializeSize(uint64(len(utxo.Script))) + len(utxo.Script) +
+			VarIntSerializeSize(uint64(len(utxo.PubKey))) + len(utxo.PubKey) +
+			VarIntSerializeSize(uint64(len(utxo.Signature))) + len(utxo.Signature) +
+			1
+	}
+
+	// Has change flag 1 byte + optional change output.
+	n += 1
+	if msg.Change != nil {
+		n += msg.Change.SerializeSize()
+	}
+
+	// Flags 1 byte + pairing flags 1 byte.
+	n += 2
+
+	return n
 }
 
 // Pub returns the message sender's public key identity.

--- a/wire/msgmixpairreq_test.go
+++ b/wire/msgmixpairreq_test.go
@@ -166,6 +166,13 @@ func TestMsgMixPairReqWire(t *testing.T) {
 
 	assertSerializationEqual(t, buf.Bytes(), expected)
 
+	// Ensure the serialize size is the actual encoded size.
+	sz := pr.SerializeSize()
+	actualSz := len(buf.Bytes())
+	if sz != actualSz {
+		t.Errorf("Wrong serialize size - got: %d want: %d", sz, actualSz)
+	}
+
 	decodedPR := new(MsgMixPairReq)
 	err = decodedPR.BtcDecode(bytes.NewReader(buf.Bytes()), pver)
 	if err != nil {

--- a/wire/msgmixsecrets.go
+++ b/wire/msgmixsecrets.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 The Decred developers
+// Copyright (c) 2023-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -297,6 +297,35 @@ func (msg *MsgMixSecrets) MaxPayloadLength(pver uint32) uint32 {
 
 	// See tests for this calculation
 	return 70831
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgMixSecrets) SerializeSize() int {
+	// Signature 64 bytes + identity 33 bytes + session id 32 bytes +
+	// run 4 bytes + seed 32 bytes.
+	const fixedSize = 64 + 33 + 32 + 4 + 32
+
+	// Fixed fields + num slot reserve messages (varInt) + slot reserve
+	// messages (each a varInt-prefixed byte slice).
+	n := fixedSize + VarIntSerializeSize(uint64(len(msg.SlotReserveMsgs)))
+	for _, sr := range msg.SlotReserveMsgs {
+		n += VarIntSerializeSize(uint64(len(sr))) + len(sr)
+	}
+
+	// DC-net mixed messages vector, serialized as the number of messages
+	// (varInt) and, when non-empty, the message size varInt plus the
+	// fixed-size messages themselves.
+	n += VarIntSerializeSize(uint64(len(msg.DCNetMsgs)))
+	if len(msg.DCNetMsgs) > 0 {
+		n += VarIntSerializeSize(MixMsgSize) + len(msg.DCNetMsgs)*MixMsgSize
+	}
+
+	// Num seen secrets messages (varInt) + seen secret hashes.
+	n += VarIntSerializeSize(uint64(len(msg.SeenSecrets))) +
+		len(msg.SeenSecrets)*chainhash.HashSize
+
+	return n
 }
 
 // Pub returns the message sender's public key identity.

--- a/wire/msgmixsecrets_test.go
+++ b/wire/msgmixsecrets_test.go
@@ -89,6 +89,13 @@ func TestMsgMixSecretsWire(t *testing.T) {
 
 	assertSerializationEqual(t, buf.Bytes(), expected)
 
+	// Ensure the serialize size is the actual encoded size.
+	sz := rs.SerializeSize()
+	actualSz := len(buf.Bytes())
+	if sz != actualSz {
+		t.Errorf("Wrong serialize size - got: %d want: %d", sz, actualSz)
+	}
+
 	decodedRS := new(MsgMixSecrets)
 	err = decodedRS.BtcDecode(bytes.NewReader(buf.Bytes()), pver)
 	if err != nil {

--- a/wire/msgmixslotreserve.go
+++ b/wire/msgmixslotreserve.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 The Decred developers
+// Copyright (c) 2023-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -271,6 +271,38 @@ func (msg *MsgMixSlotReserve) MaxPayloadLength(pver uint32) uint32 {
 
 	// See tests for this calculation.
 	return 17318030
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgMixSlotReserve) SerializeSize() int {
+	// Signature 64 bytes + identity 33 bytes + session id 32 bytes +
+	// run 4 bytes.
+	const fixedSize = 64 + 33 + 32 + 4
+
+	mcount := len(msg.DCMix)
+	kpcount := 0
+	if mcount > 0 {
+		kpcount = len(msg.DCMix[0])
+	}
+
+	// Fixed fields + mcount (varInt) + kpcount (varInt).
+	n := fixedSize + VarIntSerializeSize(uint64(mcount)) +
+		VarIntSerializeSize(uint64(kpcount))
+
+	// DC-net mix matrix values, each a varInt-prefixed byte slice.
+	for i := range msg.DCMix {
+		for j := range msg.DCMix[i] {
+			v := msg.DCMix[i][j]
+			n += VarIntSerializeSize(uint64(len(v))) + len(v)
+		}
+	}
+
+	// Num seen ciphertexts (varInt) + seen ciphertext hashes.
+	n += VarIntSerializeSize(uint64(len(msg.SeenCiphertexts))) +
+		len(msg.SeenCiphertexts)*chainhash.HashSize
+
+	return n
 }
 
 // Pub returns the message sender's public key identity.

--- a/wire/msgmixslotreserve_test.go
+++ b/wire/msgmixslotreserve_test.go
@@ -106,6 +106,13 @@ func TestMsgMixSlotReserveWire(t *testing.T) {
 
 	assertSerializationEqual(t, buf.Bytes(), expected)
 
+	// Ensure the serialize size is the actual encoded size.
+	sz := sr.SerializeSize()
+	actualSz := len(buf.Bytes())
+	if sz != actualSz {
+		t.Errorf("Wrong serialize size - got: %d want: %d", sz, actualSz)
+	}
+
 	decodedSR := new(MsgMixSlotReserve)
 	err = decodedSR.BtcDecode(bytes.NewReader(buf.Bytes()), pver)
 	if err != nil {

--- a/wire/msgnotfound.go
+++ b/wire/msgnotfound.go
@@ -106,6 +106,14 @@ func (msg *MsgNotFound) MaxPayloadLength(pver uint32) uint32 {
 		maxInvVectPayload)
 }
 
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgNotFound) SerializeSize() int {
+	// Num inventory vectors (varInt) + total size of the inventory vectors.
+	return VarIntSerializeSize(uint64(len(msg.InvList))) +
+		len(msg.InvList)*maxInvVectPayload
+}
+
 // NewMsgNotFound returns a new Decred notfound message that conforms to the
 // Message interface.  See MsgNotFound for details.
 func NewMsgNotFound() *MsgNotFound {

--- a/wire/msgnotfound_test.go
+++ b/wire/msgnotfound_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -148,6 +148,14 @@ func TestNotFoundWire(t *testing.T) {
 			t.Errorf("BtcEncode #%d\n got: %s want: %s", i,
 				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
 			continue
+		}
+
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
 		}
 
 		// Decode the message from wire format.

--- a/wire/msgping.go
+++ b/wire/msgping.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -55,6 +55,13 @@ func (msg *MsgPing) MaxPayloadLength(pver uint32) uint32 {
 	plen += 8
 
 	return plen
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgPing) SerializeSize() int {
+	// Nonce 8 bytes.
+	return 8
 }
 
 // NewMsgPing returns a new Decred ping message that conforms to the Message

--- a/wire/msgping_test.go
+++ b/wire/msgping_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -85,6 +85,14 @@ func TestPingWire(t *testing.T) {
 			t.Errorf("BtcEncode #%d\n got: %s want: %s", i,
 				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
 			continue
+		}
+
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
 		}
 
 		// Decode the message from wire format.

--- a/wire/msgpong.go
+++ b/wire/msgpong.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -47,6 +47,13 @@ func (msg *MsgPong) MaxPayloadLength(pver uint32) uint32 {
 	plen += 8
 
 	return plen
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgPong) SerializeSize() int {
+	// Nonce 8 bytes.
+	return 8
 }
 
 // NewMsgPong returns a new Decred pong message that conforms to the Message

--- a/wire/msgpong_test.go
+++ b/wire/msgpong_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -103,6 +103,14 @@ func TestPongWire(t *testing.T) {
 			t.Errorf("BtcEncode #%d\n got: %s want: %s", i,
 				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
 			continue
+		}
+
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
 		}
 
 		// Decode the message from wire format.

--- a/wire/msgreject.go
+++ b/wire/msgreject.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2016 The btcsuite developers
-// Copyright (c) 2015-2023 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -210,6 +210,23 @@ func (msg *MsgReject) MaxPayloadLength(pver uint32) uint32 {
 	// limit on the length of the reason, so the max payload is the
 	// overall maximum message payload.
 	return uint32(MaxMessagePayload)
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgReject) SerializeSize() int {
+	// Rejected command (varInt + string) + code 1 byte + reason (varInt +
+	// string).
+	n := VarIntSerializeSize(uint64(len(msg.Cmd))) + len(msg.Cmd) + 1 +
+		VarIntSerializeSize(uint64(len(msg.Reason))) + len(msg.Reason)
+
+	// CmdBlock and CmdTx messages have an additional hash field that
+	// identifies the specific block or transaction.
+	if msg.Cmd == CmdBlock || msg.Cmd == CmdTx {
+		n += chainhash.HashSize
+	}
+
+	return n
 }
 
 // NewMsgReject returns a new Decred reject message that conforms to the

--- a/wire/msgreject_test.go
+++ b/wire/msgreject_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2016 The btcsuite developers
-// Copyright (c) 2015-2021 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -220,6 +220,14 @@ func TestRejectWire(t *testing.T) {
 			t.Errorf("BtcEncode #%d\n got: %s want: %s", i,
 				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
 			continue
+		}
+
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.msg.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
 		}
 
 		// Decode the message from wire format.

--- a/wire/msgsendheaders.go
+++ b/wire/msgsendheaders.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2016 The btcsuite developers
-// Copyright (c) 2016-2020 The Decred developers
+// Copyright (c) 2016-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -53,6 +53,13 @@ func (msg *MsgSendHeaders) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgSendHeaders) MaxPayloadLength(pver uint32) uint32 {
+	return 0
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgSendHeaders) SerializeSize() int {
+	// Empty message.
 	return 0
 }
 

--- a/wire/msgsendheaders_test.go
+++ b/wire/msgsendheaders_test.go
@@ -177,6 +177,14 @@ func TestSendHeadersWire(t *testing.T) {
 			continue
 		}
 
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
+		}
+
 		// Decode the message from wire format.
 		var msg MsgSendHeaders
 		rbuf := bytes.NewReader(test.buf)

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -1048,7 +1048,7 @@ func (msg *MsgTx) BytesWitness() ([]byte, error) {
 }
 
 // SerializeSize returns the number of bytes it would take to serialize the
-// transaction.
+// transaction.  This is part of the Message interface implementation.
 func (msg *MsgTx) SerializeSize() int {
 	// Unknown type return 0.
 	n := 0

--- a/wire/msgverack.go
+++ b/wire/msgverack.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -37,6 +37,13 @@ func (msg *MsgVerAck) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgVerAck) MaxPayloadLength(pver uint32) uint32 {
+	return 0
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgVerAck) SerializeSize() int {
+	// Empty message.
 	return 0
 }
 

--- a/wire/msgverack_test.go
+++ b/wire/msgverack_test.go
@@ -78,6 +78,14 @@ func TestVerAckWire(t *testing.T) {
 			continue
 		}
 
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
+		}
+
 		// Decode the message from wire format.
 		var msg MsgVerAck
 		rbuf := bytes.NewReader(test.buf)

--- a/wire/msgversion.go
+++ b/wire/msgversion.go
@@ -212,8 +212,21 @@ func (msg *MsgVersion) MaxPayloadLength(pver uint32) uint32 {
 	// remote and local net addresses + nonce 8 bytes + length of user
 	// agent (varInt) + max allowed useragent length + last block 4 bytes +
 	// relay transactions flag 1 byte.
-	return 33 + (maxNetAddressPayload(pver) * 2) + MaxVarIntPayload +
+	return 33 + (maxNetAddressPayload * 2) + MaxVarIntPayload +
 		MaxUserAgentLen
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// message.  This is part of the Message interface implementation.
+func (msg *MsgVersion) SerializeSize() int {
+	// Protocol version 4 bytes + services 8 bytes + timestamp 8 bytes + remote
+	// and local net addresses (without timestamp) + nonce 8 bytes + user agent
+	// (varInt + string) + last block 4 bytes + relay transactions flag 1 byte.
+	const includeTimestamp = false
+	return 4 + 8 + 8 + msg.AddrYou.SerializeSize(includeTimestamp) +
+		msg.AddrMe.SerializeSize(includeTimestamp) + 8 +
+		VarIntSerializeSize(uint64(len(msg.UserAgent))) + len(msg.UserAgent) +
+		4 + 1
 }
 
 // NewMsgVersion returns a new Decred version message that conforms to the

--- a/wire/msgversion_test.go
+++ b/wire/msgversion_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -224,6 +224,14 @@ func TestVersionWire(t *testing.T) {
 			t.Errorf("BtcEncode #%d\n got: %s want: %s", i,
 				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
 			continue
+		}
+
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize()
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
 		}
 
 		// Decode the message from wire format.

--- a/wire/netaddress.go
+++ b/wire/netaddress.go
@@ -16,17 +16,9 @@ import (
 // a TCP address as required.
 var ErrInvalidNetAddr = errors.New("provided net.Addr is not a net.TCPAddr")
 
-// maxNetAddressPayload returns the max payload size for a Decred NetAddress
-// based on the protocol version.
-func maxNetAddressPayload(pver uint32) uint32 {
-	// Services 8 bytes + ip 16 bytes + port 2 bytes.
-	plen := uint32(26)
-
-	// Timestamp 4 bytes.
-	plen += 4
-
-	return plen
-}
+// maxNetAddressPayload returns the max payload size for a NetAddress.
+// Timestamp 4 bytes + services 8 bytes + ip 16 bytes + port 2 bytes.
+const maxNetAddressPayload = 30
 
 // NetAddress defines information about a peer on the network including the time
 // it was last seen, the services it supports, its IP address, and port.
@@ -57,6 +49,21 @@ func (na *NetAddress) HasService(service ServiceFlag) bool {
 // message.
 func (na *NetAddress) AddService(service ServiceFlag) {
 	na.Services |= service
+}
+
+// SerializeSize returns the number of bytes it would take to serialize the
+// network address.  The ts flag indicates whether or not the timestamp is
+// included in the encoding.
+func (na *NetAddress) SerializeSize(ts bool) int {
+	// Services 8 bytes + ip 16 bytes + port 2 bytes.
+	n := 8 + 16 + 2
+
+	// Timestamp 4 bytes.
+	if ts {
+		n += 4
+	}
+
+	return n
 }
 
 // NewNetAddressIPPort returns a new NetAddress using the provided IP, port, and

--- a/wire/netaddress_test.go
+++ b/wire/netaddress_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -60,8 +60,8 @@ func TestNetAddress(t *testing.T) {
 
 	// Ensure max payload is expected value for latest protocol version.
 	pver := ProtocolVersion
-	wantPayload := uint32(30)
-	maxPayload := maxNetAddressPayload(ProtocolVersion)
+	wantPayload := 30
+	maxPayload := maxNetAddressPayload
 	if maxPayload != wantPayload {
 		t.Errorf("maxNetAddressPayload: wrong max payload length for "+
 			"protocol version %d - got %v, want %v", pver,
@@ -157,6 +157,14 @@ func TestNetAddressWire(t *testing.T) {
 			t.Errorf("writeNetAddress #%d\n got: %s want: %s", i,
 				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
 			continue
+		}
+
+		// Ensure the serialize size is the actual encoded size.
+		sz := test.in.SerializeSize(test.ts)
+		actualSz := len(buf.Bytes())
+		if sz != actualSz {
+			t.Errorf("Wrong serialize size #%d\n got: %d want: %d", i,
+				sz, actualSz)
 		}
 
 		// Decode the message from wire format.

--- a/wire/netaddressv2.go
+++ b/wire/netaddressv2.go
@@ -41,6 +41,14 @@ type NetAddressV2 struct {
 	Port uint16
 }
 
+// SerializeSize returns the number of bytes it would take to serialize the
+// network address.
+func (na *NetAddressV2) SerializeSize() int {
+	// Timestamp 8 bytes + services 8 bytes + address type 1 byte + encoded
+	// address bytes + port 2 bytes.
+	return 8 + 8 + 1 + len(na.EncodedAddr) + 2
+}
+
 // NewNetAddressV2 creates a new network address using the provided parameters
 // without validation.
 func NewNetAddressV2(netAddressType NetAddressType, addrBytes []byte, port uint16, timestamp time.Time, services ServiceFlag) NetAddressV2 {


### PR DESCRIPTION
**Based on #3744** 

Add SerializeSize to the Message interface, and add an implementation of SerializeSize to every message which was missing one. Also update the tests of every message so that SerializeSize is exercised at least once.

