### PR TITLE
[release-v2.1] main: Use backported standalone updates.

### DIFF
--- a/blockchain/standalone/error.go
+++ b/blockchain/standalone/error.go
@@ -49,6 +49,11 @@ const (
 	// invalid in some way such as being out of range.
 	ErrBadTxOutValue = ErrorKind("ErrBadTxOutValue")
 
+	// ErrFraudAmountIn indicates a fraud proof witness amount (aka the input
+	// value) for a transaction is invalid in some way such as being out of
+	// range.
+	ErrFraudAmountIn = ErrorKind("ErrFraudAmountIn")
+
 	// ErrDuplicateTxInputs indicates a transaction references the same
 	// input more than once.
 	ErrDuplicateTxInputs = ErrorKind("ErrDuplicateTxInputs")

--- a/blockchain/standalone/error_test.go
+++ b/blockchain/standalone/error_test.go
@@ -23,6 +23,7 @@ func TestErrorKindStringer(t *testing.T) {
 		{ErrNoTxOutputs, "ErrNoTxOutputs"},
 		{ErrTxTooBig, "ErrTxTooBig"},
 		{ErrBadTxOutValue, "ErrBadTxOutValue"},
+		{ErrFraudAmountIn, "ErrFraudAmountIn"},
 		{ErrDuplicateTxInputs, "ErrDuplicateTxInputs"},
 	}
 

--- a/blockchain/standalone/tx.go
+++ b/blockchain/standalone/tx.go
@@ -199,6 +199,22 @@ func CheckTransactionSanity(tx *wire.MsgTx, maxTxSize uint64) error {
 		}
 	}
 
