### PR TITLE
main: Use latest Go 1.26 features if possible.

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -18,8 +18,8 @@
 // changes in the newer versions of Go that are disabled by default due to not
 // being strictly backwards compatible will break the existing code.
 
-//go:build go1.25
+//go:build go1.26
 
-//go:debug default=go1.25
+//go:debug default=go1.26
 
 package main


### PR DESCRIPTION
**This is rebased on #3775**.

The existing code in the main module will all work properly with all changes in Go 1.26, so this updates the default `GODEBUG` directive to ensure the new features and security updates implemented in Go 1.26 are enabled when building with Go 1.26 or newer.

The specific `GODEBUG` flags removed are:

* `cryptocustomrand=1`
* `tlssecpmlkem=0`
* `urlstrictcolons=0`

None of these will affect existing deployments.
