### PR TITLE
docs: Update docs for peer/v4.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -180,7 +180,7 @@ The following versioned modules are provided by dcrd repository:
   return values, and notifications
 * [wire](https://github.com/decred/dcrd/tree/master/wire) - Implements the
   Decred wire protocol
-* [peer/v3](https://github.com/decred/dcrd/tree/master/peer) - Provides a common
+* [peer/v4](https://github.com/decred/dcrd/tree/master/peer) - Provides a common
   base for creating and managing Decred network peers
 * [blockchain/v5](https://github.com/decred/dcrd/tree/master/blockchain) -
   Implements Decred block handling and chain selection rules

--- a/docs/assets/module_hierarchy.gv
+++ b/docs/assets/module_hierarchy.gv
@@ -24,7 +24,7 @@ digraph {
 	gcs [label="gcs/v4" fillcolor=gold]
 	standalone [label="blockchain/standalone/v2" fillcolor=firebrick4]
 	lru [label="container/lru" fillcolor=royalblue3]
-	peer [label="peer/v3" fillcolor=khaki]
+	peer [label="peer/v4" fillcolor=khaki]
 	rpcclient [label="rpcclient/v8" fillcolor=mediumseagreen]
 	addrmgr [label="addrmgr/v3" fillcolor=lightsalmon]
 	blockchain [label="blockchain/v5" fillcolor=orchid]

--- a/docs/assets/module_hierarchy.svg
+++ b/docs/assets/module_hierarchy.svg
@@ -307,7 +307,7 @@
 <g id="node23" class="node">
 <title>peer</title>
 <path fill="khaki" stroke="black" d="M286.65,-108C286.65,-108 255,-108 255,-108 249,-108 243,-102 243,-96 243,-96 243,-84 243,-84 243,-78 249,-72 255,-72 255,-72 286.65,-72 286.65,-72 292.65,-72 298.65,-78 298.65,-84 298.65,-84 298.65,-96 298.65,-96 298.65,-102 292.65,-108 286.65,-108"/>
-<text text-anchor="middle" x="270.82" y="-84.58" font-family="Times New Roman,serif" font-size="14.00">peer/v3</text>
+<text text-anchor="middle" x="270.82" y="-84.58" font-family="Times New Roman,serif" font-size="14.00">peer/v4</text>
 </g>
 <!-- txscript&#45;&gt;peer -->
 <g id="edge15" class="edge">

--- a/peer/README.md
+++ b/peer/README.md
@@ -3,7 +3,7 @@ peer
 
 [![Build Status](https://github.com/decred/dcrd/workflows/Build%20and%20Test/badge.svg)](https://github.com/decred/dcrd/actions)
 [![ISC License](https://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![Doc](https://img.shields.io/badge/doc-reference-blue.svg)](https://pkg.go.dev/github.com/decred/dcrd/peer/v2)
+[![Doc](https://img.shields.io/badge/doc-reference-blue.svg)](https://pkg.go.dev/github.com/decred/dcrd/peer/v4)
 
 Package peer provides a common base for creating and managing Decred network
 peers.
@@ -53,12 +53,12 @@ A quick overview of the major features peer provides are as follows:
 
 ## Installation and Updating
 
-This package is part of the `github.com/decred/dcrd/peer/v3` module.  Use the
+This package is part of the `github.com/decred/dcrd/peer/v4` module.  Use the
 standard go tooling for working with modules to incorporate it.
 
 ## Examples
 
-* [New Outbound Peer Example](https://pkg.go.dev/github.com/decred/dcrd/peer/v3#example-package-NewOutboundPeer)
+* [New Outbound Peer Example](https://pkg.go.dev/github.com/decred/dcrd/peer/v4#example-package-NewOutboundPeer)
   Demonstrates the basic process for initializing and creating an outbound peer.
   Peers negotiate by exchanging version and verack messages.  For demonstration,
   a simple handler for the version message is attached to the peer.


### PR DESCRIPTION
Various instances of module version were not updated when go.mod was bumped to v4.
