### PR TITLE
peer: Add a write deadline for message sends

### DIFF
--- a/peer/README.md
+++ b/peer/README.md
@@ -28,6 +28,8 @@ A quick overview of the major features peer provides are as follows:
    protocol version negotiation
  - Asynchronous message queueing of outbound messages with optional channel for
    notification when the message is actually sent
+ - Size-dependent deadline on every message write which disconnects peers that
+   do not read data quickly enough
  - Flexible peer configuration
    - Caller is responsible for creating outgoing connections and listening for
      incoming connections so they have flexibility to establish connections as

--- a/peer/doc.go
+++ b/peer/doc.go
@@ -97,6 +97,11 @@ done channel which will be notified when the message is actually sent can
 optionally be specified.  There are certain message types which are better sent
 using other functions which provide additional functionality.
 
+Remote peers that do not read data quickly enough would otherwise cause queued
+messages to accumulate.  Consequently, every message write is subject to a
+deadline that scales with the size of the message and peers that exceed it are
+disconnected.
+
 Of special interest are inventory messages.  Rather than manually sending MsgInv
 messages via [Peer.QueueMessage], the inventory vectors should be queued using
 the [Peer.QueueInventory] function.  It employs batching and trickling along

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -76,6 +76,18 @@ const (
 	// pingInterval is the interval of time to wait in between sending ping
 	// messages.
 	pingInterval = defaultIdleTimeout - 13*time.Second
+
+	// writeStallTimeout is the base amount of time a single message write is
+	// allowed to take before the peer is considered stalled and disconnected.
+	// A size-proportional allowance (see writeStallBytesPerSec) is added to it
+	// so that larger messages are afforded proportionally more time.
+	writeStallTimeout = 20 * time.Second
+
+	// writeStallBytesPerSec is the number of message bytes afforded one
+	// additional second on top of writeStallTimeout.  In other words, one
+	// second is added to the deadline for every 256 KiB of the message, so the
+	// largest possible message (32 MiB) gets roughly two extra minutes.
+	writeStallBytesPerSec = 256 * 1024 // 256 KiB
 )
 
 var (
@@ -994,6 +1006,17 @@ func (p *Peer) writeMessage(msg wire.Message) error {
 		if err == nil {
 			log.Trace(spew.Sdump(buf.Bytes()))
 		}
+	}
+
+	// Limit how long the write is allowed to block.  A base timeout plus an
+	// allowance proportional to the message size affords larger messages
+	// proportionally more time.
+	msgSize := wire.MessageHeaderSize + msg.SerializeSize()
+	allowance := time.Duration(msgSize/writeStallBytesPerSec) * time.Second
+	deadline := p.nowFn().Add(writeStallTimeout + allowance)
+	err := p.conn.SetWriteDeadline(deadline)
+	if err != nil {
+		return err
 	}
 
 	// Write the message to the peer.

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -473,6 +473,7 @@ type Peer struct {
 	remoteAddr net.Addr
 	cfg        Config
 	inbound    bool
+	nowFn      func() time.Time
 
 	flagsMtx             sync.Mutex // protects the peer flags below
 	id                   int32
@@ -911,7 +912,7 @@ func (p *Peer) handlePongMsg(msg *wire.MsgPong) {
 	// enough that if they overlap we would have timed out the peer.
 	p.statsMtx.Lock()
 	if p.lastPingNonce != 0 && msg.Nonce == p.lastPingNonce {
-		p.lastPingMicros = time.Since(p.lastPingTime).Nanoseconds()
+		p.lastPingMicros = p.nowFn().Sub(p.lastPingTime).Nanoseconds()
 		p.lastPingMicros /= 1000 // convert to usec.
 		p.lastPingNonce = 0
 	}
@@ -929,7 +930,7 @@ type hashable interface {
 
 // readMessage reads the next wire message from the peer with logging.
 func (p *Peer) readMessage() (wire.Message, []byte, error) {
-	err := p.conn.SetReadDeadline(time.Now().Add(p.cfg.IdleTimeout))
+	err := p.conn.SetReadDeadline(p.nowFn().Add(p.cfg.IdleTimeout))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1059,7 +1060,7 @@ func (p *Peer) maybeAddDeadline(d *pendingDeadlines, msg wire.Message) {
 	// - [wire.MsgGetHeaders] is not required to send a response if the remote
 	//   peer does not have any headers for the locator
 	var addedDeadline bool
-	deadline := time.Now().Add(stallResponseTimeout)
+	deadline := p.nowFn().Add(stallResponseTimeout)
 	switch msg := msg.(type) {
 	case *wire.MsgGetData:
 		// Prevent the peer from getting too far ahead with advertised inventory
@@ -1193,7 +1194,7 @@ out:
 				}
 
 				handlerActive = true
-				handlersStartTime = time.Now()
+				handlersStartTime = p.nowFn()
 
 			case sccHandlerDone:
 				// Warn on unbalanced callback signaling.
@@ -1205,7 +1206,7 @@ out:
 
 				// Extend active deadlines by the time it took to execute the
 				// callback.
-				duration := time.Since(handlersStartTime)
+				duration := p.nowFn().Sub(handlersStartTime)
 				deadlineOffset += duration
 				handlerActive = false
 
@@ -1216,7 +1217,7 @@ out:
 		case <-stallTicker.C:
 			// Calculate the offset to apply to the deadline based on how long
 			// the handlers have taken to execute since the last tick.
-			now := time.Now()
+			now := p.nowFn()
 			offset := deadlineOffset
 			if handlerActive {
 				offset += now.Sub(handlersStartTime)
@@ -1524,7 +1525,7 @@ out:
 
 			break out
 		}
-		atomic.StoreInt64(&p.lastRecv, time.Now().Unix())
+		atomic.StoreInt64(&p.lastRecv, p.nowFn().Unix())
 		select {
 		case p.stallControl <- stallControlMsg{sccReceiveMessage, rmsg}:
 		case <-p.quit:
@@ -1725,7 +1726,7 @@ out:
 				// Setup ping statistics.
 				p.statsMtx.Lock()
 				p.lastPingNonce = m.Nonce
-				p.lastPingTime = time.Now()
+				p.lastPingTime = p.nowFn()
 				p.statsMtx.Unlock()
 			}
 
@@ -1751,7 +1752,7 @@ out:
 			// message that it has been sent (if requested), and
 			// signal the send queue to the deliver the next queued
 			// message.
-			atomic.StoreInt64(&p.lastSend, time.Now().Unix())
+			atomic.StoreInt64(&p.lastSend, p.nowFn().Unix())
 			if msg.doneChan != nil {
 				msg.doneChan <- struct{}{}
 			}
@@ -1943,7 +1944,7 @@ func (p *Peer) readRemoteVersionMsg(onVersion OnVersionCallback) error {
 	p.startingHeight = int64(msg.LastBlock)
 
 	// Set the peer's time offset.
-	p.timeOffset = msg.Timestamp.Unix() - time.Now().Unix()
+	p.timeOffset = msg.Timestamp.Unix() - p.nowFn().Unix()
 	p.statsMtx.Unlock()
 
 	// Set the peer's ID and user agent.
@@ -2346,6 +2347,7 @@ func newPeerBase(cfgOrig *Config, conn net.Conn, inbound bool) *Peer {
 		blake256Hasher: blake256.NewHasher256(),
 		conn:           conn,
 		inbound:        inbound,
+		nowFn:          time.Now,
 		knownInventory: lru.NewSetWithDefaultTTL[wire.InvVect](
 			maxKnownInventory, maxKnownInventoryTTL),
 		timeConnected:   time.Now(),

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -36,17 +36,23 @@ type conn struct {
 	// remote network, address for the connection.
 	rnet, raddr string
 
-	// mocks socks proxy if true
+	// mocks socks proxy if true.
 	proxy bool
+
+	// setWriteDeadlineErr is returned by SetWriteDeadline when it is non-nil.
+	setWriteDeadlineErr error
+
+	// writeDeadline stores the most recent deadline set by SetWriteDeadline.
+	writeDeadline time.Time
 }
 
 // LocalAddr returns the local address for the connection.
-func (c conn) LocalAddr() net.Addr {
+func (c *conn) LocalAddr() net.Addr {
 	return &addr{c.lnet, c.laddr}
 }
 
 // Remote returns the remote address for the connection.
-func (c conn) RemoteAddr() net.Addr {
+func (c *conn) RemoteAddr() net.Addr {
 	if !c.proxy {
 		return &addr{c.rnet, c.raddr}
 	}
@@ -60,7 +66,7 @@ func (c conn) RemoteAddr() net.Addr {
 }
 
 // Close handles closing the connection.
-func (c conn) Close() error {
+func (c *conn) Close() error {
 	readCloseErr := c.ReadCloser.Close()
 	writeCloseErr := c.WriteCloser.Close()
 	if readCloseErr != nil {
@@ -69,9 +75,17 @@ func (c conn) Close() error {
 	return writeCloseErr
 }
 
-func (c conn) SetDeadline(t time.Time) error      { return nil }
-func (c conn) SetReadDeadline(t time.Time) error  { return nil }
-func (c conn) SetWriteDeadline(t time.Time) error { return nil }
+func (c *conn) SetDeadline(t time.Time) error     { return nil }
+func (c *conn) SetReadDeadline(t time.Time) error { return nil }
+
+func (c *conn) SetWriteDeadline(t time.Time) error {
+	if c.setWriteDeadlineErr != nil {
+		return c.setWriteDeadlineErr
+	}
+
+	c.writeDeadline = t
+	return nil
+}
 
 // addr mocks a network address.
 type addr struct {
@@ -908,6 +922,92 @@ func TestPushAddrV2Msg(t *testing.T) {
 			t.Errorf("%s: expected %d addresses sent, got %d", test.name,
 				test.wantSentLen, got)
 		}
+	}
+}
+
+// sizedMsg implements the wire.Message interface with a configurable serialized
+// size.
+type sizedMsg struct {
+	size int
+}
+
+func (msg *sizedMsg) BtcDecode(io.Reader, uint32) error { return nil }
+func (msg *sizedMsg) BtcEncode(io.Writer, uint32) error { return nil }
+func (msg *sizedMsg) Command() string                   { return "sized" }
+func (msg *sizedMsg) MaxPayloadLength(uint32) uint32    { return uint32(msg.size) }
+func (msg *sizedMsg) SerializeSize() int                { return msg.size }
+
+// TestWriteMessageDeadline ensures the write deadline applied to each outgoing
+// message is the base timeout plus an allowance that is proportional to the
+// total serialized size of the message.
+func TestWriteMessageDeadline(t *testing.T) {
+	tests := []struct {
+		name          string        // test description
+		payloadSize   int           // serialized size of the message payload
+		wantAllowance time.Duration // expected time allowed beyond the base timeout
+	}{{
+		name:          "empty payload",
+		payloadSize:   0,
+		wantAllowance: 0,
+	}, {
+		name:          "one byte below increased allowance",
+		payloadSize:   writeStallBytesPerSec - wire.MessageHeaderSize - 1,
+		wantAllowance: 0,
+	}, {
+		name:          "exactly a full second allowance",
+		payloadSize:   writeStallBytesPerSec - wire.MessageHeaderSize,
+		wantAllowance: time.Second,
+	}, {
+		name:          "exactly a two second allowance",
+		payloadSize:   2*writeStallBytesPerSec - wire.MessageHeaderSize,
+		wantAllowance: 2 * time.Second,
+	}, {
+		name:          "largest possible message (32 MiB)",
+		payloadSize:   wire.MaxMessagePayload - wire.MessageHeaderSize,
+		wantAllowance: 128 * time.Second,
+	}}
+
+	// Create a peer with a mock connection along with a goroutine that discards
+	// everything written to the other end so the writes below do not block.
+	inConn, outConn := pipe("10.0.0.1:9108", "10.0.0.2:9108")
+	defer inConn.Close()
+	defer outConn.Close()
+	go io.Copy(io.Discard, outConn)
+	p := NewInboundPeer(mockPeerConfig(), inConn)
+
+	// Override the now function so the deadlines are deterministic.
+	mockNow := time.Now()
+	mockNowFn := func() time.Time { return mockNow }
+	p.nowFn = mockNowFn
+
+	for _, test := range tests {
+		if err := p.writeMessage(&sizedMsg{size: test.payloadSize}); err != nil {
+			t.Fatalf("%s: unexpected error writing message: %v", test.name, err)
+		}
+
+		got := inConn.writeDeadline
+		want := mockNow.Add(writeStallTimeout + test.wantAllowance)
+		if !got.Equal(want) {
+			t.Fatalf("%s: wrong write deadline - got %v, want %v", test.name, got,
+				want)
+		}
+	}
+}
+
+// TestWriteMessageDeadlineError ensures a failure to set the write deadline on
+// the underlying connection is returned to the caller.
+func TestWriteMessageDeadlineError(t *testing.T) {
+	inConn, outConn := pipe("10.0.0.1:9108", "10.0.0.2:9108")
+	defer inConn.Close()
+	defer outConn.Close()
+	p := NewInboundPeer(mockPeerConfig(), inConn)
+
+	wantErr := errors.New("set write deadline failed")
+	inConn.setWriteDeadlineErr = wantErr
+
+	got := p.writeMessage(&sizedMsg{})
+	if !errors.Is(got, wantErr) {
+		t.Fatalf("wrong error - got %v, want %v", got, wantErr)
 	}
 }
 


### PR DESCRIPTION
Set a write deadline before each message write and disconnect peers who exceed this deadline. The deadline is a base timeout plus an allowance proportional to the message size so that larger messages are afforded proportionally more time and well-behaved peers on slower links are not disconnected.

## Note for review

The limits added in this PR have been set somewhat arbitrarily and are worth scrutiny:

- 20 second base allowance
- 1 additional second allowed per 256 KiB of message size