+	// Input values in the fraud proof must either be in the valid range or the
+	// special sentinel value that signals it needs to be filled in later.
+	for _, txIn := range tx.TxIn {
+		atoms := txIn.ValueIn
+		if atoms < 0 && atoms != wire.NullValueIn {
+			str := fmt.Sprintf("transaction input value has negative value of "+
+				"%v", atoms)
+			return ruleError(ErrFraudAmountIn, str)
+		}
+		if atoms > maxAtoms {
+			str := fmt.Sprintf("transaction input value %v is higher than max "+
+				"allowed value of %v", atoms, maxAtoms)
+			return ruleError(ErrFraudAmountIn, str)
+		}
+	}
+
 	// Check for duplicate transaction inputs.
 	existingTxOut := make(map[wire.OutPoint]struct{})
 	for _, txIn := range tx.TxIn {

--- a/blockchain/standalone/tx_test.go
+++ b/blockchain/standalone/tx_test.go
@@ -370,6 +370,29 @@ func TestCheckTransactionSanity(t *testing.T) {
 		}(),
 		err: ErrBadTxOutValue,
 	}, {
+		name: "transaction with input value == wire.NullValueIn (ok)",
+		tx: func() *wire.MsgTx {
+			tx := baseTx.Copy()
+			tx.TxIn[0].ValueIn = wire.NullValueIn
+			return tx
+		}(),
+	}, {
+		name: "transaction with negative input value",
+		tx: func() *wire.MsgTx {
+			tx := baseTx.Copy()
+			tx.TxIn[0].ValueIn = -2
+			return tx
+		}(),
+		err: ErrFraudAmountIn,
+	}, {
+		name: "transaction with single input value > max per tx",
+		tx: func() *wire.MsgTx {
+			tx := baseTx.Copy()
+			tx.TxIn[0].ValueIn = maxAtoms + 1
+			return tx
+		}(),
+		err: ErrFraudAmountIn,
+	}, {
 		name: "transaction spending duplicate input",
 		tx: func() *wire.MsgTx {
 			tx := baseTx.Copy()

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/decred/dcrd/dcrutil/v4 v4.0.3
 	github.com/decred/dcrd/gcs/v4 v4.1.1
 	github.com/decred/dcrd/math/uint256 v1.0.2
-	github.com/decred/dcrd/mixing v0.7.3
+	github.com/decred/dcrd/mixing v0.7.4
 	github.com/decred/dcrd/peer/v3 v3.2.0
 	github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.4.0
 	github.com/decred/dcrd/rpcclient/v8 v8.1.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/decred/dcrd/addrmgr/v3 v3.0.0
 	github.com/decred/dcrd/bech32 v1.1.4
 	github.com/decred/dcrd/blockchain/stake/v5 v5.0.2
-	github.com/decred/dcrd/blockchain/standalone/v2 v2.2.2
+	github.com/decred/dcrd/blockchain/standalone/v2 v2.3.0
 	github.com/decred/dcrd/blockchain/v5 v5.1.0
 	github.com/decred/dcrd/certgen v1.2.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/decred/dcrd/hdkeychain/v3 v3.1.3 h1:Kn2wfj5cOR6pQO/WrYOMT1KK12IgWFEeQ
 github.com/decred/dcrd/hdkeychain/v3 v3.1.3/go.mod h1:mDAuGaH6InRD+hKVeVJsjLD/ih1mD3aCKURNHS8Tq2s=
 github.com/decred/dcrd/math/uint256 v1.0.2 h1:o8peafL5QmuXGTergI3YDpDU0eq5Z0pQi88B8ym4PRA=
 github.com/decred/dcrd/math/uint256 v1.0.2/go.mod h1:7M/y9wJJvlyNG/f/X6mxxhxo9dgloZHFiOfbiscl75A=
-github.com/decred/dcrd/mixing v0.7.3 h1:zrMPKvR3GP2stDiqT9tiv0e8GGnFpgl1EClNRew7FFk=
-github.com/decred/dcrd/mixing v0.7.3/go.mod h1:riSgG1GpWXl8LVuBvo8WXuFgcBj01ZGpTAxT/4PrtU0=
+github.com/decred/dcrd/mixing v0.7.4 h1:jfFVqx5OQXP7DYUB+9bxYbKRWlWCg5nqYP1HlKJ19sg=
+github.com/decred/dcrd/mixing v0.7.4/go.mod h1:v8bSiELRzTlKNxRgukVscuLV3TLLf6y4d5bp7pV0D0c=
 github.com/decred/dcrd/peer/v3 v3.2.0 h1:6PxoGcsyjV3me/WLjIZdmWs4Pma5jYGi40CmzNCzeNY=
 github.com/decred/dcrd/peer/v3 v3.2.0/go.mod h1:OUFvMboEQvnq4V8CRw2RUn/fFls0rpVuDN0QT0zq8RA=
 github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.4.0 h1:BBVaYemabsFsaqNVlCmacoZlSsLDqwHYIs8ty6fg59Q=

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/decred/dcrd/bech32 v1.1.4 h1:wFlLM7Oic0MlIhQZdCQhdIqVc4CNaQ0vNR9fgCoW
 github.com/decred/dcrd/bech32 v1.1.4/go.mod h1:jliqHZmCbVfT06Lh1mQywEKFVidRclbBJIUmwdoKhu0=
 github.com/decred/dcrd/blockchain/stake/v5 v5.0.2 h1:5SZwlt0oJRuj64MqSFyQItSvfnd6hEgkkx4LySK9Zxo=
 github.com/decred/dcrd/blockchain/stake/v5 v5.0.2/go.mod h1:h6Xw2ECYewEb27i8yVsjOKktVIIu0TTS6EKhqfxfnbA=
-github.com/decred/dcrd/blockchain/standalone/v2 v2.2.2 h1:mQA1cEzMS6EHbgV50wb2VFx4VQjNE8+n/B5BKvp5HWk=
-github.com/decred/dcrd/blockchain/standalone/v2 v2.2.2/go.mod h1:lkBXrIA42dLYG4nDKAf08RlAeO4c4FC5YeDh8if91Hc=
+github.com/decred/dcrd/blockchain/standalone/v2 v2.3.0 h1:AbHhFQE0paPmhRumRkoeRUTrWh0Gb0409exls+yU3VM=
+github.com/decred/dcrd/blockchain/standalone/v2 v2.3.0/go.mod h1:9r5PlToh/WNrP3UJ4mG7Hq1U2WQ6I0uu9qMCpsRw22s=
 github.com/decred/dcrd/blockchain/v5 v5.1.0 h1:Uo4I57Z1rqYEGNR0z+JZcUXExG8PAZwVBbvMjF6VJBU=
 github.com/decred/dcrd/blockchain/v5 v5.1.0/go.mod h1:ZrMZIQGFdxxyfKd9aiz00yVNRi5RB0MIAxFsalqHAt0=
 github.com/decred/dcrd/certgen v1.2.0 h1:FF6XXV//5q38/c6QbGQdR35ZJz0GPIkejsZZU3oHuBQ=

--- a/internal/blockchain/validate.go
+++ b/internal/blockchain/validate.go
@@ -663,10 +663,10 @@ func CheckProofOfStake(block *dcrutil.Block, posLimit int64) error {
 }
 
 // standaloneToChainRuleError attempts to convert the passed error from a
-// standalone.RuleError to a blockchain.RuleError with the equivalent error
-// kind.  The error is simply passed through without modification if it is
-// not a standalone.RuleError, not one of the specifically recognized
-// error kinds, or nil.
+// [standalone.RuleError] to a [RuleError] with the equivalent error kind.  The
+// error is simply passed through without modification if it is not a
+// [standalone.RuleError], not one of the specifically recognized error kinds,
+// or nil.
 func standaloneToChainRuleError(err error) error {
 	// Convert standalone package rule errors to blockchain rule errors.
 	switch {
@@ -682,6 +682,8 @@ func standaloneToChainRuleError(err error) error {
 		return ruleError(ErrTxTooBig, err.Error())
 	case errors.Is(err, standalone.ErrBadTxOutValue):
 		return ruleError(ErrBadTxOutValue, err.Error())
+	case errors.Is(err, standalone.ErrFraudAmountIn):
+		return ruleError(ErrFraudAmountIn, err.Error())
 	case errors.Is(err, standalone.ErrDuplicateTxInputs):
 		return ruleError(ErrDuplicateTxInputs, err.Error())
 	}

--- a/mixing/mixpool/mixpool.go
+++ b/mixing/mixpool/mixpool.go
@@ -1676,7 +1676,7 @@ func (p *Pool) acceptKE(ke *wire.MsgMixKeyExchange, hash *chainhash.Hash, id *id
 	// is saved as an orphan and may be processed later.
 	// Of all PRs that are known, their pairing types must be compatible.
 	var missingOwnPR *chainhash.Hash
-	prs := make([]*wire.MsgMixPairReq, 0, len(ke.SeenPRs))
+	expiry := ^uint32(0)
 	var pairing []byte
 	for i := range ke.SeenPRs {
 		seenPR := &ke.SeenPRs[i]
@@ -1686,6 +1686,9 @@ func (p *Pool) acceptKE(ke *wire.MsgMixKeyExchange, hash *chainhash.Hash, id *id
 				missingOwnPR = seenPR
 			}
 			continue
+		}
+		if prExpiry := pr.Expires(); expiry > prExpiry {
+			expiry = prExpiry
 		}
 		if uint32(i) == ke.Pos && pr.Identity != ke.Identity {
 			// This cannot be a bannable rule error.  One peer may
@@ -1729,13 +1732,6 @@ func (p *Pool) acceptKE(ke *wire.MsgMixKeyExchange, hash *chainhash.Hash, id *id
 
 	// Create a session for the first KE
 	if ses == nil {
-		expiry := ^uint32(0)
-		for i := range prs {
-			prExpiry := prs[i].Expires()
-			if expiry > prExpiry {
-				expiry = prExpiry
-			}
-		}
 		ses = &session{
 			sid:    sid,
 			prs:    ke.SeenPRs,


### PR DESCRIPTION
This updates the 2.1 release branch to use the latest version of the `blockchain/standalone` module which includes an update to reject obviously impossible values very early in the validation process.

In particular, the following updated module version is used:

- github.com/decred/dcrd/blockchain/standalone@v2.3.0

The following PRs are included:

- https://github.com/decred/dcrd/pull/3677