### PR TITLE
main: Add python bytecode cache to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ cmd/promptsecret/promptsecret
 # Vim
 *.sw*
 Session.vim
+
+# Python bytecode cache
+__pycache__/


### PR DESCRIPTION
Useful since adding formal proofs of secp256k1 implemented in Python.