### PR TITLE
[release-v2.1] main: Use backported mixing updates.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/decred/dcrd/dcrutil/v4 v4.0.3
 	github.com/decred/dcrd/gcs/v4 v4.1.1
 	github.com/decred/dcrd/math/uint256 v1.0.2
-	github.com/decred/dcrd/mixing v0.7.3
+	github.com/decred/dcrd/mixing v0.7.4
 	github.com/decred/dcrd/peer/v3 v3.2.0
 	github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.4.0
 	github.com/decred/dcrd/rpcclient/v8 v8.1.0

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/decred/dcrd/hdkeychain/v3 v3.1.3 h1:Kn2wfj5cOR6pQO/WrYOMT1KK12IgWFEeQ
 github.com/decred/dcrd/hdkeychain/v3 v3.1.3/go.mod h1:mDAuGaH6InRD+hKVeVJsjLD/ih1mD3aCKURNHS8Tq2s=
 github.com/decred/dcrd/math/uint256 v1.0.2 h1:o8peafL5QmuXGTergI3YDpDU0eq5Z0pQi88B8ym4PRA=
 github.com/decred/dcrd/math/uint256 v1.0.2/go.mod h1:7M/y9wJJvlyNG/f/X6mxxhxo9dgloZHFiOfbiscl75A=
-github.com/decred/dcrd/mixing v0.7.3 h1:zrMPKvR3GP2stDiqT9tiv0e8GGnFpgl1EClNRew7FFk=
-github.com/decred/dcrd/mixing v0.7.3/go.mod h1:riSgG1GpWXl8LVuBvo8WXuFgcBj01ZGpTAxT/4PrtU0=
+github.com/decred/dcrd/mixing v0.7.4 h1:jfFVqx5OQXP7DYUB+9bxYbKRWlWCg5nqYP1HlKJ19sg=
+github.com/decred/dcrd/mixing v0.7.4/go.mod h1:v8bSiELRzTlKNxRgukVscuLV3TLLf6y4d5bp7pV0D0c=
 github.com/decred/dcrd/peer/v3 v3.2.0 h1:6PxoGcsyjV3me/WLjIZdmWs4Pma5jYGi40CmzNCzeNY=
 github.com/decred/dcrd/peer/v3 v3.2.0/go.mod h1:OUFvMboEQvnq4V8CRw2RUn/fFls0rpVuDN0QT0zq8RA=
 github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.4.0 h1:BBVaYemabsFsaqNVlCmacoZlSsLDqwHYIs8ty6fg59Q=

--- a/mixing/mixpool/mixpool.go
+++ b/mixing/mixpool/mixpool.go
@@ -1676,7 +1676,7 @@ func (p *Pool) acceptKE(ke *wire.MsgMixKeyExchange, hash *chainhash.Hash, id *id
 	// is saved as an orphan and may be processed later.
 	// Of all PRs that are known, their pairing types must be compatible.
 	var missingOwnPR *chainhash.Hash
-	prs := make([]*wire.MsgMixPairReq, 0, len(ke.SeenPRs))
+	expiry := ^uint32(0)
 	var pairing []byte
 	for i := range ke.SeenPRs {
 		seenPR := &ke.SeenPRs[i]
@@ -1686,6 +1686,9 @@ func (p *Pool) acceptKE(ke *wire.MsgMixKeyExchange, hash *chainhash.Hash, id *id
 				missingOwnPR = seenPR
 			}
 			continue
+		}
+		if prExpiry := pr.Expires(); expiry > prExpiry {
+			expiry = prExpiry
 		}
 		if uint32(i) == ke.Pos && pr.Identity != ke.Identity {
 			// This cannot be a bannable rule error.  One peer may
@@ -1729,13 +1732,6 @@ func (p *Pool) acceptKE(ke *wire.MsgMixKeyExchange, hash *chainhash.Hash, id *id
 
 	// Create a session for the first KE
 	if ses == nil {
-		expiry := ^uint32(0)
-		for i := range prs {
-			prExpiry := prs[i].Expires()
-			if expiry > prExpiry {
-				expiry = prExpiry
-			}
-		}
 		ses = &session{
 			sid:    sid,
 			prs:    ke.SeenPRs,


### PR DESCRIPTION
This updates the 2.1 release branch to use the latest version of the `mixing` module which includes a fix for a potential periodic deanonymization attack and improved session expiry.

In particular, the following updated module version is used:

- github.com/decred/dcrd/mixing@v0.7.4

The following PRs are included:

- https://github.com/decred/dcrd/pull/3683
- https://github.com/decred/dcrd/pull/3765
- https://github.com/decred/dcrd/pull/3760

