### PR TITLE
mixclient: Override timeout and jitter for testing

### DIFF
--- a/mixing/mixclient/client.go
+++ b/mixing/mixclient/client.go
@@ -40,7 +40,9 @@ const MinPeers = mixing.MinPeers
 
 const pairingVersion byte = 3
 
-const (
+// durations below should be treated as constants, they are only variables so
+// they can be overridden in tests.
+var (
 	timeoutDuration = 30 * time.Second
 	maxJitter       = timeoutDuration / 10
 	msgJitter       = 300 * time.Millisecond

--- a/mixing/mixclient/client_test.go
+++ b/mixing/mixclient/client_test.go
@@ -174,6 +174,13 @@ func (w *testWallet) privForPkScript(p2pkhScript []byte) *secp256k1.PrivateKey {
 	return w.privForHash160(hash160)
 }
 
+func TestMain(t *testing.T) {
+	timeoutDuration = 1 * time.Second
+	maxJitter = timeoutDuration / 10
+	msgJitter = 10 * time.Millisecond
+	peerJitter = maxJitter - msgJitter
+}
+
 func TestHonest(t *testing.T) {
 	requireCsppsolver(t)
 


### PR DESCRIPTION
This reduces the total runtime for the mixclient package tests from ~975s to ~39s.

This is an alternative to #3732, demonstrating that the runtime can still be dramatically reduced regardless of the introduction of DCRS phase.

While this solution has a nice benefit of not needing changes in wallet, I still prefer the parameter solution rather than overriding package variables. Perhaps the ideal option is to make all of the timeout and jitter durations parameters?