### PR TITLE
mixclient: remove shadowed roots declaration

### DIFF
--- a/mixing/mixclient/client.go
+++ b/mixing/mixclient/client.go
@@ -2184,10 +2184,6 @@ func (c *Client) roots(ctx context.Context, seenSRs []chainhash.Hash,
 			if len(fp.Roots) != len(a)-1 {
 				continue
 			}
-			roots := make([]*big.Int, 0, sesRun.mtot)
-			if len(fp.Roots) <= len(roots) {
-				continue
-			}
 
 			for i := range fp.Roots {
 				root := new(big.Int).SetBytes(fp.Roots[i])


### PR DESCRIPTION
Fixes #3777.

## Problem

In `mixing/mixclient/client.go` (`receiveOwnRoots` wait loop), each factored-polynomial iteration begins with `roots = roots[:0]` on the **outer** `roots`, then declares a **fresh inner** `roots := make([]*big.Int, 0, sesRun.mtot)` that shadows it (#3777):

```go
roots = roots[:0]                                  // resets the outer slice — uselessly
...
if len(fp.Roots) != len(a)-1 { continue }
roots := make([]*big.Int, 0, sesRun.mtot)          // shadows the outer variable
if len(fp.Roots) <= len(roots) {                   // len(roots) is always 0 → dead check
    continue
}
```

The `len(fp.Roots) <= len(roots)` guard compares against a freshly-created slice, so it is dead code; and the per-iteration reset of the outer slice does nothing.

## Fix

Remove the shadowing declaration and the dead length check. The loop appends to the reset outer `roots` (capacity `len(a)-1`, exactly the number of roots a valid factored polynomial carries), and the `return roots, nil` at the bottom of the loop returns the same slice that was built. Behavior is unchanged — the returned values are identical — but there is one variable, one reset, and no dead branch left to mislead.

## Validation

`go build ./...` and `go vet ./...` in the `mixing` module are clean.
