### PR TITLE
multi: Build and doco updates for Go 1.27.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
       module_dirs: ${{ steps.resolve_module_dirs.outputs.module_dirs }}
     steps:
       - name: Check out source
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Resolve go module directories
         id: resolve_module_dirs
         run: |
@@ -26,9 +26,9 @@ jobs:
         go: ["1.25", "1.26"]
     steps:
       - name: Check out source
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ matrix.go }}
       - name: Stablilize testdata timestamps
@@ -48,13 +48,13 @@ jobs:
         module_dirs: ${{ fromJson(needs.resolve-modules.outputs.module_dirs ) }}
     steps:
       - name: Check out source
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.25"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           install-mode: "goinstall"
           version: 8f3b0c7ed018e57905fbd873c697e0b1ede605a5 # v2.11.4

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.25", "1.26"]
+        go: ["1.26", "1.27"]
     steps:
       - name: Check out source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.25"
+          go-version: "1.26"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -57,5 +57,5 @@ jobs:
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           install-mode: "goinstall"
-          version: 8f3b0c7ed018e57905fbd873c697e0b1ede605a5 # v2.11.4
+          version: 6d2288e072e6f9c9bca28180cae9ce58a049c912 # v2.13.1
           working-directory: ${{ matrix.module_dirs }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,11 @@ linters:
     - unconvert
     - unused
     - usetesting
+  exclusions:
+    rules:
+      - linters:
+        - govet
+        text: 'Constant reflect\.Ptr should be inlined'
   settings:
     staticcheck:
       checks:

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ https://decred.org/downloads/
 
 <details><summary><b>Install Dependencies</b></summary>
 
-- **Go 1.25 or 1.26**
+- **Go 1.26 or 1.27**
 
   Installation instructions can be found here: https://golang.org/doc/install.
   Ensure Go was installed properly and is a supported version:


### PR DESCRIPTION
This consists of several commits to update the CI and documentation for Go 1.27. It also takes the opportunity to bump to the latest linter and action versions.

In particular:

- build: Update to latest action versions.
  - actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
  - actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
  - golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
- build: Update golangci-lint to v2.13.1.
- build: Test against Go 1.27 and remove Go 1.25 accordingly.
- docs: Update README.md to required Go 1.26/1.27.